### PR TITLE
feat(ai): introduce colonial_phase_planner with planColonialPeace (Refs #2509 S3)

### DIFF
--- a/packages/colonizethis_ai/lib/src/planning/colonial_phase_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/colonial_phase_planner.dart
@@ -1,0 +1,142 @@
+/// COLONIAL-phase planner (Refs #2509 S3 / S10).
+///
+/// Phase planner module from the single-goal architecture in
+/// [GitHub issue #2509](https://github.com/waigore/colonizethisv3/issues/2509)
+/// and `SPEC/ai/ai-architecture.md` § Observer goal phases. The planner is a
+/// pure-function module that makes one primary decision per domain with no
+/// cross-phase score aggregation.
+///
+/// COLONIAL phase goal: transfer every `newWorld|` province to GP ownership
+/// using the fastest legal acquisition path (Join Empire, `purchase_land`,
+/// or `declareWar` + invasion). Callers are expected to dispatch to this
+/// module **only** when `observerGoalPhaseFor` resolves to
+/// `ObserverGoalPhase.colonial`; the planner functions themselves do not
+/// re-check the phase, matching the convention established by
+/// `develop_phase_planner.dart` (Refs #2509 S4) and
+/// `expand_phase_planner.dart` (Refs #2509 S2).
+///
+/// Wiring this module into the orchestrator, replacing the legacy
+/// `colonialPhaseGpPeaceTargets` helper in `observer_goal_phase.dart`, and
+/// retiring the `colonial_pressure.dart` / `diplomacy_planner_peace_targets.dart`
+/// ratchet helpers are out of scope for this slice (tracked under S5 / S1
+/// of #2509). Both the legacy `colonialPhaseGpPeaceTargets` helper and the
+/// new `planColonialPeace` function remain pinned at the function-unit
+/// level until the orchestrator rewrite reconciles them, so this slice
+/// carries **zero behavior change** and **zero regression risk** for live
+/// AI play.
+///
+/// In-module contracts shipped to date (see issue #2509 § COLONIAL phase
+/// planner for the full set, including the deferred
+/// `planColonialAcquisition`, `planColonialMilitary`, `planColonialNaval`,
+/// `planColonialCivilian`, `planColonialLiteOvertures`, and
+/// `planColonialLiteNaval`):
+///
+///   `planColonialPeace(game, snapshot) → List<String>`
+///     Returns the deterministic list of at-war Great Powers the active
+///     player should `offerPeace` toward in COLONIAL. Defaults to peacing
+///     **all** at-war GPs except the one identified by
+///     [primaryColonialGpBlocker] (the GP owning the most invadable
+///     `newWorld|` provinces -- the primary colonial NW frontier blocker).
+///     The new spec text from issue #2509 § COLONIAL phase planner §
+///     planColonialPeace is "Peace all at-war Great Powers, with ONE
+///     exception: Keep fighting a GP that owns a province blocking the
+///     primary colonial NW target". Tribe and minor at-war factions are
+///     filtered out via [Game.playerById] returning `null` for non-player
+///     ids -- COLONIAL diplomatic peace is GP-vs-GP only; tribe/minor
+///     colonial wars are pursued through other phase-planner contracts
+///     (`planColonialAcquisition` for `establishOverture` / Join Empire
+///     / `purchase_land`, `planColonialMilitary` for NW conquest army
+///     moves) which are deferred to follow-up S3 slices.
+library;
+
+import 'package:colonizethis_logic/ai_api.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import '../perception/perception_snapshot.dart';
+import 'observer_goal_phase.dart' show primaryColonialGpBlocker;
+
+/// Returns the deterministic list of at-war Great Powers the active player
+/// should `offerPeace` toward this turn while in COLONIAL phase.
+///
+/// Contract (issue #2509 § COLONIAL phase planner § planColonialPeace):
+///
+///   "Peace all at-war Great Powers, with ONE exception:
+///    → Keep fighting a GP that owns a province blocking the primary
+///      colonial NW target (primaryColonialGpBlocker).
+///
+///    Never peace tribe/minor colonial targets until:
+///    → Objective met (tribe no longer owns the target NW province), OR
+///    → War is unwinnable (zero regiments, no treasury, can't build)."
+///
+/// The tribe/minor exception is handled structurally by this function: a
+/// tribe or minor in [ThreatSummary.atWarWith] does not satisfy
+/// `game.playerById(factionId) != null` (only [Player] entries are
+/// returned from that lookup), so non-GP factions are filtered out before
+/// the blocker pass. `offerPeace` toward tribes / minors therefore is
+/// **never** emitted by this planner — the tribe / minor war-continuation
+/// rule is preserved by exclusion. Conversely, `establishOverture`,
+/// `purchase_land`, and NW conquest are emitted by sibling phase-planner
+/// functions (`planColonialAcquisition`, `planColonialMilitary` —
+/// deferred to follow-up S3 slices) rather than reasoned about here.
+///
+/// Inputs:
+///   - [game]: used to (a) filter [ThreatSummary.atWarWith] down to
+///     Great Power factions via [Game.playerById]; (b) compute the
+///     primary colonial NW frontier blocker via
+///     [primaryColonialGpBlocker], which maps the active player's
+///     visible invadable NW provinces to their current owners and picks
+///     the GP with the largest invadable-NW ownership share.
+///   - [snapshot]: per-player [AIWorldSnapshot] supplying
+///     [ThreatSummary.atWarWith] and
+///     [ColonialSummary.invadableNewWorldProvinceIdsSorted] (consumed
+///     transitively by [primaryColonialGpBlocker]).
+///
+/// Output:
+///   - Empty list when no Great Powers are at war with the active
+///     player (the GP filter loop produces an empty `gpWars` and the
+///     trailing sort is a no-op).
+///   - All GPs sorted ascending when the blocker is `null` (no
+///     invadable NW province is owned by a Great Power) or when the
+///     blocker is not among the at-war GPs (the membership guard arm).
+///     The legacy "no exception applies" path: peace **all** live GP
+///     fronts.
+///   - All GPs except the blocker sorted ascending when the blocker is
+///     among the at-war GPs (canonical COLONIAL-peace happy path:
+///     keep fighting the colonial blocker, peace every other GP front).
+///   - Empty list when the active player is at war with exactly one
+///     GP **and** that GP is the colonial blocker (the lone war IS the
+///     blocker war -- keep fighting it; nothing else to peace).
+///   - The single GP (as a 1-element list) when the active player is
+///     at war with exactly one GP and that GP is **not** the colonial
+///     blocker. This is the explicit divergence from the legacy
+///     [colonialPhaseGpPeaceTargets] helper, which short-circuits with
+///     `return const []` when `gpWars.length <= 1`. The new spec wording
+///     "Peace all at-war Great Powers" does not carry the legacy
+///     `>= 2 GPs` guard: every non-blocker GP front must peace so the
+///     orchestrator (#2509 S5) can drive NW acquisition / improvement
+///     work without an idle GP-vs-GP distraction war.
+///
+/// The function is pure and deterministic — identical inputs always yield
+/// identical lists (Refs #2509 Must-have #7).
+List<String> planColonialPeace({
+  required Game game,
+  required AIWorldSnapshot snapshot,
+}) {
+  final gpWars = <String>[
+    for (final factionId in snapshot.threats.atWarWith)
+      if (game.playerById(factionId) != null) factionId,
+  ];
+  if (gpWars.isEmpty) {
+    return const [];
+  }
+
+  final blocker = primaryColonialGpBlocker(game: game, snapshot: snapshot);
+  if (blocker == null || !gpWars.contains(blocker)) {
+    return gpWars..sort();
+  }
+
+  return <String>[
+    for (final factionId in gpWars)
+      if (factionId != blocker) factionId,
+  ]..sort();
+}

--- a/packages/colonizethis_ai/test/planning/colonial_phase_planner_test.dart
+++ b/packages/colonizethis_ai/test/planning/colonial_phase_planner_test.dart
@@ -1,0 +1,370 @@
+// Unit tests for the COLONIAL-phase planner contracts in
+// `packages/colonizethis_ai/lib/src/planning/colonial_phase_planner.dart`
+// (Refs #2509 S3 / S10).
+//
+// Spec contract (issue #2509 § COLONIAL phase planner § planColonialPeace):
+//
+//   "Peace all at-war Great Powers, with ONE exception:
+//    → Keep fighting a GP that owns a province blocking the primary
+//      colonial NW target (primaryColonialGpBlocker).
+//
+//    Never peace tribe/minor colonial targets until:
+//    → Objective met (tribe no longer owns the target NW province), OR
+//    → War is unwinnable (zero regiments, no treasury, can't build)."
+//
+// Mirrors the test pattern established for the EXPAND-phase planner in
+// `expand_phase_planner_test.dart` and the DEVELOP-phase planner in
+// `develop_phase_planner_test.dart`: small synthetic fixtures, one
+// branch arm per test, in-module pin (planner module never re-checks
+// phase, so these tests stay scoped to the GP filter, blocker scan,
+// blocker membership guard, and deterministic-sort contract). The
+// tribe / minor "never peace" rule is preserved structurally via the
+// `game.playerById` filter; the tests pin that behavior directly.
+//
+// `planColonialPeace` tests:
+//
+//   1. **Empty `atWarWith`:** no live wars -> empty list (loop body
+//      never runs; trailing sort is a no-op; blocker scan does not run).
+//   2. **Only tribes/minors in `atWarWith`:** non-GP factions are
+//      filtered via `game.playerById` returning null -> empty (COLONIAL
+//      peace is GP-only; tribe / minor wars continue per the
+//      "Never peace tribe/minor" rule).
+//   3. **Multi-GP, no invadable NW (blocker null):** peace ALL GPs
+//      sorted ascending (no exception applies; legacy "peace all" arm).
+//   4. **Multi-GP, blocker is a non-at-war GP:** the blocker is a
+//      different GP than any live war front -> peace all live fronts
+//      ascending (`!gpWars.contains(blocker)` guard arm).
+//   5. **Multi-GP, blocker among `gpWars`:** peace all GPs except the
+//      blocker, sorted ascending (canonical COLONIAL-peace happy path).
+//   6. **Sole GP at war IS the blocker:** keep fighting the lone
+//      blocker -> empty (the lone war IS the colonial blocker war).
+//   7. **Sole GP at war is NOT the blocker:** peace that single GP
+//      -> `[that GP]` (explicit divergence from the legacy
+//      `colonialPhaseGpPeaceTargets` `gpWars.length <= 1 → const []`
+//      short-circuit; new spec says "Peace all" with no length guard).
+//   8. **Three GPs at war (input order shuffled):** trailing
+//      `..sort()` restores ascending order (Must-have #7 pin).
+//   9. **Mixed GP + non-GP `atWarWith` with blocker:** non-GP ids
+//      dropped before the blocker filter; remaining GPs sorted
+//      ascending less blocker (composite filter pin).
+//  10. **Determinism:** identical inputs yield identical lists across
+//      repeated calls (Must-have #7).
+//
+// This file is the in-module pin for the new COLONIAL planner. The
+// existing function-unit pins on the legacy `colonialPhaseGpPeaceTargets`
+// helper in `observer_goal_phase_colonial_peace_blocker_branches_test.dart`
+// keep the legacy code path covered until the S5 orchestrator wiring
+// lands. Both will be reconciled when the legacy helper is removed
+// (#2509 S1).
+
+import 'package:colonizethis_ai/colonizethis_ai.dart';
+import 'package:colonizethis_ai/src/planning/colonial_phase_planner.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+const String _gp1 = 'gp1';
+const String _gp2 = 'gp2';
+const String _gp3 = 'gp3';
+const String _gp4 = 'gp4';
+const String _tribe1 = 'tribe1';
+const String _minor1 = 'minor1';
+
+/// Game scaffold with a 4-GP roster + optional tribes / minors. New World
+/// provinces are passed in directly so each test can shape ownership for
+/// the blocker scan; Old World is intentionally left empty (COLONIAL
+/// peace planner does not query OW state -- it consumes the GP-vs-GP
+/// at-war roster and the NW invadable blocker lookup).
+Game _colonialGame({
+  int turnNumber = 130,
+  List<Province> newWorldProvinces = const [],
+  List<Player> players = const [
+    Player(id: _gp1, displayName: 'GP1', isHuman: false),
+    Player(id: _gp2, displayName: 'GP2', isHuman: false),
+    Player(id: _gp3, displayName: 'GP3', isHuman: false),
+    Player(id: _gp4, displayName: 'GP4', isHuman: false),
+  ],
+  List<Tribe> tribes = const [],
+  List<MinorNation> minorNations = const [],
+}) {
+  return Game(
+    id: 'g-2509-colonial-phase-planner-peace-t$turnNumber',
+    worldState: WorldState(
+      turnState: TurnState(turnNumber: turnNumber, phase: TurnPhase.orders),
+      oldWorld: const RegionData(),
+      newWorld: RegionData(provinces: newWorldProvinces),
+    ),
+    players: players,
+    tribes: tribes,
+    minorNations: minorNations,
+  );
+}
+
+/// Snapshot tuned for COLONIAL: own OW defaults to 10 (at quota), no OW
+/// invadable, NW invadable list configurable per test so the blocker
+/// scan can produce the desired result. The planner does not re-check
+/// the phase so these tests do not need to satisfy
+/// `observerGoalPhaseFor`; the values are still consistent with
+/// COLONIAL so debugging traces stay coherent.
+AIWorldSnapshot _colonialSnapshot({
+  required List<String> atWarWith,
+  List<String> invadableNw = const [],
+  String playerId = _gp1,
+}) {
+  return AIWorldSnapshot(
+    playerId: playerId,
+    threats: ThreatSummary(atWarWith: atWarWith),
+    opportunities: const OpportunitySummary(),
+    conquest: const ConquestSummary(
+      oldWorldProvincesOwned: 10,
+      provincesToVictory: 31,
+    ),
+    colonial: ColonialSummary(invadableNewWorldProvinceIdsSorted: invadableNw),
+    economy: const EconomySummary(),
+    relations: const {},
+  );
+}
+
+void main() {
+  group('planColonialPeace', () {
+    test('empty atWarWith -> empty', () {
+      // No live wars -> the GP filter loop body never runs and the
+      // function short-circuits before the blocker scan. A regression
+      // that always emitted the at-peace GP roster here would emit
+      // `offerPeace` toward neutral powers and break the "peace ALL
+      // at-war GPs" wording (we have nothing to peace).
+      final game = _colonialGame();
+      final snapshot = _colonialSnapshot(atWarWith: const []);
+      expect(
+        planColonialPeace(game: game, snapshot: snapshot),
+        isEmpty,
+        reason:
+            'No GPs are at war so the planner has no peace targets to '
+            'emit; the blocker scan should not run at all.',
+      );
+    });
+
+    test('only tribes/minors in atWarWith -> empty', () {
+      // COLONIAL peace contract is GP-only: tribe / minor wars are
+      // pursued through `planColonialAcquisition` (deferred S3 slice)
+      // and `planColonialMilitary`. The `game.playerById` filter drops
+      // every non-GP id, so even with a tribe and a minor in
+      // `atWarWith` the planner returns empty. This also pins the
+      // structural "Never peace tribe/minor colonial targets" rule: a
+      // regression that left tribe/minor ids in the output would emit
+      // `offerPeace` toward non-GP factions and prematurely end the
+      // ongoing tribe / minor conquest required for NW acquisition.
+      final game = _colonialGame(
+        tribes: const [Tribe(id: _tribe1, displayName: 'T1')],
+        minorNations: const [MinorNation(id: _minor1, displayName: 'M1')],
+      );
+      final snapshot = _colonialSnapshot(atWarWith: const [_tribe1, _minor1]);
+      expect(
+        planColonialPeace(game: game, snapshot: snapshot),
+        isEmpty,
+        reason:
+            'Non-GP factions are filtered out via `game.playerById`. '
+            'With only non-GP wars present the planner must return '
+            'empty (and tribe / minor colonial wars must continue).',
+      );
+    });
+
+    test('multi-GP, no invadable NW -> peace ALL GPs sorted ascending', () {
+      // No invadable NW means `primaryColonialGpBlocker` returns null
+      // -> the "no exception applies" arm. Every at-war GP must be
+      // peaced (sorted ascending). Input order shuffled to `[gp3, gp2]`
+      // so a regression that dropped the trailing `..sort()` would
+      // surface here.
+      final game = _colonialGame();
+      final snapshot = _colonialSnapshot(atWarWith: const [_gp3, _gp2]);
+      expect(
+        planColonialPeace(game: game, snapshot: snapshot),
+        const [_gp2, _gp3],
+        reason:
+            'Null blocker -> "Peace ALL at-war Great Powers" with no '
+            'exception. Returned list is ascending-sorted regardless of '
+            'input order (Refs #2509 Must-have #7).',
+      );
+    });
+
+    test('multi-GP, blocker is a non-at-war GP -> peace ALL gpWars', () {
+      // Blocker = gp4 (owns invadable NW), but gp4 is NOT in `atWarWith`.
+      // The `!gpWars.contains(blocker)` guard skips the
+      // blocker-exclusion branch, so all live war fronts (gp2, gp3)
+      // must be peaced. A regression that filtered by blocker without
+      // the membership guard would silently leave a non-blocker GP
+      // war open while peacing the others.
+      final game = _colonialGame(
+        newWorldProvinces: const [
+          Province(id: 'newWorld|gp4_a', regionId: 'newWorld', ownerId: _gp4),
+          Province(id: 'newWorld|gp4_b', regionId: 'newWorld', ownerId: _gp4),
+        ],
+      );
+      final snapshot = _colonialSnapshot(
+        atWarWith: const [_gp2, _gp3],
+        invadableNw: const ['newWorld|gp4_a', 'newWorld|gp4_b'],
+      );
+      expect(
+        planColonialPeace(game: game, snapshot: snapshot),
+        const [_gp2, _gp3],
+        reason:
+            'Blocker is gp4 (owns the invadable NW) but gp4 is not in '
+            '`gpWars` -- peace ALL live war fronts (the membership guard '
+            'forces fall-through to the "peace all" arm).',
+      );
+    });
+
+    test('multi-GP, blocker among gpWars -> peace all except blocker', () {
+      // Canonical COLONIAL happy path: gp2 owns the invadable NW
+      // (blocker), gp3 + gp4 are non-blocker fronts -> peace gp3 and
+      // gp4 sorted ascending; keep fighting gp2.
+      final game = _colonialGame(
+        newWorldProvinces: const [
+          Province(id: 'newWorld|gp2_a', regionId: 'newWorld', ownerId: _gp2),
+          Province(id: 'newWorld|gp2_b', regionId: 'newWorld', ownerId: _gp2),
+        ],
+      );
+      final snapshot = _colonialSnapshot(
+        atWarWith: const [_gp2, _gp3, _gp4],
+        invadableNw: const ['newWorld|gp2_a', 'newWorld|gp2_b'],
+      );
+      expect(
+        planColonialPeace(game: game, snapshot: snapshot),
+        const [_gp3, _gp4],
+        reason:
+            'Blocker gp2 is preserved (keep fighting the colonial NW '
+            'blocker); non-blocker GPs gp3 + gp4 are peaced in '
+            'ascending sort (canonical COLONIAL-peace happy path).',
+      );
+    });
+
+    test('sole GP at war IS the blocker -> empty (keep fighting)', () {
+      // Exactly one GP at war (gp2) and that GP IS the colonial
+      // blocker. The function falls through to the
+      // "exclude blocker" comprehension which yields an empty list
+      // because the only candidate equals the blocker. A regression
+      // that emitted `[gp2]` here would prematurely peace the
+      // colonial blocker and stall NW acquisition.
+      final game = _colonialGame(
+        newWorldProvinces: const [
+          Province(id: 'newWorld|gp2_a', regionId: 'newWorld', ownerId: _gp2),
+        ],
+      );
+      final snapshot = _colonialSnapshot(
+        atWarWith: const [_gp2],
+        invadableNw: const ['newWorld|gp2_a'],
+      );
+      expect(
+        planColonialPeace(game: game, snapshot: snapshot),
+        isEmpty,
+        reason:
+            'Sole GP front IS the colonial NW blocker -- keep fighting; '
+            'the planner returns empty so the orchestrator emits no '
+            '`offerPeace` toward gp2 this turn.',
+      );
+    });
+
+    test('sole GP at war is NOT the blocker -> peace that single GP', () {
+      // Exactly one GP at war (gp3) and the colonial blocker is a
+      // different GP (gp4) NOT in `atWarWith`. The membership guard
+      // fires (`!gpWars.contains(gp4)`) -> peace all `gpWars`
+      // sorted. Result: `[gp3]`. This is the explicit divergence
+      // from the legacy `colonialPhaseGpPeaceTargets` short-circuit
+      // `gpWars.length <= 1 → const []`: the new spec says "Peace
+      // all at-war Great Powers" without a length guard, so a lone
+      // non-blocker war must still be peaced.
+      final game = _colonialGame(
+        newWorldProvinces: const [
+          Province(id: 'newWorld|gp4_a', regionId: 'newWorld', ownerId: _gp4),
+        ],
+      );
+      final snapshot = _colonialSnapshot(
+        atWarWith: const [_gp3],
+        invadableNw: const ['newWorld|gp4_a'],
+      );
+      expect(
+        planColonialPeace(game: game, snapshot: snapshot),
+        const [_gp3],
+        reason:
+            'Sole non-blocker GP front -- new spec "Peace all" arm '
+            'fires regardless of `gpWars.length`. The single GP is '
+            'returned (divergence from legacy `gpWars.length <= 1` '
+            'short-circuit).',
+      );
+    });
+
+    test('3 GPs at war (input order shuffled) -> ascending sort', () {
+      // Determinism pin (Must-have #7). Three GP fronts (gp4, gp3, gp2)
+      // with gp2 as blocker -> peace gp3 + gp4 in ascending order
+      // regardless of input order. A regression that returned the
+      // input order would surface here as `[gp4, gp3]`.
+      final game = _colonialGame(
+        newWorldProvinces: const [
+          Province(id: 'newWorld|gp2_a', regionId: 'newWorld', ownerId: _gp2),
+        ],
+      );
+      final snapshot = _colonialSnapshot(
+        atWarWith: const [_gp4, _gp3, _gp2],
+        invadableNw: const ['newWorld|gp2_a'],
+      );
+      expect(
+        planColonialPeace(game: game, snapshot: snapshot),
+        const [_gp3, _gp4],
+        reason:
+            'Trailing `..sort()` restores ascending order regardless of '
+            'input order (Refs #2509 Must-have #7).',
+      );
+    });
+
+    test(
+      'mixed GP + non-GP atWarWith with blocker -> only non-blocker GPs',
+      () {
+        // Composes both filters in one fixture: tribe1 + minor1 must
+        // drop before the GP-only blocker filter; the surviving GP
+        // fronts (gp2, gp3, gp4) are then thinned to exclude the
+        // blocker (gp2). Input order `[gp4, tribe1, gp3, minor1, gp2]`
+        // exercises the GP filter, the blocker scan, and the trailing
+        // sort all together.
+        final game = _colonialGame(
+          newWorldProvinces: const [
+            Province(id: 'newWorld|gp2_a', regionId: 'newWorld', ownerId: _gp2),
+          ],
+          tribes: const [Tribe(id: _tribe1, displayName: 'T1')],
+          minorNations: const [MinorNation(id: _minor1, displayName: 'M1')],
+        );
+        final snapshot = _colonialSnapshot(
+          atWarWith: const [_gp4, _tribe1, _gp3, _minor1, _gp2],
+          invadableNw: const ['newWorld|gp2_a'],
+        );
+        expect(
+          planColonialPeace(game: game, snapshot: snapshot),
+          const [_gp3, _gp4],
+          reason:
+              'Non-GP factions filtered out via `game.playerById`; '
+              'blocker (gp2) excluded; remaining GP fronts (gp3, gp4) '
+              'returned sorted ascending.',
+        );
+      },
+    );
+
+    test('determinism: identical inputs produce identical lists', () {
+      // Pins Must-have #7 (determinism) at the in-module level. The
+      // mixed-input fixture exercises the GP filter, the blocker
+      // scan, and the sort in one pass; repeating the call must
+      // yield byte-identical lists.
+      final game = _colonialGame(
+        newWorldProvinces: const [
+          Province(id: 'newWorld|gp2_a', regionId: 'newWorld', ownerId: _gp2),
+        ],
+        tribes: const [Tribe(id: _tribe1, displayName: 'T1')],
+        minorNations: const [MinorNation(id: _minor1, displayName: 'M1')],
+      );
+      final snapshot = _colonialSnapshot(
+        atWarWith: const [_gp4, _tribe1, _gp3, _minor1, _gp2],
+        invadableNw: const ['newWorld|gp2_a'],
+      );
+      final first = planColonialPeace(game: game, snapshot: snapshot);
+      final second = planColonialPeace(game: game, snapshot: snapshot);
+      expect(second, first);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

First isolatable slice of issue #2509 S3 single-goal phase-planner architecture: a new pure-function module `packages/colonizethis_ai/lib/src/planning/colonial_phase_planner.dart` exposing `planColonialPeace(game, snapshot)` matching the COLONIAL contract from the issue spec.

The function returns every at-war Great Power as a deterministic ascending-sorted list, except the GP identified by `primaryColonialGpBlocker` (the GP owning the most invadable `newWorld|` provinces -- the primary colonial NW frontier blocker). Non-GP factions (tribes, minor nations) are filtered via `game.playerById` returning null; this structurally preserves the "Never peace tribe/minor colonial targets" rule from the spec by exclusion. Suppression of phase routing is structural: the planner does not re-check phase, trusting its caller (later the orchestrator under S5) to dispatch only when in COLONIAL.

This mirrors the pattern set by `develop_phase_planner.dart` (Refs #2509 S4, PR #2695) and `expand_phase_planner.dart` (Refs #2509 S2, PR #2697): single new pure-function file + in-module unit tests, no orchestrator wiring, legacy helper preserved at the function-unit level.

## Done in this PR

- New `colonial_phase_planner.dart` module under `packages/colonizethis_ai/lib/src/planning/`
- Ten in-module unit tests at `packages/colonizethis_ai/test/planning/colonial_phase_planner_test.dart`:
  - empty `atWarWith` -> empty
  - tribes/minors-only `atWarWith` -> empty (GP-only filter)
  - multi-GP, null blocker (no invadable NW) -> peace ALL sorted
  - multi-GP, blocker is a non-at-war GP -> peace ALL gpWars (membership guard)
  - multi-GP, blocker among gpWars -> peace all except blocker (canonical happy path)
  - sole GP at war IS the blocker -> empty (keep fighting)
  - sole GP at war is NOT the blocker -> `[that GP]` (divergence from legacy `gpWars.length <= 1` short-circuit)
  - 3 GPs at war (input order shuffled) -> ascending sort (determinism pin)
  - mixed GP + non-GP `atWarWith` with blocker -> composite filter (only non-blocker GPs)
  - determinism: identical inputs yield identical lists

## Deferred for #2509 (out of scope for this PR)

- **S3 sibling planner functions** — `planColonialAcquisition`, `planColonialMilitary`, `planColonialNaval`, `planColonialCivilian`, `planColonialLiteOvertures`, `planColonialLiteNaval`. Each will land as a separate slice on its own PR with synthetic-game-state unit tests.
- **S1** delete `colonial_pressure.dart` / `diplomacy_planner_peace_targets.dart` and reduce `ai_victory_config.dart` constants.
- **S5** orchestrator dispatch refactor in `domain_planner_orchestrator.dart`; legacy `colonialPhaseGpPeaceTargets` (and EXPAND / DEVELOP siblings) stay live until then.
- **S6** rewrite `SPEC/ai/ai-architecture.md` § Observer goal phases (will reconcile the legacy "two or more GPs" wording with the new "Peace all at-war GPs" wording the planner implements).
- **S7** observer integration + phase-planner tuning.
- **S8** un-skip `seed42_observer_conquest_regression_test`.

Both the legacy `colonialPhaseGpPeaceTargets` helper and the new `planColonialPeace` function remain pinned at the function-unit level until the orchestrator rewrite reconciles them, so this slice carries **zero behavior change** and **zero regression risk**.

## Acceptance criteria coverage

- **(COLONIAL peace)** AC: "Given a GP in COLONIAL at war with two GPs where only one owns a province blocking the primary colonial target, when `planColonialPeace` runs, then the return list includes the non-blocking GP and excludes the blocking GP." — covered by the `multi-GP, blocker among gpWars` and `mixed GP + non-GP atWarWith with blocker` tests.
- **(Determinism, Must-have #7)** AC: "Given identical inputs … the return value is identical (pure functions, deterministic inputs)." — covered by the `3 GPs at war (input order shuffled)` and `determinism` tests.

The remaining COLONIAL / COLONIAL-lite / DEVELOP / EXPAND ACs from the issue body are deferred to the slices listed above.

## Test plan

- [x] `dart analyze packages/colonizethis_ai/lib/src/planning/colonial_phase_planner.dart packages/colonizethis_ai/test/planning/colonial_phase_planner_test.dart` — `No issues found!`
- [x] `dart analyze packages/colonizethis_ai` — issue count unchanged (24 pre-existing → 24 with change; zero new warnings)
- [x] `dart format` clean on the new files
- [x] `dart test packages/colonizethis_ai/test/planning/colonial_phase_planner_test.dart` — 10 passed
- [x] `dart test packages/colonizethis_ai` (full suite) — 706 passed, 2 skipped, 0 failed
- [ ] CI quality gates (Quality workflow on push)

Refs #2509

Tracked by #2509


Made with [Cursor](https://cursor.com)