### PR TITLE
refactor(app): bus-based decoupling for debug menu + new-game flow (Refs #2626)

### DIFF
--- a/SPEC/program/app-ui-wiring.md
+++ b/SPEC/program/app-ui-wiring.md
@@ -151,6 +151,14 @@ In **`colonizethis_app`**, widgets and services that hold **one or more** `Strea
 - **Cross-cutting UI** must not use **`Ref` / `BuildContext` / `Navigator` chains** between unrelated widgets; use **`AppEventBus`** and **`AppEventHandler`**. **Panel-to-panel `onXxx` orchestration is disallowed.**
 - **Dialog builders** and route handling: one place at shell init — see [app-event-bus.md](app-event-bus.md) constraints for package boundaries and event payload rules.
 
+### CI gate — `repo.app_event_bus_decoupling` (Refs #2626)
+
+`tool/check_app_event_bus_decoupling.dart` (wired through `tool/ct_repo_lint_manifest.yaml`) enforces three invariants against `app/lib/**`:
+
+- **No `AppEventBus()` singleton** in production code (under `app/lib/**`, excluding `app/lib/widgetbook/**`). Use `appEventBusProvider` (or an `AppEventBus.create()` instance held by the owning widget/service).
+- **`appNavigatorKey.currentContext` / `.currentState` / equivalent property access** is restricted to `app/lib/core/services/**` and `app/lib/app.dart`. Other layers must thread an explicit `GlobalKey<NavigatorState>` parameter or use the bus.
+- **`showDialog` / `showModalBottomSheet` calls under `app/lib/features/**`** are restricted to the documented "Local by design" allow-list above (plus the per-panel carve-outs for split/move fleet, move army, train at-capital). New call sites outside the allow-list must use a typed `AppEvent` instead. Adding a new local-by-design dialog requires extending **both** this SPEC section **and** the lint allow-list.
+
 ---
 
 ## Acceptance Criteria (Given–When–Then)

--- a/app/lib/app.dart
+++ b/app/lib/app.dart
@@ -5,6 +5,7 @@ import 'package:colonizethis_app/l10n/l10n.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_app/config/app_display_strings.dart';
 import 'package:colonizethis_app/config/desktop_window_settings.dart';
+import 'package:colonizethis_app/providers/app_event_bus_provider.dart';
 import 'package:colonizethis_app/providers/settings_provider.dart';
 
 import 'config/routes.dart';
@@ -45,7 +46,9 @@ class App extends ConsumerWidget {
             PlatformMenuItem(
               label: rootL10n.menu_debugLog,
               onSelected: () {
-                AppEventBus().emit(const NavigateToRouteEvent(Routes.debugLog));
+                ref
+                    .read(appEventBusProvider)
+                    .emit(const NavigateToRouteEvent(Routes.debugLog));
               },
             ),
             if (isDesktopMenuPlatform)

--- a/app/lib/core/services/app_event_handler_scope_dialog_builders.dart
+++ b/app/lib/core/services/app_event_handler_scope_dialog_builders.dart
@@ -59,6 +59,7 @@ extension _DialogBuilders on _AppEventHandlerScopeState {
         );
         unawaited(
           runNewGameSetupAfterLeaderPick(
+            navigatorKey: appNavigatorKey,
             container: rootContainer,
             templateConfig: templateConfig,
           ),

--- a/app/lib/core/services/turn_resolution_blocking_service.dart
+++ b/app/lib/core/services/turn_resolution_blocking_service.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../app.dart' show appNavigatorKey;
+import '../../providers/turn_resolution_blocking_provider.dart';
+
+/// Clears [turnResolutionBlockingProvider] via the root navigator context so
+/// the flag flips off even when the originating widget (for example
+/// `GameMapArea`) has disposed during async completion (#2160, Refs #2277).
+///
+/// Lives in `core/services/` per `SPEC/program/app-ui-wiring.md`: only
+/// `app/lib/core/services/` and `app/lib/app.dart` may access
+/// `appNavigatorKey` directly — all other layers must thread a navigator key
+/// explicitly or use the bus.
+bool clearTurnResolutionBlockingFlag() {
+  final ctx = appNavigatorKey.currentContext;
+  if (ctx == null) return false;
+  try {
+    ProviderScope.containerOf(
+      ctx,
+      listen: false,
+    ).read(turnResolutionBlockingProvider.notifier).setBlocking(false);
+    return true;
+  } catch (_) {
+    return false;
+  }
+}

--- a/app/lib/features/game/flame/game_map_area.dart
+++ b/app/lib/features/game/flame/game_map_area.dart
@@ -28,6 +28,7 @@ import 'region_map_component.dart' show BaseLayerDisplayMode;
 import '../../../../providers/turn_resolution_blocking_provider.dart';
 import '../../../../providers/turn_resolution_runner_provider.dart';
 import '../../../core/services/subscription_tracker.dart';
+import '../../../core/services/turn_resolution_blocking_service.dart';
 import '../../../core/services/turn_resolution_runner.dart';
 import 'region_map_viewport_snapshot.dart';
 import '../../../../providers/home_fleet_cargo_provider.dart';

--- a/app/lib/features/game/flame/game_screen.dart
+++ b/app/lib/features/game/flame/game_screen.dart
@@ -16,6 +16,7 @@ import '../../../../providers/games_provider.dart';
 import '../../../../providers/map_view_provider.dart';
 import '../../../../providers/turn_resolution_blocking_provider.dart';
 import '../../../../providers/turn_resolution_runner_provider.dart';
+import '../../../core/services/turn_resolution_blocking_service.dart';
 import '../../../core/services/turn_resolution_runner.dart';
 import '../../../../widgets/ct_dialog_shell.dart';
 import '../../../widgets/ct_nine_patch_button.dart';

--- a/app/lib/features/shell/new_game_setup_flow.dart
+++ b/app/lib/features/shell/new_game_setup_flow.dart
@@ -10,7 +10,6 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import 'package:colonizethis_app/app.dart';
 import 'package:colonizethis_app/config/routes.dart';
 import 'package:colonizethis_app/perf/app_perf_trace.dart';
 import 'package:colonizethis_app/core/services/game_service.dart';
@@ -39,7 +38,13 @@ class _NewGameOutcomeFailure extends _NewGameOutcome {
 
 /// Runs phased new-game creation after leader selection: progress dialog, navigate on success,
 /// error dialog with retry. SPEC/ui/game-initializing.md.
+///
+/// [navigatorKey] is the long-lived root navigator handle used to show the
+/// progress and error dialogs after the leader-selection dialog has popped
+/// itself. Inject explicitly (do not read a global) so the dependency is
+/// visible at the call site and testable: SPEC/program/app-ui-wiring.md.
 Future<void> runNewGameSetupAfterLeaderPick({
+  required GlobalKey<NavigatorState> navigatorKey,
   required ProviderContainer container,
   required GameSetupConfig templateConfig,
 }) async {
@@ -73,6 +78,7 @@ Future<void> runNewGameSetupAfterLeaderPick({
     );
 
     final outcome = await _showNewGameProgressDialog(
+      navigatorKey: navigatorKey,
       config: config,
       service: service,
     );
@@ -88,7 +94,10 @@ Future<void> runNewGameSetupAfterLeaderPick({
         bus.emit(const NavigateToRouteEvent(Routes.game));
         return;
       case _NewGameOutcomeFailure(:final error):
-        final retry = await _showNewGameErrorDialog(error);
+        final retry = await _showNewGameErrorDialog(
+          navigatorKey: navigatorKey,
+          error: error,
+        );
         if (retry) {
           attemptIndex++;
           continue;
@@ -99,10 +108,11 @@ Future<void> runNewGameSetupAfterLeaderPick({
 }
 
 Future<_NewGameOutcome?> _showNewGameProgressDialog({
+  required GlobalKey<NavigatorState> navigatorKey,
   required GameSetupConfig config,
   required GameService service,
 }) async {
-  final ctx = appNavigatorKey.currentContext;
+  final ctx = navigatorKey.currentContext;
   if (ctx == null) {
     return null;
   }
@@ -115,8 +125,11 @@ Future<_NewGameOutcome?> _showNewGameProgressDialog({
   );
 }
 
-Future<bool> _showNewGameErrorDialog(Object error) async {
-  final ctx = appNavigatorKey.currentContext;
+Future<bool> _showNewGameErrorDialog({
+  required GlobalKey<NavigatorState> navigatorKey,
+  required Object error,
+}) async {
+  final ctx = navigatorKey.currentContext;
   if (ctx == null) {
     return false;
   }

--- a/app/lib/providers/turn_resolution_blocking_provider.dart
+++ b/app/lib/providers/turn_resolution_blocking_provider.dart
@@ -1,12 +1,16 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../app.dart' show appNavigatorKey;
-
 /// True while isolate turn resolution is active from the map or Flame canvas
 /// game screen (#2160, Refs #2277).
 /// [AppEventHandler] and shell session listeners consume this flag to suppress
 /// disallowed navigation/panels/commands; only pause-menu opens remain allowed at
 /// handler level unless otherwise documented in SPEC/program/app-event-bus.md.
+///
+/// Cross-cutting cleanup that needs to flip this flag off even when the
+/// originating widget has disposed lives in
+/// `core/services/turn_resolution_blocking_service.dart`
+/// (`clearTurnResolutionBlockingFlag`); the navigator-key choke point belongs
+/// in `core/services/` per `SPEC/program/app-ui-wiring.md`.
 class TurnResolutionBlockingNotifier extends Notifier<bool> {
   @override
   bool build() => false;
@@ -18,18 +22,3 @@ final turnResolutionBlockingProvider =
     NotifierProvider<TurnResolutionBlockingNotifier, bool>(
       TurnResolutionBlockingNotifier.new,
     );
-
-/// Clears blocking using the root navigator context (survives [GameMapArea] dispose during async completion).
-bool clearTurnResolutionBlockingFlag() {
-  final ctx = appNavigatorKey.currentContext;
-  if (ctx == null) return false;
-  try {
-    ProviderScope.containerOf(
-      ctx,
-      listen: false,
-    ).read(turnResolutionBlockingProvider.notifier).setBlocking(false);
-    return true;
-  } catch (_) {
-    return false;
-  }
-}

--- a/app/test/new_game_setup_flow_test.dart
+++ b/app/test/new_game_setup_flow_test.dart
@@ -1,0 +1,169 @@
+// Tests for runNewGameSetupAfterLeaderPick (Refs #2626).
+//
+// AC: `new_game_setup_flow.dart` no longer reads `appNavigatorKey.currentContext`;
+// the navigator key is received as an explicit `GlobalKey<NavigatorState>`
+// parameter; new-game progress/error dialogs open, retry, and dismiss
+// identically. SPEC/program/app-ui-wiring.md; SPEC/ui/game-initializing.md.
+
+import 'dart:async';
+
+import 'package:colonizethis_app/config/constants.dart';
+import 'package:colonizethis_app/core/services/game_service.dart';
+import 'package:colonizethis_app/features/shell/new_game_setup_flow.dart';
+import 'package:colonizethis_app/l10n/l10n.dart';
+import 'package:colonizethis_app/providers/app_event_bus_provider.dart';
+import 'package:colonizethis_app/providers/game_service_provider.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_save/colonizethis_save.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+
+class _StubGameService extends GameService {
+  _StubGameService(super.box, super.adapter);
+
+  int createCallCount = 0;
+
+  @override
+  Future<Game> createNewGameAsync({
+    String? id,
+    GameSetupConfig? config,
+    void Function(int stepIndex, int totalSteps)? onProgress,
+  }) async {
+    createCallCount++;
+    const total = GameService.newGameSetupProgressStepCount;
+    for (var i = 0; i < total; i++) {
+      onProgress?.call(i, total);
+      await Future<void>.delayed(Duration.zero);
+    }
+    return Game(
+      id: id ?? 'g1',
+      worldState: const WorldState(
+        turnState: TurnState(phase: TurnPhase.orders, turnNumber: 0),
+        oldWorld: RegionData(),
+        newWorld: RegionData(),
+      ),
+      players: const [
+        Player(id: 'gp1', displayName: 'Human', isHuman: true, treasury: 0),
+      ],
+    );
+  }
+}
+
+void main() {
+  suppressLogsForTests();
+
+  late Box<dynamic> gamesBox;
+  late _StubGameService stubService;
+
+  setUpAll(() async {
+    Hive.init('./.dart_tool/test_hive_new_game_setup_flow');
+    gamesBox = await Hive.openBox<dynamic>(HiveBoxNames.games);
+  });
+
+  setUp(() {
+    AppEventBus.reset();
+    stubService = _StubGameService(gamesBox, GameSaveAdapter());
+  });
+
+  GameSetupConfig templateConfig() => GameSetupConfig(
+    selectedGreatPowerIds: const ['gp1'],
+    leaderVariantByGpId: const {},
+    continentCount: 1,
+    minorNationCount: 0,
+    tribeCount: 0,
+    numProvincesOldWorld: 1,
+    numProvincesNewWorld: 1,
+    minProvincesPerMinor: 1,
+    seed: 1,
+    infiniteMode: false,
+  );
+
+  testWidgets(
+    'runNewGameSetupAfterLeaderPick returns early when navigator key has no '
+    'attached context (negative path)',
+    (WidgetTester tester) async {
+      // Detached key: no MaterialApp wires it in, so currentContext == null.
+      final detachedKey = GlobalKey<NavigatorState>();
+      final container = ProviderContainer(
+        overrides: [
+          gameServiceProvider.overrideWith((ref) => stubService),
+          appEventBusProvider.overrideWith((ref) => AppEventBus.create()),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      expect(detachedKey.currentContext, isNull);
+
+      // Run on the real async zone so `Future.delayed(Duration.zero)` resolves
+      // without requiring further pumps. The flow should complete without
+      // throwing and without invoking the game service stub.
+      await tester.runAsync(() async {
+        await runNewGameSetupAfterLeaderPick(
+          navigatorKey: detachedKey,
+          container: container,
+          templateConfig: templateConfig(),
+        );
+      });
+
+      expect(stubService.createCallCount, 0);
+    },
+  );
+
+  testWidgets(
+    'runNewGameSetupAfterLeaderPick uses the injected navigator key to show '
+    'the progress dialog (positive path) and creates a new game',
+    (WidgetTester tester) async {
+      // Attached key: wired into MaterialApp so currentContext is non-null
+      // once the widget is pumped. The flow must use this injected key, not a
+      // global reference, to drive the progress dialog.
+      final injectedKey = GlobalKey<NavigatorState>();
+      final container = ProviderContainer(
+        overrides: [
+          gameServiceProvider.overrideWith((ref) => stubService),
+          appEventBusProvider.overrideWith((ref) => AppEventBus.create()),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp(
+            navigatorKey: injectedKey,
+            localizationsDelegates:
+                AppLocalizationsBinding.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: const Scaffold(body: Text('shell')),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(injectedKey.currentContext, isNotNull);
+
+      // Drive the flow on the real async zone so `Future.delayed` and the
+      // post-frame callback inside the progress dialog can settle while we
+      // pump frames. The observable invariant we assert is that the
+      // injected key was used to reach the stub service.
+      await tester.runAsync(() async {
+        unawaited(
+          runNewGameSetupAfterLeaderPick(
+            navigatorKey: injectedKey,
+            container: container,
+            templateConfig: templateConfig(),
+          ),
+        );
+        // Yield repeatedly so the leader-dialog delay and progress dialog
+        // post-frame callbacks have time to run.
+        for (var i = 0; i < 20; i++) {
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+        }
+      });
+      await tester.pumpAndSettle();
+      expect(stubService.createCallCount, 1);
+    },
+  );
+}

--- a/test/check_app_event_bus_decoupling_test.dart
+++ b/test/check_app_event_bus_decoupling_test.dart
@@ -1,0 +1,294 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+import '../tool/check_app_event_bus_decoupling.dart';
+
+/// Tests for `runCheckAppEventBusDecoupling` (Refs #2626).
+///
+/// SPEC: `SPEC/program/app-ui-wiring.md` (coupling rules and "Local by design"
+/// allow-list); `SPEC/program/app-event-bus.md` (`AppEventBus.create`).
+void main() {
+  group('AppEventBus() singleton check', () {
+    test(
+      'fails when production app/lib code constructs AppEventBus() directly',
+      () {
+        final root = _writeAppFile(
+          'app/lib/features/game/widgets/bad_panel.dart',
+          '''
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+void emitDebug() {
+  AppEventBus().emit(const Object());
+}
+''',
+        );
+        final stderrLines = <String>[];
+        final code = runCheckAppEventBusDecoupling(
+          root.path,
+          err: stderrLines.add,
+        );
+        expect(code, 1);
+        expect(
+          stderrLines.join('\n'),
+          contains('AppEventBus() singleton calls'),
+        );
+        expect(
+          stderrLines.join('\n'),
+          contains('app/lib/features/game/widgets/bad_panel.dart:4'),
+        );
+      },
+    );
+
+    test('ignores AppEventBus() under app/lib/widgetbook/', () {
+      final root = _writeAppFile(
+        'app/lib/widgetbook/catalog_demo.dart',
+        '''
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+final bus = AppEventBus();
+''',
+      );
+      final stdoutLines = <String>[];
+      final code = runCheckAppEventBusDecoupling(
+        root.path,
+        info: stdoutLines.add,
+      );
+      expect(code, 0);
+      expect(stdoutLines.join('\n'), contains('no violations found'));
+    });
+
+    test('passes when production code uses AppEventBus.create()', () {
+      final root = _writeAppFile(
+        'app/lib/features/shell/good_flow.dart',
+        '''
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+final bus = AppEventBus.create();
+''',
+      );
+      final code = runCheckAppEventBusDecoupling(root.path);
+      expect(code, 0);
+    });
+  });
+
+  group('appNavigatorKey choke-point check', () {
+    test('fails when app/lib/providers/ reads appNavigatorKey.currentContext',
+        () {
+      final root = _writeAppFile(
+        'app/lib/providers/leaky_provider.dart',
+        '''
+import '../app.dart' show appNavigatorKey;
+
+void doStuff() {
+  final ctx = appNavigatorKey.currentContext;
+  if (ctx == null) return;
+}
+''',
+      );
+      final stderrLines = <String>[];
+      final code = runCheckAppEventBusDecoupling(
+        root.path,
+        err: stderrLines.add,
+      );
+      expect(code, 1);
+      expect(
+        stderrLines.join('\n'),
+        contains('appNavigatorKey property access'),
+      );
+      expect(
+        stderrLines.join('\n'),
+        contains('app/lib/providers/leaky_provider.dart:4'),
+      );
+    });
+
+    test('fails when app/lib/features/ reads appNavigatorKey.currentState', () {
+      final root = _writeAppFile(
+        'app/lib/features/shell/leaky_flow.dart',
+        '''
+import 'package:colonizethis_app/app.dart' show appNavigatorKey;
+
+void doStuff() {
+  final state = appNavigatorKey.currentState;
+  state?.pop();
+}
+''',
+      );
+      final stderrLines = <String>[];
+      final code = runCheckAppEventBusDecoupling(
+        root.path,
+        err: stderrLines.add,
+      );
+      expect(code, 1);
+      expect(
+        stderrLines.join('\n'),
+        contains('app/lib/features/shell/leaky_flow.dart:4'),
+      );
+    });
+
+    test(
+      'allows appNavigatorKey access under app/lib/core/services/',
+      () {
+        final root = _writeAppFile(
+          'app/lib/core/services/some_service.dart',
+          '''
+import '../../app.dart' show appNavigatorKey;
+
+void doStuff() {
+  final ctx = appNavigatorKey.currentContext;
+  if (ctx == null) return;
+}
+''',
+        );
+        final code = runCheckAppEventBusDecoupling(root.path);
+        expect(code, 0);
+      },
+    );
+
+    test('allows appNavigatorKey access in app/lib/app.dart itself', () {
+      final root = _writeAppFile(
+        'app/lib/app.dart',
+        '''
+import 'package:flutter/widgets.dart';
+
+final appNavigatorKey = GlobalKey<NavigatorState>();
+
+void boot() {
+  final ctx = appNavigatorKey.currentContext;
+  if (ctx == null) return;
+}
+''',
+      );
+      final code = runCheckAppEventBusDecoupling(root.path);
+      expect(code, 0);
+    });
+  });
+
+  group('features/ showDialog allow-list check', () {
+    test(
+      'fails when a new file under app/lib/features/ calls showDialog',
+      () {
+        final root = _writeAppFile(
+          'app/lib/features/game/widgets/new_panel.dart',
+          '''
+import 'package:flutter/material.dart';
+
+Future<void> open(BuildContext context) {
+  return showDialog<void>(context: context, builder: (_) => const Text('x'));
+}
+''',
+        );
+        final stderrLines = <String>[];
+        final code = runCheckAppEventBusDecoupling(
+          root.path,
+          err: stderrLines.add,
+        );
+        expect(code, 1);
+        expect(
+          stderrLines.join('\n'),
+          contains(
+            'showDialog / showModalBottomSheet in features/ outside the '
+            'documented local-by-design allow-list',
+          ),
+        );
+        expect(
+          stderrLines.join('\n'),
+          contains('app/lib/features/game/widgets/new_panel.dart:4'),
+        );
+      },
+    );
+
+    test(
+      'fails when a new file under app/lib/features/ calls '
+      'showModalBottomSheet',
+      () {
+        final root = _writeAppFile(
+          'app/lib/features/game/widgets/new_sheet.dart',
+          '''
+import 'package:flutter/material.dart';
+
+Future<void> open(BuildContext context) {
+  return showModalBottomSheet<void>(
+    context: context,
+    builder: (_) => const Text('x'),
+  );
+}
+''',
+        );
+        final code = runCheckAppEventBusDecoupling(root.path);
+        expect(code, 1);
+      },
+    );
+
+    test(
+      'allows showDialog inside the documented local-by-design files',
+      () {
+        // `new_game_setup_flow.dart` is in the allow-list per
+        // SPEC/program/app-ui-wiring.md § "Local by design".
+        final root = _writeAppFile(
+          'app/lib/features/shell/new_game_setup_flow.dart',
+          '''
+import 'package:flutter/material.dart';
+
+Future<void> open(BuildContext context) {
+  return showDialog<void>(context: context, builder: (_) => const Text('x'));
+}
+''',
+        );
+        final stdoutLines = <String>[];
+        final code = runCheckAppEventBusDecoupling(
+          root.path,
+          info: stdoutLines.add,
+        );
+        expect(code, 0);
+        expect(stdoutLines.join('\n'), contains('no violations found'));
+      },
+    );
+
+    test('ignores showDialog outside features/ (e.g. shell widgets root)', () {
+      final root = _writeAppFile(
+        'app/lib/widgets/some_widget.dart',
+        '''
+import 'package:flutter/material.dart';
+
+Future<void> open(BuildContext context) {
+  return showDialog<void>(context: context, builder: (_) => const Text('x'));
+}
+''',
+      );
+      final code = runCheckAppEventBusDecoupling(root.path);
+      expect(code, 0);
+    });
+
+    test('ignores method-target invocations like ref.showDialog(...)', () {
+      // Sanity-check that the rule only flags the Flutter free functions, not
+      // unrelated identifiers that happen to use the same name as a method on
+      // another object.
+      final root = _writeAppFile(
+        'app/lib/features/game/widgets/method_target.dart',
+        '''
+class Wrapper {
+  Future<void> showDialog() async {}
+}
+
+Future<void> open(Wrapper w) => w.showDialog();
+''',
+      );
+      final code = runCheckAppEventBusDecoupling(root.path);
+      expect(code, 0);
+    });
+  });
+}
+
+Directory _writeAppFile(String relativePath, String content) {
+  final tempDir = Directory.systemTemp.createTempSync(
+    'check_app_event_bus_decoupling_test_',
+  );
+  addTearDown(() => tempDir.deleteSync(recursive: true));
+  final targetPath = p.join(tempDir.path, relativePath);
+  File(targetPath)
+    ..createSync(recursive: true)
+    ..writeAsStringSync(content);
+  return tempDir;
+}

--- a/tool/check_app_event_bus_decoupling.dart
+++ b/tool/check_app_event_bus_decoupling.dart
@@ -1,0 +1,262 @@
+import 'dart:io';
+
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/source/line_info.dart';
+import 'package:path/path.dart' as p;
+
+/// Enforces the `AppEventBus` / `appNavigatorKey` decoupling architecture in
+/// `app/lib/**` (Refs #2626).
+///
+/// SPEC source of truth:
+/// - `SPEC/program/app-ui-wiring.md` (when to use the bus vs local Flutter
+///   APIs; documented local-by-design dialog/sheet carve-outs).
+/// - `SPEC/program/app-event-bus.md` (bus API and `AppEventBus.create`).
+///
+/// Three sub-checks (any violation flips the rule red):
+///
+/// 1. Production code under `app/lib/**` (excluding `app/lib/widgetbook/**`)
+///    must not call the `AppEventBus()` singleton factory — use the
+///    `appEventBusProvider` (or an `AppEventBus.create()` instance held by
+///    the owning widget/service) so test containers can dispose without
+///    closing the legacy global bus.
+///
+/// 2. `appNavigatorKey.currentContext`, `appNavigatorKey.currentState`, and
+///    any other property access on `appNavigatorKey` is restricted to
+///    `app/lib/core/services/**` and `app/lib/app.dart`. Other layers must
+///    thread an explicit `GlobalKey<NavigatorState>` parameter or use the
+///    bus, so the global lookup stays hidden behind the documented choke
+///    point.
+///
+/// 3. Inside `app/lib/features/**` (which covers `features/shell/**`,
+///    `features/game/widgets/**`, `features/game/flame/**`, and feature
+///    screens), `showDialog` / `showModalBottomSheet` invocations are
+///    restricted to a documented allow-list of local-by-design files
+///    (`SPEC/program/app-ui-wiring.md` § "Local by design" plus the per-panel
+///    carve-outs for split / move fleet, move army, train at-capital). Any
+///    new call site outside that allow-list is a violation; emit a typed
+///    `AppEvent` via `AppEventBus` instead.
+
+const _disallowedSingletonName = 'AppEventBus';
+
+const Set<String> _appNavigatorKeyAllowedPathPrefixes = <String>{
+  'app/lib/core/services/',
+  'app/lib/app.dart',
+};
+
+/// Files under `app/lib/features/**` that may keep `showDialog` /
+/// `showModalBottomSheet` calls per `SPEC/program/app-ui-wiring.md`
+/// § "Local by design" (line 84) plus per-panel carve-outs documented
+/// elsewhere in that file. Each entry should map to one SPEC paragraph
+/// (referenced in the trailing comment) so the gate stays auditable.
+const Set<String> _allowedFeatureLocalDialogFiles = <String>{
+  // Local by design — `SPEC/program/app-ui-wiring.md` line 84.
+  'app/lib/features/game/widgets/civilian_units_panel_support.dart',
+  'app/lib/features/game/flame/game_map_area_part1.dart',
+  'app/lib/features/game/flame/game_map_area_part2.dart',
+  'app/lib/features/game/flame/next_turn_confirmation_dialog.dart',
+  'app/lib/features/game/flame/game_screen.dart',
+  'app/lib/features/game/widgets/tech_tree_widget.dart',
+  'app/lib/features/game/widgets/technology_panel.dart',
+  'app/lib/features/shell/new_game_setup_flow.dart',
+  // Split / move fleet — `SPEC/program/app-ui-wiring.md` "Split fleet" /
+  // "Move fleet" paragraphs.
+  'app/lib/features/game/widgets/naval_units_panel.dart',
+  // Land armies — `SPEC/program/app-ui-wiring.md` "Land armies" paragraph
+  // (split / move army; invasion confirm sub-dialog of move army).
+  'app/lib/features/game/widgets/military_units_panel.dart',
+  'app/lib/features/game/widgets/move_army_dialog.dart',
+  // Deferred per #2626 scope (game-side menu game-parameters dialog and
+  // production breakdown). Migrating these to typed bus events is
+  // explicitly out of scope for #2626 and must be filed as separate
+  // issues before removal from this allow-list.
+  'app/lib/features/game/flame/game_side_menu.dart',
+  'app/lib/features/game/screens/production_screen.dart',
+};
+
+const _scanRoot = 'app/lib';
+const _excludedRoot = 'app/lib/widgetbook';
+const _featuresRoot = 'app/lib/features';
+
+int runCheckAppEventBusDecoupling(
+  String repoRoot, {
+  void Function(String line)? info,
+  void Function(String line)? err,
+}) {
+  final logI = info ?? stdout.writeln;
+  final logE = err ?? stderr.writeln;
+  final root = p.normalize(repoRoot);
+  final libDir = Directory(p.join(root, _scanRoot));
+  if (!libDir.existsSync()) {
+    logE('check_app_event_bus_decoupling: $_scanRoot not found.');
+    return 1;
+  }
+
+  final singletonViolations = <String>[];
+  final navigatorKeyViolations = <String>[];
+  final dialogViolations = <String>[];
+
+  for (final entity in libDir.listSync(recursive: true, followLinks: false)) {
+    if (entity is! File || !entity.path.endsWith('.dart')) {
+      continue;
+    }
+    final relativePath = p.posix.joinAll(
+      p.split(p.relative(entity.path, from: root)),
+    );
+    if (relativePath.startsWith('$_excludedRoot/')) {
+      continue;
+    }
+    final content = entity.readAsStringSync();
+    final parsed = parseString(content: content, path: relativePath);
+    final visitor = _AppEventBusDecouplingVisitor(
+      relativePath: relativePath,
+      lineInfo: parsed.lineInfo,
+    );
+    parsed.unit.accept(visitor);
+    singletonViolations.addAll(visitor.singletonViolations);
+    navigatorKeyViolations.addAll(visitor.navigatorKeyViolations);
+    dialogViolations.addAll(visitor.dialogViolations);
+  }
+
+  final total = singletonViolations.length +
+      navigatorKeyViolations.length +
+      dialogViolations.length;
+  if (total == 0) {
+    logI('check_app_event_bus_decoupling: no violations found.');
+    return 0;
+  }
+  logE(
+    'check_app_event_bus_decoupling: found $total violation(s):',
+  );
+  if (singletonViolations.isNotEmpty) {
+    logE(
+      ' AppEventBus() singleton calls (use appEventBusProvider or '
+      'AppEventBus.create()):',
+    );
+    for (final v in singletonViolations) {
+      logE(' - $v');
+    }
+  }
+  if (navigatorKeyViolations.isNotEmpty) {
+    logE(
+      ' appNavigatorKey property access outside core/services/ + app.dart '
+      '(thread GlobalKey<NavigatorState> explicitly):',
+    );
+    for (final v in navigatorKeyViolations) {
+      logE(' - $v');
+    }
+  }
+  if (dialogViolations.isNotEmpty) {
+    logE(
+      ' showDialog / showModalBottomSheet in features/ outside the '
+      'documented local-by-design allow-list (emit an AppEvent instead):',
+    );
+    for (final v in dialogViolations) {
+      logE(' - $v');
+    }
+  }
+  return 1;
+}
+
+class _AppEventBusDecouplingVisitor extends RecursiveAstVisitor<void> {
+  _AppEventBusDecouplingVisitor({
+    required this.relativePath,
+    required this.lineInfo,
+  });
+
+  final String relativePath;
+  final LineInfo lineInfo;
+
+  final List<String> singletonViolations = <String>[];
+  final List<String> navigatorKeyViolations = <String>[];
+  final List<String> dialogViolations = <String>[];
+
+  bool get _appNavigatorKeyAllowed {
+    for (final prefix in _appNavigatorKeyAllowedPathPrefixes) {
+      if (prefix.endsWith('/')) {
+        if (relativePath.startsWith(prefix)) return true;
+      } else if (relativePath == prefix) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  bool get _isFeatureFile => relativePath.startsWith('$_featuresRoot/');
+
+  bool get _featureFileAllowed =>
+      _allowedFeatureLocalDialogFiles.contains(relativePath);
+
+  @override
+  void visitInstanceCreationExpression(InstanceCreationExpression node) {
+    final type = node.constructorName.type;
+    final name = type.name.lexeme;
+    final ctorName = node.constructorName.name?.name;
+    if (name == _disallowedSingletonName && ctorName == null) {
+      singletonViolations.add(_format(node.offset));
+    }
+    super.visitInstanceCreationExpression(node);
+  }
+
+  bool _isAppEventBusBareCall(MethodInvocation node) {
+    // `parseString` does not resolve types, so `AppEventBus()` is parsed as a
+    // MethodInvocation (target == null, methodName == 'AppEventBus') instead
+    // of an InstanceCreationExpression. Detect that shape directly. Named
+    // constructors such as `AppEventBus.create()` parse as MethodInvocation
+    // with target == SimpleIdentifier('AppEventBus'); those must not trigger.
+    if (node.target != null) return false;
+    if (node.methodName.name != _disallowedSingletonName) return false;
+    return node.argumentList.arguments.isEmpty;
+  }
+
+  @override
+  void visitPrefixedIdentifier(PrefixedIdentifier node) {
+    _checkAppNavigatorKeyAccess(node.prefix, node);
+    super.visitPrefixedIdentifier(node);
+  }
+
+  @override
+  void visitPropertyAccess(PropertyAccess node) {
+    final target = node.target;
+    if (target is SimpleIdentifier) {
+      _checkAppNavigatorKeyAccess(target, node);
+    }
+    super.visitPropertyAccess(node);
+  }
+
+  void _checkAppNavigatorKeyAccess(SimpleIdentifier target, AstNode node) {
+    if (target.name != 'appNavigatorKey') return;
+    if (_appNavigatorKeyAllowed) return;
+    navigatorKeyViolations.add(_format(node.offset));
+  }
+
+  @override
+  void visitMethodInvocation(MethodInvocation node) {
+    if (_isAppEventBusBareCall(node)) {
+      singletonViolations.add(_format(node.offset));
+    }
+    if (_isFeatureFile && !_featureFileAllowed) {
+      final name = node.methodName.name;
+      if (name == 'showDialog' || name == 'showModalBottomSheet') {
+        // Only flag top-level / library calls (no explicit target other than a
+        // package reference). This keeps `someObj.showDialog(...)` overloads
+        // from false-positiving; in practice the Flutter free functions have
+        // no target.
+        if (node.target == null) {
+          dialogViolations.add(_format(node.offset));
+        }
+      }
+    }
+    super.visitMethodInvocation(node);
+  }
+
+  String _format(int offset) {
+    final loc = lineInfo.getLocation(offset);
+    return '$relativePath:${loc.lineNumber}';
+  }
+}
+
+void main() {
+  exit(runCheckAppEventBusDecoupling(Directory.current.path));
+}

--- a/tool/ct_repo_lint_lib.dart
+++ b/tool/ct_repo_lint_lib.dart
@@ -4,8 +4,9 @@ import 'dart:io';
 import 'package:path/path.dart' as p;
 import 'package:yaml/yaml.dart';
 
-import 'check_app_hardcoded_ui_strings.dart';
+import 'check_app_event_bus_decoupling.dart';
 import 'check_app_event_handler_scope_logic_boundary.dart';
+import 'check_app_hardcoded_ui_strings.dart';
 import 'check_app_no_duplicate_helpers.dart';
 import 'check_app_widget_imports.dart';
 import 'check_asset_path_constants.dart';
@@ -729,6 +730,8 @@ int? _tryRunDartRuleInProcess({
       return runCheckDebugConsoleSharedHelpers(repoRoot);
     case 'repo.app_event_handler_scope_logic_boundary':
       return runCheckAppEventHandlerScopeLogicBoundary(repoRoot);
+    case 'repo.app_event_bus_decoupling':
+      return runCheckAppEventBusDecoupling(repoRoot);
     case 'repo.control_flow_nesting_depth':
       return runCheckControlFlowNestingDepth(repoRoot);
     case 'repo.repeated_magic_numbers':

--- a/tool/ct_repo_lint_manifest.yaml
+++ b/tool/ct_repo_lint_manifest.yaml
@@ -172,6 +172,13 @@ rules:
     runner: dart
     script: tool/check_app_event_handler_scope_logic_boundary.dart
 
+  - rule_id: repo.app_event_bus_decoupling
+    group: architecture
+    title: app/lib must decouple via AppEventBus / appNavigatorKey choke point (Refs #2626)
+    spec: SPEC/program/app-ui-wiring.md
+    runner: dart
+    script: tool/check_app_event_bus_decoupling.dart
+
   - rule_id: repo.subscription_tracker
     group: structure
     title: app feature subscriptions must use SubscriptionTracker


### PR DESCRIPTION
## Summary

Close the two production-code decoupling leaks identified in #2626 and add a CI gate (`repo.app_event_bus_decoupling`) so the architecture invariants stay enforced.

| Concern | Before | After |
|---------|--------|-------|
| `app.dart:46` debug-log menu | `AppEventBus().emit(...)` singleton (contradicts `app_event_bus_provider.dart` doc contract) | `ref.read(appEventBusProvider).emit(...)` via the provider |
| `new_game_setup_flow.dart:103,117` async flow | Hidden `appNavigatorKey.currentContext` lookup after the leader dialog popped | Explicit `GlobalKey<NavigatorState>` parameter on `runNewGameSetupAfterLeaderPick`, `_showNewGameProgressDialog`, `_showNewGameErrorDialog`; caller threads `appNavigatorKey` through |
| `providers/turn_resolution_blocking_provider.dart` `clearTurnResolutionBlockingFlag()` | `appNavigatorKey.currentContext` access inside `app/lib/providers/` (forbidden by AC5) | Helper moved to `app/lib/core/services/turn_resolution_blocking_service.dart` (documented navigator-key choke point); callers re-import from `core/services/` |

The local-by-design `showDialog` calls in the new-game progress and error dialogs keep their `useRootNavigator: true` semantics unchanged — the only change is **how** the navigator handle reaches them (parameter, not global).

## CI / enforcement

New manifest rule **`repo.app_event_bus_decoupling`** (analyzer AST, `tool/check_app_event_bus_decoupling.dart`) gates three invariants on `app/lib/**`:

1. **No `AppEventBus()` singleton** in production code (excluding `app/lib/widgetbook/`).
2. **`appNavigatorKey.currentContext` / `.currentState` / equivalent property access** restricted to `app/lib/core/services/**` and `app/lib/app.dart`.
3. **`showDialog` / `showModalBottomSheet` in `app/lib/features/**`** restricted to a documented `SPEC/program/app-ui-wiring.md` "Local by design" allow-list (plus the per-panel carve-outs for split/move fleet, move army, train at-capital). New call sites outside the list must use a typed `AppEvent` instead.

Wired through `tool/ct_repo_lint_manifest.yaml` + `tool/ct_repo_lint_lib.dart`. The existing `dart test test/check_*_test.dart` glob in `quality.yml` picks up the new test automatically.

## ACs covered

- **AC1** — macOS Debug-log menu uses `appEventBusProvider` (no `AppEventBus()` singleton).
- **AC2** — `new_game_setup_flow.dart` no longer reads `appNavigatorKey.currentContext`; navigator key arrives as an explicit `GlobalKey<NavigatorState>` parameter visible at every signature.
- **AC3** — Existing bus tests (`app_event_handler_test.dart`, `app_event_bus_test.dart`, `game_to_ui_bus_listener_test.dart`, `app_event_handler_scope_*_test.dart`, `shell_screen_test.dart`, `turn_resolution_event_blocking_test.dart`) continue to pass.
- **AC4** — New `check_app_event_bus_decoupling.dart` gate passes on the repo (verified locally via `dart run tool/ct_repo_lint.dart --rule repo.app_event_bus_decoupling`).
- **AC5** — `appNavigatorKey.currentContext` / `.currentState` no longer appears under `app/lib/providers/` or `app/lib/features/`; only `app/lib/core/services/` and `app/lib/app.dart`.
- **AC6** — No `AppEventBus()` singleton construction in production `app/lib/`.

## Deferred (kept on the lint allow-list with annotated rationale)

Per issue § Non-goals / Deferred:

- `GameParametersDialog` / `_openGameParameters` (`game_side_menu.dart`) — needs its own issue once the SPEC carve-out is decided.
- `ProductionCommodityBreakdownDialog` (`production_screen.dart`) — local affordance inside a full-screen route; not in current SPEC list.
- `_showExitToMainMenuConfirmDialog` (`game_screen.dart`) — already SPEC-allowed (`SPEC/program/app-ui-wiring.md` line 84); any change requires a SPEC update first **and** a `barrierDismissible` extension to `ConfirmDialogEvent`.

These remain in `tool/check_app_event_bus_decoupling.dart` `_allowedFeatureLocalDialogFiles` with comments calling out the deferral so future PRs can remove them as separate refactors.

## Tests

- `test/check_app_event_bus_decoupling_test.dart` — 12 tests covering positive (allow-listed paths, widgetbook exemption, `AppEventBus.create()`) and negative (singleton call, navigator-key leak in `providers/`/`features/`, new `showDialog` outside allow-list, method-target sanity check) paths for each sub-check.
- `app/test/new_game_setup_flow_test.dart` — 2 widget tests:
  - **Negative:** detached `GlobalKey<NavigatorState>` (no attached navigator) → flow returns early without invoking the game service.
  - **Positive:** key attached via `MaterialApp` → flow reaches `createNewGameAsync` exactly once.

### Local verification

- `dart test test/check_app_event_bus_decoupling_test.dart` → `00:00 +12: All tests passed!`
- `flutter test app/test/new_game_setup_flow_test.dart` → `00:02 +2: All tests passed!`
- `flutter test app/test/shell_screen_test.dart app/test/turn_resolution_event_blocking_test.dart` → 5 tests pass
- `flutter test app/test/app_event_handler_scope*_test.dart` → 35 tests pass
- `dart test test/check_*_test.dart` (full lint test group) → 249 tests pass
- `dart test test/ct_repo_lint*_test.dart` → 30 tests pass
- `dart run tool/ct_repo_lint.dart --rule repo.app_event_bus_decoupling` → `all 1 rule(s) passed`
- `dart analyze tool/check_app_event_bus_decoupling.dart test/check_app_event_bus_decoupling_test.dart` → no issues

Refs #2626

Made with [Cursor](https://cursor.com)