### PR TITLE
perf(e2e): larger default batch for parallel asset decode (Refs #2336)

### DIFF
--- a/app/integration_test/e2e_test_shared_bootstrap.dart
+++ b/app/integration_test/e2e_test_shared_bootstrap.dart
@@ -17,10 +17,20 @@ import 'e2e_test_shared.dart';
 
 /// Loads and decodes each path with bounded concurrency (overlapping I/O +
 /// image decode completion) instead of strictly serial awaits.
+///
+/// Larger batches reduce the number of synchronization points where the loop
+/// awaits *all* in-flight decodes before scheduling the next group, so a slow
+/// decode no longer blocks every other decode in the same batch. The default
+/// is sized to comfortably cover the relocated 64px icon manifest (~60 assets)
+/// in a single batch, while still allowing callers on memory-constrained CI
+/// runners to opt back into smaller chunks. Refs GitHub #2336 AC3.
 Future<List<String>> e2eDecodePngAssetPathsParallel(
   List<String> assetPaths, {
-  int batchSize = 8,
+  int batchSize = 64,
 }) async {
+  if (batchSize <= 0) {
+    throw ArgumentError.value(batchSize, 'batchSize', 'must be positive');
+  }
   final failures = <String>[];
   for (var i = 0; i < assetPaths.length; i += batchSize) {
     final end = i + batchSize > assetPaths.length

--- a/app/test/e2e_decode_png_assets_parallel_test.dart
+++ b/app/test/e2e_decode_png_assets_parallel_test.dart
@@ -1,0 +1,69 @@
+// Asserts the batched-concurrent behavior of `e2eDecodePngAssetPathsParallel`
+// (Refs GitHub #2336 AC3): the helper must decode every asset path it is
+// given, surface failed paths in the returned list, and respect the
+// `batchSize` parameter as an upper bound on in-flight decodes — never a
+// strict serial-iteration limit.
+
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter_test/flutter_test.dart';
+
+import '../integration_test/e2e_test_shared_bootstrap.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  suppressLogsForTests();
+
+  test('returns an empty failure list when given no paths', () async {
+    final failures = await e2eDecodePngAssetPathsParallel(const <String>[]);
+    expect(failures, isEmpty);
+  });
+
+  test('surfaces every missing asset path in the failure list', () async {
+    final failures = await e2eDecodePngAssetPathsParallel(const <String>[
+      'assets/icons/64/missing_one.png',
+      'assets/icons/64/missing_two.png',
+      'assets/icons/64/missing_three.png',
+    ]);
+    expect(failures, hasLength(3));
+    expect(
+      failures.every(
+        (entry) => entry.startsWith('assets/icons/64/missing_'),
+      ),
+      isTrue,
+      reason:
+          'Each failure entry must begin with the offending asset path so '
+          'maintainers can attribute decode errors without re-running the '
+          'integration suite.',
+    );
+  });
+
+  test('rejects non-positive batch sizes', () {
+    expect(
+      () => e2eDecodePngAssetPathsParallel(
+        const <String>['assets/icons/64/missing.png'],
+        batchSize: 0,
+      ),
+      throwsArgumentError,
+    );
+    expect(
+      () => e2eDecodePngAssetPathsParallel(
+        const <String>['assets/icons/64/missing.png'],
+        batchSize: -3,
+      ),
+      throwsArgumentError,
+    );
+  });
+
+  test('honors a tighter batchSize without losing failures', () async {
+    final failures = await e2eDecodePngAssetPathsParallel(
+      const <String>[
+        'assets/icons/64/missing_a.png',
+        'assets/icons/64/missing_b.png',
+        'assets/icons/64/missing_c.png',
+        'assets/icons/64/missing_d.png',
+      ],
+      batchSize: 2,
+    );
+    expect(failures, hasLength(4));
+  });
+}


### PR DESCRIPTION
## Summary

Bump `e2eDecodePngAssetPathsParallel`'s default `batchSize` from **8** to **64** so the relocated 64px icon manifest (~60 assets) decodes in a single `Future.wait` group, removing the inter-batch synchronization gaps where a slow decode in batch *N* blocked every fast decode in batch *N+1*.

This narrows the wall-clock cost of the suite-once warm-cache pass (`e2eEnsureAllRelocated64pxPngsLoadSuiteOnce`) executed before the first E2E scenario, which is one of the larger fixed setup costs documented under issue #2336 Bottleneck 1.

## Why

Issue #2336 AC3 mandates parallel asset decode via `Future.wait`, and AC9 requires an aggregate ≥25% suite median reduction. The previous batch of 8 forced ~7-8 sequential awaits across the ~60-asset manifest, paying the slowest decode in every batch even when the other 7 finished in microseconds. Setting the default batch to 64 fits the full manifest in one `Future.wait` while still allowing tighter explicit batching on memory-constrained CI runners.

## Changes

- `app/integration_test/e2e_test_shared_bootstrap.dart`: raise default `batchSize` from 8 to 64; add an `ArgumentError` guard so `batchSize <= 0` fails fast at the helper boundary rather than silently looping forever.
- `app/test/e2e_decode_png_assets_parallel_test.dart` (new): unit-test the helper's contract without booting the Linux integration desktop (empty input fast path, per-path failure surfacing, non-positive `batchSize` rejection, tighter explicit `batchSize` still surfaces every failure).

## SPEC

No SPEC changes — `SPEC/program/e2e-integration-tests.md` already documents `e2eDecodePngAssetPathsParallel` as a bounded-concurrency decode helper without pinning a default batch size.

## Done in this push

- AC3 reinforcement: parallel decode now lands in a single `Future.wait` for the canonical manifest.
- New unit tests cover the helper's argument validation and failure-collection contract.
- `flutter analyze` on touched files: clean.
- `flutter test app/test/e2e_decode_png_assets_parallel_test.dart` — 4 tests pass.
- `flutter test app/test/e2e_close_bottom_sheet_test.dart app/test/e2e_test_shared_smoke_test.dart app/test/e2e_open_panel_prepump_test.dart app/test/e2e_adaptive_poll_ramp_test.dart` — 24 tests pass.

## Deferred (still tracked under #2336)

- **AC6 / AC7 / AC10:** 3× consecutive Linux desktop integration_test passes per scenario (maintainer run; this agent host has no `xvfb`/display).
- **AC8 / AC9:** baseline-vs-after wall-clock table (`tool/run_e2e_timing.sh` on `dev` tip then this branch; `tool/compare_e2e_timing.sh` for the PR description summary).

`Refs #2336`


Made with [Cursor](https://cursor.com)