### PR TITLE
refactor(logic): dedupe connectivity topology helpers onto shared scanners (Refs #2560)

### DIFF
--- a/packages/colonizethis_logic/lib/src/world/connectivity_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/world/connectivity_resolver.dart
@@ -9,7 +9,6 @@ import '../utils/graph_traversal.dart';
 import '../diplomacy/diplomacy_relation_lookup.dart';
 import 'connectivity_blockade_target.dart';
 import 'port_seaboard_registry_key.dart';
-import 'province_lookup.dart';
 import 'province_traversal.dart';
 import 'tile_key_coordinates.dart';
 import 'topology_helpers.dart';
@@ -119,7 +118,7 @@ Map<String, ConnectivityResult> resolveConnectivity({
     'connectivity resolve start players=${game.players.length} regions=${tileMapByRegion.keys.join(",")}',
   );
   final provinceIdsByType = provinceNodeIds(topology);
-  final seaZoneNodeIds = _topologySeaZoneNodeIds(topology);
+  final topologySeaZones = seaZoneNodeIds(topology);
   final blockadedByPlayer =
       blockadedPortProvincesByPlayerId ??
       computeBlockadedPortProvincesByPlayer(game, topology);
@@ -148,7 +147,7 @@ Map<String, ConnectivityResult> resolveConnectivity({
       tileMapByRegion: tileMapByRegion,
       topology: topology,
       provinceIdsByType: provinceIdsByType,
-      seaZoneNodeIds: seaZoneNodeIds,
+      seaZoneNodeIds: topologySeaZones,
       portInfo: portInfo,
       owned: ownedByPlayer[player.id] ?? const <String>{},
       townByTileKey:
@@ -190,56 +189,6 @@ _buildPerPlayerProvinceCaches(Game game) {
     ownedByPlayer: ownedByPlayer,
     townByTileKeyByPlayer: townByTileKeyByPlayer,
   );
-}
-
-bool _topologyUsesPrefixedIds(MapTopology topology) {
-  return topology.nodes.any((n) => n.id.contains('|'));
-}
-
-/// Topology sea-zone node ids, built once per connectivity resolve (Refs #2394).
-Set<String> _topologySeaZoneNodeIds(MapTopology topology) {
-  return {
-    for (final n in topology.nodes)
-      if (n.type == TopologyNodeType.seaZone) n.id,
-  };
-}
-
-/// Sea zones reachable from [startSeaZoneIds] by following S–S edges in [topology]. SPEC/game/map-topology, capital-and-connectivity § Sea paths.
-Set<String> _seaZonesReachableBySeaPath(
-  MapTopology topology,
-  Set<String> startSeaZoneIds, {
-  required Set<String> seaZoneNodeIds,
-}) {
-  final neighbours = <String, Set<String>>{};
-  for (final e in topology.edges) {
-    final a = e.id1;
-    final b = e.id2;
-    if (seaZoneNodeIds.contains(a) && seaZoneNodeIds.contains(b)) {
-      neighbours.putIfAbsent(a, () => {}).add(b);
-      neighbours.putIfAbsent(b, () => {}).add(a);
-    }
-  }
-  return breadthFirstReachableInSubgraph(
-    startSeaZoneIds,
-    neighbours,
-    seaZoneNodeIds,
-    onDequeue: _recordSeaZoneBfsDequeue,
-  );
-}
-
-/// Sea zone ids adjacent to province [localProvinceId] in topology (P–S edges).
-Set<String> _seaZonesAdjacentToProvince(
-  MapTopology topology,
-  String localProvinceId, {
-  required Set<String> seaZoneNodeIds,
-}) {
-  final out = <String>{};
-  for (final edge in topology.edges) {
-    if (edge.id1 != localProvinceId && edge.id2 != localProvinceId) continue;
-    final other = edge.id1 == localProvinceId ? edge.id2 : edge.id1;
-    if (seaZoneNodeIds.contains(other)) out.add(other);
-  }
-  return out;
 }
 
 /// True if the capital tile is adjacent to sea (seaboard). SPEC/game/capital-and-connectivity § Port connection to capital.
@@ -509,21 +458,20 @@ Set<String> _seaConnectedPortKeysForCapital({
     provinceIdsByType,
   );
   if (capitalOnSeaboard && !capitalProvinceBlockaded) {
-    final prefixedTopology = _topologyUsesPrefixedIds(topology);
+    final prefixedTopology = topologyUsesPrefixedIds(topology);
     final provinceIdForLookup = prefixedTopology
         ? capital.provinceId
         : (ProvinceId.isPrefixed(capital.provinceId)
               ? ProvinceId.localIdFrom(capital.provinceId)
               : capital.provinceId);
-    final capitalSeaZones = _seaZonesAdjacentToProvince(
+    final capitalSeaZones = seaZonesAdjacentToProvince(
       topology,
       provinceIdForLookup,
-      seaZoneNodeIds: seaZoneNodeIds,
     );
-    final seaReachable = _seaZonesReachableBySeaPath(
+    final seaReachable = seaZonesReachableBySeaPath(
       topology,
       capitalSeaZones,
-      seaZoneNodeIds: seaZoneNodeIds,
+      onDequeue: _recordSeaZoneBfsDequeue,
     );
     for (final entry in worldState.portsByProvinceSeaboard.entries) {
       final portMeta = decodePortSeaboardRegistryKey(entry.key);

--- a/packages/colonizethis_logic/lib/src/world/fog_resolution.dart
+++ b/packages/colonizethis_logic/lib/src/world/fog_resolution.dart
@@ -256,6 +256,27 @@ class ProvinceOwnershipVisibilitySummary {
   final int tilesDowngradedForFormerOwner;
 }
 
+Map<String, Map<String, String>> _mutableGpVisibilityCopy(
+  Map<String, Map<String, String>> visibility,
+) => {
+  for (final entry in visibility.entries)
+    entry.key: Map<String, String>.from(entry.value),
+};
+
+void _forEachGpPlayerVisibility({
+  required Game game,
+  required Set<String> gpIds,
+  required Map<String, Map<String, String>> result,
+  required void Function(String playerId, Map<String, String> vis) action,
+}) {
+  for (final player in game.players) {
+    if (!gpIds.contains(player.id)) continue;
+    final vis = result[player.id];
+    if (vis == null) continue;
+    action(player.id, vis);
+  }
+}
+
 void _fullyVisibleAllTilesInSeaZoneBuckets(
   Map<String, String> vis,
   Map<String, List<String>> regionTileKeys,
@@ -307,35 +328,29 @@ Map<String, Map<String, String>> applyCoastalSeaZoneFullVisibility(
 }) {
   final gpIds = game.players.map((p) => p.id).toSet();
   final tileKeysByRegion = game.worldState.tileKeysByRegionAndProvince;
-  final result = <String, Map<String, String>>{};
-  for (final entry in visibilityAfterFogDecay.entries) {
-    result[entry.key] = Map<String, String>.from(entry.value);
-  }
+  final result = _mutableGpVisibilityCopy(visibilityAfterFogDecay);
 
   forEachWorldRegion(game.worldState, (regionId, regionData) {
+    final regionTileKeys = tileKeysByRegion[regionId];
+    if (regionTileKeys == null) return;
     final regionTopology = topologyForRegion(
       topology,
       regionId,
       topologyByRegion: topologyByRegion,
     );
-    final regionTileKeys = tileKeysByRegion[regionId];
-    if (regionTileKeys == null) return;
-
-    for (final player in game.players) {
-      if (!gpIds.contains(player.id)) continue;
-      final playerId = player.id;
-      final vis = result[playerId];
-      if (vis == null) continue;
-
-      _applyCoastalFullVisibilityForGpPlayerInRegion(
+    _forEachGpPlayerVisibility(
+      game: game,
+      gpIds: gpIds,
+      result: result,
+      action: (playerId, vis) => _applyCoastalFullVisibilityForGpPlayerInRegion(
         playerId: playerId,
         regionId: regionId,
         regionData: regionData,
         regionTopology: regionTopology,
         regionTileKeys: regionTileKeys,
         vis: vis,
-      );
-    }
+      ),
+    );
   });
 
   return result;
@@ -494,34 +509,26 @@ Map<String, Map<String, String>> applyDistantSeaZoneFogRevert(
 }) {
   final gpIds = game.players.map((p) => p.id).toSet();
   final tileKeysByRegion = game.worldState.tileKeysByRegionAndProvince;
-  final result = <String, Map<String, String>>{};
-  for (final entry in visibility.entries) {
-    result[entry.key] = Map<String, String>.from(entry.value);
-  }
+  final result = _mutableGpVisibilityCopy(visibility);
 
   forEachWorldRegion(game.worldState, (regionId, _) {
+    final regionTileKeys = tileKeysByRegion[regionId];
+    if (regionTileKeys == null) return;
     final regionTopology = topologyForRegion(
       topology,
       regionId,
       topologyByRegion: topologyByRegion,
     );
-    final seaZoneIds = regionTopology.nodes
-        .where((n) => n.type == TopologyNodeType.seaZone)
-        .map((n) => n.id);
-    final regionTileKeys = tileKeysByRegion[regionId];
-    if (regionTileKeys == null) return;
+    final seaZoneIds = seaZoneNodeIds(regionTopology);
     final fleetAtSeaZoneKeysByPlayer = _fleetAtSeaZoneKeysByPlayerInRegion(
       game,
       regionId,
     );
-
-    for (final player in game.players) {
-      if (!gpIds.contains(player.id)) continue;
-      final playerId = player.id;
-      final vis = result[playerId];
-      if (vis == null) continue;
-
-      _applyDistantSeaFogForGpPlayerInRegion(
+    _forEachGpPlayerVisibility(
+      game: game,
+      gpIds: gpIds,
+      result: result,
+      action: (playerId, vis) => _applyDistantSeaFogForGpPlayerInRegion(
         game: game,
         playerId: playerId,
         regionId: regionId,
@@ -530,8 +537,8 @@ Map<String, Map<String, String>> applyDistantSeaZoneFogRevert(
         regionTileKeys: regionTileKeys,
         fleetAtSeaZoneKeysByPlayer: fleetAtSeaZoneKeysByPlayer,
         vis: vis,
-      );
-    }
+      ),
+    );
   });
 
   return result;

--- a/packages/colonizethis_logic/lib/src/world/topology_helpers.dart
+++ b/packages/colonizethis_logic/lib/src/world/topology_helpers.dart
@@ -86,10 +86,14 @@ Set<String> seaZoneNodeIds(MapTopology topology) {
 
 /// Sea zones reachable from [startSeaZoneIds] by following S–S edges in [topology].
 /// SPEC/game/map-topology.md, capital-and-connectivity § Sea paths.
+///
+/// When [onDequeue] is set, it is invoked once per BFS dequeue (connectivity hot-path
+/// metrics in `connectivity_resolver.dart`).
 Set<String> seaZonesReachableBySeaPath(
   MapTopology topology,
-  Set<String> startSeaZoneIds,
-) {
+  Set<String> startSeaZoneIds, {
+  void Function()? onDequeue,
+}) {
   final seaZoneIds = seaZoneNodeIds(topology);
   final neighbours = <String, Set<String>>{};
   for (final e in topology.edges) {
@@ -104,6 +108,7 @@ Set<String> seaZonesReachableBySeaPath(
   final queue = Queue<String>()..addAll(startSeaZoneIds);
   while (queue.isNotEmpty) {
     final z = queue.removeFirst();
+    onDequeue?.call();
     for (final n in neighbours[z] ?? {}) {
       if (reachable.contains(n)) continue;
       reachable.add(n);


### PR DESCRIPTION
## Summary

Follow-up slice for **#2560** AC-5 (combined ≥100-line reduction across `connectivity_resolver.dart`, `fog_resolution.dart`, and `naval_resolution.dart`).

Builds on landed PR #2609 (`topology_helpers.dart` shared scanners) by:

- **Routing connectivity sea-zone work through `topology_helpers.dart`.** Removes four local private helpers from `connectivity_resolver.dart` (`_topologyUsesPrefixedIds`, `_topologySeaZoneNodeIds`, `_seaZonesReachableBySeaPath`, `_seaZonesAdjacentToProvince`) in favor of the existing cached helpers (`topologyUsesPrefixedIds`, `seaZoneNodeIds`, `seaZonesReachableBySeaPath`, `seaZonesAdjacentToProvince`). Preserves the connectivity sea-zone BFS dequeue metric via a new optional `onDequeue` callback on `seaZonesReachableBySeaPath`.
- **Extracting shared fog GP visibility helpers.** Both `applyCoastalSeaZoneFullVisibility` and `applyDistantSeaZoneFogRevert` duplicated the same `for (entry in vis) Map.from(entry.value)` copy idiom and per-region GP iteration loop. Pulled into `_mutableGpVisibilityCopy` and `_forEachGpPlayerVisibility` inside `fog_resolution.dart`. `applyDistantSeaZoneFogRevert` now uses the cached `seaZoneNodeIds(regionTopology)` instead of its own inline filter over `regionTopology.nodes`.

No behavioral changes intended; this is a deduplication + reuse slice.

## SPEC

No SPEC change. Existing `topology_helpers` contract (`SPEC/game/map-topology.md`, `SPEC/program/logic-dual-region-province-access.md`) covers the moved call sites; `seaZonesReachableBySeaPath` documents the new optional `onDequeue` parameter.

## AC mapping (Refs #2560)

| AC | Status |
|----|--------|
| AC-5 (combined ≥100-line reduction across the three world scanners) | **Partial.** Combined reduction across `connectivity_resolver.dart` + `fog_resolution.dart` + `naval_resolution.dart` after this PR (vs pre-#2609 baseline): **~77 lines** removed. `naval_resolution.dart` consolidation remains in scope for a follow-up slice — its sea-zone adjacency helper (`_adjacentSeaZones`) and fleet-by-zone index do not share a candidate shape with the now-canonical `topology_helpers` API. |
| Other ACs | Unaffected by this slice. |

## Tests

Verified locally (PR-quality parity, repo-lint, target packages):

- `dart test packages/colonizethis_logic/test/connectivity_resolver_test.dart packages/colonizethis_logic/test/connectivity_resolver_sea_test.dart packages/colonizethis_logic/test/connectivity_resolver_blockade_additional_test.dart packages/colonizethis_logic/test/connectivity_resolver_per_player_province_cache_test.dart packages/colonizethis_logic/test/connectivity_resolver_town_closure_worklist_test.dart packages/colonizethis_logic/test/gp_land_connectivity_repair_test.dart` → all pass.
- `dart test packages/colonizethis_logic/test/fog_resolution_part{1,2,3}_test.dart packages/colonizethis_logic/test/fog_resolution_distant_sea_zone_fog_revert*_test.dart packages/colonizethis_logic/test/fog_spy_reveal_decay_test.dart` → all pass.
- `dart test packages/colonizethis_logic/test/movement_test.dart packages/colonizethis_logic/test/movement_logging_test.dart packages/colonizethis_logic/test/movement_phase_bundled_work_test.dart packages/colonizethis_logic/test/movement_phase_spy_reveal_timer_test.dart` → all pass.
- `dart test packages/colonizethis_logic/test/topology_helpers_test.dart packages/colonizethis_logic/test/topology_for_region_test.dart packages/colonizethis_logic/test/world/province_traversal_test.dart` → all pass.
- `dart analyze packages/colonizethis_logic/lib/src/world/` → no issues.
- `dart run tool/check_dart_file_non_comment_line_size.dart` → no violations.
- `dart run tool/check_logic_test_file_size.dart` → no violations.
- `dart run tool/ct_repo_lint.dart --rule repo.logic_all_provinces_sanctioned_calls` → passed (14 sanctioned sites).

## Scope

- **Done in this PR.** Connectivity → shared topology helpers + fog GP visibility extraction.
- **Deferred.** `naval_resolution.dart` consolidation toward the remaining AC-5 line budget (and any further reduction on the other two files) — separate follow-up slice on #2560.

Refs #2560


Made with [Cursor](https://cursor.com)