### PR TITLE
test(e2e): consolidate E2E helper test pins (Refs #2336)

### DIFF
--- a/app/test/e2e_advance_one_human_turn_test.dart
+++ b/app/test/e2e_advance_one_human_turn_test.dart
@@ -1,0 +1,396 @@
+/// Pins the **early-advance**, **confirm-then-advance**, and **timeout**
+/// branches of `e2eAdvanceOneHumanTurn` (Refs GitHub #2336 AC2 / AC5 / AC10).
+///
+/// `e2eAdvanceOneHumanTurn` is the most-called E2E helper in the suite — every
+/// turn step in `new_game_full_turn_e2e_test.dart` and
+/// `new_game_fleet_reaches_new_world_e2e_test.dart` calls it once. Its
+/// pre-pump short-circuit (`earlyAfter`) lets the helper skip the inner
+/// [e2eWaitForNextTurnLabelAdvance] call when the next-turn label has already
+/// changed by the time the post-tap settle finishes (for example a synchronous
+/// turn resolution on `kCtE2EEnabled`). The confirm-then-advance branch covers
+/// the canonical asynchronous resolution path where a `common_yes` confirm
+/// dialog opens after the next-turn tap and the helper must tap it before
+/// waiting for the label to change. The timeout branch ensures persistent
+/// absence (no confirm dialog, no label change) surfaces a [TestFailure] from
+/// the inner `e2eWaitForNextTurnLabelAdvance` call so a future regression that
+/// silently no-ops the helper is caught at the widget-test layer.
+///
+/// `integration_test/` is not part of the PR `quality` workflow (see
+/// `SPEC/program/e2e-integration-tests.md` § CI — `app_e2e_linux` lane is a
+/// no-op), so this widget-test pin is the only automated guard against a
+/// regression of these branches in PR checks. Companion pins:
+///
+///   - `e2e_wait_for_next_turn_label_advance_test.dart` (#2620) pins the
+///     inner helper's pre-pump short-circuit and processing-dialog gate.
+///   - `e2e_open_panel_prepump_test.dart` (#2586) pins the same prepump
+///     short-circuit pattern on the civilian/naval panel openers.
+library;
+
+import 'dart:async';
+
+import 'package:colonizethis_app/features/game/flame/game_screen_shared.dart';
+import 'package:colonizethis_app/l10n/l10n.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../integration_test/e2e_test_shared.dart';
+
+/// Initial next-turn label the host renders before any flip lands. The
+/// helper reads this via `e2eReadNextTurnButtonLabel` (single descendant
+/// `Text` rule pinned in `e2e_wait_for_next_turn_label_advance_test.dart`)
+/// so the button child must remain a single `Text` widget here.
+const String _labelBefore = 'Next turn (1 / 1492)';
+
+/// Label the host flips to in the early-advance and confirm-then-advance
+/// scenarios. Differs from [_labelBefore] in the `(turn / year)` slot so the
+/// helper sees a strict `before != after` transition.
+const String _labelAfter = 'Next turn (2 / 1492)';
+
+/// Stateful host that mounts a key-tagged next-turn button (with whichever
+/// label [_NextTurnAdvanceController] currently reports) plus an optional
+/// `common_yes` confirm chip whose tap callback fires
+/// [_NextTurnAdvanceController.onConfirmTapped]. A fake-async `Timer`
+/// scheduled in [State.initState] can flip the label or the dialog
+/// visibility after a delay so the helper's pump loop observes the change
+/// without the test calling `tester.pump` itself (the same pattern as
+/// `e2e_wait_for_next_turn_label_advance_test.dart`).
+class _NextTurnAdvanceHost extends StatefulWidget {
+  const _NextTurnAdvanceHost({
+    required this.controller,
+    this.flipAfter,
+    this.flipToLabel,
+    this.flipToShowConfirm,
+  });
+
+  final _NextTurnAdvanceController controller;
+  final Duration? flipAfter;
+  final String? flipToLabel;
+  final bool? flipToShowConfirm;
+
+  @override
+  State<_NextTurnAdvanceHost> createState() => _NextTurnAdvanceHostState();
+}
+
+class _NextTurnAdvanceHostState extends State<_NextTurnAdvanceHost> {
+  Timer? _flipTimer;
+
+  @override
+  void initState() {
+    super.initState();
+    widget.controller.addListener(_onControllerChanged);
+    final after = widget.flipAfter;
+    if (after != null) {
+      _flipTimer = Timer(after, _applyFlip);
+    }
+  }
+
+  void _applyFlip() {
+    final newLabel = widget.flipToLabel;
+    if (newLabel != null) {
+      widget.controller.label = newLabel;
+    }
+    final newShow = widget.flipToShowConfirm;
+    if (newShow != null) {
+      widget.controller.showConfirm = newShow;
+    }
+  }
+
+  @override
+  void dispose() {
+    _flipTimer?.cancel();
+    widget.controller.removeListener(_onControllerChanged);
+    super.dispose();
+  }
+
+  void _onControllerChanged() {
+    if (!mounted) return;
+    setState(() {});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    return Stack(
+      children: [
+        Center(
+          child: TextButton(
+            key: kGameMapNextTurnButtonKey,
+            onPressed: widget.controller.onNextTurnTapped,
+            child: Text(widget.controller.label),
+          ),
+        ),
+        if (widget.controller.showConfirm)
+          Positioned(
+            top: 32,
+            left: 32,
+            child: Material(
+              child: TextButton(
+                onPressed: widget.controller.onConfirmTapped,
+                child: Text(l10n.common_yes),
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _NextTurnAdvanceController extends ChangeNotifier {
+  _NextTurnAdvanceController({
+    required String initialLabel,
+    bool initialShowConfirm = false,
+    this.onNextTurnTapped,
+    this.onConfirmTapped,
+  })  : _label = initialLabel,
+        _showConfirm = initialShowConfirm;
+
+  String _label;
+  bool _showConfirm;
+
+  /// Optional hook fired when the next-turn button is tapped. Used by the
+  /// `taps next-turn-button before checking for confirm` sanity assertion.
+  final VoidCallback? onNextTurnTapped;
+
+  /// Optional hook fired when the `common_yes` confirm chip is tapped. The
+  /// confirm-then-advance test uses this to hide the dialog and schedule
+  /// the label flip on the very tap that the helper performs.
+  final VoidCallback? onConfirmTapped;
+
+  String get label => _label;
+  set label(String value) {
+    if (_label == value) return;
+    _label = value;
+    notifyListeners();
+  }
+
+  bool get showConfirm => _showConfirm;
+  set showConfirm(bool value) {
+    if (_showConfirm == value) return;
+    _showConfirm = value;
+    notifyListeners();
+  }
+}
+
+Future<void> _pumpHost(
+  WidgetTester tester,
+  _NextTurnAdvanceController controller, {
+  Duration? flipAfter,
+  String? flipToLabel,
+  bool? flipToShowConfirm,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      localizationsDelegates: AppLocalizationsBinding.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: _NextTurnAdvanceHost(
+          controller: controller,
+          flipAfter: flipAfter,
+          flipToLabel: flipToLabel,
+          flipToShowConfirm: flipToShowConfirm,
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  suppressLogsForTests();
+
+  testWidgets(
+    'returns via earlyAfter when label advances before confirm appears',
+    (WidgetTester tester) async {
+      var nextTurnTaps = 0;
+      var confirmTaps = 0;
+      final controller = _NextTurnAdvanceController(
+        initialLabel: _labelBefore,
+        onNextTurnTapped: () {
+          nextTurnTaps += 1;
+        },
+        onConfirmTapped: () {
+          confirmTaps += 1;
+        },
+      );
+      // Flip the label after 80ms of fake-async time. The helper's
+      // `e2ePumpUntilConditionOrIdle` loop advances clock past this Timer
+      // deadline and observes the change before any confirm appears, so
+      // the helper should short-circuit via the `earlyAfter` branch and
+      // skip the inner `e2eWaitForNextTurnLabelAdvance` call entirely.
+      await _pumpHost(
+        tester,
+        controller,
+        flipAfter: const Duration(milliseconds: 80),
+        flipToLabel: _labelAfter,
+      );
+
+      final l10n = await AppLocalizationsBinding.delegate.load(
+        const Locale('en'),
+      );
+      final returned = await e2eAdvanceOneHumanTurn(
+        tester,
+        l10n: l10n,
+        timeout: const Duration(seconds: 5),
+      );
+
+      expect(
+        nextTurnTaps,
+        1,
+        reason:
+            'Helper must tap the next-turn button exactly once on entry, '
+            'regardless of which branch it returns through (earlyAfter or '
+            'confirm-then-advance).',
+      );
+      expect(
+        confirmTaps,
+        0,
+        reason:
+            'earlyAfter branch must skip the confirm tap entirely when the '
+            'label already changed during the post-tap settle (#2336 AC5: '
+            'condition-based wait short-circuits the slower fallback).',
+      );
+      expect(
+        controller.label,
+        _labelAfter,
+        reason:
+            'Sanity check: the scheduled flip must have landed before the '
+            'helper returned, otherwise the earlyAfter branch would not '
+            'have been exercised.',
+      );
+      expect(
+        returned,
+        lessThan(const Duration(seconds: 5)),
+        reason:
+            'Helper must complete strictly within its timeout when the '
+            'label change is observed; reaching the timeout indicates the '
+            'earlyAfter branch missed the flip and fell through to the '
+            'inner waiter.',
+      );
+    },
+  );
+
+  testWidgets(
+    'taps confirm and waits for label advance when confirm dialog appears',
+    (WidgetTester tester) async {
+      var nextTurnTaps = 0;
+      var confirmTaps = 0;
+      _NextTurnAdvanceController? controllerRef;
+      Timer? labelFlipTimer;
+      final controller = _NextTurnAdvanceController(
+        initialLabel: _labelBefore,
+        initialShowConfirm: true,
+        onNextTurnTapped: () {
+          nextTurnTaps += 1;
+        },
+        onConfirmTapped: () {
+          confirmTaps += 1;
+          // Hide the dialog and schedule the label flip from the very tap
+          // the helper performs on the confirm chip — mirrors the
+          // canonical app path where confirming the next turn kicks off
+          // turn resolution and the map chip label updates a beat later.
+          controllerRef?.showConfirm = false;
+          labelFlipTimer = Timer(const Duration(milliseconds: 60), () {
+            controllerRef?.label = _labelAfter;
+          });
+        },
+      );
+      controllerRef = controller;
+      addTearDown(() => labelFlipTimer?.cancel());
+
+      await _pumpHost(tester, controller);
+      expect(
+        find.text('Yes').hitTestable(),
+        findsOneWidget,
+        reason:
+            'Pre-condition: confirm chip must be hit-testable on first '
+            'pump so the helper observes it on the post-tap settle.',
+      );
+
+      final l10n = await AppLocalizationsBinding.delegate.load(
+        const Locale('en'),
+      );
+      final returned = await e2eAdvanceOneHumanTurn(
+        tester,
+        l10n: l10n,
+        timeout: const Duration(seconds: 5),
+      );
+
+      expect(
+        nextTurnTaps,
+        1,
+        reason: 'Helper must tap the next-turn button exactly once on entry.',
+      );
+      expect(
+        confirmTaps,
+        1,
+        reason:
+            'Confirm-then-advance branch must tap the `common_yes` chip '
+            'exactly once when it appears in the post-tap window. A 0 here '
+            'indicates the helper short-circuited on a stale label change; '
+            'a >1 indicates a duplicate confirm tap regression.',
+      );
+      expect(
+        controller.label,
+        _labelAfter,
+        reason:
+            'Sanity check: the scheduled label flip after confirm must have '
+            'landed before the helper returned.',
+      );
+      expect(
+        controller.showConfirm,
+        isFalse,
+        reason:
+            'Sanity check: confirm dialog must have dismissed in response '
+            'to the helper\'s tap before the helper returned.',
+      );
+      expect(
+        returned,
+        lessThan(const Duration(seconds: 5)),
+        reason:
+            'Helper must observe the post-confirm label advance and return '
+            'within the 5s budget; reaching the timeout would indicate the '
+            'inner waiter missed the flip.',
+      );
+    },
+  );
+
+  testWidgets(
+    'fails with TestFailure when neither confirm nor label advance occurs',
+    (WidgetTester tester) async {
+      final controller = _NextTurnAdvanceController(
+        initialLabel: _labelBefore,
+      );
+      await _pumpHost(tester, controller);
+      final l10n = await AppLocalizationsBinding.delegate.load(
+        const Locale('en'),
+      );
+      Object? caught;
+      try {
+        await e2eAdvanceOneHumanTurn(
+          tester,
+          l10n: l10n,
+          timeout: const Duration(milliseconds: 250),
+        );
+      } catch (e) {
+        caught = e;
+      }
+      expect(
+        caught,
+        isA<TestFailure>(),
+        reason:
+            'Persistent absence (no confirm dialog, no label change) must '
+            'surface a TestFailure via the inner waiter so a future '
+            'regression that silently no-ops the helper is caught at the '
+            'widget-test layer (#2336 AC10: no new flakiness).',
+      );
+      expect(
+        controller.label,
+        _labelBefore,
+        reason:
+            'Sanity check: label must remain at the pre-tap value through '
+            'the timeout path so the test does not coincidentally observe '
+            'an unscheduled flip.',
+      );
+    },
+  );
+}

--- a/app/test/e2e_collect_text_preorder_test.dart
+++ b/app/test/e2e_collect_text_preorder_test.dart
@@ -1,0 +1,274 @@
+// Pins the contract of `e2eCollectTextPreorder` — the helper that backs
+// `collectTextPreorder` in `app/integration_test/e2e_helpers.dart` and is
+// consumed by the snapshot-text assertions in
+// `new_game_full_turn_e2e_test.dart` (civilian, naval, production panels) and
+// `new_game_capital_panel_e2e_test.dart` (province panel) via
+// `orderedEquals(expected)` comparisons against
+// `civilianUnitsPanelExpectedTexts` / `navalPanelExpectedTexts` /
+// `productionPanelWideExpectedTexts` / `provincePanelWideLayoutExpectedTexts`.
+//
+// Those expected-text mirrors are *order-sensitive*: they list strings in
+// the deterministic order they should appear in the rendered widget tree.
+// If the collector regressed to anything other than depth-first pre-order
+// (e.g. post-order, breadth-first, reverse sibling order) or stopped
+// filtering empty / null `Text.data` values, the affected E2E scenarios
+// would suddenly fail with confusing ordering diffs even when the panels
+// rendered correctly. There is no existing direct contract test for this
+// helper; the smoke suite only exercises sibling helpers
+// (`e2e_test_shared_smoke_test.dart`).
+//
+// Coverage layers:
+//   - Empty subtree (no Text descendants) — out list stays untouched.
+//   - Single `Text('foo')` — captured exactly once.
+//   - `Text('')` and `Text.rich(...)` — skipped (null/empty `data` guard).
+//   - Mixed siblings — captured in left-to-right pre-order.
+//   - Nested subtree — parent before descendants; depth-first recursion.
+//   - Non-`Text` widgets interleaved — traversed without contributing strings.
+//   - Output list mutation — pre-existing entries preserved; new entries
+//     appended.
+//
+// SPEC:
+//   - `SPEC/program/e2e-integration-tests.md` § Local run (snapshot mirrors).
+//   - Issue #2336 (Refs): shared E2E helpers and snapshot-text assertions.
+
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../integration_test/e2e_test_shared_bootstrap.dart';
+
+void main() {
+  suppressLogsForTests();
+
+  testWidgets('returns without appending when subtree has no Text', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(body: SizedBox(key: Key('root'))),
+      ),
+    );
+    final out = <String>[];
+    e2eCollectTextPreorder(tester.element(find.byKey(const Key('root'))), out);
+    expect(
+      out,
+      isEmpty,
+      reason:
+          'Subtrees free of Text widgets must leave the output list untouched '
+          'so callers can compose multiple roots without spurious entries.',
+    );
+  });
+
+  testWidgets('captures the single non-empty Text.data exactly once', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: KeyedSubtree(key: Key('root'), child: Text('hello')),
+        ),
+      ),
+    );
+    final out = <String>[];
+    e2eCollectTextPreorder(tester.element(find.byKey(const Key('root'))), out);
+    expect(
+      out,
+      const ['hello'],
+      reason:
+          'A single non-empty Text under the root must be captured exactly '
+          'once — the snapshot mirrors compare with orderedEquals so any '
+          'duplication would silently fail E2E assertions.',
+    );
+  });
+
+  testWidgets('skips Text widgets whose data is empty', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: KeyedSubtree(
+            key: Key('root'),
+            child: Column(
+              children: [Text(''), Text('keep'), Text('')],
+            ),
+          ),
+        ),
+      ),
+    );
+    final out = <String>[];
+    e2eCollectTextPreorder(tester.element(find.byKey(const Key('root'))), out);
+    expect(
+      out,
+      const ['keep'],
+      reason:
+          'Empty Text.data entries must be filtered so panels using "" as a '
+          'layout spacer do not bleed extra rows into the orderedEquals '
+          'comparison.',
+    );
+  });
+
+  testWidgets('skips Text.rich widgets (null data branch)', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: KeyedSubtree(
+            key: const Key('root'),
+            child: Column(
+              children: [
+                Text.rich(
+                  TextSpan(
+                    children: const [
+                      TextSpan(text: 'rich-span-a'),
+                      TextSpan(text: 'rich-span-b'),
+                    ],
+                  ),
+                ),
+                const Text('plain'),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+    final out = <String>[];
+    e2eCollectTextPreorder(tester.element(find.byKey(const Key('root'))), out);
+    expect(
+      out,
+      const ['plain'],
+      reason:
+          'Text.rich leaves `Text.data == null` and feeds children through '
+          '`textSpan`; the helper must skip the null-data branch and capture '
+          'only the plain Text sibling. The snapshot mirrors do not expand '
+          'rich-span children, so capturing them here would invert the '
+          'invariant.',
+    );
+  });
+
+  testWidgets('returns siblings in left-to-right order', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: KeyedSubtree(
+            key: Key('root'),
+            child: Row(
+              children: [Text('A'), Text('B'), Text('C')],
+            ),
+          ),
+        ),
+      ),
+    );
+    final out = <String>[];
+    e2eCollectTextPreorder(tester.element(find.byKey(const Key('root'))), out);
+    expect(
+      out,
+      const ['A', 'B', 'C'],
+      reason:
+          'Sibling order must follow the widget tree (Element.visitChildren '
+          'visits children in declared order), matching the left-to-right '
+          'reading order encoded in the snapshot expected-text mirrors.',
+    );
+  });
+
+  testWidgets('emits parent before descendants in depth-first preorder', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: KeyedSubtree(
+            key: Key('root'),
+            child: Column(
+              children: [
+                Text('outer-1'),
+                Column(
+                  children: [Text('inner-1a'), Text('inner-1b')],
+                ),
+                Text('outer-2'),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+    final out = <String>[];
+    e2eCollectTextPreorder(tester.element(find.byKey(const Key('root'))), out);
+    expect(
+      out,
+      const ['outer-1', 'inner-1a', 'inner-1b', 'outer-2'],
+      reason:
+          'Depth-first pre-order is the contract that the snapshot mirrors '
+          'rely on: a regression to post-order (children before parent) or '
+          'breadth-first would shuffle every panel-level orderedEquals match.',
+    );
+  });
+
+  testWidgets('traverses non-Text widgets without contributing strings', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: KeyedSubtree(
+            key: const Key('root'),
+            child: Card(
+              child: Padding(
+                padding: const EdgeInsets.all(4),
+                child: Row(
+                  children: [
+                    const Icon(Icons.check),
+                    Container(
+                      key: const Key('intermediate'),
+                      child: const Text('inside-container'),
+                    ),
+                    const Text('after-container'),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    final out = <String>[];
+    e2eCollectTextPreorder(tester.element(find.byKey(const Key('root'))), out);
+    expect(
+      out,
+      const ['inside-container', 'after-container'],
+      reason:
+          'Card / Padding / Row / Icon / Container are not Text widgets and '
+          'must not appear in the output list, but the helper must still '
+          'descend through them so wrapped Text leaves are captured.',
+    );
+  });
+
+  testWidgets('appends to pre-existing output list without clearing it', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: KeyedSubtree(
+            key: Key('root'),
+            child: Text('new-entry'),
+          ),
+        ),
+      ),
+    );
+    final out = <String>['pre-existing'];
+    e2eCollectTextPreorder(tester.element(find.byKey(const Key('root'))), out);
+    expect(
+      out,
+      const ['pre-existing', 'new-entry'],
+      reason:
+          'The helper takes the list by reference (no return value) and '
+          'appends; callers concatenate results across multiple root '
+          'elements, so wiping the list would break panel-by-panel snapshot '
+          'composition.',
+    );
+  });
+}

--- a/app/test/e2e_dismiss_transient_ui_test.dart
+++ b/app/test/e2e_dismiss_transient_ui_test.dart
@@ -1,0 +1,258 @@
+// Pins the branch behaviour of `e2eDismissTransientUi` (Refs GitHub #2336
+// AC2 / AC5 — shared E2E helper hardening).
+//
+// `e2eDismissTransientUi` is one of the most-called shared helpers across
+// every integration_test (panel openers, fleet/turn loops, region tab
+// flips). Its dismissal path is a multi-branch waterfall: GameStartIntro
+// blocker → SnackBar action → top-level OK → AlertDialog labelled close →
+// AlertDialog pop fallback → BottomSheet → CtDialogShell. A tuning
+// regression that silently reorders or skips any branch would inflate every
+// scenario's wall-clock cost (and, in the AlertDialog/SnackBar cases, can
+// strand transient UI so subsequent opener calls time out).
+//
+// `integration_test/` is not part of the PR `quality` workflow (SPEC §
+// `e2e-integration-tests.md`), so this widget-test layer is the only
+// per-PR pin for the dismissal contract. Tests mirror the structure of
+// the existing helper pins for sibling helpers
+// (`app/test/e2e_close_bottom_sheet_test.dart`,
+// `app/test/e2e_open_panel_prepump_test.dart`,
+// `app/test/e2e_advance_game_start_intro_test.dart`).
+//
+// Coverage layers:
+//   - Pre-pump short-circuit: an empty widget tree must not pay even one
+//     idle pump (mirrors the AC5 prepump short-circuit pins for the panel
+//     openers).
+//   - SnackBar with action: tapping the SnackBar action removes the
+//     SnackBar from the tree before the helper returns.
+//   - Top-level OK button: tapping OK removes the OK label.
+//   - AlertDialog with `Close` label: helper prefers the labelled close
+//     button over the generic pop-route fallback.
+//   - AlertDialog with no labelled close button: helper falls through to
+//     `handlePopRoute` and clears the dialog.
+//
+// The `CtDialogShell` and `BottomSheet` branches are pinned in their own
+// helpers (`e2e_close_bottom_sheet_test.dart` and the existing
+// integration paths) and rely on Flame asset loading, so they are not
+// exercised again here.
+
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../integration_test/e2e_test_shared.dart';
+
+class _SnackBarHost extends StatefulWidget {
+  const _SnackBarHost();
+
+  @override
+  State<_SnackBarHost> createState() => _SnackBarHostState();
+}
+
+class _SnackBarHostState extends State<_SnackBarHost> {
+  bool _shown = false;
+
+  void _show(BuildContext context) {
+    if (_shown) return;
+    _shown = true;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        duration: const Duration(seconds: 30),
+        content: const Text('snack-content'),
+        action: SnackBarAction(label: 'Undo', onPressed: () {}),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Builder(
+        builder: (innerCtx) {
+          WidgetsBinding.instance.addPostFrameCallback((_) => _show(innerCtx));
+          return const SizedBox.expand();
+        },
+      ),
+    );
+  }
+}
+
+class _AlertDialogHost extends StatefulWidget {
+  const _AlertDialogHost({required this.actions});
+
+  final List<Widget> actions;
+
+  @override
+  State<_AlertDialogHost> createState() => _AlertDialogHostState();
+}
+
+class _AlertDialogHostState extends State<_AlertDialogHost> {
+  bool _shown = false;
+
+  void _show(BuildContext context) {
+    if (_shown) return;
+    _shown = true;
+    showDialog<void>(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('alert-title'),
+        content: const Text('alert-content'),
+        actions: widget.actions,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Builder(
+        builder: (innerCtx) {
+          WidgetsBinding.instance.addPostFrameCallback((_) => _show(innerCtx));
+          return const SizedBox.expand();
+        },
+      ),
+    );
+  }
+}
+
+void main() {
+  suppressLogsForTests();
+
+  testWidgets(
+    'e2eDismissTransientUi short-circuits when no transient UI is present',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(home: Scaffold(body: SizedBox())),
+      );
+      final sw = Stopwatch()..start();
+      await e2eDismissTransientUi(tester);
+      expect(
+        sw.elapsed < const Duration(milliseconds: 150),
+        isTrue,
+        reason:
+            'Empty transient-UI tree must return before paying any pump frame '
+            '(GitHub #2336 AC5: prepump short-circuit parity with sibling '
+            'panel-opener helpers).',
+      );
+    },
+  );
+
+  testWidgets(
+    'e2eDismissTransientUi taps SnackBar action and removes the SnackBar',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(const MaterialApp(home: _SnackBarHost()));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 250));
+      expect(
+        find.byType(SnackBar),
+        findsOneWidget,
+        reason: 'Test fixture must surface a SnackBar before the helper runs.',
+      );
+
+      await e2eDismissTransientUi(tester);
+      // Allow the SnackBar dismissal animation to settle within the
+      // helper's 2s pump-until-empty budget.
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(
+        find.byType(SnackBar),
+        findsNothing,
+        reason:
+            'SnackBar with a tappable TextButton action must be dismissed via '
+            'the action tap (e2eDismissTransientUi SnackBar branch) so the '
+            'next caller does not race a still-mounted overlay.',
+      );
+    },
+  );
+
+  testWidgets(
+    'e2eDismissTransientUi taps a top-level OK button',
+    (WidgetTester tester) async {
+      var tapped = false;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: TextButton(
+                onPressed: () {
+                  tapped = true;
+                },
+                child: const Text('OK'),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await e2eDismissTransientUi(tester);
+
+      expect(
+        tapped,
+        isTrue,
+        reason:
+            'Top-level OK button must be tapped by the OK branch of '
+            'e2eDismissTransientUi when no SnackBar/AlertDialog/BottomSheet '
+            'is present.',
+      );
+    },
+  );
+
+  testWidgets(
+    'e2eDismissTransientUi taps a labelled Close action on an AlertDialog',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: _AlertDialogHost(
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(tester.element(find.text('Close'))).pop(),
+                child: const Text('Close'),
+              ),
+            ],
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 250));
+      expect(find.byType(AlertDialog), findsOneWidget);
+
+      await e2eDismissTransientUi(tester);
+      // Dialog dismissal animations need a few extra frames after the
+      // helper returns to fully unmount the route.
+      await tester.pump(const Duration(milliseconds: 250));
+
+      expect(
+        find.byType(AlertDialog),
+        findsNothing,
+        reason:
+            'AlertDialog with a labelled Close action must be dismissed via '
+            'the labelled-button branch (preferred over the pop-route '
+            'fallback) so future calls do not race an extra pop.',
+      );
+    },
+  );
+
+  testWidgets(
+    'e2eDismissTransientUi pops an AlertDialog with no recognised label',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(home: _AlertDialogHost(actions: <Widget>[])),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 250));
+      expect(find.byType(AlertDialog), findsOneWidget);
+
+      await e2eDismissTransientUi(tester);
+      await tester.pump(const Duration(milliseconds: 250));
+
+      expect(
+        find.byType(AlertDialog),
+        findsNothing,
+        reason:
+            'AlertDialog with none of {Close, OK, Cancel, Yes} must be '
+            'dismissed via the handlePopRoute fallback so the helper never '
+            'returns with a stranded modal that blocks subsequent panel '
+            'opener calls.',
+      );
+    },
+  );
+}

--- a/app/test/e2e_open_naval_panel_test.dart
+++ b/app/test/e2e_open_naval_panel_test.dart
@@ -1,0 +1,277 @@
+/// Widget-test coverage for `e2eOpenNavalPanel`, the shared helper that
+/// drives fleet E2E paths into the naval units panel from either the empire
+/// rail (H6 site in `colonizethis_app/integration_test/`) or the first-fleet
+/// map marker.
+///
+/// The prepump short-circuit branch (panel already mounted) is pinned by
+/// `app/test/e2e_open_panel_prepump_test.dart`. This file pins the **other**
+/// branches of the naval opener loop, mirroring the structurally similar
+/// civilian opener pins in `app/test/e2e_open_civilian_panel_test.dart`:
+///
+///   - Empire rail tap on a synchronously-mounted panel (sync detect).
+///   - First-fleet marker tap when the rail button is absent.
+///   - Empire rail tap on a panel that mounts after a short delay (async
+///     detect via the helper's `e2ePumpUntilConditionOrIdle` post-tap wait).
+///   - Persistent absence of both triggers (helper must surface a
+///     `TestFailure` rather than silently returning).
+///
+/// Because `integration_test/` is not part of the PR `quality` workflow
+/// (`SPEC/program/e2e-integration-tests.md` § CI — `app_e2e_linux` lane is a
+/// no-op), the widget-test layer carries the behavioural pins for the AC2
+/// "single canonical opener" and AC5 "adaptive polling with pre-pump
+/// short-circuit" contracts for this opener. The naval opener has had at
+/// least one real defect previously (rail tap could time out because the
+/// in-flight implementation used `e2eWaitUntilFound + fail()` instead of the
+/// bounded `e2ePumpUntilConditionOrIdle` used by the civilian opener — see
+/// GitHub PR #2555). Without these pins, a future refactor of the
+/// rail/marker selection or the post-tap fallback window could silently
+/// regress at the integration-test wall-clock layer with no unit-level
+/// signal.
+///
+/// Refs GitHub #2336 (AC2 — shared helpers used by E2E tests; AC5 — adaptive
+/// polling with pre-pump short-circuit; AC10 — no silent flakiness from
+/// timeout regressions).
+library;
+
+import 'dart:async';
+
+import 'package:colonizethis_app/config/ct_e2e.dart';
+import 'package:colonizethis_app/features/game/flame/game_screen_shared.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../integration_test/e2e_test_shared.dart';
+
+void main() {
+  suppressLogsForTests();
+
+  testWidgets(
+    'e2eOpenNavalPanel taps the empire rail button and detects the panel',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(home: _NavalRailHarness()),
+      );
+      expect(find.byKey(kEmpireNavalUnitsButtonKey), findsOneWidget);
+      expect(find.byKey(kCtE2ENavalPanelRootKey), findsNothing);
+      await e2eOpenNavalPanel(
+        tester,
+        timeout: const Duration(seconds: 5),
+      );
+      expect(
+        find.byKey(kCtE2ENavalPanelRootKey),
+        findsOneWidget,
+        reason:
+            'After tapping the keyed empire naval rail button, the helper '
+            'must detect the panel root on the next pump and return '
+            '(Refs GitHub #2336 AC2 — single canonical opener).',
+      );
+    },
+  );
+
+  testWidgets(
+    'e2eOpenNavalPanel falls back to the first-fleet marker '
+    'when the empire rail button is absent',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(home: _NavalMarkerOnlyHarness()),
+      );
+      expect(find.byKey(kEmpireNavalUnitsButtonKey), findsNothing);
+      expect(
+        find.byKey(kCtE2EOpenFirstFleetMarkerPanelKey),
+        findsOneWidget,
+      );
+      expect(find.byKey(kCtE2ENavalPanelRootKey), findsNothing);
+      await e2eOpenNavalPanel(
+        tester,
+        timeout: const Duration(seconds: 5),
+      );
+      expect(
+        find.byKey(kCtE2ENavalPanelRootKey),
+        findsOneWidget,
+        reason:
+            'When the empire rail button is not in the tree, the helper must '
+            'tap the first-fleet map marker as the second canonical '
+            'trigger (Refs GitHub #2336 AC2 — single canonical opener).',
+      );
+    },
+  );
+
+  testWidgets(
+    'e2eOpenNavalPanel returns once the panel root mounts asynchronously '
+    'after the rail tap',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: _DelayedNavalPanelHarness(
+            mountAfter: Duration(milliseconds: 120),
+          ),
+        ),
+      );
+      expect(find.byKey(kCtE2ENavalPanelRootKey), findsNothing);
+      await e2eOpenNavalPanel(
+        tester,
+        timeout: const Duration(seconds: 5),
+      );
+      expect(
+        find.byKey(kCtE2ENavalPanelRootKey),
+        findsOneWidget,
+        reason:
+            'Adaptive polling must keep pumping past the post-tap fallback '
+            'window until the naval panel root mounts (Refs GitHub #2336 '
+            'AC5 — condition-based wait, not a fixed sleep; also guards '
+            'against PR #2555 regression where the rail tap could time out '
+            'because tryOpen failed instead of bounded-polling).',
+      );
+    },
+  );
+
+  testWidgets(
+    'e2eOpenNavalPanel times out with TestFailure when no opener surfaces',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(const MaterialApp(home: Scaffold()));
+      Object? caught;
+      try {
+        await e2eOpenNavalPanel(
+          tester,
+          timeout: const Duration(milliseconds: 250),
+        );
+      } catch (e) {
+        caught = e;
+      }
+      expect(
+        caught,
+        isA<TestFailure>(),
+        reason:
+            'Persistent absence of both the empire rail button and the '
+            'first-fleet marker must surface a TestFailure rather than '
+            'silently returning (Refs GitHub #2336 AC10 — no silent '
+            'flakiness from timeout regressions).',
+      );
+    },
+  );
+}
+
+/// Test harness that mounts the naval panel root synchronously when the
+/// keyed empire rail button is tapped, so the helper detects the panel on
+/// the very next frame.
+class _NavalRailHarness extends StatefulWidget {
+  const _NavalRailHarness();
+
+  @override
+  State<_NavalRailHarness> createState() => _NavalRailHarnessState();
+}
+
+class _NavalRailHarnessState extends State<_NavalRailHarness> {
+  bool _panelOpen = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Column(
+        children: <Widget>[
+          TextButton(
+            key: kEmpireNavalUnitsButtonKey,
+            onPressed: () => setState(() => _panelOpen = true),
+            child: const Text('Naval'),
+          ),
+          if (_panelOpen)
+            const KeyedSubtree(
+              key: kCtE2ENavalPanelRootKey,
+              child: SizedBox(width: 100, height: 100),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Test harness that exposes the first-fleet marker but no empire rail
+/// button, so the helper must take the marker branch as the second canonical
+/// trigger.
+class _NavalMarkerOnlyHarness extends StatefulWidget {
+  const _NavalMarkerOnlyHarness();
+
+  @override
+  State<_NavalMarkerOnlyHarness> createState() =>
+      _NavalMarkerOnlyHarnessState();
+}
+
+class _NavalMarkerOnlyHarnessState extends State<_NavalMarkerOnlyHarness> {
+  bool _panelOpen = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Column(
+        children: <Widget>[
+          TextButton(
+            key: kCtE2EOpenFirstFleetMarkerPanelKey,
+            onPressed: () => setState(() => _panelOpen = true),
+            child: const Text('Marker'),
+          ),
+          if (_panelOpen)
+            const KeyedSubtree(
+              key: kCtE2ENavalPanelRootKey,
+              child: SizedBox(width: 100, height: 100),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Test harness that mounts the naval panel root only after an in-test
+/// timer fires so the helper exercises its adaptive post-tap waits before
+/// returning. The keyed empire rail button drives the schedule, mirroring
+/// the civilian async harness pattern in
+/// `app/test/e2e_open_civilian_panel_test.dart` and the production-panel
+/// async harness in `app/test/e2e_open_production_panel_test.dart`.
+class _DelayedNavalPanelHarness extends StatefulWidget {
+  const _DelayedNavalPanelHarness({required this.mountAfter});
+
+  final Duration mountAfter;
+
+  @override
+  State<_DelayedNavalPanelHarness> createState() =>
+      _DelayedNavalPanelHarnessState();
+}
+
+class _DelayedNavalPanelHarnessState
+    extends State<_DelayedNavalPanelHarness> {
+  bool _panelOpen = false;
+  bool _scheduled = false;
+
+  void _handleTap() {
+    if (_scheduled) {
+      return;
+    }
+    _scheduled = true;
+    Timer(widget.mountAfter, () {
+      if (!mounted) {
+        return;
+      }
+      setState(() => _panelOpen = true);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Column(
+        children: <Widget>[
+          TextButton(
+            key: kEmpireNavalUnitsButtonKey,
+            onPressed: _handleTap,
+            child: const Text('Naval'),
+          ),
+          if (_panelOpen)
+            const KeyedSubtree(
+              key: kCtE2ENavalPanelRootKey,
+              child: SizedBox(width: 100, height: 100),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/app/test/e2e_open_production_panel_test.dart
+++ b/app/test/e2e_open_production_panel_test.dart
@@ -1,0 +1,209 @@
+/// Widget-test coverage for `e2eOpenProductionPanel`, the shared helper used
+/// by the full-turn E2E to enter the production screen from the empire rail
+/// (Bottleneck 2 / H7 site in `colonizethis_app/integration_test/`).
+///
+/// The integration tests pay the realistic wall-clock cost of the helper, but
+/// `integration_test/` is not part of the PR `quality` workflow
+/// (`SPEC/program/e2e-integration-tests.md` § CI — `app_e2e_linux` lane is a
+/// no-op). Widget-level pins keep the AC2/AC5 contract for this opener live
+/// in the unit-test layer so a future refactor cannot silently regress the
+/// short-circuit or tap-once-then-detect-mount paths.
+///
+/// Refs GitHub #2336 (AC2 — shared helpers used by E2E tests; AC5 — adaptive
+/// polling with pre-pump short-circuit; AC10 — no silent flakiness from
+/// timeout regressions).
+library;
+
+import 'package:colonizethis_app/config/ct_e2e.dart';
+import 'package:colonizethis_app/features/game/flame/game_screen_shared.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../integration_test/e2e_test_shared.dart';
+
+void main() {
+  suppressLogsForTests();
+
+  testWidgets(
+    'e2eOpenProductionPanel short-circuits when panel root already mounted',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: KeyedSubtree(
+              key: kCtE2EProductionPanelRootKey,
+              child: Container(width: 200, height: 200, color: Colors.green),
+            ),
+          ),
+        ),
+      );
+      final sw = Stopwatch()..start();
+      await e2eOpenProductionPanel(tester);
+      expect(
+        sw.elapsed < const Duration(milliseconds: 200),
+        isTrue,
+        reason:
+            'Already-mounted production panel root must return before the '
+            'loop pays any rail-tap probing budget (Refs GitHub #2336 AC5).',
+      );
+    },
+  );
+
+  testWidgets(
+    'e2eOpenProductionPanel taps the empire rail button and detects the panel',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(home: _ProductionRailHarness()),
+      );
+      expect(find.byKey(kEmpireProductionButtonKey), findsOneWidget);
+      expect(find.byKey(kCtE2EProductionPanelRootKey), findsNothing);
+      await e2eOpenProductionPanel(
+        tester,
+        timeout: const Duration(seconds: 5),
+      );
+      expect(
+        find.byKey(kCtE2EProductionPanelRootKey),
+        findsOneWidget,
+        reason:
+            'After tapping the keyed production button, the helper must wait '
+            'for the panel root to mount and return on the next pump '
+            '(Refs GitHub #2336 AC2 — single canonical opener).',
+      );
+    },
+  );
+
+  testWidgets(
+    'e2eOpenProductionPanel returns once the panel root mounts asynchronously',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: _DelayedProductionPanelHarness(
+            mountAfter: Duration(milliseconds: 120),
+          ),
+        ),
+      );
+      expect(find.byKey(kCtE2EProductionPanelRootKey), findsNothing);
+      await e2eOpenProductionPanel(
+        tester,
+        timeout: const Duration(seconds: 5),
+      );
+      expect(
+        find.byKey(kCtE2EProductionPanelRootKey),
+        findsOneWidget,
+        reason:
+            'Adaptive polling must keep pumping past the post-tap fallback '
+            'window until the panel root mounts (Refs GitHub #2336 AC5 — '
+            'condition-based wait).',
+      );
+    },
+  );
+
+  testWidgets(
+    'e2eOpenProductionPanel times out with TestFailure when no entry surfaces',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(const MaterialApp(home: Scaffold()));
+      Object? caught;
+      try {
+        await e2eOpenProductionPanel(
+          tester,
+          timeout: const Duration(milliseconds: 250),
+        );
+      } catch (e) {
+        caught = e;
+      }
+      expect(
+        caught,
+        isA<TestFailure>(),
+        reason:
+            'Persistent absence of both the production button and panel root '
+            'must surface a TestFailure rather than silently returning '
+            '(Refs GitHub #2336 AC10 — no silent flakiness).',
+      );
+    },
+  );
+}
+
+/// Test harness that mounts the panel root synchronously on the rail tap so
+/// the helper detects it on the very next frame.
+class _ProductionRailHarness extends StatefulWidget {
+  const _ProductionRailHarness();
+
+  @override
+  State<_ProductionRailHarness> createState() => _ProductionRailHarnessState();
+}
+
+class _ProductionRailHarnessState extends State<_ProductionRailHarness> {
+  bool _panelOpen = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Column(
+        children: <Widget>[
+          TextButton(
+            key: kEmpireProductionButtonKey,
+            onPressed: () => setState(() => _panelOpen = true),
+            child: const Text('Production'),
+          ),
+          if (_panelOpen)
+            const KeyedSubtree(
+              key: kCtE2EProductionPanelRootKey,
+              child: SizedBox(width: 100, height: 100),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Test harness that mounts the panel root only after an in-test [Timer] fires
+/// so the helper exercises its adaptive post-tap waits before returning.
+class _DelayedProductionPanelHarness extends StatefulWidget {
+  const _DelayedProductionPanelHarness({required this.mountAfter});
+
+  final Duration mountAfter;
+
+  @override
+  State<_DelayedProductionPanelHarness> createState() =>
+      _DelayedProductionPanelHarnessState();
+}
+
+class _DelayedProductionPanelHarnessState
+    extends State<_DelayedProductionPanelHarness> {
+  bool _panelOpen = false;
+  bool _scheduled = false;
+
+  void _handleTap() {
+    if (_scheduled) {
+      return;
+    }
+    _scheduled = true;
+    Future<void>.delayed(widget.mountAfter, () {
+      if (!mounted) {
+        return;
+      }
+      setState(() => _panelOpen = true);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Column(
+        children: <Widget>[
+          TextButton(
+            key: kEmpireProductionButtonKey,
+            onPressed: _handleTap,
+            child: const Text('Production'),
+          ),
+          if (_panelOpen)
+            const KeyedSubtree(
+              key: kCtE2EProductionPanelRootKey,
+              child: SizedBox(width: 100, height: 100),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/app/test/e2e_wait_until_any_finder_hit_testable_test.dart
+++ b/app/test/e2e_wait_until_any_finder_hit_testable_test.dart
@@ -1,0 +1,277 @@
+/// Pins the **empty-list no-op**, **pre-pump short-circuit**, **adaptive
+/// doubling backoff**, and **timeout fail-fast** contracts of
+/// `e2eWaitUntilAnyFinderHitTestable` (Refs GitHub #2336 AC2 / AC5 /
+/// `SPEC/program/e2e-integration-tests.md` § Adaptive poll pacing).
+///
+/// The helper is the canonical "wait for any one of several openers /
+/// transient widgets to become tappable" primitive used by `e2eOpenNavalPanel`
+/// and other panel openers. Because the `integration_test/` suite runs behind
+/// a no-op `app_e2e_linux` lane today (`SPEC/program/e2e-integration-tests.md`
+/// § CI), the behavioral pins live in the widget-test layer and use
+/// fake-async `Timer` flips so the helper's `tester.pump` loop observes the
+/// mounted finders without the test driving extra pumps itself.
+library;
+
+import 'dart:async';
+
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../integration_test/e2e_test_shared.dart';
+
+/// Host that mounts zero or more keyed `TextButton` finders on demand so the
+/// test can flip visibility while the helper polls.
+///
+/// `Timer` callbacks scheduled in [State.initState] fire when `tester.pump`
+/// advances fake-time past the registered duration, so the helper sees the
+/// newly mounted widget on a later iteration without the test calling
+/// `tester.pump` itself (which would deadlock against the helper's guarded
+/// pump loop).
+class _MountKeysHost extends StatefulWidget {
+  const _MountKeysHost({
+    required this.controller,
+    this.mountAfter,
+    this.mountKeys = const <Key>[],
+  });
+
+  final _MountKeysController controller;
+
+  /// Fake-async delay before the host mounts [mountKeys], or `null` to leave
+  /// the controller untouched.
+  final Duration? mountAfter;
+
+  /// Keys to mount as visible, hit-testable `TextButton`s when [mountAfter]
+  /// elapses.
+  final List<Key> mountKeys;
+
+  @override
+  State<_MountKeysHost> createState() => _MountKeysHostState();
+}
+
+class _MountKeysHostState extends State<_MountKeysHost> {
+  Timer? _mountTimer;
+
+  @override
+  void initState() {
+    super.initState();
+    widget.controller.addListener(_onControllerChanged);
+    final after = widget.mountAfter;
+    if (after != null) {
+      _mountTimer = Timer(after, _applyMount);
+    }
+  }
+
+  void _applyMount() {
+    widget.controller.mountedKeys = widget.mountKeys;
+  }
+
+  @override
+  void dispose() {
+    _mountTimer?.cancel();
+    widget.controller.removeListener(_onControllerChanged);
+    super.dispose();
+  }
+
+  void _onControllerChanged() {
+    if (!mounted) return;
+    setState(() {});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final keys = widget.controller.mountedKeys;
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: <Widget>[
+        for (final k in keys)
+          TextButton(
+            key: k,
+            onPressed: () {},
+            child: const Text('btn'),
+          ),
+      ],
+    );
+  }
+}
+
+class _MountKeysController extends ChangeNotifier {
+  _MountKeysController({List<Key> initialKeys = const <Key>[]})
+      : _mountedKeys = List<Key>.of(initialKeys);
+
+  List<Key> _mountedKeys;
+
+  List<Key> get mountedKeys => _mountedKeys;
+
+  set mountedKeys(List<Key> value) {
+    _mountedKeys = List<Key>.of(value);
+    notifyListeners();
+  }
+}
+
+Future<void> _pumpHost(
+  WidgetTester tester,
+  _MountKeysController controller, {
+  Duration? mountAfter,
+  List<Key> mountKeys = const <Key>[],
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: _MountKeysHost(
+            controller: controller,
+            mountAfter: mountAfter,
+            mountKeys: mountKeys,
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  suppressLogsForTests();
+
+  testWidgets(
+    'returns immediately when the finder list is empty (no pump, no throw)',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(const MaterialApp(home: SizedBox()));
+      final sw = Stopwatch()..start();
+      await e2eWaitUntilAnyFinderHitTestable(
+        tester,
+        const <Finder>[],
+        timeout: const Duration(seconds: 5),
+      );
+      expect(
+        sw.elapsed,
+        lessThan(const Duration(milliseconds: 200)),
+        reason:
+            'Empty finder list must short-circuit before any pump or timeout '
+            'accrual; callers may legitimately pass an empty list when no '
+            'opener is in scope yet.',
+      );
+    },
+  );
+
+  testWidgets(
+    'short-circuits before any pump when the first finder is already hit-testable',
+    (WidgetTester tester) async {
+      const onlyKey = Key('e2e_only_btn');
+      final controller =
+          _MountKeysController(initialKeys: const <Key>[onlyKey]);
+      await _pumpHost(tester, controller);
+      final sw = Stopwatch()..start();
+      await e2eWaitUntilAnyFinderHitTestable(
+        tester,
+        <Finder>[find.byKey(onlyKey)],
+        timeout: const Duration(seconds: 5),
+      );
+      expect(
+        sw.elapsed,
+        lessThan(const Duration(milliseconds: 200)),
+        reason:
+            'Pre-pump short-circuit must return well before the timeout cap '
+            'when a finder is already hit-testable on entry (#2336 AC5).',
+      );
+    },
+  );
+
+  testWidgets(
+    'short-circuits before any pump when a later finder is already hit-testable',
+    (WidgetTester tester) async {
+      const firstKey = Key('e2e_first_btn');
+      const secondKey = Key('e2e_second_btn');
+      // Only the second key is mounted, so the first finder is empty.
+      final controller =
+          _MountKeysController(initialKeys: const <Key>[secondKey]);
+      await _pumpHost(tester, controller);
+      final sw = Stopwatch()..start();
+      await e2eWaitUntilAnyFinderHitTestable(
+        tester,
+        <Finder>[find.byKey(firstKey), find.byKey(secondKey)],
+        timeout: const Duration(seconds: 5),
+      );
+      expect(
+        sw.elapsed,
+        lessThan(const Duration(milliseconds: 200)),
+        reason:
+            'Helper must scan the full finder list on the pre-pump pass; a '
+            'later finder that is already hit-testable must short-circuit the '
+            'wait the same as the first one.',
+      );
+    },
+  );
+
+  testWidgets(
+    'returns once a scheduled mount makes one finder hit-testable during pump',
+    (WidgetTester tester) async {
+      const targetKey = Key('e2e_target_btn');
+      final controller = _MountKeysController();
+      // The host starts with no widgets; schedule a mount after enough
+      // fake-async time that the helper has already passed its pre-pump scan
+      // and is inside the adaptive pump loop.
+      await _pumpHost(
+        tester,
+        controller,
+        mountAfter: const Duration(milliseconds: 80),
+        mountKeys: const <Key>[targetKey],
+      );
+      expect(find.byKey(targetKey), findsNothing);
+
+      await e2eWaitUntilAnyFinderHitTestable(
+        tester,
+        <Finder>[find.byKey(targetKey)],
+        timeout: const Duration(seconds: 5),
+      );
+
+      expect(
+        controller.mountedKeys,
+        contains(targetKey),
+        reason:
+            'Sanity check: the scheduled mount must have run before the '
+            'helper returned, otherwise the helper saw a stale empty finder.',
+      );
+      expect(
+        find.byKey(targetKey).hitTestable(),
+        findsOneWidget,
+        reason:
+            'The target finder must be hit-testable at return time, since '
+            'that is the exact condition the helper waits on.',
+      );
+    },
+  );
+
+  testWidgets(
+    'fails with TestFailure when no finder ever becomes hit-testable within timeout',
+    (WidgetTester tester) async {
+      const missingKey = Key('e2e_missing_btn');
+      await tester.pumpWidget(const MaterialApp(home: SizedBox()));
+      Object? caught;
+      try {
+        await e2eWaitUntilAnyFinderHitTestable(
+          tester,
+          <Finder>[find.byKey(missingKey)],
+          timeout: const Duration(milliseconds: 200),
+        );
+      } catch (e) {
+        caught = e;
+      }
+      expect(
+        caught,
+        isA<TestFailure>(),
+        reason:
+            'Persistent absence must hit the timeout failure path so missing '
+            'panel openers do not silently no-op and leak into later test '
+            'steps (#2336 AC10).',
+      );
+      expect(
+        caught.toString(),
+        contains('Timed out'),
+        reason:
+            'Failure message must call out the timeout so the helper failure '
+            'is attributable in CI logs.',
+      );
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Consolidates 6 individual test-pin PRs targeting #2336 (E2E integration test refactor) into a single reviewable PR. Each commit pins the contract/branches of one E2E helper used by `app/integration_test/` so future helper extraction (per #2336's AC1/AC2) does not silently change behavior.

## Cherry-picked commits (preserved authorship)

| Commit | Helper pinned | Replaces PR |
|---|---|---|
| `3b3aea69` | `e2eOpenNavalPanel` (rail/marker/async/timeout) | #2643 |
| `c473b96f` | `e2eCollectTextPreorder` | #2639 |
| `551b90ea` | `e2eAdvanceOneHumanTurn` (earlyAfter, confirm-then-advance, timeout) | #2633 |
| `368e547b` | `e2eWaitUntilAnyFinderHitTestable` | #2632 |
| `ca0baf74` | `e2eDismissTransientUi` branch waterfall | #2628 |
| `60211593` | `e2eOpenProductionPanel` short-circuit/post-tap detection | #2622 |

## Scope

- Pure additive: 6 new files under `app/test/`, no production code touched.
- No conflicts with `dev` tip (`32fe3738`); each test file is unique.
- All six original branches/PRs to be closed in favor of this one.

Refs #2336

Made with [Cursor](https://cursor.com)