### PR TITLE
feat(ai): planExpandMilitary — EXPAND-phase OW conquest destination filter (Refs #2509 S2)

### DIFF
--- a/packages/colonizethis_ai/lib/src/planning/expand_phase_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/expand_phase_planner.dart
@@ -69,9 +69,27 @@
 ///     phase income (Refs #2509 § Observer goal phases § EXPAND
 ///     "Pending riches treasury").
 ///
-/// Functions left for follow-up slices on this issue:
-///   - `planExpandMilitary` — OW-only conquest army moves toward the
-///     declare-war target (#2509 S2).
+///   `planExpandMilitary(game, snapshot, declaredWarTargetFactionId)
+///                                                  → ExpandMilitaryPlan`
+///     Returns the deterministic OW-only conquest destination filter for
+///     the active EXPAND player. The plan carries the priority subset of
+///     [ConquestSummary.invadableProvinceIdsSorted] (always OW by
+///     construction — see `_invadableOldWorldProvinceIds` in the
+///     perception snapshot builder) that conquest army moves should
+///     target this turn: provinces owned by the declare-war target when
+///     one was chosen, otherwise provinces owned by any at-war faction.
+///     Returns [ExpandMilitaryPlan.defaultPlan] (no constraint) for the
+///     outer EXPAND guards (at quota, missing player, empty invadable
+///     frontier) and for the priority arms that resolve to an empty
+///     province set; the orchestrator (#2509 S5) treats `defaultPlan`
+///     as "free choice within OW invadable" and a non-default plan as
+///     "restrict conquest army moves to this subset" (Refs #2509 §
+///     EXPAND phase planner § planExpandMilitary "Use existing
+///     runConquestArmyMovePlanner with EXPAND-only destination filter").
+///     Structural NW suppression: the planner never reads
+///     [ColonialSummary.invadableNewWorldProvinceIdsSorted] so a New
+///     World invadable province cannot appear in the plan even if the
+///     snapshot exposes one.
 library;
 
 import 'package:colonizethis_data/colonizethis_data.dart';
@@ -608,4 +626,211 @@ int _cheapestRegimentBuildTreasuryCost() {
     }
   }
   return min;
+}
+
+/// EXPAND-phase conquest destination filter returned by [planExpandMilitary].
+///
+/// Two ascending-sorted lists describe the priority subset of OW
+/// invadable provinces (and the owning faction(s)) that conquest army
+/// moves should target this turn. The lists never contain New World
+/// provinces — structural suppression in [planExpandMilitary] (the
+/// planner only reads [ConquestSummary.invadableProvinceIdsSorted],
+/// which is OW-only by construction in the perception-snapshot builder).
+///
+/// The orchestrator (Refs #2509 S5) consumes the plan as a filter on
+/// `runConquestArmyMovePlanner`:
+///   - [defaultPlan] (`priorityDestinationProvinceIdsSorted` empty) =
+///     "no constraint"; the orchestrator chooses freely from the full
+///     OW invadable set (legacy behavior).
+///   - A non-default plan = "restrict OW conquest destinations to this
+///     subset". Empty plans never carry [priorityTargetOwnerFactionIdsSorted]
+///     entries; non-empty plans always carry at least one owner.
+///
+/// `const`-friendly so the default "no override" return uses a single
+/// shared instance ([defaultPlan]) without per-call allocations on the
+/// hot AI path.
+class ExpandMilitaryPlan {
+  const ExpandMilitaryPlan({
+    required this.priorityDestinationProvinceIdsSorted,
+    required this.priorityTargetOwnerFactionIdsSorted,
+  });
+
+  /// Reusable "no override" plan returned for non-EXPAND callers, GPs
+  /// at quota, the empty-invadable guard, and the priority-arm
+  /// fall-through (declared-war target owns nothing in OW invadable
+  /// and no at-war faction owns OW invadable either).
+  static const ExpandMilitaryPlan defaultPlan = ExpandMilitaryPlan(
+    priorityDestinationProvinceIdsSorted: <String>[],
+    priorityTargetOwnerFactionIdsSorted: <String>[],
+  );
+
+  /// Subset of [ConquestSummary.invadableProvinceIdsSorted] (OW only)
+  /// whose owners match the priority-arm filter for this turn. Sorted
+  /// ascending so identical inputs yield identical lists (Refs #2509
+  /// Must-have #7). Empty for [defaultPlan].
+  final List<String> priorityDestinationProvinceIdsSorted;
+
+  /// Faction ids of the owners covered by
+  /// [priorityDestinationProvinceIdsSorted]. Sorted ascending and
+  /// deduplicated:
+  ///   - Single-element list when the declared-war target arm fires
+  ///     ([planExpandMilitary] § Priority 1).
+  ///   - One or more entries (sorted at-war owners) when the at-war
+  ///     fallback arm fires ([planExpandMilitary] § Priority 2).
+  ///   - Empty for [defaultPlan].
+  final List<String> priorityTargetOwnerFactionIdsSorted;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ExpandMilitaryPlan &&
+          _listEquals(
+            priorityDestinationProvinceIdsSorted,
+            other.priorityDestinationProvinceIdsSorted,
+          ) &&
+          _listEquals(
+            priorityTargetOwnerFactionIdsSorted,
+            other.priorityTargetOwnerFactionIdsSorted,
+          );
+
+  @override
+  int get hashCode => Object.hash(
+    Object.hashAll(priorityDestinationProvinceIdsSorted),
+    Object.hashAll(priorityTargetOwnerFactionIdsSorted),
+  );
+
+  @override
+  String toString() =>
+      'ExpandMilitaryPlan('
+      'priorityDestinationProvinceIdsSorted: $priorityDestinationProvinceIdsSorted, '
+      'priorityTargetOwnerFactionIdsSorted: $priorityTargetOwnerFactionIdsSorted)';
+}
+
+bool _listEquals(List<String> a, List<String> b) {
+  if (identical(a, b)) return true;
+  if (a.length != b.length) return false;
+  for (var i = 0; i < a.length; i++) {
+    if (a[i] != b[i]) return false;
+  }
+  return true;
+}
+
+/// Returns the deterministic EXPAND-phase conquest destination filter
+/// for the active player as an [ExpandMilitaryPlan].
+///
+/// Contract (issue #2509 § EXPAND phase planner § planExpandMilitary):
+///
+///   "Conquest army moves toward OW invadable provinces only.
+///      → Source: invadableProvinceIdsSorted, filtered to provinces
+///        owned by the declare-war target (or any at-war owner if no
+///        target).
+///      → Use existing runConquestArmyMovePlanner with EXPAND-only
+///        destination filter.
+///      → No NW army moves (structural — planner never queries
+///        colonial summary)."
+///
+/// Inputs:
+///   - [game]: resolves the active player ([Game.playerById]) for the
+///     defensive guard and walks the province-owner map
+///     ([getProvinceOwnerMap]) to partition
+///     [ConquestSummary.invadableProvinceIdsSorted] by owner faction.
+///   - [snapshot]: per-player [AIWorldSnapshot] supplying
+///     [ConquestSummary.invadableProvinceIdsSorted] (the OW-only
+///     candidate pool),
+///     [ConquestSummary.oldWorldProvincesOwned] (the EXPAND outer
+///     quota gate), and [ThreatSummary.atWarWith] (the Priority 2
+///     fallback when no declare-war target is given).
+///   - [declaredWarTargetFactionId]: optional declare-war target from
+///     [planExpandDeclareWar] for the same turn; when non-null, the
+///     planner restricts conquest destinations to provinces owned by
+///     that faction (Priority 1).
+///
+/// Priority arms (first match wins; each arm produces a sorted-ascending,
+/// deduplicated province list):
+///   1. **Declared-war target** — when [declaredWarTargetFactionId] is
+///      non-null and owns at least one province in
+///      [ConquestSummary.invadableProvinceIdsSorted], the plan
+///      restricts to those provinces and lists only the target as
+///      `priorityTargetOwnerFactionIdsSorted`.
+///   2. **At-war owners fallback** — when no declare-war target is given
+///      and at least one faction in [ThreatSummary.atWarWith] owns an
+///      OW invadable province, the plan restricts to the union of those
+///      provinces and lists the at-war owners sorted ascending.
+///   3. **Default plan** — when the declare-war target owns nothing in
+///      OW invadable, or when no declare-war target is given and no
+///      at-war faction owns OW invadable, or for the outer guards (at
+///      quota, missing player, empty OW invadable). Empty plan signals
+///      the orchestrator to fall back to its existing free-choice
+///      conquest behaviour over the full invadable set.
+///
+/// Structural NW suppression: this function reads only
+/// [ConquestSummary.invadableProvinceIdsSorted] (OW-only by builder
+/// contract). It never reads [ColonialSummary.invadableNewWorldProvinceIdsSorted],
+/// so a New World province cannot appear in the plan even when the
+/// snapshot exposes one (Refs #2509 § EXPAND phase planner
+/// "Suppressions" / Phase planner unit tests § "EXPAND NW
+/// suppression"). The actual order emission and the conquest army-move
+/// pass live in `runConquestArmyMovePlanner`; the orchestrator (#2509
+/// S5) wires this plan in as a filter on that pass.
+///
+/// The function is pure and deterministic — identical inputs always
+/// yield identical [ExpandMilitaryPlan]s (Refs #2509 Must-have #7).
+ExpandMilitaryPlan planExpandMilitary({
+  required Game game,
+  required AIWorldSnapshot snapshot,
+  String? declaredWarTargetFactionId,
+}) {
+  if (!isBelowObserverConquestQuota(snapshot.conquest.oldWorldProvincesOwned)) {
+    return ExpandMilitaryPlan.defaultPlan;
+  }
+  if (game.playerById(snapshot.playerId) == null) {
+    return ExpandMilitaryPlan.defaultPlan;
+  }
+  final invadable = snapshot.conquest.invadableProvinceIdsSorted;
+  if (invadable.isEmpty) {
+    return ExpandMilitaryPlan.defaultPlan;
+  }
+
+  final provinceOwner = getProvinceOwnerMap(game);
+
+  if (declaredWarTargetFactionId != null) {
+    final destinations = <String>[
+      for (final pid in invadable)
+        if (provinceOwner[pid] == declaredWarTargetFactionId) pid,
+    ];
+    if (destinations.isEmpty) {
+      return ExpandMilitaryPlan.defaultPlan;
+    }
+    destinations.sort();
+    return ExpandMilitaryPlan(
+      priorityDestinationProvinceIdsSorted: List<String>.unmodifiable(
+        destinations,
+      ),
+      priorityTargetOwnerFactionIdsSorted: List<String>.unmodifiable(<String>[
+        declaredWarTargetFactionId,
+      ]),
+    );
+  }
+
+  final atWarOwners = <String>{};
+  final atWarSet = snapshot.threats.atWarWith.toSet();
+  final destinations = <String>[];
+  for (final pid in invadable) {
+    final owner = provinceOwner[pid];
+    if (owner == null) continue;
+    if (!atWarSet.contains(owner)) continue;
+    destinations.add(pid);
+    atWarOwners.add(owner);
+  }
+  if (destinations.isEmpty) {
+    return ExpandMilitaryPlan.defaultPlan;
+  }
+  destinations.sort();
+  final owners = atWarOwners.toList()..sort();
+  return ExpandMilitaryPlan(
+    priorityDestinationProvinceIdsSorted: List<String>.unmodifiable(
+      destinations,
+    ),
+    priorityTargetOwnerFactionIdsSorted: List<String>.unmodifiable(owners),
+  );
 }

--- a/packages/colonizethis_ai/test/planning/expand_phase_planner_military_test.dart
+++ b/packages/colonizethis_ai/test/planning/expand_phase_planner_military_test.dart
@@ -1,0 +1,645 @@
+// Unit tests for `planExpandMilitary` in
+// `packages/colonizethis_ai/lib/src/planning/expand_phase_planner.dart`
+// (Refs #2509 S2 / S10).
+//
+// Spec contract (issue #2509 § EXPAND phase planner § planExpandMilitary):
+//
+//   "Conquest army moves toward OW invadable provinces only.
+//      → Source: invadableProvinceIdsSorted, filtered to provinces owned
+//        by the declare-war target (or any at-war owner if no target).
+//      → Use existing runConquestArmyMovePlanner with EXPAND-only
+//        destination filter.
+//      → No NW army moves (structural — planner never queries colonial
+//        summary)."
+//
+// Mirrors the test pattern established for the other EXPAND-phase
+// planner contracts (`expand_phase_planner_test.dart`,
+// `expand_phase_planner_declare_war_test.dart`,
+// `expand_phase_planner_economy_test.dart`): small synthetic fixtures,
+// one branch arm per test, in-module pin (the planner module never
+// re-checks phase, so these tests stay scoped to the priority-arm
+// branches plus the structural NW suppression).
+//
+// The "runConquestArmyMovePlanner" wiring + actual ArmyMoveOrder
+// emission live at the orchestrator layer (#2509 S5) and are
+// intentionally out of scope for this in-module pin — the unit pins
+// the deterministic destination filter that the orchestrator consumes.
+
+import 'package:colonizethis_ai/colonizethis_ai.dart';
+import 'package:colonizethis_ai/src/planning/expand_phase_planner.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+const String _gp1 = 'gp1';
+const String _gp2 = 'gp2';
+const String _gp3 = 'gp3';
+const String _minor1 = 'minor1';
+const String _minor2 = 'minor2';
+const String _tribe1 = 'tribe1';
+
+/// Game scaffold for EXPAND-phase military tests. Old World provinces,
+/// players, minors, and tribes are passed in so each test can shape
+/// ownership independently. The planner does not read armies or
+/// treasury for the destination filter, but defaulting to a populated
+/// player roster keeps the defensive `playerById` guard satisfied.
+Game _expandGame({
+  int turnNumber = 50,
+  List<Province> oldWorldProvinces = const [],
+  List<Player> players = const [
+    Player(id: _gp1, displayName: 'GP1', isHuman: false, treasury: 9999),
+    Player(id: _gp2, displayName: 'GP2', isHuman: false, treasury: 9999),
+    Player(id: _gp3, displayName: 'GP3', isHuman: false, treasury: 9999),
+  ],
+  List<MinorNation> minorNations = const [],
+  List<Tribe> tribes = const [],
+}) {
+  return Game(
+    id: 'g-2509-expand-phase-planner-military-t$turnNumber',
+    worldState: WorldState(
+      turnState: TurnState(turnNumber: turnNumber, phase: TurnPhase.orders),
+      oldWorld: RegionData(provinces: oldWorldProvinces),
+      newWorld: const RegionData(),
+    ),
+    players: players,
+    minorNations: minorNations,
+    tribes: tribes,
+  );
+}
+
+/// Snapshot tuned for EXPAND. Defaults to OW=8 (below quota of 10) with
+/// `playerId = gp1`. Tests shape `atWarWith`, `invadableOw`,
+/// `invadableNw`, and `oldWorldProvincesOwned` to exercise specific
+/// priority arms and the structural NW suppression.
+AIWorldSnapshot _expandSnapshot({
+  required List<String> atWarWith,
+  List<String> invadableOw = const [],
+  List<String> invadableNw = const [],
+  int oldWorldProvincesOwned = 8,
+  String playerId = _gp1,
+}) {
+  return AIWorldSnapshot(
+    playerId: playerId,
+    threats: ThreatSummary(atWarWith: atWarWith),
+    opportunities: const OpportunitySummary(),
+    conquest: ConquestSummary(
+      oldWorldProvincesOwned: oldWorldProvincesOwned,
+      provincesToVictory: kObserverConquestMinOwProvincesPerGp * 3,
+      invadableProvinceIdsSorted: invadableOw,
+    ),
+    colonial: ColonialSummary(invadableNewWorldProvinceIdsSorted: invadableNw),
+    economy: const EconomySummary(),
+    relations: const {},
+  );
+}
+
+void main() {
+  group('planExpandMilitary', () {
+    test('at quota (own OW = 10) -> defaultPlan', () {
+      // EXPAND outer gate: `isBelowObserverConquestQuota` is false when
+      // own OW reaches `kObserverConquestMinOwProvincesPerGp` (10), so
+      // the planner short-circuits before reading invadable or owner
+      // state. A regression that dropped the outer gate would surface
+      // a non-default plan for an at-quota GP.
+      final game = _expandGame(
+        oldWorldProvinces: const [
+          Province(id: 'oldWorld|m1_a', regionId: 'oldWorld', ownerId: _minor1),
+        ],
+        minorNations: const [MinorNation(id: _minor1, displayName: 'M1')],
+      );
+      final snapshot = _expandSnapshot(
+        atWarWith: const [_minor1],
+        invadableOw: const ['oldWorld|m1_a'],
+        oldWorldProvincesOwned: 10,
+      );
+      expect(
+        planExpandMilitary(game: game, snapshot: snapshot),
+        same(ExpandMilitaryPlan.defaultPlan),
+        reason:
+            'GP at the observer OW quota is no longer EXPAND territory '
+            'for this planner; the outer `isBelowObserverConquestQuota` '
+            'gate must short-circuit before reading invadable state.',
+      );
+    });
+
+    test('player not in game -> defaultPlan (defensive guard)', () {
+      // Defensive guard pin: snapshots pointing at a non-existent
+      // player must not crash; the planner returns the default plan.
+      // Matches the equivalent guard in `planExpandDeclareWar` and
+      // `planExpandEconomy`.
+      final game = _expandGame(
+        oldWorldProvinces: const [
+          Province(id: 'oldWorld|m1_a', regionId: 'oldWorld', ownerId: _minor1),
+        ],
+        minorNations: const [MinorNation(id: _minor1, displayName: 'M1')],
+      );
+      final snapshot = _expandSnapshot(
+        atWarWith: const [_minor1],
+        invadableOw: const ['oldWorld|m1_a'],
+        playerId: 'ghost-player',
+      );
+      expect(
+        planExpandMilitary(game: game, snapshot: snapshot),
+        ExpandMilitaryPlan.defaultPlan,
+      );
+    });
+
+    test('empty invadable -> defaultPlan', () {
+      // No OW frontier means there is no province to filter; the
+      // function must short-circuit before any priority-arm scan so
+      // an empty constraint never leaks to the orchestrator.
+      final game = _expandGame();
+      final snapshot = _expandSnapshot(
+        atWarWith: const [_gp2],
+        invadableOw: const [],
+      );
+      expect(
+        planExpandMilitary(game: game, snapshot: snapshot),
+        same(ExpandMilitaryPlan.defaultPlan),
+      );
+    });
+
+    test('AC: declared-war target owns one invadable OW -> restrict to that '
+        'province + target only owner', () {
+      // Acceptance criterion (issue #2509 Phase planner unit tests):
+      // priority 1 fires when the declare-war target owns at least
+      // one invadable OW province. The plan restricts conquest to
+      // exactly that province and lists only the target as the
+      // priority owner.
+      final game = _expandGame(
+        oldWorldProvinces: const [
+          Province(id: 'oldWorld|m1_a', regionId: 'oldWorld', ownerId: _minor1),
+        ],
+        minorNations: const [MinorNation(id: _minor1, displayName: 'M1')],
+      );
+      final snapshot = _expandSnapshot(
+        atWarWith: const [],
+        invadableOw: const ['oldWorld|m1_a'],
+      );
+      expect(
+        planExpandMilitary(
+          game: game,
+          snapshot: snapshot,
+          declaredWarTargetFactionId: _minor1,
+        ),
+        const ExpandMilitaryPlan(
+          priorityDestinationProvinceIdsSorted: <String>['oldWorld|m1_a'],
+          priorityTargetOwnerFactionIdsSorted: <String>[_minor1],
+        ),
+        reason:
+            'Priority 1: declare-war target owns one OW invadable '
+            'province -> plan restricts to that province and lists '
+            'only the target as the priority owner.',
+      );
+    });
+
+    test('declared-war target owns multiple invadable OW -> all those '
+        'provinces, sorted ascending', () {
+      // Multiple invadable provinces under the same declared target:
+      // the plan keeps all of them, sorted ascending, regardless of
+      // the input order in invadableProvinceIdsSorted (defensive
+      // determinism against future builder changes).
+      final game = _expandGame(
+        oldWorldProvinces: const [
+          Province(id: 'oldWorld|m1_a', regionId: 'oldWorld', ownerId: _minor1),
+          Province(id: 'oldWorld|m1_b', regionId: 'oldWorld', ownerId: _minor1),
+        ],
+        minorNations: const [MinorNation(id: _minor1, displayName: 'M1')],
+      );
+      final snapshot = _expandSnapshot(
+        atWarWith: const [],
+        // Provide in reverse-sorted order to verify the sort.
+        invadableOw: const ['oldWorld|m1_b', 'oldWorld|m1_a'],
+      );
+      expect(
+        planExpandMilitary(
+          game: game,
+          snapshot: snapshot,
+          declaredWarTargetFactionId: _minor1,
+        ),
+        const ExpandMilitaryPlan(
+          priorityDestinationProvinceIdsSorted: <String>[
+            'oldWorld|m1_a',
+            'oldWorld|m1_b',
+          ],
+          priorityTargetOwnerFactionIdsSorted: <String>[_minor1],
+        ),
+        reason:
+            'Priority 1 keeps ALL invadable provinces owned by the '
+            'declared target, sorted ascending. Output order is '
+            'independent of the input invadable list order.',
+      );
+    });
+
+    test('declared-war target owns no invadable -> defaultPlan', () {
+      // Priority 1 fails when the declared target owns nothing in OW
+      // invadable. Per the spec the orchestrator should fall back to
+      // its existing free-choice behaviour, so the planner returns
+      // the default plan rather than an empty constraint.
+      final game = _expandGame(
+        oldWorldProvinces: const [
+          Province(id: 'oldWorld|m1_a', regionId: 'oldWorld', ownerId: _minor1),
+        ],
+        minorNations: const [
+          MinorNation(id: _minor1, displayName: 'M1'),
+          MinorNation(id: _minor2, displayName: 'M2'),
+        ],
+      );
+      final snapshot = _expandSnapshot(
+        atWarWith: const [],
+        invadableOw: const ['oldWorld|m1_a'],
+      );
+      expect(
+        planExpandMilitary(
+          game: game,
+          snapshot: snapshot,
+          // minor2 owns nothing in OW invadable.
+          declaredWarTargetFactionId: _minor2,
+        ),
+        same(ExpandMilitaryPlan.defaultPlan),
+        reason:
+            'When the declared-war target owns nothing in OW '
+            'invadable, the plan falls back to defaultPlan so the '
+            'orchestrator can pick freely (legacy behaviour). An '
+            'empty constraint must never leak.',
+      );
+    });
+
+    test('AC: no declared-war target, at-war minor owns invadable OW -> '
+        'restrict to those provinces + sorted at-war owners', () {
+      // Priority 2 fires when no declared target is given and at
+      // least one at-war faction owns an OW invadable province. The
+      // plan restricts to the union of those provinces and lists the
+      // at-war owners sorted ascending.
+      final game = _expandGame(
+        oldWorldProvinces: const [
+          Province(id: 'oldWorld|m1_a', regionId: 'oldWorld', ownerId: _minor1),
+        ],
+        minorNations: const [MinorNation(id: _minor1, displayName: 'M1')],
+      );
+      final snapshot = _expandSnapshot(
+        atWarWith: const [_minor1],
+        invadableOw: const ['oldWorld|m1_a'],
+      );
+      expect(
+        planExpandMilitary(game: game, snapshot: snapshot),
+        const ExpandMilitaryPlan(
+          priorityDestinationProvinceIdsSorted: <String>['oldWorld|m1_a'],
+          priorityTargetOwnerFactionIdsSorted: <String>[_minor1],
+        ),
+        reason:
+            'Priority 2 (at-war fallback): no declare-war target + '
+            'an at-war minor owns one OW invadable -> plan restricts '
+            'to that province and lists the at-war owner.',
+      );
+    });
+
+    test('no declared-war target, multiple at-war owners (GP + minor) -> '
+        'union of their invadable + sorted owners', () {
+      // At-war fallback covers any faction class (GP, minor, tribe).
+      // Two at-war owners contribute provinces; the plan unions them
+      // and lists both owners sorted ascending.
+      final game = _expandGame(
+        oldWorldProvinces: const [
+          Province(id: 'oldWorld|gp2_0', regionId: 'oldWorld', ownerId: _gp2),
+          Province(id: 'oldWorld|m1_a', regionId: 'oldWorld', ownerId: _minor1),
+        ],
+        minorNations: const [MinorNation(id: _minor1, displayName: 'M1')],
+      );
+      final snapshot = _expandSnapshot(
+        atWarWith: const [_gp2, _minor1],
+        invadableOw: const ['oldWorld|m1_a', 'oldWorld|gp2_0'],
+      );
+      expect(
+        planExpandMilitary(game: game, snapshot: snapshot),
+        ExpandMilitaryPlan(
+          priorityDestinationProvinceIdsSorted: List<String>.unmodifiable(
+            const <String>['oldWorld|gp2_0', 'oldWorld|m1_a'],
+          ),
+          priorityTargetOwnerFactionIdsSorted: List<String>.unmodifiable(
+            const <String>[_gp2, _minor1],
+          ),
+        ),
+        reason:
+            'Priority 2 unions provinces across all at-war owners '
+            '(GP + minor). Provinces and owners are both sorted '
+            'ascending in the plan output.',
+      );
+    });
+
+    test('at-war owner with no invadable contribution is dropped from owner '
+        'list', () {
+      // An at-war faction that does NOT own any invadable OW province
+      // must NOT appear in priorityTargetOwnerFactionIdsSorted. This
+      // pins the "owner list mirrors actual destinations" contract so
+      // a downstream orchestrator never sees a phantom target.
+      final game = _expandGame(
+        oldWorldProvinces: const [
+          Province(id: 'oldWorld|m1_a', regionId: 'oldWorld', ownerId: _minor1),
+        ],
+        minorNations: const [
+          MinorNation(id: _minor1, displayName: 'M1'),
+          MinorNation(id: _minor2, displayName: 'M2'),
+        ],
+      );
+      final snapshot = _expandSnapshot(
+        // minor2 is at war but owns nothing in OW invadable, so should
+        // be dropped from the owner list.
+        atWarWith: const [_minor1, _minor2],
+        invadableOw: const ['oldWorld|m1_a'],
+      );
+      expect(
+        planExpandMilitary(game: game, snapshot: snapshot),
+        const ExpandMilitaryPlan(
+          priorityDestinationProvinceIdsSorted: <String>['oldWorld|m1_a'],
+          priorityTargetOwnerFactionIdsSorted: <String>[_minor1],
+        ),
+        reason:
+            'Only at-war owners that actually contribute an invadable '
+            'province appear in priorityTargetOwnerFactionIdsSorted. '
+            'minor2 is at war but contributes nothing so it is dropped.',
+      );
+    });
+
+    test('no declared-war target, no at-war owners hold invadable -> '
+        'defaultPlan', () {
+      // Priority 2 fails when no at-war faction owns an invadable OW
+      // province. Both priority arms exhausted -> defaultPlan; the
+      // orchestrator falls back to legacy free-choice conquest.
+      final game = _expandGame(
+        oldWorldProvinces: const [
+          Province(id: 'oldWorld|m1_a', regionId: 'oldWorld', ownerId: _minor1),
+        ],
+        minorNations: const [
+          MinorNation(id: _minor1, displayName: 'M1'),
+          MinorNation(id: _minor2, displayName: 'M2'),
+        ],
+      );
+      final snapshot = _expandSnapshot(
+        // minor2 is at war but does NOT own the invadable province.
+        atWarWith: const [_minor2],
+        invadableOw: const ['oldWorld|m1_a'],
+      );
+      expect(
+        planExpandMilitary(game: game, snapshot: snapshot),
+        same(ExpandMilitaryPlan.defaultPlan),
+        reason:
+            'No declare-war target + no at-war faction owning an '
+            'OW invadable -> defaultPlan (the orchestrator falls '
+            'back to the legacy free-choice conquest behaviour).',
+      );
+    });
+
+    test(
+      'declared-war target wins over at-war fallback (priority 1 over 2)',
+      () {
+        // Both arms could fire (target owns invadable AND another at-war
+        // faction owns invadable), but priority 1 (declare-war target)
+        // takes precedence and excludes the at-war non-target from the
+        // owner list.
+        final game = _expandGame(
+          oldWorldProvinces: const [
+            Province(
+              id: 'oldWorld|m1_a',
+              regionId: 'oldWorld',
+              ownerId: _minor1,
+            ),
+            Province(
+              id: 'oldWorld|m2_a',
+              regionId: 'oldWorld',
+              ownerId: _minor2,
+            ),
+          ],
+          minorNations: const [
+            MinorNation(id: _minor1, displayName: 'M1'),
+            MinorNation(id: _minor2, displayName: 'M2'),
+          ],
+        );
+        final snapshot = _expandSnapshot(
+          atWarWith: const [_minor1, _minor2],
+          invadableOw: const ['oldWorld|m1_a', 'oldWorld|m2_a'],
+        );
+        expect(
+          planExpandMilitary(
+            game: game,
+            snapshot: snapshot,
+            declaredWarTargetFactionId: _minor1,
+          ),
+          const ExpandMilitaryPlan(
+            priorityDestinationProvinceIdsSorted: <String>['oldWorld|m1_a'],
+            priorityTargetOwnerFactionIdsSorted: <String>[_minor1],
+          ),
+          reason:
+              'Priority 1 (declare-war target) wins over priority 2 '
+              '(at-war fallback). minor2 is at war and owns an invadable '
+              'province but is correctly excluded from the plan because '
+              'a declare-war target is given.',
+        );
+      },
+    );
+
+    test('AC: NW invadable structurally suppressed (#2509 EXPAND NW '
+        'suppression)', () {
+      // Acceptance criterion (issue #2509 Phase planner unit tests §
+      // "EXPAND NW suppression"): given an at-war tribe owning a New
+      // World province that appears in
+      // ColonialSummary.invadableNewWorldProvinceIdsSorted, the plan
+      // must NOT include the NW province. The planner only reads the
+      // OW invadable list — NW suppression is structural, not
+      // predicate-based.
+      final game = _expandGame(
+        oldWorldProvinces: const [
+          Province(id: 'oldWorld|m1_a', regionId: 'oldWorld', ownerId: _minor1),
+        ],
+        minorNations: const [MinorNation(id: _minor1, displayName: 'M1')],
+        tribes: const [Tribe(id: _tribe1, displayName: 'T1')],
+      );
+      final snapshot = _expandSnapshot(
+        atWarWith: const [_minor1, _tribe1],
+        invadableOw: const ['oldWorld|m1_a'],
+        // Even though the tribe is at war AND owns a NW invadable
+        // province in the colonial summary, the plan must not pick
+        // up the NW province.
+        invadableNw: const ['newWorld|tribe1_a'],
+      );
+      expect(
+        planExpandMilitary(game: game, snapshot: snapshot),
+        const ExpandMilitaryPlan(
+          priorityDestinationProvinceIdsSorted: <String>['oldWorld|m1_a'],
+          priorityTargetOwnerFactionIdsSorted: <String>[_minor1],
+        ),
+        reason:
+            'EXPAND NW suppression: the planner only reads '
+            'snapshot.conquest.invadableProvinceIdsSorted (OW-only). '
+            'The NW invadable province must NOT leak into the plan '
+            'even when an at-war owner is mentioned in the colonial '
+            'summary.',
+      );
+    });
+
+    test('declared-war target on NW province -> defaultPlan (structural '
+        'NW suppression)', () {
+      // Even with a declared-war target that owns ONLY NW invadable
+      // provinces, the planner must return defaultPlan because the
+      // target owns nothing in OW invadable. Combined with the
+      // previous test this pins the structural NW suppression from
+      // both sides.
+      final game = _expandGame(
+        tribes: const [Tribe(id: _tribe1, displayName: 'T1')],
+      );
+      final snapshot = _expandSnapshot(
+        atWarWith: const [_tribe1],
+        invadableOw: const [],
+        invadableNw: const ['newWorld|tribe1_a'],
+      );
+      expect(
+        planExpandMilitary(
+          game: game,
+          snapshot: snapshot,
+          declaredWarTargetFactionId: _tribe1,
+        ),
+        same(ExpandMilitaryPlan.defaultPlan),
+        reason:
+            'OW invadable list is empty -> the outer guard fires '
+            'and returns defaultPlan regardless of any NW invadable '
+            'state. EXPAND NW suppression is structural at the '
+            'planner level.',
+      );
+    });
+
+    test('unowned invadable province is skipped (defensive)', () {
+      // Defensive pin: an invadable province whose owner is missing
+      // from the world (orphan / mid-transition) is silently skipped
+      // rather than crashing. Tests the `if (owner == null) continue`
+      // branch in the at-war fallback arm.
+      final game = _expandGame(
+        oldWorldProvinces: const [
+          Province(id: 'oldWorld|m1_a', regionId: 'oldWorld', ownerId: _minor1),
+        ],
+        minorNations: const [MinorNation(id: _minor1, displayName: 'M1')],
+      );
+      final snapshot = _expandSnapshot(
+        atWarWith: const [_minor1],
+        // Include an unknown id that won't be in provinceOwner map.
+        invadableOw: const ['oldWorld|m1_a', 'oldWorld|ghost'],
+      );
+      expect(
+        planExpandMilitary(game: game, snapshot: snapshot),
+        const ExpandMilitaryPlan(
+          priorityDestinationProvinceIdsSorted: <String>['oldWorld|m1_a'],
+          priorityTargetOwnerFactionIdsSorted: <String>[_minor1],
+        ),
+        reason:
+            'Orphan invadable id with no owner is silently skipped; '
+            'the rest of the priority 2 scan still produces a valid '
+            'plan.',
+      );
+    });
+
+    test('Refs #2509 Must-have #7 determinism: identical inputs -> identical '
+        'plan', () {
+      // Determinism pin (issue #2509 Must-have #7). Mixed-input
+      // fixture exercises both priority arms via a tie between
+      // declare-war target and an additional at-war faction; the
+      // same plan must come out twice in a row.
+      final game = _expandGame(
+        oldWorldProvinces: const [
+          Province(id: 'oldWorld|m1_a', regionId: 'oldWorld', ownerId: _minor1),
+          Province(id: 'oldWorld|m1_b', regionId: 'oldWorld', ownerId: _minor1),
+        ],
+        minorNations: const [MinorNation(id: _minor1, displayName: 'M1')],
+      );
+      final snapshot = _expandSnapshot(
+        atWarWith: const [_minor1, _gp2],
+        invadableOw: const ['oldWorld|m1_b', 'oldWorld|m1_a'],
+      );
+      final first = planExpandMilitary(
+        game: game,
+        snapshot: snapshot,
+        declaredWarTargetFactionId: _minor1,
+      );
+      final second = planExpandMilitary(
+        game: game,
+        snapshot: snapshot,
+        declaredWarTargetFactionId: _minor1,
+      );
+      expect(second, first, reason: 'Same inputs -> same plan.');
+    });
+
+    test('multi-player game: invadable filter is owner-scoped, not '
+        'active-player-scoped', () {
+      // Isolation pin: the active player is gp1 but the planner is
+      // filtering invadable provinces by their OWNER (the enemy
+      // faction). gp1's own province ownership is irrelevant to the
+      // filter — what matters is whether the invadable list contains
+      // provinces owned by the declared target / at-war factions.
+      final game = _expandGame(
+        oldWorldProvinces: const [
+          // gp3 owns this — at war but should be ignored because not
+          // the declared target.
+          Province(id: 'oldWorld|gp3_0', regionId: 'oldWorld', ownerId: _gp3),
+          Province(id: 'oldWorld|m1_a', regionId: 'oldWorld', ownerId: _minor1),
+        ],
+        minorNations: const [MinorNation(id: _minor1, displayName: 'M1')],
+      );
+      final snapshot = _expandSnapshot(
+        atWarWith: const [_gp3, _minor1],
+        invadableOw: const ['oldWorld|gp3_0', 'oldWorld|m1_a'],
+      );
+      expect(
+        planExpandMilitary(
+          game: game,
+          snapshot: snapshot,
+          declaredWarTargetFactionId: _minor1,
+        ),
+        const ExpandMilitaryPlan(
+          priorityDestinationProvinceIdsSorted: <String>['oldWorld|m1_a'],
+          priorityTargetOwnerFactionIdsSorted: <String>[_minor1],
+        ),
+        reason:
+            'Priority 1 restricts ONLY to the declared target. gp3 '
+            'is also at war and also owns an invadable province but '
+            'is correctly excluded because the planner is keyed on '
+            'owner == declaredWarTargetFactionId.',
+      );
+    });
+
+    test('ExpandMilitaryPlan value equality: same fields compare equal', () {
+      // Value-class pin: `==` and `hashCode` must compare by list
+      // contents so tests can assert against literal constructions
+      // without relying on object identity.
+      const a = ExpandMilitaryPlan(
+        priorityDestinationProvinceIdsSorted: <String>['oldWorld|m1_a'],
+        priorityTargetOwnerFactionIdsSorted: <String>[_minor1],
+      );
+      const b = ExpandMilitaryPlan(
+        priorityDestinationProvinceIdsSorted: <String>['oldWorld|m1_a'],
+        priorityTargetOwnerFactionIdsSorted: <String>[_minor1],
+      );
+      const c = ExpandMilitaryPlan(
+        priorityDestinationProvinceIdsSorted: <String>['oldWorld|m2_a'],
+        priorityTargetOwnerFactionIdsSorted: <String>[_minor2],
+      );
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+      expect(a, isNot(equals(c)));
+    });
+
+    test(
+      'ExpandMilitaryPlan.defaultPlan equals an explicit all-empty instance',
+      () {
+        // Default-plan pin: tests in the orchestrator wiring slice
+        // (#2509 S5) may compare planner output against the shared
+        // default instance OR a fresh `const ExpandMilitaryPlan(...)`.
+        // Both must succeed.
+        expect(
+          ExpandMilitaryPlan.defaultPlan,
+          const ExpandMilitaryPlan(
+            priorityDestinationProvinceIdsSorted: <String>[],
+            priorityTargetOwnerFactionIdsSorted: <String>[],
+          ),
+        );
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Adds the final S2 function `planExpandMilitary` (and the
`ExpandMilitaryPlan` value class) to `expand_phase_planner.dart`,
**completing the EXPAND-phase planner module** per issue #2509 §
EXPAND phase planner. Pure function
`(Game, AIWorldSnapshot, declaredWarTargetFactionId) → ExpandMilitaryPlan`
returning the deterministic OW-only conquest destination filter for
an EXPAND-phase Great Power.

SPEC authorization:

- Issue #2509 § EXPAND phase planner § planExpandMilitary
  ("Conquest army moves toward OW invadable provinces only; source:
  invadableProvinceIdsSorted, filtered to provinces owned by the
  declare-war target (or any at-war owner if no target). No NW army
  moves — structural.").
- `SPEC/ai/ai-architecture.md` § Observer goal phases § EXPAND.

## Done in this PR

`packages/colonizethis_ai/lib/src/planning/expand_phase_planner.dart`

- New `ExpandMilitaryPlan` value class:
  - `priorityDestinationProvinceIdsSorted` — OW invadable province ids
    matched by the priority arm, sorted ascending.
  - `priorityTargetOwnerFactionIdsSorted` — owners of those provinces,
    sorted ascending and deduplicated.
  - `ExpandMilitaryPlan.defaultPlan` — shared all-empty instance for
    fall-through paths (orchestrator treats as "free choice from full
    OW invadable" — legacy behavior).
  - Hand-rolled `==` / `hashCode` / `toString` so the S5 orchestrator
    rewrite can compare planner output against literal expectations.
- New top-level `planExpandMilitary({game, snapshot,
  declaredWarTargetFactionId}) → ExpandMilitaryPlan`. Priority-arm
  filter from #2509:
  - **Outer guards** (return `defaultPlan`): at quota
    (`!isBelowObserverConquestQuota`), player not in game (defensive
    guard mirroring `planExpandEconomy` / `planExpandDeclareWar`), or
    empty OW invadable list.
  - **Priority 1**: when `declaredWarTargetFactionId` is non-null and
    owns at least one OW invadable province, restrict to those
    provinces and list only the target as the priority owner.
  - **Priority 2**: when no declare-war target is given and one or
    more at-war factions own OW invadable, union their provinces and
    list the at-war owners sorted ascending. Drops at-war owners that
    contribute no invadable destination.
  - **Fall-through**: declared-war target owns nothing in OW
    invadable, or no at-war faction owns OW invadable → `defaultPlan`
    so the orchestrator falls back to legacy free-choice conquest
    behaviour (empty constraints never leak).
- **Structural NW suppression**: the planner reads only
  `snapshot.conquest.invadableProvinceIdsSorted` (OW-only by builder
  contract `_invadableOldWorldProvinceIds`). It never touches
  `snapshot.colonial.invadableNewWorldProvinceIdsSorted`, so a New
  World province can never appear in the plan (Refs #2509 § EXPAND NW
  suppression). Pinned by two dedicated tests.

## Tests

New `packages/colonizethis_ai/test/planning/expand_phase_planner_military_test.dart`
— 18 unit tests:

1. At quota (OW = 10) → `defaultPlan`.
2. Player not in game → `defaultPlan` (defensive guard).
3. Empty OW invadable → `defaultPlan`.
4. **AC**: declared-war target owns one OW invadable → restrict to
   that province + target-only owner.
5. Declared-war target owns multiple OW invadable → all those
   provinces sorted ascending (independent of input order).
6. Declared-war target owns no OW invadable → `defaultPlan`.
7. **AC**: no target, at-war minor owns OW invadable → restrict to
   those provinces + sorted at-war owners.
8. No target, GP + minor both at-war and own invadable → union of
   provinces, sorted owners.
9. At-war owner with no invadable contribution dropped from owner list.
10. No target, no at-war owners own OW invadable → `defaultPlan`.
11. Declared-war target wins over at-war fallback (priority 1 > 2).
12. **AC** (EXPAND NW suppression): NW invadable structurally
    excluded even when at-war owner mentioned in colonial summary.
13. Declared-war target on NW-only province → `defaultPlan` (OW
    invadable empty triggers outer guard).
14. Orphan invadable id with no owner silently skipped.
15. **Refs #2509 Must-have #7 determinism**: same inputs → identical
    plan across repeated calls.
16. Multi-player isolation: filter is keyed on `owner`, not active
    player; non-target at-war owner excluded.
17. `ExpandMilitaryPlan` value equality + hashCode.
18. `ExpandMilitaryPlan.defaultPlan` equals explicit all-empty
    instance.

- [x] `dart test packages/colonizethis_ai/test/planning/expand_phase_planner_military_test.dart` — **18 passed**.
- [x] `dart test packages/colonizethis_ai` — **696 passed, 2 skipped** (no regressions).
- [x] `dart analyze` on changed files — `No issues found!`.
- [x] `dart format` clean on the new/modified files.
- [ ] CI quality gates (Quality + App tests on push).

## Acceptance criteria coverage (from issue #2509)

This PR completes S2 of #2509: the EXPAND phase planner module now
has all four contracted functions (`planExpandPeace`,
`planExpandDeclareWar`, `planExpandEconomy`, `planExpandMilitary`).
ACs touched directly:

- **(EXPAND declare-war military integration)** — Priority 1 pin
  (declare-war target ownership of OW invadable).
- **(EXPAND NW suppression)** — Structural; pinned by tests #12 and #13.
- **(Determinism)** — Must-have #7 pin.

## Zero behavior change today

Like the prior in-module S2 slices, the EXPAND-phase planner module
is a **function-unit pin** until S5 wires it into the orchestrator.
The legacy NW-suppression predicates in `colonial_pressure.dart` still
gate live conquest army moves; `runConquestArmyMovePlanner` is
unchanged. No regression risk for live AI play.

## Deferred for #2509 (out of scope for this PR)

- **S5 orchestrator rewrite** to wire `planExpandMilitary` into
  `domain_planner_orchestrator.dart` (filtered dispatch over
  `runConquestArmyMovePlanner`).
- **S3 COLONIAL phase planner** (acquisition / peace / military /
  naval / civilian, including COLONIAL-lite safeguards).
- **S6 SPEC rewrite** (`SPEC/ai/ai-architecture.md` § Observer goal
  phases — single-goal architecture documentation).
- **S7 observer integration** + **S8 seed-42 regression test enable**.

Refs #2509

Tracked by #2509

Made with [Cursor](https://cursor.com)