### PR TITLE
refactor(logic): reuse _fullProvinceIdFromTileKey + collection-if for capital port set (Refs #2560)

### DIFF
--- a/packages/colonizethis_logic/lib/src/world/connectivity_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/world/connectivity_resolver.dart
@@ -263,9 +263,8 @@ void _removeBlockadedPortTilesExceptCapital({
   required String capitalProvinceId,
 }) {
   for (final key in connected.toList()) {
-    final coords = parseTileKeyCoordinates(key);
-    if (coords == null) continue;
-    final fullProvinceId = '${coords.regionId}|${coords.provinceLocalId}';
+    final fullProvinceId = _fullProvinceIdFromTileKey(key);
+    if (fullProvinceId == null) continue;
     if (!blockadedPortProvinces.contains(fullProvinceId)) continue;
     if (fullProvinceId == capitalProvinceId) continue;
     connected.remove(key);
@@ -316,14 +315,12 @@ ConnectivityResult _connectedTilesForPlayer({
   );
 
   // Port connection rule: (1) capital on seaboard → ports reachable via sea-path (BFS S–S); (2) else only ports reachable by road/rail from capital. SPEC/game/capital-and-connectivity § Port connection to capital, Sea paths.
-  final capitalRegionPortKeys = <String>{};
-  for (final k in connected) {
-    final info = portInfo[k];
-    if (info == null) continue;
-    final coords = parseTileKeyCoordinates(k);
-    if (coords == null) continue;
-    if (coords.regionId == capitalRegionId) capitalRegionPortKeys.add(k);
-  }
+  final capitalRegionPortKeys = <String>{
+    for (final k in connected)
+      if (portInfo[k] != null &&
+          parseTileKeyCoordinates(k)?.regionId == capitalRegionId)
+        k,
+  };
 
   final seaConnectedPortKeys = _seaConnectedPortKeysForCapital(
     capital: capital,


### PR DESCRIPTION
## Summary

Two small dedups inside `packages/colonizethis_logic/lib/src/world/connectivity_resolver.dart`:

- `_removeBlockadedPortTilesExceptCapital` reuses the existing `_fullProvinceIdFromTileKey` helper instead of re-parsing tile-key coordinates inline and re-composing the `regionId|provinceLocalId` string by hand.
- `_connectedTilesForPlayer` builds the `capitalRegionPortKeys` set via a collection-if literal that short-circuits on the cheaper `portInfo[k] != null` test before parsing tile-key coordinates, preserving the existing fast-path (parse only on port-tile keys).

No behavior change; tile-key parsing and ownership semantics are unchanged.

## Why

Refs #2560 acceptance criterion: \"`connectivity_resolver.dart`, `fog_resolution.dart`, and `naval_resolution.dart` share a common province-traversal utility; their combined line count decreases by at least 100 lines.\"

Pre-#2560 baseline (commit `972d77c65^`): `660 + 570 + 576 = 1806` lines.
After this PR: `607 + 545 + 553 = 1705` lines (net -101).

This puts the combined shrink at -101 vs. the -100 bar (previously at -98 after #2611 landed), closing the AC with a small focused dedup that also removes a hand-rolled copy of the `_fullProvinceIdFromTileKey` helper.

## Test plan

- [x] `dart analyze packages/colonizethis_logic/lib/src/world/connectivity_resolver.dart` -> No issues found.
- [x] `dart test` on connectivity-related suites (30 tests pass):
  - `test/connectivity_resolver_test.dart`
  - `test/connectivity_resolver_blockade_additional_test.dart`
  - `test/world/connectivity_resolver_blockade_segment{1,2,3}_test.dart`
  - `test/connectivity_resolver_sea_test.dart`
  - `test/connectivity_resolver_town_closure_worklist_test.dart`
  - `test/connectivity_resolver_per_player_province_cache_test.dart`
  - `test/gp_land_connectivity_repair_test.dart`

Refs #2560

Made with [Cursor](https://cursor.com)