### PR TITLE
feat(workers): suggestRecruitWorkerOrders order suggestion API (Refs #2692 S7)

### DIFF
--- a/SPEC/program/order-suggestions.md
+++ b/SPEC/program/order-suggestions.md
@@ -6,7 +6,7 @@
 
 ## Responsibility
 
-Given a player, their current valid order list, and game context, enumerate **candidate orders** (move, build, work, research, naval, diplomatic) guaranteed to be accepted if appended.
+Given a player, their current valid order list, and game context, enumerate **candidate orders** (move, build, work, research, naval, diplomatic, recruit worker) guaranteed to be accepted if appended.
 
 ---
 
@@ -63,6 +63,7 @@ For every suggested order `o`, appending it to the current list and validating v
 - Given a `basePrefix` whose every order is `accepted` for player P and a candidate army move `c`, when the system evaluates `c` via the incremental primitive and via the existing army-move acceptance probe, then both return the same boolean accept/reject decision for `c`.
 - Given a `basePrefix` whose every order is `accepted` for player P and a candidate naval move `c`, when the system evaluates `c` via the incremental primitive and via `OrderEngine(initialOrders: basePrefix).addNavalMoveOrderWithContext(...)`, then both return the same boolean accept/reject decision for `c`.
 - Given a `basePrefix` whose every order is `accepted` for player P and a candidate naval mission `c`, when the system evaluates `c` via the incremental primitive and via `OrderEngine(initialOrders: basePrefix).addNavalMissionOrderWithContext(...)`, then both return the same boolean accept/reject decision for `c`.
+- Given a `basePrefix` whose every order is `accepted` for player P and a candidate `RecruitWorkerOrder` `c`, when the system evaluates `c` via the incremental primitive (`isRecruitWorkerAccepted` / `isRecruitWorkerOrderAcceptedWithValidator`) and via `OrderEngine(initialOrders: basePrefix).addRecruitWorkerOrderWithContext(...)`, then both return the same boolean accept/reject decision for `c`.
 
 ---
 
@@ -76,6 +77,7 @@ For every suggested order `o`, appending it to the current list and validating v
 - **Visibility:** Uses PlayerView only; may not inspect hidden tiles or enemy units directly. Checks per [fog-and-exploration-resolution.md](fog-and-exploration-resolution.md). Undiscovered factions are **never** valid diplomatic targets for order suggestions.
 - **Determinism:** Fixed inputs produce the same set and ordering of suggestions.
 - **Build orders:** `suggestBuildOrders` returns affordable, valid build-unit orders for both **military (regiment)** and **naval (ship)** unit types. Each candidate is validated (treasury, stockpile, tech, capital) via the order engine. For build affordability, validation adds [pending riches treasury](turn-resolution-phases.md) (`pendingRichesTreasuryDelta` on the current stockpile) to treasury because `TurnPhase.richesToTreasury` runs before `TurnPhase.buildWork` in the same turn. Ordering is deterministic (e.g. by unit type id).
+- **Recruit worker orders (`suggestRecruitWorkerOrders`):** Returns affordable, valid `RecruitWorkerOrder` candidates for `view.playerId` against the prefix in `currentOrders`, one candidate probed per [`WorkerTier`](../game/workers-and-population.md) value (`peasant`, `apprentice`, `journeyman`, `master`). Each candidate is validated via the same `RecruitWorkerOrderValidator` chain the order engine uses in the recruit worker sub-phase: the player's `WorkerPool` / `Stockpile` / `treasury` snapshot is replayed through every accepted recruit worker order in `currentOrders` (peasant reservation ledger per [workers-and-population.md](../game/workers-and-population.md) § Peasant reservation), then the candidate is validated against the post-prefix snapshot. Tech gates, treasury, paper / fabric stockpile, and consumed-peasant headcount are checked per [workers-and-population.md](../game/workers-and-population.md) § Recruiting, Training, and Disbanding. **Disband** is **not** a queued order ([workers-and-population.md](../game/workers-and-population.md) § Disband) and is therefore not enumerated here. Ordering is deterministic by `WorkerTier.index` (`peasant`, `apprentice`, `journeyman`, `master`).
 - **Naval mission orders (`suggestNavalMissionOrders`):** For each eligible fleet, the system tries each value of `FleetMission` (serialized as `FleetMission.name` on `NavalMissionOrder.mission`) and keeps candidates accepted by the order engine. Adding or renaming enum values in [ships-and-naval.md](../game/ships-and-naval.md) therefore updates suggestion enumeration without a separate hardcoded mission list.
 - **Diplomatic orders (`suggestDiplomaticOrders`):** Suggests valid diplomatic orders (Declare War, Offer Peace, Alliance, Establish Overture, Grant Aid, Set Subsidy) targeting factions the player knows about. Each candidate is validated with the order engine (`addDiplomaticOrderWithContext`), same as other suggestion families. Optional `tileMapByRegion` matches `suggestWorkOrders` for API symmetry. Visibility rules per [regional discovery model](../game/diplomacy.md):
   - **GP↔GP:** Always visible (global knowledge of major powers).
@@ -92,6 +94,14 @@ For every suggested order `o`, appending it to the current list and validating v
 - Given `currentOrders` already includes a non-economic diplomatic order from P to target T, when `suggestDiplomaticOrders` runs with those `currentOrders`, then L contains **no** order with `targetFactionId == T`.
 - Given `currentOrders` includes only a valid pending `grantAid` from P to T, when `suggestDiplomaticOrders` runs, then L **may** include a `setSubsidy` toward T if the engine accepts it when merged with `currentOrders`.
 - Given `currentOrders` includes no diplomatic order to T, when a prior call returned suggestions toward T and the player removed all diplomatic orders to T from the draft, when `suggestDiplomaticOrders` runs again with the updated `currentOrders`, then the system **may** again include valid suggestions toward T subject to game rules and engine validation.
+
+**Acceptance criteria (recruit worker suggestions)**
+
+- Given fixed `Game`, `MapTopology`, `PlayerView`, and `Orders` for a Great Power player P with `pool.peasants ≥ 1`, treasury / paper covering the apprentice cost row, and `apprentice_workers + sugar_refining` in `techUnlocked`, when `suggestRecruitWorkerOrders` runs, then the returned list contains a `RecruitWorkerOrder(targetTier: apprentice)` and the candidate is `accepted` by `OrderEngine(initialOrders: currentOrders).addRecruitWorkerOrderWithContext(...)` for that candidate.
+- Given a Great Power player P whose `techUnlocked` does not contain the target tier's required techs, when `suggestRecruitWorkerOrders` runs for `currentOrders` with no recruit worker prefix, then the returned list contains **no** `RecruitWorkerOrder` with that `targetTier`.
+- Given a Great Power player P whose stockpile or treasury cannot pay the cost row for a target tier (e.g. `fabric < 2` for `peasant`, or `treasury < 200` for `apprentice`), when `suggestRecruitWorkerOrders` runs for `currentOrders` with no recruit worker prefix, then the returned list contains **no** `RecruitWorkerOrder` with that `targetTier`.
+- Given a Great Power player P with `pool.peasants == N` and `currentOrders.recruitWorkerOrdersByPlayerId[P]` containing exactly `N` accepted apprentice / journeyman / master recruits (each consuming a peasant per [workers-and-population.md](../game/workers-and-population.md) § Recruit), when `suggestRecruitWorkerOrders` runs, then the returned list contains **no** `RecruitWorkerOrder` whose row sets `consumesPeasant == true` (peasant reservation ledger drained), and may still contain `RecruitWorkerOrder(targetTier: peasant)` when fabric is available.
+- Given any fixed `(Game, MapTopology, PlayerView, currentOrders)` tuple for player P, when `suggestRecruitWorkerOrders` returns a list L, then for each `c ∈ L` the result of `OrderEngine(initialOrders: currentOrders).addRecruitWorkerOrderWithContext(game, topology, P, c)` is `accepted`, and L is sorted ascending by `c.targetTier.index`.
 
 ---
 

--- a/packages/colonizethis_ai/test/domain_planner_test_fake_api.dart
+++ b/packages/colonizethis_ai/test/domain_planner_test_fake_api.dart
@@ -13,6 +13,7 @@ class FakeOrderSuggestionAPIForDomainPlannerTests implements OrderSuggestionAPI 
     required this.navalMission,
     this.diplomatic = const [],
     this.armyMove = const [],
+    this.recruitWorker = const [],
   });
 
   final List<WorkOrder> work;
@@ -23,6 +24,7 @@ class FakeOrderSuggestionAPIForDomainPlannerTests implements OrderSuggestionAPI 
   final List<NavalMissionOrder> navalMission;
   final List<DiplomaticOrder> diplomatic;
   final List<ArmyMoveOrder> armyMove;
+  final List<RecruitWorkerOrder> recruitWorker;
 
   @override
   List<MoveOrder> suggestMoveOrders(
@@ -56,6 +58,14 @@ class FakeOrderSuggestionAPIForDomainPlannerTests implements OrderSuggestionAPI 
     MapTopology topology,
     Orders currentOrders,
   ) => build;
+
+  @override
+  List<RecruitWorkerOrder> suggestRecruitWorkerOrders(
+    PlayerView view,
+    Game game,
+    MapTopology topology,
+    Orders currentOrders,
+  ) => recruitWorker;
 
   @override
   List<ResearchOrder> suggestResearchOrders(

--- a/packages/colonizethis_logic/lib/src/orders/incremental_candidate_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/incremental_candidate_validator.dart
@@ -124,6 +124,13 @@ class IncrementalCandidateValidator {
   bool? _cachedBuildPrefixReplaySucceeded;
   ({Stockpile stockpile, int treasury, WorkerPool workers})?
   _cachedPostBuildPrefixEconomy;
+
+  /// When [false], existing recruit worker orders in [basePrefix] failed
+  /// incremental replay; every [isRecruitWorkerAccepted] probe must reject
+  /// (Refs #2692 S7).
+  bool? _cachedRecruitWorkerPrefixReplaySucceeded;
+  ({Stockpile stockpile, int treasury, WorkerPool workers})?
+  _cachedPostRecruitWorkerPrefixEconomy;
   Map<String, Army>? _cachedArmiesById;
   DiplomacyFactionMembership? _cachedFactionMembership;
   NavalOrderValidator? _cachedNavalOrderValidator;
@@ -250,6 +257,61 @@ class IncrementalCandidateValidator {
   bool isNavalMissionAccepted(NavalMissionOrder candidate) {
     return _navalOrderValidator()
         .validateNavalMission(candidate, previousRejected: false)
+        .isAccepted;
+  }
+
+  /// Validates a [RecruitWorkerOrder] candidate against accepted recruit
+  /// worker orders in [basePrefix] (Refs #2692 S7,
+  /// SPEC/program/order-suggestions.md § Recruit worker orders).
+  ///
+  /// Mirrors the order-engine recruit worker phase: existing recruit orders
+  /// in [basePrefix] are replayed in submission order against the player's
+  /// snapshot worker pool / stockpile / treasury so the candidate sees the
+  /// post-prefix peasant reservation ledger.
+  bool isRecruitWorkerAccepted(RecruitWorkerOrder candidate) {
+    final player = _player();
+    if (player == null) return false;
+    if (_cachedRecruitWorkerPrefixReplaySucceeded == false) {
+      return false;
+    }
+    if (_cachedPostRecruitWorkerPrefixEconomy == null) {
+      final prefixValidator = RecruitWorkerOrderValidator.withProjectedEconomy(
+        player: player,
+        stockpile: player.stockpile,
+        treasury: player.treasury,
+        workerPool: player.workerPool,
+      );
+      final existing =
+          basePrefix.recruitWorkerOrdersByPlayerId[playerId] ??
+          const <RecruitWorkerOrder>[];
+      for (final order in existing) {
+        final result = prefixValidator.validate(
+          order,
+          previousRejected: false,
+        );
+        if (!result.isAccepted) {
+          _cachedRecruitWorkerPrefixReplaySucceeded = false;
+          return false;
+        }
+      }
+      _cachedRecruitWorkerPrefixReplaySucceeded = true;
+      _cachedPostRecruitWorkerPrefixEconomy = (
+        stockpile: prefixValidator.stockpile,
+        treasury: prefixValidator.treasury,
+        workers: prefixValidator.workers,
+      );
+    }
+    final snap = _cachedPostRecruitWorkerPrefixEconomy!;
+    final candidateValidator = RecruitWorkerOrderValidator.withProjectedEconomy(
+      player: player,
+      stockpile: Stockpile(
+        quantities: Map<String, int>.from(snap.stockpile.quantities),
+      ),
+      treasury: snap.treasury,
+      workerPool: snap.workers,
+    );
+    return candidateValidator
+        .validate(candidate, previousRejected: false)
         .isAccepted;
   }
 

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion.dart
@@ -8,6 +8,11 @@ export 'order_suggestion_context.dart'
         resetIncrementalCandidateValidatorBuildCountForTests,
         setOrderSuggestionWorkOrderAcceptanceProbeTrackingForTests;
 export 'order_suggestion_build.dart' show suggestBuildOrders;
+export 'order_suggestion_recruit_worker.dart'
+    show
+        isRecruitWorkerOrderAccepted,
+        isRecruitWorkerOrderAcceptedWithValidator,
+        suggestRecruitWorkerOrders;
 export 'order_suggestion_research.dart' show suggestResearchOrders;
 export 'order_suggestion_work_tile_keys.dart'
     show getValidWorkOrderTileKeys, getValidWorkOrderTileKeysWithVisibility;

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion_api.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion_api.dart
@@ -31,6 +31,12 @@ abstract class OrderSuggestionAPI {
     MapTopology topology,
     Orders currentOrders,
   );
+  List<RecruitWorkerOrder> suggestRecruitWorkerOrders(
+    PlayerView view,
+    Game game,
+    MapTopology topology,
+    Orders currentOrders,
+  );
   List<ResearchOrder> suggestResearchOrders(
     PlayerView view,
     Game game,

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion_api_impl.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion_api_impl.dart
@@ -75,6 +75,24 @@ class DefaultOrderSuggestionAPI implements OrderSuggestionAPI {
   }
 
   @override
+  List<RecruitWorkerOrder> suggestRecruitWorkerOrders(
+    PlayerView view,
+    Game game,
+    MapTopology topology,
+    Orders currentOrders,
+  ) {
+    logicLog.d(
+      'order suggestion API suggestRecruitWorkerOrders player=${view.playerId}',
+    );
+    return suggestion.suggestRecruitWorkerOrders(
+      view,
+      game,
+      topology,
+      currentOrders,
+    );
+  }
+
+  @override
   List<ResearchOrder> suggestResearchOrders(
     PlayerView view,
     Game game,

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion_recruit_worker.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion_recruit_worker.dart
@@ -1,0 +1,121 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import '../diplomacy/diplomacy_resolver.dart';
+import '../world/player_view.dart';
+import '../world/unit_lookup.dart';
+import 'incremental_candidate_validator.dart';
+import 'order_suggestion_context.dart';
+
+/// Suggests `RecruitWorkerOrder` candidates that are affordable and valid
+/// for [view.playerId] against the prefix in [currentOrders] (Refs #2692 S7,
+/// SPEC/program/order-suggestions.md § Recruit worker orders).
+///
+/// One candidate is probed per [WorkerTier]; the order engine validation
+/// chain (`RecruitWorkerOrderValidator`) decides per tier whether the cost
+/// row, peasant reservation, and tech gates per
+/// SPEC/game/workers-and-population.md § Recruiting, Training, and
+/// Disbanding pass against the projected economy after every accepted
+/// recruit worker order in [currentOrders]. Disband is **not** a queued
+/// order and is not enumerated here (SPEC/game/workers-and-population.md
+/// § Disband).
+///
+/// Throughput hook: callers that enumerate multiple suggestion families
+/// against the same `(game, view.playerId, currentOrders)` may supply
+/// [sharedCandidateValidator] to amortize `PlayerView` / units-by-id
+/// construction across families (Refs #2394). The shared instance must be
+/// built with the same inputs; observable suggestions must match the
+/// default path.
+List<RecruitWorkerOrder> suggestRecruitWorkerOrders(
+  PlayerView view,
+  Game game,
+  MapTopology topology,
+  Orders currentOrders, {
+  IncrementalCandidateValidator? sharedCandidateValidator,
+}) {
+  orderSuggestionLog.d('suggestRecruitWorkerOrders player=${view.playerId}');
+  final playerId = view.playerId;
+  final suggestions = <RecruitWorkerOrder>[];
+
+  assert(
+    sharedCandidateValidator == null ||
+        sharedCandidateValidator.playerId == playerId,
+    'sharedCandidateValidator playerId must match view.playerId',
+  );
+  final effectiveUnits =
+      sharedCandidateValidator?.unitsById ??
+      unitsByIdFromWorld(game.worldState);
+  final candidateValidator =
+      sharedCandidateValidator ??
+      buildIncrementalCandidateValidator(
+        game: game,
+        topology: topology,
+        playerId: playerId,
+        baseOrders: currentOrders,
+        view: view,
+        unitsById: effectiveUnits,
+        factionMembership: DiplomacyFactionMembership.from(game),
+      );
+
+  for (final tier in WorkerTier.values) {
+    final candidate = RecruitWorkerOrder(targetTier: tier);
+    if (isRecruitWorkerOrderAcceptedWithValidator(
+      candidateValidator,
+      candidate,
+    )) {
+      suggestions.add(candidate);
+    }
+  }
+
+  suggestions.sort((a, b) => a.targetTier.index.compareTo(b.targetTier.index));
+
+  orderSuggestionLog.d(
+    'suggestRecruitWorkerOrders player=$playerId candidates=${suggestions.length}',
+  );
+  if (suggestions.isEmpty) {
+    orderSuggestionLog.d(
+      'suggestRecruitWorkerOrders no candidates player=$playerId',
+    );
+  }
+  return suggestions;
+}
+
+/// Validates a [RecruitWorkerOrder] candidate using a pre-built
+/// [IncrementalCandidateValidator]. Mirrors the per-type
+/// `is*OrderAcceptedWithValidator` helpers exposed by other suggestion
+/// families (Refs #2692 S7, `SPEC/program/order-suggestions.md`).
+bool isRecruitWorkerOrderAcceptedWithValidator(
+  IncrementalCandidateValidator validator,
+  RecruitWorkerOrder candidate,
+) {
+  return validator.isRecruitWorkerAccepted(candidate);
+}
+
+/// Stateless candidate-probe helper for `RecruitWorkerOrder`. Builds an
+/// [IncrementalCandidateValidator] when one is not supplied and returns the
+/// same accept/reject decision as `validatePlayerOrdersWithContext` for the
+/// candidate against [baseOrders] (SPEC/program/order-suggestions.md
+/// § Incremental candidate validation).
+bool isRecruitWorkerOrderAccepted(
+  Game game,
+  MapTopology topology,
+  String playerId,
+  Orders baseOrders,
+  RecruitWorkerOrder candidate, {
+  IncrementalCandidateValidator? sharedCandidateValidator,
+  PlayerView? view,
+  Map<String, Unit>? unitsById,
+  DiplomacyFactionMembership? factionMembership,
+}) {
+  final validator = incrementalValidatorForCandidateProbe(
+    game: game,
+    topology: topology,
+    playerId: playerId,
+    baseOrders: baseOrders,
+    view: view,
+    unitsById: unitsById,
+    factionMembership: factionMembership,
+    sharedCandidateValidator: sharedCandidateValidator,
+  );
+  return isRecruitWorkerOrderAcceptedWithValidator(validator, candidate);
+}

--- a/packages/colonizethis_logic/test/order_suggestion_api_impl_test.dart
+++ b/packages/colonizethis_logic/test/order_suggestion_api_impl_test.dart
@@ -213,5 +213,72 @@ void main() {
       );
       expect(list, isA<List<DiplomaticOrder>>());
     });
+
+    test('suggestRecruitWorkerOrders returns list (#2692 S7)', () {
+      const api = DefaultOrderSuggestionAPI();
+      final list = api.suggestRecruitWorkerOrders(
+        view,
+        game,
+        topology,
+        emptyOrders,
+      );
+      expect(list, isA<List<RecruitWorkerOrder>>());
+    });
+
+    test(
+      'suggestRecruitWorkerOrders includes peasant when fabric is affordable '
+      '(#2692 S7)',
+      () {
+        const api = DefaultOrderSuggestionAPI();
+        const ow = 'oldWorld';
+        final stockpile = const Stockpile().applyDelta(
+          CommodityCatalog.fabric.id,
+          4,
+        );
+        final gameWithFabric = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+            oldWorld: RegionData(
+              provinces: [Province(id: '$ow|p1', regionId: ow, ownerId: 'gp1')],
+            ),
+            newWorld: const RegionData(),
+          ),
+          players: [
+            Player(
+              id: 'gp1',
+              displayName: 'A',
+              isHuman: false,
+              capitalProvinceId: '$ow|p1',
+              stockpile: stockpile,
+            ),
+          ],
+        );
+        final topo = MapTopology(
+          nodes: const [
+            TopologyNode(
+              id: 'p1',
+              regionId: 'oldWorld',
+              type: TopologyNodeType.province,
+            ),
+          ],
+          edges: const [],
+        );
+        final v = buildPlayerView(gameWithFabric, topo, 'gp1');
+        final list = api.suggestRecruitWorkerOrders(
+          v,
+          gameWithFabric,
+          topo,
+          const Orders(),
+        );
+        expect(
+          list.any((o) => o.targetTier == WorkerTier.peasant),
+          isTrue,
+          reason:
+              'API impl must surface peasant recruit when 2 fabric affords '
+              'the cost row',
+        );
+      },
+    );
   });
 }

--- a/packages/colonizethis_logic/test/order_suggestion_recruit_worker_parity_test.dart
+++ b/packages/colonizethis_logic/test/order_suggestion_recruit_worker_parity_test.dart
@@ -1,0 +1,240 @@
+/// All-tiers ordering, peasant reservation, and engine round-trip parity
+/// coverage for `suggestRecruitWorkerOrders` (Refs #2692 S7,
+/// SPEC/program/order-suggestions.md § Recruit worker orders).
+///
+/// Smaller per-tier inclusion scenarios live in
+/// `order_suggestion_recruit_worker_test.dart`. The split keeps each file
+/// under the `repo.logic_test_file_size` 400 physical line limit.
+library;
+
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+import 'order_suggestion_recruit_worker_test_support.dart';
+
+void main() {
+  group('suggestRecruitWorkerOrders (#2692 S7) — parity and ordering', () {
+    test(
+      'returns all four tiers when all techs unlocked and resources support '
+      'every cost row',
+      () {
+        final game = recruitWorkerTestGameWith(
+          player: Player(
+            id: 'p1',
+            displayName: 'P',
+            isHuman: true,
+            stockpile: Stockpile(
+              quantities: {
+                CommodityCatalog.fabric.id: 4,
+                CommodityCatalog.paper.id: 50,
+              },
+            ),
+            // Three peasants -> apprentice, journeyman, master each consume one.
+            workerPool: const WorkerPool(peasants: 3),
+            treasury: 5000,
+            techUnlocked: const {
+              kTechIdApprenticeWorkers: true,
+              kTechIdSugarRefining: true,
+              kTechIdTrainedJourneymen: true,
+              kTechIdCigarProduction: true,
+              kTechIdMasterArtisans: true,
+              kTechIdHatProduction: true,
+            },
+          ),
+        );
+
+        final list = suggestRecruitWorkerOrders(
+          recruitWorkerTestViewFor(game, 'p1'),
+          game,
+          recruitWorkerTestTopology,
+          const Orders(),
+        );
+
+        // Determinism: ordering follows WorkerTier.index ascending.
+        expect(
+          list.map((o) => o.targetTier).toList(),
+          <WorkerTier>[
+            WorkerTier.peasant,
+            WorkerTier.apprentice,
+            WorkerTier.journeyman,
+            WorkerTier.master,
+          ],
+        );
+        for (final candidate in list) {
+          expect(
+            recruitWorkerTestEngineAccepts(
+              game,
+              const Orders(),
+              'p1',
+              candidate,
+            ),
+            isTrue,
+            reason: 'engine accepts every emitted candidate (parity)',
+          );
+        }
+      },
+    );
+
+    test(
+      'peasant reservation: pending apprentice recruit drains the only peasant '
+      'so a candidate apprentice is excluded but candidate peasant remains',
+      () {
+        final game = recruitWorkerTestGameWith(
+          player: Player(
+            id: 'p1',
+            displayName: 'P',
+            isHuman: true,
+            stockpile: Stockpile(
+              quantities: {
+                CommodityCatalog.fabric.id: 4,
+                CommodityCatalog.paper.id: 50,
+              },
+            ),
+            workerPool: const WorkerPool(peasants: 1),
+            treasury: 5000,
+            techUnlocked: const {
+              kTechIdApprenticeWorkers: true,
+              kTechIdSugarRefining: true,
+            },
+          ),
+        );
+
+        final pending = const Orders(
+          recruitWorkerOrdersByPlayerId: {
+            'p1': [RecruitWorkerOrder(targetTier: WorkerTier.apprentice)],
+          },
+        );
+
+        final list = suggestRecruitWorkerOrders(
+          recruitWorkerTestViewFor(game, 'p1'),
+          game,
+          recruitWorkerTestTopology,
+          pending,
+        );
+
+        expect(
+          list.any((o) => o.targetTier == WorkerTier.apprentice),
+          isFalse,
+          reason:
+              'peasant reservation ledger: pending apprentice already '
+              'consumed the only peasant',
+        );
+        // Peasant recruit row only needs fabric, no peasant consumed.
+        expect(
+          list.any((o) => o.targetTier == WorkerTier.peasant),
+          isTrue,
+          reason: 'peasant recruit does not consume peasants',
+        );
+      },
+    );
+
+    test(
+      'engine round-trip parity: accept/reject decision matches '
+      'addRecruitWorkerOrderWithContext for every WorkerTier in a partial '
+      'tech / peasant / treasury fixture',
+      () {
+        // Partial: only apprentice tech; treasury below journeyman/master cost
+        // rows; one peasant available; fabric for peasant.
+        final game = recruitWorkerTestGameWith(
+          player: Player(
+            id: 'p1',
+            displayName: 'P',
+            isHuman: true,
+            stockpile: Stockpile(
+              quantities: {
+                CommodityCatalog.fabric.id: 4,
+                CommodityCatalog.paper.id: 50,
+              },
+            ),
+            workerPool: const WorkerPool(peasants: 1),
+            treasury: 250,
+            techUnlocked: const {
+              kTechIdApprenticeWorkers: true,
+              kTechIdSugarRefining: true,
+              kTechIdTrainedJourneymen: true,
+              kTechIdCigarProduction: true,
+              kTechIdMasterArtisans: true,
+              kTechIdHatProduction: true,
+            },
+          ),
+        );
+
+        final list = suggestRecruitWorkerOrders(
+          recruitWorkerTestViewFor(game, 'p1'),
+          game,
+          recruitWorkerTestTopology,
+          const Orders(),
+        );
+
+        // Suggestion includes peasant + apprentice; treasury too low for
+        // journeyman (500) or master (1000).
+        expect(
+          list.map((o) => o.targetTier).toSet(),
+          {WorkerTier.peasant, WorkerTier.apprentice},
+        );
+
+        for (final tier in recruitWorkerTestAllTiers) {
+          final candidate = RecruitWorkerOrder(targetTier: tier);
+          final inSuggestions = list.any(
+            (o) => o.targetTier == candidate.targetTier,
+          );
+          final engineAccepts = recruitWorkerTestEngineAccepts(
+            game,
+            const Orders(),
+            'p1',
+            candidate,
+          );
+          expect(
+            inSuggestions,
+            engineAccepts,
+            reason:
+                '${tier.name}: suggestion inclusion ($inSuggestions) must '
+                'match engine accept ($engineAccepts) — '
+                'SPEC equivalence guarantee for incremental candidate '
+                'validation',
+          );
+        }
+      },
+    );
+
+    test(
+      'empty stockpile + zero treasury + zero peasants -> empty list',
+      () {
+        final game = recruitWorkerTestGameWith(
+          player: Player(
+            id: 'p1',
+            displayName: 'P',
+            isHuman: true,
+          ),
+        );
+
+        final list = suggestRecruitWorkerOrders(
+          recruitWorkerTestViewFor(game, 'p1'),
+          game,
+          recruitWorkerTestTopology,
+          const Orders(),
+        );
+        expect(list, isEmpty);
+
+        // Negative parity: every WorkerTier candidate is rejected by the
+        // engine when the player has no resources.
+        for (final tier in recruitWorkerTestAllTiers) {
+          expect(
+            recruitWorkerTestEngineAccepts(
+              game,
+              const Orders(),
+              'p1',
+              RecruitWorkerOrder(targetTier: tier),
+            ),
+            isFalse,
+            reason:
+                '${tier.name} candidate must be engine-rejected '
+                '(empty player has nothing to spend)',
+          );
+        }
+      },
+    );
+  });
+}

--- a/packages/colonizethis_logic/test/order_suggestion_recruit_worker_test.dart
+++ b/packages/colonizethis_logic/test/order_suggestion_recruit_worker_test.dart
@@ -1,11 +1,11 @@
-/// Coverage for `suggestRecruitWorkerOrders` (Refs #2692 S7,
+/// Per-tier positive / negative inclusion coverage for
+/// `suggestRecruitWorkerOrders` (Refs #2692 S7,
 /// SPEC/program/order-suggestions.md § Recruit worker orders).
 ///
-/// Each scenario asserts both the suggestion list (positive / negative
-/// inclusion per `WorkerTier`) and the engine round-trip equivalence
-/// guarantee: every emitted candidate must be `accepted` by
-/// `OrderEngine(initialOrders: currentOrders).addRecruitWorkerOrderWithContext`,
-/// matching the SPEC § Incremental candidate validation primitive contract.
+/// All-tiers ordering, peasant-reservation, and engine round-trip parity
+/// coverage live in `order_suggestion_recruit_worker_parity_test.dart`
+/// so each file stays under the
+/// `repo.logic_test_file_size` 400 physical line limit.
 library;
 
 import 'package:colonizethis_data/colonizethis_data.dart';
@@ -13,64 +13,17 @@ import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart';
 
-const _regionId = 'oldWorld';
-const _provinceId = '$_regionId|P1';
-
-final _topology = MapTopology(
-  nodes: const [
-    TopologyNode(
-      id: 'P1',
-      regionId: _regionId,
-      type: TopologyNodeType.province,
-    ),
-  ],
-  edges: const [],
-);
-
-Game _gameWith({required Player player}) => Game(
-  id: 'g',
-  worldState: WorldState(
-    turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
-    oldWorld: RegionData(
-      provinces: [
-        Province(id: _provinceId, regionId: _regionId, ownerId: player.id),
-      ],
-    ),
-    newWorld: const RegionData(),
-  ),
-  players: [player],
-);
-
-PlayerView _viewFor(Game game, String playerId) =>
-    buildPlayerView(game, _topology, playerId);
-
-bool _engineAcceptsRecruit(
-  Game game,
-  Orders currentOrders,
-  String playerId,
-  RecruitWorkerOrder candidate,
-) {
-  final engine = OrderEngine(initialOrders: currentOrders);
-  final result = engine.addRecruitWorkerOrderWithContext(
-    game,
-    _topology,
-    playerId,
-    candidate,
-  );
-  return result.isAccepted;
-}
-
-const _allTiers = WorkerTier.values;
+import 'order_suggestion_recruit_worker_test_support.dart';
 
 void main() {
-  group('suggestRecruitWorkerOrders (#2692 S7)', () {
+  group('suggestRecruitWorkerOrders (#2692 S7) — per-tier inclusion', () {
     test(
       'returns peasant and apprentice when fabric, treasury, paper, and '
       'apprentice tech support both rows',
       () {
         // Peasant row: fabric x 2; Apprentice row: 1 peasant + 200 ducats +
         // 2 paper. Other trained tiers locked.
-        final game = _gameWith(
+        final game = recruitWorkerTestGameWith(
           player: Player(
             id: 'p1',
             displayName: 'P',
@@ -91,9 +44,9 @@ void main() {
         );
 
         final list = suggestRecruitWorkerOrders(
-          _viewFor(game, 'p1'),
+          recruitWorkerTestViewFor(game, 'p1'),
           game,
-          _topology,
+          recruitWorkerTestTopology,
           const Orders(),
         );
 
@@ -117,7 +70,12 @@ void main() {
 
         for (final candidate in list) {
           expect(
-            _engineAcceptsRecruit(game, const Orders(), 'p1', candidate),
+            recruitWorkerTestEngineAccepts(
+              game,
+              const Orders(),
+              'p1',
+              candidate,
+            ),
             isTrue,
             reason:
                 'engine round-trip must accept emitted candidate '
@@ -132,7 +90,7 @@ void main() {
       () {
         // Affordability satisfied for all trained tiers; tech gates entirely
         // missing.
-        final game = _gameWith(
+        final game = recruitWorkerTestGameWith(
           player: Player(
             id: 'p1',
             displayName: 'P',
@@ -149,19 +107,26 @@ void main() {
         );
 
         final list = suggestRecruitWorkerOrders(
-          _viewFor(game, 'p1'),
+          recruitWorkerTestViewFor(game, 'p1'),
           game,
-          _topology,
+          recruitWorkerTestTopology,
           const Orders(),
         );
 
         expect(list.map((o) => o.targetTier).toList(), [WorkerTier.peasant]);
 
         // Engine must reject every locked-tier candidate (negative parity).
-        for (final tier in _allTiers.where((t) => t != WorkerTier.peasant)) {
+        for (final tier in recruitWorkerTestAllTiers.where(
+          (t) => t != WorkerTier.peasant,
+        )) {
           final candidate = RecruitWorkerOrder(targetTier: tier);
           expect(
-            _engineAcceptsRecruit(game, const Orders(), 'p1', candidate),
+            recruitWorkerTestEngineAccepts(
+              game,
+              const Orders(),
+              'p1',
+              candidate,
+            ),
             isFalse,
             reason: '${tier.name} candidate rejected at the order engine '
                 'because tech gate is locked',
@@ -173,7 +138,7 @@ void main() {
     test(
       'omits peasant recruit when fabric is insufficient',
       () {
-        final game = _gameWith(
+        final game = recruitWorkerTestGameWith(
           player: Player(
             id: 'p1',
             displayName: 'P',
@@ -185,9 +150,9 @@ void main() {
         );
 
         final list = suggestRecruitWorkerOrders(
-          _viewFor(game, 'p1'),
+          recruitWorkerTestViewFor(game, 'p1'),
           game,
-          _topology,
+          recruitWorkerTestTopology,
           const Orders(),
         );
 
@@ -202,7 +167,7 @@ void main() {
     test(
       'omits apprentice recruit when treasury is below 200 ducats',
       () {
-        final game = _gameWith(
+        final game = recruitWorkerTestGameWith(
           player: Player(
             id: 'p1',
             displayName: 'P',
@@ -220,9 +185,9 @@ void main() {
         );
 
         final list = suggestRecruitWorkerOrders(
-          _viewFor(game, 'p1'),
+          recruitWorkerTestViewFor(game, 'p1'),
           game,
-          _topology,
+          recruitWorkerTestTopology,
           const Orders(),
         );
 
@@ -237,7 +202,7 @@ void main() {
     test(
       'omits apprentice recruit when peasant pool is empty',
       () {
-        final game = _gameWith(
+        final game = recruitWorkerTestGameWith(
           player: Player(
             id: 'p1',
             displayName: 'P',
@@ -255,9 +220,9 @@ void main() {
         );
 
         final list = suggestRecruitWorkerOrders(
-          _viewFor(game, 'p1'),
+          recruitWorkerTestViewFor(game, 'p1'),
           game,
-          _topology,
+          recruitWorkerTestTopology,
           const Orders(),
         );
 
@@ -266,222 +231,6 @@ void main() {
           isFalse,
           reason: 'apprentice row consumes 1 peasant',
         );
-      },
-    );
-
-    test(
-      'returns all four tiers when all techs unlocked and resources support '
-      'every cost row',
-      () {
-        final game = _gameWith(
-          player: Player(
-            id: 'p1',
-            displayName: 'P',
-            isHuman: true,
-            stockpile: Stockpile(
-              quantities: {
-                CommodityCatalog.fabric.id: 4,
-                CommodityCatalog.paper.id: 50,
-              },
-            ),
-            // Three peasants -> apprentice, journeyman, master each consume one.
-            workerPool: const WorkerPool(peasants: 3),
-            treasury: 5000,
-            techUnlocked: const {
-              kTechIdApprenticeWorkers: true,
-              kTechIdSugarRefining: true,
-              kTechIdTrainedJourneymen: true,
-              kTechIdCigarProduction: true,
-              kTechIdMasterArtisans: true,
-              kTechIdHatProduction: true,
-            },
-          ),
-        );
-
-        final list = suggestRecruitWorkerOrders(
-          _viewFor(game, 'p1'),
-          game,
-          _topology,
-          const Orders(),
-        );
-
-        // Determinism: ordering follows WorkerTier.index ascending.
-        expect(
-          list.map((o) => o.targetTier).toList(),
-          <WorkerTier>[
-            WorkerTier.peasant,
-            WorkerTier.apprentice,
-            WorkerTier.journeyman,
-            WorkerTier.master,
-          ],
-        );
-        for (final candidate in list) {
-          expect(
-            _engineAcceptsRecruit(game, const Orders(), 'p1', candidate),
-            isTrue,
-            reason: 'engine accepts every emitted candidate (parity)',
-          );
-        }
-      },
-    );
-
-    test(
-      'peasant reservation: pending apprentice recruit drains the only peasant '
-      'so a candidate apprentice is excluded but candidate peasant remains',
-      () {
-        final game = _gameWith(
-          player: Player(
-            id: 'p1',
-            displayName: 'P',
-            isHuman: true,
-            stockpile: Stockpile(
-              quantities: {
-                CommodityCatalog.fabric.id: 4,
-                CommodityCatalog.paper.id: 50,
-              },
-            ),
-            workerPool: const WorkerPool(peasants: 1),
-            treasury: 5000,
-            techUnlocked: const {
-              kTechIdApprenticeWorkers: true,
-              kTechIdSugarRefining: true,
-            },
-          ),
-        );
-
-        final pending = const Orders(
-          recruitWorkerOrdersByPlayerId: {
-            'p1': [RecruitWorkerOrder(targetTier: WorkerTier.apprentice)],
-          },
-        );
-
-        final list = suggestRecruitWorkerOrders(
-          _viewFor(game, 'p1'),
-          game,
-          _topology,
-          pending,
-        );
-
-        expect(
-          list.any((o) => o.targetTier == WorkerTier.apprentice),
-          isFalse,
-          reason:
-              'peasant reservation ledger: pending apprentice already '
-              'consumed the only peasant',
-        );
-        // Peasant recruit row only needs fabric, no peasant consumed.
-        expect(
-          list.any((o) => o.targetTier == WorkerTier.peasant),
-          isTrue,
-          reason: 'peasant recruit does not consume peasants',
-        );
-      },
-    );
-
-    test(
-      'engine round-trip parity: accept/reject decision matches '
-      'addRecruitWorkerOrderWithContext for every WorkerTier in a partial '
-      'tech / peasant / treasury fixture',
-      () {
-        // Partial: only apprentice tech; treasury below journeyman/master cost
-        // rows; one peasant available; fabric for peasant.
-        final game = _gameWith(
-          player: Player(
-            id: 'p1',
-            displayName: 'P',
-            isHuman: true,
-            stockpile: Stockpile(
-              quantities: {
-                CommodityCatalog.fabric.id: 4,
-                CommodityCatalog.paper.id: 50,
-              },
-            ),
-            workerPool: const WorkerPool(peasants: 1),
-            treasury: 250,
-            techUnlocked: const {
-              kTechIdApprenticeWorkers: true,
-              kTechIdSugarRefining: true,
-              kTechIdTrainedJourneymen: true,
-              kTechIdCigarProduction: true,
-              kTechIdMasterArtisans: true,
-              kTechIdHatProduction: true,
-            },
-          ),
-        );
-
-        final list = suggestRecruitWorkerOrders(
-          _viewFor(game, 'p1'),
-          game,
-          _topology,
-          const Orders(),
-        );
-
-        // Suggestion includes peasant + apprentice; treasury too low for
-        // journeyman (500) or master (1000).
-        expect(
-          list.map((o) => o.targetTier).toSet(),
-          {WorkerTier.peasant, WorkerTier.apprentice},
-        );
-
-        for (final tier in _allTiers) {
-          final candidate = RecruitWorkerOrder(targetTier: tier);
-          final inSuggestions = list.any(
-            (o) => o.targetTier == candidate.targetTier,
-          );
-          final engineAccepts = _engineAcceptsRecruit(
-            game,
-            const Orders(),
-            'p1',
-            candidate,
-          );
-          expect(
-            inSuggestions,
-            engineAccepts,
-            reason:
-                '${tier.name}: suggestion inclusion ($inSuggestions) must '
-                'match engine accept ($engineAccepts) — '
-                'SPEC equivalence guarantee for incremental candidate '
-                'validation',
-          );
-        }
-      },
-    );
-
-    test(
-      'empty stockpile + zero treasury + zero peasants -> empty list',
-      () {
-        final game = _gameWith(
-          player: Player(
-            id: 'p1',
-            displayName: 'P',
-            isHuman: true,
-          ),
-        );
-
-        final list = suggestRecruitWorkerOrders(
-          _viewFor(game, 'p1'),
-          game,
-          _topology,
-          const Orders(),
-        );
-        expect(list, isEmpty);
-
-        // Negative parity: every WorkerTier candidate is rejected by the
-        // engine when the player has no resources.
-        for (final tier in _allTiers) {
-          expect(
-            _engineAcceptsRecruit(
-              game,
-              const Orders(),
-              'p1',
-              RecruitWorkerOrder(targetTier: tier),
-            ),
-            isFalse,
-            reason:
-                '${tier.name} candidate must be engine-rejected '
-                '(empty player has nothing to spend)',
-          );
-        }
       },
     );
   });

--- a/packages/colonizethis_logic/test/order_suggestion_recruit_worker_test.dart
+++ b/packages/colonizethis_logic/test/order_suggestion_recruit_worker_test.dart
@@ -1,0 +1,488 @@
+/// Coverage for `suggestRecruitWorkerOrders` (Refs #2692 S7,
+/// SPEC/program/order-suggestions.md § Recruit worker orders).
+///
+/// Each scenario asserts both the suggestion list (positive / negative
+/// inclusion per `WorkerTier`) and the engine round-trip equivalence
+/// guarantee: every emitted candidate must be `accepted` by
+/// `OrderEngine(initialOrders: currentOrders).addRecruitWorkerOrderWithContext`,
+/// matching the SPEC § Incremental candidate validation primitive contract.
+library;
+
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+const _regionId = 'oldWorld';
+const _provinceId = '$_regionId|P1';
+
+final _topology = MapTopology(
+  nodes: const [
+    TopologyNode(
+      id: 'P1',
+      regionId: _regionId,
+      type: TopologyNodeType.province,
+    ),
+  ],
+  edges: const [],
+);
+
+Game _gameWith({required Player player}) => Game(
+  id: 'g',
+  worldState: WorldState(
+    turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+    oldWorld: RegionData(
+      provinces: [
+        Province(id: _provinceId, regionId: _regionId, ownerId: player.id),
+      ],
+    ),
+    newWorld: const RegionData(),
+  ),
+  players: [player],
+);
+
+PlayerView _viewFor(Game game, String playerId) =>
+    buildPlayerView(game, _topology, playerId);
+
+bool _engineAcceptsRecruit(
+  Game game,
+  Orders currentOrders,
+  String playerId,
+  RecruitWorkerOrder candidate,
+) {
+  final engine = OrderEngine(initialOrders: currentOrders);
+  final result = engine.addRecruitWorkerOrderWithContext(
+    game,
+    _topology,
+    playerId,
+    candidate,
+  );
+  return result.isAccepted;
+}
+
+const _allTiers = WorkerTier.values;
+
+void main() {
+  group('suggestRecruitWorkerOrders (#2692 S7)', () {
+    test(
+      'returns peasant and apprentice when fabric, treasury, paper, and '
+      'apprentice tech support both rows',
+      () {
+        // Peasant row: fabric x 2; Apprentice row: 1 peasant + 200 ducats +
+        // 2 paper. Other trained tiers locked.
+        final game = _gameWith(
+          player: Player(
+            id: 'p1',
+            displayName: 'P',
+            isHuman: true,
+            stockpile: Stockpile(
+              quantities: {
+                CommodityCatalog.fabric.id: 4,
+                CommodityCatalog.paper.id: 5,
+              },
+            ),
+            workerPool: const WorkerPool(peasants: 1),
+            treasury: 500,
+            techUnlocked: const {
+              kTechIdApprenticeWorkers: true,
+              kTechIdSugarRefining: true,
+            },
+          ),
+        );
+
+        final list = suggestRecruitWorkerOrders(
+          _viewFor(game, 'p1'),
+          game,
+          _topology,
+          const Orders(),
+        );
+
+        expect(
+          list.map((o) => o.targetTier),
+          containsAllInOrder(<WorkerTier>[
+            WorkerTier.peasant,
+            WorkerTier.apprentice,
+          ]),
+        );
+        expect(
+          list.any((o) => o.targetTier == WorkerTier.journeyman),
+          isFalse,
+          reason: 'journeyman tech is locked',
+        );
+        expect(
+          list.any((o) => o.targetTier == WorkerTier.master),
+          isFalse,
+          reason: 'master tech is locked',
+        );
+
+        for (final candidate in list) {
+          expect(
+            _engineAcceptsRecruit(game, const Orders(), 'p1', candidate),
+            isTrue,
+            reason:
+                'engine round-trip must accept emitted candidate '
+                '${candidate.targetTier.name} per SPEC equivalence guarantee',
+          );
+        }
+      },
+    );
+
+    test(
+      'omits trained tiers when their required techs are locked',
+      () {
+        // Affordability satisfied for all trained tiers; tech gates entirely
+        // missing.
+        final game = _gameWith(
+          player: Player(
+            id: 'p1',
+            displayName: 'P',
+            isHuman: true,
+            stockpile: Stockpile(
+              quantities: {
+                CommodityCatalog.fabric.id: 10,
+                CommodityCatalog.paper.id: 50,
+              },
+            ),
+            workerPool: const WorkerPool(peasants: 5),
+            treasury: 5000,
+          ),
+        );
+
+        final list = suggestRecruitWorkerOrders(
+          _viewFor(game, 'p1'),
+          game,
+          _topology,
+          const Orders(),
+        );
+
+        expect(list.map((o) => o.targetTier).toList(), [WorkerTier.peasant]);
+
+        // Engine must reject every locked-tier candidate (negative parity).
+        for (final tier in _allTiers.where((t) => t != WorkerTier.peasant)) {
+          final candidate = RecruitWorkerOrder(targetTier: tier);
+          expect(
+            _engineAcceptsRecruit(game, const Orders(), 'p1', candidate),
+            isFalse,
+            reason: '${tier.name} candidate rejected at the order engine '
+                'because tech gate is locked',
+          );
+        }
+      },
+    );
+
+    test(
+      'omits peasant recruit when fabric is insufficient',
+      () {
+        final game = _gameWith(
+          player: Player(
+            id: 'p1',
+            displayName: 'P',
+            isHuman: true,
+            stockpile: Stockpile(
+              quantities: {CommodityCatalog.fabric.id: 1},
+            ),
+          ),
+        );
+
+        final list = suggestRecruitWorkerOrders(
+          _viewFor(game, 'p1'),
+          game,
+          _topology,
+          const Orders(),
+        );
+
+        expect(
+          list.any((o) => o.targetTier == WorkerTier.peasant),
+          isFalse,
+          reason: 'peasant row needs 2 fabric',
+        );
+      },
+    );
+
+    test(
+      'omits apprentice recruit when treasury is below 200 ducats',
+      () {
+        final game = _gameWith(
+          player: Player(
+            id: 'p1',
+            displayName: 'P',
+            isHuman: true,
+            stockpile: Stockpile(
+              quantities: {CommodityCatalog.paper.id: 5},
+            ),
+            workerPool: const WorkerPool(peasants: 1),
+            treasury: 100,
+            techUnlocked: const {
+              kTechIdApprenticeWorkers: true,
+              kTechIdSugarRefining: true,
+            },
+          ),
+        );
+
+        final list = suggestRecruitWorkerOrders(
+          _viewFor(game, 'p1'),
+          game,
+          _topology,
+          const Orders(),
+        );
+
+        expect(
+          list.any((o) => o.targetTier == WorkerTier.apprentice),
+          isFalse,
+          reason: 'apprentice row needs 200 ducats; treasury == 100',
+        );
+      },
+    );
+
+    test(
+      'omits apprentice recruit when peasant pool is empty',
+      () {
+        final game = _gameWith(
+          player: Player(
+            id: 'p1',
+            displayName: 'P',
+            isHuman: true,
+            stockpile: Stockpile(
+              quantities: {CommodityCatalog.paper.id: 5},
+            ),
+            workerPool: const WorkerPool(),
+            treasury: 500,
+            techUnlocked: const {
+              kTechIdApprenticeWorkers: true,
+              kTechIdSugarRefining: true,
+            },
+          ),
+        );
+
+        final list = suggestRecruitWorkerOrders(
+          _viewFor(game, 'p1'),
+          game,
+          _topology,
+          const Orders(),
+        );
+
+        expect(
+          list.any((o) => o.targetTier == WorkerTier.apprentice),
+          isFalse,
+          reason: 'apprentice row consumes 1 peasant',
+        );
+      },
+    );
+
+    test(
+      'returns all four tiers when all techs unlocked and resources support '
+      'every cost row',
+      () {
+        final game = _gameWith(
+          player: Player(
+            id: 'p1',
+            displayName: 'P',
+            isHuman: true,
+            stockpile: Stockpile(
+              quantities: {
+                CommodityCatalog.fabric.id: 4,
+                CommodityCatalog.paper.id: 50,
+              },
+            ),
+            // Three peasants -> apprentice, journeyman, master each consume one.
+            workerPool: const WorkerPool(peasants: 3),
+            treasury: 5000,
+            techUnlocked: const {
+              kTechIdApprenticeWorkers: true,
+              kTechIdSugarRefining: true,
+              kTechIdTrainedJourneymen: true,
+              kTechIdCigarProduction: true,
+              kTechIdMasterArtisans: true,
+              kTechIdHatProduction: true,
+            },
+          ),
+        );
+
+        final list = suggestRecruitWorkerOrders(
+          _viewFor(game, 'p1'),
+          game,
+          _topology,
+          const Orders(),
+        );
+
+        // Determinism: ordering follows WorkerTier.index ascending.
+        expect(
+          list.map((o) => o.targetTier).toList(),
+          <WorkerTier>[
+            WorkerTier.peasant,
+            WorkerTier.apprentice,
+            WorkerTier.journeyman,
+            WorkerTier.master,
+          ],
+        );
+        for (final candidate in list) {
+          expect(
+            _engineAcceptsRecruit(game, const Orders(), 'p1', candidate),
+            isTrue,
+            reason: 'engine accepts every emitted candidate (parity)',
+          );
+        }
+      },
+    );
+
+    test(
+      'peasant reservation: pending apprentice recruit drains the only peasant '
+      'so a candidate apprentice is excluded but candidate peasant remains',
+      () {
+        final game = _gameWith(
+          player: Player(
+            id: 'p1',
+            displayName: 'P',
+            isHuman: true,
+            stockpile: Stockpile(
+              quantities: {
+                CommodityCatalog.fabric.id: 4,
+                CommodityCatalog.paper.id: 50,
+              },
+            ),
+            workerPool: const WorkerPool(peasants: 1),
+            treasury: 5000,
+            techUnlocked: const {
+              kTechIdApprenticeWorkers: true,
+              kTechIdSugarRefining: true,
+            },
+          ),
+        );
+
+        final pending = const Orders(
+          recruitWorkerOrdersByPlayerId: {
+            'p1': [RecruitWorkerOrder(targetTier: WorkerTier.apprentice)],
+          },
+        );
+
+        final list = suggestRecruitWorkerOrders(
+          _viewFor(game, 'p1'),
+          game,
+          _topology,
+          pending,
+        );
+
+        expect(
+          list.any((o) => o.targetTier == WorkerTier.apprentice),
+          isFalse,
+          reason:
+              'peasant reservation ledger: pending apprentice already '
+              'consumed the only peasant',
+        );
+        // Peasant recruit row only needs fabric, no peasant consumed.
+        expect(
+          list.any((o) => o.targetTier == WorkerTier.peasant),
+          isTrue,
+          reason: 'peasant recruit does not consume peasants',
+        );
+      },
+    );
+
+    test(
+      'engine round-trip parity: accept/reject decision matches '
+      'addRecruitWorkerOrderWithContext for every WorkerTier in a partial '
+      'tech / peasant / treasury fixture',
+      () {
+        // Partial: only apprentice tech; treasury below journeyman/master cost
+        // rows; one peasant available; fabric for peasant.
+        final game = _gameWith(
+          player: Player(
+            id: 'p1',
+            displayName: 'P',
+            isHuman: true,
+            stockpile: Stockpile(
+              quantities: {
+                CommodityCatalog.fabric.id: 4,
+                CommodityCatalog.paper.id: 50,
+              },
+            ),
+            workerPool: const WorkerPool(peasants: 1),
+            treasury: 250,
+            techUnlocked: const {
+              kTechIdApprenticeWorkers: true,
+              kTechIdSugarRefining: true,
+              kTechIdTrainedJourneymen: true,
+              kTechIdCigarProduction: true,
+              kTechIdMasterArtisans: true,
+              kTechIdHatProduction: true,
+            },
+          ),
+        );
+
+        final list = suggestRecruitWorkerOrders(
+          _viewFor(game, 'p1'),
+          game,
+          _topology,
+          const Orders(),
+        );
+
+        // Suggestion includes peasant + apprentice; treasury too low for
+        // journeyman (500) or master (1000).
+        expect(
+          list.map((o) => o.targetTier).toSet(),
+          {WorkerTier.peasant, WorkerTier.apprentice},
+        );
+
+        for (final tier in _allTiers) {
+          final candidate = RecruitWorkerOrder(targetTier: tier);
+          final inSuggestions = list.any(
+            (o) => o.targetTier == candidate.targetTier,
+          );
+          final engineAccepts = _engineAcceptsRecruit(
+            game,
+            const Orders(),
+            'p1',
+            candidate,
+          );
+          expect(
+            inSuggestions,
+            engineAccepts,
+            reason:
+                '${tier.name}: suggestion inclusion ($inSuggestions) must '
+                'match engine accept ($engineAccepts) — '
+                'SPEC equivalence guarantee for incremental candidate '
+                'validation',
+          );
+        }
+      },
+    );
+
+    test(
+      'empty stockpile + zero treasury + zero peasants -> empty list',
+      () {
+        final game = _gameWith(
+          player: Player(
+            id: 'p1',
+            displayName: 'P',
+            isHuman: true,
+          ),
+        );
+
+        final list = suggestRecruitWorkerOrders(
+          _viewFor(game, 'p1'),
+          game,
+          _topology,
+          const Orders(),
+        );
+        expect(list, isEmpty);
+
+        // Negative parity: every WorkerTier candidate is rejected by the
+        // engine when the player has no resources.
+        for (final tier in _allTiers) {
+          expect(
+            _engineAcceptsRecruit(
+              game,
+              const Orders(),
+              'p1',
+              RecruitWorkerOrder(targetTier: tier),
+            ),
+            isFalse,
+            reason:
+                '${tier.name} candidate must be engine-rejected '
+                '(empty player has nothing to spend)',
+          );
+        }
+      },
+    );
+  });
+}

--- a/packages/colonizethis_logic/test/order_suggestion_recruit_worker_test_support.dart
+++ b/packages/colonizethis_logic/test/order_suggestion_recruit_worker_test_support.dart
@@ -1,0 +1,69 @@
+/// Shared fixture for `order_suggestion_recruit_worker_*_test.dart`
+/// (Refs #2692 S7, SPEC/program/order-suggestions.md § Recruit worker orders).
+///
+/// Centralizes the single-province / single-player topology and the
+/// `OrderEngine.addRecruitWorkerOrderWithContext` round-trip helper used to
+/// assert the SPEC equivalence guarantee between suggestion inclusion and
+/// order-engine acceptance.
+library;
+
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+const recruitWorkerTestRegionId = 'oldWorld';
+const recruitWorkerTestProvinceId = '$recruitWorkerTestRegionId|P1';
+
+final recruitWorkerTestTopology = MapTopology(
+  nodes: const [
+    TopologyNode(
+      id: 'P1',
+      regionId: recruitWorkerTestRegionId,
+      type: TopologyNodeType.province,
+    ),
+  ],
+  edges: const [],
+);
+
+/// Builds a single-province game owned by [player] in Orders phase.
+Game recruitWorkerTestGameWith({required Player player}) => Game(
+  id: 'g',
+  worldState: WorldState(
+    turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+    oldWorld: RegionData(
+      provinces: [
+        Province(
+          id: recruitWorkerTestProvinceId,
+          regionId: recruitWorkerTestRegionId,
+          ownerId: player.id,
+        ),
+      ],
+    ),
+    newWorld: const RegionData(),
+  ),
+  players: [player],
+);
+
+/// Builds the canonical [PlayerView] for [playerId] in [game].
+PlayerView recruitWorkerTestViewFor(Game game, String playerId) =>
+    buildPlayerView(game, recruitWorkerTestTopology, playerId);
+
+/// Round-trips [candidate] through `OrderEngine.addRecruitWorkerOrderWithContext`
+/// (initialized with [currentOrders]) for the SPEC equivalence assertion.
+bool recruitWorkerTestEngineAccepts(
+  Game game,
+  Orders currentOrders,
+  String playerId,
+  RecruitWorkerOrder candidate,
+) {
+  final engine = OrderEngine(initialOrders: currentOrders);
+  final result = engine.addRecruitWorkerOrderWithContext(
+    game,
+    recruitWorkerTestTopology,
+    playerId,
+    candidate,
+  );
+  return result.isAccepted;
+}
+
+const recruitWorkerTestAllTiers = WorkerTier.values;


### PR DESCRIPTION
## Summary

Add the **worker recruit / train** suggestion family to
`OrderSuggestionAPI` per
**SPEC/program/order-suggestions.md § Recruit worker orders**, the next
slice of issue #2692 after S5 (#2709) merged.

`suggestRecruitWorkerOrders(view, game, topology, currentOrders)` returns
the affordable, valid `RecruitWorkerOrder` candidates for the active
player, one probed per `WorkerTier`. Each candidate is validated through
the same `RecruitWorkerOrderValidator` chain the order engine uses in
the recruit worker sub-phase: existing recruit orders in `currentOrders`
are replayed against the player's `WorkerPool` / `Stockpile` /
`treasury` snapshot so the candidate sees the post-prefix peasant
reservation ledger
([workers-and-population.md](../../SPEC/game/workers-and-population.md)
§ Peasant reservation, Recruiting / Training / Disbanding).

This unlocks the **recruitment planner** integration (#2692 S8 /
#2509 phase planners) without changing live AI behavior in this PR — no
caller emits these suggestions yet. Carries **zero behavior change** for
human or AI play; the API surface is now ready for the planner slice.

## Done in this PR

### `suggestRecruitWorkerOrders` — top-level function

- New `packages/colonizethis_logic/lib/src/orders/order_suggestion_recruit_worker.dart`:
  - `suggestRecruitWorkerOrders` enumerates `WorkerTier.values` and
    keeps every candidate that the incremental validator accepts.
  - `isRecruitWorkerOrderAcceptedWithValidator(validator, candidate)` /
    `isRecruitWorkerOrderAccepted(...)` — symmetric helpers matching
    the existing `is*OrderAcceptedWithValidator` family.
- Output is sorted by `WorkerTier.index` (peasant -> apprentice ->
  journeyman -> master) for determinism (SPEC § Determinism).

### `IncrementalCandidateValidator.isRecruitWorkerAccepted`

- New per-validator cached prefix replay
  (`_cachedPostRecruitWorkerPrefixEconomy`,
  `_cachedRecruitWorkerPrefixReplaySucceeded`) using
  `RecruitWorkerOrderValidator.withProjectedEconomy` so each candidate
  probe pays per-suggestion-pass setup once.
- Mirrors the order-engine recruit worker phase behavior so the
  incremental decision matches `OrderEngine(initialOrders: basePrefix)
  .addRecruitWorkerOrderWithContext(...)` (SPEC § Incremental candidate
  validation, equivalence guarantee).

### Wiring

- `OrderSuggestionAPI` interface: `suggestRecruitWorkerOrders`.
- `DefaultOrderSuggestionAPI` impl forwards to the new top-level
  function with the standard `logicLog.d` trace line.
- `colonizethis_ai` test fake `FakeOrderSuggestionAPIForDomainPlannerTests`
  gets a matching `recruitWorker` field + override so existing AI
  domain-planner tests keep compiling under the extended interface.

### SPEC

- `SPEC/program/order-suggestions.md`:
  - Top-of-file Responsibility line lists the new family.
  - New rule bullet under § Rules describing recruit worker semantics
    (4 candidate tiers, prefix replay, peasant reservation,
    deterministic ordering).
  - **Acceptance criteria (recruit worker suggestions)** — four
    GIVEN/WHEN/THEN ACs covering positive inclusion (apprentice
    affordability), tech-locked exclusion, treasury / stockpile
    insufficiency exclusion, peasant-reservation drain, and
    engine round-trip parity / sorted output.
  - New AC bullet under § Incremental candidate validation
    confirming the equivalence guarantee for `RecruitWorkerOrder`
    candidates.

## Tests

Test coverage for `suggestRecruitWorkerOrders` is split across three
files in `packages/colonizethis_logic/test/` to stay under the
`repo.logic_test_file_size` 400 physical-line ceiling. Same **9 cases**
in total; no test logic was changed by the split.

- `order_suggestion_recruit_worker_test_support.dart` — shared topology,
  single-province game / view fixtures, and the
  `OrderEngine.addRecruitWorkerOrderWithContext` round-trip helper
  (matches the existing `*_test_support.dart` convention used elsewhere
  under the same `test/` tree).
- `order_suggestion_recruit_worker_test.dart` — per-tier positive /
  negative inclusion (**5 cases**):
  - Peasant + apprentice positive inclusion when fabric / treasury /
    paper / apprentice tech all support the cost rows.
  - Negative tech-locked exclusion for trained tiers (parity with
    engine reject).
  - Negative fabric-insufficient exclusion for peasant.
  - Negative treasury-insufficient exclusion for apprentice.
  - Negative peasant-empty exclusion for apprentice.
- `order_suggestion_recruit_worker_parity_test.dart` — ordering,
  reservation, engine round-trip parity (**4 cases**):
  - Positive all-four-tiers inclusion + ordering pin (peasant ->
    apprentice -> journeyman -> master).
  - **Peasant reservation:** pending apprentice in `currentOrders`
    drains the only peasant; the new candidate apprentice is excluded
    while peasant recruit (no consume) remains.
  - **Engine round-trip parity:** for every `WorkerTier`, suggestion
    inclusion matches `addRecruitWorkerOrderWithContext` accept/reject
    decision (SPEC equivalence guarantee).
  - Empty-resources fixture: no suggestions and engine rejects every
    tier candidate.

Smoke pin (`suggestRecruitWorkerOrders` returns the expected list type)
+ peasant-affordability inclusion test through the public
`DefaultOrderSuggestionAPI` live in
`order_suggestion_api_impl_test.dart`.

### Test plan (commands run)

- [x] `dart analyze` on the touched files in `colonizethis_logic` —
  `No issues found!`
- [x] `dart test packages/colonizethis_logic/test/order_suggestion_recruit_worker_test.dart packages/colonizethis_logic/test/order_suggestion_recruit_worker_parity_test.dart`
  — **9 passed** (5 + 4).
- [x] `dart test packages/colonizethis_logic/test/order_suggestion_api_impl_test.dart`
  — **11 passed** (10 prior + 1 new).
- [x] `dart test packages/colonizethis_logic` (full package suite) —
  **1781 passed** (zero new failures).
- [x] `dart test packages/colonizethis_ai` (full package suite, since
  the test fake API was extended) — **718 passed, 2 skipped**.
- [x] `dart run tool/ct_repo_lint.dart` (full repo lint) — **47/47
  rules passed** including `repo.logic_test_file_size`.

## Acceptance criteria coverage (issue #2692)

This PR satisfies issue **§12 Suggestion API** (`Extend
OrderSuggestionAPI with suggestRecruitWorkerOrders(...) returning
List<RecruitWorkerOrder>`) and the matching SPEC ACs in
`SPEC/program/order-suggestions.md` § Acceptance criteria (recruit
worker suggestions). It is a **pre-requisite** for issue AC #6 (Full AI
DEVELOP-phase recruitment planner emits worker orders **via the
OrderSuggestionAPI.suggestRecruitWorkerOrders path**), which lands as
the planner integration in S8.

## Deferred for #2692 (out of scope for this PR)

- **S6** Production panel Labour UI + disband control + orders
  persistence.
- **S8** Recruitment planner (workers + regiments + ships) and
  phase-planner integration; per the issue body the planner consumes
  this API and applies the soft luxury cap rule.
- **S9** Additional logic / preview / UI helper / AI determinism tests
  beyond the suggestion-API surface tested here.
- **S10a / S10** Observer trace metric definition and the nightly
  workforce gate.

Refs #2692

Tracked by #2692

Made with [Cursor](https://cursor.com)
