### PR TITLE
feat(ai): add planDevelopCivilian to develop_phase_planner (Refs #2509 S4)

### DIFF
--- a/packages/colonizethis_ai/lib/src/planning/develop_phase_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/develop_phase_planner.dart
@@ -1,6 +1,6 @@
 /// DEVELOP-phase planner (Refs #2509 S4 / S10).
 ///
-/// First slice of the single-goal phase-planner architecture described in
+/// First slices of the single-goal phase-planner architecture described in
 /// [GitHub issue #2509](https://github.com/waigore/colonizethisv3/issues/2509)
 /// and `SPEC/ai/ai-architecture.md` § Observer goal phases. Each phase
 /// dispatches to a self-contained pure-function planner module that makes
@@ -15,16 +15,22 @@
 ///
 /// Wiring this module into the orchestrator and removing the legacy
 /// `developPhaseGpPeaceTargets` helper from `observer_goal_phase.dart`
-/// are out of scope for this slice (tracked under S5 / S1 of #2509). The
-/// in-module contract documented here matches the issue spec:
+/// are out of scope for these slices (tracked under S5 / S1 of #2509).
+/// The in-module contracts documented here match the issue spec:
 ///
 ///   `planDevelopPeace(game, snapshot) → List<String>`
 ///     Returns all at-war Great Power faction ids (deterministic, sorted
 ///     ascending). No exceptions: every GP front is peaced so the
 ///     orchestrator can drive improvement-first civilian work in the
 ///     DEVELOP phase.
+///
+///   `planDevelopCivilian(game, snapshot) → List<WorkOrder>`
+///     Returns `build_improvement` work orders for the active player's
+///     idle Builder units, targeting unimproved extractable resource
+///     tiles on GP-owned land, deterministically priority-ordered.
 library;
 
+import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/ai_api.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
@@ -56,4 +62,141 @@ List<String> planDevelopPeace({
     for (final factionId in snapshot.threats.atWarWith)
       if (game.playerById(factionId) != null) factionId,
   ]..sort();
+}
+
+/// Returns deterministic `build_improvement` work orders for the active
+/// player's idle Builder units, ranked by extractable-tile priority.
+///
+/// This is the DEVELOP-phase civilian contract from the #2509 S10
+/// single-goal architecture: improve unimproved extractable resource
+/// tiles on owned land, with higher-priority tiles assigned first. The
+/// priority key uses the same per-tile scoring constants as the existing
+/// logic-side civilian selection (`kBuildImprovementExtractableResourceScore`,
+/// `kBuildImprovementNewWorldResourceBonus`,
+/// `kBuildImprovementOwnedNewWorldResourceBonus`) so the DEVELOP planner
+/// remains consistent with the resolver-facing scoring during the
+/// transition until S5 wires this module into the orchestrator.
+///
+/// Filtering (each is a structural gate from issue #2509 DEVELOP planner spec):
+///   1. Tile must be in a province owned by the active player
+///      ([AIWorldSnapshot.playerId]).
+///   2. Tile must carry a non-empty resource id in
+///      [WorldState.resourceByTileKey] (extractable resource tile).
+///   3. Tile must not be the province's town tile
+///      ([Province.townTileKey]); town and capital tiles do not carry
+///      resources per `SPEC/game/extraction-and-improvements.md`
+///      § Town and capital tile occupancy, but the explicit exclusion
+///      pins the contract against future model changes.
+///   4. Tile's existing improvement level
+///      ([TileMapState.improvementLevel]) must be `< 1`.
+///
+/// Ranking (deterministic; ties broken lexicographically by tile key):
+///   - Base score per extractable tile: `kBuildImprovementExtractableResourceScore`.
+///   - `+kBuildImprovementNewWorldResourceBonus` when the tile is in the
+///     New World region.
+///   - `+kBuildImprovementOwnedNewWorldResourceBonus` when the tile is in
+///     an active-player-owned New World province (S10 colonial pressure;
+///     supports the turn-150 improvement gate).
+///
+/// Builder selection: every active-player [Unit] with
+/// `type == kUnitTypeBuilder` and `status == UnitStatus.idle` is included,
+/// sorted ascending by `unit.id`. Builders are assigned one-to-one to the
+/// top-priority unimproved tiles. Distance-from-Builder ordering and
+/// per-Builder pathfinding are deferred to follow-up tuning under
+/// #2509 S5 (orchestrator wiring) / S7 (observer integration); the current
+/// deterministic-priority assignment satisfies the issue's
+/// "highest-yield first" contract and the determinism Must-have #7.
+///
+/// Output: a new `List<WorkOrder>` of at most
+/// `min(idleBuilders, eligibleTiles)` entries, each with
+/// `target == kWorkTargetBuildImprovement`. Empty when no idle Builders
+/// or no eligible tiles exist. The function is pure and deterministic —
+/// identical inputs always yield identical lists.
+List<WorkOrder> planDevelopCivilian({
+  required Game game,
+  required AIWorldSnapshot snapshot,
+}) {
+  final playerId = snapshot.playerId;
+  final world = game.worldState;
+
+  final ownedProvinceIds = <String>{};
+  final townTileKeys = <String>{};
+  for (final region in <RegionData>[world.oldWorld, world.newWorld]) {
+    for (final province in region.provinces) {
+      if (province.ownerId != playerId) continue;
+      ownedProvinceIds.add(province.id);
+      final townTileKey = province.townTileKey;
+      if (townTileKey != null && townTileKey.isNotEmpty) {
+        townTileKeys.add(townTileKey);
+      }
+    }
+  }
+  if (ownedProvinceIds.isEmpty) {
+    return const [];
+  }
+
+  final builders = <Unit>[
+    for (final unit in allUnitsFromWorld(world))
+      if (unit.ownerId == playerId &&
+          unit.type == kUnitTypeBuilder &&
+          unit.status == UnitStatus.idle)
+        unit,
+  ]..sort((a, b) => a.id.compareTo(b.id));
+  if (builders.isEmpty) {
+    return const [];
+  }
+
+  final tileState = world.tileState;
+  final eligibleTileKeys = <String>[];
+  for (final entry in world.resourceByTileKey.entries) {
+    final tileKey = entry.key;
+    final resourceId = entry.value;
+    if (resourceId.isEmpty) continue;
+    final provinceId = Unit.provinceIdFromTileKey(tileKey);
+    if (provinceId == null || !ownedProvinceIds.contains(provinceId)) {
+      continue;
+    }
+    if (townTileKeys.contains(tileKey)) continue;
+    if (tileState.improvementLevel(tileKey) >= 1) continue;
+    eligibleTileKeys.add(tileKey);
+  }
+  if (eligibleTileKeys.isEmpty) {
+    return const [];
+  }
+
+  eligibleTileKeys.sort((a, b) {
+    final scoreCmp = _developCivilianTileScore(b).compareTo(
+      _developCivilianTileScore(a),
+    );
+    if (scoreCmp != 0) return scoreCmp;
+    return a.compareTo(b);
+  });
+
+  final pairCount = eligibleTileKeys.length < builders.length
+      ? eligibleTileKeys.length
+      : builders.length;
+  final orders = <WorkOrder>[
+    for (var i = 0; i < pairCount; i++)
+      WorkOrder(
+        unitId: builders[i].id,
+        target: kWorkTargetBuildImprovement,
+        targetTileKey: eligibleTileKeys[i],
+      ),
+  ];
+  return orders;
+}
+
+/// Deterministic priority score for an unimproved extractable tile in
+/// [planDevelopCivilian]. Higher score = higher build-improvement
+/// priority. Mirrors the per-tile component of the logic-side
+/// `_buildImprovementWorkScore` so DEVELOP-phase planner ranking stays
+/// consistent with resolver-facing civilian selection until the S5
+/// orchestrator refactor lands.
+int _developCivilianTileScore(String tileKey) {
+  var score = kBuildImprovementExtractableResourceScore;
+  if (Unit.regionIdFromTileKey(tileKey) == kNewWorldRegionId) {
+    score += kBuildImprovementNewWorldResourceBonus;
+    score += kBuildImprovementOwnedNewWorldResourceBonus;
+  }
+  return score;
 }

--- a/packages/colonizethis_ai/test/planning/develop_phase_planner_test.dart
+++ b/packages/colonizethis_ai/test/planning/develop_phase_planner_test.dart
@@ -1,17 +1,23 @@
-// Unit tests for `planDevelopPeace` from
+// Unit tests for the DEVELOP-phase planner contracts in
 // `packages/colonizethis_ai/lib/src/planning/develop_phase_planner.dart`
 // (Refs #2509 S4 / S10).
 //
-// Spec contract (issue #2509 § DEVELOP phase planner / planDevelopPeace):
-//   "Peace ALL at-war Great Powers. No exceptions.
-//    (No new wars. No NW acquisition. Only defend + improve.)"
+// Spec contract (issue #2509 § DEVELOP phase planner):
+//   planDevelopPeace:
+//     "Peace ALL at-war Great Powers. No exceptions.
+//      (No new wars. No NW acquisition. Only defend + improve.)"
+//   planDevelopCivilian:
+//     "For each owned province (OW + NW), scan unimproved extractable
+//      resource tiles ... Sort remaining by effective yield ...
+//      Assign nearest idle Builder to highest-yield unimproved tile."
 //
-// The planner is a pure function with deterministic inputs (Refs #2509
+// Both planners are pure functions with deterministic inputs (Refs #2509
 // Must-have #7). Suppression is structural: callers only dispatch to this
-// module when [observerGoalPhaseFor] resolves to DEVELOP, so the function
-// does NOT re-check the phase. These tests pin the in-module contract
-// only:
+// module when [observerGoalPhaseFor] resolves to DEVELOP, so the
+// functions do NOT re-check the phase. These tests pin the in-module
+// contracts only.
 //
+// `planDevelopPeace` tests:
 //   1. **Empty `atWarWith`:** no live wars -> empty list.
 //   2. **Single GP at war:** one GP front -> one-element list (DEVELOP has
 //      no `gpWars.length <= 1` early return — every GP front must peace).
@@ -25,6 +31,29 @@
 //   6. **Determinism:** identical inputs yield identical results across
 //      repeated calls (Must-have #7).
 //
+// `planDevelopCivilian` tests:
+//   1. **No owned provinces:** empty owner set -> empty list (structural
+//      gate; ownership is the outermost filter).
+//   2. **No idle Builders:** owned provinces with resource tiles but no
+//      idle Builder units -> empty list.
+//   3. **All tiles already improved:** unimproved-tile filter removes
+//      `improvementLevel >= 1` tiles -> empty list.
+//   4. **Town tile excluded:** tile keys matching the province's
+//      `townTileKey` are filtered out even when a resource entry exists
+//      (regression guard against future model changes).
+//   5. **Foreign-owned tiles excluded:** resource tiles in another
+//      player's province never appear in output.
+//   6. **Tile sorted by priority:** mixed OW + NW unimproved resource
+//      tiles return NW (higher score) before OW; lex tie-break is
+//      ascending by tile key.
+//   7. **Builder-to-tile pairing:** `min(builders, tiles)` cap; surplus
+//      builders / tiles ignored; output ascending by builder id over
+//      priority-sorted tiles.
+//   8. **Working / non-Builder units skipped:** non-Builder civilians
+//      and Builders with `status == working` are excluded.
+//   9. **Determinism:** identical inputs yield identical orders across
+//      repeated calls (Must-have #7).
+//
 // This file is the in-module pin for the new DEVELOP planner. The
 // existing function-unit pin on the legacy
 // `developPhaseGpPeaceTargets` helper in
@@ -34,6 +63,8 @@
 
 import 'package:colonizethis_ai/colonizethis_ai.dart';
 import 'package:colonizethis_ai/src/planning/develop_phase_planner.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/ai_api.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart';
 
@@ -197,6 +228,378 @@ void main() {
       );
       final first = planDevelopPeace(game: game, snapshot: snapshot);
       final second = planDevelopPeace(game: game, snapshot: snapshot);
+      expect(second, first);
+    });
+  });
+
+  group('planDevelopCivilian', () {
+    // gp1 is the active player; other GPs are foreign owners used in the
+    // ownership-exclusion test.
+    const String owProv1 = 'oldWorld|p_alpha';
+    const String owProv2 = 'oldWorld|p_beta';
+    const String nwProv1 = 'newWorld|p_gamma';
+
+    // Tile keys laid out as regionId|provinceId|x|y per
+    // SPEC/game/world-model-identity.md. The province id is derived back
+    // out via [Unit.provinceIdFromTileKey], so the keys must match the
+    // owned-province ids byte-for-byte.
+    const String owTileA = 'oldWorld|p_alpha|1|1';
+    const String owTileB = 'oldWorld|p_alpha|2|2';
+    const String owTileTown = 'oldWorld|p_alpha|0|0';
+    const String owTileImproved = 'oldWorld|p_beta|1|1';
+    const String nwTileA = 'newWorld|p_gamma|1|1';
+
+    Game civilianGame({
+      required List<Province> provinces,
+      required List<Unit> owUnits,
+      List<Unit> nwUnits = const [],
+      Map<String, String> resourceByTileKey = const {},
+      TileMapState tileState = const TileMapState(),
+    }) {
+      final byRegion = <String, List<Province>>{};
+      for (final province in provinces) {
+        byRegion
+            .putIfAbsent(province.regionId, () => <Province>[])
+            .add(province);
+      }
+      return Game(
+        id: 'g-2509-develop-phase-planner-civilian',
+        worldState: WorldState(
+          turnState: const TurnState(turnNumber: 145, phase: TurnPhase.orders),
+          oldWorld: RegionData(
+            provinces: byRegion[kOldWorldRegionId] ?? const [],
+            units: owUnits,
+          ),
+          newWorld: RegionData(
+            provinces: byRegion[kNewWorldRegionId] ?? const [],
+            units: nwUnits,
+          ),
+          resourceByTileKey: resourceByTileKey,
+          tileState: tileState,
+        ),
+        players: const [
+          Player(id: _gp1, displayName: 'GP1', isHuman: false),
+          Player(id: _gp2, displayName: 'GP2', isHuman: false),
+        ],
+      );
+    }
+
+    AIWorldSnapshot civilianSnapshot() {
+      return AIWorldSnapshot(
+        playerId: _gp1,
+        threats: const ThreatSummary(atWarWith: []),
+        opportunities: const OpportunitySummary(),
+        conquest: const ConquestSummary(),
+        colonial: const ColonialSummary(),
+        economy: const EconomySummary(),
+        relations: const {},
+      );
+    }
+
+    Unit idleBuilder(String id, {String regionId = kOldWorldRegionId}) {
+      final provinceId = regionId == kOldWorldRegionId ? owProv1 : nwProv1;
+      return Unit(
+        id: id,
+        type: kUnitTypeBuilder,
+        ownerId: _gp1,
+        locationProvinceId: provinceId,
+        tileKey: '$provinceId|9|9',
+      );
+    }
+
+    test('no owned provinces -> empty', () {
+      // Active player has no owned provinces; ownership is the outermost
+      // structural filter so the function must short-circuit before
+      // scanning resource tiles or builders. A regression that scanned
+      // tiles for unowned provinces would emit `build_improvement` orders
+      // toward foreign territory and fail order validation.
+      final game = civilianGame(
+        provinces: const [
+          Province(id: owProv1, regionId: kOldWorldRegionId, ownerId: _gp2),
+        ],
+        owUnits: [idleBuilder('b1')],
+        resourceByTileKey: const {owTileA: 'grain'},
+      );
+      expect(
+        planDevelopCivilian(game: game, snapshot: civilianSnapshot()),
+        isEmpty,
+        reason:
+            'Active player owns zero provinces -> no eligible tiles; the '
+            'ownership filter must short-circuit before resource scanning.',
+      );
+    });
+
+    test('no idle builders -> empty', () {
+      // Active player owns a province with an unimproved resource tile,
+      // but no Builder units are present. A regression that emitted a
+      // `build_improvement` order without a builder would fail unit
+      // assignment validation downstream.
+      final game = civilianGame(
+        provinces: const [
+          Province(id: owProv1, regionId: kOldWorldRegionId, ownerId: _gp1),
+        ],
+        owUnits: const [],
+        resourceByTileKey: const {owTileA: 'grain'},
+      );
+      expect(
+        planDevelopCivilian(game: game, snapshot: civilianSnapshot()),
+        isEmpty,
+        reason:
+            'No idle Builders -> no orders. The function must skip its '
+            'tile scan when builders are empty (early-exit contract).',
+      );
+    });
+
+    test('all tiles already improved -> empty', () {
+      // The `improvementLevel >= 1` gate must drop every tile that is
+      // already at improvement level 1+. A regression that emitted
+      // `build_improvement` toward an already-improved tile would waste
+      // a Builder cycle and could re-trigger work that the resolver
+      // rejects.
+      final game = civilianGame(
+        provinces: const [
+          Province(id: owProv2, regionId: kOldWorldRegionId, ownerId: _gp1),
+        ],
+        owUnits: [idleBuilder('b1')],
+        resourceByTileKey: const {owTileImproved: 'iron'},
+        tileState: const TileMapState(
+          improvementByTile: {owTileImproved: 1},
+        ),
+      );
+      expect(
+        planDevelopCivilian(game: game, snapshot: civilianSnapshot()),
+        isEmpty,
+        reason:
+            'All eligible tiles already at improvementLevel >= 1; the '
+            'planner must emit no orders.',
+      );
+    });
+
+    test('town tile is excluded even with resource entry', () {
+      // `townTileKey` exclusion pins the spec rule "Exclude capital
+      // tiles and province town tiles (no resources)". Even when the
+      // (synthetic) world state pairs a resource with a town tile, the
+      // planner must skip it: relying on `resourceByTileKey` alone would
+      // permit a regression that places a resource on a town tile and
+      // emits an improvement order against the town.
+      final game = civilianGame(
+        provinces: const [
+          Province(
+            id: owProv1,
+            regionId: kOldWorldRegionId,
+            ownerId: _gp1,
+            townTileKey: owTileTown,
+          ),
+        ],
+        owUnits: [idleBuilder('b1')],
+        resourceByTileKey: const {
+          owTileTown: 'grain',
+          owTileA: 'grain',
+        },
+      );
+      final orders = planDevelopCivilian(
+        game: game,
+        snapshot: civilianSnapshot(),
+      );
+      expect(orders.map((o) => o.targetTileKey), const [owTileA]);
+    });
+
+    test('foreign-owned tiles excluded from output', () {
+      // Province ownership is the structural gate: even when a foreign
+      // province has a richer resource yield than an owned tile, the
+      // planner must only emit orders for tiles inside owned provinces.
+      // A regression that scanned `resourceByTileKey` without the
+      // province-ownership filter would route the lone Builder onto a
+      // foreign NW tile and lose the entire owned-OW improvement.
+      const foreignNwTile = 'newWorld|p_foreign|5|5';
+      final game = civilianGame(
+        provinces: const [
+          Province(id: owProv1, regionId: kOldWorldRegionId, ownerId: _gp1),
+          Province(
+            id: 'newWorld|p_foreign',
+            regionId: kNewWorldRegionId,
+            ownerId: _gp2,
+          ),
+        ],
+        owUnits: [idleBuilder('b1')],
+        resourceByTileKey: const {
+          foreignNwTile: 'gold',
+          owTileA: 'grain',
+        },
+      );
+      final orders = planDevelopCivilian(
+        game: game,
+        snapshot: civilianSnapshot(),
+      );
+      expect(orders.map((o) => o.targetTileKey), const [owTileA]);
+    });
+
+    test('NW resource tile outranks OW tile (yield score)', () {
+      // Score ordering pin (AC "build_improvement orders are generated
+      // for the highest-yield unimproved tiles before lower-priority
+      // work"). NW owned tile = base + NW bonus + owned-NW bonus; OW
+      // tile = base alone. With two builders and one tile per region,
+      // builder `b1` (sorted first) must target the NW tile.
+      final game = civilianGame(
+        provinces: const [
+          Province(id: owProv1, regionId: kOldWorldRegionId, ownerId: _gp1),
+          Province(id: nwProv1, regionId: kNewWorldRegionId, ownerId: _gp1),
+        ],
+        owUnits: [idleBuilder('b1'), idleBuilder('b2')],
+        resourceByTileKey: const {owTileA: 'grain', nwTileA: 'tobacco'},
+      );
+      final orders = planDevelopCivilian(
+        game: game,
+        snapshot: civilianSnapshot(),
+      );
+      expect(orders.length, 2);
+      expect(orders.first.targetTileKey, nwTileA);
+      expect(orders.first.unitId, 'b1');
+      expect(orders[1].targetTileKey, owTileA);
+      expect(orders[1].unitId, 'b2');
+      expect(
+        orders.every((o) => o.target == kWorkTargetBuildImprovement),
+        isTrue,
+        reason: 'Every emitted order must target build_improvement.',
+      );
+    });
+
+    test('same-score tiles tie-break ascending by tile key', () {
+      // Same-region same-score tiles fall back to lex tile-key sort.
+      // Builder `b1` (lex-first builder id) -> `owTileA` (lex-first
+      // tile key). A regression that flipped the tie-break would break
+      // determinism on multi-tile OW provinces.
+      final game = civilianGame(
+        provinces: const [
+          Province(id: owProv1, regionId: kOldWorldRegionId, ownerId: _gp1),
+        ],
+        owUnits: [idleBuilder('b1'), idleBuilder('b2')],
+        resourceByTileKey: const {owTileA: 'grain', owTileB: 'iron'},
+      );
+      final orders = planDevelopCivilian(
+        game: game,
+        snapshot: civilianSnapshot(),
+      );
+      expect(orders.length, 2);
+      expect(orders[0].unitId, 'b1');
+      expect(orders[0].targetTileKey, owTileA);
+      expect(orders[1].unitId, 'b2');
+      expect(orders[1].targetTileKey, owTileB);
+    });
+
+    test('builder count caps emitted orders below tile count', () {
+      // `min(builders, tiles)` cap: two tiles available, one builder ->
+      // exactly one order targeting the higher-priority NW tile. The
+      // surplus OW tile is left unimproved this turn (acceptable; the
+      // remaining builder slot will fill on a subsequent turn).
+      final game = civilianGame(
+        provinces: const [
+          Province(id: owProv1, regionId: kOldWorldRegionId, ownerId: _gp1),
+          Province(id: nwProv1, regionId: kNewWorldRegionId, ownerId: _gp1),
+        ],
+        owUnits: [idleBuilder('b1')],
+        resourceByTileKey: const {owTileA: 'grain', nwTileA: 'spices'},
+      );
+      final orders = planDevelopCivilian(
+        game: game,
+        snapshot: civilianSnapshot(),
+      );
+      expect(orders.length, 1);
+      expect(orders.single.targetTileKey, nwTileA);
+      expect(orders.single.unitId, 'b1');
+    });
+
+    test('tile count caps emitted orders below builder count', () {
+      // Reverse cap: two builders, one tile -> exactly one order
+      // bound to `b1` (lex-first builder id). The surplus builder
+      // remains idle (no fabricated order, no duplicate targeting).
+      final game = civilianGame(
+        provinces: const [
+          Province(id: owProv1, regionId: kOldWorldRegionId, ownerId: _gp1),
+        ],
+        owUnits: [idleBuilder('b1'), idleBuilder('b2')],
+        resourceByTileKey: const {owTileA: 'grain'},
+      );
+      final orders = planDevelopCivilian(
+        game: game,
+        snapshot: civilianSnapshot(),
+      );
+      expect(orders.length, 1);
+      expect(orders.single.unitId, 'b1');
+      expect(orders.single.targetTileKey, owTileA);
+    });
+
+    test('working builders and non-Builder units excluded', () {
+      // Only `status == idle` Builder units count. Working Builders
+      // and idle non-Builder civilians (e.g. Farmer-like worker
+      // placeholders typed as `'Farmer'`) must be skipped.
+      final game = civilianGame(
+        provinces: const [
+          Province(id: owProv1, regionId: kOldWorldRegionId, ownerId: _gp1),
+        ],
+        owUnits: [
+          Unit(
+            id: 'b_busy',
+            type: kUnitTypeBuilder,
+            ownerId: _gp1,
+            locationProvinceId: owProv1,
+            tileKey: '$owProv1|9|9',
+            status: UnitStatus.working,
+          ),
+          Unit(
+            id: 'farmer1',
+            type: 'Farmer',
+            ownerId: _gp1,
+            locationProvinceId: owProv1,
+            tileKey: '$owProv1|8|8',
+          ),
+        ],
+        resourceByTileKey: const {owTileA: 'grain'},
+      );
+      expect(
+        planDevelopCivilian(game: game, snapshot: civilianSnapshot()),
+        isEmpty,
+        reason:
+            'Working builders + non-Builder civilians are both filtered '
+            'out; with no idle Builder present the planner returns empty.',
+      );
+    });
+
+    test('determinism: identical inputs yield identical orders', () {
+      // Mixed-region scenario exercises ownership, town exclusion,
+      // improvement-level filter, score ordering, builder sort, and
+      // the min cap in one fixture. Two calls must produce the same
+      // list (Must-have #7).
+      final game = civilianGame(
+        provinces: const [
+          Province(
+            id: owProv1,
+            regionId: kOldWorldRegionId,
+            ownerId: _gp1,
+            townTileKey: owTileTown,
+          ),
+          Province(id: nwProv1, regionId: kNewWorldRegionId, ownerId: _gp1),
+        ],
+        owUnits: [idleBuilder('b2'), idleBuilder('b1')],
+        nwUnits: [idleBuilder('b3', regionId: kNewWorldRegionId)],
+        resourceByTileKey: const {
+          owTileA: 'grain',
+          owTileB: 'iron',
+          owTileTown: 'grain',
+          nwTileA: 'spices',
+        },
+      );
+      final first =
+          planDevelopCivilian(game: game, snapshot: civilianSnapshot());
+      final second =
+          planDevelopCivilian(game: game, snapshot: civilianSnapshot());
+      expect(
+        first.map((o) => '${o.unitId}->${o.targetTileKey}').toList(),
+        const ['b1->newWorld|p_gamma|1|1', 'b2->oldWorld|p_alpha|1|1', 'b3->oldWorld|p_alpha|2|2'],
+        reason:
+            'NW tile ranks first (highest score), then OW tiles in lex '
+            'order; builder ids assigned ascending; town tile excluded.',
+      );
       expect(second, first);
     });
   });


### PR DESCRIPTION
## Summary

Second slice of issue #2509 S4 (DEVELOP phase planner) on top of the now-merged PR #2695 (`planDevelopPeace`). Adds a new pure-function `planDevelopCivilian(game, snapshot)` to `packages/colonizethis_ai/lib/src/planning/develop_phase_planner.dart`, matching the DEVELOP civilian contract from the issue spec.

The function returns deterministic `build_improvement` work orders for the active player's idle Builder units, targeting unimproved extractable resource tiles on owned land. Structural filtering pins the spec gates from issue #2509 § DEVELOP phase planner / planDevelopCivilian:

1. Active player ownership (province in active player's `ownerId`).
2. Extractable resource entry in `WorldState.resourceByTileKey` (non-empty resource id).
3. Town-tile exclusion via `Province.townTileKey` (capital and town tiles do not extract per `SPEC/game/extraction-and-improvements.md`).
4. Improvement-level gate (`TileMapState.improvementLevel(tileKey) < 1`).

Tile priority mirrors the per-tile components of the existing logic-side `_buildImprovementWorkScore` (`kBuildImprovementExtractableResourceScore` + `kBuildImprovementNewWorldResourceBonus` + `kBuildImprovementOwnedNewWorldResourceBonus`) so DEVELOP ranking stays consistent with resolver-facing civilian selection until the S5 orchestrator wiring lands. Builders are sorted ascending by `unit.id` and matched one-to-one with the priority-sorted tiles, capped at `min(builders, tiles)`.

## Done in this PR

- New `planDevelopCivilian` function in `develop_phase_planner.dart` (~95 lines including the deterministic priority helper).
- Eleven in-module unit tests in `develop_phase_planner_test.dart` covering: no owned provinces, no idle builders, all tiles already improved, town-tile excluded, foreign-owned tiles excluded, NW outranks OW (yield score), lex tie-break, builder-count cap, tile-count cap, working / non-Builder unit exclusion, and a mixed-region determinism scenario.

## Deferred for #2509 (out of scope for this PR)

- **S1** delete `colonial_pressure.dart` / `diplomacy_planner_peace_targets.dart` and reduce `ai_victory_config.dart` constants.
- **S2** `expand_phase_planner.dart`.
- **S3** `colonial_phase_planner.dart` + COLONIAL-lite safeguard functions.
- **S5** orchestrator dispatch refactor in `domain_planner_orchestrator.dart`; legacy `developPhaseGpPeaceTargets` (and EXPAND / COLONIAL siblings), `full_ai_civilian_work_selection.dart`-based selection stay live until then.
- **S6** rewrite `SPEC/ai/ai-architecture.md` § Observer goal phases.
- **S7** observer integration + phase-planner tuning (also where distance-from-Builder ordering and per-Builder pathfinding refinements land).
- **S8** un-skip `seed42_observer_conquest_regression_test`.

`planDevelopCivilian` is **not yet wired** into `domain_planner_orchestrator.dart`; both the legacy civilian path and the new function remain pinned at the function-unit level until S5 reconciles them, so this slice carries **zero behavior change** and **zero regression risk**.

## Acceptance criteria coverage

- **(DEVELOP civilian)** AC: "Given a GP in DEVELOP with unimproved extractable resource tiles and idle Builder units, when `planDevelopCivilian` runs, then `build_improvement` orders are generated for the highest-yield unimproved tiles before lower-priority work." — covered by the `NW resource tile outranks OW tile (yield score)`, `same-score tiles tie-break ascending by tile key`, `builder count caps emitted orders below tile count`, and the mixed-region determinism scenarios.
- **(Determinism, Must-have #7)** AC: "Given identical inputs … the return value is identical (pure functions, deterministic inputs)." — covered by the new `determinism` test and the deterministic ordering pinned across the score/tile-key/builder-id sort tests.

The remaining DEVELOP NW-suppression and full DEVELOP / EXPAND / COLONIAL ACs from the issue body are deferred to the slices listed above (NW suppression in DEVELOP is structurally enforced once S5 wiring lands and the orchestrator stops dispatching the legacy NW work paths in DEVELOP).

## Test plan

- [x] `dart analyze packages/colonizethis_ai/lib/src/planning/develop_phase_planner.dart` — `No issues found!`
- [x] `dart analyze packages/colonizethis_ai/test/planning/develop_phase_planner_test.dart` — `No issues found!`
- [x] `dart analyze` on full `colonizethis_ai` package — issue count unchanged (24 pre-existing → 24 with change; zero new warnings)
- [x] `dart test test/planning/develop_phase_planner_test.dart` — 17 passed (6 `planDevelopPeace` + 11 new `planDevelopCivilian`)
- [x] `dart test` (full `colonizethis_ai` suite) — 635 passed, 2 skipped, 0 failed (was 624 before; +11 new tests)
- [ ] CI quality gates (Quality workflow on push)

Refs #2509

Made with [Cursor](https://cursor.com)