### PR TITLE
test(ai): pin COLONIAL tribe declareWar at planner output (Refs #2509)

### DIFF
--- a/packages/colonizethis_ai/test/domain_planner_orchestrator_colonial_tribe_declare_war_test.dart
+++ b/packages/colonizethis_ai/test/domain_planner_orchestrator_colonial_tribe_declare_war_test.dart
@@ -1,0 +1,339 @@
+// Pins the COLONIAL-phase tribe `declareWar` AC from issue #2509 at the
+// `runDomainPlanners` integration boundary:
+//
+//   Given a GP in COLONIAL phase with a visible tribe owning a sea-reachable
+//   unowned `newWorld|` province and valid declare-war preconditions, when
+//   diplomacy planning runs, then `declareWar` toward that tribe is among
+//   suggested orders (deterministic for fixed seed).
+//
+// The candidate-emission contract for `suggestDeclareWarOrders` itself is
+// pinned in the logic layer
+// (`packages/colonizethis_logic/test/order_suggestion_colonial_acquisition_join_empire_or_war_test.dart`,
+// PR #2603). The AI scoring contract that the candidate is **not** zeroed
+// while in COLONIAL is pinned at the predicate level in
+// `packages/colonizethis_ai/test/observer_goal_phase_test.dart`
+// (group `COLONIAL allows NW tribe declareWar scoring`). Neither of those
+// tests runs the orchestrator, so a future tuning slice could leave both
+// the suggestion API and the predicate scoring intact while bypassing the
+// orchestrator's integration of those scores into merged diplomatic orders
+// (for example by short-circuiting the declare-war pass when the GP already
+// has a peace order against the tribe target, or by widening the
+// COLONIAL-suppression filter in `domain_planner_orchestrator.dart` so it
+// silently drops tribe declare-war candidates). That regression would
+// directly threaten the turn-150 NW ownership gate by removing the only
+// AC-sanctioned conquest path against tribes still holding `newWorld|`
+// provinces.
+//
+// The negative control asserts the symmetric EXPAND-phase suppression at
+// the same `runDomainPlanners` boundary so a regression that over-emits NW
+// tribe declare-war below OW quota is also caught (mirrors the EXPAND
+// scoring-suppression group in `observer_goal_phase_test.dart`).
+//
+// SPEC:
+//   - `SPEC/ai/ai-architecture.md` § Observer goal phases (Full AI),
+//     COLONIAL phase declare-war / overture rule.
+//   - `SPEC/program/order-suggestions.md` § Diplomatic orders.
+//
+// Coverage layers:
+//   - Positive: COLONIAL-phase merged diplomatic orders contain
+//     `declareWar` toward the visible tribe owning a sea-reachable NW
+//     province.
+//   - Negative: EXPAND-phase merged diplomatic orders do **not** contain
+//     `declareWar` toward the same tribe (NW suppression below OW quota).
+//   - Determinism guard: re-running with identical inputs produces an
+//     identical diplomatic-order fingerprint (must-have #7).
+
+import 'package:colonizethis_test/test.dart';
+import 'package:colonizethis_ai/colonizethis_ai.dart';
+import 'package:colonizethis_ai/src/planning/observer_goal_phase.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import 'domain_planner_test_fake_api.dart';
+
+const String _nationId = 'gp1';
+const String _tribeId = 'tribe1';
+const String _tribeNwProvince = 'newWorld|tribe1_nw0';
+
+// gp1 owns 11 OW provinces (>= the observer quota of 10), so the GP is
+// past EXPAND and `isBelowObserverConquestQuota` is false. Combined with
+// a non-empty `invadableNewWorldProvinceIdsSorted` set, this places the
+// GP in COLONIAL per `observerGoalPhaseFor`.
+const List<String> _gp1OwProvincesAtQuota = <String>[
+  'oldWorld|gp1_0',
+  'oldWorld|gp1_1',
+  'oldWorld|gp1_2',
+  'oldWorld|gp1_3',
+  'oldWorld|gp1_4',
+  'oldWorld|gp1_5',
+  'oldWorld|gp1_6',
+  'oldWorld|gp1_7',
+  'oldWorld|gp1_8',
+  'oldWorld|gp1_9',
+  'oldWorld|gp1_10',
+];
+
+// Sub-quota OW set used for the EXPAND negative control.
+const List<String> _gp1OwProvincesBelowQuota = <String>[
+  'oldWorld|gp1_0',
+  'oldWorld|gp1_1',
+  'oldWorld|gp1_2',
+  'oldWorld|gp1_3',
+  'oldWorld|gp1_4',
+  'oldWorld|gp1_5',
+  'oldWorld|gp1_6',
+];
+
+Game _scenarioGame({required List<String> gp1OwProvinces}) {
+  return Game(
+    id: 'g-2509-colonial-tribe-declare',
+    worldState: WorldState(
+      turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 110),
+      oldWorld: RegionData(
+        provinces: [
+          for (final id in gp1OwProvinces)
+            Province(id: id, regionId: 'oldWorld', ownerId: _nationId),
+        ],
+      ),
+      newWorld: const RegionData(
+        provinces: [
+          Province(
+            id: _tribeNwProvince,
+            regionId: 'newWorld',
+            ownerId: _tribeId,
+          ),
+        ],
+      ),
+      // Non-empty Home Army for gp1 keeps `regimentCountForPlayer` > 0 and
+      // avoids the zero-regiment stalemate peace paths that would coexist
+      // with declare-war scoring in unrelated ways. Mirrors the guard used
+      // in the EXPAND/COLONIAL two-GP peace pins
+      // (`domain_planner_orchestrator_{expand,colonial}_two_gp_peace_test.dart`).
+      armies: [
+        Army(
+          id: homeArmyIdFor(_nationId),
+          ownerId: _nationId,
+          regionId: 'oldWorld',
+          stationedProvinceId: gp1OwProvinces.first,
+          regimentUnitIds: const ['u_gp1'],
+          isHomeArmy: true,
+        ),
+      ],
+    ),
+    players: const [
+      Player(
+        id: _nationId,
+        displayName: 'GP1',
+        isHuman: false,
+        leaderKey: 'henry',
+      ),
+    ],
+    tribes: const [Tribe(id: _tribeId, displayName: 'T1')],
+    minorNations: const [],
+  );
+}
+
+const FakeOrderSuggestionAPIForDomainPlannerTests _tribeDeclareWarApi =
+    FakeOrderSuggestionAPIForDomainPlannerTests(
+  work: [],
+  build: [],
+  move: [],
+  research: [],
+  navalMove: [],
+  navalMission: [],
+  diplomatic: [
+    DiplomaticOrder(
+      type: DiplomaticOrderType.declareWar,
+      targetFactionId: _tribeId,
+    ),
+  ],
+);
+
+const EconomyPlan _economyPlan = EconomyPlan(
+  productionAssignments: [],
+  cargoPreference: CargoPreference.none,
+);
+
+// Match the personality/agenda that scores tribe declare-war > 0 in the
+// pinned predicate test (`COLONIAL allows NW tribe declareWar scoring` in
+// `observer_goal_phase_test.dart`). The `peacemaker` agenda zeroes
+// declare-war candidates regardless of phase, so it would not exercise
+// the COLONIAL emission contract this file pins. `henry` / `merchant` is
+// a colonial-leaning leader/agenda combo aligned with the AC text
+// ("personality may bias military vs diplomatic route").
+const AIConfig _aiConfig = AIConfig(
+  leaderId: 'henry',
+  personalityId: 'henry',
+  hiddenAgendaId: 'merchant',
+);
+
+AIWorldSnapshot _colonialSnapshot() {
+  return const AIWorldSnapshot(
+    playerId: _nationId,
+    threats: ThreatSummary(),
+    opportunities: OpportunitySummary(),
+    // 11 OW provinces -> COLONIAL when colonial acquisition targets are
+    // visible in the snapshot.
+    conquest: ConquestSummary(
+      oldWorldProvincesOwned: 11,
+      provincesToVictory: 20,
+    ),
+    colonial: ColonialSummary(
+      newWorldProvincesOwned: 0,
+      invadableNewWorldProvinceIdsSorted: [_tribeNwProvince],
+      adjacentNewWorldOwnerFactionIdsSorted: [_tribeId],
+      preferredColonialTargetFactionIdsSorted: [_tribeId],
+    ),
+    economy: EconomySummary(ownProvinceCount: 11),
+    relations: {},
+  );
+}
+
+AIWorldSnapshot _expandSnapshot() {
+  return const AIWorldSnapshot(
+    playerId: _nationId,
+    threats: ThreatSummary(),
+    opportunities: OpportunitySummary(),
+    // 7 OW provinces -> EXPAND while invadable NW is visible: the AI
+    // must suppress NW tribe declare-war candidates below OW quota
+    // even though the suggestion API surfaces them.
+    conquest: ConquestSummary(
+      oldWorldProvincesOwned: 7,
+      provincesToVictory: 24,
+    ),
+    colonial: ColonialSummary(
+      invadableNewWorldProvinceIdsSorted: [_tribeNwProvince],
+      adjacentNewWorldOwnerFactionIdsSorted: [_tribeId],
+      preferredColonialTargetFactionIdsSorted: [_tribeId],
+    ),
+    economy: EconomySummary(ownProvinceCount: 7),
+    relations: {},
+  );
+}
+
+List<String> _declareWarTargets(Orders orders) => <String>[
+      for (final order
+          in orders.diplomaticOrdersByPlayerId[_nationId] ?? const [])
+        if (order.type == DiplomaticOrderType.declareWar)
+          order.targetFactionId,
+    ];
+
+void main() {
+  group('runDomainPlanners COLONIAL tribe declareWar', () {
+    test('emits declareWar toward visible NW tribe when in COLONIAL', () {
+      final game = _scenarioGame(gp1OwProvinces: _gp1OwProvincesAtQuota);
+      const topology = MapTopology(nodes: [], edges: []);
+      final view = buildPlayerView(game, topology, _nationId);
+      final snapshot = _colonialSnapshot();
+
+      expect(
+        observerGoalPhaseFor(snapshot: snapshot, game: game),
+        ObserverGoalPhase.colonial,
+        reason:
+            'Fixture must place GP in COLONIAL so the tribe declare-war '
+            'AC is exercised by the orchestrator (not the EXPAND '
+            'fall-through, which suppresses NW declare-war).',
+      );
+
+      final orders = runDomainPlanners(
+        game: game,
+        topology: topology,
+        nationId: _nationId,
+        view: view,
+        snapshot: snapshot,
+        config: _aiConfig,
+        primaryGoal: StrategicGoal.conquer,
+        seeds: AISeedBundle.fromTurnSeed(2509120),
+        suggestionAPI: _tribeDeclareWarApi,
+        economyPlan: _economyPlan,
+      );
+
+      expect(
+        _declareWarTargets(orders),
+        contains(_tribeId),
+        reason:
+            'COLONIAL with a visible tribe owning a sea-reachable NW '
+            'province must surface the tribe declare-war candidate in '
+            'merged diplomatic orders (SPEC § Observer goal phases (Full '
+            'AI), COLONIAL declare-war rule).',
+      );
+    });
+
+    test('suppresses tribe declareWar in EXPAND below OW quota', () {
+      final game = _scenarioGame(gp1OwProvinces: _gp1OwProvincesBelowQuota);
+      const topology = MapTopology(nodes: [], edges: []);
+      final view = buildPlayerView(game, topology, _nationId);
+      final snapshot = _expandSnapshot();
+
+      expect(
+        observerGoalPhaseFor(snapshot: snapshot, game: game),
+        ObserverGoalPhase.expand,
+        reason:
+            'Negative-control fixture must place GP in EXPAND so the NW '
+            'declare-war suppression is verified (otherwise the test would '
+            'silently exercise COLONIAL).',
+      );
+
+      final orders = runDomainPlanners(
+        game: game,
+        topology: topology,
+        nationId: _nationId,
+        view: view,
+        snapshot: snapshot,
+        config: _aiConfig,
+        primaryGoal: StrategicGoal.expand,
+        seeds: AISeedBundle.fromTurnSeed(2509121),
+        suggestionAPI: _tribeDeclareWarApi,
+        economyPlan: _economyPlan,
+      );
+
+      expect(
+        _declareWarTargets(orders),
+        isNot(contains(_tribeId)),
+        reason:
+            'EXPAND below OW quota must drop NW tribe declare-war '
+            'candidates so OW conquest pressure is preserved (SPEC § '
+            'Observer goal phases (Full AI), EXPAND suppression rule).',
+      );
+    });
+
+    test('emits identical diplomatic orders for identical COLONIAL inputs',
+        () {
+      final game = _scenarioGame(gp1OwProvinces: _gp1OwProvincesAtQuota);
+      const topology = MapTopology(nodes: [], edges: []);
+      final view = buildPlayerView(game, topology, _nationId);
+      final snapshot = _colonialSnapshot();
+
+      Orders runOnce(int turnSeed) => runDomainPlanners(
+            game: game,
+            topology: topology,
+            nationId: _nationId,
+            view: view,
+            snapshot: snapshot,
+            config: _aiConfig,
+            primaryGoal: StrategicGoal.conquer,
+            seeds: AISeedBundle.fromTurnSeed(turnSeed),
+            suggestionAPI: _tribeDeclareWarApi,
+            economyPlan: _economyPlan,
+          );
+
+      final firstRun = runOnce(2509122);
+      final secondRun = runOnce(2509122);
+
+      List<String> diplomaticFingerprint(Orders orders) => <String>[
+            for (final o
+                in orders.diplomaticOrdersByPlayerId[_nationId] ?? const [])
+              '${o.type}|${o.targetFactionId}|${o.overtureStage}',
+          ];
+
+      expect(
+        diplomaticFingerprint(secondRun),
+        diplomaticFingerprint(firstRun),
+        reason:
+            'Determinism (must-have #7): identical COLONIAL-phase inputs '
+            'must produce identical diplomatic orders across runs.',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Pins the **COLONIAL-phase tribe `declareWar`** AC from issue #2509 at the `runDomainPlanners` integration boundary:

> Given a GP in COLONIAL phase with a visible tribe owning a sea-reachable unowned `newWorld|` province and valid declare-war preconditions, when diplomacy planning runs, then `declareWar` toward that tribe is among suggested orders (deterministic for fixed seed).

The candidate-emission contract for `suggestDeclareWarOrders` is already pinned at the **logic suggestion API** layer by PR #2603 (`order_suggestion_colonial_acquisition_join_empire_or_war_test.dart`). The AI **scoring** contract that the candidate is not zeroed in COLONIAL is pinned at the **predicate** level in `observer_goal_phase_test.dart` (group `COLONIAL allows NW tribe declareWar scoring`). Neither of those tests runs the orchestrator, so a future tuning slice could leave both intact while bypassing the orchestrator's integration of those scores into merged diplomatic orders — for example by widening the COLONIAL suppression filter in `domain_planner_orchestrator.dart` or short-circuiting the declare-war pass when the GP already has a peace order against the tribe target. That regression would directly threaten the **turn-150 NW ownership gate** by removing the only AC-sanctioned conquest path against tribes still holding `newWorld|` provinces.

This PR is the **declare-war counterpart** to the colonial civilian-work pin (`domain_planner_orchestrator_colonial_civilian_work_test.dart` § COLONIAL purchase_land) and the symmetric mirror of the EXPAND scoring suppression pinned in `observer_goal_phase_test.dart` (`EXPAND suppresses NW declareWar scoring`).

## Scope

- **Added** `packages/colonizethis_ai/test/domain_planner_orchestrator_colonial_tribe_declare_war_test.dart` (test-only, 339 LOC).
- No production code changes; no SPEC changes (existing `SPEC/ai/ai-architecture.md` § Observer goal phases (Full AI) COLONIAL declare-war / overture rule already authorizes the behavior).
- Fixture deliberately mirrors the EXPAND/COLONIAL two-GP peace pin shape (same `_emptyApi` + `_economyPlan` + `_aiConfig` style, three-test shape, `homeArmyIdFor` guard so per-faction `regimentCountForPlayer` > 0) so the EXPAND/COLONIAL phase pair stays symmetric and side-by-side reviewable.

## What the test pins

| Case | Scenario | Expected merged diplomatic orders |
|------|----------|------------------------------------|
| Positive | gp1 owns 11 OW (COLONIAL); tribe1 owns the only invadable `newWorld|` province; fake API yields `declareWar(tribe1)` | Contains `declareWar(tribe1)` |
| Negative | gp1 owns 7 OW (EXPAND below quota); same fake API | Does **not** contain `declareWar(tribe1)` (NW suppression below OW quota preserved) |
| Determinism (must-have #7) | Same COLONIAL inputs run twice | Identical diplomatic-order fingerprint |

Precondition guards inside both behavior sub-tests assert `observerGoalPhaseFor` resolves to the intended phase before exercising the orchestrator — so a future change that accidentally re-routed the fixture into a different phase would fail the assertion explicitly instead of silently testing a different rule.

`AIConfig` uses `henry` / `merchant` (matches the proven personality/agenda combo from the predicate test `COLONIAL allows NW tribe declareWar scoring`); a `peacemaker` agenda zeroes declare-war candidates regardless of phase and would not exercise the COLONIAL emission contract.

## ACs / SPEC clauses covered (Refs #2509)

- **AI S10 AC:** *"Given a GP in COLONIAL phase with a visible tribe owning a sea-reachable unowned `newWorld|` province and valid declare-war preconditions, when diplomacy planning runs, then `declareWar` toward that tribe is among suggested orders (deterministic for fixed seed)."* — pinned at the orchestrator boundary by this PR.
- **Must-have #7 (determinism)** — guarded by the third sub-test.
- **SPEC pointers** (no change):
  - `SPEC/ai/ai-architecture.md` § Observer goal phases (Full AI), COLONIAL declare-war / overture rule.
  - `SPEC/program/order-suggestions.md` § Diplomatic orders.

## Verification

```
cd packages/colonizethis_ai
dart test test/domain_planner_orchestrator_colonial_tribe_declare_war_test.dart
# 3/3 pass

dart test
# 298/298 pass (full colonizethis_ai suite, no regressions)

dart analyze test/domain_planner_orchestrator_colonial_tribe_declare_war_test.dart
# No issues found!

cd ../..
dart run tool/check_dart_file_non_comment_line_size.dart
# check_dart_file_non_comment_line_size: no violations found.

bash tool/check_test_imports.sh
# Test import convention check passed.
```

## Done in this push / Remaining for #2509

- **Done:** orchestrator-level pin for the COLONIAL tribe `declareWar` S10 AC (declare-war counterpart to the COLONIAL purchase_land pin, mirror of the EXPAND scoring-suppression pin).
- **Remaining on #2509 (unrelated to this slice):**
  - S10 observer-trace tuning toward the turn-100 `--verify-conquest` and turn-150 `--verify-colonial-expansion` gates (observer-campaign iteration, not a unit-test boundary).
  - In-flight test pins on other open PRs (#2604, #2607, #2615) cover separate EXPAND-minor-declareWar / DEVELOP-NW-purchase-suppression / COLONIAL-two-GP-peace contracts.

Refs #2509

Made with [Cursor](https://cursor.com)