### PR TITLE
test(e2e): pin waitForNextTurnLabelAdvance contract (Refs #2336)

### DIFF
--- a/app/test/e2e_wait_for_next_turn_label_advance_test.dart
+++ b/app/test/e2e_wait_for_next_turn_label_advance_test.dart
@@ -1,0 +1,374 @@
+/// Pins the **pre-pump short-circuit** and **`TurnResolutionProcessingDialog`
+/// race-gate** contracts of `e2eWaitForNextTurnLabelAdvance` (Refs GitHub
+/// #2336 AC2 / AC5).
+///
+/// The helper is the source of truth for "the next-turn map chip label
+/// changed" in every E2E scenario (`e2eAdvanceOneHumanTurn`, fleet reach
+/// turn loops, bundled explore retries). The integration test suite cannot
+/// validate this in CI (`integration_test/` runs are gated behind a
+/// no-op `app_e2e_linux` lane today, per `SPEC/program/e2e-integration-tests.md`
+/// § CI), so the widget-test layer carries the behavioral pins.
+library;
+
+import 'dart:async';
+
+import 'package:colonizethis_app/features/game/flame/game_screen_shared.dart';
+import 'package:colonizethis_app/features/game/flame/turn_resolution_processing_dialog.dart';
+import 'package:colonizethis_app/l10n/l10n.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../integration_test/e2e_test_shared.dart';
+
+/// Host that mounts a key-tagged next-turn label (and an optional
+/// [TurnResolutionProcessingDialog]) and exposes a fake-async `Timer`-driven
+/// hook for tests to flip the label or dismiss the dialog while the
+/// helper's `tester.pump` loop is running.
+///
+/// `Timer` callbacks scheduled in [State.initState] fire when `tester.pump`
+/// advances fake-time past the registered duration, so the helper observes
+/// the flip on a later polling iteration without the test needing to call
+/// `tester.pump` itself (which would deadlock against the helper's guarded
+/// pump).
+class _NextTurnLabelHost extends StatefulWidget {
+  const _NextTurnLabelHost({
+    required this.controller,
+    this.flipAfter,
+    this.flipToLabel,
+    this.flipToShowDialog,
+  });
+
+  final _NextTurnLabelController controller;
+
+  /// Fake-async delay before the host flips the controller, or `null` to
+  /// leave the controller untouched (no scheduled flip).
+  final Duration? flipAfter;
+
+  /// New label to apply when [flipAfter] elapses, or `null` to leave the
+  /// label unchanged.
+  final String? flipToLabel;
+
+  /// New processing-dialog visibility to apply when [flipAfter] elapses,
+  /// or `null` to leave the visibility unchanged.
+  final bool? flipToShowDialog;
+
+  @override
+  State<_NextTurnLabelHost> createState() => _NextTurnLabelHostState();
+}
+
+class _NextTurnLabelHostState extends State<_NextTurnLabelHost> {
+  Timer? _flipTimer;
+
+  @override
+  void initState() {
+    super.initState();
+    widget.controller.addListener(_onControllerChanged);
+    final after = widget.flipAfter;
+    if (after != null) {
+      _flipTimer = Timer(after, _applyFlip);
+    }
+  }
+
+  void _applyFlip() {
+    final newLabel = widget.flipToLabel;
+    if (newLabel != null) {
+      widget.controller.label = newLabel;
+    }
+    final newDialog = widget.flipToShowDialog;
+    if (newDialog != null) {
+      widget.controller.showProcessingDialog = newDialog;
+    }
+  }
+
+  @override
+  void dispose() {
+    _flipTimer?.cancel();
+    widget.controller.removeListener(_onControllerChanged);
+    super.dispose();
+  }
+
+  void _onControllerChanged() {
+    if (!mounted) return;
+    setState(() {});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final showDialog = widget.controller.showProcessingDialog;
+    final label = widget.controller.label;
+    return Stack(
+      children: [
+        Center(
+          child: TextButton(
+            key: kGameMapNextTurnButtonKey,
+            onPressed: () {},
+            child: Text(label),
+          ),
+        ),
+        if (showDialog)
+          const Positioned.fill(
+            child: ColoredBox(
+              color: Color(0x88000000),
+              child: Center(
+                child: TurnResolutionProcessingDialog(
+                  phaseText: 'Validating orders...',
+                ),
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _NextTurnLabelController extends ChangeNotifier {
+  _NextTurnLabelController({
+    required String initialLabel,
+    bool initialShowProcessingDialog = false,
+  })  : _label = initialLabel,
+        _showProcessingDialog = initialShowProcessingDialog;
+
+  String _label;
+  bool _showProcessingDialog;
+
+  String get label => _label;
+
+  set label(String value) {
+    if (_label == value) {
+      return;
+    }
+    _label = value;
+    notifyListeners();
+  }
+
+  bool get showProcessingDialog => _showProcessingDialog;
+
+  set showProcessingDialog(bool value) {
+    if (_showProcessingDialog == value) {
+      return;
+    }
+    _showProcessingDialog = value;
+    notifyListeners();
+  }
+}
+
+Future<void> _pumpHost(
+  WidgetTester tester,
+  _NextTurnLabelController controller, {
+  Duration? flipAfter,
+  String? flipToLabel,
+  bool? flipToShowDialog,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      localizationsDelegates: AppLocalizationsBinding.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: _NextTurnLabelHost(
+          controller: controller,
+          flipAfter: flipAfter,
+          flipToLabel: flipToLabel,
+          flipToShowDialog: flipToShowDialog,
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  suppressLogsForTests();
+
+  testWidgets(
+    'returns immediately when current label already differs from before',
+    (WidgetTester tester) async {
+      final controller = _NextTurnLabelController(
+        initialLabel: 'Next turn (2 / 1492)',
+      );
+      await _pumpHost(tester, controller);
+      final sw = Stopwatch()..start();
+      final elapsed = await e2eWaitForNextTurnLabelAdvance(
+        tester,
+        turnLabelBefore: 'Next turn (1 / 1492)',
+        timeout: const Duration(seconds: 5),
+      );
+      expect(
+        elapsed,
+        lessThan(const Duration(milliseconds: 100)),
+        reason:
+            'Pre-pump short-circuit must return ~Duration.zero when the label '
+            'already changed before the helper started polling (#2336 AC5).',
+      );
+      expect(
+        sw.elapsed,
+        lessThan(const Duration(milliseconds: 200)),
+        reason:
+            'Wall-clock for the pre-pump short-circuit path must stay well '
+            'under the timeout cap; large drift signals a regression in the '
+            'condition-before-first-pump contract.',
+      );
+    },
+  );
+
+  testWidgets('returns once a scheduled label flip lands during pump', (
+    WidgetTester tester,
+  ) async {
+    final controller = _NextTurnLabelController(
+      initialLabel: 'Next turn (1 / 1492)',
+    );
+    // Schedule the host to flip the label after 80ms of fake-async time so
+    // the helper's adaptive pump loop advances clock past the Timer
+    // deadline and observes the change on a later iteration (no guarded
+    // `tester.pump` from the test itself; #2336 AC5).
+    await _pumpHost(
+      tester,
+      controller,
+      flipAfter: const Duration(milliseconds: 80),
+      flipToLabel: 'Next turn (2 / 1492)',
+    );
+
+    final returned = await e2eWaitForNextTurnLabelAdvance(
+      tester,
+      turnLabelBefore: 'Next turn (1 / 1492)',
+      timeout: const Duration(seconds: 5),
+    );
+
+    expect(
+      controller.label,
+      'Next turn (2 / 1492)',
+      reason:
+          'Sanity check: the scheduled flip must have landed before the '
+          'helper returned, otherwise the helper short-circuited on a '
+          'stale label.',
+    );
+    expect(
+      returned,
+      lessThan(const Duration(seconds: 5)),
+      reason:
+          'Helper must complete strictly within its timeout when the label '
+          'change is observed; reaching the timeout would indicate the '
+          'adaptive backoff missed the flip.',
+    );
+  });
+
+  testWidgets(
+    'fails with TestFailure when label never advances within timeout',
+    (WidgetTester tester) async {
+      final controller = _NextTurnLabelController(
+        initialLabel: 'Next turn (1 / 1492)',
+      );
+      await _pumpHost(tester, controller);
+      Object? caught;
+      try {
+        await e2eWaitForNextTurnLabelAdvance(
+          tester,
+          turnLabelBefore: 'Next turn (1 / 1492)',
+          timeout: const Duration(milliseconds: 200),
+        );
+      } catch (e) {
+        caught = e;
+      }
+      expect(
+        caught,
+        isA<TestFailure>(),
+        reason:
+            'Persistent identical label must hit the timeout failure path so '
+            'real regressions are not silently swallowed (#2336 AC10).',
+      );
+    },
+  );
+
+  testWidgets(
+    'holds return until TurnResolutionProcessingDialog clears even if label already differs',
+    (WidgetTester tester) async {
+      final controller = _NextTurnLabelController(
+        initialLabel: 'Next turn (2 / 1492)',
+        initialShowProcessingDialog: true,
+      );
+      // Schedule dialog dismissal after a fake-async delay; the helper must
+      // observe `sawProcessingDialog=true` on early iterations and refuse to
+      // return until the dialog leaves the tree, even though the label
+      // already differs from `turnLabelBefore`.
+      await _pumpHost(
+        tester,
+        controller,
+        flipAfter: const Duration(milliseconds: 250),
+        flipToShowDialog: false,
+      );
+      expect(find.byType(TurnResolutionProcessingDialog), findsOneWidget);
+
+      final returned = await e2eWaitForNextTurnLabelAdvance(
+        tester,
+        turnLabelBefore: 'Next turn (1 / 1492)',
+        timeout: const Duration(seconds: 5),
+      );
+
+      expect(
+        find.byType(TurnResolutionProcessingDialog),
+        findsNothing,
+        reason:
+            'Dialog must have cleared by the time the helper returned — '
+            'otherwise the dialog-gate race was lost.',
+      );
+      expect(
+        controller.showProcessingDialog,
+        isFalse,
+        reason:
+            'Sanity check: the scheduled flip must have run before the '
+            'helper returned.',
+      );
+      expect(
+        returned,
+        lessThan(const Duration(seconds: 5)),
+        reason:
+            'Once the processing dialog clears, the helper must observe the '
+            'already-different label on the next adaptive poll step and '
+            'return within the 5s budget.',
+      );
+    },
+  );
+
+  testWidgets(
+    'e2eReadNextTurnButtonLabel returns null when no next-turn button is mounted',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(home: Scaffold(body: SizedBox.shrink())),
+      );
+      expect(e2eReadNextTurnButtonLabel(tester), isNull);
+    },
+  );
+
+  testWidgets(
+    'e2eReadNextTurnButtonLabel returns null when subtree has more than one Text',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: TextButton(
+                key: kGameMapNextTurnButtonKey,
+                onPressed: () {},
+                child: const Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text('Next turn'),
+                    SizedBox(width: 4),
+                    Text('(1 / 1492)'),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      expect(
+        e2eReadNextTurnButtonLabel(tester),
+        isNull,
+        reason:
+            'Two-text layout breaks the single-Text contract; helper must '
+            'return null so callers fall back to other readiness signals '
+            '(`SPEC/program/e2e-integration-tests.md`).',
+      );
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Adds widget-test coverage for `e2eWaitForNextTurnLabelAdvance`, the shared next-turn label helper that every E2E scenario calls through `e2eAdvanceOneHumanTurn`, the fleet-reach turn loop, and bundled-explore retries. Because `integration_test/` is not part of the PR `quality` workflow (no-op `app_e2e_linux` lane per `SPEC/program/e2e-integration-tests.md` § CI), the widget-test layer carries the behavioral pins for this AC2 helper.

## Refs

Refs #2336 (issue stays open; this is a hardening slice for AC2/AC5/AC10).

## Done in this push

- New widget-test file `app/test/e2e_wait_for_next_turn_label_advance_test.dart` with six cases:
  - **Pre-pump short-circuit** when the current label already differs from \`turnLabelBefore\` (AC5).
  - **Adaptive convergence** when a fake-async \`Timer\`-scheduled flip lands during the helper's pump loop.
  - **\`TurnResolutionProcessingDialog\` race-gate**: helper must not return while the processing dialog is mounted, even if the label already differs.
  - **\`TestFailure\` on timeout** for a persistently identical label (AC10 / no-silent-flake guarantee).
  - **\`e2eReadNextTurnButtonLabel\` returns null** when no next-turn button is mounted.
  - **\`e2eReadNextTurnButtonLabel\` returns null** when the keyed subtree has more than one \`Text\` child.

Tests schedule label / dialog flips via fake-async \`Timer\` from the host widget (not \`tester.runAsync\`) so the helper's guarded \`tester.pump\` advances clock past the Timer deadline without the test itself calling \`tester.pump\` concurrently — avoiding guarded-pump conflicts.

## ACs covered now vs follow-up

| AC | Status before | This PR |
|----|---------------|---------|
| AC1 (shared helpers exist) | satisfied on dev | unchanged |
| AC2 (E2E tests use shared helpers) | satisfied on dev | **hardens the \`waitForNextTurnLabelAdvance\` surface with positive + negative widget tests** |
| AC3 (parallel asset preload) | satisfied on dev | unchanged |
| AC4 (H1–H10 pump sites) | satisfied on dev | unchanged |
| AC5 (adaptive polling, pre-pump short-circuit) | satisfied in code | **pins the pre-pump short-circuit at the test layer** |
| AC6–AC9 (local Linux E2E runs, timing tables) | deferred to maintainer Linux measurement (per #2336 comments) | unchanged |
| AC10 (no new flakiness) | n/a | **adds a timeout-failure regression pin so a future "always-pass" stub regression is detected at the unit layer** |

## Deferred

- AC6 / AC7 / AC8 / AC9 still require \`tool/run_e2e_timing.sh\` runs on Linux desktop with a graphical session or \`xvfb-run\`. That measurement work is out of scope here; this PR only hardens the shared helper contract.

## Tests run

- \`flutter test app/test/e2e_wait_for_next_turn_label_advance_test.dart\` — 6/6 pass.
- \`flutter test app/test/e2e_*_test.dart\` — 47/47 pass (no regressions in existing e2e helper unit tests).
- \`flutter analyze app/test/e2e_wait_for_next_turn_label_advance_test.dart\` — no issues.

## Risks

- Tests rely on fake-async \`Timer\` behavior during \`tester.pump(Duration)\`. The Stopwatch-driven helper returns a real-time elapsed value that is effectively microseconds in widget tests, so the tests check qualitative properties (\`lessThan(timeout)\`, sanity-check on observed state) rather than absolute timing. This keeps the suite stable on slower CI runners.

Made with [Cursor](https://cursor.com)