### PR TITLE
perf(e2e): bound production opener post-tap wait (Refs #2336)

### DIFF
--- a/app/integration_test/e2e_test_shared_panels.dart
+++ b/app/integration_test/e2e_test_shared_panels.dart
@@ -425,29 +425,23 @@ Future<void> e2eOpenProductionPanel(
         perf?.timing('open_panel_production', sw.elapsed);
         return;
       }
-      idlePollMs = 25;
       await tester.pump();
       if (productionPanel.evaluate().isNotEmpty) {
         perf?.timing('open_panel_production', sw.elapsed);
         return;
       }
-      await e2eWaitUntilFound(
-        tester,
-        productionPanel,
-        timeout: const Duration(seconds: 5),
-        perf: perf,
-        phaseName: 'wait_until_production_panel_after_rail_tap',
-      );
-      if (productionPanel.evaluate().isNotEmpty) {
-        perf?.timing('open_panel_production', sw.elapsed);
-        return;
-      }
+      // Match civilian/naval `tryOpen` contract: bounded poll without `fail()`
+      // so the outer opener loop can dismiss transient overlays and retry the
+      // rail tap when a race covers the panel mount. Without this, a single
+      // rail-tap miss surfaced as a hard `TestFailure` (`wait_until_...` path)
+      // even though the outer loop still had budget to recover. Aligns with
+      // PR #2555 fix for the naval opener (Refs GitHub #2336).
       if (await e2ePumpUntilConditionOrIdle(
         tester,
         () => productionPanel.evaluate().isNotEmpty,
-        timeout: const Duration(milliseconds: 600),
+        timeout: const Duration(seconds: 5),
         perf: perf,
-        phaseName: 'pump_until_production_panel_after_rail_tap_miss',
+        phaseName: 'pump_until_production_panel_after_rail_tap',
       )) {
         perf?.timing('open_panel_production', sw.elapsed);
         return;

--- a/app/test/e2e_open_production_panel_test.dart
+++ b/app/test/e2e_open_production_panel_test.dart
@@ -9,9 +9,18 @@
 /// in the unit-test layer so a future refactor cannot silently regress the
 /// short-circuit or tap-once-then-detect-mount paths.
 ///
+/// The opener previously used `e2eWaitUntilFound + fail()` for the post-rail-
+/// tap wait, mirroring the naval opener defect surfaced and fixed in PR #2555.
+/// The production opener now uses `e2ePumpUntilConditionOrIdle` (bounded poll
+/// without `fail()`) so a single rail-tap that fails to mount the panel does
+/// not surface as a hard `TestFailure` from the inner wait — instead, the
+/// outer opener loop dismisses any racing overlays/sheets and re-taps the
+/// rail until the overall [timeout] elapses. The negative test below still
+/// pins outer-timeout failure semantics.
+///
 /// Refs GitHub #2336 (AC2 — shared helpers used by E2E tests; AC5 — adaptive
 /// polling with pre-pump short-circuit; AC10 — no silent flakiness from
-/// timeout regressions).
+/// timeout regressions); aligns with PR #2555 fix for the naval opener.
 library;
 
 import 'package:colonizethis_app/config/ct_e2e.dart';
@@ -122,6 +131,83 @@ void main() {
       );
     },
   );
+
+  testWidgets(
+    'e2eOpenProductionPanel timeout failure surfaces the outer opener message, '
+    'not the inner post-tap wait',
+    (WidgetTester tester) async {
+      // Rail button is present but tapping it never mounts the panel, so the
+      // inner post-rail-tap wait must exhaust without `fail()`-ing the helper.
+      // Once the outer timeout elapses, the failure must come from the outer
+      // `Timed out opening production panel` path (PR #2555 contract for the
+      // naval opener; this pins the same contract for production).
+      await tester.pumpWidget(
+        const MaterialApp(home: _NoOpProductionRailHarness()),
+      );
+      expect(find.byKey(kEmpireProductionButtonKey), findsOneWidget);
+      expect(find.byKey(kCtE2EProductionPanelRootKey), findsNothing);
+      Object? caught;
+      try {
+        await e2eOpenProductionPanel(
+          tester,
+          // Small outer timeout keeps the test bounded; the inner 5s post-tap
+          // poll is the path under test — it must return without `fail()`.
+          timeout: const Duration(milliseconds: 250),
+        );
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught, isA<TestFailure>());
+      final message = caught.toString();
+      expect(
+        message,
+        contains('Timed out opening production panel'),
+        reason:
+            'After the post-rail-tap wait is bounded by '
+            '`e2ePumpUntilConditionOrIdle` (no `fail()`), only the outer '
+            'opener loop owns the timeout failure path. A regression to '
+            '`e2eWaitUntilFound` would surface the inner `Timed out after Ns '
+            'waiting for ...` message instead (Refs GitHub #2336; aligns '
+            'with PR #2555 fix for the naval opener).',
+      );
+      expect(
+        message,
+        isNot(contains('wait_until_production_panel_after_rail_tap')),
+        reason:
+            'The legacy inner-wait phase name must not appear in any failure '
+            'path; the helper now uses `pump_until_...` semantics so the '
+            'outer loop can dismiss racing overlays and retry the rail tap '
+            '(Refs GitHub #2336).',
+      );
+    },
+  );
+}
+
+/// Test harness where the production rail button is present but tapping it
+/// never mounts the panel root. Used by the failure-message pin to validate
+/// that the helper's post-rail-tap wait does not surface its own `fail()`
+/// — the outer opener loop must own the timeout failure path.
+class _NoOpProductionRailHarness extends StatelessWidget {
+  const _NoOpProductionRailHarness();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Column(
+        children: <Widget>[
+          TextButton(
+            key: kEmpireProductionButtonKey,
+            onPressed: () {
+              // Intentionally no panel-mount side effect — the inner post-tap
+              // wait must exhaust without `fail()`, and the outer loop must
+              // surface the timeout failure (Refs GitHub #2336).
+            },
+            child: const Text('Production'),
+          ),
+        ],
+      ),
+    );
+  }
 }
 
 /// Test harness that mounts the panel root synchronously on the rail tap so

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -149,10 +149,10 @@ packages:
     dependency: transitive
     description:
       name: code_assets
-      sha256: "83ccdaa064c980b5596c35dd64a8d3ecc68620174ab9b90b6343b753aa721687"
+      sha256: dad6bf6b9f4f378b0a69edbf42584d336efd1a9ce15deb1ba591cbb1b5ff440f
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0"
   collection:
     dependency: transitive
     description:
@@ -395,10 +395,10 @@ packages:
     dependency: transitive
     description:
       name: hooks
-      sha256: "025f060e86d2d4c3c47b56e33caf7f93bf9283340f26d23424ebcfccf34f621e"
+      sha256: a41af4e8fc687cd6d33de9751eb936c8c0204ebe2bcb6c15ecf707504bf47f31
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "2.0.0"
   hotreloader:
     dependency: transitive
     description:
@@ -624,10 +624,10 @@ packages:
     dependency: transitive
     description:
       name: objective_c
-      sha256: "02f4ff97ac95fa4abe561242eb033239e08e8903a46eaecf61b047761b89fe1f"
+      sha256: "6cb691c686fa2838c6deb34980d426145c2a5d537491cb83d463c33cdbc726ed"
       url: "https://pub.dev"
     source: hosted
-    version: "9.4.0"
+    version: "9.4.1"
   ordered_set:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary

`e2eOpenProductionPanel` previously used `e2eWaitUntilFound + fail()` for the
post-rail-tap wait, mirroring the naval opener defect already fixed in PR
[#2555](https://github.com/waigore/colonizethisv3/pull/2555). A single rail-tap
miss therefore surfaced as a hard `TestFailure` from the inner wait, preventing
the outer opener loop from dismissing racing overlays (`CtDialogShell` /
`BottomSheet`) and retrying the rail tap inside the helper's own `timeout`
budget.

This change harmonises the production opener with the bounded
`e2ePumpUntilConditionOrIdle` contract used by `e2eOpenCivilianPanel` and
`e2eOpenNavalPanel`:

- Post-rail-tap wait returns `false` on miss instead of calling `fail()`.
- Outer loop `continue`s and re-checks for transient UI (sheets, shells),
  dismisses them, and re-taps the rail until the outer `timeout` elapses.
- Failure now surfaces from the outer `Timed out opening production panel`
  path, owned by a single source of truth.
- Removed dead-code follow-up `pump_until_..._after_rail_tap_miss` 600ms poll
  (previously unreachable when the inner wait `fail()`-ed).

## Why this slice

Issue [#2336](https://github.com/waigore/colonizethisv3/issues/2336) AC4 / H7
calls out the production opener as a high-impact pump site. PR #2555 already
addressed the analogous naval opener defect; the production opener was left on
the old (brittle) pattern. This slice closes that asymmetry so a future
maintainer Linux desktop AC6–AC10 capture is not blocked by a transient overlay
racing the rail tap.

## Test plan

- [x] `flutter analyze app/integration_test/e2e_test_shared_panels.dart
  app/test/e2e_open_production_panel_test.dart` — clean on touched files (one
  pre-existing unused_element warning unrelated to this change).
- [x] `flutter test app/test/e2e_open_production_panel_test.dart` — 5/5 pass,
  including the new behavioural pin asserting the failure message comes from
  the outer opener loop (not the legacy inner `wait_until_...` phase name).
- [x] `flutter test app/test/e2e_open_*_test.dart
  app/test/e2e_test_shared_smoke_test.dart
  app/test/e2e_pump_until_test.dart
  app/test/e2e_pump_until_finder_empty_test.dart` — 48/48 pass.
- [ ] AC6–AC10 / AC8–AC9 timing capture: still deferred to a maintainer Linux
  desktop run via `tool/run_e2e_timing.sh` (this agent host has no `xvfb-run`
  / display). The change is structural and preserves the helper's documented
  semantics for all existing positive paths.

## Scope (this PR)

- Implemented: production opener bounded post-tap wait + behavioural test
  pin + doc comment update.
- Deferred: AC8–AC9 baseline-vs-after table (maintainer host); other H1–H10
  sites remain as previously addressed on `origin/dev`.

Refs #2336

Made with [Cursor](https://cursor.com)