### PR TITLE
test(ai): pin COLONIAL-lite colonial naval ALLOW at planner output (Refs #2509)

### DIFF
--- a/packages/colonizethis_ai/test/domain_planner_orchestrator_colonial_lite_invasion_army_move_suppression_test.dart
+++ b/packages/colonizethis_ai/test/domain_planner_orchestrator_colonial_lite_invasion_army_move_suppression_test.dart
@@ -1,0 +1,446 @@
+// Pins the COLONIAL-lite phase **NW invasion army move suppression** at the
+// `runDomainPlanners` integration boundary (Refs #2509 S10).
+//
+//   SPEC/ai/ai-architecture.md § Observer goal phases (Full AI), COLONIAL-lite:
+//     "turn >= kObserverColonialLiteMinTurn (120), OW
+//      >= kObserverColonialLiteNearQuotaOw (9) and below quota, global
+//      newWorld| not all GP-owned: allows establishOverture, colonial
+//      naval/cargo; suppresses NW declareWar, **invasion army moves**, and
+//      purchase_land only."
+//
+// Coverage map for the COLONIAL-lite three-part suppression contract at the
+// orchestrator boundary:
+//
+// | Suppression                       | Existing orchestrator pin                                                |
+// |-----------------------------------|--------------------------------------------------------------------------|
+// | NW `purchase_land` (work)         | `domain_planner_orchestrator_colonial_lite_test.dart`                    |
+// | NW `declareWar` (diplomacy)       | `domain_planner_orchestrator_colonial_lite_declare_war_suppression_test` |
+// | NW invasion `ArmyMoveOrder`       | **this file**                                                            |
+//
+// The underlying predicate
+// (`shouldSuppressNewWorldDeclareWarInvasionAndPurchase` returning `true` in
+// COLONIAL-lite) is pinned at the unit level in
+// `observer_goal_phase_test.dart` group `observerGoalPhaseFor`. The
+// **conquest-planner integration** that consumes that predicate — building
+// the `invadable` set (`conquest_planner.dart:162-169`) and short-circuiting
+// `_scoreArmyMoveDestination` to `0` for NW invadable destinations
+// (`conquest_planner.dart:457-464`) under
+// `shouldSuppressNewWorldDeclareWarInvasionAndPurchase` — is not currently
+// asserted at the `runDomainPlanners` boundary for the COLONIAL-lite branch.
+// A tuning slice that left the predicate intact but rewired the conquest
+// planner (for example by using `shouldSuppressNewWorldColonialOrders`
+// (EXPAND-only) instead, or by dropping the NW short-circuit in
+// `_scoreArmyMoveDestination`) could silently emit NW invasion army moves
+// from near-quota GPs at turn 120, eroding OW expansion pressure exactly
+// when the COLONIAL-lite safeguard is supposed to keep both OW and NW
+// progress in motion without trading the turn-100 OW gate for NW work.
+//
+// The mixed-candidate fixture mirrors
+// `domain_planner_orchestrator_expand_nw_work_suppression_test.dart`'s sibling
+// pin "EXPAND conquest army move prefers OW invadable minor over NW tribe":
+// one OW invadable minor + one NW tribe province as the two army-move
+// candidates for a single field army. In COLONIAL-lite the OW path stays
+// invadable (the GP is below quota and at war with the minor), while the NW
+// path must be scored to `0` by
+// `shouldSuppressNewWorldDeclareWarInvasionAndPurchase` and dropped by the
+// conquest planner's stalled multi-army selection. The negative control
+// re-runs the same fixture at OW=10 (COLONIAL) where the NW invasion
+// suppression must not fire — proving the orchestrator does not over-suppress
+// NW army moves once the OW quota is met.
+//
+// Coverage layers:
+//   - Positive (COLONIAL-lite): NW invasion army move dropped, OW invadable
+//     army move kept (chosen by the stalled multi-army fallback).
+//   - Negative control (COLONIAL): same fixture at OW=10; NW invasion army
+//     move survives because COLONIAL is the only phase where
+//     `shouldSuppressNewWorldDeclareWarInvasionAndPurchase` returns `false`.
+//   - Determinism guard (must-have #7): identical COLONIAL-lite inputs
+//     produce identical army move order fingerprints across runs.
+
+import 'package:colonizethis_test/test.dart';
+import 'package:colonizethis_ai/colonizethis_ai.dart';
+import 'package:colonizethis_ai/src/planning/observer_goal_phase.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import 'domain_planner_test_fake_api.dart';
+
+const String _nationId = 'gp1';
+const String _tribeId = 'tribe1';
+const String _minorId = 'minor1';
+const String _owProvincePrefix = 'oldWorld|gp1_';
+const String _owMinorProvince = 'oldWorld|minor1_p0';
+const String _owFieldArmyHome = 'oldWorld|gp1_0';
+const String _nwTribeProvince = 'newWorld|tribe1_nw0';
+const String _fieldArmyId = 'field_a';
+
+// 9 OW provinces matches `kObserverColonialLiteNearQuotaOw`; turn 120 vs an
+// earlier turn flips the COLONIAL-lite / EXPAND decision in
+// `isObserverColonialLitePhase`. The COLONIAL negative control raises OW to 10
+// (quota met) and reuses the same fixture otherwise.
+List<String> _gpOwProvincesAt(int count) => <String>[
+  for (var i = 0; i < count; i++) '$_owProvincePrefix$i',
+];
+
+/// Builds a GP scenario with:
+///   - `gpOwProvinceCount` GP-owned OW provinces (9 → near-quota; 10 → quota).
+///   - One OW minor-owned invadable province (`_owMinorProvince`) the GP is
+///     already at war with — gives the stalled multi-army fallback a positive
+///     OW candidate so the COLONIAL-lite suppression's effect (drop NW) is
+///     observable as a phase contract, not a "nothing selected" side effect.
+///   - One tribe-owned NW province (`_nwTribeProvince`) that the GP is at war
+///     with — satisfies both
+///     [globalNewWorldHasNonGpOwnership] (COLONIAL-lite precondition) and the
+///     `filterArmyMoveOrdersByDiplomacy` at-war passthrough so the NW invasion
+///     candidate reaches the conquest planner's scoring path.
+///   - One field army stationed in the GP's home OW province so the fake API
+///     can submit cross-region army-move candidates with consistent army id.
+Game _scenarioGame({
+  required int turnNumber,
+  required int gpOwProvinceCount,
+}) {
+  final gpOwProvinces = _gpOwProvincesAt(gpOwProvinceCount);
+  return Game(
+    id: 'g-2509-colonial-lite-invasion-army-move-suppression',
+    worldState: WorldState(
+      turnState: TurnState(
+        phase: TurnPhase.orders,
+        turnNumber: turnNumber,
+      ),
+      oldWorld: RegionData(
+        provinces: [
+          for (final id in gpOwProvinces)
+            Province(id: id, regionId: 'oldWorld', ownerId: _nationId),
+          const Province(
+            id: _owMinorProvince,
+            regionId: 'oldWorld',
+            ownerId: _minorId,
+          ),
+        ],
+      ),
+      newWorld: const RegionData(
+        provinces: [
+          Province(
+            id: _nwTribeProvince,
+            regionId: 'newWorld',
+            ownerId: _tribeId,
+          ),
+        ],
+      ),
+      armies: [
+        Army(
+          id: homeArmyIdFor(_nationId),
+          ownerId: _nationId,
+          regionId: 'oldWorld',
+          stationedProvinceId: _owFieldArmyHome,
+          regimentUnitIds: const ['u_home'],
+          isHomeArmy: true,
+        ),
+        Army(
+          id: _fieldArmyId,
+          ownerId: _nationId,
+          regionId: 'oldWorld',
+          stationedProvinceId: _owFieldArmyHome,
+          regimentUnitIds: const ['u_field'],
+          isHomeArmy: false,
+        ),
+      ],
+    ),
+    players: const [
+      Player(
+        id: _nationId,
+        displayName: 'GP1',
+        isHuman: false,
+        leaderKey: 'henry',
+      ),
+    ],
+    tribes: const [Tribe(id: _tribeId, displayName: 'T1')],
+    minorNations: const [MinorNation(id: _minorId, displayName: 'M1')],
+    diplomacyRelations: const [
+      DiplomacyRelation(
+        factionId1: _nationId,
+        factionId2: _tribeId,
+        state: RelationState.atWar,
+        score: -20,
+      ),
+      DiplomacyRelation(
+        factionId1: _nationId,
+        factionId2: _minorId,
+        state: RelationState.atWar,
+        score: -20,
+      ),
+    ],
+  );
+}
+
+/// Fake suggestion API surfacing the two phase-distinguishing army-move
+/// candidates: one OW invadable minor (must survive in COLONIAL-lite) and one
+/// NW tribe invadable (must be dropped in COLONIAL-lite, kept in COLONIAL).
+///
+/// Mirrors `_mixedOwNwArmyMoveApi` from
+/// `domain_planner_orchestrator_expand_nw_work_suppression_test.dart` so the
+/// two phase pins exercise the same orchestrator code path with the same
+/// candidate shape.
+const FakeOrderSuggestionAPIForDomainPlannerTests _mixedOwNwArmyMoveApi =
+    FakeOrderSuggestionAPIForDomainPlannerTests(
+  work: [],
+  build: [],
+  move: [],
+  research: [],
+  navalMove: [],
+  navalMission: [],
+  armyMove: [
+    ArmyMoveOrder(
+      armyId: _fieldArmyId,
+      destinationProvinceId: _nwTribeProvince,
+    ),
+    ArmyMoveOrder(
+      armyId: _fieldArmyId,
+      destinationProvinceId: _owMinorProvince,
+    ),
+  ],
+);
+
+const EconomyPlan _economyPlan = EconomyPlan(
+  productionAssignments: [],
+  cargoPreference: CargoPreference.none,
+);
+
+// `henry` + `merchant` matches `domain_planner_orchestrator_colonial_lite_test`
+// so the existing COLONIAL-lite pin and this army-move pin share personality
+// inputs and a regression that selectively breaks one phase decision is more
+// likely to fail both files together (helps triage).
+const AIConfig _aiConfig = AIConfig(
+  leaderId: 'henry',
+  personalityId: 'henry',
+  hiddenAgendaId: 'merchant',
+);
+
+AIWorldSnapshot _snapshotFor({required int oldWorldProvincesOwned}) {
+  return AIWorldSnapshot(
+    playerId: _nationId,
+    threats: const ThreatSummary(atWarWith: [_minorId, _tribeId]),
+    opportunities: const OpportunitySummary(),
+    conquest: ConquestSummary(
+      oldWorldProvincesOwned: oldWorldProvincesOwned,
+      invadableProvinceIdsSorted: const [_owMinorProvince],
+    ),
+    colonial: const ColonialSummary(
+      invadableNewWorldProvinceIdsSorted: [_nwTribeProvince],
+      adjacentNewWorldOwnerFactionIdsSorted: [_tribeId],
+      preferredColonialTargetFactionIdsSorted: [_tribeId],
+    ),
+    economy: const EconomySummary(ownProvinceCount: 9),
+    relations: const {
+      _tribeId: DiplomacyRelation(
+        factionId1: _nationId,
+        factionId2: _tribeId,
+        state: RelationState.atWar,
+        score: -20,
+      ),
+      _minorId: DiplomacyRelation(
+        factionId1: _nationId,
+        factionId2: _minorId,
+        state: RelationState.atWar,
+        score: -20,
+      ),
+    },
+  );
+}
+
+List<ArmyMoveOrder> _armyMoves(Orders orders) =>
+    orders.armyMoveOrdersByPlayerId[_nationId] ?? const [];
+
+void main() {
+  group('runDomainPlanners COLONIAL-lite NW invasion army move suppression', () {
+    test(
+      'COLONIAL-lite drops NW invasion army move, keeps OW invadable minor move',
+      () {
+        // Turn 120 + OW=9 + tribe-owned NW = COLONIAL-lite per
+        // `isObserverColonialLitePhase`. The conquest planner is in stalled
+        // expansion (below quota), so the multi-army fallback path runs.
+        final game = _scenarioGame(
+          turnNumber: kObserverColonialLiteMinTurn,
+          gpOwProvinceCount: kObserverColonialLiteNearQuotaOw,
+        );
+        const topology = MapTopology(nodes: [], edges: []);
+        final view = buildPlayerView(game, topology, _nationId);
+        final snapshot = _snapshotFor(
+          oldWorldProvincesOwned: kObserverColonialLiteNearQuotaOw,
+        );
+
+        expect(
+          observerGoalPhaseFor(snapshot: snapshot, game: game),
+          ObserverGoalPhase.colonialLite,
+          reason:
+              'Fixture must place GP in COLONIAL-lite so the SPEC § '
+              'COLONIAL-lite "invasion army moves" suppression is exercised '
+              'by the orchestrator. EXPAND would over-suppress unrelated '
+              'paths (work / overture) so the COLONIAL-lite branch must own '
+              'this contract.',
+        );
+
+        final orders = runDomainPlanners(
+          game: game,
+          topology: topology,
+          nationId: _nationId,
+          view: view,
+          snapshot: snapshot,
+          config: _aiConfig,
+          primaryGoal: StrategicGoal.expand,
+          seeds: AISeedBundle.fromTurnSeed(2509240),
+          suggestionAPI: _mixedOwNwArmyMoveApi,
+          economyPlan: _economyPlan,
+        );
+
+        final armyMoves = _armyMoves(orders);
+        expect(
+          armyMoves,
+          isNotEmpty,
+          reason:
+              'COLONIAL-lite is still below the OW quota and at war with an '
+              'invadable OW minor — the conquest planner must emit the OW '
+              'army move so the suppression contract is observable as a '
+              'phase choice rather than a "no orders" side effect.',
+        );
+        expect(
+          armyMoves.any(
+            (m) => m.destinationProvinceId == _nwTribeProvince,
+          ),
+          isFalse,
+          reason:
+              'COLONIAL-lite must drop NW invasion army moves (SPEC § '
+              'COLONIAL-lite: suppress list is "NW declareWar, invasion '
+              'army moves, purchase_land only"). A surviving NW '
+              'army move here indicates either the conquest planner '
+              'stopped consulting shouldSuppressNewWorldDeclareWarInvasion'
+              'AndPurchase when building the invadable set / scoring NW '
+              'destinations, or the orchestrator started forwarding the '
+              'EXPAND predicate (shouldSuppressNewWorldColonialOrders) — '
+              'both regressions would let near-quota GPs at turn 120 '
+              'burn turns invading tribes instead of pushing to OW=10.',
+        );
+        expect(
+          armyMoves.any(
+            (m) => m.destinationProvinceId == _owMinorProvince,
+          ),
+          isTrue,
+          reason:
+              'COLONIAL-lite must keep the OW invadable minor army move so '
+              'GPs near the OW quota continue applying expansion pressure '
+              'toward the turn-100 / turn-120 OW threshold (must-have #5: '
+              'OW conquest pressure not weakened by NW work).',
+        );
+      },
+    );
+
+    test(
+      'COLONIAL control: turn 120 with OW=10 keeps NW invasion army move',
+      () {
+        // Same turn 120 + tribe-owned NW fixture, but OW=10 meets the
+        // observer quota → phase becomes COLONIAL. COLONIAL is the only
+        // phase where shouldSuppressNewWorldDeclareWarInvasionAndPurchase
+        // returns false; the NW invasion army move must survive.
+        final game = _scenarioGame(
+          turnNumber: kObserverColonialLiteMinTurn,
+          gpOwProvinceCount: kObserverConquestMinOwProvincesPerGp,
+        );
+        const topology = MapTopology(nodes: [], edges: []);
+        final view = buildPlayerView(game, topology, _nationId);
+        final snapshot = _snapshotFor(
+          oldWorldProvincesOwned: kObserverConquestMinOwProvincesPerGp,
+        );
+
+        expect(
+          observerGoalPhaseFor(snapshot: snapshot, game: game),
+          ObserverGoalPhase.colonial,
+          reason:
+              'Negative-control fixture must place GP in COLONIAL so the '
+              'COLONIAL-lite suppression is verified to **not** fire here. '
+              'Otherwise a regression that mis-tags COLONIAL as COLONIAL-'
+              'lite (over-suppressing post-quota NW invasion) would also '
+              'pass the positive case.',
+        );
+
+        final orders = runDomainPlanners(
+          game: game,
+          topology: topology,
+          nationId: _nationId,
+          view: view,
+          snapshot: snapshot,
+          config: _aiConfig,
+          primaryGoal: StrategicGoal.conquer,
+          seeds: AISeedBundle.fromTurnSeed(2509241),
+          suggestionAPI: _mixedOwNwArmyMoveApi,
+          economyPlan: _economyPlan,
+        );
+
+        final armyMoves = _armyMoves(orders);
+        expect(
+          armyMoves.any(
+            (m) => m.destinationProvinceId == _nwTribeProvince,
+          ),
+          isTrue,
+          reason:
+              'COLONIAL must allow NW invasion army moves toward visible '
+              'colonial targets — this is the key contract differentiating '
+              'COLONIAL from COLONIAL-lite. A dropped NW move here means '
+              'the COLONIAL-lite suppression leaked into COLONIAL and the '
+              'orchestrator is over-filtering post-quota NW work (which '
+              'would make the turn-150 NW ownership gate unreachable).',
+        );
+      },
+    );
+
+    test(
+      'emits identical army move orders for identical COLONIAL-lite inputs',
+      () {
+        // Determinism guard for must-have #7. The COLONIAL-lite phase
+        // decision depends on game.turnNumber + snapshot.conquest +
+        // globalNewWorldHasNonGpOwnership(game); a flaky path here would
+        // mask the suppression contract by intermittently mis-tagging the
+        // phase.
+        final game = _scenarioGame(
+          turnNumber: kObserverColonialLiteMinTurn,
+          gpOwProvinceCount: kObserverColonialLiteNearQuotaOw,
+        );
+        const topology = MapTopology(nodes: [], edges: []);
+        final view = buildPlayerView(game, topology, _nationId);
+        final snapshot = _snapshotFor(
+          oldWorldProvincesOwned: kObserverColonialLiteNearQuotaOw,
+        );
+
+        Orders runOnce(int turnSeed) => runDomainPlanners(
+          game: game,
+          topology: topology,
+          nationId: _nationId,
+          view: view,
+          snapshot: snapshot,
+          config: _aiConfig,
+          primaryGoal: StrategicGoal.expand,
+          seeds: AISeedBundle.fromTurnSeed(turnSeed),
+          suggestionAPI: _mixedOwNwArmyMoveApi,
+          economyPlan: _economyPlan,
+        );
+
+        final first = runOnce(2509242);
+        final second = runOnce(2509242);
+
+        List<String> armyFingerprint(Orders orders) => <String>[
+          for (final m in _armyMoves(orders))
+            '${m.armyId}|${m.destinationProvinceId}',
+        ];
+
+        expect(
+          armyFingerprint(second),
+          armyFingerprint(first),
+          reason:
+              'Determinism (must-have #7): identical COLONIAL-lite inputs '
+              'must produce identical army move orders so a flaky phase-'
+              'gate path cannot mask the NW invasion suppression contract.',
+        );
+      },
+    );
+  });
+}

--- a/packages/colonizethis_ai/test/domain_planner_orchestrator_colonial_lite_naval_allow_test.dart
+++ b/packages/colonizethis_ai/test/domain_planner_orchestrator_colonial_lite_naval_allow_test.dart
@@ -1,0 +1,367 @@
+// Pins the COLONIAL-lite phase **naval move ALLOW** contract at the
+// `runDomainPlanners` integration boundary (Refs #2509 S10).
+//
+//   SPEC/ai/ai-architecture.md § Observer goal phases (Full AI),
+//   COLONIAL-lite: "turn >= kObserverColonialLiteMinTurn (120), OW
+//   >= kObserverColonialLiteNearQuotaOw (9) and below quota, global
+//   newWorld| not all GP-owned: **allows establishOverture, colonial
+//   naval/cargo**; suppresses NW declareWar, invasion army moves, and
+//   purchase_land only."
+//
+// Coverage map for the COLONIAL-lite contract at the orchestrator boundary:
+//
+// | Contract                          | Existing orchestrator pin                                                |
+// |-----------------------------------|--------------------------------------------------------------------------|
+// | NW `purchase_land` suppressed     | `domain_planner_orchestrator_colonial_lite_test.dart`                    |
+// | NW `build_improvement` allowed    | `domain_planner_orchestrator_colonial_lite_test.dart`                    |
+// | NW-tribe `establishOverture`      | `domain_planner_orchestrator_colonial_lite_test.dart`                    |
+// | NW `declareWar` suppressed        | `domain_planner_orchestrator_colonial_lite_declare_war_suppression_test` |
+// | NW invasion `ArmyMoveOrder`       | `domain_planner_orchestrator_colonial_lite_invasion_army_move_suppression_test` |
+// | Colonial naval move **allowed**   | **this file**                                                            |
+//
+// `runNavalPlanner` (`packages/colonizethis_ai/lib/src/planning/naval_planner.dart`)
+// gates the colonial-pressure naval boost on
+// `!shouldSuppressNewWorldColonialOrders(...)` (EXPAND-only suppression):
+//
+//   final hasColonialTargets = hasColonialAcquisitionTargets(colonial) &&
+//       !shouldSuppressNewWorldColonialOrders(
+//         snapshot: snapshot,
+//         game: ctx.game,
+//       );
+//   if (hasColonialTargets) {
+//     weight += kColonialNavalWeightBonus;          // +65
+//   }
+//   if (hasColonialTargets && weight < kColonialNavalMinWeightWhenPressure) {
+//     weight = kColonialNavalMinWeightWhenPressure; // floor 85
+//   }
+//   if (weight < 25) return ctx.orders;             // skip planner entirely
+//
+// `shouldSuppressNewWorldColonialOrders` returns `true` only in EXPAND
+// (`observer_goal_phase.dart`), so COLONIAL-lite **must** receive the
+// colonial naval boost: the SPEC explicitly allows "colonial naval/cargo"
+// in COLONIAL-lite. A tuning slice that swapped that predicate for
+// `shouldSuppressNewWorldDeclareWarInvasionAndPurchase` (which **does**
+// fire in COLONIAL-lite to gate `declareWar` / invasion / `purchase_land`)
+// would silently strip the colonial naval boost and the naval planner
+// would skip in COLONIAL-lite for a low-military leader (henry: military
+// weight 20, below the 25 floor) — eroding the "allows colonial
+// naval/cargo" half of the COLONIAL-lite safeguard exactly when the
+// near-quota GP needs naval missions to keep NW expansion alive while OW
+// expansion catches up.
+//
+// The negative control re-runs the same scenario at turn 90 so the GP
+// stays in EXPAND. EXPAND suppresses colonial naval orders via
+// `shouldSuppressNewWorldColonialOrders`, dropping `hasColonialTargets` to
+// `false`. With `primaryGoal = expand` the naval base weight resolves to
+// `domainWeights.military = 20` for henry (`ai_personality_config.dart`),
+// no colonial boost applies, and the planner short-circuits at `weight < 25`
+// — emitting **zero** naval moves. The contrast is deterministic and does
+// not depend on the rng-based `take = 1 + rng.nextInt(cap)` EXPAND fallback,
+// because the planner returns before reaching the `take` calculation.
+//
+// Coverage layers:
+//   - Positive (COLONIAL-lite): naval move toward the NW-priority sea zone
+//     is emitted; orchestrator-level evidence of "allows colonial naval".
+//   - Negative control (EXPAND): same fixture at turn 90; naval planner
+//     short-circuits (military 20 < 25 floor, no colonial boost) and no
+//     naval move orders are emitted.
+//   - Determinism guard (must-have #7): identical COLONIAL-lite inputs
+//     produce identical naval move order fingerprints across runs.
+
+import 'package:colonizethis_test/test.dart';
+import 'package:colonizethis_ai/colonizethis_ai.dart';
+import 'package:colonizethis_ai/src/planning/observer_goal_phase.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import 'domain_planner_test_fake_api.dart';
+
+const String _nationId = 'gp1';
+const String _tribeId = 'tribe1';
+const String _owProvincePrefix = 'oldWorld|gp1_';
+const String _nwTribeProvince = 'newWorld|tribe1_nw0';
+const String _fleetId = 'f_nw';
+const String _nwSeaZoneId = 'newWorld|sea_priority';
+
+// 9 GP-owned OW provinces (`kObserverColonialLiteNearQuotaOw`). At turn
+// `kObserverColonialLiteMinTurn` the GP enters COLONIAL-lite; at turn 90
+// the same OW count keeps the GP in EXPAND (the EXPAND/COLONIAL-lite
+// branch flips purely on the turn number, isolating the contract under
+// test).
+const List<String> _gp1OwProvincesNearQuota = <String>[
+  '${_owProvincePrefix}0',
+  '${_owProvincePrefix}1',
+  '${_owProvincePrefix}2',
+  '${_owProvincePrefix}3',
+  '${_owProvincePrefix}4',
+  '${_owProvincePrefix}5',
+  '${_owProvincePrefix}6',
+  '${_owProvincePrefix}7',
+  '${_owProvincePrefix}8',
+];
+
+/// Builds a near-quota GP scenario where the only NW province is owned by
+/// a tribe — satisfying `isObserverColonialLitePhase`'s
+/// `globalNewWorldHasNonGpOwnership` precondition. The Game holds no fleet
+/// units (the `runNavalPlanner` skip check fires on `weight` only; naval
+/// candidates are supplied entirely by the fake suggestion API, so the
+/// fixture stays minimal).
+Game _scenarioGame({required int turnNumber}) {
+  return Game(
+    id: 'g-2509-colonial-lite-naval-allow',
+    worldState: WorldState(
+      turnState: TurnState(
+        phase: TurnPhase.orders,
+        turnNumber: turnNumber,
+      ),
+      oldWorld: RegionData(
+        provinces: [
+          for (final id in _gp1OwProvincesNearQuota)
+            Province(id: id, regionId: 'oldWorld', ownerId: _nationId),
+        ],
+      ),
+      newWorld: const RegionData(
+        provinces: [
+          Province(
+            id: _nwTribeProvince,
+            regionId: 'newWorld',
+            ownerId: _tribeId,
+          ),
+        ],
+      ),
+    ),
+    players: const [
+      Player(
+        id: _nationId,
+        displayName: 'GP1',
+        isHuman: false,
+        // `henry` has the lowest military weight (20) among canonical
+        // leaders (`ai_personality_config.dart`). The < 25 naval skip
+        // floor depends on this — a higher-military leader (e.g.
+        // `napoleon` military=90) would emit naval moves even without
+        // the colonial boost, hiding the negative-control regression.
+        leaderKey: 'henry',
+      ),
+    ],
+    tribes: const [Tribe(id: _tribeId, displayName: 'T1')],
+    minorNations: const [],
+  );
+}
+
+/// Fake API surfaces a single colonial naval move candidate (toward a
+/// `newWorld|` sea zone) so the orchestrator output cleanly reflects
+/// whether the naval planner ran or short-circuited.
+const FakeOrderSuggestionAPIForDomainPlannerTests _navalCandidateApi =
+    FakeOrderSuggestionAPIForDomainPlannerTests(
+  work: [],
+  build: [],
+  move: [],
+  research: [],
+  navalMove: [
+    NavalMoveOrder(
+      fleetId: _fleetId,
+      destinationSeaZoneId: _nwSeaZoneId,
+    ),
+  ],
+  navalMission: [],
+);
+
+const EconomyPlan _economyPlan = EconomyPlan(
+  productionAssignments: [],
+  cargoPreference: CargoPreference.none,
+);
+
+// `henry` + `merchant` matches the personality/agenda used by the COLONIAL
+// personality scoring tests
+// (`diplomatic_candidate_scoring_personality_colonial_divergence_test.dart`,
+// `observer_goal_phase_test.dart`) and by the COLONIAL-lite orchestrator
+// pin (`domain_planner_orchestrator_colonial_lite_test.dart`).
+const AIConfig _aiConfig = AIConfig(
+  leaderId: 'henry',
+  personalityId: 'henry',
+  hiddenAgendaId: 'merchant',
+);
+
+AIWorldSnapshot _nearQuotaSnapshotWithColonialTarget() {
+  return const AIWorldSnapshot(
+    playerId: _nationId,
+    threats: ThreatSummary(),
+    opportunities: OpportunitySummary(),
+    // OW 9 -> below quota. Phase decided by turn number (>= 120 enters
+    // COLONIAL-lite; otherwise EXPAND).
+    conquest: ConquestSummary(
+      oldWorldProvincesOwned: kObserverColonialLiteNearQuotaOw,
+      provincesToVictory: 22,
+    ),
+    // Visible NW tribe province satisfies `hasColonialAcquisitionTargets`
+    // — required for the colonial naval boost to engage in COLONIAL-lite.
+    colonial: ColonialSummary(
+      newWorldProvincesOwned: 0,
+      invadableNewWorldProvinceIdsSorted: [_nwTribeProvince],
+      adjacentNewWorldOwnerFactionIdsSorted: [_tribeId],
+      preferredColonialTargetFactionIdsSorted: [_tribeId],
+    ),
+    economy: EconomySummary(ownProvinceCount: 9),
+    relations: {},
+  );
+}
+
+List<NavalMoveOrder> _navalMoves(Orders orders) =>
+    orders.navalMoveOrdersByPlayerId[_nationId] ?? const [];
+
+void main() {
+  group('runDomainPlanners COLONIAL-lite naval move ALLOW contract', () {
+    test(
+      'COLONIAL-lite emits the colonial naval move candidate under the '
+      'colonial pressure boost',
+      () {
+        final game = _scenarioGame(turnNumber: kObserverColonialLiteMinTurn);
+        const topology = MapTopology(nodes: [], edges: []);
+        final view = buildPlayerView(game, topology, _nationId);
+        final snapshot = _nearQuotaSnapshotWithColonialTarget();
+
+        expect(
+          observerGoalPhaseFor(snapshot: snapshot, game: game),
+          ObserverGoalPhase.colonialLite,
+          reason:
+              'Fixture must place GP in COLONIAL-lite so the colonial naval '
+              'ALLOW contract is exercised, not EXPAND (which suppresses the '
+              'naval colonial boost) or COLONIAL (which does not require '
+              'the COLONIAL-lite safeguard).',
+        );
+
+        final orders = runDomainPlanners(
+          game: game,
+          topology: topology,
+          nationId: _nationId,
+          view: view,
+          snapshot: snapshot,
+          config: _aiConfig,
+          // `expand` (or `conquer`/`defend`) resolves the naval base
+          // weight to `domainWeights.military` for henry (20), so the
+          // colonial boost is the only path past the < 25 skip floor.
+          primaryGoal: StrategicGoal.expand,
+          seeds: AISeedBundle.fromTurnSeed(2509200),
+          suggestionAPI: _navalCandidateApi,
+          economyPlan: _economyPlan,
+        );
+
+        final navalMoves = _navalMoves(orders);
+        expect(
+          navalMoves,
+          isNotEmpty,
+          reason:
+              'COLONIAL-lite must allow colonial naval moves (SPEC § '
+              'Observer goal phases (Full AI), COLONIAL-lite allow list: '
+              '"colonial naval/cargo"). An empty list here means the '
+              'colonial naval boost has been stripped in COLONIAL-lite '
+              '(`hasColonialTargets` false) and `runNavalPlanner` skipped '
+              'at the < 25 weight floor.',
+        );
+        expect(
+          navalMoves.first.destinationSeaZoneId,
+          _nwSeaZoneId,
+          reason:
+              'The single candidate targets the visible NW sea zone — when '
+              'emitted, the colonial-pressure-ranked output must surface '
+              'that NW destination so the COLONIAL-lite safeguard actually '
+              'advances NW progress for the near-quota GP.',
+        );
+      },
+    );
+
+    test(
+      'EXPAND control: turn 90 with the same fixture skips the naval planner '
+      '(military 20 < 25 floor, no colonial boost) and emits no naval moves',
+      () {
+        // Same OW=9 + tribe-owned NW fixture, but turn 90 is below
+        // `kObserverColonialLiteMinTurn` (120) so the GP stays in EXPAND
+        // and `shouldSuppressNewWorldColonialOrders` returns `true`,
+        // dropping `hasColonialTargets` to `false` inside the naval
+        // planner.
+        final game = _scenarioGame(turnNumber: 90);
+        const topology = MapTopology(nodes: [], edges: []);
+        final view = buildPlayerView(game, topology, _nationId);
+        final snapshot = _nearQuotaSnapshotWithColonialTarget();
+
+        expect(
+          observerGoalPhaseFor(snapshot: snapshot, game: game),
+          ObserverGoalPhase.expand,
+          reason:
+              'Negative-control fixture must place GP in EXPAND so the '
+              'COLONIAL-lite naval ALLOW contract is verified to **not** '
+              'fire here. Otherwise a regression that mis-tagged EXPAND as '
+              'COLONIAL-lite (re-enabling the colonial naval boost before '
+              'turn 100) would also pass the positive case.',
+        );
+
+        final orders = runDomainPlanners(
+          game: game,
+          topology: topology,
+          nationId: _nationId,
+          view: view,
+          snapshot: snapshot,
+          config: _aiConfig,
+          primaryGoal: StrategicGoal.expand,
+          seeds: AISeedBundle.fromTurnSeed(2509201),
+          suggestionAPI: _navalCandidateApi,
+          economyPlan: _economyPlan,
+        );
+
+        expect(
+          _navalMoves(orders),
+          isEmpty,
+          reason:
+              'EXPAND must drop the colonial naval boost (SPEC § Observer '
+              'goal phases (Full AI), EXPAND suppressions: "colonial naval '
+              'ranking/caps"). With `primaryGoal = expand` and henry '
+              '(military 20), the resolved naval base weight stays below '
+              'the < 25 skip floor; any emitted naval move here means the '
+              'EXPAND colonial naval suppression has been weakened.',
+        );
+      },
+    );
+
+    test(
+      'emits identical naval move orders for identical COLONIAL-lite inputs',
+      () {
+        final game = _scenarioGame(turnNumber: kObserverColonialLiteMinTurn);
+        const topology = MapTopology(nodes: [], edges: []);
+        final view = buildPlayerView(game, topology, _nationId);
+        final snapshot = _nearQuotaSnapshotWithColonialTarget();
+
+        Orders runOnce(int turnSeed) => runDomainPlanners(
+          game: game,
+          topology: topology,
+          nationId: _nationId,
+          view: view,
+          snapshot: snapshot,
+          config: _aiConfig,
+          primaryGoal: StrategicGoal.expand,
+          seeds: AISeedBundle.fromTurnSeed(turnSeed),
+          suggestionAPI: _navalCandidateApi,
+          economyPlan: _economyPlan,
+        );
+
+        final first = runOnce(2509202);
+        final second = runOnce(2509202);
+
+        List<String> navalMoveFingerprint(Orders orders) => <String>[
+          for (final m in _navalMoves(orders))
+            '${m.fleetId}|${m.destinationSeaZoneId ?? ''}|'
+                '${m.destinationPortProvinceId ?? ''}',
+        ];
+
+        expect(
+          navalMoveFingerprint(second),
+          navalMoveFingerprint(first),
+          reason:
+              'Determinism (must-have #7): identical COLONIAL-lite inputs '
+              'must produce identical naval move orders so a flaky '
+              'colonial naval boost path cannot mask the ALLOW contract.',
+        );
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Pins the COLONIAL-lite phase **colonial naval ALLOW** contract at the `runDomainPlanners` integration boundary. Closes the only remaining COLONIAL-lite contract gap at the orchestrator boundary — naval/cargo ALLOW alongside the existing NW suppressions and overture ALLOW pins.

| Contract | Existing orchestrator pin |
|----------|---------------------------|
| NW `purchase_land` suppressed | `domain_planner_orchestrator_colonial_lite_test.dart` |
| NW `build_improvement` allowed | `domain_planner_orchestrator_colonial_lite_test.dart` |
| NW-tribe `establishOverture` allowed | `domain_planner_orchestrator_colonial_lite_test.dart` |
| NW `declareWar` suppressed | `domain_planner_orchestrator_colonial_lite_declare_war_suppression_test.dart` (#2649) |
| NW invasion `ArmyMoveOrder` suppressed | `domain_planner_orchestrator_colonial_lite_invasion_army_move_suppression_test.dart` (#2652) |
| **Colonial naval move allowed** | **this PR** |

## Why this matters

`SPEC/ai/ai-architecture.md` § Observer goal phases (Full AI), COLONIAL-lite explicitly lists `colonial naval/cargo` in the allow set. `runNavalPlanner` gates the +65 weight boost + 85 floor on `!shouldSuppressNewWorldColonialOrders(...)` (EXPAND-only suppression). For a low-military canonical leader (`henry`: military weight **20**), the colonial boost is the **only** path past the planner's `weight < 25` skip floor in COLONIAL-lite.

A tuning slice that swapped that predicate for `shouldSuppressNewWorldDeclareWarInvasionAndPurchase` (which **does** fire in COLONIAL-lite to gate `declareWar` / invasion / `purchase_land`) would silently strip the naval boost — `hasColonialTargets` drops to `false` in COLONIAL-lite, the planner short-circuits, and the COLONIAL-lite safeguard loses its NW-progress lifeline exactly when the near-quota GP needs naval missions while OW expansion catches up.

## Test layers

- **Positive (COLONIAL-lite, turn 120, OW=9, tribe-owned NW visible):** the single colonial naval move candidate (`fleetId=f_nw → destinationSeaZoneId=newWorld|sea_priority`) is emitted; the NW destination survives.
- **Negative control (EXPAND, turn 90, same OW/NW fixture):** `shouldSuppressNewWorldColonialOrders` returns `true`, `hasColonialTargets` is `false`, henry's military weight (20) keeps the naval base below the < 25 floor with no boost — the planner short-circuits and the orchestrator emits **zero** naval move orders. Log confirms: `naval skipped nationId=gp1 weight=20 < 25`.
- **Determinism guard (must-have #7):** identical COLONIAL-lite inputs produce identical naval move fingerprints across runs.

## ACs covered (scope of this slice)

This PR adds an orchestrator-level pin for the COLONIAL-lite SPEC contract (`SPEC/ai/ai-architecture.md` § Observer goal phases (Full AI)); no new ACs are introduced. The pin protects the existing AI ACs that depend on COLONIAL-lite keeping NW progress (overture / naval) alive while OW catches up to the quota.

## Deferred

None — this PR is a focused test pin only. SPEC text and runtime behavior are unchanged.

## Verification

\`\`\`
cd packages/colonizethis_ai
dart analyze test/domain_planner_orchestrator_colonial_lite_naval_allow_test.dart
# -> No issues found!
dart test test/domain_planner_orchestrator_colonial_lite_naval_allow_test.dart
# -> All tests passed!
dart test \
  test/domain_planner_orchestrator_colonial_lite_test.dart \
  test/observer_goal_phase_test.dart \
  test/observer_goal_phase_work_order_filter_branches_test.dart \
  test/domain_planner_orchestrator_colonial_lite_naval_allow_test.dart
# -> +42: All tests passed!
\`\`\`

Refs #2509

Made with [Cursor](https://cursor.com)