### PR TITLE
feat(ai): planColonialAcquisition Join Empire path (Refs #2509 S3)

### DIFF
--- a/packages/colonizethis_ai/lib/src/planning/colonial_phase_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/colonial_phase_planner.dart
@@ -27,9 +27,8 @@
 ///
 /// In-module contracts shipped to date (see issue #2509 § COLONIAL phase
 /// planner for the full set, including the deferred
-/// `planColonialAcquisition`, `planColonialMilitary`, `planColonialNaval`,
-/// `planColonialCivilian`, `planColonialLiteOvertures`, and
-/// `planColonialLiteNaval`):
+/// `planColonialMilitary`, `planColonialNaval`, `planColonialCivilian`,
+/// `planColonialLiteOvertures`, and `planColonialLiteNaval`):
 ///
 ///   `planColonialPeace(game, snapshot) → List<String>`
 ///     Returns the deterministic list of at-war Great Powers the active
@@ -44,9 +43,30 @@
 ///     filtered out via [Game.playerById] returning `null` for non-player
 ///     ids -- COLONIAL diplomatic peace is GP-vs-GP only; tribe/minor
 ///     colonial wars are pursued through other phase-planner contracts
-///     (`planColonialAcquisition` for `establishOverture` / Join Empire
-///     / `purchase_land`, `planColonialMilitary` for NW conquest army
-///     moves) which are deferred to follow-up S3 slices.
+///     (`planColonialAcquisition` Join-Empire path lives in this file;
+///     `purchase_land` and NW conquest army moves are deferred to
+///     follow-up S3 slices) rather than reasoned about here.
+///
+///   `planColonialAcquisition(game, snapshot) → ColonialAcquisitionTarget?`
+///     Returns the deterministic Join-Empire acquisition target for the
+///     active COLONIAL player when one is achievable this turn, or
+///     `null` when no Join-Empire target is reachable. Iterates over
+///     [ColonialSummary.invadableNewWorldProvinceIdsSorted] in sorted
+///     order (adjacency-distance reordering deferred to a follow-up
+///     slice — see § planColonialAcquisition for the spec ordering)
+///     and returns the first NW province whose tribe/minor owner has
+///     an `OvertureState.nap` with the active player, Friendly+
+///     relations, and treasury covering [joinEmpireCostForMinorOrTribe].
+///     The `purchase_land` and `declareWar` acquisition methods from
+///     issue #2509 § planColonialAcquisition § Acquisition method 2/3
+///     are deferred to follow-up S3 slices (idle-Merchant scan and
+///     sea-reachability + regiment-build gates respectively); this
+///     slice carries **only** the Join-Empire path so the orchestrator
+///     (#2509 S5) can begin consuming the Join-Empire signal without
+///     waiting for the full acquisition pipeline. Returning `null` when
+///     Join Empire is unavailable preserves the legacy fall-through
+///     behaviour (no acquisition order emitted) until follow-up slices
+///     wire the remaining methods.
 library;
 
 import 'package:colonizethis_logic/ai_api.dart';
@@ -139,4 +159,189 @@ List<String> planColonialPeace({
     for (final factionId in gpWars)
       if (factionId != blocker) factionId,
   ]..sort();
+}
+
+/// Method by which a COLONIAL acquisition target should be pursued
+/// (issue #2509 § COLONIAL phase planner § planColonialAcquisition).
+///
+/// Three methods are defined by the spec — Join Empire is the cheapest
+/// path and always preferred first when available; `purchase_land`
+/// applies when an idle Merchant and a valid purchase tile are present;
+/// `declareWar` applies when treasury / regiments support the conquest
+/// path and the target is sea-reachable. Only [joinEmpire] is emitted
+/// by [planColonialAcquisition] in this slice — [purchaseLand] and
+/// [declareWar] remain enum entries so the contract is stable across
+/// follow-up S3 slices but are not yet returned.
+enum AcquisitionMethod {
+  /// `establishOverture` advancing the chain to `joinEmpire`. The
+  /// fastest, cheapest acquisition path (issue #2509 § Acquisition
+  /// method 1).
+  joinEmpire,
+
+  /// `purchase_land` work order for an idle Merchant unit (issue
+  /// #2509 § Acquisition method 2). Reserved for a follow-up slice.
+  purchaseLand,
+
+  /// `declareWar` + NW army move toward a sea-reachable tribe / minor
+  /// (issue #2509 § Acquisition method 3). Reserved for a follow-up
+  /// slice.
+  declareWar,
+}
+
+/// Deterministic acquisition target picked by [planColonialAcquisition].
+///
+/// Pairs the faction id owning the chosen NW province with the
+/// [AcquisitionMethod] the orchestrator should use this turn. The pair
+/// is stable: identical inputs always yield identical targets (Refs
+/// #2509 Must-have #7). The pair is materialized as a small value
+/// class (not a record) to keep value-equality semantics explicit for
+/// tests and to mirror the shape of other phase-planner return types
+/// under construction in this file.
+class ColonialAcquisitionTarget {
+  const ColonialAcquisitionTarget({
+    required this.targetFactionId,
+    required this.method,
+  });
+
+  /// Faction id of the tribe or minor that currently owns the chosen
+  /// NW province. Never a Great Power — Join Empire toward a GP is
+  /// gated by Empire Building tech and the "nearly defeated" check in
+  /// the join-empire validator (see
+  /// `join_empire_validator.dart`), neither of which fits the COLONIAL
+  /// phase's "acquire tribe / minor NW" objective. The planner skips
+  /// GP-owned NW provinces structurally.
+  final String targetFactionId;
+
+  /// Resolution path the orchestrator should use. Always
+  /// [AcquisitionMethod.joinEmpire] in this slice;
+  /// [AcquisitionMethod.purchaseLand] and [AcquisitionMethod.declareWar]
+  /// are reserved for follow-up slices and never appear in returns
+  /// produced by [planColonialAcquisition] today.
+  final AcquisitionMethod method;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ColonialAcquisitionTarget &&
+          targetFactionId == other.targetFactionId &&
+          method == other.method;
+
+  @override
+  int get hashCode => Object.hash(targetFactionId, method);
+
+  @override
+  String toString() =>
+      'ColonialAcquisitionTarget('
+      'targetFactionId: $targetFactionId, method: $method)';
+}
+
+/// Returns the deterministic Join-Empire acquisition target for the
+/// active COLONIAL player this turn, or `null` when no Join-Empire
+/// target is achievable.
+///
+/// Contract (issue #2509 § COLONIAL phase planner § planColonialAcquisition,
+/// Acquisition method 1):
+///
+///   "Join Empire
+///      → Conditions: embassy with owning tribe, treasury ≥ cost.
+///      → Generate establishOverture(tribe) targeting Join Empire chain.
+///      → This is the cheapest, fastest path — always preferred first."
+///
+/// The "embassy with owning tribe" phrasing in the issue body is
+/// tightened here to align with the order-engine validator in
+/// `packages/colonizethis_logic/lib/src/orders/validators/diplomatic/`
+/// `join_empire_validator.dart`: Join Empire requires the active
+/// player's overture toward the tribe / minor target to already be at
+/// [OvertureStage.nap], plus a Friendly+ relation score, plus treasury
+/// covering [joinEmpireCostForMinorOrTribe]. Suggesting `joinEmpire`
+/// from a lower overture stage would be rejected by the validator and
+/// produce no order, so the planner gates on the same `nap` precondition
+/// the validator enforces. Advancing the chain through earlier stages
+/// (`consulate`, `embassy`) is the responsibility of sibling overture
+/// planners (`planColonialLiteOvertures` and the legacy overture
+/// helpers) — Join Empire kicks in only on the terminal
+/// `nap → joinEmpire` step.
+///
+/// Iteration ordering:
+///   - Walks [ColonialSummary.invadableNewWorldProvinceIdsSorted] in
+///     the sorted order provided by the perception snapshot. The
+///     issue body asks for adjacency-distance ordering ("sorted by
+///     adjacency distance to owned territory"); that re-ranking is
+///     deferred to a follow-up slice — switching the iteration to an
+///     adjacency-distance key changes which Join-Empire target wins on
+///     ties but does not change the gate set this slice pins.
+///     `invadableNewWorldProvinceIdsSorted` is itself sorted ascending
+///     by the snapshot builder, so the iteration is deterministic
+///     today (Refs #2509 Must-have #7).
+///
+/// Inputs:
+///   - [game]: resolves the active player ([Game.playerById]) for the
+///     defensive guard, looks up the province-owner map
+///     ([getProvinceOwnerMap]) to find each NW province's current
+///     owner, queries [getOverture] / [getRelation] for the gate
+///     evaluation, and computes [joinEmpireCostForMinorOrTribe] for
+///     the treasury check.
+///   - [snapshot]: per-player [AIWorldSnapshot] supplying
+///     [ColonialSummary.invadableNewWorldProvinceIdsSorted] (the
+///     candidate NW province pool) and [EconomySummary.treasury] (the
+///     active player's spendable cash for the Join-Empire payment).
+///
+/// Output:
+///   - [ColonialAcquisitionTarget] with [AcquisitionMethod.joinEmpire]
+///     when the first NW province in
+///     [ColonialSummary.invadableNewWorldProvinceIdsSorted] whose
+///     owner satisfies the four Join-Empire gates (overture stage =
+///     [OvertureStage.nap], relation score ≥ [relationScoreMinFriendly],
+///     treasury ≥ [joinEmpireCostForMinorOrTribe], owner is a
+///     tribe / minor and not a Great Power).
+///   - `null` when no NW province satisfies all four gates, or when
+///     the outer guards trip (missing active player record, empty NW
+///     invadable list). The follow-up `purchase_land` /
+///     `declareWar` slices will replace this null fall-through with
+///     their own acquisition methods; consumers must treat `null` as
+///     "no acquisition order this turn" rather than "acquisition path
+///     impossible".
+///
+/// The function is pure and deterministic — identical inputs always
+/// yield identical [ColonialAcquisitionTarget]s (Refs #2509
+/// Must-have #7).
+ColonialAcquisitionTarget? planColonialAcquisition({
+  required Game game,
+  required AIWorldSnapshot snapshot,
+}) {
+  if (game.playerById(snapshot.playerId) == null) {
+    return null;
+  }
+  final invadable = snapshot.colonial.invadableNewWorldProvinceIdsSorted;
+  if (invadable.isEmpty) {
+    return null;
+  }
+
+  final provinceOwner = getProvinceOwnerMap(game);
+  final treasury = snapshot.economy.treasury;
+
+  for (final provinceId in invadable) {
+    final ownerId = provinceOwner[provinceId];
+    if (ownerId == null) continue;
+    if (game.playerById(ownerId) != null) continue;
+
+    final overture = getOverture(game, snapshot.playerId, ownerId);
+    if (overture == null) continue;
+    if (overture.stage != OvertureStage.nap) continue;
+
+    final relation = getRelation(game, snapshot.playerId, ownerId);
+    if (relation == null || relation.score < relationScoreMinFriendly) {
+      continue;
+    }
+
+    final cost = joinEmpireCostForMinorOrTribe(game, ownerId);
+    if (treasury < cost) continue;
+
+    return ColonialAcquisitionTarget(
+      targetFactionId: ownerId,
+      method: AcquisitionMethod.joinEmpire,
+    );
+  }
+
+  return null;
 }

--- a/packages/colonizethis_ai/lib/src/planning/colonial_phase_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/colonial_phase_planner.dart
@@ -48,25 +48,39 @@
 ///     S3 slices) rather than reasoned about here.
 ///
 ///   `planColonialAcquisition(game, snapshot) → ColonialAcquisitionTarget?`
-///     Returns the deterministic Join-Empire acquisition target for the
-///     active COLONIAL player when one is achievable this turn, or
-///     `null` when no Join-Empire target is reachable. Iterates over
+///     Returns the deterministic acquisition target for the active
+///     COLONIAL player when one is achievable this turn, or `null`
+///     when no method is reachable. Iterates over
 ///     [ColonialSummary.invadableNewWorldProvinceIdsSorted] in sorted
 ///     order (adjacency-distance reordering deferred to a follow-up
 ///     slice — see § planColonialAcquisition for the spec ordering)
-///     and returns the first NW province whose tribe/minor owner has
-///     an `OvertureState.nap` with the active player, Friendly+
-///     relations, and treasury covering [joinEmpireCostForMinorOrTribe].
-///     The `purchase_land` and `declareWar` acquisition methods from
-///     issue #2509 § planColonialAcquisition § Acquisition method 2/3
-///     are deferred to follow-up S3 slices (idle-Merchant scan and
-///     sea-reachability + regiment-build gates respectively); this
-///     slice carries **only** the Join-Empire path so the orchestrator
-///     (#2509 S5) can begin consuming the Join-Empire signal without
-///     waiting for the full acquisition pipeline. Returning `null` when
-///     Join Empire is unavailable preserves the legacy fall-through
-///     behaviour (no acquisition order emitted) until follow-up slices
-///     wire the remaining methods.
+///     and tries methods in priority order:
+///
+///       1. **Join Empire** (Acquisition method 1) — first NW
+///          province whose tribe/minor owner has an
+///          [OvertureStage.nap] with the active player, Friendly+
+///          relations, and treasury covering
+///          [joinEmpireCostForMinorOrTribe]. The cheapest, fastest
+///          path; always preferred first across all candidate
+///          provinces.
+///       2. **`purchase_land`** (Acquisition method 2) — only
+///          considered when the Join Empire pass yielded no target.
+///          Active player must hold at least one idle Merchant unit;
+///          per-province gates mirror
+///          `precheckPurchaseLand` in `work_order_target_prechecks.dart`
+///          (tribe / minor owner, not at war, embassy with that
+///          tribe / minor, plus at least one tile in the province
+///          with a non-empty resource that is unprospected-mineral
+///          safe, not already purchased, and whose
+///          [purchaseLandCost] is within treasury).
+///
+///     The `declareWar` acquisition method from issue #2509 §
+///     planColonialAcquisition § Acquisition method 3 is deferred to
+///     a follow-up S3 slice (sea-reachability + regiment-build
+///     gates); the function returns `null` when neither Join Empire
+///     nor `purchase_land` is reachable so consumers must treat
+///     `null` as "no acquisition order this turn" rather than
+///     "acquisition path impossible".
 ///
 ///   `planColonialCivilian(game, snapshot) → List<WorkOrder>`
 ///     Returns deterministic `build_improvement` work orders for the
@@ -184,10 +198,10 @@ List<String> planColonialPeace({
 /// path and always preferred first when available; `purchase_land`
 /// applies when an idle Merchant and a valid purchase tile are present;
 /// `declareWar` applies when treasury / regiments support the conquest
-/// path and the target is sea-reachable. Only [joinEmpire] is emitted
-/// by [planColonialAcquisition] in this slice — [purchaseLand] and
-/// [declareWar] remain enum entries so the contract is stable across
-/// follow-up S3 slices but are not yet returned.
+/// path and the target is sea-reachable. [joinEmpire] and
+/// [purchaseLand] are emitted by [planColonialAcquisition] in this
+/// slice; [declareWar] remains an enum entry so the contract stays
+/// stable across the follow-up S3 slice but is not yet returned.
 enum AcquisitionMethod {
   /// `establishOverture` advancing the chain to `joinEmpire`. The
   /// fastest, cheapest acquisition path (issue #2509 § Acquisition
@@ -195,7 +209,7 @@ enum AcquisitionMethod {
   joinEmpire,
 
   /// `purchase_land` work order for an idle Merchant unit (issue
-  /// #2509 § Acquisition method 2). Reserved for a follow-up slice.
+  /// #2509 § Acquisition method 2).
   purchaseLand,
 
   /// `declareWar` + NW army move toward a sea-reachable tribe / minor
@@ -228,11 +242,12 @@ class ColonialAcquisitionTarget {
   /// GP-owned NW provinces structurally.
   final String targetFactionId;
 
-  /// Resolution path the orchestrator should use. Always
-  /// [AcquisitionMethod.joinEmpire] in this slice;
-  /// [AcquisitionMethod.purchaseLand] and [AcquisitionMethod.declareWar]
-  /// are reserved for follow-up slices and never appear in returns
-  /// produced by [planColonialAcquisition] today.
+  /// Resolution path the orchestrator should use. Today the planner
+  /// can return [AcquisitionMethod.joinEmpire] (Acquisition method 1)
+  /// and [AcquisitionMethod.purchaseLand] (Acquisition method 2);
+  /// [AcquisitionMethod.declareWar] is reserved for a follow-up slice
+  /// and never appears in returns produced by
+  /// [planColonialAcquisition] today.
   final AcquisitionMethod method;
 
   @override
@@ -251,20 +266,24 @@ class ColonialAcquisitionTarget {
       'targetFactionId: $targetFactionId, method: $method)';
 }
 
-/// Returns the deterministic Join-Empire acquisition target for the
-/// active COLONIAL player this turn, or `null` when no Join-Empire
-/// target is achievable.
+/// Returns the deterministic acquisition target for the active
+/// COLONIAL player this turn, or `null` when no method is achievable.
 ///
 /// Contract (issue #2509 § COLONIAL phase planner § planColonialAcquisition,
-/// Acquisition method 1):
+/// Acquisition methods 1 and 2):
 ///
-///   "Join Empire
+///   "1. Join Empire
 ///      → Conditions: embassy with owning tribe, treasury ≥ cost.
 ///      → Generate establishOverture(tribe) targeting Join Empire chain.
-///      → This is the cheapest, fastest path — always preferred first."
+///      → This is the cheapest, fastest path — always preferred first.
+///    2. purchase_land
+///      → Conditions: idle Merchant unit, tile has resource (prospected
+///        if mineral), treasury ≥ purchase cost.
+///      → Generate purchase_land work order for Merchant."
 ///
-/// The "embassy with owning tribe" phrasing in the issue body is
-/// tightened here to align with the order-engine validator in
+/// **Method 1 — Join Empire.** The "embassy with owning tribe" phrasing
+/// in the issue body is tightened here to align with the order-engine
+/// validator in
 /// `packages/colonizethis_logic/lib/src/orders/validators/diplomatic/`
 /// `join_empire_validator.dart`: Join Empire requires the active
 /// player's overture toward the tribe / minor target to already be at
@@ -278,14 +297,45 @@ class ColonialAcquisitionTarget {
 /// helpers) — Join Empire kicks in only on the terminal
 /// `nap → joinEmpire` step.
 ///
+/// **Method 2 — `purchase_land`.** Mirrors the validator-side gates in
+/// `precheckPurchaseLand` (`work_order_target_prechecks.dart`) so the
+/// planner never suggests a target the engine would reject:
+///
+///   - active player must hold at least one idle Merchant
+///     ([Unit.type] == [kUnitTypeMerchant], [Unit.status] ==
+///     [UnitStatus.idle]) anywhere in the world; the orchestrator and
+///     resolver handle the staging movement on follow-up turns;
+///   - target province owner must be a tribe / minor (not a Great
+///     Power; not the active player itself);
+///   - active player must not be at war with that owner
+///     ([DiplomacyRelation.atWar] == false);
+///   - active player must have at least an embassy-stage overture with
+///     that owner ([OvertureState.hasEmbassy] == true, i.e. stage in
+///     `{embassy, nap, joinEmpire}`);
+///   - the province must contain at least one tile that is itself a
+///     valid `purchase_land` candidate: non-empty resource id, not
+///     already purchased by any GP, treasury covering
+///     [purchaseLandCost], and — for mineral resource ids in
+///     [kMineralResourceIds] — already in the active player's
+///     prospected-tile set ([WorldState.playerProspectedTiles]).
+///
+/// The Method 1 pass scans every NW invadable province first; if no
+/// Join Empire target is reachable, the Method 2 pass scans the same
+/// list with the `purchase_land` gate set. This implements the spec
+/// "Join Empire is always preferred first" while still letting
+/// `purchase_land` rescue an acquisition slot when Join Empire fails
+/// (e.g. treasury shortfall, sub-`nap` overture stage, or no
+/// satisfying tribe-owned NW province). Method 3 (`declareWar`) is a
+/// follow-up slice and not yet wired.
+///
 /// Iteration ordering:
 ///   - Walks [ColonialSummary.invadableNewWorldProvinceIdsSorted] in
 ///     the sorted order provided by the perception snapshot. The
 ///     issue body asks for adjacency-distance ordering ("sorted by
 ///     adjacency distance to owned territory"); that re-ranking is
 ///     deferred to a follow-up slice — switching the iteration to an
-///     adjacency-distance key changes which Join-Empire target wins on
-///     ties but does not change the gate set this slice pins.
+///     adjacency-distance key changes which target wins on ties but
+///     does not change the gate set this slice pins.
 ///     `invadableNewWorldProvinceIdsSorted` is itself sorted ascending
 ///     by the snapshot builder, so the iteration is deterministic
 ///     today (Refs #2509 Must-have #7).
@@ -295,12 +345,15 @@ class ColonialAcquisitionTarget {
 ///     defensive guard, looks up the province-owner map
 ///     ([getProvinceOwnerMap]) to find each NW province's current
 ///     owner, queries [getOverture] / [getRelation] for the gate
-///     evaluation, and computes [joinEmpireCostForMinorOrTribe] for
-///     the treasury check.
+///     evaluation, and computes [joinEmpireCostForMinorOrTribe] /
+///     [purchaseLandCost] for the treasury check. The Method 2 pass
+///     also reads [WorldState.playerProspectedTiles],
+///     [WorldState.purchasedTilesByTileKey], and
+///     [WorldState.resourceByTileKey] to validate per-tile gates.
 ///   - [snapshot]: per-player [AIWorldSnapshot] supplying
 ///     [ColonialSummary.invadableNewWorldProvinceIdsSorted] (the
 ///     candidate NW province pool) and [EconomySummary.treasury] (the
-///     active player's spendable cash for the Join-Empire payment).
+///     active player's spendable cash for the acquisition payment).
 ///
 /// Output:
 ///   - [ColonialAcquisitionTarget] with [AcquisitionMethod.joinEmpire]
@@ -310,13 +363,18 @@ class ColonialAcquisitionTarget {
 ///     [OvertureStage.nap], relation score ≥ [relationScoreMinFriendly],
 ///     treasury ≥ [joinEmpireCostForMinorOrTribe], owner is a
 ///     tribe / minor and not a Great Power).
-///   - `null` when no NW province satisfies all four gates, or when
-///     the outer guards trip (missing active player record, empty NW
-///     invadable list). The follow-up `purchase_land` /
-///     `declareWar` slices will replace this null fall-through with
-///     their own acquisition methods; consumers must treat `null` as
-///     "no acquisition order this turn" rather than "acquisition path
-///     impossible".
+///   - [ColonialAcquisitionTarget] with
+///     [AcquisitionMethod.purchaseLand] when no Join-Empire target is
+///     reachable but the active player has at least one idle Merchant
+///     and the first NW province in the sorted list whose owner
+///     satisfies the embassy + non-war gates also contains at least
+///     one tile satisfying the per-tile `purchase_land` gates.
+///   - `null` when no NW province satisfies any acquisition method,
+///     or when the outer guards trip (missing active player record,
+///     empty NW invadable list). The follow-up `declareWar` slice
+///     will replace this null fall-through with its own acquisition
+///     method; consumers must treat `null` as "no acquisition order
+///     this turn" rather than "acquisition path impossible".
 ///
 /// The function is pure and deterministic — identical inputs always
 /// yield identical [ColonialAcquisitionTarget]s (Refs #2509
@@ -359,7 +417,101 @@ ColonialAcquisitionTarget? planColonialAcquisition({
     );
   }
 
+  if (!_hasIdleMerchant(game.worldState, snapshot.playerId)) {
+    return null;
+  }
+
+  final prospected =
+      game.worldState.playerProspectedTiles[snapshot.playerId] ??
+      const <String>{};
+  final purchasedByTile = game.worldState.purchasedTilesByTileKey;
+
+  for (final provinceId in invadable) {
+    final ownerId = provinceOwner[provinceId];
+    if (ownerId == null) continue;
+    if (game.playerById(ownerId) != null) continue;
+
+    final relation = getRelation(game, snapshot.playerId, ownerId);
+    if (relation != null && relation.atWar) continue;
+
+    final overture = getOverture(game, snapshot.playerId, ownerId);
+    if (overture == null || !overture.hasEmbassy) continue;
+
+    if (!_provinceHasValidPurchaseLandTile(
+      world: game.worldState,
+      provinceId: provinceId,
+      treasury: treasury,
+      prospected: prospected,
+      purchasedByTile: purchasedByTile,
+    )) {
+      continue;
+    }
+
+    return ColonialAcquisitionTarget(
+      targetFactionId: ownerId,
+      method: AcquisitionMethod.purchaseLand,
+    );
+  }
+
   return null;
+}
+
+/// True when [playerId] owns at least one [kUnitTypeMerchant] unit
+/// with [UnitStatus.idle] in either region. Region of the Merchant is
+/// not constrained — the orchestrator and resolver handle staging
+/// movement on follow-up turns (mirrors the Builder selection
+/// convention in [planColonialCivilian]).
+bool _hasIdleMerchant(WorldState world, String playerId) {
+  for (final unit in allUnitsFromWorld(world)) {
+    if (unit.ownerId == playerId &&
+        unit.type == kUnitTypeMerchant &&
+        unit.status == UnitStatus.idle) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/// True when [provinceId] contains at least one tile satisfying every
+/// per-tile gate from `precheckPurchaseLand`:
+///
+///   - non-empty resource id in [WorldState.resourceByTileKey];
+///   - not present in [purchasedByTile] (no other GP has bought it,
+///     and the active player has not already purchased it either);
+///   - mineral resource ids ([kMineralResourceIds]) require the tile
+///     to be in [prospected] (the active player's prospected-tile
+///     set);
+///   - [purchaseLandCost] for the resource must be within [treasury].
+///
+/// Iteration over [WorldState.resourceByTileKey] is bounded by the
+/// total number of tiles with a resource entry (much smaller than the
+/// global tile count); per-tile checks are O(1). The function returns
+/// the existence answer only — picking a specific tile for the
+/// `purchase_land` work order is the orchestrator's job (the planner
+/// contract returns the *target faction* and the *method*, not the
+/// exact tile, mirroring the [AcquisitionMethod.joinEmpire] return
+/// shape).
+bool _provinceHasValidPurchaseLandTile({
+  required WorldState world,
+  required String provinceId,
+  required int treasury,
+  required Set<String> prospected,
+  required Map<String, String> purchasedByTile,
+}) {
+  for (final entry in world.resourceByTileKey.entries) {
+    final tileKey = entry.key;
+    if (Unit.provinceIdFromTileKey(tileKey) != provinceId) continue;
+    final resourceId = entry.value;
+    if (resourceId.isEmpty) continue;
+    if (purchasedByTile.containsKey(tileKey)) continue;
+    if (kMineralResourceIds.contains(resourceId) &&
+        !prospected.contains(tileKey)) {
+      continue;
+    }
+    if (treasury < purchaseLandCost(resourceId)) continue;
+    return true;
+  }
+  return false;
 }
 
 /// Returns deterministic `build_improvement` work orders for the active

--- a/packages/colonizethis_ai/test/planning/colonial_phase_planner_acquisition_join_empire_test.dart
+++ b/packages/colonizethis_ai/test/planning/colonial_phase_planner_acquisition_join_empire_test.dart
@@ -1,0 +1,466 @@
+// Unit tests for the Join-Empire arm of `planColonialAcquisition` in
+// `packages/colonizethis_ai/lib/src/planning/colonial_phase_planner.dart`
+// (Refs #2509 S3).
+//
+// Spec contract (issue #2509 § COLONIAL phase planner §
+// planColonialAcquisition, Acquisition method 1):
+//
+//   "Join Empire
+//      → Conditions: embassy with owning tribe, treasury ≥ cost.
+//      → Generate establishOverture(tribe) targeting Join Empire chain.
+//      → This is the cheapest, fastest path — always preferred first."
+//
+// The planner aligns the loose "embassy" phrasing with the order-engine
+// validator in
+// `packages/colonizethis_logic/lib/src/orders/validators/diplomatic/`
+// `join_empire_validator.dart`: Join Empire requires the active player's
+// overture toward the tribe / minor target to already be at
+// `OvertureStage.nap`, plus relation score ≥
+// `relationScoreMinFriendly`, plus treasury ≥
+// `joinEmpireCostForMinorOrTribe`. These tests pin each gate in
+// isolation plus the deterministic-iteration contract on
+// `ColonialSummary.invadableNewWorldProvinceIdsSorted`.
+//
+// `planColonialAcquisition` Join-Empire tests:
+//
+//   1. **Empty NW invadable -> null:** structural outer guard; no
+//      candidate provinces, no acquisition.
+//   2. **Missing active player record -> null:** structural outer
+//      guard against mis-dispatched calls (e.g. legacy code that
+//      reads a snapshot for a non-Player faction).
+//   3. **GP-owned NW province -> skip:** Join Empire toward a Great
+//      Power has different gates (Empire Building tech + nearly
+//      defeated) per the validator; the planner skips GP-owned NW
+//      provinces structurally so a tribe-targeted Join Empire is
+//      never accidentally emitted toward a GP.
+//   4. **Tribe owner without overture -> null:** missing
+//      `OvertureState(gpId, targetId)` row -> Join Empire not yet
+//      reachable via the validator's `nap` gate.
+//   5. **Tribe owner overture at `embassy` (not `nap`) -> null:**
+//      validator pin -- Join Empire requires `nap` specifically; an
+//      earlier stage cannot advance directly to `joinEmpire`.
+//   6. **Tribe owner overture at `nap` + treasury below cost -> null:**
+//      treasury gate -- the £$cost = $joinEmpireBaseCost + $n *
+//      $joinEmpirePerProvinceCost check from the validator.
+//   7. **Tribe owner overture at `nap` + relation below Friendly ->
+//      null:** Friendly+ relation gate from the validator.
+//   8. **Tribe owner overture at `nap` + Friendly relation + treasury
+//      sufficient -> Join Empire target:** canonical happy path.
+//   9. **Two valid tribe targets -> first sorted NW province wins:**
+//      deterministic iteration over
+//      `ColonialSummary.invadableNewWorldProvinceIdsSorted`. The
+//      planner picks the tribe whose first sorted invadable NW
+//      province has the lowest provinceId.
+//  10. **Determinism (Must-have #7):** identical inputs produce
+//      identical `ColonialAcquisitionTarget`s across repeated calls.
+//
+// All tests use synthetic Game/AIWorldSnapshot fixtures with one
+// active GP (`gp1`), the candidate tribe / minor (`tribe1`), and
+// optional GP-owned NW provinces. The fixtures intentionally keep OW
+// state empty -- this planner consumes the colonial NW invadable
+// list, treasury, overture state, and province-owner map; nothing
+// else.
+
+import 'package:colonizethis_ai/colonizethis_ai.dart';
+import 'package:colonizethis_ai/src/planning/colonial_phase_planner.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+const String _gp1 = 'gp1';
+const String _gp2 = 'gp2';
+const String _tribe1 = 'tribe1';
+const String _tribe2 = 'tribe2';
+const String _minor1 = 'minor1';
+
+const String _province1 = 'newWorld|tribe1_a';
+const String _province2 = 'newWorld|tribe2_b';
+const String _province3 = 'newWorld|gp2_a';
+
+Game _acquisitionGame({
+  int turnNumber = 130,
+  int activePlayerTreasury = 100000,
+  List<Province> newWorldProvinces = const [],
+  List<Player> players = const [
+    Player(id: _gp1, displayName: 'GP1', isHuman: false, treasury: 100000),
+    Player(id: _gp2, displayName: 'GP2', isHuman: false),
+  ],
+  List<Tribe> tribes = const [
+    Tribe(id: _tribe1, displayName: 'T1'),
+    Tribe(id: _tribe2, displayName: 'T2'),
+  ],
+  List<MinorNation> minorNations = const [
+    MinorNation(id: _minor1, displayName: 'M1'),
+  ],
+  List<OvertureState> overtureStates = const [],
+  List<DiplomacyRelation> diplomacyRelations = const [],
+}) {
+  final patchedPlayers = <Player>[
+    for (final p in players)
+      if (p.id == _gp1) p.copyWith(treasury: activePlayerTreasury) else p,
+  ];
+  return Game(
+    id: 'g-2509-colonial-acquisition-t$turnNumber',
+    worldState: WorldState(
+      turnState: TurnState(turnNumber: turnNumber, phase: TurnPhase.orders),
+      oldWorld: const RegionData(),
+      newWorld: RegionData(provinces: newWorldProvinces),
+    ),
+    players: patchedPlayers,
+    tribes: tribes,
+    minorNations: minorNations,
+    overtureStates: overtureStates,
+    diplomacyRelations: diplomacyRelations,
+  );
+}
+
+AIWorldSnapshot _acquisitionSnapshot({
+  required List<String> invadableNw,
+  String playerId = _gp1,
+  int treasury = 100000,
+}) {
+  return AIWorldSnapshot(
+    playerId: playerId,
+    threats: const ThreatSummary(),
+    opportunities: const OpportunitySummary(),
+    conquest: const ConquestSummary(
+      oldWorldProvincesOwned: 10,
+      provincesToVictory: 31,
+    ),
+    colonial: ColonialSummary(invadableNewWorldProvinceIdsSorted: invadableNw),
+    economy: EconomySummary(treasury: treasury),
+    relations: const {},
+  );
+}
+
+OvertureState _nap(String gpId, String targetId, {int sinceTurn = 100}) =>
+    OvertureState(
+      gpId: gpId,
+      targetId: targetId,
+      stage: OvertureStage.nap,
+      sinceTurn: sinceTurn,
+    );
+
+OvertureState _embassy(String gpId, String targetId, {int sinceTurn = 100}) =>
+    OvertureState(
+      gpId: gpId,
+      targetId: targetId,
+      stage: OvertureStage.embassy,
+      sinceTurn: sinceTurn,
+    );
+
+DiplomacyRelation _friendly(String a, String b, {int score = 60}) =>
+    DiplomacyRelation(
+      factionId1: a,
+      factionId2: b,
+      score: score,
+      level: RelationLevel.friendly,
+    );
+
+void main() {
+  group('planColonialAcquisition (Join Empire path)', () {
+    test('empty invadable NW -> null (outer guard)', () {
+      // No NW provinces to acquire -> the planner short-circuits
+      // before reading the overture / relation / treasury gates. A
+      // regression that emitted a target for an empty list would
+      // produce an out-of-band acquisition order.
+      final game = _acquisitionGame();
+      final snapshot = _acquisitionSnapshot(invadableNw: const []);
+      expect(
+        planColonialAcquisition(game: game, snapshot: snapshot),
+        isNull,
+        reason:
+            'Empty invadable NW list short-circuits before the gate '
+            'loop runs.',
+      );
+    });
+
+    test('missing active player record -> null (outer guard)', () {
+      // The snapshot references a player id that does not exist in
+      // `game.players`. The planner's outer guard returns null so a
+      // mis-dispatched call (e.g. snapshot built for a stale roster)
+      // cannot emit an acquisition order.
+      final game = _acquisitionGame();
+      final snapshot = _acquisitionSnapshot(
+        invadableNw: const [_province1],
+        playerId: 'gp-ghost',
+      );
+      expect(
+        planColonialAcquisition(game: game, snapshot: snapshot),
+        isNull,
+        reason:
+            'No matching Player record -> outer guard returns null '
+            'before the candidate loop.',
+      );
+    });
+
+    test('GP-owned NW province -> skip (no Join Empire toward GP)', () {
+      // The candidate NW province is owned by another Great Power
+      // (gp2). Join Empire toward a Great Power has different gates
+      // (Empire Building tech + "nearly defeated") per the validator
+      // and is out of scope for COLONIAL tribe / minor acquisition.
+      // The planner skips GP-owned NW provinces structurally so the
+      // tribe-targeted Join Empire is never accidentally emitted
+      // toward a GP.
+      final game = _acquisitionGame(
+        newWorldProvinces: const [
+          Province(id: _province3, regionId: 'newWorld', ownerId: _gp2),
+        ],
+        overtureStates: <OvertureState>[_nap(_gp1, _gp2)],
+        diplomacyRelations: <DiplomacyRelation>[_friendly(_gp1, _gp2)],
+      );
+      final snapshot = _acquisitionSnapshot(
+        invadableNw: const [_province3],
+      );
+      expect(
+        planColonialAcquisition(game: game, snapshot: snapshot),
+        isNull,
+        reason:
+            'GP-owned NW provinces are skipped by `game.playerById` '
+            'returning non-null; Join Empire toward another GP has '
+            'separate gates and never resolves through this planner.',
+      );
+    });
+
+    test('tribe owner without overture -> null', () {
+      // No `OvertureState(gpId, targetId)` row -> the overture
+      // chain has not started, so Join Empire is not reachable
+      // (`nap` is the precondition).
+      final game = _acquisitionGame(
+        newWorldProvinces: const [
+          Province(id: _province1, regionId: 'newWorld', ownerId: _tribe1),
+        ],
+        diplomacyRelations: <DiplomacyRelation>[_friendly(_gp1, _tribe1)],
+      );
+      final snapshot = _acquisitionSnapshot(
+        invadableNw: const [_province1],
+      );
+      expect(
+        planColonialAcquisition(game: game, snapshot: snapshot),
+        isNull,
+        reason:
+            'Missing overture state -> Join Empire precondition '
+            '(stage == nap) not met; planner returns null.',
+      );
+    });
+
+    test('overture stage = embassy (not nap) -> null', () {
+      // The validator gates on `currentStage == OvertureStage.nap`;
+      // an earlier stage like `embassy` cannot advance directly to
+      // `joinEmpire`. The planner mirrors the validator's gate.
+      final game = _acquisitionGame(
+        newWorldProvinces: const [
+          Province(id: _province1, regionId: 'newWorld', ownerId: _tribe1),
+        ],
+        overtureStates: <OvertureState>[_embassy(_gp1, _tribe1)],
+        diplomacyRelations: <DiplomacyRelation>[_friendly(_gp1, _tribe1)],
+      );
+      final snapshot = _acquisitionSnapshot(
+        invadableNw: const [_province1],
+      );
+      expect(
+        planColonialAcquisition(game: game, snapshot: snapshot),
+        isNull,
+        reason:
+            'Overture at embassy stage (not nap) -> Join Empire '
+            'precondition not met; planner returns null and the '
+            'follow-up overture planner advances the chain.',
+      );
+    });
+
+    test('nap + treasury below joinEmpireCostForMinorOrTribe -> null', () {
+      // The validator rejects with "Join Empire requires £$cost" when
+      // treasury < cost. The planner mirrors the same threshold so
+      // it does not suggest an order the engine would reject.
+      // `tribe1` owns one NW province -> joinEmpire cost =
+      // joinEmpireBaseCost (5000) + 1 * joinEmpirePerProvinceCost
+      // (2000) = 7000. Treasury 6999 -> reject.
+      final game = _acquisitionGame(
+        activePlayerTreasury: 6999,
+        newWorldProvinces: const [
+          Province(id: _province1, regionId: 'newWorld', ownerId: _tribe1),
+        ],
+        overtureStates: <OvertureState>[_nap(_gp1, _tribe1)],
+        diplomacyRelations: <DiplomacyRelation>[_friendly(_gp1, _tribe1)],
+      );
+      final snapshot = _acquisitionSnapshot(
+        invadableNw: const [_province1],
+        treasury: 6999,
+      );
+      expect(
+        planColonialAcquisition(game: game, snapshot: snapshot),
+        isNull,
+        reason:
+            'Treasury (6999) below joinEmpireBaseCost + 1 * '
+            'joinEmpirePerProvinceCost (7000) -> validator would '
+            'reject; planner returns null.',
+      );
+    });
+
+    test('nap + relation below Friendly -> null', () {
+      // The validator rejects with "Join Empire requires at least
+      // Friendly relations" when score < relationScoreMinFriendly
+      // (51). The planner mirrors the gate so it does not suggest
+      // a rejected order.
+      final game = _acquisitionGame(
+        newWorldProvinces: const [
+          Province(id: _province1, regionId: 'newWorld', ownerId: _tribe1),
+        ],
+        overtureStates: <OvertureState>[_nap(_gp1, _tribe1)],
+        diplomacyRelations: <DiplomacyRelation>[
+          DiplomacyRelation(
+            factionId1: _gp1,
+            factionId2: _tribe1,
+            score: 50,
+            level: RelationLevel.neutral,
+          ),
+        ],
+      );
+      final snapshot = _acquisitionSnapshot(
+        invadableNw: const [_province1],
+      );
+      expect(
+        planColonialAcquisition(game: game, snapshot: snapshot),
+        isNull,
+        reason:
+            'Relation score 50 (Neutral) below Friendly threshold '
+            '(51) -> validator would reject; planner returns null.',
+      );
+    });
+
+    test('nap + Friendly + treasury sufficient -> Join Empire target', () {
+      // Canonical happy path: all four gates pass for tribe1 over
+      // its single NW province `province1`. The planner returns the
+      // `(tribe1, joinEmpire)` target so the orchestrator can emit
+      // `establishOverture(tribe1)` advancing the chain
+      // nap -> joinEmpire on resolution.
+      final game = _acquisitionGame(
+        newWorldProvinces: const [
+          Province(id: _province1, regionId: 'newWorld', ownerId: _tribe1),
+        ],
+        overtureStates: <OvertureState>[_nap(_gp1, _tribe1)],
+        diplomacyRelations: <DiplomacyRelation>[_friendly(_gp1, _tribe1)],
+      );
+      final snapshot = _acquisitionSnapshot(
+        invadableNw: const [_province1],
+      );
+      expect(
+        planColonialAcquisition(game: game, snapshot: snapshot),
+        const ColonialAcquisitionTarget(
+          targetFactionId: _tribe1,
+          method: AcquisitionMethod.joinEmpire,
+        ),
+        reason:
+            'All four Join Empire gates pass (stage == nap, '
+            'Friendly+ relation, treasury >= cost, tribe owner) -> '
+            'planner returns the canonical (tribe1, joinEmpire) '
+            'target.',
+      );
+    });
+
+    test('two valid tribe targets -> first sorted invadable NW wins', () {
+      // Both tribe1 and tribe2 satisfy every Join Empire gate. The
+      // planner picks the tribe whose NW province appears first in
+      // `invadableNewWorldProvinceIdsSorted` (ascending). With
+      // `province1 = newWorld|tribe1_a` < `province2 = newWorld|tribe2_b`
+      // the iteration hits tribe1 first.
+      final game = _acquisitionGame(
+        newWorldProvinces: const [
+          Province(id: _province1, regionId: 'newWorld', ownerId: _tribe1),
+          Province(id: _province2, regionId: 'newWorld', ownerId: _tribe2),
+        ],
+        overtureStates: <OvertureState>[
+          _nap(_gp1, _tribe1),
+          _nap(_gp1, _tribe2),
+        ],
+        diplomacyRelations: <DiplomacyRelation>[
+          _friendly(_gp1, _tribe1),
+          _friendly(_gp1, _tribe2),
+        ],
+      );
+      final snapshot = _acquisitionSnapshot(
+        invadableNw: const [_province1, _province2],
+      );
+      expect(
+        planColonialAcquisition(game: game, snapshot: snapshot),
+        const ColonialAcquisitionTarget(
+          targetFactionId: _tribe1,
+          method: AcquisitionMethod.joinEmpire,
+        ),
+        reason:
+            'Iteration over `invadableNewWorldProvinceIdsSorted` is '
+            'ascending; the first satisfying province (tribe1) wins '
+            'the deterministic tie-break (Refs #2509 Must-have #7).',
+      );
+    });
+
+    test('second sorted tribe wins when first sorted tribe fails a gate', () {
+      // Same two-target setup, but tribe1 fails the treasury gate
+      // (single-province join-empire cost 7000 > 5000 treasury) while
+      // tribe2 (also single-province, cost 7000) also fails. Drop the
+      // treasury below tribe1 cost but raise NW province count so
+      // tribe2 fails earlier. We instead use overture stage: tribe1
+      // at `embassy` (fails the nap gate), tribe2 at `nap` -> tribe2
+      // wins. Pins the per-target gate evaluation order independently
+      // of the iteration order.
+      final game = _acquisitionGame(
+        newWorldProvinces: const [
+          Province(id: _province1, regionId: 'newWorld', ownerId: _tribe1),
+          Province(id: _province2, regionId: 'newWorld', ownerId: _tribe2),
+        ],
+        overtureStates: <OvertureState>[
+          _embassy(_gp1, _tribe1),
+          _nap(_gp1, _tribe2),
+        ],
+        diplomacyRelations: <DiplomacyRelation>[
+          _friendly(_gp1, _tribe1),
+          _friendly(_gp1, _tribe2),
+        ],
+      );
+      final snapshot = _acquisitionSnapshot(
+        invadableNw: const [_province1, _province2],
+      );
+      expect(
+        planColonialAcquisition(game: game, snapshot: snapshot),
+        const ColonialAcquisitionTarget(
+          targetFactionId: _tribe2,
+          method: AcquisitionMethod.joinEmpire,
+        ),
+        reason:
+            'tribe1 fails the nap gate (overture at embassy) so the '
+            'iteration falls through to tribe2 whose overture is at '
+            'nap. The second-sorted province wins when the first '
+            'fails a gate.',
+      );
+    });
+
+    test('determinism: identical inputs produce identical targets', () {
+      // Must-have #7 pin: repeated calls on the same game / snapshot
+      // must return byte-identical results.
+      final game = _acquisitionGame(
+        newWorldProvinces: const [
+          Province(id: _province1, regionId: 'newWorld', ownerId: _tribe1),
+          Province(id: _province2, regionId: 'newWorld', ownerId: _tribe2),
+        ],
+        overtureStates: <OvertureState>[
+          _nap(_gp1, _tribe1),
+          _nap(_gp1, _tribe2),
+        ],
+        diplomacyRelations: <DiplomacyRelation>[
+          _friendly(_gp1, _tribe1),
+          _friendly(_gp1, _tribe2),
+        ],
+      );
+      final snapshot = _acquisitionSnapshot(
+        invadableNw: const [_province1, _province2],
+      );
+      final first = planColonialAcquisition(game: game, snapshot: snapshot);
+      final second = planColonialAcquisition(game: game, snapshot: snapshot);
+      expect(second, first);
+      expect(
+        first,
+        isNotNull,
+        reason: 'Determinism test must run on a satisfying input.',
+      );
+    });
+  });
+}

--- a/packages/colonizethis_ai/test/planning/colonial_phase_planner_acquisition_purchase_land_test.dart
+++ b/packages/colonizethis_ai/test/planning/colonial_phase_planner_acquisition_purchase_land_test.dart
@@ -1,0 +1,739 @@
+// Unit tests for the `purchase_land` arm (Acquisition method 2) of
+// `planColonialAcquisition` in
+// `packages/colonizethis_ai/lib/src/planning/colonial_phase_planner.dart`
+// (Refs #2509 S3).
+//
+// Spec contract (issue #2509 § COLONIAL phase planner §
+// planColonialAcquisition, Acquisition method 2):
+//
+//   "purchase_land
+//      → Conditions: idle Merchant unit, tile has resource (prospected
+//        if mineral), treasury ≥ purchase cost.
+//      → Generate purchase_land work order for Merchant."
+//
+// The planner's `purchase_land` arm runs only when the Join-Empire
+// pass yields no target. Per-province gates mirror the order-engine
+// validator in
+// `packages/colonizethis_logic/lib/src/orders/validators/`
+// `work_order_target_prechecks.dart` (`precheckPurchaseLand`):
+//
+//   - target province owner is a tribe / minor (not GP, not self);
+//   - active player is not at war with that owner;
+//   - active player has at least an embassy-stage overture
+//     (`OvertureState.hasEmbassy`);
+//   - the province contains at least one tile that is itself a valid
+//     `purchase_land` candidate: non-empty resource id, not already
+//     purchased, treasury covers `purchaseLandCost`, mineral-resource
+//     tiles already prospected by the active player.
+//
+// In addition, the arm has an outer guard: the active player must
+// hold at least one idle Merchant ([Unit.type] == [kUnitTypeMerchant],
+// [Unit.status] == [UnitStatus.idle]) anywhere in the world.
+//
+// `planColonialAcquisition` purchase_land tests:
+//
+//   1. **No idle Merchant -> null:** outer guard pin. Even when a
+//      satisfying province exists, missing-Merchant short-circuits
+//      the second pass before any per-province loop runs.
+//   2. **Working Merchant does not satisfy the guard -> null:**
+//      [UnitStatus.working] explicitly excluded, parallels the
+//      Builder-status filter pinned by `planColonialCivilian`.
+//   3. **GP-owned NW province -> skip (no purchase from GP):**
+//      structural mirror of validator's "must be a Minor or Tribe
+//      province"; Join Empire and `purchase_land` both filter GPs at
+//      `game.playerById(ownerId) != null`.
+//   4. **At-war tribe -> skip:** validator-side
+//      `relation?.atWar == true` rejection. The planner must not
+//      suggest `purchase_land` against a faction it is currently
+//      fighting.
+//   5. **No overture -> skip:** missing
+//      `OvertureState(gpId, targetId)` -> `overture == null` ->
+//      `purchase_land` not yet legal (validator requires embassy).
+//   6. **Overture at `tradeConsulate` (no embassy yet) -> skip:**
+//      pins `OvertureState.hasEmbassy` semantics — only stages in
+//      `{embassy, nap, joinEmpire}` satisfy the gate, and
+//      `tradeConsulate` is one rung below `embassy`.
+//   7. **Tile has no resource entry -> skip:** validator rejects with
+//      "Tile has no resource"; the planner mirrors the gate by
+//      requiring at least one resource tile in the province.
+//   8. **Mineral tile not prospected -> skip:** validator rejects
+//      with "Mineral tile must be prospected first"; the planner
+//      mirrors the gate using `WorldState.playerProspectedTiles`.
+//   9. **Treasury below purchase cost -> skip:** validator rejects
+//      with "Insufficient treasury for purchase_land"; the planner
+//      mirrors the gate using `purchaseLandCost(resourceId)`.
+//  10. **Tile already purchased -> skip:** validator rejects when a
+//      tile is already in `WorldState.purchasedTilesByTileKey`; the
+//      planner mirrors the gate.
+//  11. **Embassy + valid grain tile + idle Merchant -> purchase_land
+//      target:** canonical happy path with a non-mineral resource
+//      (no prospect requirement). Matches the AC text "Given a GP in
+//      COLONIAL with idle Merchant, treasury ≥ purchase cost, and a
+//      visible newWorld| province with a valid purchase_land target
+//      tile, when planColonialAcquisition runs and Join Empire is
+//      unavailable, then the return value is `(tribeFactionId,
+//      AcquisitionMethod.purchaseLand)`."
+//  12. **Embassy + valid prospected mineral tile + idle Merchant ->
+//      purchase_land target:** same path through the mineral-prospect
+//      gate. Pins that the planner accepts mineral resources when the
+//      tile is in the active player's prospected-tile set.
+//  13. **Join Empire and purchase_land both reachable -> Join Empire
+//      wins:** priority pin. Even with a valid Merchant + tile pair,
+//      a satisfying Join-Empire candidate suppresses the
+//      `purchase_land` arm entirely (the spec calls Join Empire "the
+//      cheapest, fastest path — always preferred first").
+//  14. **Join Empire treasury shortfall -> purchase_land rescue:**
+//      the active player has Join-Empire-eligible state (overture at
+//      `nap`, Friendly relation) but the treasury does not cover
+//      `joinEmpireCostForMinorOrTribe`; treasury still covers the
+//      smaller `purchaseLandCost`, so the planner falls through to
+//      the second pass and returns `(tribe1, purchaseLand)`. Pins
+//      that the second pass exists and that the iteration is *not*
+//      collapsed into a single per-province method-tree.
+//  15. **Two valid tribe targets -> first sorted invadable NW
+//      province wins:** deterministic iteration over
+//      `ColonialSummary.invadableNewWorldProvinceIdsSorted`, mirroring
+//      the Join-Empire arm's tie-break (Refs #2509 Must-have #7).
+//  16. **Determinism (Must-have #7):** identical inputs produce
+//      identical `ColonialAcquisitionTarget`s across repeated calls.
+//
+// All tests use synthetic Game/AIWorldSnapshot fixtures with one
+// active GP (`gp1`), the candidate tribe (`tribe1` / `tribe2`), and
+// optional GP-owned NW provinces. The fixtures intentionally keep OW
+// state empty -- this arm consumes the colonial NW invadable list,
+// treasury, overture state, relation state, prospected-tile set,
+// purchased-tile map, resource-by-tile map, and the active player's
+// idle Merchant roster; nothing else.
+
+import 'package:colonizethis_ai/colonizethis_ai.dart';
+import 'package:colonizethis_ai/src/planning/colonial_phase_planner.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+const String _gp1 = 'gp1';
+const String _gp2 = 'gp2';
+const String _tribe1 = 'tribe1';
+const String _tribe2 = 'tribe2';
+
+const String _nwProv1 = 'newWorld|tribe1_a';
+const String _nwProv2 = 'newWorld|tribe2_b';
+const String _nwProvGp = 'newWorld|gp2_c';
+
+const String _nwTile1 = 'newWorld|tribe1_a|1|1';
+const String _nwTile1Alt = 'newWorld|tribe1_a|2|2';
+const String _nwTile2 = 'newWorld|tribe2_b|1|1';
+
+/// Builds a `Game` for the `purchase_land` arm tests.
+///
+/// `units` are placed in the New World region — the Merchant lookup
+/// scans both regions via [allUnitsFromWorld], so the test fixture
+/// can keep OW empty. `prospectedTilesForGp1` seeds the active
+/// player's [WorldState.playerProspectedTiles] entry; `purchasedTiles`
+/// seeds [WorldState.purchasedTilesByTileKey] (existing buyer ownership
+/// of a tile blocks new `purchase_land` orders).
+Game _purchaseLandGame({
+  int turnNumber = 130,
+  int activePlayerTreasury = 100000,
+  List<Province> newWorldProvinces = const [],
+  List<Unit> newWorldUnits = const [],
+  Map<String, String> resourceByTileKey = const {},
+  Set<String> prospectedTilesForGp1 = const {},
+  Map<String, String> purchasedTiles = const {},
+  List<OvertureState> overtureStates = const [],
+  List<DiplomacyRelation> diplomacyRelations = const [],
+}) {
+  return Game(
+    id: 'g-2509-colonial-acquisition-purchase-land-t$turnNumber',
+    worldState: WorldState(
+      turnState: TurnState(turnNumber: turnNumber, phase: TurnPhase.orders),
+      oldWorld: const RegionData(),
+      newWorld: RegionData(provinces: newWorldProvinces, units: newWorldUnits),
+      resourceByTileKey: resourceByTileKey,
+      playerProspectedTiles: prospectedTilesForGp1.isEmpty
+          ? const <String, Set<String>>{}
+          : <String, Set<String>>{_gp1: prospectedTilesForGp1},
+      purchasedTilesByTileKey: purchasedTiles,
+    ),
+    players: [
+      Player(
+        id: _gp1,
+        displayName: 'GP1',
+        isHuman: false,
+        treasury: activePlayerTreasury,
+      ),
+      const Player(id: _gp2, displayName: 'GP2', isHuman: false),
+    ],
+    tribes: const [
+      Tribe(id: _tribe1, displayName: 'T1'),
+      Tribe(id: _tribe2, displayName: 'T2'),
+    ],
+    overtureStates: overtureStates,
+    diplomacyRelations: diplomacyRelations,
+  );
+}
+
+AIWorldSnapshot _purchaseLandSnapshot({
+  required List<String> invadableNw,
+  String playerId = _gp1,
+  int treasury = 100000,
+}) {
+  return AIWorldSnapshot(
+    playerId: playerId,
+    threats: const ThreatSummary(),
+    opportunities: const OpportunitySummary(),
+    conquest: const ConquestSummary(
+      oldWorldProvincesOwned: 10,
+      provincesToVictory: 31,
+    ),
+    colonial: ColonialSummary(invadableNewWorldProvinceIdsSorted: invadableNw),
+    economy: EconomySummary(treasury: treasury),
+    relations: const {},
+  );
+}
+
+OvertureState _embassy(String gpId, String targetId, {int sinceTurn = 100}) =>
+    OvertureState(
+      gpId: gpId,
+      targetId: targetId,
+      stage: OvertureStage.embassy,
+      sinceTurn: sinceTurn,
+    );
+
+OvertureState _nap(String gpId, String targetId, {int sinceTurn = 100}) =>
+    OvertureState(
+      gpId: gpId,
+      targetId: targetId,
+      stage: OvertureStage.nap,
+      sinceTurn: sinceTurn,
+    );
+
+OvertureState _tradeConsulate(
+  String gpId,
+  String targetId, {
+  int sinceTurn = 100,
+}) => OvertureState(
+  gpId: gpId,
+  targetId: targetId,
+  stage: OvertureStage.tradeConsulate,
+  sinceTurn: sinceTurn,
+);
+
+DiplomacyRelation _peaceFriendly(String a, String b, {int score = 60}) =>
+    DiplomacyRelation(
+      factionId1: a,
+      factionId2: b,
+      score: score,
+      level: RelationLevel.friendly,
+    );
+
+DiplomacyRelation _atWar(String a, String b, {int score = 10}) =>
+    DiplomacyRelation(
+      factionId1: a,
+      factionId2: b,
+      score: score,
+      level: RelationLevel.hostile,
+      state: RelationState.atWar,
+    );
+
+Unit _merchant(
+  String id, {
+  String provinceId = _nwProv1,
+  UnitStatus status = UnitStatus.idle,
+  String tileSuffix = '5|5',
+}) => Unit(
+  id: id,
+  type: kUnitTypeMerchant,
+  ownerId: _gp1,
+  locationProvinceId: provinceId,
+  tileKey: '$provinceId|$tileSuffix',
+  status: status,
+);
+
+void main() {
+  group('planColonialAcquisition (purchase_land path)', () {
+    test('no idle Merchant -> null (outer guard)', () {
+      // The Join-Empire pass returns null because the overture is at
+      // `embassy` (not `nap`). The purchase_land pass would otherwise
+      // accept the tribe1 fixture, but the active player has zero
+      // Merchant units -> outer guard short-circuits the second
+      // loop. A regression that suggested `purchase_land` here would
+      // emit an order with no eligible Merchant to execute it.
+      final game = _purchaseLandGame(
+        newWorldProvinces: const [
+          Province(id: _nwProv1, regionId: 'newWorld', ownerId: _tribe1),
+        ],
+        resourceByTileKey: const {_nwTile1: 'grain'},
+        overtureStates: <OvertureState>[_embassy(_gp1, _tribe1)],
+        diplomacyRelations: <DiplomacyRelation>[_peaceFriendly(_gp1, _tribe1)],
+      );
+      final snapshot = _purchaseLandSnapshot(invadableNw: const [_nwProv1]);
+      expect(
+        planColonialAcquisition(game: game, snapshot: snapshot),
+        isNull,
+        reason:
+            'Outer Merchant guard must short-circuit before the per-'
+            'province loop fires; otherwise a regression could emit a '
+            'purchase_land target with no Merchant to execute it.',
+      );
+    });
+
+    test('working Merchant does not satisfy outer guard -> null', () {
+      // A Merchant exists but is mid-work (`status == working`).
+      // [UnitStatus.idle] is required so the resolver can re-task
+      // the unit; mirror the Builder-idle filter pinned in
+      // `planColonialCivilian`.
+      final game = _purchaseLandGame(
+        newWorldProvinces: const [
+          Province(id: _nwProv1, regionId: 'newWorld', ownerId: _tribe1),
+        ],
+        newWorldUnits: <Unit>[_merchant('m_busy', status: UnitStatus.working)],
+        resourceByTileKey: const {_nwTile1: 'grain'},
+        overtureStates: <OvertureState>[_embassy(_gp1, _tribe1)],
+        diplomacyRelations: <DiplomacyRelation>[_peaceFriendly(_gp1, _tribe1)],
+      );
+      final snapshot = _purchaseLandSnapshot(invadableNw: const [_nwProv1]);
+      expect(
+        planColonialAcquisition(game: game, snapshot: snapshot),
+        isNull,
+        reason:
+            'Working Merchants are not assignable to a new purchase_'
+            'land directive; the planner must short-circuit when no '
+            'idle Merchant exists.',
+      );
+    });
+
+    test('GP-owned NW province -> skip (no purchase from GP)', () {
+      // Validator: "purchase_land target must be a Minor or Tribe
+      // province". The planner enforces this structurally via
+      // `game.playerById(ownerId) != null` -> skip; mirrors the
+      // Join-Empire arm's GP-skip pin.
+      final game = _purchaseLandGame(
+        newWorldProvinces: const [
+          Province(id: _nwProvGp, regionId: 'newWorld', ownerId: _gp2),
+        ],
+        newWorldUnits: <Unit>[_merchant('m1')],
+        resourceByTileKey: const {'newWorld|gp2_c|1|1': 'grain'},
+        overtureStates: <OvertureState>[_embassy(_gp1, _gp2)],
+        diplomacyRelations: <DiplomacyRelation>[_peaceFriendly(_gp1, _gp2)],
+      );
+      final snapshot = _purchaseLandSnapshot(invadableNw: const [_nwProvGp]);
+      expect(
+        planColonialAcquisition(game: game, snapshot: snapshot),
+        isNull,
+        reason:
+            'Validator rejects purchase_land when the owner is another '
+            'GP; the planner skips GP-owned NW provinces structurally '
+            'so the purchase_land arm is never emitted toward a GP.',
+      );
+    });
+
+    test('at-war tribe -> skip', () {
+      // Validator: "Cannot purchase land: at war with that faction".
+      // Even with embassy + valid tile + idle Merchant, the at-war
+      // gate must reject the candidate.
+      final game = _purchaseLandGame(
+        newWorldProvinces: const [
+          Province(id: _nwProv1, regionId: 'newWorld', ownerId: _tribe1),
+        ],
+        newWorldUnits: <Unit>[_merchant('m1')],
+        resourceByTileKey: const {_nwTile1: 'grain'},
+        overtureStates: <OvertureState>[_embassy(_gp1, _tribe1)],
+        diplomacyRelations: <DiplomacyRelation>[_atWar(_gp1, _tribe1)],
+      );
+      final snapshot = _purchaseLandSnapshot(invadableNw: const [_nwProv1]);
+      expect(
+        planColonialAcquisition(game: game, snapshot: snapshot),
+        isNull,
+        reason:
+            'At-war relation rejects purchase_land via the validator; '
+            'the planner mirrors that gate.',
+      );
+    });
+
+    test('no overture -> skip', () {
+      // Validator: "Cannot purchase land: embassy required ...". With
+      // no `OvertureState(gpId, targetId)` row, `getOverture` returns
+      // null -> embassy gate fails.
+      final game = _purchaseLandGame(
+        newWorldProvinces: const [
+          Province(id: _nwProv1, regionId: 'newWorld', ownerId: _tribe1),
+        ],
+        newWorldUnits: <Unit>[_merchant('m1')],
+        resourceByTileKey: const {_nwTile1: 'grain'},
+        diplomacyRelations: <DiplomacyRelation>[_peaceFriendly(_gp1, _tribe1)],
+      );
+      final snapshot = _purchaseLandSnapshot(invadableNw: const [_nwProv1]);
+      expect(
+        planColonialAcquisition(game: game, snapshot: snapshot),
+        isNull,
+        reason:
+            'Missing overture state -> validator rejects with embassy '
+            'requirement; planner mirrors the gate.',
+      );
+    });
+
+    test('overture at tradeConsulate (no embassy) -> skip', () {
+      // `OvertureState.hasEmbassy` is true only for stages in
+      // `{embassy, nap, joinEmpire}`. The `tradeConsulate` stage
+      // sits one rung below `embassy` and must be rejected by the
+      // planner just as it is by the validator.
+      final game = _purchaseLandGame(
+        newWorldProvinces: const [
+          Province(id: _nwProv1, regionId: 'newWorld', ownerId: _tribe1),
+        ],
+        newWorldUnits: <Unit>[_merchant('m1')],
+        resourceByTileKey: const {_nwTile1: 'grain'},
+        overtureStates: <OvertureState>[_tradeConsulate(_gp1, _tribe1)],
+        diplomacyRelations: <DiplomacyRelation>[_peaceFriendly(_gp1, _tribe1)],
+      );
+      final snapshot = _purchaseLandSnapshot(invadableNw: const [_nwProv1]);
+      expect(
+        planColonialAcquisition(game: game, snapshot: snapshot),
+        isNull,
+        reason:
+            'Stage `tradeConsulate` -> hasEmbassy = false; validator '
+            'and planner both reject. Pins that early-stage overtures '
+            'do not unlock the purchase_land path.',
+      );
+    });
+
+    test('tile has no resource entry -> skip', () {
+      // Validator: "Tile has no resource". Without at least one tile
+      // in the province carrying a non-empty resource id, the
+      // planner cannot find a satisfying `purchase_land` candidate.
+      final game = _purchaseLandGame(
+        newWorldProvinces: const [
+          Province(id: _nwProv1, regionId: 'newWorld', ownerId: _tribe1),
+        ],
+        newWorldUnits: <Unit>[_merchant('m1')],
+        resourceByTileKey: const <String, String>{},
+        overtureStates: <OvertureState>[_embassy(_gp1, _tribe1)],
+        diplomacyRelations: <DiplomacyRelation>[_peaceFriendly(_gp1, _tribe1)],
+      );
+      final snapshot = _purchaseLandSnapshot(invadableNw: const [_nwProv1]);
+      expect(
+        planColonialAcquisition(game: game, snapshot: snapshot),
+        isNull,
+        reason:
+            'No resource tiles in the province -> no valid '
+            'purchase_land target; validator rejects with "Tile has '
+            'no resource"; planner mirrors that gate.',
+      );
+    });
+
+    test('mineral tile not prospected -> skip', () {
+      // Validator: "Mineral tile must be prospected first". The
+      // planner mirrors the gate using the active player's
+      // `WorldState.playerProspectedTiles` entry. With no entry for
+      // gp1, the iron tile fails the gate.
+      final game = _purchaseLandGame(
+        newWorldProvinces: const [
+          Province(id: _nwProv1, regionId: 'newWorld', ownerId: _tribe1),
+        ],
+        newWorldUnits: <Unit>[_merchant('m1')],
+        resourceByTileKey: const {_nwTile1: 'iron'},
+        overtureStates: <OvertureState>[_embassy(_gp1, _tribe1)],
+        diplomacyRelations: <DiplomacyRelation>[_peaceFriendly(_gp1, _tribe1)],
+      );
+      final snapshot = _purchaseLandSnapshot(invadableNw: const [_nwProv1]);
+      expect(
+        planColonialAcquisition(game: game, snapshot: snapshot),
+        isNull,
+        reason:
+            'Mineral tile (`iron`) not in active player\'s prospected '
+            'set -> validator rejects; planner mirrors the gate so a '
+            'purchase_land target is never emitted toward an '
+            'unprospected mineral tile.',
+      );
+    });
+
+    test('treasury below purchaseLandCost -> skip', () {
+      // Validator: "Insufficient treasury for purchase_land (need
+      // $cost)". `purchaseLandCost('grain') = 15 *
+      // landPurchaseDefaultBasePrice (10) = 150`; treasury 149 fails
+      // the gate.
+      final game = _purchaseLandGame(
+        activePlayerTreasury: 149,
+        newWorldProvinces: const [
+          Province(id: _nwProv1, regionId: 'newWorld', ownerId: _tribe1),
+        ],
+        newWorldUnits: <Unit>[_merchant('m1')],
+        resourceByTileKey: const {_nwTile1: 'grain'},
+        overtureStates: <OvertureState>[_embassy(_gp1, _tribe1)],
+        diplomacyRelations: <DiplomacyRelation>[_peaceFriendly(_gp1, _tribe1)],
+      );
+      final snapshot = _purchaseLandSnapshot(
+        invadableNw: const [_nwProv1],
+        treasury: 149,
+      );
+      expect(
+        planColonialAcquisition(game: game, snapshot: snapshot),
+        isNull,
+        reason:
+            'Treasury (149) below purchaseLandCost("grain") (150) -> '
+            'validator rejects; planner mirrors the gate.',
+      );
+    });
+
+    test('tile already purchased -> skip', () {
+      // Validator: "Tile already purchased by another power" or "You
+      // already own this tile". A tile present in
+      // `WorldState.purchasedTilesByTileKey` is locked out of
+      // additional `purchase_land` orders regardless of buyer
+      // identity.
+      final game = _purchaseLandGame(
+        newWorldProvinces: const [
+          Province(id: _nwProv1, regionId: 'newWorld', ownerId: _tribe1),
+        ],
+        newWorldUnits: <Unit>[_merchant('m1')],
+        resourceByTileKey: const {_nwTile1: 'grain'},
+        purchasedTiles: const {_nwTile1: _gp2},
+        overtureStates: <OvertureState>[_embassy(_gp1, _tribe1)],
+        diplomacyRelations: <DiplomacyRelation>[_peaceFriendly(_gp1, _tribe1)],
+      );
+      final snapshot = _purchaseLandSnapshot(invadableNw: const [_nwProv1]);
+      expect(
+        planColonialAcquisition(game: game, snapshot: snapshot),
+        isNull,
+        reason:
+            'Tile in purchasedTilesByTileKey is unavailable for new '
+            'purchase_land orders; planner skips and finds no other '
+            'satisfying tile in the province.',
+      );
+    });
+
+    test(
+      'embassy + valid grain tile + idle Merchant -> purchase_land target',
+      () {
+        // Canonical happy path with a non-mineral resource (`grain`)
+        // so the prospect gate is structurally satisfied. The
+        // active player has an embassy-stage overture, peace
+        // relations, treasury well above purchaseLandCost, an idle
+        // Merchant, and exactly one resource tile in the candidate
+        // province. Acceptance criterion #2509 § "(COLONIAL
+        // acquisition — purchase_land)": "Given a GP in COLONIAL
+        // with idle Merchant, treasury ≥ purchase cost, and a
+        // visible newWorld| province with a valid purchase_land
+        // target tile, when planColonialAcquisition runs and Join
+        // Empire is unavailable, then the return value is
+        // (tribeFactionId, AcquisitionMethod.purchaseLand)."
+        final game = _purchaseLandGame(
+          newWorldProvinces: const [
+            Province(id: _nwProv1, regionId: 'newWorld', ownerId: _tribe1),
+          ],
+          newWorldUnits: <Unit>[_merchant('m1')],
+          resourceByTileKey: const {_nwTile1: 'grain'},
+          overtureStates: <OvertureState>[_embassy(_gp1, _tribe1)],
+          diplomacyRelations: <DiplomacyRelation>[
+            _peaceFriendly(_gp1, _tribe1),
+          ],
+        );
+        final snapshot = _purchaseLandSnapshot(invadableNw: const [_nwProv1]);
+        expect(
+          planColonialAcquisition(game: game, snapshot: snapshot),
+          const ColonialAcquisitionTarget(
+            targetFactionId: _tribe1,
+            method: AcquisitionMethod.purchaseLand,
+          ),
+          reason:
+              'All purchase_land gates pass (embassy stage, peace, '
+              'idle Merchant, grain tile not minerally gated, '
+              'treasury covers cost) -> planner returns the canonical '
+              '(tribe1, purchaseLand) target. Join Empire is '
+              'unavailable here because the overture is at `embassy` '
+              'not `nap`.',
+        );
+      },
+    );
+
+    test(
+      'embassy + prospected mineral tile + idle Merchant -> purchase_land target',
+      () {
+        // Same happy path but with an `iron` (mineral) resource. The
+        // tile is in the active player's prospected set so the
+        // mineral-gate is satisfied; the planner returns the
+        // canonical purchase_land target.
+        final game = _purchaseLandGame(
+          newWorldProvinces: const [
+            Province(id: _nwProv1, regionId: 'newWorld', ownerId: _tribe1),
+          ],
+          newWorldUnits: <Unit>[_merchant('m1')],
+          resourceByTileKey: const {_nwTile1: 'iron'},
+          prospectedTilesForGp1: const {_nwTile1},
+          overtureStates: <OvertureState>[_embassy(_gp1, _tribe1)],
+          diplomacyRelations: <DiplomacyRelation>[
+            _peaceFriendly(_gp1, _tribe1),
+          ],
+        );
+        final snapshot = _purchaseLandSnapshot(invadableNw: const [_nwProv1]);
+        expect(
+          planColonialAcquisition(game: game, snapshot: snapshot),
+          const ColonialAcquisitionTarget(
+            targetFactionId: _tribe1,
+            method: AcquisitionMethod.purchaseLand,
+          ),
+          reason:
+              'Mineral resource (`iron`) gated on prospected-tile '
+              'membership; with the tile in playerProspectedTiles, '
+              'the planner accepts and returns (tribe1, '
+              'purchaseLand).',
+        );
+      },
+    );
+
+    test(
+      'Join Empire and purchase_land both reachable -> Join Empire wins',
+      () {
+        // Same `tribe1` is reachable via both paths: overture at
+        // `nap` (Join Empire eligible), Friendly+ relation, treasury
+        // covering joinEmpire cost AND purchaseLand cost, valid tile
+        // and idle Merchant in scope. The Method 1 pass must win;
+        // the planner should never even reach the second pass.
+        final game = _purchaseLandGame(
+          newWorldProvinces: const [
+            Province(id: _nwProv1, regionId: 'newWorld', ownerId: _tribe1),
+          ],
+          newWorldUnits: <Unit>[_merchant('m1')],
+          resourceByTileKey: const {_nwTile1: 'grain'},
+          overtureStates: <OvertureState>[_nap(_gp1, _tribe1)],
+          diplomacyRelations: <DiplomacyRelation>[
+            _peaceFriendly(_gp1, _tribe1),
+          ],
+        );
+        final snapshot = _purchaseLandSnapshot(invadableNw: const [_nwProv1]);
+        expect(
+          planColonialAcquisition(game: game, snapshot: snapshot),
+          const ColonialAcquisitionTarget(
+            targetFactionId: _tribe1,
+            method: AcquisitionMethod.joinEmpire,
+          ),
+          reason:
+              'Join Empire is "the cheapest, fastest path — always '
+              'preferred first" per the spec; when Method 1 is '
+              'reachable the second pass is suppressed.',
+        );
+      },
+    );
+
+    test('Join Empire treasury shortfall + purchase_land treasury OK -> '
+        'purchase_land target', () {
+      // Active player has Join-Empire-eligible overture / relation
+      // state for `tribe1`, but treasury is below
+      // joinEmpireBaseCost (5000) + 1 * joinEmpirePerProvinceCost
+      // (2000) = 7000. Treasury is still well above
+      // purchaseLandCost('grain') (150), so the second pass
+      // accepts. Pins that:
+      //   - the second pass actually runs after Method 1 fails;
+      //   - the Method 2 gates differ from Method 1's (e.g. no
+      //     `nap` requirement; embassy is enough).
+      final game = _purchaseLandGame(
+        activePlayerTreasury: 1000,
+        newWorldProvinces: const [
+          Province(id: _nwProv1, regionId: 'newWorld', ownerId: _tribe1),
+        ],
+        newWorldUnits: <Unit>[_merchant('m1')],
+        resourceByTileKey: const {_nwTile1: 'grain'},
+        overtureStates: <OvertureState>[_nap(_gp1, _tribe1)],
+        diplomacyRelations: <DiplomacyRelation>[_peaceFriendly(_gp1, _tribe1)],
+      );
+      final snapshot = _purchaseLandSnapshot(
+        invadableNw: const [_nwProv1],
+        treasury: 1000,
+      );
+      expect(
+        planColonialAcquisition(game: game, snapshot: snapshot),
+        const ColonialAcquisitionTarget(
+          targetFactionId: _tribe1,
+          method: AcquisitionMethod.purchaseLand,
+        ),
+        reason:
+            'Method 1 fails the joinEmpire treasury gate (1000 < '
+            '7000); Method 2 accepts because purchaseLandCost("grain") '
+            '(150) is well within treasury and the embassy gate is '
+            'satisfied by stage `nap` (hasEmbassy = true).',
+      );
+    });
+
+    test('two valid tribe targets -> first sorted invadable NW wins', () {
+      // Both tribe1 and tribe2 satisfy every purchase_land gate
+      // (embassy, peace, valid grain tile, no purchasedTiles
+      // collision). The planner picks the tribe whose NW province
+      // appears first in `invadableNewWorldProvinceIdsSorted`
+      // (ascending). With `_nwProv1 = newWorld|tribe1_a` <
+      // `_nwProv2 = newWorld|tribe2_b` the iteration hits tribe1
+      // first.
+      final game = _purchaseLandGame(
+        newWorldProvinces: const [
+          Province(id: _nwProv1, regionId: 'newWorld', ownerId: _tribe1),
+          Province(id: _nwProv2, regionId: 'newWorld', ownerId: _tribe2),
+        ],
+        newWorldUnits: <Unit>[_merchant('m1')],
+        resourceByTileKey: const {_nwTile1: 'grain', _nwTile2: 'grain'},
+        overtureStates: <OvertureState>[
+          _embassy(_gp1, _tribe1),
+          _embassy(_gp1, _tribe2),
+        ],
+        diplomacyRelations: <DiplomacyRelation>[
+          _peaceFriendly(_gp1, _tribe1),
+          _peaceFriendly(_gp1, _tribe2),
+        ],
+      );
+      final snapshot = _purchaseLandSnapshot(
+        invadableNw: const [_nwProv1, _nwProv2],
+      );
+      expect(
+        planColonialAcquisition(game: game, snapshot: snapshot),
+        const ColonialAcquisitionTarget(
+          targetFactionId: _tribe1,
+          method: AcquisitionMethod.purchaseLand,
+        ),
+        reason:
+            'Iteration over `invadableNewWorldProvinceIdsSorted` is '
+            'ascending; the first satisfying province (tribe1) wins '
+            'the deterministic tie-break (Refs #2509 Must-have #7).',
+      );
+    });
+
+    test('determinism: identical inputs produce identical targets', () {
+      // Must-have #7 pin: repeated calls on the same game / snapshot
+      // must return byte-identical results. Mixed fixture exercises
+      // the at-war filter (tribe2 atWar), the embassy gate (tribe1
+      // embassy), the alt-tile selection (`_nwTile1Alt` carrying
+      // `grain` while `_nwTile1` lacks any resource entry), and the
+      // sorted iteration over invadable NW provinces.
+      final game = _purchaseLandGame(
+        newWorldProvinces: const [
+          Province(id: _nwProv1, regionId: 'newWorld', ownerId: _tribe1),
+          Province(id: _nwProv2, regionId: 'newWorld', ownerId: _tribe2),
+        ],
+        newWorldUnits: <Unit>[_merchant('m1')],
+        resourceByTileKey: const {_nwTile1Alt: 'grain', _nwTile2: 'grain'},
+        overtureStates: <OvertureState>[
+          _embassy(_gp1, _tribe1),
+          _embassy(_gp1, _tribe2),
+        ],
+        diplomacyRelations: <DiplomacyRelation>[
+          _peaceFriendly(_gp1, _tribe1),
+          _atWar(_gp1, _tribe2),
+        ],
+      );
+      final snapshot = _purchaseLandSnapshot(
+        invadableNw: const [_nwProv1, _nwProv2],
+      );
+      final first = planColonialAcquisition(game: game, snapshot: snapshot);
+      final second = planColonialAcquisition(game: game, snapshot: snapshot);
+      expect(second, first);
+      expect(
+        first,
+        const ColonialAcquisitionTarget(
+          targetFactionId: _tribe1,
+          method: AcquisitionMethod.purchaseLand,
+        ),
+        reason:
+            'Determinism test must run on a satisfying input. tribe1 '
+            'wins because tribe2 is at war (excluded) and tribe1 has '
+            'a valid grain tile in `_nwTile1Alt`.',
+      );
+    });
+  });
+}

--- a/packages/colonizethis_logic/lib/ai_api.dart
+++ b/packages/colonizethis_logic/lib/ai_api.dart
@@ -20,9 +20,12 @@ export 'src/constants.dart'
         kWorkTargetStealTech;
 export 'src/diplomacy/diplomacy_relation_lookup.dart'
     show
+        getOverture,
         getRelation,
         greatPowerPowerScore,
+        joinEmpireCostForMinorOrTribe,
         provinceCountOwnedBy,
+        relationScoreMinFriendly,
         shipCountForFaction;
 export 'src/diplomacy/diplomacy_resolver.dart' show DiplomacyFactionMembership;
 export 'src/orders/incremental_candidate_validator.dart'

--- a/packages/colonizethis_logic/lib/ai_api.dart
+++ b/packages/colonizethis_logic/lib/ai_api.dart
@@ -14,6 +14,7 @@ export 'src/ai/simple_ai_heuristics.dart' show turnSeedForPlayer;
 export 'src/constants.dart'
     show
         GamePlayerLookup,
+        kMineralResourceIds,
         kWorkTargetBuildImprovement,
         kWorkTargetCounterSpy,
         kWorkTargetPurchaseLand,


### PR DESCRIPTION
## Summary

Builds out the deterministic acquisition path of `planColonialAcquisition`
in `colonial_phase_planner.dart` per issue #2509 § COLONIAL phase
planner § planColonialAcquisition. The PR now ships **two of the three**
acquisition methods from the spec:

1. **Join Empire** (Acquisition method 1) — first NW province whose
   tribe / minor owner has an `OvertureStage.nap` with the active player,
   Friendly+ relations, and treasury covering
   `joinEmpireCostForMinorOrTribe`. The cheapest, fastest path; always
   preferred first across all candidate NW provinces.
2. **`purchase_land`** (Acquisition method 2) — only considered when the
   Join Empire pass yielded no target. Active player must hold at least
   one idle Merchant unit; per-province gates mirror
   `precheckPurchaseLand` in `work_order_target_prechecks.dart` (tribe /
   minor owner, not at war, embassy with that tribe / minor, plus at
   least one tile in the province with a non-empty resource that is
   unprospected-mineral safe, not already purchased, and whose
   `purchaseLandCost` is within treasury).

`declareWar` (Acquisition method 3) remains an enum entry but is not
yet returned; it will land as a follow-up slice with sea-reachability
+ regiment-build gates.

## Done in this PR

### Method 1 — Join Empire (initial commit)

- `AcquisitionMethod` enum (`joinEmpire`, `purchaseLand`, `declareWar`).
- `ColonialAcquisitionTarget` value class with `==` / `hashCode` /
  `toString`.
- `planColonialAcquisition({game, snapshot}) -> ColonialAcquisitionTarget?`
  with the Join-Empire path fully implemented and gated for engine
  parity.
- 11 in-module tests in
  `colonial_phase_planner_acquisition_join_empire_test.dart`.

### Method 2 — `purchase_land` (latest commit)

- New idle-Merchant outer guard via existing `allUnitsFromWorld` +
  `kUnitTypeMerchant` + `UnitStatus.idle`.
- New per-province gates mirroring `precheckPurchaseLand`:
  GP-skip (structural via `Game.playerById`), at-war reject
  (`DiplomacyRelation.atWar`), embassy gate
  (`OvertureState.hasEmbassy`), per-tile resource / prospect /
  not-purchased / treasury checks via
  `_provinceHasValidPurchaseLandTile`.
- 16 in-module tests in
  `colonial_phase_planner_acquisition_purchase_land_test.dart`.

### Narrow logic→AI contract additions

- `colonizethis_logic/lib/ai_api.dart` exports
  `joinEmpireCostForMinorOrTribe`, `getOverture`, `relationScoreMinFriendly`
  (Method 1), and `kMineralResourceIds` (Method 2 prospect gate).
- No broad-barrel imports per `colonizethis-logic-ai-decoupling.mdc`.

## Deferred (follow-up S3 slices)

- **Acquisition method 3 (`declareWar`)**: sea-reachability +
  regiment-build gates.
- **Adjacency-distance iteration ordering** (currently uses the
  snapshot's ascending sort key — deterministic but does not yet
  prefer "closest to owned territory").
- **Personality-based ranking** between `joinEmpire` and `declareWar`
  (depends on Acquisition method 3).
- **`planColonialNaval`** and **`planColonialLiteNaval`** (other
  remaining S3 functions in the same file).

## AC coverage (issue #2509)

- ✅ **(COLONIAL acquisition — Join Empire)**: pinned by happy-path
  test (`nap + Friendly + treasury sufficient -> Join Empire target`)
  + 7 gate-isolation negative tests.
- ✅ **(COLONIAL acquisition — purchase_land)**: pinned by happy-path
  tests (`embassy + valid grain tile + idle Merchant -> purchase_land
  target`, `embassy + prospected mineral tile -> purchase_land target`)
  + 8 gate-isolation negative tests + Join-Empire-priority and
  Join-Empire-shortfall-rescue tests.
- ✅ **(Determinism / Must-have #7)**: pinned by repeated-call
  identity tests on both Method 1 and Method 2.
- ⏳ **(COLONIAL acquisition — declareWar)**: deferred (Acquisition
  method 3).
- ⏳ **(COLONIAL personality divergence)**: deferred (depends on
  declareWar arm).

## Tests run

- `dart test test/planning/colonial_phase_planner_acquisition_join_empire_test.dart` → 11/11 pass
- `dart test test/planning/colonial_phase_planner_acquisition_purchase_land_test.dart` → 16/16 pass
- `dart test test/planning/` → 127/127 pass (full planning suite,
  includes purchase_land arm + all sibling phase planners)
- `dart analyze lib/src/planning/colonial_phase_planner.dart test/planning/colonial_phase_planner_acquisition_purchase_land_test.dart` → No issues found
- `dart analyze packages/colonizethis_ai` → 24 pre-existing warnings
  (unchanged); no new warnings introduced
- `dart format` clean on the new / edited files

## SPEC

No SPEC changes. The acquisition arms are fully authorized by:

- `SPEC/game/diplomacy.md` § Join Empire (cost formula, friendly+
  threshold, nap precondition).
- `SPEC/game/civilian-units.md` § Merchant `purchase_land`
  (embassy + treasury + resource gates; mineral prospect
  prerequisite).
- issue #2509 § COLONIAL phase planner § planColonialAcquisition
  (Acquisition methods 1 and 2; Method 3 deferred).
- `SPEC/ai/ai-architecture.md` § Observer goal phases (planner contract
  shape, pure-function determinism).

Refs #2509

Made with [Cursor](https://cursor.com)
