### PR TITLE
test(observer): Join Empire NW snapshot post-resolution AC (Refs #2509)

### DIFF
--- a/tool/run_observer_game/test/observer_snapshot_join_empire_test.dart
+++ b/tool/run_observer_game/test/observer_snapshot_join_empire_test.dart
@@ -1,0 +1,175 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+import 'package:logger/logger.dart';
+
+import 'package:run_observer_game/observer_snapshot_v1.dart';
+
+/// Refs #2509: Observer snapshots are written **post-resolution**. When a
+/// Join Empire order absorbs a Tribe owning a `newWorld|` province in
+/// [validateOrdersAndResolveTurnFromTrustedOrders], the post-resolution
+/// snapshot must list that province under the absorbing Great Power.
+void main() {
+  setUpAll(() {
+    CtLogger.level = Level.off;
+  });
+
+  group('observer snapshot Join Empire post-resolution timing', () {
+    MapTopology buildTopology() {
+      return MapTopology(
+        nodes: const [
+          TopologyNode(
+            id: 'capital',
+            regionId: 'oldWorld',
+            type: TopologyNodeType.province,
+          ),
+          TopologyNode(
+            id: 'nw1',
+            regionId: 'newWorld',
+            type: TopologyNodeType.province,
+          ),
+        ],
+        edges: const [],
+      );
+    }
+
+    Game buildPreResolutionGame({required int treasury}) {
+      const ow = 'oldWorld';
+      const nw = 'newWorld';
+      return Game(
+        id: 'g-join-empire-nw',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: const RegionData(
+            provinces: [
+              Province(id: '$ow|capital', regionId: ow, ownerId: 'gp1'),
+            ],
+          ),
+          newWorld: const RegionData(
+            provinces: [
+              Province(id: '$nw|nw1', regionId: nw, ownerId: 'tribe1'),
+            ],
+          ),
+        ),
+        players: [
+          const Player(
+            id: 'gp1',
+            displayName: 'GP1',
+            isHuman: true,
+            treasury: 0,
+          ).copyWith(treasury: treasury),
+        ],
+        tribes: const [Tribe(id: 'tribe1', displayName: 'Tribe 1')],
+        minorNations: const [],
+        overtureStates: const [
+          OvertureState(
+            gpId: 'gp1',
+            targetId: 'tribe1',
+            stage: OvertureStage.nap,
+            sinceTurn: 0,
+          ),
+        ],
+        diplomacyRelations: const [
+          DiplomacyRelation(
+            factionId1: 'gp1',
+            factionId2: 'tribe1',
+            score: relationScoreMinFriendly + 10,
+            level: RelationLevel.friendly,
+          ),
+        ],
+      );
+    }
+
+    Orders buildJoinEmpireOrders() => Orders(
+          diplomaticOrdersByPlayerId: {
+            'gp1': const [
+              DiplomaticOrder(
+                type: DiplomaticOrderType.establishOverture,
+                targetFactionId: 'tribe1',
+                overtureStage: OvertureStage.joinEmpire,
+              ),
+            ],
+          },
+        );
+
+    test(
+      'snapshot.provinceOwnershipSorted lists absorbed NW province under '
+      'absorbing GP when treasury covers Join Empire cost',
+      () {
+        final topology = buildTopology();
+        // Cost = base 5000 + 1 province * 2000 = 7000; supply 15000 to cover.
+        final game = buildPreResolutionGame(treasury: 15000);
+
+        final result = validateOrdersAndResolveTurnFromTrustedOrders(
+          game: game,
+          topology: topology,
+          orders: buildJoinEmpireOrders(),
+        );
+        final after = requireTurnResolutionComplete(result);
+
+        expect(
+          after.tribes.any((t) => t.id == 'tribe1'),
+          isFalse,
+          reason: 'Tribe must be removed from game after Join Empire absorbs it',
+        );
+
+        final snapshot = buildObserverSnapshotJson(
+          after,
+          postResolutionTurnNumber: after.worldState.turnState.turnNumber,
+        );
+        final rows =
+            snapshot['provinceOwnershipSorted'] as List<Object?>;
+        final nwRow = rows
+            .cast<Map<String, Object?>>()
+            .firstWhere((r) => r['id'] == 'newWorld|nw1');
+        expect(nwRow['ownerId'], 'gp1');
+
+        final tribeOwned = rows
+            .cast<Map<String, Object?>>()
+            .where((r) => r['ownerId'] == 'tribe1')
+            .toList();
+        expect(
+          tribeOwned,
+          isEmpty,
+          reason: 'No province should still be owned by the absorbed tribe',
+        );
+      },
+    );
+
+    test(
+      'snapshot retains NW province under tribe when Join Empire is rejected '
+      'for insufficient treasury (negative case)',
+      () {
+        final topology = buildTopology();
+        // Cost = 5000 + 2000 = 7000; treasury below cost rejects absorption.
+        final game = buildPreResolutionGame(treasury: 100);
+
+        final result = validateOrdersAndResolveTurnFromTrustedOrders(
+          game: game,
+          topology: topology,
+          orders: buildJoinEmpireOrders(),
+        );
+        final after = requireTurnResolutionComplete(result);
+
+        expect(
+          after.tribes.any((t) => t.id == 'tribe1'),
+          isTrue,
+          reason: 'Tribe must remain when absorption rejected',
+        );
+
+        final snapshot = buildObserverSnapshotJson(
+          after,
+          postResolutionTurnNumber: after.worldState.turnState.turnNumber,
+        );
+        final rows =
+            snapshot['provinceOwnershipSorted'] as List<Object?>;
+        final nwRow = rows
+            .cast<Map<String, Object?>>()
+            .firstWhere((r) => r['id'] == 'newWorld|nw1');
+        expect(nwRow['ownerId'], 'tribe1');
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Closes an AC test gap for #2509 — observer snapshot timing after Join Empire absorption of a Tribe owning a `newWorld|` province.

Adds positive + negative integration tests under `tool/run_observer_game/test/observer_snapshot_join_empire_test.dart` exercising the path:

1. Set up a `Game` where a Tribe owns a `newWorld|` province with an existing `OvertureState.nap` and friendly relation toward the absorbing GP.
2. Submit an `establishOverture` with `OvertureStage.joinEmpire` via `validateOrdersAndResolveTurnFromTrustedOrders`.
3. Build the post-resolution `ObserverSnapshot` via `buildObserverSnapshotJson`.
4. Assert `provinceOwnershipSorted` reflects the resolved ownership.

| Case | Treasury | Expected snapshot result |
|------|----------|--------------------------|
| Positive | `15000` (≥ 5000 base + 1 × 2000) | NW province listed under `gp1`; tribe removed |
| Negative | `100` (below cost) | NW province retained under `tribe1`; tribe remains |

## Issue AC covered

> Given a resolved turn where Join Empire transfers a `newWorld|` province from a tribe to a Great Power, when `turn-<nnnnnn>.snapshot.json` is written post-resolution (after diplomacy in `validateOrdersAndResolveTurnFromTrustedOrders`), then `provinceOwnershipSorted` lists that province under the absorbing GP's `ownerId`.

This AC was previously not exercised by `tool/run_observer_game/test/`. Earlier `colonizethis_logic` tests verify the absorption mechanic itself; this PR adds the integration layer that the observer snapshot reflects the post-resolution state — the actual contract the issue's nightly gate depends on.

## Scope

| In scope | Out of scope |
|----------|--------------|
| Positive + negative integration test for Join Empire → observer snapshot ownership | Production code (no behavior change) |
| New file under `tool/run_observer_game/test/` | SPEC updates (existing language already describes post-resolution snapshots) |
| `Refs #2509` (no auto-close) | Turn-100 seed-42 conquest tuning (separate slices) |

## Deferred (still open under #2509)

- S10 seed-42 turn-100 OW conquest gate (gp3–gp6 still short of +3 OW; addressed in further tuning slices).
- Nightly green for `--verify-conquest` + `--verify-colonial-expansion` on seed 42.

## Tests

```bash
dart test tool/run_observer_game/test/observer_snapshot_join_empire_test.dart
```

Result: **2/2 pass**; full `tool/run_observer_game` suite: **35/35 pass** (no regressions).

```bash
dart analyze tool/run_observer_game/test/observer_snapshot_join_empire_test.dart
# No issues found!

cd tool/run_observer_game && dart run custom_lint
# No issues found!
```

Refs #2509

Made with [Cursor](https://cursor.com)