### PR TITLE
feat(ai): planExpandEconomy — EXPAND-phase build/cargo directive (Refs #2509 S2)

### DIFF
--- a/packages/colonizethis_ai/lib/src/planning/expand_phase_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/expand_phase_planner.dart
@@ -53,9 +53,23 @@
 ///     spec is enforced at the orchestrator layer (#2509 S5) so this
 ///     module remains a pure-function planner.
 ///
+///   `planExpandEconomy(game, snapshot) → ExpandEconomyPlan`
+///     Returns the EXPAND-phase economy directive for the active player:
+///     `forceCheapestRegimentBuild` (set the orchestrator build threshold
+///     to zero and pick the cheapest regiment in
+///     [RegimentEconomyCatalog]) and / or `boostTreasuryRecoveryCargo`
+///     (raise economy weight for overseas cargo so riches deliver to
+///     stockpile before the next build pass). Implements the
+///     three-arm decision tree from issue #2509 § EXPAND phase planner
+///     § planExpandEconomy (zero-regiment rebuild, insufficient-regiment
+///     rebuild with affordable treasury, treasury-recovery cargo boost).
+///     Effective treasury is `Player.treasury` plus
+///     [pendingRichesTreasuryDelta] so the planner aligns with build
+///     validation that already credits same-turn `richesToTreasury`
+///     phase income (Refs #2509 § Observer goal phases § EXPAND
+///     "Pending riches treasury").
+///
 /// Functions left for follow-up slices on this issue:
-///   - `planExpandEconomy` — force-regiment-rebuild trap and treasury-
-///     recovery cargo boost (#2509 S2).
 ///   - `planExpandMilitary` — OW-only conquest army moves toward the
 ///     declare-war target (#2509 S2).
 library;
@@ -387,6 +401,195 @@ String? planExpandDeclareWar({
   final partnerRegiments = regimentCountForPlayer(game, blockerId);
   if (ownRegiments < partnerRegiments) return null;
   return blockerId;
+}
+
+/// EXPAND-phase economy directive returned by [planExpandEconomy].
+///
+/// Two independent booleans describe the orchestrator overrides for the
+/// active player this turn. The planner stays a pure function: the
+/// orchestrator (Refs #2509 S5) translates these flags into the actual
+/// build-threshold reset and economy-weight cargo boost when wiring the
+/// EXPAND dispatch.
+///
+/// The flags compose — a GP can both be told to force a regiment build
+/// and to raise cargo preference in the same turn (canonical "rebuild
+/// fast while overseas riches keep arriving" arm when reg = 0 and
+/// effective treasury is still under the cheapest regiment cost).
+///
+/// `const`-friendly so the default "no override" return uses a single
+/// shared instance ([defaultPlan]) without per-call allocations on the
+/// hot AI path.
+class ExpandEconomyPlan {
+  const ExpandEconomyPlan({
+    required this.forceCheapestRegimentBuild,
+    required this.boostTreasuryRecoveryCargo,
+  });
+
+  /// Reusable "no override" plan returned for non-EXPAND callers, GPs
+  /// at quota, defensive guards, and the priority-arm fall-through.
+  static const ExpandEconomyPlan defaultPlan = ExpandEconomyPlan(
+    forceCheapestRegimentBuild: false,
+    boostTreasuryRecoveryCargo: false,
+  );
+
+  /// True when the orchestrator should drop the build-pass economy
+  /// threshold to zero and pick the cheapest entry in
+  /// [RegimentEconomyCatalog] (military rebuild crisis).
+  ///
+  /// Set under either of the two regiment-rebuild arms in issue #2509
+  /// § EXPAND phase planner § planExpandEconomy:
+  /// (a) `regimentCount == 0` with a non-empty
+  ///     [ConquestSummary.invadableProvinceIdsSorted] (the
+  ///     `brokeBelowQuotaAtPeace` / `needRegimentsToExpand` legacy
+  ///     condition collapsed into the phase planner); or
+  /// (b) the trap condition
+  ///     `0 < regimentCount < kBelowQuotaPeaceMinRegimentsBeforeDeclareWar`
+  ///     with non-empty invadable OW frontier and effective treasury
+  ///     (cash + [pendingRichesTreasuryDelta]) at or above
+  ///     `_cheapestRegimentBuildTreasuryCost()`.
+  final bool forceCheapestRegimentBuild;
+
+  /// True when the orchestrator should add
+  /// [kBelowQuotaPeaceTreasuryRecoveryCargoBoost] to economy weight so
+  /// overseas cargo preference rises (deliver NW riches to stockpile)
+  /// even in EXPAND.
+  ///
+  /// Set when below quota AND effective treasury (cash +
+  /// [pendingRichesTreasuryDelta]) is strictly below
+  /// `_cheapestRegimentBuildTreasuryCost()` (issue #2509 § EXPAND phase
+  /// planner § planExpandEconomy "treasury < cheapest" arm). The
+  /// boost composes with [forceCheapestRegimentBuild] so a GP that is
+  /// told to force a build AND cannot currently afford one still gets
+  /// the cargo signal to chase incoming riches.
+  final bool boostTreasuryRecoveryCargo;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ExpandEconomyPlan &&
+          other.forceCheapestRegimentBuild == forceCheapestRegimentBuild &&
+          other.boostTreasuryRecoveryCargo == boostTreasuryRecoveryCargo;
+
+  @override
+  int get hashCode =>
+      Object.hash(forceCheapestRegimentBuild, boostTreasuryRecoveryCargo);
+
+  @override
+  String toString() =>
+      'ExpandEconomyPlan('
+      'forceCheapestRegimentBuild: $forceCheapestRegimentBuild, '
+      'boostTreasuryRecoveryCargo: $boostTreasuryRecoveryCargo)';
+}
+
+/// Returns the deterministic EXPAND-phase economy directive for the
+/// active player as an [ExpandEconomyPlan].
+///
+/// Contract (issue #2509 § EXPAND phase planner § planExpandEconomy):
+///
+///   "Force-regiment-rebuild when:
+///      ow < 10 AND (
+///        regimentCount == 0 AND hasInvadableProvinces
+///          → set buildThreshold = 0, force cheapest regiment
+///        OR
+///        0 < regimentCount < kBelowQuotaPeaceMinRegimentsBeforeDeclareWar
+///          AND treasury >= cheapestRegimentBuildTreasuryCost
+///          → set buildThreshold = 0, force cheapest regiment
+///        OR
+///        treasury < cheapestRegimentBuildTreasuryCost
+///          → add cargo preference boost (deliver riches to stockpile)
+///      )"
+///
+/// Effective treasury used by the regiment-affordability and cargo
+/// arms is `player.treasury + pendingRichesTreasuryDelta(...)` so the
+/// planner agrees with the build pipeline that already credits the
+/// same-turn `richesToTreasury` phase income before `buildWork`
+/// (Refs #2509 § Observer goal phases § EXPAND "Pending riches
+/// treasury"). The OW improvements / NW suppressions arms of the spec
+/// are out of scope for this planner contract — those orders are
+/// produced by `planDevelopCivilian` (DEVELOP) and the conquest
+/// army-move planner (EXPAND military) respectively; the EXPAND
+/// economy planner only emits the build/cargo override directive.
+///
+/// Inputs:
+///   - [game]: resolves the active player ([Game.playerById]) to read
+///     [Player.treasury] and [Player.stockpile] (for the pending-riches
+///     credit) and walks [WorldState.armies] via [regimentCountForPlayer]
+///     for the standing regiment count.
+///   - [snapshot]: per-player [AIWorldSnapshot] supplying
+///     [ConquestSummary.oldWorldProvincesOwned] (quota guard) and
+///     [ConquestSummary.invadableProvinceIdsSorted] (the "has invadable
+///     frontier" arms of the spec).
+///
+/// Output:
+///   - [ExpandEconomyPlan.defaultPlan] when the active player is at or
+///     above [kObserverConquestMinOwProvincesPerGp] OW provinces (not
+///     in EXPAND territory for this planner) or when
+///     [Game.playerById] returns `null` (defensive guard for snapshots
+///     pointing at non-existent players; matches the
+///     [planExpandDeclareWar] guard).
+///   - `forceCheapestRegimentBuild: true` when arm A
+///     (`regimentCount == 0` and non-empty invadable OW frontier) holds.
+///     Treasury is intentionally **not** part of arm A's gate per the
+///     issue spec — the orchestrator's existing build pipeline still
+///     handles the case where no regiment is affordable yet, but the
+///     phase planner signals intent unconditionally so the rebuild
+///     trap cannot stick.
+///   - `forceCheapestRegimentBuild: true` when arm B
+///     (`0 < regimentCount < kBelowQuotaPeaceMinRegimentsBeforeDeclareWar`
+///     and non-empty invadable OW frontier and effective treasury
+///     ≥ cheapest regiment cost) holds.
+///   - `boostTreasuryRecoveryCargo: true` when arm C
+///     (effective treasury < cheapest regiment cost) holds. Composes
+///     with arm A: a GP with `regimentCount == 0` and effective
+///     treasury below the cheapest cost gets **both** flags set, so
+///     the orchestrator forces the build attempt and also boosts
+///     cargo for the next turn's riches delivery.
+///
+/// The function is pure and deterministic — identical inputs always
+/// yield identical [ExpandEconomyPlan]s (Refs #2509 Must-have #7).
+ExpandEconomyPlan planExpandEconomy({
+  required Game game,
+  required AIWorldSnapshot snapshot,
+}) {
+  if (!isBelowObserverConquestQuota(snapshot.conquest.oldWorldProvincesOwned)) {
+    return ExpandEconomyPlan.defaultPlan;
+  }
+  final player = game.playerById(snapshot.playerId);
+  if (player == null) {
+    return ExpandEconomyPlan.defaultPlan;
+  }
+
+  final hasInvadable = snapshot.conquest.invadableProvinceIdsSorted.isNotEmpty;
+  final regimentCount = regimentCountForPlayer(game, snapshot.playerId);
+  final effectiveTreasury =
+      player.treasury + pendingRichesTreasuryDelta(stockpile: player.stockpile);
+  final cheapest = _cheapestRegimentBuildTreasuryCost();
+
+  // Arm A: regimentCount == 0 AND hasInvadable -> force rebuild
+  // (no treasury gate per spec; the build pipeline still applies its
+  // own affordability check, but the directive remains so the phase
+  // planner cannot be silently overridden by a treasury hiccup).
+  final armA = regimentCount == 0 && hasInvadable;
+
+  // Arm B: 0 < regimentCount < min AND hasInvadable AND effective
+  // treasury affords the cheapest regiment.
+  final armB =
+      regimentCount > 0 &&
+      regimentCount < kBelowQuotaPeaceMinRegimentsBeforeDeclareWar &&
+      hasInvadable &&
+      effectiveTreasury >= cheapest;
+
+  // Arm C: effective treasury below cheapest regiment cost (independent
+  // of regimentCount per the spec literal wording — boosts cargo so a
+  // GP in EXPAND with low cash always benefits from delivering riches,
+  // matching the SPEC/ai/ai-architecture.md "Treasury recovery cargo"
+  // intent).
+  final armC = effectiveTreasury < cheapest;
+
+  return ExpandEconomyPlan(
+    forceCheapestRegimentBuild: armA || armB,
+    boostTreasuryRecoveryCargo: armC,
+  );
 }
 
 /// Minimum [RegimentEconomyCatalog] build treasury cost (deterministic

--- a/packages/colonizethis_ai/test/planning/expand_phase_planner_economy_test.dart
+++ b/packages/colonizethis_ai/test/planning/expand_phase_planner_economy_test.dart
@@ -1,0 +1,537 @@
+// Unit tests for `planExpandEconomy` in
+// `packages/colonizethis_ai/lib/src/planning/expand_phase_planner.dart`
+// (Refs #2509 S2 / S10).
+//
+// Spec contract (issue #2509 § EXPAND phase planner § planExpandEconomy):
+//
+//   "Force-regiment-rebuild when:
+//      ow < 10 AND (
+//        [A] regimentCount == 0 AND hasInvadableProvinces
+//            → set buildThreshold = 0, force cheapest regiment
+//        OR
+//        [B] 0 < regimentCount < kBelowQuotaPeaceMinRegimentsBeforeDeclareWar
+//              AND treasury >= cheapestRegimentBuildTreasuryCost
+//            → set buildThreshold = 0, force cheapest regiment
+//        OR
+//        [C] treasury < cheapestRegimentBuildTreasuryCost
+//            → add cargo preference boost (deliver riches to stockpile)
+//      )"
+//
+// Effective treasury is `Player.treasury + pendingRichesTreasuryDelta(...)`
+// per `SPEC/ai/ai-architecture.md` § Observer goal phases § EXPAND
+// "Pending riches treasury" so arms B and C agree with build validation.
+//
+// Mirrors the test pattern established for the other EXPAND-phase
+// planner contracts (`expand_phase_planner_test.dart`,
+// `expand_phase_planner_declare_war_test.dart`): small synthetic
+// fixtures, one branch arm per test, in-module pin (planner module
+// never re-checks phase, so these tests stay scoped to the three
+// regiment / treasury arms and the EXPAND outer gate). Tests reference
+// `ExpandEconomyPlan.defaultPlan` so a regression that allocates a new
+// "all false" instance on every miss path still satisfies value
+// equality (the planner's `==` is hand-rolled to make this safe).
+
+import 'package:colonizethis_ai/colonizethis_ai.dart';
+import 'package:colonizethis_ai/src/planning/expand_phase_planner.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+const String _gp1 = 'gp1';
+const String _gp2 = 'gp2';
+
+int _cheapestRegimentBuildCost() {
+  var min = 999999999;
+  for (final econ in RegimentEconomyCatalog.byId.values) {
+    if (econ.buildTreasuryCost < min) {
+      min = econ.buildTreasuryCost;
+    }
+  }
+  return min;
+}
+
+/// Build a `Stockpile` whose [pendingRichesTreasuryDelta] equals
+/// approximately [targetCash] (cash from spices at `spicesBasePrice = 50`).
+/// Spices are chosen so the math is `qty × 50`; the helper rounds up to the
+/// nearest whole spice unit so the resulting delta is always `>= targetCash`.
+Stockpile _stockpileWithPendingRiches(int targetCash) {
+  if (targetCash <= 0) {
+    return Stockpile.empty;
+  }
+  const pricePerSpice = 50;
+  final qty = (targetCash + pricePerSpice - 1) ~/ pricePerSpice;
+  return Stockpile(quantities: {'spices': qty});
+}
+
+/// Game scaffold for EXPAND-phase economy tests. Players, armies, and
+/// (optionally) Old World provinces are passed in so each test can
+/// shape ownership, regiment counts, treasury, and stockpile
+/// independently.
+Game _expandGame({
+  int turnNumber = 50,
+  required List<Player> players,
+  List<Army> armies = const [],
+  List<Province> oldWorldProvinces = const [],
+}) {
+  return Game(
+    id: 'g-2509-expand-phase-planner-economy-t$turnNumber',
+    worldState: WorldState(
+      turnState: TurnState(turnNumber: turnNumber, phase: TurnPhase.orders),
+      oldWorld: RegionData(provinces: oldWorldProvinces),
+      newWorld: const RegionData(),
+      armies: armies,
+    ),
+    players: players,
+  );
+}
+
+/// Snapshot tuned for EXPAND: own OW defaults to 8 (below quota of 10).
+/// Tests shape `oldWorldProvincesOwned` and `invadableProvinceIdsSorted`
+/// to exercise the outer quota gate and the "hasInvadable" arms. The
+/// planner does not re-check the phase so these tests do not need to
+/// satisfy `observerGoalPhaseFor`.
+AIWorldSnapshot _expandSnapshot({
+  List<String> invadableOw = const [],
+  int oldWorldProvincesOwned = 8,
+  String playerId = _gp1,
+}) {
+  return AIWorldSnapshot(
+    playerId: playerId,
+    threats: const ThreatSummary(),
+    opportunities: const OpportunitySummary(),
+    conquest: ConquestSummary(
+      oldWorldProvincesOwned: oldWorldProvincesOwned,
+      provincesToVictory: kObserverConquestMinOwProvincesPerGp * 3,
+      invadableProvinceIdsSorted: invadableOw,
+    ),
+    colonial: const ColonialSummary(),
+    economy: const EconomySummary(),
+    relations: const {},
+  );
+}
+
+/// Home Army for [ownerId] containing [regimentCount] dummy regiment
+/// unit ids; matches the [regimentCountForPlayer] walk used by the
+/// planner.
+Army _homeArmyWithRegiments(String ownerId, int regimentCount) {
+  return Army(
+    id: 'home_army:$ownerId',
+    ownerId: ownerId,
+    regionId: 'oldWorld',
+    stationedProvinceId: 'oldWorld|capital_$ownerId',
+    isHomeArmy: true,
+    regimentUnitIds: <String>[
+      for (var i = 0; i < regimentCount; i++) 'reg_${ownerId}_$i',
+    ],
+  );
+}
+
+/// Construct a [Player] with explicit treasury and stockpile so each
+/// test can pin effective-treasury behaviour against arm B / arm C
+/// boundaries without depending on default `Player` construction
+/// changes elsewhere.
+Player _player({
+  String id = _gp1,
+  String displayName = 'GP1',
+  int treasury = 0,
+  Stockpile stockpile = Stockpile.empty,
+}) {
+  return Player(
+    id: id,
+    displayName: displayName,
+    isHuman: false,
+    treasury: treasury,
+    stockpile: stockpile,
+  );
+}
+
+void main() {
+  group('planExpandEconomy', () {
+    test(
+      'at quota (own OW = 10) -> defaultPlan even with low treasury / 0 regs',
+      () {
+        // EXPAND outer gate: `isBelowObserverConquestQuota` is false when
+        // own OW reaches `kObserverConquestMinOwProvincesPerGp` (10), so
+        // the planner short-circuits before reading regiments or
+        // treasury. A regression that dropped the outer gate would emit
+        // a forceRebuild=true plan for an at-quota GP.
+        final game = _expandGame(
+          players: [_player(treasury: 0)],
+          armies: [_homeArmyWithRegiments(_gp1, 0)],
+        );
+        final snapshot = _expandSnapshot(
+          oldWorldProvincesOwned: 10,
+          invadableOw: const ['oldWorld|gp2_0'],
+        );
+        expect(
+          planExpandEconomy(game: game, snapshot: snapshot),
+          same(ExpandEconomyPlan.defaultPlan),
+          reason:
+              'GP at the observer OW quota is no longer EXPAND territory '
+              'for this planner; the outer `isBelowObserverConquestQuota` '
+              'gate must short-circuit before reading regiment / treasury '
+              'state.',
+        );
+      },
+    );
+
+    test('player not in game -> defaultPlan (defensive guard)', () {
+      // Defensive guard pin: snapshots pointing at a non-existent
+      // player must not crash; the planner returns the default plan.
+      // Matches the equivalent guard in `planExpandDeclareWar`.
+      final game = _expandGame(players: [_player()]);
+      final snapshot = _expandSnapshot(playerId: 'ghost-player');
+      expect(
+        planExpandEconomy(game: game, snapshot: snapshot),
+        ExpandEconomyPlan.defaultPlan,
+      );
+    });
+
+    test('AC: arm A — reg == 0 AND hasInvadable -> forceRebuild=true', () {
+      // Acceptance criterion: a below-quota GP with zero standing
+      // regiments and a non-empty invadable OW frontier must be told
+      // to force a cheapest-regiment build (the `brokeBelowQuotaAtPeace`
+      // / `needRegimentsToExpand` legacy condition collapsed into the
+      // phase planner). Treasury is set well above the cheapest cost
+      // so arm C does not fire, isolating the forceRebuild flag.
+      final cheapest = _cheapestRegimentBuildCost();
+      final game = _expandGame(
+        players: [_player(treasury: cheapest * 10)],
+        armies: [_homeArmyWithRegiments(_gp1, 0)],
+      );
+      final snapshot = _expandSnapshot(invadableOw: const ['oldWorld|gp2_0']);
+      expect(
+        planExpandEconomy(game: game, snapshot: snapshot),
+        const ExpandEconomyPlan(
+          forceCheapestRegimentBuild: true,
+          boostTreasuryRecoveryCargo: false,
+        ),
+        reason:
+            'Arm A: regimentCount == 0 + invadable OW frontier -> force '
+            'rebuild; treasury well above cheapest so arm C stays off.',
+      );
+    });
+
+    test('arm A blocked: reg == 0 but no invadable -> defaultPlan', () {
+      // The "hasInvadable" gate on arm A prevents force-rebuild when
+      // there is no OW frontier to invade. Treasury > cheapest ensures
+      // arm C also stays off.
+      final cheapest = _cheapestRegimentBuildCost();
+      final game = _expandGame(
+        players: [_player(treasury: cheapest * 10)],
+        armies: [_homeArmyWithRegiments(_gp1, 0)],
+      );
+      final snapshot = _expandSnapshot(invadableOw: const []);
+      expect(
+        planExpandEconomy(game: game, snapshot: snapshot),
+        ExpandEconomyPlan.defaultPlan,
+        reason:
+            'Empty `invadableProvinceIdsSorted` -> arm A cannot fire; '
+            'a GP with no OW frontier should not force a regiment build.',
+      );
+    });
+
+    test('AC: arm B — 0<reg<min AND hasInvadable AND treasury>=cheapest '
+        '-> forceRebuild=true', () {
+      // Acceptance criterion: the seed-42 turn-100 trap. GP has some
+      // regiments (3) but below the at-war declare-war floor
+      // (`kBelowQuotaPeaceMinRegimentsBeforeDeclareWar` = 6); treasury
+      // covers the cheapest regiment cost; invadable OW frontier
+      // exists. Force-rebuild must fire so the orchestrator builds the
+      // missing regiments before EXPAND declare-war scoring picks the
+      // next target.
+      final cheapest = _cheapestRegimentBuildCost();
+      final game = _expandGame(
+        players: [_player(treasury: cheapest)],
+        armies: [_homeArmyWithRegiments(_gp1, 3)],
+      );
+      final snapshot = _expandSnapshot(invadableOw: const ['oldWorld|gp2_0']);
+      expect(
+        planExpandEconomy(game: game, snapshot: snapshot),
+        const ExpandEconomyPlan(
+          forceCheapestRegimentBuild: true,
+          boostTreasuryRecoveryCargo: false,
+        ),
+        reason:
+            'Arm B: 3 regiments (< 6 floor) + invadable + treasury '
+            'exactly at cheapest cost -> force rebuild without cargo '
+            'boost. Boundary: treasury >= cheapest is `>=` (inclusive).',
+      );
+    });
+
+    test('arm B blocked: reg at the min floor (== min) -> defaultPlan', () {
+      // Boundary pin: `regimentCount < kBelowQuotaPeaceMinRegimentsBeforeDeclareWar`
+      // is strict less-than. A GP exactly at the floor is no longer in
+      // the trap band — declare-war scoring should pick its own target.
+      final cheapest = _cheapestRegimentBuildCost();
+      final game = _expandGame(
+        players: [_player(treasury: cheapest * 10)],
+        armies: [
+          _homeArmyWithRegiments(
+            _gp1,
+            kBelowQuotaPeaceMinRegimentsBeforeDeclareWar,
+          ),
+        ],
+      );
+      final snapshot = _expandSnapshot(invadableOw: const ['oldWorld|gp2_0']);
+      expect(
+        planExpandEconomy(game: game, snapshot: snapshot),
+        ExpandEconomyPlan.defaultPlan,
+        reason:
+            'regimentCount == kBelowQuotaPeaceMinRegimentsBeforeDeclareWar '
+            'sits OUTSIDE the trap band (gate is strict `<`); the GP is '
+            'free to pursue its own declare-war target without an '
+            'orchestrator override.',
+      );
+    });
+
+    test('arm B blocked: no invadable -> defaultPlan', () {
+      // Empty `invadableProvinceIdsSorted` disables arm B even with the
+      // right regiment band and treasury. The planner only forces
+      // builds when there is a frontier to invade.
+      final cheapest = _cheapestRegimentBuildCost();
+      final game = _expandGame(
+        players: [_player(treasury: cheapest * 10)],
+        armies: [_homeArmyWithRegiments(_gp1, 3)],
+      );
+      final snapshot = _expandSnapshot(invadableOw: const []);
+      expect(
+        planExpandEconomy(game: game, snapshot: snapshot),
+        ExpandEconomyPlan.defaultPlan,
+        reason:
+            'Without an OW frontier, neither arm A nor arm B can fire; '
+            'no forced-rebuild override.',
+      );
+    });
+
+    test(
+      'arm C alone — high regiments, low treasury -> boostCargo=true only',
+      () {
+        // Arm C is the "treasury-recovery cargo" lever. Per the spec
+        // literal wording, arm C fires whenever effective treasury is
+        // below the cheapest regiment cost — independent of
+        // regimentCount. A GP with 20 regiments and almost no treasury
+        // still benefits from boosting cargo so overseas riches deliver
+        // to stockpile (and bankroll the next build pass).
+        final game = _expandGame(
+          players: [_player(treasury: 0)],
+          armies: [_homeArmyWithRegiments(_gp1, 20)],
+        );
+        final snapshot = _expandSnapshot(invadableOw: const ['oldWorld|gp2_0']);
+        expect(
+          planExpandEconomy(game: game, snapshot: snapshot),
+          const ExpandEconomyPlan(
+            forceCheapestRegimentBuild: false,
+            boostTreasuryRecoveryCargo: true,
+          ),
+          reason:
+              'Arm C only: regimentCount above the trap band so neither '
+              'arm A nor arm B fires; treasury 0 < cheapest -> cargo '
+              'boost on its own. Spec literal: arm C is independent of '
+              'regimentCount.',
+        );
+      },
+    );
+
+    test('arm A + arm C combine — reg=0, hasInvadable, treasury<cheapest '
+        '-> both flags true', () {
+      // Composition pin: arm A triggers forceRebuild on its own (no
+      // treasury gate); arm C triggers cargo boost when effective
+      // treasury is below cheapest. A GP with zero regiments AND zero
+      // treasury must get BOTH signals — try to rebuild AND chase
+      // incoming riches.
+      final game = _expandGame(
+        players: [_player(treasury: 0)],
+        armies: [_homeArmyWithRegiments(_gp1, 0)],
+      );
+      final snapshot = _expandSnapshot(invadableOw: const ['oldWorld|gp2_0']);
+      expect(
+        planExpandEconomy(game: game, snapshot: snapshot),
+        const ExpandEconomyPlan(
+          forceCheapestRegimentBuild: true,
+          boostTreasuryRecoveryCargo: true,
+        ),
+        reason:
+            'Arm A: reg=0 + invadable -> forceRebuild (no treasury '
+            'gate). Arm C: effective treasury 0 < cheapest -> cargo '
+            'boost. Both flags fire together; the orchestrator '
+            'translates the dual signal into a build attempt AND a '
+            'cargo preference bump.',
+      );
+    });
+
+    test(
+      'arm B blocked by treasury -> arm C alone (reg in trap band, treasury<cheapest)',
+      () {
+        // The seed-42 gp3 turn-100 trap with no liquidity. Arm B
+        // requires treasury >= cheapest, which is false here; arm C
+        // fires alone so the cargo boost still raises overseas
+        // priority. This is the "boost cargo so the next turn can
+        // build" branch from the spec.
+        final game = _expandGame(
+          players: [_player(treasury: 0)],
+          armies: [_homeArmyWithRegiments(_gp1, 3)],
+        );
+        final snapshot = _expandSnapshot(invadableOw: const ['oldWorld|gp2_0']);
+        expect(
+          planExpandEconomy(game: game, snapshot: snapshot),
+          const ExpandEconomyPlan(
+            forceCheapestRegimentBuild: false,
+            boostTreasuryRecoveryCargo: true,
+          ),
+          reason:
+              'Arm B blocked (effective treasury 0 < cheapest); arm C '
+              'fires; arm A blocked (reg > 0). Cargo boost only.',
+        );
+      },
+    );
+
+    test('pending-riches credit lifts effective treasury -> arm B fires', () {
+      // Effective-treasury contract pin: cash alone is 0, but a
+      // stockpile of spices (50 cash/unit at base price) pushes
+      // `effectiveTreasury = treasury + pendingRichesTreasuryDelta`
+      // above the cheapest regiment cost so arm B fires WITHOUT arm C.
+      // A regression that read `player.treasury` directly (ignoring
+      // pending riches) would still see treasury == 0, fall to arm C
+      // only, and emit boostCargo=true / forceRebuild=false — this
+      // test fails in that case.
+      final cheapest = _cheapestRegimentBuildCost();
+      final game = _expandGame(
+        players: [
+          _player(
+            treasury: 0,
+            stockpile: _stockpileWithPendingRiches(cheapest),
+          ),
+        ],
+        armies: [_homeArmyWithRegiments(_gp1, 3)],
+      );
+      final snapshot = _expandSnapshot(invadableOw: const ['oldWorld|gp2_0']);
+      expect(
+        planExpandEconomy(game: game, snapshot: snapshot),
+        const ExpandEconomyPlan(
+          forceCheapestRegimentBuild: true,
+          boostTreasuryRecoveryCargo: false,
+        ),
+        reason:
+            'Pending riches (spices at base price 50) credit '
+            'effectiveTreasury above the cheapest regiment cost. Arm '
+            'B fires alone; arm C must be suppressed because '
+            'effectiveTreasury >= cheapest.',
+      );
+    });
+
+    test(
+      'effective treasury exactly at cheapest -> arm B fires (boundary)',
+      () {
+        // Boundary pin: arm B's gate is `effectiveTreasury >= cheapest`.
+        // Arm C's gate is `effectiveTreasury < cheapest`. At the equality
+        // boundary, arm B fires and arm C does NOT.
+        final cheapest = _cheapestRegimentBuildCost();
+        final game = _expandGame(
+          players: [_player(treasury: cheapest)],
+          armies: [_homeArmyWithRegiments(_gp1, 3)],
+        );
+        final snapshot = _expandSnapshot(invadableOw: const ['oldWorld|gp2_0']);
+        expect(
+          planExpandEconomy(game: game, snapshot: snapshot),
+          const ExpandEconomyPlan(
+            forceCheapestRegimentBuild: true,
+            boostTreasuryRecoveryCargo: false,
+          ),
+          reason:
+              'Boundary: effectiveTreasury == cheapest is inside arm B '
+              '(`>=`) and outside arm C (strict `<`). Forcerebuild fires; '
+              'no cargo boost.',
+        );
+      },
+    );
+
+    test(
+      'Refs #2509 Must-have #7 determinism: identical inputs -> identical plan',
+      () {
+        // Determinism pin (issue #2509 Must-have #7). Mixed-input fixture
+        // exercises both the regiment scan and the pending-riches
+        // computation, so repeating the call must yield the same plan.
+        final cheapest = _cheapestRegimentBuildCost();
+        final game = _expandGame(
+          players: [
+            _player(
+              treasury: cheapest ~/ 2,
+              stockpile: _stockpileWithPendingRiches(cheapest ~/ 2),
+            ),
+          ],
+          armies: [_homeArmyWithRegiments(_gp1, 4)],
+        );
+        final snapshot = _expandSnapshot(invadableOw: const ['oldWorld|gp2_0']);
+        final first = planExpandEconomy(game: game, snapshot: snapshot);
+        final second = planExpandEconomy(game: game, snapshot: snapshot);
+        expect(second, first, reason: 'Same inputs -> same plan.');
+      },
+    );
+
+    test('multi-player game: regiment / treasury reads are player-scoped', () {
+      // Isolation pin: armies/treasury belonging to other players must
+      // NOT contribute to the active player's plan. gp2 has a full
+      // home army and large treasury; gp1 (active) has none of either.
+      // The planner reads only gp1's state.
+      final game = _expandGame(
+        players: [
+          _player(treasury: 0),
+          _player(id: _gp2, displayName: 'GP2', treasury: 999999),
+        ],
+        armies: [_homeArmyWithRegiments(_gp2, 20)],
+      );
+      final snapshot = _expandSnapshot(invadableOw: const ['oldWorld|gp2_0']);
+      expect(
+        planExpandEconomy(game: game, snapshot: snapshot),
+        const ExpandEconomyPlan(
+          // gp1 has no regiments (arm A fires) and no treasury (arm C
+          // fires). gp2's wealth / regiments are correctly ignored.
+          forceCheapestRegimentBuild: true,
+          boostTreasuryRecoveryCargo: true,
+        ),
+        reason:
+            'The planner must filter by `snapshot.playerId`. gp2 having '
+            'wealth and regiments is irrelevant to gp1\'s plan.',
+      );
+    });
+
+    test('ExpandEconomyPlan value equality: same flags compare equal', () {
+      // Value-class pin: `==` and `hashCode` must compare by flag
+      // values so tests can assert against literal constructions
+      // without relying on object identity.
+      const a = ExpandEconomyPlan(
+        forceCheapestRegimentBuild: true,
+        boostTreasuryRecoveryCargo: false,
+      );
+      const b = ExpandEconomyPlan(
+        forceCheapestRegimentBuild: true,
+        boostTreasuryRecoveryCargo: false,
+      );
+      const c = ExpandEconomyPlan(
+        forceCheapestRegimentBuild: false,
+        boostTreasuryRecoveryCargo: true,
+      );
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+      expect(a, isNot(equals(c)));
+    });
+
+    test(
+      'ExpandEconomyPlan.defaultPlan equals an explicit all-false instance',
+      () {
+        // Default-plan pin: tests in the orchestrator wiring slice (#2509
+        // S5) may compare planner output against the shared default
+        // instance OR a fresh `const ExpandEconomyPlan(...)`. Both must
+        // succeed.
+        expect(
+          ExpandEconomyPlan.defaultPlan,
+          const ExpandEconomyPlan(
+            forceCheapestRegimentBuild: false,
+            boostTreasuryRecoveryCargo: false,
+          ),
+        );
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Adds `planExpandEconomy` (and the `ExpandEconomyPlan` value-class) to
`expand_phase_planner.dart` — the next in-module slice of issue #2509
S2 / S10 EXPAND-phase planner. Pure function
`(Game, AIWorldSnapshot) -> ExpandEconomyPlan` returning the
deterministic build-threshold and cargo-boost overrides for an
EXPAND-phase Great Power.

SPEC authorization:

- Issue #2509 § EXPAND phase planner § planExpandEconomy (three-arm rule:
  zero-regiment rebuild, insufficient-regiment rebuild with affordable
  treasury, treasury-recovery cargo boost).
- `SPEC/ai/ai-architecture.md` § Observer goal phases § EXPAND
  ("Pending riches treasury": build affordability uses effective treasury
  = `Player.treasury + pendingRichesTreasuryDelta(stockpile: ...)`).

## Done in this PR

`packages/colonizethis_ai/lib/src/planning/expand_phase_planner.dart`

- New `ExpandEconomyPlan` value class:
  - `forceCheapestRegimentBuild` — orchestrator should drop economy
    build threshold to zero and pick the cheapest entry in
    `RegimentEconomyCatalog`.
  - `boostTreasuryRecoveryCargo` — orchestrator should add
    `kBelowQuotaPeaceTreasuryRecoveryCargoBoost` to economy weight so
    overseas cargo preference rises (deliver NW riches to stockpile).
  - `ExpandEconomyPlan.defaultPlan` — shared all-false const instance for
    fall-through paths.
  - Hand-rolled `==` / `hashCode` / `toString` so the orchestrator
    rewrite (S5) can compare planner output against literal expectations.
- New top-level `planExpandEconomy({required Game game, required
  AIWorldSnapshot snapshot}) -> ExpandEconomyPlan`. Implements the
  three-arm decision tree from issue #2509:
  - **Outer gate**: GP at quota (\`oldWorldProvincesOwned >= 10\`) or
    unknown player -> \`ExpandEconomyPlan.defaultPlan\` (defensive
    guard mirrors \`planExpandDeclareWar\`).
  - **Arm A**: \`regimentCount == 0\` + non-empty
    \`invadableProvinceIdsSorted\` -> \`forceCheapestRegimentBuild = true\`
    (no treasury gate per spec).
  - **Arm B**: \`0 < regimentCount < kBelowQuotaPeaceMinRegimentsBeforeDeclareWar\`
    + non-empty invadable + effective treasury \`>=\` cheapest regiment
    cost -> \`forceCheapestRegimentBuild = true\` (seed-42 turn-100 trap
    collapsed into the phase planner).
  - **Arm C**: effective treasury \`<\` cheapest regiment cost ->
    \`boostTreasuryRecoveryCargo = true\` (independent of regimentCount
    per the spec literal wording; composes with arm A).
- Reuses the existing private \`_cheapestRegimentBuildTreasuryCost()\`
  helper and the \`regimentCountForPlayer\` / \`pendingRichesTreasuryDelta\`
  contracts already imported by the file (logic decoupling rule
  preserved — only the AI -> logic direction via narrow contracts).
- Library docstring updated: \`planExpandEconomy\` is no longer listed as
  a follow-up slice; only \`planExpandMilitary\` remains.

`packages/colonizethis_ai/test/planning/expand_phase_planner_economy_test.dart` (new)

16 unit tests in one \`group('planExpandEconomy', ...)\`:

- Outer gate: at quota / missing player -> defaultPlan.
- Arm A: reg = 0 + invadable -> forceRebuild only (high treasury).
- Arm A blocked: reg = 0 but no invadable -> defaultPlan.
- Arm B: 0 < reg < 6 + invadable + treasury == cheapest -> forceRebuild
  only.
- Arm B blocked at the regiment-floor boundary
  (\`reg == kBelowQuotaPeaceMinRegimentsBeforeDeclareWar\`).
- Arm B blocked by empty invadable.
- Arm C alone (high regiments, low treasury) -> boostCargo only.
- Arm A + arm C combine (reg = 0, treasury = 0) -> both flags true.
- Arm B blocked by treasury -> arm C alone (the seed-42 gp3 trap with
  no liquidity branch).
- Pending-riches credit lifts effective treasury so arm B fires WITHOUT
  arm C (catches a regression that reads \`player.treasury\` directly).
- Effective-treasury boundary at \`==\` cheapest (arm B inclusive, arm C
  strict).
- Multi-player isolation (gp2 wealth/armies do not affect gp1's plan).
- Determinism pin (Refs #2509 Must-have #7).
- \`ExpandEconomyPlan\` value-equality / \`hashCode\` pins so test
  comparisons stay stable across planner refactors.

## Tests

- [x] \`dart analyze packages/colonizethis_ai/lib/src/planning/expand_phase_planner.dart packages/colonizethis_ai/test/planning/expand_phase_planner_economy_test.dart\` — \`No issues found!\`
- [x] \`dart test packages/colonizethis_ai/test/planning/expand_phase_planner_economy_test.dart\` — **16 passing**.
- [x] \`dart test packages/colonizethis_ai\` — **678 passing, 2 skipped** (pre-existing baseline; no regressions).
- [x] \`dart format\` clean on both new/modified files.
- [ ] CI quality gates (Quality + App tests on push).

## Acceptance criteria coverage (from issue #2509)

This PR adds in-module unit-test coverage for the EXPAND-phase
\`planExpandEconomy\` pure-function contract (three rebuild/cargo arms
plus the outer quota gate, effective-treasury credit, multi-player
isolation, and determinism Must-have #7). It does **not** claim the
AC #5 / #6 / Must-have #5 nightly observer measurements; those remain
a later-slice / final-PR concern as the orchestrator (S5) wires the
phase-planner output into the actual build pipeline.

## Deferred for #2509 (out of scope for this PR)

- **S2 \`planExpandMilitary\`** — OW-only conquest army moves toward
  the declare-war target.
- **S5 orchestrator rewrite** — wire \`planExpandEconomy\` into
  \`domain_planner_orchestrator.dart\` build-threshold + economy-weight
  pipeline; remove the legacy
  \`isBelowQuotaPeaceInsufficientRegiments\` /
  \`isBelowQuotaPeaceZeroRegimentsRebuild\` /
  \`isBelowQuotaPeaceTreasuryRecovery\` helpers and their call sites in
  \`colonial_pressure.dart\` / \`diplomacy_planner_peace_targets.dart\`.
- **S1 spec strip** — remove the suppression helpers / per-phase peace
  functions from \`observer_goal_phase.dart\` once S5 lands.
- **S6 \`SPEC/ai/ai-architecture.md\` rewrite** — replace § Observer
  goal phases with the single-goal phase-planner architecture document.
- **S7 observer integration / S8 enable
  \`seed42_observer_conquest_regression_test\`** — final-slice gate pass.

Refs #2509

Tracked by #2509

Made with [Cursor](https://cursor.com)