### PR TITLE
feat(ai): planExpandDeclareWar — EXPAND-phase declare-war target (Refs #2509 S2)

### DIFF
--- a/packages/colonizethis_ai/lib/src/planning/expand_phase_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/expand_phase_planner.dart
@@ -342,17 +342,19 @@ String? planExpandDeclareWar({
   for (final pid in invadable) {
     final owner = provinceOwner[pid];
     if (owner == null) continue;
-    if (minorIds.contains(owner)) {
-      anyMinorOnInvadable = true;
-      if (atWarWith.contains(owner)) {
-        atWarMinors.add(owner);
-      } else if (adjacentOwners.contains(owner)) {
-        adjacentNewWarMinors.add(owner);
+    if (!minorIds.contains(owner)) {
+      if (game.playerById(owner) != null) {
+        gpInvadableCounts[owner] = (gpInvadableCounts[owner] ?? 0) + 1;
       }
       continue;
     }
-    if (game.playerById(owner) != null) {
-      gpInvadableCounts[owner] = (gpInvadableCounts[owner] ?? 0) + 1;
+    anyMinorOnInvadable = true;
+    if (atWarWith.contains(owner)) {
+      atWarMinors.add(owner);
+      continue;
+    }
+    if (adjacentOwners.contains(owner)) {
+      adjacentNewWarMinors.add(owner);
     }
   }
 

--- a/packages/colonizethis_ai/lib/src/planning/expand_phase_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/expand_phase_planner.dart
@@ -27,7 +27,7 @@
 /// rewrite reconciles them, so this slice carries **zero behavior change**
 /// and **zero regression risk** for live AI play.
 ///
-/// In-module contracts shipped in this slice (see issue #2509 § EXPAND phase
+/// In-module contracts shipped to date (see issue #2509 § EXPAND phase
 /// planner for the full set):
 ///
 ///   `planExpandPeace(game, snapshot) → List<String>`
@@ -40,9 +40,20 @@
 ///     minors remaining (Refs #2509 § EXPAND phase planner § planExpandPeace
 ///     "peace to exit stalemate").
 ///
+///   `planExpandDeclareWar(game, snapshot) → String?`
+///     Returns the deterministic factionId of the next declare-war target
+///     for the active EXPAND player, scanning [ConquestSummary]
+///     `invadableProvinceIdsSorted` in priority order: (1) adjacent
+///     minor not yet at war, (2) already-at-war minor (formalize war so
+///     conquest army-move pass fires), (3) sole GP frontier blocker on a
+///     GP-only mutual-plateau frontier when our regiment count and
+///     treasury cover engagement. Returns `null` when no priority arm
+///     applies (Refs #2509 § EXPAND phase planner § planExpandDeclareWar).
+///     The "suggestDeclareWarOrders rejects" runtime gate noted in the
+///     spec is enforced at the orchestrator layer (#2509 S5) so this
+///     module remains a pure-function planner.
+///
 /// Functions left for follow-up slices on this issue:
-///   - `planExpandDeclareWar` — adjacent / already-at-war minor priority
-///     scan, then sole-GP frontier blocker fallback (#2509 S2).
 ///   - `planExpandEconomy` — force-regiment-rebuild trap and treasury-
 ///     recovery cargo boost (#2509 S2).
 ///   - `planExpandMilitary` — OW-only conquest army moves toward the
@@ -54,6 +65,7 @@ import 'package:colonizethis_logic/ai_api.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../perception/perception_snapshot.dart';
+import 'army_conquest_prep.dart' show regimentCountForPlayer;
 
 /// Returns the deterministic list of at-war Great Powers the active player
 /// should `offerPeace` toward this turn while in EXPAND phase.
@@ -199,12 +211,12 @@ bool _isOldWorldGpOnlyInvadableFrontier({
     return false;
   }
   final provinceOwner = getProvinceOwnerMap(game);
-  final minorsOwnInvadable = snapshot.conquest.invadableProvinceIdsSorted.any(
-    (pid) {
-      final owner = provinceOwner[pid];
-      return owner != null && game.minorNations.any((m) => m.id == owner);
-    },
-  );
+  final minorsOwnInvadable = snapshot.conquest.invadableProvinceIdsSorted.any((
+    pid,
+  ) {
+    final owner = provinceOwner[pid];
+    return owner != null && game.minorNations.any((m) => m.id == owner);
+  });
   if (minorsOwnInvadable) {
     return false;
   }
@@ -250,3 +262,145 @@ bool _isMutualBelowQuotaPlateauPeer({
     isBelowObserverConquestQuota(ownOw) &&
     isBelowObserverConquestQuota(partnerOw) &&
     (partnerOw - ownOw).abs() <= 1;
+
+/// Returns the deterministic factionId of the next declare-war target for
+/// the active EXPAND player, or `null` when no priority arm applies.
+///
+/// Contract (issue #2509 § EXPAND phase planner § planExpandDeclareWar):
+///
+///   "Priority-ordered scan of `invadableProvinceIdsSorted` (OW only).
+///    Pick the first valid candidate:
+///      1. Adjacent minor with uninvaded OW province
+///      2. Already-at-war minor with uninvaded OW province
+///      3. Sole GP frontier blocker (GP-only frontiers only, mutual
+///         plateau, our regiments ≥ partner's, treasury ≥ regiment cost)
+///      4. null — skip declaring."
+///
+/// The function is pure and deterministic — identical inputs always yield
+/// identical results (Refs #2509 Must-have #7). Tiebreaks are
+/// lexicographic ascending across factionIds within each priority arm.
+///
+/// Inputs:
+///   - [game]: used to (a) resolve the active player via
+///     [Game.playerById] for treasury and regiment-count gating; (b) walk
+///     the province-owner map for minor-vs-GP partitioning of
+///     [ConquestSummary.invadableProvinceIdsSorted]; (c) compute the lone
+///     GP blocker's holdings for mutual-plateau and regiment comparisons.
+///   - [snapshot]: per-player [AIWorldSnapshot] supplying
+///     [ThreatSummary.atWarWith], [ConquestSummary.invadableProvinceIdsSorted],
+///     [ConquestSummary.adjacentOwnerFactionIdsSorted], and
+///     [ConquestSummary.oldWorldProvincesOwned].
+///
+/// Returns:
+///   - `null` when [ConquestSummary.invadableProvinceIdsSorted] is empty
+///     (no OW frontier to expand into) or when treasury is below
+///     `_cheapestRegimentBuildTreasuryCost()` (the player cannot afford a
+///     regiment to follow up the declaration; the spec
+///     "skip if treasury < cheapestRegimentBuildTreasuryCost" arm).
+///   - The lowest-id minor faction owning an invadable OW province and
+///     present in [ConquestSummary.adjacentOwnerFactionIdsSorted] but not
+///     in [ThreatSummary.atWarWith] (priority 1: adjacent minor scan).
+///   - The lowest-id minor faction owning an invadable OW province and
+///     already in [ThreatSummary.atWarWith] (priority 2: formalize the
+///     existing war so the conquest army-move pass fires).
+///   - The single GP whose ownership covers the entire invadable OW
+///     frontier (priority 3) when: the frontier is GP-only (no minor
+///     holds an invadable OW tile), exactly one GP owns invadable
+///     provinces, both sides are mutual-plateau peers
+///     ([_isMutualBelowQuotaPlateauPeer]), and the active player's
+///     regiment count is ≥ that GP's regiment count.
+///   - `null` when none of the priority arms qualify.
+///
+/// The runtime "suggestDeclareWarOrders rejects" gate noted in the issue
+/// spec is enforced at the orchestrator layer (#2509 S5) so this pure
+/// function remains free of the order-suggestion API dispatch.
+String? planExpandDeclareWar({
+  required Game game,
+  required AIWorldSnapshot snapshot,
+}) {
+  final invadable = snapshot.conquest.invadableProvinceIdsSorted;
+  if (invadable.isEmpty) return null;
+  final player = game.playerById(snapshot.playerId);
+  if (player == null) return null;
+  if (player.treasury < _cheapestRegimentBuildTreasuryCost()) {
+    return null;
+  }
+
+  final atWarWith = snapshot.threats.atWarWith.toSet();
+  final adjacentOwners = snapshot.conquest.adjacentOwnerFactionIdsSorted
+      .toSet();
+  final minorIds = <String>{for (final m in game.minorNations) m.id};
+  final provinceOwner = getProvinceOwnerMap(game);
+
+  // Priority 1: adjacent minor not yet at war.
+  final adjacentNewWarMinors = <String>{};
+  // Priority 2: already-at-war minor with invadable OW province.
+  final atWarMinors = <String>{};
+  // Priority 3 prep: tally GP ownership across invadable provinces.
+  final gpInvadableCounts = <String, int>{};
+  var anyMinorOnInvadable = false;
+  for (final pid in invadable) {
+    final owner = provinceOwner[pid];
+    if (owner == null) continue;
+    if (minorIds.contains(owner)) {
+      anyMinorOnInvadable = true;
+      if (atWarWith.contains(owner)) {
+        atWarMinors.add(owner);
+      } else if (adjacentOwners.contains(owner)) {
+        adjacentNewWarMinors.add(owner);
+      }
+      continue;
+    }
+    if (game.playerById(owner) != null) {
+      gpInvadableCounts[owner] = (gpInvadableCounts[owner] ?? 0) + 1;
+    }
+  }
+
+  if (adjacentNewWarMinors.isNotEmpty) {
+    final sorted = adjacentNewWarMinors.toList()..sort();
+    return sorted.first;
+  }
+  if (atWarMinors.isNotEmpty) {
+    final sorted = atWarMinors.toList()..sort();
+    return sorted.first;
+  }
+
+  // Priority 3: sole GP frontier blocker on GP-only mutual-plateau front.
+  if (anyMinorOnInvadable) return null;
+  if (gpInvadableCounts.length != 1) return null;
+  final blockerId = gpInvadableCounts.keys.single;
+  if (atWarWith.contains(blockerId)) {
+    // Already at war — formalize is a no-op for GPs at this layer; the
+    // declare-war target is `null` so we do not re-issue declareWar.
+    return null;
+  }
+  final blockerOw = provinceCountOwnedBy(game, blockerId);
+  if (!_isMutualBelowQuotaPlateauPeer(
+    ownOw: snapshot.conquest.oldWorldProvincesOwned,
+    partnerOw: blockerOw,
+  )) {
+    return null;
+  }
+  final ownRegiments = regimentCountForPlayer(game, snapshot.playerId);
+  final partnerRegiments = regimentCountForPlayer(game, blockerId);
+  if (ownRegiments < partnerRegiments) return null;
+  return blockerId;
+}
+
+/// Minimum [RegimentEconomyCatalog] build treasury cost (deterministic
+/// catalog scan).
+///
+/// Mirrors `cheapestRegimentBuildTreasuryCost` from `colonial_pressure.dart`
+/// so the new planner stays self-contained against the S1 deletion of
+/// that file (Refs #2509 § EXPAND phase planner). Linear in the catalog
+/// size, matching the budget-rule note in
+/// `colonizethis-turn-resolution-budget.mdc`.
+int _cheapestRegimentBuildTreasuryCost() {
+  var min = 999999999;
+  for (final econ in RegimentEconomyCatalog.byId.values) {
+    if (econ.buildTreasuryCost < min) {
+      min = econ.buildTreasuryCost;
+    }
+  }
+  return min;
+}

--- a/packages/colonizethis_ai/test/planning/expand_phase_planner_declare_war_test.dart
+++ b/packages/colonizethis_ai/test/planning/expand_phase_planner_declare_war_test.dart
@@ -1,0 +1,548 @@
+// Unit tests for `planExpandDeclareWar` in
+// `packages/colonizethis_ai/lib/src/planning/expand_phase_planner.dart`
+// (Refs #2509 S2 / S10).
+//
+// Spec contract (issue #2509 § EXPAND phase planner § planExpandDeclareWar):
+//
+//   "Priority-ordered scan of `invadableProvinceIdsSorted` (OW only).
+//    Pick the first valid candidate:
+//      1. Adjacent minor with uninvaded OW province
+//         → Tiebreaker: lowest factionId.
+//         → Skip if already at war with all candidates,
+//           treasury < cheapestRegimentBuildTreasuryCost,
+//           or suggestDeclareWarOrders rejects.
+//      2. Already-at-war minor with uninvaded OW province
+//      3. Sole GP frontier blocker (GP-only frontiers only):
+//         declare on that GP only if mutual-plateau, our regiments
+//         ≥ partner's, treasury ≥ regiment build cost.
+//      4. null — skip declaring."
+//
+// Mirrors the test pattern established for `planExpandPeace` in the same
+// package (`expand_phase_planner_test.dart`): small synthetic fixtures,
+// one branch arm per test, in-module pin (the planner module never
+// re-checks phase, so these tests stay scoped to the priority scan
+// branches and the deterministic-tiebreak / treasury / regiment gates).
+//
+// The "suggestDeclareWarOrders rejects" gate noted in the spec is
+// enforced at the orchestrator layer (#2509 S5) and is intentionally
+// out of scope for this in-module pin.
+
+import 'package:colonizethis_ai/colonizethis_ai.dart';
+import 'package:colonizethis_ai/src/planning/expand_phase_planner.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+const String _gp1 = 'gp1';
+const String _gp2 = 'gp2';
+const String _gp3 = 'gp3';
+const String _minor1 = 'minor1';
+const String _minor2 = 'minor2';
+const String _minor3 = 'minor3';
+
+int _cheapestRegimentBuildCost() {
+  var min = 999999999;
+  for (final econ in RegimentEconomyCatalog.byId.values) {
+    if (econ.buildTreasuryCost < min) {
+      min = econ.buildTreasuryCost;
+    }
+  }
+  return min;
+}
+
+/// Game scaffold supporting both the "adjacent minor" and "sole GP
+/// blocker" arms. Old World provinces, players, minors, and unit-bearing
+/// armies are passed in so each test can shape ownership and regiment
+/// counts independently.
+Game _expandGame({
+  int turnNumber = 50,
+  List<Province> oldWorldProvinces = const [],
+  List<Player> players = const [
+    Player(id: _gp1, displayName: 'GP1', isHuman: false, treasury: 9999),
+    Player(id: _gp2, displayName: 'GP2', isHuman: false, treasury: 9999),
+    Player(id: _gp3, displayName: 'GP3', isHuman: false, treasury: 9999),
+  ],
+  List<MinorNation> minorNations = const [],
+  List<Army> armies = const [],
+  List<Unit> units = const [],
+}) {
+  return Game(
+    id: 'g-2509-expand-phase-planner-declare-war-t$turnNumber',
+    worldState: WorldState(
+      turnState: TurnState(turnNumber: turnNumber, phase: TurnPhase.orders),
+      oldWorld: RegionData(provinces: oldWorldProvinces, units: units),
+      newWorld: const RegionData(),
+      armies: armies,
+    ),
+    players: players,
+    minorNations: minorNations,
+  );
+}
+
+/// Snapshot tuned for EXPAND. Defaults to OW=8 (below quota of 10) with
+/// `playerId = gp1`; tests shape `atWarWith`, `invadableOw`,
+/// `adjacentOwners`, and `oldWorldProvincesOwned` to exercise specific
+/// priority arms. The planner does not re-check the phase so these
+/// tests do not need to satisfy `observerGoalPhaseFor`.
+AIWorldSnapshot _expandSnapshot({
+  required List<String> atWarWith,
+  List<String> invadableOw = const [],
+  List<String> adjacentOwners = const [],
+  int oldWorldProvincesOwned = 8,
+  String playerId = _gp1,
+}) {
+  return AIWorldSnapshot(
+    playerId: playerId,
+    threats: ThreatSummary(atWarWith: atWarWith),
+    opportunities: const OpportunitySummary(),
+    conquest: ConquestSummary(
+      oldWorldProvincesOwned: oldWorldProvincesOwned,
+      provincesToVictory: kObserverConquestMinOwProvincesPerGp * 3,
+      invadableProvinceIdsSorted: invadableOw,
+      adjacentOwnerFactionIdsSorted: adjacentOwners,
+    ),
+    colonial: const ColonialSummary(),
+    economy: const EconomySummary(),
+    relations: const {},
+  );
+}
+
+/// Build a Home Army for [ownerId] containing [regimentCount] dummy
+/// regiment unit ids. Matches the `regimentCountForPlayer` walk that
+/// counts `army.regimentUnitIds.length` summed across owned armies.
+Army _homeArmyWithRegiments(String ownerId, int regimentCount) {
+  return Army(
+    id: 'home_army:$ownerId',
+    ownerId: ownerId,
+    regionId: 'oldWorld',
+    stationedProvinceId: 'oldWorld|capital_$ownerId',
+    isHomeArmy: true,
+    regimentUnitIds: <String>[
+      for (var i = 0; i < regimentCount; i++) 'reg_${ownerId}_$i',
+    ],
+  );
+}
+
+void main() {
+  group('planExpandDeclareWar', () {
+    test('empty invadable list -> null', () {
+      // No OW frontier means there is no province to expand into. The
+      // function must short-circuit before any priority-arm scan or
+      // treasury check.
+      final game = _expandGame();
+      final snapshot = _expandSnapshot(atWarWith: const []);
+      expect(planExpandDeclareWar(game: game, snapshot: snapshot), isNull);
+    });
+
+    test('treasury below cheapest regiment cost -> null', () {
+      // Treasury gate: even when an adjacent minor candidate exists, a
+      // GP that cannot afford a single regiment is told not to declare
+      // war (the conquest army-move pass would have nothing to commit).
+      final game = _expandGame(
+        players: const [
+          Player(id: _gp1, displayName: 'GP1', isHuman: false, treasury: 0),
+          Player(id: _gp2, displayName: 'GP2', isHuman: false, treasury: 9999),
+          Player(id: _gp3, displayName: 'GP3', isHuman: false, treasury: 9999),
+        ],
+        oldWorldProvinces: const [
+          Province(id: 'oldWorld|m1_a', regionId: 'oldWorld', ownerId: _minor1),
+        ],
+        minorNations: const [MinorNation(id: _minor1, displayName: 'M1')],
+      );
+      final snapshot = _expandSnapshot(
+        atWarWith: const [],
+        invadableOw: const ['oldWorld|m1_a'],
+        adjacentOwners: const [_minor1],
+      );
+      expect(planExpandDeclareWar(game: game, snapshot: snapshot), isNull);
+    });
+
+    test('AC: adjacent minor with invadable OW -> that minor factionId', () {
+      // Acceptance criterion (issue #2509 § Phase planner unit tests):
+      // GP at OW=8 + adjacent minor owning a province in
+      // invadableProvinceIdsSorted -> declare-war target = that minor.
+      final game = _expandGame(
+        oldWorldProvinces: const [
+          Province(id: 'oldWorld|m1_a', regionId: 'oldWorld', ownerId: _minor1),
+        ],
+        minorNations: const [MinorNation(id: _minor1, displayName: 'M1')],
+      );
+      final snapshot = _expandSnapshot(
+        atWarWith: const [],
+        invadableOw: const ['oldWorld|m1_a'],
+        adjacentOwners: const [_minor1],
+      );
+      expect(
+        planExpandDeclareWar(game: game, snapshot: snapshot),
+        _minor1,
+        reason:
+            'Priority 1: an adjacent minor (in '
+            'adjacentOwnerFactionIdsSorted) that owns an invadable OW '
+            'province and is not yet at war is the canonical EXPAND '
+            'declare-war target.',
+      );
+    });
+
+    test('multiple adjacent minor candidates -> lowest factionId tiebreak', () {
+      // Two adjacent minors both own invadable OW provinces; the
+      // lexicographic ascending tiebreak surfaces minor1 over minor2.
+      final game = _expandGame(
+        oldWorldProvinces: const [
+          Province(id: 'oldWorld|m1_a', regionId: 'oldWorld', ownerId: _minor1),
+          Province(id: 'oldWorld|m2_a', regionId: 'oldWorld', ownerId: _minor2),
+        ],
+        minorNations: const [
+          MinorNation(id: _minor1, displayName: 'M1'),
+          MinorNation(id: _minor2, displayName: 'M2'),
+        ],
+      );
+      final snapshot = _expandSnapshot(
+        atWarWith: const [],
+        // Reverse-sorted invadable list to verify the tiebreak does
+        // NOT depend on iteration order of invadable provinces.
+        invadableOw: const ['oldWorld|m2_a', 'oldWorld|m1_a'],
+        adjacentOwners: const [_minor1, _minor2],
+      );
+      expect(
+        planExpandDeclareWar(game: game, snapshot: snapshot),
+        _minor1,
+        reason:
+            'Tiebreak: lowest factionId (minor1) wins over minor2 even '
+            'when minor2 appears first in invadableProvinceIdsSorted.',
+      );
+    });
+
+    test('adjacent minor already at war -> drops from priority 1', () {
+      // The candidate set for priority 1 excludes minors already in
+      // atWarWith so we do not re-issue a declareWar on a faction we
+      // are already fighting. The next priority arm picks it up.
+      final game = _expandGame(
+        oldWorldProvinces: const [
+          Province(id: 'oldWorld|m1_a', regionId: 'oldWorld', ownerId: _minor1),
+        ],
+        minorNations: const [MinorNation(id: _minor1, displayName: 'M1')],
+      );
+      final snapshot = _expandSnapshot(
+        atWarWith: const [_minor1],
+        invadableOw: const ['oldWorld|m1_a'],
+        adjacentOwners: const [_minor1],
+      );
+      // Priority 2 fires (already-at-war minor with invadable OW) and
+      // returns the same minor as a "formalize" target.
+      expect(
+        planExpandDeclareWar(game: game, snapshot: snapshot),
+        _minor1,
+        reason:
+            'A minor in atWarWith is excluded from priority 1 but '
+            'matches priority 2 (already-at-war minor with invadable '
+            'OW province) so the planner formalizes the war target.',
+      );
+    });
+
+    test('priority 2: only at-war minor candidates -> lowest factionId', () {
+      // Two minors both already at war and both own invadable OW.
+      // Tiebreak ascending picks minor1.
+      final game = _expandGame(
+        oldWorldProvinces: const [
+          Province(id: 'oldWorld|m1_a', regionId: 'oldWorld', ownerId: _minor1),
+          Province(id: 'oldWorld|m2_a', regionId: 'oldWorld', ownerId: _minor2),
+        ],
+        minorNations: const [
+          MinorNation(id: _minor1, displayName: 'M1'),
+          MinorNation(id: _minor2, displayName: 'M2'),
+        ],
+      );
+      final snapshot = _expandSnapshot(
+        atWarWith: const [_minor1, _minor2],
+        invadableOw: const ['oldWorld|m2_a', 'oldWorld|m1_a'],
+        // adjacentOwners does NOT contain either minor so priority 1
+        // must fall through to priority 2.
+        adjacentOwners: const [],
+      );
+      expect(
+        planExpandDeclareWar(game: game, snapshot: snapshot),
+        _minor1,
+        reason:
+            'Priority 2 (at-war minors with invadable OW) returns the '
+            'lowest factionId regardless of invadable list order.',
+      );
+    });
+
+    test('AC: sole GP frontier blocker, mutual-plateau, regiments OK -> '
+        'blocker GP factionId', () {
+      // Acceptance criterion (issue #2509 § Phase planner unit tests):
+      // GP at OW=8 with a sole GP owning the only invadable OW
+      // frontier, both sides mutual-plateau, regiments parity ->
+      // declare-war target = blocker GP.
+      final owProvinces = <Province>[
+        for (var i = 0; i < 8; i++)
+          Province(id: 'oldWorld|gp1_$i', regionId: 'oldWorld', ownerId: _gp1),
+        for (var i = 0; i < 8; i++)
+          Province(id: 'oldWorld|gp2_$i', regionId: 'oldWorld', ownerId: _gp2),
+      ];
+      final game = _expandGame(
+        oldWorldProvinces: owProvinces,
+        armies: [
+          _homeArmyWithRegiments(_gp1, 5),
+          _homeArmyWithRegiments(_gp2, 5),
+        ],
+      );
+      final snapshot = _expandSnapshot(
+        atWarWith: const [],
+        invadableOw: const ['oldWorld|gp2_0'],
+        adjacentOwners: const [_gp2],
+        oldWorldProvincesOwned: 8,
+      );
+      expect(
+        planExpandDeclareWar(game: game, snapshot: snapshot),
+        _gp2,
+        reason:
+            'Priority 3 (sole GP blocker on a GP-only mutual-plateau '
+            'frontier with our regiments >= partner) returns the '
+            'blocker GP factionId. Refs #2509 § EXPAND declare-war.',
+      );
+    });
+
+    test('AC: sole GP blocker, mutual-plateau, but our regiments < partner '
+        '-> null', () {
+      // Same scenario but with regiment parity flipped: our 3 < their
+      // 5. Per the spec, declare-war is suppressed.
+      final owProvinces = <Province>[
+        for (var i = 0; i < 8; i++)
+          Province(id: 'oldWorld|gp1_$i', regionId: 'oldWorld', ownerId: _gp1),
+        for (var i = 0; i < 8; i++)
+          Province(id: 'oldWorld|gp2_$i', regionId: 'oldWorld', ownerId: _gp2),
+      ];
+      final game = _expandGame(
+        oldWorldProvinces: owProvinces,
+        armies: [
+          _homeArmyWithRegiments(_gp1, 3),
+          _homeArmyWithRegiments(_gp2, 5),
+        ],
+      );
+      final snapshot = _expandSnapshot(
+        atWarWith: const [],
+        invadableOw: const ['oldWorld|gp2_0'],
+        adjacentOwners: const [_gp2],
+        oldWorldProvincesOwned: 8,
+      );
+      expect(
+        planExpandDeclareWar(game: game, snapshot: snapshot),
+        isNull,
+        reason:
+            'Regiment shortfall blocks priority 3 (issue spec: declare '
+            'on the blocker GP only if our regiments >= partners). '
+            'Refs #2509 § EXPAND declare-war.',
+      );
+    });
+
+    test('sole GP blocker but at quota (our OW = 10) -> null '
+        '(carve-out blocked: not mutual plateau)', () {
+      // When `oldWorldProvincesOwned` reaches the quota, the planner
+      // is no longer in EXPAND territory for the carve-out: the
+      // mutual-plateau predicate requires both sides below quota.
+      final owProvinces = <Province>[
+        for (var i = 0; i < 10; i++)
+          Province(id: 'oldWorld|gp1_$i', regionId: 'oldWorld', ownerId: _gp1),
+        for (var i = 0; i < 8; i++)
+          Province(id: 'oldWorld|gp2_$i', regionId: 'oldWorld', ownerId: _gp2),
+      ];
+      final game = _expandGame(
+        oldWorldProvinces: owProvinces,
+        armies: [
+          _homeArmyWithRegiments(_gp1, 5),
+          _homeArmyWithRegiments(_gp2, 5),
+        ],
+      );
+      final snapshot = _expandSnapshot(
+        atWarWith: const [],
+        invadableOw: const ['oldWorld|gp2_0'],
+        adjacentOwners: const [_gp2],
+        oldWorldProvincesOwned: 10,
+      );
+      expect(
+        planExpandDeclareWar(game: game, snapshot: snapshot),
+        isNull,
+        reason:
+            'Carve-out gates on `_isMutualBelowQuotaPlateauPeer`; with '
+            'own OW = 10 the carve-out cannot fire and the planner '
+            'leaves the at-quota GP alone (DEVELOP / COLONIAL phases '
+            'will dispatch instead).',
+      );
+    });
+
+    test('sole GP blocker but already at war -> null', () {
+      // Priority 3 is suppressed when the sole GP blocker is already
+      // at war so the orchestrator does not re-issue a declareWar.
+      final game = _expandGame(
+        oldWorldProvinces: const [
+          Province(id: 'oldWorld|gp2_0', regionId: 'oldWorld', ownerId: _gp2),
+        ],
+        armies: [
+          _homeArmyWithRegiments(_gp1, 5),
+          _homeArmyWithRegiments(_gp2, 5),
+        ],
+      );
+      final snapshot = _expandSnapshot(
+        atWarWith: const [_gp2],
+        invadableOw: const ['oldWorld|gp2_0'],
+        adjacentOwners: const [_gp2],
+        oldWorldProvincesOwned: 8,
+      );
+      expect(
+        planExpandDeclareWar(game: game, snapshot: snapshot),
+        isNull,
+        reason:
+            'Already-at-war GP is skipped in priority 3 (declareWar is '
+            'a no-op against an active war front).',
+      );
+    });
+
+    test('frontier mixes GP + minor owner -> null', () {
+      // A minor owns one invadable OW tile -> the frontier is not
+      // GP-only and priority 3 is short-circuited. The minor itself is
+      // not adjacent and not at war, so priorities 1 and 2 do not
+      // qualify either: result is null.
+      final game = _expandGame(
+        oldWorldProvinces: const [
+          Province(id: 'oldWorld|m1_a', regionId: 'oldWorld', ownerId: _minor1),
+          Province(id: 'oldWorld|gp2_0', regionId: 'oldWorld', ownerId: _gp2),
+        ],
+        minorNations: const [MinorNation(id: _minor1, displayName: 'M1')],
+        armies: [
+          _homeArmyWithRegiments(_gp1, 5),
+          _homeArmyWithRegiments(_gp2, 5),
+        ],
+      );
+      final snapshot = _expandSnapshot(
+        atWarWith: const [],
+        invadableOw: const ['oldWorld|m1_a', 'oldWorld|gp2_0'],
+        // No adjacent owners declared -> minor1 cannot match priority 1.
+        adjacentOwners: const [],
+        oldWorldProvincesOwned: 8,
+      );
+      expect(
+        planExpandDeclareWar(game: game, snapshot: snapshot),
+        isNull,
+        reason:
+            'Priority 3 requires a GP-only frontier; a minor on the '
+            'invadable list disables the carve-out. With no priority-1 '
+            'or priority-2 minor match either, the planner returns null.',
+      );
+    });
+
+    test('two GPs both own invadable OW -> null (frontier not "sole")', () {
+      // Priority 3 fires only for a SOLE GP blocker.
+      final game = _expandGame(
+        oldWorldProvinces: const [
+          Province(id: 'oldWorld|gp2_0', regionId: 'oldWorld', ownerId: _gp2),
+          Province(id: 'oldWorld|gp3_0', regionId: 'oldWorld', ownerId: _gp3),
+        ],
+        armies: [
+          _homeArmyWithRegiments(_gp1, 5),
+          _homeArmyWithRegiments(_gp2, 5),
+          _homeArmyWithRegiments(_gp3, 5),
+        ],
+      );
+      final snapshot = _expandSnapshot(
+        atWarWith: const [],
+        invadableOw: const ['oldWorld|gp2_0', 'oldWorld|gp3_0'],
+        adjacentOwners: const [_gp2, _gp3],
+        oldWorldProvincesOwned: 8,
+      );
+      expect(
+        planExpandDeclareWar(game: game, snapshot: snapshot),
+        isNull,
+        reason:
+            'When the GP-only invadable frontier has two GP owners, '
+            'priority 3 short-circuits because the spec carve-out '
+            'requires "exactly ONE GP owns the frontier".',
+      );
+    });
+
+    test('determinism: identical inputs yield identical output', () {
+      // Refs #2509 Must-have #7: pure-function determinism pin.
+      final game = _expandGame(
+        oldWorldProvinces: const [
+          Province(id: 'oldWorld|m1_a', regionId: 'oldWorld', ownerId: _minor1),
+          Province(id: 'oldWorld|m3_a', regionId: 'oldWorld', ownerId: _minor3),
+        ],
+        minorNations: const [
+          MinorNation(id: _minor1, displayName: 'M1'),
+          MinorNation(id: _minor3, displayName: 'M3'),
+        ],
+      );
+      final snapshot = _expandSnapshot(
+        atWarWith: const [],
+        invadableOw: const ['oldWorld|m3_a', 'oldWorld|m1_a'],
+        adjacentOwners: const [_minor1, _minor3],
+      );
+      final first = planExpandDeclareWar(game: game, snapshot: snapshot);
+      final second = planExpandDeclareWar(game: game, snapshot: snapshot);
+      expect(first, _minor1);
+      expect(second, _minor1, reason: 'Same inputs -> same output.');
+    });
+
+    test('treasury exactly at cheapest regiment cost -> qualifies', () {
+      // Boundary pin: the gate is `treasury < cheapest`, so `==` must
+      // pass (a regression flipping `<` to `<=` would surface here).
+      final cheapest = _cheapestRegimentBuildCost();
+      final game = _expandGame(
+        players: [
+          Player(
+            id: _gp1,
+            displayName: 'GP1',
+            isHuman: false,
+            treasury: cheapest,
+          ),
+          const Player(
+            id: _gp2,
+            displayName: 'GP2',
+            isHuman: false,
+            treasury: 9999,
+          ),
+          const Player(
+            id: _gp3,
+            displayName: 'GP3',
+            isHuman: false,
+            treasury: 9999,
+          ),
+        ],
+        oldWorldProvinces: const [
+          Province(id: 'oldWorld|m1_a', regionId: 'oldWorld', ownerId: _minor1),
+        ],
+        minorNations: const [MinorNation(id: _minor1, displayName: 'M1')],
+      );
+      final snapshot = _expandSnapshot(
+        atWarWith: const [],
+        invadableOw: const ['oldWorld|m1_a'],
+        adjacentOwners: const [_minor1],
+      );
+      expect(
+        planExpandDeclareWar(game: game, snapshot: snapshot),
+        _minor1,
+        reason:
+            'Boundary: treasury == cheapestRegimentBuildTreasuryCost '
+            'must pass (gate is strict less-than).',
+      );
+    });
+
+    test('player not in game -> null (defensive)', () {
+      // Defensive guard: a snapshot.playerId pointing at a non-existent
+      // player must not crash; the planner returns null.
+      final game = _expandGame(
+        oldWorldProvinces: const [
+          Province(id: 'oldWorld|m1_a', regionId: 'oldWorld', ownerId: _minor1),
+        ],
+        minorNations: const [MinorNation(id: _minor1, displayName: 'M1')],
+      );
+      final snapshot = _expandSnapshot(
+        atWarWith: const [],
+        invadableOw: const ['oldWorld|m1_a'],
+        adjacentOwners: const [_minor1],
+        playerId: 'ghost-player',
+      );
+      expect(planExpandDeclareWar(game: game, snapshot: snapshot), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds `planExpandDeclareWar` to `expand_phase_planner.dart` — the next
in-module slice of issue #2509 S2 / S10 EXPAND-phase planner. Pure
function `(Game, AIWorldSnapshot) -> String?` returning the deterministic
faction id of the next declare-war target for an EXPAND-phase Great
Power, or `null` when no priority arm qualifies.

SPEC authorization:

- Issue #2509 § EXPAND phase planner § `planExpandDeclareWar` (priority
  scan: adjacent minor → already-at-war minor → sole GP frontier blocker).
- `SPEC/ai/ai-architecture.md` § Observer goal phases (single-goal
  phase-planner architecture, pure-function contracts, structural NW
  suppression).

## Done in this PR

`packages/colonizethis_ai/lib/src/planning/expand_phase_planner.dart`

- New top-level `planExpandDeclareWar({required Game game, required
  AIWorldSnapshot snapshot}) -> String?`.
- Priority arms (issue spec, in order):
  1. **Adjacent minor** in `adjacentOwnerFactionIdsSorted` not yet in
     `atWarWith`, owning an `invadableProvinceIdsSorted` OW province.
     Lowest factionId tiebreak; skipped when treasury <
     cheapest regiment build cost.
  2. **Already-at-war minor** owning an invadable OW province
     (formalize so the conquest army-move pass fires). Lowest
     factionId tiebreak.
  3. **Sole GP frontier blocker** on a **GP-only** mutual-plateau
     front (`_isMutualBelowQuotaPlateauPeer`) when active player's
     regiment count >= the blocker's. Already-at-war GPs are skipped
     (declareWar is a no-op against an active war front).
  4. `null` when no priority arm qualifies.
- New private helper `_cheapestRegimentBuildTreasuryCost()` mirrors the
  legacy `cheapestRegimentBuildTreasuryCost` from `colonial_pressure.dart`
  to keep the planner self-contained against the S1 deletion of that
  file (matches the pattern used for `_primaryInvadableOldWorldGpBlocker`,
  `_isMutualBelowQuotaPlateauPeer`, etc. in the merged `planExpandPeace`
  slice).
- Re-uses existing `regimentCountForPlayer` (army_conquest_prep.dart)
  for own / partner regiment count.
- Imports: adds `army_conquest_prep.dart show regimentCountForPlayer`
  (no broad logic barrels; respects `colonizethis-logic-ai-decoupling`).

The runtime "suggestDeclareWarOrders rejects" gate noted in the issue
spec is enforced at the orchestrator layer (#2509 S5) so this module
remains a pure-function planner.

## Tests

`packages/colonizethis_ai/test/planning/expand_phase_planner_declare_war_test.dart`
— **15 unit tests**, one branch arm per test:

- empty `invadableProvinceIdsSorted` -> null.
- treasury < cheapest regiment cost -> null.
- **AC** adjacent minor with invadable OW -> that minor's factionId.
- multiple adjacent minor candidates -> lowest factionId tiebreak.
- adjacent minor already at war -> drops from priority 1, falls
  through to priority 2.
- priority 2 only at-war minor candidates -> lowest factionId tiebreak.
- **AC** sole GP frontier blocker, mutual-plateau, regiments OK ->
  blocker GP factionId.
- **AC** sole GP blocker, mutual-plateau, but our regiments < partner's
  -> null (regiment-shortfall gate).
- sole GP blocker but at quota (own OW = 10) -> null (mutual-plateau
  predicate gates the carve-out).
- sole GP blocker already at war -> null (no re-issue against active
  war).
- frontier mixes GP + minor owner -> null (GP-only requirement).
- two GPs both own invadable OW -> null (frontier not "sole").
- determinism: identical inputs -> identical output (Must-have #7).
- treasury exactly at cheapest regiment cost -> qualifies (boundary
  pin against `<` -> `<=` regression).
- player not in game -> null (defensive guard).

Verification:

- [x] `dart test packages/colonizethis_ai/test/planning/expand_phase_planner_declare_war_test.dart` — 15 passed.
- [x] `dart test packages/colonizethis_ai/test/planning/` — 44 passed.
- [x] `dart test packages/colonizethis_ai` — **662 passed**.
- [x] `dart analyze` on touched files — `No issues found!`.
- [x] `dart analyze packages/colonizethis_ai` — baseline preserved (24
  pre-existing issues, **zero new issues**).
- [x] `dart format` clean on all touched files.
- [x] `tool/check_function_size.dart` — `no function-size violations`.
- [x] `tool/check_ai_planner_context.dart` — `no violations found`.
- [ ] CI quality gates (Quality + App tests on push).

## Acceptance criteria coverage (from issue #2509)

This PR covers the following ACs from § Phase planner unit tests:

- **(EXPAND declare-war)** — Given a GP with `oldWorldProvincesOwned = 8`
  and an adjacent minor owning a province in `invadableProvinceIdsSorted`,
  when `planExpandDeclareWar` runs, then the return value is that
  minor's `factionId`. ✅
- **(EXPAND declare-war — GP-only frontier)** — Given a GP with
  `oldWorldProvincesOwned = 8`, no uninvaded minors, and a solitary GP
  owning the sole invadable OW frontier province (both sides mutually
  below quota), when `planExpandDeclareWar` runs, then the return value
  is that blocker GP's `factionId` (or `null` if our regiments <
  partner's). ✅ (both arms)

## Deferred for #2509 (out of scope for this PR)

- **S2 follow-up — `planExpandEconomy`**: force-regiment-rebuild trap
  and treasury-recovery cargo boost.
- **S2 follow-up — `planExpandMilitary`**: OW-only conquest army
  moves toward the declare-war target.
- **S5 — orchestrator wiring**: dispatch to `planExpandDeclareWar`
  from `domain_planner_orchestrator.dart` (also enforces the runtime
  "suggestDeclareWarOrders rejects" gate that lives outside the pure
  planner).
- **S1 — legacy deletion**: the legacy declare-war helpers in
  `colonial_pressure.dart` and the predicate fan-out in
  `diplomatic_candidate_scoring_declare_war.dart` remain pinned at the
  function-unit level until S5 lands; both legacy and new paths
  coexist with **zero behavior change** for live AI play.
- **S6 — SPEC sync** of `SPEC/ai/ai-architecture.md` § Observer goal
  phases.
- **S7–S8 — observer integration / nightly gate enable**.

Refs #2509

Tracked by #2509

Made with [Cursor](https://cursor.com)