### PR TITLE
feat(workers): RecruitWorkerOrder validation + Build/work phase wiring (Refs #2692 S4)

### DIFF
--- a/packages/colonizethis_logic/lib/src/economy/worker_action_cost.dart
+++ b/packages/colonizethis_logic/lib/src/economy/worker_action_cost.dart
@@ -1,0 +1,122 @@
+/// Shared affordability and deduction for [RecruitWorkerOrder]. Single source
+/// of truth used by [RecruitWorkerOrderValidator], the Build / work worker
+/// pool phase, and the economy preview pipeline so submission, validation,
+/// resolution, and projection share one cost table.
+///
+/// SPEC source of truth:
+/// - `SPEC/game/workers-and-population.md` § Recruiting, Training, and
+///   Disbanding (cost table, rejection reasons).
+/// - `SPEC/program/orders.md` § RecruitWorkerOrder.
+/// - `SPEC/program/turn-resolution-phase-details.md` § Build / work
+///   (worker pool orders resolve before [BuildUnitOrder]).
+library;
+
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+/// Rejection reason vocabulary (matches GDD § Order rejection reasons).
+///
+/// These strings are part of the user-visible UI contract; do not change
+/// without updating both SPEC and downstream localization strings.
+const String kRecruitWorkerInsufficientWorkers = 'Insufficient workers';
+const String kRecruitWorkerInsufficientMaterials = 'Insufficient materials';
+const String kRecruitWorkerInsufficientTreasury = 'Insufficient treasury';
+const String kRecruitWorkerTechLocked = 'Required technology not unlocked';
+
+/// Checks whether the player can pay for one [RecruitWorkerOrder] given the
+/// running worker pool, stockpile, and treasury state for that player's order
+/// chain (i.e. after deductions from prior accepted recruit / build orders).
+///
+/// Tech gates use the static catalog `WorkerActionEconomyCatalog.forTier` and
+/// the player's `techUnlocked` map; both must be true for trained tiers.
+///
+/// Returns `canAfford: true` with `reason: null` when the action is allowed.
+/// Otherwise returns the first failing reason in the canonical order:
+/// tech → workers → treasury → materials.
+({bool canAfford, String? reason}) canAffordRecruitWorker(
+  Player player,
+  RecruitWorkerOrder order,
+  WorkerPool workers,
+  Stockpile stockpile,
+  int treasury,
+) {
+  final row = WorkerActionEconomyCatalog.forTier(order.targetTier);
+  final tech = player.techUnlocked ?? const <String, bool>{};
+  for (final techId in row.requiredTechIds) {
+    if (tech[techId] != true) {
+      return (canAfford: false, reason: kRecruitWorkerTechLocked);
+    }
+  }
+  if (row.consumesPeasant && workers.peasants <= 0) {
+    return (canAfford: false, reason: kRecruitWorkerInsufficientWorkers);
+  }
+  if (treasury < row.treasuryCost) {
+    return (canAfford: false, reason: kRecruitWorkerInsufficientTreasury);
+  }
+  for (final entry in row.materialCosts.entries) {
+    if (stockpile.quantityOf(entry.key) < entry.value) {
+      return (canAfford: false, reason: kRecruitWorkerInsufficientMaterials);
+    }
+  }
+  return (canAfford: true, reason: null);
+}
+
+/// Applies the cost deduction for one [RecruitWorkerOrder] and returns the
+/// updated economy snapshot. Call only when [canAffordRecruitWorker] returned
+/// `canAfford: true` for the same inputs.
+///
+/// Increments the [order.targetTier] count by 1; decrements `peasants` by 1
+/// for non-peasant tiers (per the GDD cost row `consumesPeasant`).
+({WorkerPool workers, Stockpile stockpile, int treasury})
+applyRecruitWorkerCostDeduction(
+  RecruitWorkerOrder order,
+  WorkerPool workers,
+  Stockpile stockpile,
+  int treasury,
+) {
+  final row = WorkerActionEconomyCatalog.forTier(order.targetTier);
+  var nextStockpile = stockpile;
+  for (final entry in row.materialCosts.entries) {
+    nextStockpile = nextStockpile.applyDelta(entry.key, -entry.value);
+  }
+  final nextWorkers = _applyTierDelta(
+    workers,
+    order.targetTier,
+    increment: 1,
+    decrementPeasant: row.consumesPeasant,
+  );
+  final nextTreasury = treasury - row.treasuryCost;
+  return (
+    workers: nextWorkers,
+    stockpile: nextStockpile,
+    treasury: nextTreasury,
+  );
+}
+
+WorkerPool _applyTierDelta(
+  WorkerPool pool,
+  WorkerTier tier, {
+  required int increment,
+  required bool decrementPeasant,
+}) {
+  final peasantsAfter = decrementPeasant ? pool.peasants - 1 : pool.peasants;
+  switch (tier) {
+    case WorkerTier.peasant:
+      return pool.copyWith(peasants: peasantsAfter + increment);
+    case WorkerTier.apprentice:
+      return pool.copyWith(
+        peasants: peasantsAfter,
+        apprentices: pool.apprentices + increment,
+      );
+    case WorkerTier.journeyman:
+      return pool.copyWith(
+        peasants: peasantsAfter,
+        journeymen: pool.journeymen + increment,
+      );
+    case WorkerTier.master:
+      return pool.copyWith(
+        peasants: peasantsAfter,
+        masters: pool.masters + increment,
+      );
+  }
+}

--- a/packages/colonizethis_logic/lib/src/orders/order_engine.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_engine.dart
@@ -94,6 +94,25 @@ class _OrderSlot<T> {
   final String label;
 }
 
+/// Mutable state threaded through [OrderEngine._runOrderValidationPhases].
+/// Holds the running rejected flag, treasury, stockpile, worker pool, and
+/// the accumulated [OrderValidationResult] list. Existing only inside
+/// [OrderEngine.validatePlayerOrdersWithContext]'s call stack.
+class _OrderValidationRunState {
+  _OrderValidationRunState({
+    required this.results,
+    required this.stockpile,
+    required this.treasury,
+    required this.workerPool,
+  });
+
+  final List<OrderValidationResult> results;
+  bool rejected = false;
+  Stockpile stockpile;
+  int treasury;
+  WorkerPool workerPool;
+}
+
 typedef OrderValidatorFactory =
     OrderValidators Function(
       Game game,
@@ -239,9 +258,8 @@ class OrderEngine with _OrderEngineGeneratedOrderMethods {
     if (_trackValidatePlayerOrdersWithContextInvocationsForTests) {
       _validatePlayerOrdersWithContextInvocationCountForTests++;
     }
-    final results = <OrderValidationResult>[];
     final player = game.playerById(playerId);
-    if (player == null) return results;
+    if (player == null) return <OrderValidationResult>[];
 
     final view = buildPlayerView(game, topology, playerId);
 
@@ -254,15 +272,6 @@ class OrderEngine with _OrderEngineGeneratedOrderMethods {
     final diplomatic = _orders.diplomaticOrdersByPlayerId[playerId] ?? [];
     final navals = _orders.navalMoveOrdersByPlayerId[playerId] ?? [];
     final missions = _orders.navalMissionOrdersByPlayerId[playerId] ?? [];
-    var rejected = false;
-    var stockpile = player.stockpile;
-    var treasury = player.treasury;
-    // Peasant reservation ledger: each accepted RecruitWorkerOrder consumes
-    // peasants per `WorkerActionEconomyCatalog`, and the downstream build
-    // validator must see the post-recruit headcount so military/naval builds
-    // that consume a peasant respect the combined reservation (see
-    // SPEC/game/workers-and-population.md § Peasant reservation).
-    var workerPool = player.workerPool;
 
     final unitsById = Map<String, Unit>.from(
       unitsByIdFromWorld(game.worldState),
@@ -290,6 +299,69 @@ class OrderEngine with _OrderEngineGeneratedOrderMethods {
       for (final a in game.worldState.armies) a.id: a,
     };
 
+    // Peasant reservation ledger: each accepted RecruitWorkerOrder consumes
+    // peasants per `WorkerActionEconomyCatalog`, and the downstream build
+    // validator must see the post-recruit headcount so military/naval builds
+    // that consume a peasant respect the combined reservation (see
+    // SPEC/game/workers-and-population.md § Peasant reservation).
+    final state = _OrderValidationRunState(
+      results: <OrderValidationResult>[],
+      stockpile: player.stockpile,
+      treasury: player.treasury,
+      workerPool: player.workerPool,
+    );
+
+    _runOrderValidationPhases(
+      state: state,
+      game: game,
+      player: player,
+      playerId: playerId,
+      view: view,
+      topology: topology,
+      tileMapByRegion: tileMapByRegion,
+      unitsById: unitsById,
+      diplomatic: diplomatic,
+      civilianDraftMoveUnitIds: civilianDraftMoveUnitIds,
+      devExclusiveTiles: devExclusiveTiles,
+      factionMembership: factionMembership,
+      armiesById: armiesById,
+      moves: moves,
+      armyMoves: armyMoves,
+      recruitWorkers: recruitWorkers,
+      builds: builds,
+      works: works,
+      navals: navals,
+      missions: missions,
+    );
+    return state.results;
+  }
+
+  /// Build and run the per-category validation phases for one player.
+  /// Mutates [state] (results / rejected / stockpile / treasury / workerPool)
+  /// in submission order: move, army-move, recruit-worker, build, work,
+  /// diplomatic, naval, naval-mission.
+  void _runOrderValidationPhases({
+    required _OrderValidationRunState state,
+    required Game game,
+    required Player player,
+    required String playerId,
+    required PlayerView view,
+    required MapTopology topology,
+    required Map<String, TileMapResult>? tileMapByRegion,
+    required Map<String, Unit> unitsById,
+    required List<DiplomaticOrder> diplomatic,
+    required Set<String> civilianDraftMoveUnitIds,
+    required Set<String> devExclusiveTiles,
+    required DiplomacyFactionMembership factionMembership,
+    required Map<String, Army> armiesById,
+    required List<MoveOrder> moves,
+    required List<ArmyMoveOrder> armyMoves,
+    required List<RecruitWorkerOrder> recruitWorkers,
+    required List<BuildUnitOrder> builds,
+    required List<WorkOrder> works,
+    required List<NavalMoveOrder> navals,
+    required List<NavalMissionOrder> missions,
+  }) {
     OrderValidators newValidatorBundle() => _validatorFactory(
       game,
       player,
@@ -301,156 +373,72 @@ class OrderEngine with _OrderEngineGeneratedOrderMethods {
       tileMapByRegion,
       civilianDraftMoveUnitIds,
       devExclusiveTiles,
-      stockpile,
-      treasury,
+      state.stockpile,
+      state.treasury,
       factionMembership,
-      workerPool,
+      state.workerPool,
     );
 
     // One ordered list: move + army share the initial bundle; each later
     // category refreshes validators so stockpile/treasury/diplomatic state
     // matches incremental validation ordering (Refs #2391 AC7,
-    // SPEC/program/order-engine.md).
+    // SPEC/program/order-engine.md). Worker pool orders (recruit / train)
+    // come before unit builds in both validation and resolution so the
+    // peasant reservation ledger reflects accepted recruit consumes before
+    // military / naval builds check their own peasant requirement
+    // (SPEC/game/workers-and-population.md § Peasant reservation;
+    // SPEC/program/turn-resolution-phase-details.md § Build / work).
     final validationPhases =
         <({bool refreshBundleBefore, void Function(OrderValidators) run})>[
           (
             refreshBundleBefore: false,
-            run: (v) {
-              rejected = _appendValidationResults(
-                results,
-                moves,
-                rejected,
-                (o, prev) => v.moveValidator.validate(
-                  o,
-                  game,
-                  playerId,
-                  unitsById,
-                  diplomatic,
-                  view,
-                  topology,
-                  previousRejected: prev,
-                  factionMembership: factionMembership,
-                ),
-              );
-            },
+            run: (v) => _runMovePhase(
+              v,
+              state,
+              moves,
+              game,
+              playerId,
+              unitsById,
+              diplomatic,
+              view,
+              topology,
+              factionMembership,
+            ),
           ),
           (
             refreshBundleBefore: false,
-            run: (v) {
-              rejected = _appendValidationResults(
-                results,
-                armyMoves,
-                rejected,
-                (o, prev) => prev
-                    ? previousInvalidOrderResult
-                    : v.armyMoveValidator.validate(
-                        o,
-                        game,
-                        playerId,
-                        diplomatic,
-                        view,
-                        topology,
-                        armiesById: armiesById,
-                        factionMembership: factionMembership,
-                      ),
-              );
-            },
-          ),
-          (
-            // Worker pool orders (recruit / train) come before unit builds in
-            // both validation and resolution so the peasant reservation
-            // ledger reflects accepted recruit consumes before military /
-            // naval builds check their own peasant requirement (SPEC/game/
-            // workers-and-population.md § Peasant reservation; SPEC/program/
-            // turn-resolution-phase-details.md § Build / work).
-            refreshBundleBefore: true,
-            run: (v) {
-              rejected = _appendValidationResults(
-                results,
-                recruitWorkers,
-                rejected,
-                (o, prev) => v.recruitWorkerValidator.validate(
-                  o,
-                  previousRejected: prev,
-                ),
-              );
-              workerPool = v.recruitWorkerValidator.workers;
-              stockpile = v.recruitWorkerValidator.stockpile;
-              treasury = v.recruitWorkerValidator.treasury;
-            },
+            run: (v) => _runArmyMovePhase(
+              v,
+              state,
+              armyMoves,
+              game,
+              playerId,
+              diplomatic,
+              view,
+              topology,
+              armiesById,
+              factionMembership,
+            ),
           ),
           (
             refreshBundleBefore: true,
-            run: (v) {
-              rejected = _appendValidationResults(
-                results,
-                builds,
-                rejected,
-                (o, prev) =>
-                    v.buildValidator.validate(o, previousRejected: prev),
-              );
-              workerPool = v.buildValidator.workers;
-              stockpile = v.buildValidator.stockpile;
-              treasury = v.buildValidator.treasury;
-            },
+            run: (v) => _runRecruitWorkerPhase(v, state, recruitWorkers),
           ),
           (
             refreshBundleBefore: true,
-            run: (v) {
-              rejected = _appendValidationResults(
-                results,
-                works,
-                rejected,
-                (o, prev) =>
-                    v.workValidator.validate(o, previousRejected: prev),
-              );
-              stockpile = v.workValidator.stockpile;
-              treasury = v.workValidator.treasury;
-            },
+            run: (v) => _runBuildPhase(v, state, builds),
           ),
           (
             refreshBundleBefore: true,
-            run: (v) {
-              final afterDiplomatic =
-                  _appendValidationResultsWithState<DiplomaticOrder, int>(
-                    results,
-                    diplomatic,
-                    rejected,
-                    treasury,
-                    (o, prev) {
-                      final r = v.diplomaticValidator.validate(
-                        o,
-                        previousRejected: prev,
-                      );
-                      return (result: r.result, state: r.treasury);
-                    },
-                  );
-              rejected = afterDiplomatic.rejected;
-              treasury = afterDiplomatic.state;
-            },
+            run: (v) => _runWorkPhase(v, state, works),
           ),
           (
             refreshBundleBefore: true,
-            run: (v) {
-              rejected = _appendValidationResults(
-                results,
-                navals,
-                rejected,
-                (o, prev) => v.navalValidator.validateNavalMove(
-                  o,
-                  previousRejected: prev,
-                ),
-              );
-              rejected = _appendValidationResults(
-                results,
-                missions,
-                rejected,
-                (o, prev) => v.navalValidator.validateNavalMission(
-                  o,
-                  previousRejected: prev,
-                ),
-              );
-            },
+            run: (v) => _runDiplomaticPhase(v, state, diplomatic),
+          ),
+          (
+            refreshBundleBefore: true,
+            run: (v) => _runNavalPhase(v, state, navals, missions),
           ),
         ];
 
@@ -461,7 +449,156 @@ class OrderEngine with _OrderEngineGeneratedOrderMethods {
       }
       phase.run(validators);
     }
-    return results;
+  }
+
+  void _runMovePhase(
+    OrderValidators v,
+    _OrderValidationRunState state,
+    List<MoveOrder> moves,
+    Game game,
+    String playerId,
+    Map<String, Unit> unitsById,
+    List<DiplomaticOrder> diplomatic,
+    PlayerView view,
+    MapTopology topology,
+    DiplomacyFactionMembership factionMembership,
+  ) {
+    state.rejected = _appendValidationResults(
+      state.results,
+      moves,
+      state.rejected,
+      (o, prev) => v.moveValidator.validate(
+        o,
+        game,
+        playerId,
+        unitsById,
+        diplomatic,
+        view,
+        topology,
+        previousRejected: prev,
+        factionMembership: factionMembership,
+      ),
+    );
+  }
+
+  void _runArmyMovePhase(
+    OrderValidators v,
+    _OrderValidationRunState state,
+    List<ArmyMoveOrder> armyMoves,
+    Game game,
+    String playerId,
+    List<DiplomaticOrder> diplomatic,
+    PlayerView view,
+    MapTopology topology,
+    Map<String, Army> armiesById,
+    DiplomacyFactionMembership factionMembership,
+  ) {
+    state.rejected = _appendValidationResults(
+      state.results,
+      armyMoves,
+      state.rejected,
+      (o, prev) => prev
+          ? previousInvalidOrderResult
+          : v.armyMoveValidator.validate(
+              o,
+              game,
+              playerId,
+              diplomatic,
+              view,
+              topology,
+              armiesById: armiesById,
+              factionMembership: factionMembership,
+            ),
+    );
+  }
+
+  void _runRecruitWorkerPhase(
+    OrderValidators v,
+    _OrderValidationRunState state,
+    List<RecruitWorkerOrder> recruitWorkers,
+  ) {
+    state.rejected = _appendValidationResults(
+      state.results,
+      recruitWorkers,
+      state.rejected,
+      (o, prev) => v.recruitWorkerValidator.validate(o, previousRejected: prev),
+    );
+    state.workerPool = v.recruitWorkerValidator.workers;
+    state.stockpile = v.recruitWorkerValidator.stockpile;
+    state.treasury = v.recruitWorkerValidator.treasury;
+  }
+
+  void _runBuildPhase(
+    OrderValidators v,
+    _OrderValidationRunState state,
+    List<BuildUnitOrder> builds,
+  ) {
+    state.rejected = _appendValidationResults(
+      state.results,
+      builds,
+      state.rejected,
+      (o, prev) => v.buildValidator.validate(o, previousRejected: prev),
+    );
+    state.workerPool = v.buildValidator.workers;
+    state.stockpile = v.buildValidator.stockpile;
+    state.treasury = v.buildValidator.treasury;
+  }
+
+  void _runWorkPhase(
+    OrderValidators v,
+    _OrderValidationRunState state,
+    List<WorkOrder> works,
+  ) {
+    state.rejected = _appendValidationResults(
+      state.results,
+      works,
+      state.rejected,
+      (o, prev) => v.workValidator.validate(o, previousRejected: prev),
+    );
+    state.stockpile = v.workValidator.stockpile;
+    state.treasury = v.workValidator.treasury;
+  }
+
+  void _runDiplomaticPhase(
+    OrderValidators v,
+    _OrderValidationRunState state,
+    List<DiplomaticOrder> diplomatic,
+  ) {
+    final afterDiplomatic =
+        _appendValidationResultsWithState<DiplomaticOrder, int>(
+          state.results,
+          diplomatic,
+          state.rejected,
+          state.treasury,
+          (o, prev) {
+            final r = v.diplomaticValidator.validate(o, previousRejected: prev);
+            return (result: r.result, state: r.treasury);
+          },
+        );
+    state.rejected = afterDiplomatic.rejected;
+    state.treasury = afterDiplomatic.state;
+  }
+
+  void _runNavalPhase(
+    OrderValidators v,
+    _OrderValidationRunState state,
+    List<NavalMoveOrder> navals,
+    List<NavalMissionOrder> missions,
+  ) {
+    state.rejected = _appendValidationResults(
+      state.results,
+      navals,
+      state.rejected,
+      (o, prev) =>
+          v.navalValidator.validateNavalMove(o, previousRejected: prev),
+    );
+    state.rejected = _appendValidationResults(
+      state.results,
+      missions,
+      state.rejected,
+      (o, prev) =>
+          v.navalValidator.validateNavalMission(o, previousRejected: prev),
+    );
   }
 
   /// Dry-run: apply orders via resolver (no mutation of [game]); return projected effects.

--- a/packages/colonizethis_logic/lib/src/orders/order_engine.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_engine.dart
@@ -109,6 +109,7 @@ typedef OrderValidatorFactory =
       Stockpile stockpile,
       int treasury,
       DiplomacyFactionMembership factionMembership,
+      WorkerPool workerPool,
     );
 
 /// One post–move/army validation round: caller constructs a fresh [OrderValidators]
@@ -246,6 +247,8 @@ class OrderEngine with _OrderEngineGeneratedOrderMethods {
 
     final moves = _orders.moveOrdersByPlayerId[playerId] ?? [];
     final armyMoves = _orders.armyMoveOrdersByPlayerId[playerId] ?? [];
+    final recruitWorkers =
+        _orders.recruitWorkerOrdersByPlayerId[playerId] ?? [];
     final builds = _orders.buildUnitOrdersByPlayerId[playerId] ?? [];
     final works = _orders.workOrdersByPlayerId[playerId] ?? [];
     final diplomatic = _orders.diplomaticOrdersByPlayerId[playerId] ?? [];
@@ -254,6 +257,12 @@ class OrderEngine with _OrderEngineGeneratedOrderMethods {
     var rejected = false;
     var stockpile = player.stockpile;
     var treasury = player.treasury;
+    // Peasant reservation ledger: each accepted RecruitWorkerOrder consumes
+    // peasants per `WorkerActionEconomyCatalog`, and the downstream build
+    // validator must see the post-recruit headcount so military/naval builds
+    // that consume a peasant respect the combined reservation (see
+    // SPEC/game/workers-and-population.md § Peasant reservation).
+    var workerPool = player.workerPool;
 
     final unitsById = Map<String, Unit>.from(
       unitsByIdFromWorld(game.worldState),
@@ -295,6 +304,7 @@ class OrderEngine with _OrderEngineGeneratedOrderMethods {
       stockpile,
       treasury,
       factionMembership,
+      workerPool,
     );
 
     // One ordered list: move + army share the initial bundle; each later
@@ -347,6 +357,29 @@ class OrderEngine with _OrderEngineGeneratedOrderMethods {
             },
           ),
           (
+            // Worker pool orders (recruit / train) come before unit builds in
+            // both validation and resolution so the peasant reservation
+            // ledger reflects accepted recruit consumes before military /
+            // naval builds check their own peasant requirement (SPEC/game/
+            // workers-and-population.md § Peasant reservation; SPEC/program/
+            // turn-resolution-phase-details.md § Build / work).
+            refreshBundleBefore: true,
+            run: (v) {
+              rejected = _appendValidationResults(
+                results,
+                recruitWorkers,
+                rejected,
+                (o, prev) => v.recruitWorkerValidator.validate(
+                  o,
+                  previousRejected: prev,
+                ),
+              );
+              workerPool = v.recruitWorkerValidator.workers;
+              stockpile = v.recruitWorkerValidator.stockpile;
+              treasury = v.recruitWorkerValidator.treasury;
+            },
+          ),
+          (
             refreshBundleBefore: true,
             run: (v) {
               rejected = _appendValidationResults(
@@ -356,6 +389,7 @@ class OrderEngine with _OrderEngineGeneratedOrderMethods {
                 (o, prev) =>
                     v.buildValidator.validate(o, previousRejected: prev),
               );
+              workerPool = v.buildValidator.workers;
               stockpile = v.buildValidator.stockpile;
               treasury = v.buildValidator.treasury;
             },
@@ -472,6 +506,7 @@ OrderValidators _defaultOrderValidatorFactory(
   Stockpile stockpile,
   int treasury,
   DiplomacyFactionMembership factionMembership,
+  WorkerPool workerPool,
 ) {
   return createOrderValidators(
     game: game,
@@ -487,5 +522,6 @@ OrderValidators _defaultOrderValidatorFactory(
     stockpile: stockpile,
     treasury: treasury,
     factionMembership: factionMembership,
+    workerPool: workerPool,
   );
 }

--- a/packages/colonizethis_logic/lib/src/orders/order_engine.g.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_engine.g.dart
@@ -74,6 +74,16 @@ const _orderSlotNavalMissionOrder = _OrderSlot<NavalMissionOrder>(
   label: 'naval mission',
 );
 
+Map<String, List<RecruitWorkerOrder>> _orderEngineGetRecruitWorkerOrder(Orders o) => o.recruitWorkerOrdersByPlayerId;
+
+Orders _orderEngineWithRecruitWorkerOrder(Orders o, Map<String, List<RecruitWorkerOrder>> m) => o.copyWith(recruitWorkerOrdersByPlayerId: m);
+
+const _orderSlotRecruitWorkerOrder = _OrderSlot<RecruitWorkerOrder>(
+  getter: _orderEngineGetRecruitWorkerOrder,
+  updater: _orderEngineWithRecruitWorkerOrder,
+  label: 'recruit worker',
+);
+
 Orders copyInitialOrdersForEngine(Orders initialOrders) =>
     Orders(
       moveOrdersByPlayerId: _copyMapOfOrderLists(initialOrders.moveOrdersByPlayerId),
@@ -83,8 +93,8 @@ Orders copyInitialOrdersForEngine(Orders initialOrders) =>
       diplomaticOrdersByPlayerId: _copyMapOfOrderLists(initialOrders.diplomaticOrdersByPlayerId),
       navalMoveOrdersByPlayerId: _copyMapOfOrderLists(initialOrders.navalMoveOrdersByPlayerId),
       navalMissionOrdersByPlayerId: _copyMapOfOrderLists(initialOrders.navalMissionOrdersByPlayerId),
-      researchOrdersByPlayerId: _copyMapOfOrderLists(initialOrders.researchOrdersByPlayerId),
       recruitWorkerOrdersByPlayerId: _copyMapOfOrderLists(initialOrders.recruitWorkerOrdersByPlayerId),
+      researchOrdersByPlayerId: _copyMapOfOrderLists(initialOrders.researchOrdersByPlayerId),
     );
 
 Orders copyOrdersSnapshotForEngine(Orders o) =>
@@ -96,8 +106,8 @@ Orders copyOrdersSnapshotForEngine(Orders o) =>
       diplomaticOrdersByPlayerId: _copyMapOfOrderLists(o.diplomaticOrdersByPlayerId),
       navalMoveOrdersByPlayerId: _copyMapOfOrderLists(o.navalMoveOrdersByPlayerId),
       navalMissionOrdersByPlayerId: _copyMapOfOrderLists(o.navalMissionOrdersByPlayerId),
-      researchOrdersByPlayerId: _copyMapOfOrderLists(o.researchOrdersByPlayerId),
       recruitWorkerOrdersByPlayerId: _copyMapOfOrderLists(o.recruitWorkerOrdersByPlayerId),
+      researchOrdersByPlayerId: _copyMapOfOrderLists(o.researchOrdersByPlayerId),
     );
 
 mixin _OrderEngineGeneratedOrderMethods {
@@ -247,6 +257,27 @@ mixin _OrderEngineGeneratedOrderMethods {
 
   void removeNavalMissionOrder(String playerId, int index) =>
       (this as OrderEngine).removeOrderForSlot(playerId, index, _orderSlotNavalMissionOrder);
+
+  OrderValidationResult addRecruitWorkerOrder(String playerId, RecruitWorkerOrder order) =>
+      (this as OrderEngine).addOrderForSlot(playerId, order, _orderSlotRecruitWorkerOrder);
+
+  OrderValidationResult addRecruitWorkerOrderWithContext(
+    Game game,
+    MapTopology topology,
+    String playerId,
+    RecruitWorkerOrder order, {
+    Map<String, TileMapResult>? tileMapByRegion,
+  }) => (this as OrderEngine).addOrderForSlotWithContext(
+    game,
+    topology,
+    playerId,
+    order,
+    _orderSlotRecruitWorkerOrder,
+    tileMapByRegion: tileMapByRegion,
+  );
+
+  void removeRecruitWorkerOrder(String playerId, int index) =>
+      (this as OrderEngine).removeOrderForSlot(playerId, index, _orderSlotRecruitWorkerOrder);
 
 }
 

--- a/packages/colonizethis_logic/lib/src/orders/order_engine_manifest.yaml
+++ b/packages/colonizethis_logic/lib/src/orders/order_engine_manifest.yaml
@@ -60,13 +60,15 @@ engine_slots:
     add_with_context_method: addNavalMissionOrderWithContext
     remove_method: removeNavalMissionOrder
 
+  - order_type: RecruitWorkerOrder
+    orders_field: recruitWorkerOrdersByPlayerId
+    copy_with_param: recruitWorkerOrdersByPlayerId
+    log_label: recruit worker
+    add_method: addRecruitWorkerOrder
+    add_with_context_method: addRecruitWorkerOrderWithContext
+    remove_method: removeRecruitWorkerOrder
+
 # Copied in constructor and _copyOrders only; no engine slot or add*Order API.
-# recruitWorkerOrdersByPlayerId remains storage-only here; engine integration
-# lands with #2692 S4 (logic: validation, peasant reservation, Build/work
-# phase wiring per SPEC/game/workers-and-population.md).
 storage_only:
   - orders_field: researchOrdersByPlayerId
     copy_with_param: researchOrdersByPlayerId
-
-  - orders_field: recruitWorkerOrdersByPlayerId
-    copy_with_param: recruitWorkerOrdersByPlayerId

--- a/packages/colonizethis_logic/lib/src/orders/order_validators.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_validators.dart
@@ -6,4 +6,5 @@ export 'validators/build_order_validator.dart';
 export 'validators/diplomatic_order_validator.dart';
 export 'validators/move_validator.dart';
 export 'validators/naval_order_validator.dart';
+export 'validators/recruit_worker_order_validator.dart';
 export 'validators/work_order_validator.dart';

--- a/packages/colonizethis_logic/lib/src/orders/orders_application.dart
+++ b/packages/colonizethis_logic/lib/src/orders/orders_application.dart
@@ -15,6 +15,7 @@ import 'orders_application_completed_work.dart';
 import 'orders_application_context.dart';
 import 'orders_application_helpers.dart';
 import 'orders_application_work_phase.dart';
+import 'orders_application_worker_pool_phase.dart';
 import '../turn/trace/turn_trace_runtime.dart';
 
 /// Order application helpers for build and work phases.
@@ -56,9 +57,12 @@ Game applyBuildAndWorkOrders(
   void Function(DialogueEvent)? onDialogue,
   WorkOrderTraceCallback? onWorkOrderTrace,
 }) {
+  final recruitWorkerOrders = orders.recruitWorkerOrdersByPlayerId;
   final buildOrders = orders.buildUnitOrdersByPlayerId;
   final workOrders = orders.workOrdersByPlayerId;
-  if (buildOrders.isEmpty && workOrders.isEmpty) {
+  if (recruitWorkerOrders.isEmpty &&
+      buildOrders.isEmpty &&
+      workOrders.isEmpty) {
     return game;
   }
 
@@ -86,6 +90,7 @@ Game applyBuildAndWorkOrders(
   );
   var state = BuildWorkState(
     game: game,
+    recruitWorkerOrders: recruitWorkerOrders,
     buildOrders: buildOrders,
     workOrders: workOrders,
     topology: topology,
@@ -95,6 +100,11 @@ Game applyBuildAndWorkOrders(
     work: work,
   );
 
+  // Worker pool sub-phase runs before unit builds so any recruit / train
+  // peasant consumes settle before military / naval builds re-evaluate the
+  // peasant pool (SPEC/program/turn-resolution-phase-details.md § Build /
+  // work).
+  state = runWorkerPoolPhase(state);
   state = runBuildPhase(state);
   state = runWorkPhase(
     state,

--- a/packages/colonizethis_logic/lib/src/orders/orders_application_context.dart
+++ b/packages/colonizethis_logic/lib/src/orders/orders_application_context.dart
@@ -74,6 +74,7 @@ class BuildWorkState {
     required this.game,
     required this.buildOrders,
     required this.workOrders,
+    this.recruitWorkerOrders = const <String, List<RecruitWorkerOrder>>{},
     this.topology,
     this.tileMapByRegion,
     this.onDialogue,
@@ -82,6 +83,12 @@ class BuildWorkState {
   });
 
   final Game game;
+
+  /// Player id -> queued worker recruit / train orders applied in the worker
+  /// pool sub-phase of Build / work, **before** [buildOrders]. SPEC/game/
+  /// workers-and-population.md § Phase placement.
+  final Map<String, List<RecruitWorkerOrder>> recruitWorkerOrders;
+
   final Map<String, List<BuildUnitOrder>> buildOrders;
   final Map<String, List<WorkOrder>> workOrders;
   final MapTopology? topology;
@@ -92,6 +99,7 @@ class BuildWorkState {
 
   BuildWorkState copyWith({
     Game? game,
+    Map<String, List<RecruitWorkerOrder>>? recruitWorkerOrders,
     Map<String, List<BuildUnitOrder>>? buildOrders,
     Map<String, List<WorkOrder>>? workOrders,
     MapTopology? topology,
@@ -102,6 +110,7 @@ class BuildWorkState {
   }) {
     return BuildWorkState(
       game: game ?? this.game,
+      recruitWorkerOrders: recruitWorkerOrders ?? this.recruitWorkerOrders,
       buildOrders: buildOrders ?? this.buildOrders,
       workOrders: workOrders ?? this.workOrders,
       topology: topology ?? this.topology,

--- a/packages/colonizethis_logic/lib/src/orders/orders_application_worker_pool_phase.dart
+++ b/packages/colonizethis_logic/lib/src/orders/orders_application_worker_pool_phase.dart
@@ -1,0 +1,71 @@
+import '../economy/worker_action_cost.dart';
+import 'orders_application_context.dart';
+
+/// Worker pool sub-phase of Build / work (phase 12).
+///
+/// Applies queued `RecruitWorkerOrder`s per player, in submission order, so
+/// the WorkerPool deltas settle **before** the unit build loop in
+/// [runBuildPhase] (subsequent military / naval builds therefore see the
+/// post-recruit peasant headcount; civilian builds do not consume peasants).
+///
+/// SPEC sources:
+/// - `SPEC/game/workers-and-population.md` § Recruiting, Training, and
+///   Disbanding (cost table, peasant reservation, tech gates).
+/// - `SPEC/program/turn-resolution-phase-details.md` § Build / work
+///   (worker pool orders resolve first).
+/// - `SPEC/program/orders.md` § RecruitWorkerOrder.
+BuildWorkState runWorkerPoolPhase(BuildWorkState state) {
+  final recruitOrdersByPlayerId = state.recruitWorkerOrders;
+  if (recruitOrdersByPlayerId.isEmpty) {
+    return state;
+  }
+
+  var current = state;
+  for (final player in current.game.players) {
+    final orders = recruitOrdersByPlayerId[player.id];
+    if (orders == null || orders.isEmpty) continue;
+
+    var workers = player.workerPool;
+    var stockpile = player.stockpile;
+    var treasury = player.treasury;
+
+    for (final order in orders) {
+      final check = canAffordRecruitWorker(
+        player,
+        order,
+        workers,
+        stockpile,
+        treasury,
+      );
+      if (!check.canAfford) continue;
+
+      final after = applyRecruitWorkerCostDeduction(
+        order,
+        workers,
+        stockpile,
+        treasury,
+      );
+      workers = after.workers;
+      stockpile = after.stockpile;
+      treasury = after.treasury;
+    }
+
+    current = current.copyWith(
+      game: current.game.copyWith(
+        players: current.game.players
+            .map(
+              (p) => p.id == player.id
+                  ? p.copyWith(
+                      workerPool: workers,
+                      stockpile: stockpile,
+                      treasury: treasury,
+                    )
+                  : p,
+            )
+            .toList(),
+      ),
+    );
+  }
+
+  return current;
+}

--- a/packages/colonizethis_logic/lib/src/orders/validator_bundle.dart
+++ b/packages/colonizethis_logic/lib/src/orders/validator_bundle.dart
@@ -13,6 +13,7 @@ class OrderValidators {
   const OrderValidators({
     required this.moveValidator,
     required this.armyMoveValidator,
+    required this.recruitWorkerValidator,
     required this.buildValidator,
     required this.workValidator,
     required this.diplomaticValidator,
@@ -21,6 +22,7 @@ class OrderValidators {
 
   final MoveValidator moveValidator;
   final ArmyMoveValidator armyMoveValidator;
+  final RecruitWorkerOrderValidator recruitWorkerValidator;
   final BuildOrderValidator buildValidator;
   final WorkOrderValidator workValidator;
   final DiplomaticOrderValidator diplomaticValidator;
@@ -99,6 +101,12 @@ WorkOrderValidator createWorkOrderValidator({
 
 /// Factory for the default validator bundle used by [OrderEngine] and for
 /// economy projection inside incremental candidate validation.
+///
+/// [workerPool] is the projected worker pool state after any previously
+/// accepted `RecruitWorkerOrder`s in the same validation pass (peasant
+/// reservation ledger, SPEC/game/workers-and-population.md § Peasant
+/// reservation). Pass `player.workerPool` when no recruit orders are in
+/// scope.
 OrderValidators createOrderValidators({
   required Game game,
   required Player player,
@@ -113,21 +121,30 @@ OrderValidators createOrderValidators({
   required Stockpile stockpile,
   required int treasury,
   required DiplomacyFactionMembership factionMembership,
+  WorkerPool? workerPool,
 }) {
-  final treasuryForBuildValidation = treasury +
+  final treasuryForBuildValidation =
+      treasury +
       pendingRichesTreasuryDelta(
         stockpile: stockpile,
         richesCashMultiplier: game.richesCashMultiplier,
       );
+  final projectedWorkerPool = workerPool ?? player.workerPool;
   return OrderValidators(
     moveValidator: const MoveValidator(),
     armyMoveValidator: const ArmyMoveValidator(),
+    recruitWorkerValidator: RecruitWorkerOrderValidator.withProjectedEconomy(
+      player: player,
+      stockpile: stockpile,
+      treasury: treasury,
+      workerPool: projectedWorkerPool,
+    ),
     buildValidator: BuildOrderValidator.withProjectedEconomy(
       game: game,
       player: player,
       stockpile: stockpile,
       treasury: treasuryForBuildValidation,
-      workerPool: player.workerPool,
+      workerPool: projectedWorkerPool,
     ),
     workValidator: createWorkOrderValidator(
       game: game,

--- a/packages/colonizethis_logic/lib/src/orders/validators/recruit_worker_order_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/validators/recruit_worker_order_validator.dart
@@ -1,0 +1,91 @@
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import '../../economy/worker_action_cost.dart';
+import '../order_validation_result.dart';
+
+import 'stateful_validator.dart';
+
+/// Validates `RecruitWorkerOrder`s for a single player in submission order.
+///
+/// Mutates internal economy state (workerPool, stockpile, treasury) when an
+/// order is accepted so subsequent orders in the same player's chain — both
+/// recruit orders and (downstream) `BuildUnitOrder` peasant consumes — see the
+/// post-deduction state. This is the **peasant reservation ledger** required
+/// by `SPEC/game/workers-and-population.md` § Peasant reservation.
+///
+/// Spec:
+/// - `SPEC/game/workers-and-population.md` § Recruiting, Training, and
+///   Disbanding (cost table, rejection reasons, peasant reservation).
+/// - `SPEC/program/orders.md` § RecruitWorkerOrder.
+/// - `SPEC/program/turn-resolution-phase-details.md` § Build / work
+///   (worker pool orders resolve before [BuildUnitOrder]).
+class RecruitWorkerOrderValidator extends StatefulValidator {
+  RecruitWorkerOrderValidator({required Player player})
+    : _player = player,
+      super(
+        stockpileState: player.stockpile,
+        treasuryState: player.treasury,
+        workerPoolState: player.workerPool,
+      );
+
+  /// Allows the order engine to seed projected economy state (e.g. after a
+  /// previous validator phase deducted treasury). Mirrors
+  /// `BuildOrderValidator.withProjectedEconomy`.
+  RecruitWorkerOrderValidator.withProjectedEconomy({
+    required Player player,
+    required Stockpile stockpile,
+    required int treasury,
+    required WorkerPool workerPool,
+  }) : _player = player,
+       super(
+         stockpileState: stockpile,
+         treasuryState: treasury,
+         workerPoolState: workerPool,
+       );
+
+  final Player _player;
+
+  WorkerPool get workers => workerPoolState;
+  Stockpile get stockpile => stockpileState;
+  int get treasury => treasuryState;
+
+  /// Validates one [RecruitWorkerOrder] against the running economy snapshot.
+  /// When accepted, deducts the cost row from [workers] / [stockpile] /
+  /// [treasury] so the next order in the chain sees the post-deduction state.
+  ///
+  /// Rejection reasons come from `worker_action_cost.dart` and match the GDD
+  /// vocabulary (`Insufficient workers`, `Insufficient materials`,
+  /// `Insufficient treasury`, `Required technology not unlocked`).
+  OrderValidationResult validate(
+    RecruitWorkerOrder order, {
+    required bool previousRejected,
+  }) {
+    return shortCircuitIfPreviousRejected(
+      previousRejected: previousRejected,
+      body: () {
+        final check = canAffordRecruitWorker(
+          _player,
+          order,
+          workerPoolState,
+          stockpileState,
+          treasuryState,
+        );
+        if (!check.canAfford) {
+          return OrderValidationResult.rejected(
+            check.reason ?? kRecruitWorkerInsufficientMaterials,
+          );
+        }
+        final after = applyRecruitWorkerCostDeduction(
+          order,
+          workerPoolState,
+          stockpileState,
+          treasuryState,
+        );
+        workerPoolState = after.workers;
+        stockpileState = after.stockpile;
+        treasuryState = after.treasury;
+        return OrderValidationResult.accepted();
+      },
+    );
+  }
+}

--- a/packages/colonizethis_logic/test/order_engine_validate_recruit_worker_test.dart
+++ b/packages/colonizethis_logic/test/order_engine_validate_recruit_worker_test.dart
@@ -1,0 +1,211 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_logic/src/economy/worker_action_cost.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+/// End-to-end OrderEngine wiring for [RecruitWorkerOrder] (#2692 S4).
+///
+/// Covers the validation contract that:
+///   1. Engine validates `RecruitWorkerOrder`s in their own phase before
+///      `BuildUnitOrder` so the peasant reservation ledger drains workers
+///      before military / naval builds see them
+///      (SPEC/program/turn-resolution-phase-details.md § Build / work).
+///   2. The engine reports the same status the standalone validator would
+///      (positive accepts and tech / treasury / material / peasant
+///      rejections per SPEC/game/workers-and-population.md).
+///   3. Mixed orders — recruit consumes the last peasant; a subsequent
+///      military build (which also consumes a peasant) is rejected with
+///      `Insufficient workers`.
+const _regionId = 'oldWorld';
+const _provinceId = '$_regionId|P1';
+
+final _topology = MapTopology(
+  nodes: const [
+    TopologyNode(
+      id: 'P1',
+      regionId: _regionId,
+      type: TopologyNodeType.province,
+    ),
+  ],
+  edges: const [],
+);
+
+Game _gameWith({
+  required Player player,
+  List<Province> provinces = const [
+    Province(id: _provinceId, regionId: _regionId, ownerId: 'p1'),
+  ],
+}) {
+  return Game(
+    id: 'g',
+    worldState: WorldState(
+      turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+      oldWorld: RegionData(provinces: provinces),
+      newWorld: const RegionData(),
+    ),
+    players: [player],
+  );
+}
+
+void main() {
+  group('OrderEngine validation pass — RecruitWorkerOrder (#2692 S4)', () {
+    test('accepts a single peasant recruit when fabric is available', () {
+      final game = _gameWith(
+        player: Player(
+          id: 'p1',
+          displayName: 'P',
+          isHuman: true,
+          stockpile: Stockpile(quantities: {CommodityCatalog.fabric.id: 2}),
+        ),
+      );
+      final engine = OrderEngine()
+        ..addRecruitWorkerOrder(
+          'p1',
+          const RecruitWorkerOrder(targetTier: WorkerTier.peasant),
+        );
+
+      final results = engine.validatePlayerOrdersWithContext(
+        game,
+        _topology,
+        'p1',
+      );
+
+      expect(results, hasLength(1));
+      expect(results.single.isAccepted, isTrue);
+    });
+
+    test('rejects apprentice train when required tech is locked', () {
+      final game = _gameWith(
+        player: Player(
+          id: 'p1',
+          displayName: 'P',
+          isHuman: true,
+          stockpile: Stockpile(quantities: {CommodityCatalog.paper.id: 5}),
+          workerPool: const WorkerPool(peasants: 1),
+          treasury: 500,
+          techUnlocked: const {kTechIdApprenticeWorkers: true},
+        ),
+      );
+      final engine = OrderEngine()
+        ..addRecruitWorkerOrder(
+          'p1',
+          const RecruitWorkerOrder(targetTier: WorkerTier.apprentice),
+        );
+
+      final results = engine.validatePlayerOrdersWithContext(
+        game,
+        _topology,
+        'p1',
+      );
+
+      expect(results.single.isAccepted, isFalse);
+      expect(results.single.reason, kRecruitWorkerTechLocked);
+    });
+
+    test('recruit consumes last peasant before military build, so '
+        'subsequent regiment build is rejected with Insufficient workers', () {
+      final game = _gameWith(
+        player: Player(
+          id: 'p1',
+          displayName: 'P',
+          isHuman: true,
+          capitalProvinceId: _provinceId,
+          stockpile: Stockpile(
+            quantities: {
+              CommodityCatalog.paper.id: 50,
+              CommodityCatalog.steel.id: 50,
+              CommodityCatalog.fabric.id: 50,
+            },
+          ),
+          workerPool: const WorkerPool(peasants: 1),
+          treasury: 5000,
+          techUnlocked: const {
+            kTechIdApprenticeWorkers: true,
+            kTechIdSugarRefining: true,
+          },
+        ),
+      );
+      final engine = OrderEngine()
+        ..addRecruitWorkerOrder(
+          'p1',
+          const RecruitWorkerOrder(targetTier: WorkerTier.apprentice),
+        )
+        ..addBuildOrder(
+          'p1',
+          BuildUnitOrder(
+            unitType: 'peasant_levies',
+            isMilitary: true,
+            spawnProvinceId: _provinceId,
+          ),
+        );
+
+      final results = engine.validatePlayerOrdersWithContext(
+        game,
+        _topology,
+        'p1',
+      );
+
+      expect(results, hasLength(2));
+      expect(results[0].isAccepted, isTrue, reason: 'recruit accepted');
+      expect(
+        results[1].isAccepted,
+        isFalse,
+        reason: 'build rejected because peasant was consumed by recruit',
+      );
+      expect(results[1].reason, 'Insufficient workers');
+    });
+
+    test('civilian build (no peasant consume) is accepted after recruit '
+        'consumes the only peasant', () {
+      final game = _gameWith(
+        player: Player(
+          id: 'p1',
+          displayName: 'P',
+          isHuman: true,
+          capitalProvinceId: _provinceId,
+          capitalTile: const CapitalTile(
+            regionId: _regionId,
+            provinceId: 'P1',
+            x: 0,
+            y: 0,
+          ),
+          stockpile: Stockpile(quantities: {CommodityCatalog.paper.id: 20}),
+          workerPool: const WorkerPool(peasants: 1),
+          treasury: 5000,
+          techUnlocked: const {
+            kTechIdApprenticeWorkers: true,
+            kTechIdSugarRefining: true,
+          },
+        ),
+      );
+      final engine = OrderEngine()
+        ..addRecruitWorkerOrder(
+          'p1',
+          const RecruitWorkerOrder(targetTier: WorkerTier.apprentice),
+        )
+        ..addBuildOrder(
+          'p1',
+          BuildUnitOrder(
+            unitType: kUnitTypeBuilder,
+            isMilitary: false,
+            spawnProvinceId: _provinceId,
+          ),
+        );
+
+      final results = engine.validatePlayerOrdersWithContext(
+        game,
+        _topology,
+        'p1',
+      );
+
+      expect(results, hasLength(2));
+      expect(results[0].isAccepted, isTrue);
+      expect(
+        results[1].isAccepted,
+        isTrue,
+        reason: 'civilian builder does not consume peasants',
+      );
+    });
+  });
+}

--- a/packages/colonizethis_logic/test/order_engine_validator_injection_test.dart
+++ b/packages/colonizethis_logic/test/order_engine_validator_injection_test.dart
@@ -6,6 +6,7 @@ import 'package:colonizethis_logic/src/orders/validators/build_order_validator.d
 import 'package:colonizethis_logic/src/orders/validators/diplomatic_order_validator.dart';
 import 'package:colonizethis_logic/src/orders/validators/move_validator.dart';
 import 'package:colonizethis_logic/src/orders/validators/naval_order_validator.dart';
+import 'package:colonizethis_logic/src/orders/validators/recruit_worker_order_validator.dart';
 import 'package:colonizethis_logic/src/orders/validators/work_order_validator.dart';
 import 'package:colonizethis_logic/src/diplomacy/diplomacy_resolver.dart';
 import 'package:colonizethis_logic/src/world/player_view.dart';
@@ -61,6 +62,7 @@ void main() {
             Stockpile stockpile,
             int treasury,
             DiplomacyFactionMembership factionMembership,
+            WorkerPool workerPool,
           ) {
             final workContext = buildWorkOrderValidationContext(
               game: game,
@@ -78,6 +80,9 @@ void main() {
             return OrderValidators(
               moveValidator: const _AlwaysRejectMoveValidator(),
               armyMoveValidator: const ArmyMoveValidator(),
+              recruitWorkerValidator: RecruitWorkerOrderValidator(
+                player: player,
+              ),
               buildValidator: BuildOrderValidator(game: game, player: player),
               workValidator: WorkOrderValidator(
                 context: workContext,
@@ -109,50 +114,53 @@ void main() {
   });
 
   test(
-    'validatePlayerOrdersWithContext builds five validator bundles '
-    '(shared move+army, then fresh per later category; Refs #2391 AC7)',
+    'validatePlayerOrdersWithContext builds six validator bundles '
+    '(shared move+army, then fresh per later category; #2391 AC7, #2692 S4)',
     () {
-    var factoryCalls = 0;
-    final game = TestFixtures.minimalGame();
-    final topology = MapTopology(nodes: const [], edges: const []);
-    final engine = OrderEngine(
-      initialOrders: const Orders(),
-      validatorFactory:
-          (
-            Game game,
-            Player player,
-            String playerId,
-            PlayerView view,
-            MapTopology topology,
-            Map<String, Unit> unitsById,
-            List<DiplomaticOrder> diplomaticOrders,
-            Map<String, TileMapResult>? tileMapByRegion,
-            Set<String> civilianDraftMoveUnitIds,
-            Set<String> devExclusiveTiles,
-            Stockpile stockpile,
-            int treasury,
-            DiplomacyFactionMembership factionMembership,
-          ) {
-            factoryCalls++;
-            return createOrderValidators(
-              game: game,
-              player: player,
-              playerId: playerId,
-              view: view,
-              topology: topology,
-              unitsById: unitsById,
-              diplomaticOrders: diplomaticOrders,
-              tileMapByRegion: tileMapByRegion,
-              civilianDraftMoveUnitIds: civilianDraftMoveUnitIds,
-              devExclusiveTiles: devExclusiveTiles,
-              stockpile: stockpile,
-              treasury: treasury,
-              factionMembership: factionMembership,
-            );
-          },
-    );
+      var factoryCalls = 0;
+      final game = TestFixtures.minimalGame();
+      final topology = MapTopology(nodes: const [], edges: const []);
+      final engine = OrderEngine(
+        initialOrders: const Orders(),
+        validatorFactory:
+            (
+              Game game,
+              Player player,
+              String playerId,
+              PlayerView view,
+              MapTopology topology,
+              Map<String, Unit> unitsById,
+              List<DiplomaticOrder> diplomaticOrders,
+              Map<String, TileMapResult>? tileMapByRegion,
+              Set<String> civilianDraftMoveUnitIds,
+              Set<String> devExclusiveTiles,
+              Stockpile stockpile,
+              int treasury,
+              DiplomacyFactionMembership factionMembership,
+              WorkerPool workerPool,
+            ) {
+              factoryCalls++;
+              return createOrderValidators(
+                game: game,
+                player: player,
+                playerId: playerId,
+                view: view,
+                topology: topology,
+                unitsById: unitsById,
+                diplomaticOrders: diplomaticOrders,
+                tileMapByRegion: tileMapByRegion,
+                civilianDraftMoveUnitIds: civilianDraftMoveUnitIds,
+                devExclusiveTiles: devExclusiveTiles,
+                stockpile: stockpile,
+                treasury: treasury,
+                factionMembership: factionMembership,
+                workerPool: workerPool,
+              );
+            },
+      );
 
-    engine.validatePlayerOrdersWithContext(game, topology, 'h1');
-    expect(factoryCalls, 5);
-  });
+      engine.validatePlayerOrdersWithContext(game, topology, 'h1');
+      expect(factoryCalls, 6);
+    },
+  );
 }

--- a/packages/colonizethis_logic/test/orders/orders_application_worker_pool_phase_test.dart
+++ b/packages/colonizethis_logic/test/orders/orders_application_worker_pool_phase_test.dart
@@ -1,0 +1,122 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+/// Build / work resolution applies RecruitWorkerOrder mutations to the player
+/// snapshot before BuildUnitOrder runs (#2692 S4; SPEC/program/turn-resolution-phase-details.md).
+void main() {
+  group('applyBuildAndWorkOrders worker pool sub-phase (#2692 S4)', () {
+    test(
+      'accepted recruit peasant order adds 1 peasant and deducts fabric',
+      () {
+        final game = Game(
+          id: 'g',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+            oldWorld: const RegionData(),
+            newWorld: const RegionData(),
+          ),
+          players: [
+            Player(
+              id: 'p1',
+              displayName: 'P',
+              isHuman: true,
+              stockpile: Stockpile(quantities: {CommodityCatalog.fabric.id: 3}),
+              workerPool: const WorkerPool(peasants: 0),
+            ),
+          ],
+        );
+        final orders = Orders(
+          recruitWorkerOrdersByPlayerId: {
+            'p1': const [RecruitWorkerOrder(targetTier: WorkerTier.peasant)],
+          },
+        );
+
+        final result = applyBuildAndWorkOrders(game, orders);
+
+        final p = result.players.single;
+        expect(p.workerPool.peasants, 1);
+        expect(p.stockpile.quantityOf(CommodityCatalog.fabric.id), 1);
+        expect(p.treasury, 0);
+      },
+    );
+
+    test('accepted apprentice train consumes peasant, paper, and treasury', () {
+      final game = Game(
+        id: 'g',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+        ),
+        players: [
+          Player(
+            id: 'p1',
+            displayName: 'P',
+            isHuman: true,
+            stockpile: Stockpile(quantities: {CommodityCatalog.paper.id: 5}),
+            workerPool: const WorkerPool(peasants: 3),
+            treasury: 500,
+            techUnlocked: const {
+              kTechIdApprenticeWorkers: true,
+              kTechIdSugarRefining: true,
+            },
+          ),
+        ],
+      );
+      final orders = Orders(
+        recruitWorkerOrdersByPlayerId: {
+          'p1': const [RecruitWorkerOrder(targetTier: WorkerTier.apprentice)],
+        },
+      );
+
+      final result = applyBuildAndWorkOrders(game, orders);
+
+      final p = result.players.single;
+      expect(p.workerPool.peasants, 2);
+      expect(p.workerPool.apprentices, 1);
+      expect(p.stockpile.quantityOf(CommodityCatalog.paper.id), 3);
+      expect(p.treasury, 300);
+    });
+
+    test('recruit that fails affordability checks does not mutate the player '
+        '(no partial deduction)', () {
+      final game = Game(
+        id: 'g',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+        ),
+        players: [
+          Player(
+            id: 'p1',
+            displayName: 'P',
+            isHuman: true,
+            stockpile: Stockpile(quantities: {CommodityCatalog.paper.id: 5}),
+            workerPool: const WorkerPool(peasants: 3),
+            treasury: 100, // insufficient for apprentice (200)
+            techUnlocked: const {
+              kTechIdApprenticeWorkers: true,
+              kTechIdSugarRefining: true,
+            },
+          ),
+        ],
+      );
+      final orders = Orders(
+        recruitWorkerOrdersByPlayerId: {
+          'p1': const [RecruitWorkerOrder(targetTier: WorkerTier.apprentice)],
+        },
+      );
+
+      final result = applyBuildAndWorkOrders(game, orders);
+
+      final p = result.players.single;
+      expect(p.workerPool.peasants, 3);
+      expect(p.workerPool.apprentices, 0);
+      expect(p.stockpile.quantityOf(CommodityCatalog.paper.id), 5);
+      expect(p.treasury, 100);
+    });
+  });
+}

--- a/packages/colonizethis_logic/test/orders/validator_bundle_test.dart
+++ b/packages/colonizethis_logic/test/orders/validator_bundle_test.dart
@@ -57,6 +57,7 @@ void main() {
     expect(ctx.playerId, playerId);
     expect(bundle.moveValidator, isA<MoveValidator>());
     expect(bundle.armyMoveValidator, isA<ArmyMoveValidator>());
+    expect(bundle.recruitWorkerValidator, isA<RecruitWorkerOrderValidator>());
     expect(bundle.buildValidator, isA<BuildOrderValidator>());
     expect(bundle.workValidator, isA<WorkOrderValidator>());
     expect(bundle.diplomaticValidator, isA<DiplomaticOrderValidator>());

--- a/packages/colonizethis_logic/test/orders/validators/recruit_worker_order_validator_test.dart
+++ b/packages/colonizethis_logic/test/orders/validators/recruit_worker_order_validator_test.dart
@@ -1,0 +1,264 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/src/economy/worker_action_cost.dart';
+import 'package:colonizethis_logic/src/orders/validators/recruit_worker_order_validator.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+void main() {
+  group('RecruitWorkerOrderValidator (#2692 S4)', () {
+    /// SPEC: workers-and-population.md § Recruit Peasant — peasant row has no
+    /// tech and only costs 2 fabric, no peasant consumed.
+    test('accepts peasant recruit and deducts 2 fabric, adds peasant', () {
+      final player = Player(
+        id: 'p1',
+        displayName: 'P',
+        isHuman: true,
+        stockpile: Stockpile(quantities: {CommodityCatalog.fabric.id: 5}),
+        workerPool: const WorkerPool(peasants: 3),
+        treasury: 0,
+      );
+      final validator = RecruitWorkerOrderValidator(player: player);
+
+      final result = validator.validate(
+        const RecruitWorkerOrder(targetTier: WorkerTier.peasant),
+        previousRejected: false,
+      );
+
+      expect(result.isAccepted, isTrue);
+      expect(validator.workers.peasants, 4);
+      expect(validator.stockpile.quantityOf(CommodityCatalog.fabric.id), 3);
+      expect(validator.treasury, 0);
+    });
+
+    test('rejects peasant recruit when fabric is insufficient', () {
+      final player = Player(
+        id: 'p1',
+        displayName: 'P',
+        isHuman: true,
+        stockpile: Stockpile(quantities: {CommodityCatalog.fabric.id: 1}),
+      );
+      final validator = RecruitWorkerOrderValidator(player: player);
+
+      final result = validator.validate(
+        const RecruitWorkerOrder(targetTier: WorkerTier.peasant),
+        previousRejected: false,
+      );
+
+      expect(result.isAccepted, isFalse);
+      expect(result.reason, kRecruitWorkerInsufficientMaterials);
+    });
+
+    /// SPEC: workers-and-population.md § Train Apprentice — both tech ids
+    /// required, 200 ducats, 2 paper, consumes 1 peasant.
+    test('accepts apprentice train when tech unlocked, deducts 200 ducats, '
+        '2 paper, 1 peasant; increments apprentices', () {
+      final player = Player(
+        id: 'p1',
+        displayName: 'P',
+        isHuman: true,
+        stockpile: Stockpile(quantities: {CommodityCatalog.paper.id: 5}),
+        workerPool: const WorkerPool(peasants: 2, apprentices: 1),
+        treasury: 500,
+        techUnlocked: const {
+          kTechIdApprenticeWorkers: true,
+          kTechIdSugarRefining: true,
+        },
+      );
+      final validator = RecruitWorkerOrderValidator(player: player);
+
+      final result = validator.validate(
+        const RecruitWorkerOrder(targetTier: WorkerTier.apprentice),
+        previousRejected: false,
+      );
+
+      expect(result.isAccepted, isTrue);
+      expect(validator.workers.peasants, 1);
+      expect(validator.workers.apprentices, 2);
+      expect(validator.treasury, 300);
+      expect(validator.stockpile.quantityOf(CommodityCatalog.paper.id), 3);
+    });
+
+    test('rejects apprentice train when required tech is locked', () {
+      final player = Player(
+        id: 'p1',
+        displayName: 'P',
+        isHuman: true,
+        stockpile: Stockpile(quantities: {CommodityCatalog.paper.id: 5}),
+        workerPool: const WorkerPool(peasants: 2),
+        treasury: 500,
+        techUnlocked: const {kTechIdApprenticeWorkers: true},
+      );
+      final validator = RecruitWorkerOrderValidator(player: player);
+
+      final result = validator.validate(
+        const RecruitWorkerOrder(targetTier: WorkerTier.apprentice),
+        previousRejected: false,
+      );
+
+      expect(result.isAccepted, isFalse);
+      expect(result.reason, kRecruitWorkerTechLocked);
+    });
+
+    test('rejects apprentice train when no peasant is available', () {
+      final player = Player(
+        id: 'p1',
+        displayName: 'P',
+        isHuman: true,
+        stockpile: Stockpile(quantities: {CommodityCatalog.paper.id: 5}),
+        treasury: 500,
+        techUnlocked: const {
+          kTechIdApprenticeWorkers: true,
+          kTechIdSugarRefining: true,
+        },
+      );
+      final validator = RecruitWorkerOrderValidator(player: player);
+
+      final result = validator.validate(
+        const RecruitWorkerOrder(targetTier: WorkerTier.apprentice),
+        previousRejected: false,
+      );
+
+      expect(result.isAccepted, isFalse);
+      expect(result.reason, kRecruitWorkerInsufficientWorkers);
+    });
+
+    test('rejects apprentice train when treasury is insufficient', () {
+      final player = Player(
+        id: 'p1',
+        displayName: 'P',
+        isHuman: true,
+        stockpile: Stockpile(quantities: {CommodityCatalog.paper.id: 5}),
+        workerPool: const WorkerPool(peasants: 2),
+        treasury: 100,
+        techUnlocked: const {
+          kTechIdApprenticeWorkers: true,
+          kTechIdSugarRefining: true,
+        },
+      );
+      final validator = RecruitWorkerOrderValidator(player: player);
+
+      final result = validator.validate(
+        const RecruitWorkerOrder(targetTier: WorkerTier.apprentice),
+        previousRejected: false,
+      );
+
+      expect(result.isAccepted, isFalse);
+      expect(result.reason, kRecruitWorkerInsufficientTreasury);
+    });
+
+    /// SPEC: workers-and-population.md § Train Journeyman cost row.
+    test('accepts journeyman train and applies 500 ducat + 5 paper cost', () {
+      final player = Player(
+        id: 'p1',
+        displayName: 'P',
+        isHuman: true,
+        stockpile: Stockpile(quantities: {CommodityCatalog.paper.id: 6}),
+        workerPool: const WorkerPool(peasants: 1, journeymen: 1),
+        treasury: 600,
+        techUnlocked: const {
+          kTechIdTrainedJourneymen: true,
+          kTechIdCigarProduction: true,
+        },
+      );
+      final validator = RecruitWorkerOrderValidator(player: player);
+
+      final result = validator.validate(
+        const RecruitWorkerOrder(targetTier: WorkerTier.journeyman),
+        previousRejected: false,
+      );
+
+      expect(result.isAccepted, isTrue);
+      expect(validator.workers.peasants, 0);
+      expect(validator.workers.journeymen, 2);
+      expect(validator.treasury, 100);
+      expect(validator.stockpile.quantityOf(CommodityCatalog.paper.id), 1);
+    });
+
+    /// SPEC: workers-and-population.md § Train Master cost row.
+    test('accepts master train and applies 1000 ducat + 10 paper cost', () {
+      final player = Player(
+        id: 'p1',
+        displayName: 'P',
+        isHuman: true,
+        stockpile: Stockpile(quantities: {CommodityCatalog.paper.id: 10}),
+        workerPool: const WorkerPool(peasants: 1, masters: 1),
+        treasury: 1500,
+        techUnlocked: const {
+          kTechIdMasterArtisans: true,
+          kTechIdHatProduction: true,
+        },
+      );
+      final validator = RecruitWorkerOrderValidator(player: player);
+
+      final result = validator.validate(
+        const RecruitWorkerOrder(targetTier: WorkerTier.master),
+        previousRejected: false,
+      );
+
+      expect(result.isAccepted, isTrue);
+      expect(validator.workers.peasants, 0);
+      expect(validator.workers.masters, 2);
+      expect(validator.treasury, 500);
+      expect(validator.stockpile.quantityOf(CommodityCatalog.paper.id), 0);
+    });
+
+    test(
+      'short-circuits to "Previous invalid" when previousRejected is true',
+      () {
+        final player = Player(
+          id: 'p1',
+          displayName: 'P',
+          isHuman: true,
+          stockpile: Stockpile(quantities: {CommodityCatalog.fabric.id: 5}),
+        );
+        final validator = RecruitWorkerOrderValidator(player: player);
+
+        final result = validator.validate(
+          const RecruitWorkerOrder(targetTier: WorkerTier.peasant),
+          previousRejected: true,
+        );
+
+        expect(result.isAccepted, isFalse);
+        expect(result.reason, 'Previous invalid');
+        expect(validator.workers.peasants, 0);
+      },
+    );
+
+    test('sequential apprentice trains drain peasants in submission order', () {
+      final player = Player(
+        id: 'p1',
+        displayName: 'P',
+        isHuman: true,
+        stockpile: Stockpile(quantities: {CommodityCatalog.paper.id: 6}),
+        workerPool: const WorkerPool(peasants: 2),
+        treasury: 600,
+        techUnlocked: const {
+          kTechIdApprenticeWorkers: true,
+          kTechIdSugarRefining: true,
+        },
+      );
+      final validator = RecruitWorkerOrderValidator(player: player);
+
+      final first = validator.validate(
+        const RecruitWorkerOrder(targetTier: WorkerTier.apprentice),
+        previousRejected: false,
+      );
+      final second = validator.validate(
+        const RecruitWorkerOrder(targetTier: WorkerTier.apprentice),
+        previousRejected: false,
+      );
+      final third = validator.validate(
+        const RecruitWorkerOrder(targetTier: WorkerTier.apprentice),
+        previousRejected: false,
+      );
+
+      expect(first.isAccepted, isTrue);
+      expect(second.isAccepted, isTrue);
+      expect(third.isAccepted, isFalse);
+      expect(third.reason, kRecruitWorkerInsufficientWorkers);
+      expect(validator.workers.peasants, 0);
+      expect(validator.workers.apprentices, 2);
+      expect(validator.treasury, 200);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Implements GitHub issue #2692 slice **S4** — *Logic: validation, peasant ledger, runWorkerPoolPhase, build-phase ordering*. Adds the OrderEngine validation phase and Build/work resolution sub-phase for `RecruitWorkerOrder`, so worker recruit/train deductions settle before unit builds and the peasant reservation ledger holds end-to-end.

SPEC authorization:
- `SPEC/game/workers-and-population.md` — cost table, rejection reasons, peasant reservation, tech gates.
- `SPEC/program/orders.md` — `RecruitWorkerOrder` validation contract.
- `SPEC/program/turn-resolution-phase-details.md` — Build/work phase ordering (worker pool → unit builds).

## Scope implemented

**Validation pipeline**
- New `RecruitWorkerOrderValidator` (stateful — workers/stockpile/treasury ledger) using shared `worker_action_cost.dart` helpers for affordability + deduction.
- `OrderEngine.validatePlayerOrdersWithContext` runs a new recruit-worker phase before the build phase; the post-recruit `WorkerPool` is threaded into the build validator so military/naval peasant consumes see the reserved headcount.
- `createOrderValidators` / `OrderValidators` accept an optional `workerPool` projection and expose `recruitWorkerValidator`.
- `OrderEngine` manifest promotes `RecruitWorkerOrder` to `engine_slots`; generated `addRecruitWorkerOrder` / `addRecruitWorkerOrderWithContext` / `removeRecruitWorkerOrder` APIs land in `order_engine.g.dart`.

**Resolution (Build/work phase)**
- New `runWorkerPoolPhase` inside `applyBuildAndWorkOrders` runs before `runBuildPhase`, applying accepted recruit orders (deducts cost, mutates `WorkerPool`).
- `BuildWorkState` now carries `recruitWorkerOrders`.

**Tests**
- `recruit_worker_order_validator_test.dart` — positive (peasant/apprentice/journeyman/master) + negative (tech-locked, insufficient workers/treasury/materials, sequential drain, short-circuit on previousRejected).
- `order_engine_validate_recruit_worker_test.dart` — full-pass accept, tech reject, peasant-reservation reject across recruit + military build, civilian build unaffected.
- `orders_application_worker_pool_phase_test.dart` — `applyBuildAndWorkOrders` mutates player snapshot for accepted recruit/train; rejected recruit does not partially deduct.
- Updated existing `OrderValidators` / engine-injection tests for the new validator field and 6-bundle factory count.

## Deferred (not in this PR)

- **Disband action** — `DisbandWorkerOrder` is a separate orders-phase action with no resource cost; will land with S2/S3 follow-up if not already merged.
- **IncrementalCandidateValidator** projection for recruit-prefix economy — only matters once AI plans recruit orders (S6); current AI does not populate `recruitWorkerOrdersByPlayerId`, so equivalence with full-pass holds in practice.
- **Production UI, AI recruitment planner, observer assertions** — S6, S7, S8, S9, S10 of #2692.

## AC coverage (this slice)

| AC | Status |
|---|---|
| RecruitWorkerOrder validated for tech, peasant, treasury, materials | covered (validator + tests) |
| Accepted recruits deduct workers/stockpile/treasury | covered (validator + apply phase + tests) |
| Recruit resolves before unit builds in Build/work | covered (engine phase order + apply phase order + tests) |
| Peasant reservation ledger across mixed orders | covered (engine threads post-recruit workerPool into build validator; test asserts military build rejection) |

## Test plan

- [x] `dart analyze packages/colonizethis_logic` — clean
- [x] `dart run tool/run_workspace_analyze_errors_only.dart` — clean
- [x] `dart test packages/colonizethis_logic` — 1764 passing
- [x] `dart test packages/colonizethis_models` — 111 passing
- [x] `dart test packages/colonizethis_data` — 263 passing
- [x] `dart test packages/colonizethis_ai` — 635 passing

Refs #2692

Made with [Cursor](https://cursor.com)