### PR TITLE
feat(ai): runRecruitmentPlanner unified worker/build planner (Refs #2692 S8)

### DIFF
--- a/SPEC/ai/economy-planner.md
+++ b/SPEC/ai/economy-planner.md
@@ -100,6 +100,82 @@ Naval planner and build planner consume this preference; the economy planner onl
 
 ---
 
+## Recruitment planner
+
+The recruitment planner unifies worker recruit / train, regiment build, and ship build decisions for one AI-controlled Great Power per turn. It enforces peasant reservation across all peasant-consuming candidates and the luxury soft cap for trained tiers per [workers-and-population.md](../game/workers-and-population.md). Refs #2692 S8.
+
+### Interface (stable contract)
+
+```dart
+RecruitmentPlan runRecruitmentPlanner({
+  required Game game,
+  required PlayerView view,
+  required Orders currentOrders,
+  required AIConfig config,
+  required AISeedBundle seeds,
+  required ObserverGoalPhase goalPhase,
+  required OrderSuggestionAPI suggestionApi,
+  EconomyPlan? economyPlanHint,
+});
+
+class RecruitmentPlan {
+  final List<RecruitWorkerOrder> recruitOrders;
+  final List<BuildUnitOrder> buildUnitOrders;
+  final List<RejectedRecruitmentSuggestion> rejected;
+}
+
+class RejectedRecruitmentSuggestion {
+  /// One of: `Insufficient workers`, `Soft luxury cap exceeded`.
+  final String reason;
+  /// `WorkerTier.name` for recruit candidates; `BuildUnitOrder.unitType` for builds.
+  final String targetTier;
+}
+```
+
+The signature is **stable across #2509 orchestrator changes**: phase planners (`expand_phase_planner`, `colonial_phase_planner`, `develop_phase_planner`) are the only callers and pass their resolved `ObserverGoalPhase` directly. Algorithm internals may evolve; the public surface above must not.
+
+### Inputs
+
+- `suggestionApi` — emitted orders MUST come from `suggestionApi.suggestRecruitWorkerOrders(...)` and `suggestionApi.suggestBuildOrders(...)`. The planner does not re-validate; it filters the pre-validated candidates by planner-side rules.
+- `currentOrders` — same `Orders` passed to the suggestion API. Pending recruit / military / naval build orders are counted toward the peasant reservation ledger.
+- `goalPhase` — observer-derived phase (`expand`, `colonialLite`, `colonial`, `develop`) selects the emit-order weighting (military builds first in EXPAND / COLONIAL-lite / COLONIAL; recruit / train first in DEVELOP).
+- `economyPlanHint` (optional) — last-turn or projected `EconomyPlan` for the same player. When provided, the planner adds the projected luxury-commodity output (refinedSugar / cigars / furHats) from `productionAssignments` to the sustainable-trained-count denominator.
+
+### Rules
+
+- **Peasant reservation.** Let
+  - `pendingConsumes = (recruit orders in currentOrders that consume a peasant) + (military and naval builds in currentOrders)`
+  - `availablePeasants = view.player.workerPool.peasants − pendingConsumes − sum(this plan's accepted peasant-consuming emissions)`.
+
+  Civilian builds do not consume peasants. Any candidate that would push `availablePeasants` below `0` is dropped into `rejected` with reason `Insufficient workers` and is **not** emitted in `recruitOrders` / `buildUnitOrders`.
+
+- **Soft luxury cap (Requirement #10).** For each trained tier T ∈ {apprentice, journeyman, master}:
+  - `sustainableTrainedCount[T] = stockpile[T-luxury] + projectedOutputThisTurn[T-luxury]` where luxury commodity ids are apprentice → `refinedSugar`, journeyman → `cigars`, master → `furHats`. `projectedOutputThisTurn` is read from `economyPlanHint.productionAssignments` (per-recipe `assignedLabour` → integer runs of the recipe that produces the luxury) when `economyPlanHint` is non-null; otherwise it is `0`.
+  - `deficit = effectiveLabour < targetRecipesLabour × 0.8` where `effectiveLabour = effectiveLabourForWorkers(...)` (current `WorkerPool` + `Stockpile`) and `targetRecipesLabour = sum(assignedLabour) over economyPlanHint.productionAssignments` (or `0` when the hint is null).
+  - `projectedTrainedCount[T] = view.player.workerPool.tierCount(T) + emittedSoFar[T]`.
+  - When `deficit == false`, reject any candidate that would push `projectedTrainedCount[T] > sustainableTrainedCount[T]`.
+  - When `deficit == true`, reject only when `projectedTrainedCount[T] > 1.2 × sustainableTrainedCount[T]` (integer multiplication after rounding `floor`). Above the `1.2 ×` cap, the planner MUST NOT emit further recruit or train orders for that tier this turn (Requirement #10).
+
+  Rejected candidates appear in `rejected` with reason `Soft luxury cap exceeded`. Peasant recruit candidates are not gated by the soft cap.
+
+- **Emit order.** For `goalPhase == develop`, recruit / train candidates are processed before build candidates so trained-tier recruiting wins the peasant budget. For `goalPhase ∈ {expand, colonialLite, colonial}`, build candidates are processed before recruit candidates so military / naval rebuilds win the peasant budget. Within each step, candidates are iterated in the order returned by the suggestion API (deterministic per `SPEC/program/order-suggestions.md` § Rules).
+
+- **Determinism.** Same `(game, view, currentOrders, config, seeds, goalPhase, suggestionApi candidate outputs, economyPlanHint)` MUST produce the same `RecruitmentPlan` (same `recruitOrders`, `buildUnitOrders`, and `rejected` lists in the same order).
+
+- **Suggestion API integration.** Emitted orders MUST be drawn from the suggestion API outputs. The planner MUST NOT manufacture a `RecruitWorkerOrder` or `BuildUnitOrder` that did not come from `suggestionApi.suggestRecruitWorkerOrders(...)` / `suggestionApi.suggestBuildOrders(...)` for the same `(view, game, topology, currentOrders)`.
+
+### Acceptance criteria
+
+- **AC-RP-1 (Peasant reservation).** Given an AI-controlled Great Power player whose `workerPool.peasants == P` and `currentOrders` already consume `C` peasants (recruit train rows + military / naval builds) such that `P − C == 0`, when the recruitment planner runs with a suggestion API that returns one peasant-consuming recruit candidate and one regiment build candidate, then the resulting `RecruitmentPlan.recruitOrders` and `RecruitmentPlan.buildUnitOrders` contain no peasant-consuming entries and both candidates appear in `RecruitmentPlan.rejected` with reason `Insufficient workers`.
+
+- **AC-RP-2 (Soft cap below sustainable).** Given an AI-controlled Great Power player with `effectiveLabour ≥ targetRecipesLabour × 0.8` (no deficit), `workerPool.apprentices == 0`, and `sustainableTrainedCount[apprentice] == 0`, when the recruitment planner runs with a suggestion API that returns an `apprentice` recruit candidate, then `recruitOrders` contains no apprentice entry and the candidate appears in `rejected` with reason `Soft luxury cap exceeded`.
+
+- **AC-RP-3 (Soft cap deficit override).** Given an AI-controlled Great Power player with `effectiveLabour < targetRecipesLabour × 0.8` (deficit), `workerPool.journeymen == 1`, `sustainableTrainedCount[journeyman] == 1` (so `1.2 × 1 == 1` floor), and a `journeyman` recruit candidate from the suggestion API, then `recruitOrders` contains no journeyman entry (the deficit allows projected `2 > 1` cap of `1`, then rounds to `1`) and the candidate appears in `rejected` with reason `Soft luxury cap exceeded`.
+
+- **AC-RP-4 (Deterministic).** Given identical `(game, view, currentOrders, config, seeds, goalPhase, suggestionApi candidate outputs, economyPlanHint)`, when the recruitment planner runs twice, then both returned `RecruitmentPlan` instances have identical `recruitOrders`, `buildUnitOrders`, and `rejected` lists in the same order.
+
+- **AC-RP-5 (Emit order by phase).** Given an AI-controlled Great Power player with `workerPool.peasants == 1`, no `currentOrders` peasant consumes, a suggestion API that returns one peasant-consuming recruit candidate (`apprentice`) and one military build candidate within budget, when `goalPhase == ObserverGoalPhase.develop`, then `recruitOrders` contains the apprentice entry and `buildUnitOrders` is empty; when `goalPhase == ObserverGoalPhase.expand`, then `buildUnitOrders` contains the military entry and `recruitOrders` is empty.
+
 ## Interactions
 
 - [ai-architecture.md](ai-architecture.md) — turn pipeline, domain planning
@@ -108,3 +184,5 @@ Naval planner and build planner consume this preference; the economy planner onl
 - [ai-systems-impl.md](../program/ai-systems-impl.md) — module boundaries, who calls the planner
 - [ai-planner.md](../program/ai-planner.md) — seeding, control rules
 - [turn-resolution-phases.md](../program/turn-resolution-phases.md) — Production phase, per-player assignments
+- [order-suggestions.md](../program/order-suggestions.md) — `suggestRecruitWorkerOrders` and `suggestBuildOrders` (recruitment planner inputs)
+- [workers-and-population.md](../game/workers-and-population.md) — recruit / train cost table, peasant reservation, tech gates

--- a/packages/colonizethis_ai/lib/colonizethis_ai.dart
+++ b/packages/colonizethis_ai/lib/colonizethis_ai.dart
@@ -18,6 +18,14 @@ export 'src/planning/diplomacy_planner.dart';
 export 'src/planning/economy_planner.dart';
 export 'src/planning/full_ai_planner.dart';
 export 'src/planning/goal_manager.dart';
+export 'src/planning/observer_goal_phase.dart' show ObserverGoalPhase;
+export 'src/planning/recruitment_planner.dart'
+    show
+        RecruitmentPlan,
+        RejectedRecruitmentSuggestion,
+        kRecruitmentRejectInsufficientWorkers,
+        kRecruitmentRejectSoftLuxuryCap,
+        runRecruitmentPlanner;
 export 'src/social/hidden_agenda.dart';
 export 'src/util/ai_validation_exception.dart';
 export 'src/social/mood_state_machine.dart';

--- a/packages/colonizethis_ai/lib/src/planning/recruitment_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/recruitment_planner.dart
@@ -1,0 +1,428 @@
+// Recruitment planner: unified worker recruit/train + regiment/ship build
+// decisions for one AI-controlled Great Power per turn. SPEC/ai/economy-planner.md
+// § Recruitment planner. Refs #2692 S8.
+
+import 'package:colonizethis_logic/order_suggestion_api.dart';
+
+import 'observer_goal_phase.dart';
+import 'planning_imports.dart';
+
+final _log = packageLogger('recruitment_planner');
+
+/// Result of the recruitment planner.
+///
+/// Spec: SPEC/ai/economy-planner.md § Recruitment planner (Refs #2692 S8).
+class RecruitmentPlan {
+  const RecruitmentPlan({
+    required this.recruitOrders,
+    required this.buildUnitOrders,
+    required this.rejected,
+  });
+
+  /// Empty plan returned when the player view is missing or both candidate
+  /// lists are empty after planner-side filtering.
+  static const RecruitmentPlan empty = RecruitmentPlan(
+    recruitOrders: [],
+    buildUnitOrders: [],
+    rejected: [],
+  );
+
+  /// Recruit / train orders the planner has decided to emit this turn.
+  /// Drawn from `OrderSuggestionAPI.suggestRecruitWorkerOrders` only.
+  final List<RecruitWorkerOrder> recruitOrders;
+
+  /// Build (regiment + ship) orders the planner has decided to emit this turn.
+  /// Drawn from `OrderSuggestionAPI.suggestBuildOrders` only.
+  final List<BuildUnitOrder> buildUnitOrders;
+
+  /// Candidates dropped by planner-side rules (peasant reservation or soft
+  /// luxury cap). Order is stable for the same inputs.
+  final List<RejectedRecruitmentSuggestion> rejected;
+}
+
+/// Stable rejection reason: candidate would exceed the peasant reservation
+/// ledger including pending consumes from `currentOrders` and accepted
+/// emissions earlier in this plan.
+const String kRecruitmentRejectInsufficientWorkers = 'Insufficient workers';
+
+/// Stable rejection reason: candidate would push the trained-tier count
+/// above the (deficit-aware) soft luxury cap defined in
+/// `SPEC/game/workers-and-population.md` Requirement #10.
+const String kRecruitmentRejectSoftLuxuryCap = 'Soft luxury cap exceeded';
+
+/// One dropped candidate from [runRecruitmentPlanner]. Refs #2692 S8.
+class RejectedRecruitmentSuggestion {
+  const RejectedRecruitmentSuggestion({
+    required this.reason,
+    required this.targetTier,
+  });
+
+  /// Stable reason token. One of
+  /// [kRecruitmentRejectInsufficientWorkers] or
+  /// [kRecruitmentRejectSoftLuxuryCap].
+  final String reason;
+
+  /// For recruit candidates: `WorkerTier.name`.
+  /// For build candidates: `BuildUnitOrder.unitType`.
+  final String targetTier;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RejectedRecruitmentSuggestion &&
+          reason == other.reason &&
+          targetTier == other.targetTier;
+
+  @override
+  int get hashCode => Object.hash(reason, targetTier);
+
+  @override
+  String toString() =>
+      'RejectedRecruitmentSuggestion(reason: $reason, tier: $targetTier)';
+}
+
+/// Plans worker recruit / train, regiment builds, and ship builds for one
+/// AI-controlled player on one turn. Deterministic given inputs.
+///
+/// Contract (stable across #2509 orchestrator changes; Refs #2692 §20):
+///
+/// - Emitted orders MUST come from `suggestionApi.suggestRecruitWorkerOrders`
+///   / `suggestionApi.suggestBuildOrders` for the same
+///   `(view, game, currentOrders)`. The planner does not re-validate.
+/// - Peasant reservation: `availablePeasants = pool.peasants − pending
+///   consumes − accepted peasant-consuming emissions in this plan`. Civilian
+///   builds do not consume peasants. Over-budget candidates are dropped into
+///   [RecruitmentPlan.rejected] with reason
+///   [kRecruitmentRejectInsufficientWorkers].
+/// - Soft luxury cap (SPEC/game/workers-and-population.md §10): for trained
+///   tier T (apprentice / journeyman / master), reject when projected count
+///   exceeds `sustainableTrainedCount[T]` (no-deficit) or `1.2 ×
+///   sustainableTrainedCount[T]` (deficit). Above `1.2 ×` the planner MUST
+///   NOT emit further recruit / train orders for that tier this turn.
+/// - Emit order by [goalPhase]: DEVELOP processes recruit / train candidates
+///   first; EXPAND / COLONIAL-lite / COLONIAL process build candidates first.
+///   Within each step, candidates are iterated in suggestion-API order
+///   (deterministic per SPEC/program/order-suggestions.md).
+RecruitmentPlan runRecruitmentPlanner({
+  required Game game,
+  required PlayerView view,
+  required Orders currentOrders,
+  required AIConfig config,
+  required AISeedBundle seeds,
+  required ObserverGoalPhase goalPhase,
+  required OrderSuggestionAPI suggestionApi,
+  MapTopology? topology,
+  EconomyPlan? economyPlanHint,
+}) {
+  final playerId = view.playerId;
+  final player = game.playerById(playerId);
+  if (player == null) {
+    _log.w('no player for $playerId');
+    return RecruitmentPlan.empty;
+  }
+
+  final mapTopology = topology ?? const MapTopology(nodes: [], edges: []);
+
+  final recruitCandidates = suggestionApi.suggestRecruitWorkerOrders(
+    view,
+    game,
+    mapTopology,
+    currentOrders,
+  );
+  final buildCandidates = suggestionApi.suggestBuildOrders(
+    view,
+    game,
+    mapTopology,
+    currentOrders,
+  );
+
+  final state = _PlanState(
+    workerPool: player.workerPool,
+    stockpile: player.stockpile,
+    pendingPeasantConsumes: _pendingPeasantConsumes(currentOrders, playerId),
+    sustainable: _sustainableTrainedCounts(
+      stockpile: player.stockpile,
+      economyPlanHint: economyPlanHint,
+    ),
+    inDeficit: _isLabourDeficit(
+      player: player,
+      economyPlanHint: economyPlanHint,
+    ),
+  );
+
+  final recruitOrders = <RecruitWorkerOrder>[];
+  final buildUnitOrders = <BuildUnitOrder>[];
+  final rejected = <RejectedRecruitmentSuggestion>[];
+
+  void processRecruit() {
+    for (final candidate in recruitCandidates) {
+      final outcome = _evaluateRecruitCandidate(candidate, state);
+      switch (outcome) {
+        case _CandidateOutcome.accepted:
+          recruitOrders.add(candidate);
+          state.applyRecruit(candidate);
+        case _CandidateOutcome.rejectedInsufficientWorkers:
+          rejected.add(
+            RejectedRecruitmentSuggestion(
+              reason: kRecruitmentRejectInsufficientWorkers,
+              targetTier: candidate.targetTier.name,
+            ),
+          );
+        case _CandidateOutcome.rejectedSoftCap:
+          rejected.add(
+            RejectedRecruitmentSuggestion(
+              reason: kRecruitmentRejectSoftLuxuryCap,
+              targetTier: candidate.targetTier.name,
+            ),
+          );
+      }
+    }
+  }
+
+  void processBuilds() {
+    for (final candidate in buildCandidates) {
+      final outcome = _evaluateBuildCandidate(candidate, state);
+      switch (outcome) {
+        case _CandidateOutcome.accepted:
+          buildUnitOrders.add(candidate);
+          state.applyBuild(candidate);
+        case _CandidateOutcome.rejectedInsufficientWorkers:
+          rejected.add(
+            RejectedRecruitmentSuggestion(
+              reason: kRecruitmentRejectInsufficientWorkers,
+              targetTier: candidate.unitType,
+            ),
+          );
+        case _CandidateOutcome.rejectedSoftCap:
+          // Builds are not gated by the soft luxury cap; defensive only.
+          rejected.add(
+            RejectedRecruitmentSuggestion(
+              reason: kRecruitmentRejectSoftLuxuryCap,
+              targetTier: candidate.unitType,
+            ),
+          );
+      }
+    }
+  }
+
+  if (goalPhase == ObserverGoalPhase.develop) {
+    processRecruit();
+    processBuilds();
+  } else {
+    processBuilds();
+    processRecruit();
+  }
+
+  _log.d(
+    'recruitment plan playerId=$playerId goalPhase=${goalPhase.name} '
+    'recruit=${recruitOrders.length} build=${buildUnitOrders.length} '
+    'rejected=${rejected.length} seed=${seeds.economySeed} '
+    'personality=${config.personalityId}',
+  );
+
+  return RecruitmentPlan(
+    recruitOrders: List<RecruitWorkerOrder>.unmodifiable(recruitOrders),
+    buildUnitOrders: List<BuildUnitOrder>.unmodifiable(buildUnitOrders),
+    rejected: List<RejectedRecruitmentSuggestion>.unmodifiable(rejected),
+  );
+}
+
+enum _CandidateOutcome {
+  accepted,
+  rejectedInsufficientWorkers,
+  rejectedSoftCap,
+}
+
+/// Mutable per-plan state: tracks peasant ledger plus projected per-tier
+/// emissions for the soft luxury cap rule.
+class _PlanState {
+  _PlanState({
+    required this.workerPool,
+    required this.stockpile,
+    required this.pendingPeasantConsumes,
+    required this.sustainable,
+    required this.inDeficit,
+  });
+
+  final WorkerPool workerPool;
+  final Stockpile stockpile;
+  final int pendingPeasantConsumes;
+  final Map<WorkerTier, int> sustainable;
+  final bool inDeficit;
+
+  int _emittedPeasantConsumes = 0;
+  final Map<WorkerTier, int> _emittedTrainedCount = <WorkerTier, int>{};
+
+  int availablePeasants() =>
+      workerPool.peasants -
+      pendingPeasantConsumes -
+      _emittedPeasantConsumes;
+
+  int projectedTrainedCount(WorkerTier tier) =>
+      _currentTierCount(workerPool, tier) +
+      (_emittedTrainedCount[tier] ?? 0);
+
+  void applyRecruit(RecruitWorkerOrder order) {
+    final row = WorkerActionEconomyCatalog.forTier(order.targetTier);
+    if (row.consumesPeasant) {
+      _emittedPeasantConsumes += 1;
+    }
+    if (order.targetTier != WorkerTier.peasant) {
+      _emittedTrainedCount[order.targetTier] =
+          (_emittedTrainedCount[order.targetTier] ?? 0) + 1;
+    }
+  }
+
+  void applyBuild(BuildUnitOrder order) {
+    if (_buildConsumesPeasant(order)) {
+      _emittedPeasantConsumes += 1;
+    }
+  }
+}
+
+_CandidateOutcome _evaluateRecruitCandidate(
+  RecruitWorkerOrder candidate,
+  _PlanState state,
+) {
+  final row = WorkerActionEconomyCatalog.forTier(candidate.targetTier);
+  if (row.consumesPeasant && state.availablePeasants() < 1) {
+    return _CandidateOutcome.rejectedInsufficientWorkers;
+  }
+  if (candidate.targetTier != WorkerTier.peasant) {
+    final projected = state.projectedTrainedCount(candidate.targetTier) + 1;
+    final sustainable = state.sustainable[candidate.targetTier] ?? 0;
+    final cap = state.inDeficit
+        ? _softLuxuryCapDeficitLimit(sustainable)
+        : sustainable;
+    if (projected > cap) {
+      return _CandidateOutcome.rejectedSoftCap;
+    }
+  }
+  return _CandidateOutcome.accepted;
+}
+
+_CandidateOutcome _evaluateBuildCandidate(
+  BuildUnitOrder candidate,
+  _PlanState state,
+) {
+  if (_buildConsumesPeasant(candidate) && state.availablePeasants() < 1) {
+    return _CandidateOutcome.rejectedInsufficientWorkers;
+  }
+  return _CandidateOutcome.accepted;
+}
+
+/// Integer-floor `1.2 × sustainable` per SPEC/ai/economy-planner.md
+/// § Recruitment planner (Requirement #10).
+int _softLuxuryCapDeficitLimit(int sustainable) {
+  if (sustainable <= 0) return 0;
+  return (sustainable * 12) ~/ 10;
+}
+
+/// True iff `effectiveLabour < targetRecipesLabour × 0.8`. When the hint is
+/// null or carries zero assigned labour, returns `false` (no deficit override).
+bool _isLabourDeficit({
+  required Player player,
+  required EconomyPlan? economyPlanHint,
+}) {
+  if (economyPlanHint == null) return false;
+  final target = _totalAssignedLabour(economyPlanHint);
+  if (target <= 0) return false;
+  final effective = effectiveLabourForWorkers(
+    workers: player.workerPool,
+    stockpile: player.stockpile,
+  );
+  return effective * 10 < target * 8;
+}
+
+int _totalAssignedLabour(EconomyPlan plan) {
+  var total = 0;
+  for (final a in plan.productionAssignments) {
+    total += a.assignedLabour;
+  }
+  return total;
+}
+
+/// Sustainable trained-worker count per tier:
+/// `stockpile[T-luxury] + projectedThisTurnOutput[T-luxury]`. Luxury
+/// commodities: apprentice → refinedSugar, journeyman → cigars, master →
+/// furHats. Projected output comes from the economy plan hint when present;
+/// otherwise it is zero (SPEC/ai/economy-planner.md § Recruitment planner).
+Map<WorkerTier, int> _sustainableTrainedCounts({
+  required Stockpile stockpile,
+  required EconomyPlan? economyPlanHint,
+}) {
+  final projected = _projectedLuxuryOutput(economyPlanHint);
+  return {
+    WorkerTier.apprentice:
+        stockpile.quantityOf(CommodityCatalog.refinedSugar.id) +
+        (projected[CommodityCatalog.refinedSugar.id] ?? 0),
+    WorkerTier.journeyman:
+        stockpile.quantityOf(CommodityCatalog.cigars.id) +
+        (projected[CommodityCatalog.cigars.id] ?? 0),
+    WorkerTier.master:
+        stockpile.quantityOf(CommodityCatalog.furHats.id) +
+        (projected[CommodityCatalog.furHats.id] ?? 0),
+  };
+}
+
+Map<String, int> _projectedLuxuryOutput(EconomyPlan? plan) {
+  if (plan == null) return const {};
+  final out = <String, int>{};
+  for (final assigned in plan.productionAssignments) {
+    final recipe = ProductionRecipesCatalog.byId[assigned.recipeId];
+    if (recipe == null) continue;
+    final outputId = recipe.outputCommodityId;
+    if (outputId != CommodityCatalog.refinedSugar.id &&
+        outputId != CommodityCatalog.cigars.id &&
+        outputId != CommodityCatalog.furHats.id) {
+      continue;
+    }
+    final labourPer = recipe.labourPerOutput;
+    if (labourPer <= 0) continue;
+    final runs = assigned.assignedLabour ~/ labourPer;
+    if (runs <= 0) continue;
+    out[outputId] = (out[outputId] ?? 0) + runs * recipe.outputQuantity;
+  }
+  return out;
+}
+
+int _pendingPeasantConsumes(Orders currentOrders, String playerId) {
+  var count = 0;
+  final recruits =
+      currentOrders.recruitWorkerOrdersByPlayerId[playerId] ??
+      const <RecruitWorkerOrder>[];
+  for (final r in recruits) {
+    final row = WorkerActionEconomyCatalog.forTier(r.targetTier);
+    if (row.consumesPeasant) count += 1;
+  }
+  final builds =
+      currentOrders.buildUnitOrdersByPlayerId[playerId] ??
+      const <BuildUnitOrder>[];
+  for (final b in builds) {
+    if (_buildConsumesPeasant(b)) count += 1;
+  }
+  return count;
+}
+
+/// Military regiments and naval ships consume one peasant per build.
+/// Civilian builds do not. See SPEC/game/workers-and-population.md §
+/// Peasant reservation and SPEC/game/military-units.md /
+/// SPEC/game/ships-and-naval.md.
+bool _buildConsumesPeasant(BuildUnitOrder order) {
+  final category = buildUnitCategoryForUnitType(order.unitType);
+  return category == BuildUnitCategory.military ||
+      category == BuildUnitCategory.naval;
+}
+
+int _currentTierCount(WorkerPool pool, WorkerTier tier) {
+  switch (tier) {
+    case WorkerTier.peasant:
+      return pool.peasants;
+    case WorkerTier.apprentice:
+      return pool.apprentices;
+    case WorkerTier.journeyman:
+      return pool.journeymen;
+    case WorkerTier.master:
+      return pool.masters;
+  }
+}

--- a/packages/colonizethis_ai/test/recruitment_planner_test.dart
+++ b/packages/colonizethis_ai/test/recruitment_planner_test.dart
@@ -1,0 +1,619 @@
+// Tests for runRecruitmentPlanner (Refs #2692 S8). SPEC/ai/economy-planner.md
+// § Recruitment planner. Uses a deterministic fake [OrderSuggestionAPI] so
+// planner-side rules (peasant reservation, soft luxury cap, phase emit order,
+// determinism) are testable independently of the suggestion-validation chain.
+
+import 'package:colonizethis_ai/colonizethis_ai.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+import 'domain_planner_test_fake_api.dart';
+
+const _config = AIConfig(
+  leaderId: 'victoria',
+  personalityId: 'victoria',
+  hiddenAgendaId: 'peacemaker',
+);
+
+const _topology = MapTopology(nodes: [], edges: []);
+
+Game _gameWith(Player player) => Game(
+  id: 'g1',
+  worldState: WorldState(
+    turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+    oldWorld: RegionData(provinces: [], units: []),
+    newWorld: RegionData(provinces: [], units: []),
+  ),
+  players: [player],
+);
+
+OrderSuggestionAPI _fakeApi({
+  List<RecruitWorkerOrder> recruit = const [],
+  List<BuildUnitOrder> build = const [],
+}) {
+  return FakeOrderSuggestionAPIForDomainPlannerTests(
+    work: const [],
+    build: build,
+    move: const [],
+    research: const [],
+    navalMove: const [],
+    navalMission: const [],
+    recruitWorker: recruit,
+  );
+}
+
+void main() {
+  group('runRecruitmentPlanner — peasant reservation (AC-RP-1)', () {
+    test(
+      'drops both candidates when pending consumes already exhaust peasants',
+      () {
+        final game = _gameWith(
+          const Player(
+            id: 'gp1',
+            displayName: 'A',
+            isHuman: false,
+            workerPool: WorkerPool(peasants: 1),
+          ),
+        );
+        final view = buildPlayerView(game, _topology, 'gp1');
+        final currentOrders = const Orders(
+          buildUnitOrdersByPlayerId: {
+            'gp1': [
+              BuildUnitOrder(
+                unitType: 'peasant_levies',
+                isMilitary: true,
+                spawnProvinceId: 'oldWorld|P1',
+              ),
+            ],
+          },
+        );
+        final api = _fakeApi(
+          recruit: const [RecruitWorkerOrder(targetTier: WorkerTier.apprentice)],
+          build: const [
+            BuildUnitOrder(
+              unitType: 'pikemen',
+              isMilitary: true,
+              spawnProvinceId: 'oldWorld|P1',
+            ),
+          ],
+        );
+
+        final plan = runRecruitmentPlanner(
+          game: game,
+          view: view,
+          currentOrders: currentOrders,
+          config: _config,
+          seeds: AISeedBundle.fromTurnSeed(42),
+          goalPhase: ObserverGoalPhase.develop,
+          suggestionApi: api,
+        );
+
+        expect(plan.recruitOrders, isEmpty);
+        expect(plan.buildUnitOrders, isEmpty);
+        expect(plan.rejected, hasLength(2));
+        expect(
+          plan.rejected.every(
+            (r) => r.reason == kRecruitmentRejectInsufficientWorkers,
+          ),
+          isTrue,
+        );
+        final tierLabels = plan.rejected.map((r) => r.targetTier).toSet();
+        expect(tierLabels, containsAll(<String>{'apprentice', 'pikemen'}));
+      },
+    );
+
+    test('peasant recruit consumes no peasant (free to emit)', () {
+      final game = _gameWith(
+        const Player(
+          id: 'gp1',
+          displayName: 'A',
+          isHuman: false,
+          workerPool: WorkerPool(peasants: 0),
+        ),
+      );
+      final view = buildPlayerView(game, _topology, 'gp1');
+      final api = _fakeApi(
+        recruit: const [RecruitWorkerOrder(targetTier: WorkerTier.peasant)],
+      );
+
+      final plan = runRecruitmentPlanner(
+        game: game,
+        view: view,
+        currentOrders: const Orders(),
+        config: _config,
+        seeds: AISeedBundle.fromTurnSeed(7),
+        goalPhase: ObserverGoalPhase.develop,
+        suggestionApi: api,
+      );
+
+      expect(plan.recruitOrders, hasLength(1));
+      expect(plan.recruitOrders.single.targetTier, WorkerTier.peasant);
+      expect(plan.rejected, isEmpty);
+    });
+
+    test(
+      'civilian builds do not draw on peasant budget; trained recruit still '
+      'fits a single peasant',
+      () {
+        final game = _gameWith(
+          const Player(
+            id: 'gp1',
+            displayName: 'A',
+            isHuman: false,
+            workerPool: WorkerPool(peasants: 1, apprentices: 5),
+            stockpile: Stockpile(quantities: {'refinedSugar': 10}),
+          ),
+        );
+        final view = buildPlayerView(game, _topology, 'gp1');
+        final api = _fakeApi(
+          recruit: const [RecruitWorkerOrder(targetTier: WorkerTier.apprentice)],
+          build: const [
+            BuildUnitOrder(
+              unitType: 'builder',
+              isMilitary: false,
+              spawnProvinceId: 'oldWorld|P1',
+            ),
+          ],
+        );
+
+        final plan = runRecruitmentPlanner(
+          game: game,
+          view: view,
+          currentOrders: const Orders(),
+          config: _config,
+          seeds: AISeedBundle.fromTurnSeed(0),
+          goalPhase: ObserverGoalPhase.develop,
+          suggestionApi: api,
+        );
+
+        expect(plan.recruitOrders, hasLength(1));
+        expect(plan.recruitOrders.single.targetTier, WorkerTier.apprentice);
+        expect(plan.buildUnitOrders, hasLength(1));
+        expect(plan.buildUnitOrders.single.unitType, 'builder');
+        expect(plan.rejected, isEmpty);
+      },
+    );
+  });
+
+  group('runRecruitmentPlanner — soft luxury cap', () {
+    test(
+      'AC-RP-2: rejects apprentice when sustainableTrainedCount == 0 and '
+      'no deficit override',
+      () {
+        // sustainable[apprentice] = stockpile.refinedSugar + projected = 0 + 0 = 0
+        // projected after emit = 0 + 1 = 1 > 0 → reject.
+        final game = _gameWith(
+          const Player(
+            id: 'gp1',
+            displayName: 'A',
+            isHuman: false,
+            workerPool: WorkerPool(peasants: 5, apprentices: 0),
+          ),
+        );
+        final view = buildPlayerView(game, _topology, 'gp1');
+        final api = _fakeApi(
+          recruit: const [RecruitWorkerOrder(targetTier: WorkerTier.apprentice)],
+        );
+
+        final plan = runRecruitmentPlanner(
+          game: game,
+          view: view,
+          currentOrders: const Orders(),
+          config: _config,
+          seeds: AISeedBundle.fromTurnSeed(0),
+          goalPhase: ObserverGoalPhase.develop,
+          suggestionApi: api,
+        );
+
+        expect(plan.recruitOrders, isEmpty);
+        expect(plan.rejected, hasLength(1));
+        expect(plan.rejected.single.reason, kRecruitmentRejectSoftLuxuryCap);
+        expect(plan.rejected.single.targetTier, 'apprentice');
+      },
+    );
+
+    test(
+      'AC-RP-3: deficit override caps journeyman recruit at 1.2 × sustainable '
+      '(floor)',
+      () {
+        // sustainable[journeyman] = stockpile.cigars + projected = 1 + 0 = 1.
+        // deficit limit floor(1 * 12 / 10) = 1.
+        // current = 1, projected after one emit = 2 > 1 → reject.
+        final game = _gameWith(
+          const Player(
+            id: 'gp1',
+            displayName: 'A',
+            isHuman: false,
+            workerPool: WorkerPool(peasants: 5, journeymen: 1),
+            stockpile: Stockpile(quantities: {'cigars': 1}),
+          ),
+        );
+        final view = buildPlayerView(game, _topology, 'gp1');
+        final api = _fakeApi(
+          recruit: const [RecruitWorkerOrder(targetTier: WorkerTier.journeyman)],
+        );
+        // Deficit hint: target labour 100, effective labour from workers
+        // (5 peasants × 1 + 1 journeyman × 6 = 11) → 11 × 10 < 100 × 8 → deficit.
+        const hint = EconomyPlan(
+          productionAssignments: [
+            AssignedRecipe(recipeId: 'lumber_from_timber', assignedLabour: 100),
+          ],
+          cargoPreference: CargoPreference.none,
+        );
+
+        final plan = runRecruitmentPlanner(
+          game: game,
+          view: view,
+          currentOrders: const Orders(),
+          config: _config,
+          seeds: AISeedBundle.fromTurnSeed(0),
+          goalPhase: ObserverGoalPhase.develop,
+          suggestionApi: api,
+          economyPlanHint: hint,
+        );
+
+        expect(plan.recruitOrders, isEmpty);
+        expect(plan.rejected, hasLength(1));
+        expect(plan.rejected.single.reason, kRecruitmentRejectSoftLuxuryCap);
+        expect(plan.rejected.single.targetTier, 'journeyman');
+      },
+    );
+
+    test(
+      'accepts apprentice when projected count fits sustainableTrainedCount',
+      () {
+        // sustainable[apprentice] = 3 (stockpile) + 0 (no hint) = 3.
+        // current = 0, projected after one emit = 1 ≤ 3 → accept.
+        final game = _gameWith(
+          const Player(
+            id: 'gp1',
+            displayName: 'A',
+            isHuman: false,
+            workerPool: WorkerPool(peasants: 1, apprentices: 0),
+            stockpile: Stockpile(quantities: {'refinedSugar': 3}),
+          ),
+        );
+        final view = buildPlayerView(game, _topology, 'gp1');
+        final api = _fakeApi(
+          recruit: const [RecruitWorkerOrder(targetTier: WorkerTier.apprentice)],
+        );
+
+        final plan = runRecruitmentPlanner(
+          game: game,
+          view: view,
+          currentOrders: const Orders(),
+          config: _config,
+          seeds: AISeedBundle.fromTurnSeed(0),
+          goalPhase: ObserverGoalPhase.develop,
+          suggestionApi: api,
+        );
+
+        expect(plan.recruitOrders, hasLength(1));
+        expect(plan.recruitOrders.single.targetTier, WorkerTier.apprentice);
+        expect(plan.rejected, isEmpty);
+      },
+    );
+
+    test(
+      'economyPlanHint projected refinedSugar output raises sustainable for '
+      'apprentice tier',
+      () {
+        // sustainable[apprentice] = 0 (stockpile) + 2 (projected: 4 labour at
+        // 2 labour/run × 1 output = 2). projected after one emit = 1 ≤ 2 → accept.
+        final game = _gameWith(
+          const Player(
+            id: 'gp1',
+            displayName: 'A',
+            isHuman: false,
+            workerPool: WorkerPool(peasants: 1, apprentices: 0),
+          ),
+        );
+        final view = buildPlayerView(game, _topology, 'gp1');
+        final api = _fakeApi(
+          recruit: const [RecruitWorkerOrder(targetTier: WorkerTier.apprentice)],
+        );
+        const hint = EconomyPlan(
+          productionAssignments: [
+            AssignedRecipe(
+              recipeId: 'refinedSugar_from_sugarCane',
+              assignedLabour: 4,
+            ),
+          ],
+          cargoPreference: CargoPreference.none,
+        );
+
+        final plan = runRecruitmentPlanner(
+          game: game,
+          view: view,
+          currentOrders: const Orders(),
+          config: _config,
+          seeds: AISeedBundle.fromTurnSeed(0),
+          goalPhase: ObserverGoalPhase.develop,
+          suggestionApi: api,
+          economyPlanHint: hint,
+        );
+
+        expect(plan.recruitOrders, hasLength(1));
+        expect(plan.rejected, isEmpty);
+      },
+    );
+  });
+
+  group('runRecruitmentPlanner — emit order by phase (AC-RP-5)', () {
+    Player playerWithOnePeasant() => const Player(
+      id: 'gp1',
+      displayName: 'A',
+      isHuman: false,
+      workerPool: WorkerPool(peasants: 1, apprentices: 5),
+      stockpile: Stockpile(quantities: {'refinedSugar': 10}),
+    );
+
+    test('DEVELOP processes recruit before build (recruit wins peasant)', () {
+      final game = _gameWith(playerWithOnePeasant());
+      final view = buildPlayerView(game, _topology, 'gp1');
+      final api = _fakeApi(
+        recruit: const [RecruitWorkerOrder(targetTier: WorkerTier.apprentice)],
+        build: const [
+          BuildUnitOrder(
+            unitType: 'peasant_levies',
+            isMilitary: true,
+            spawnProvinceId: 'oldWorld|P1',
+          ),
+        ],
+      );
+
+      final plan = runRecruitmentPlanner(
+        game: game,
+        view: view,
+        currentOrders: const Orders(),
+        config: _config,
+        seeds: AISeedBundle.fromTurnSeed(0),
+        goalPhase: ObserverGoalPhase.develop,
+        suggestionApi: api,
+      );
+
+      expect(plan.recruitOrders, hasLength(1));
+      expect(plan.recruitOrders.single.targetTier, WorkerTier.apprentice);
+      expect(plan.buildUnitOrders, isEmpty);
+      expect(plan.rejected, hasLength(1));
+      expect(plan.rejected.single.reason, kRecruitmentRejectInsufficientWorkers);
+      expect(plan.rejected.single.targetTier, 'peasant_levies');
+    });
+
+    test('EXPAND processes build before recruit (military wins peasant)', () {
+      final game = _gameWith(playerWithOnePeasant());
+      final view = buildPlayerView(game, _topology, 'gp1');
+      final api = _fakeApi(
+        recruit: const [RecruitWorkerOrder(targetTier: WorkerTier.apprentice)],
+        build: const [
+          BuildUnitOrder(
+            unitType: 'peasant_levies',
+            isMilitary: true,
+            spawnProvinceId: 'oldWorld|P1',
+          ),
+        ],
+      );
+
+      final plan = runRecruitmentPlanner(
+        game: game,
+        view: view,
+        currentOrders: const Orders(),
+        config: _config,
+        seeds: AISeedBundle.fromTurnSeed(0),
+        goalPhase: ObserverGoalPhase.expand,
+        suggestionApi: api,
+      );
+
+      expect(plan.buildUnitOrders, hasLength(1));
+      expect(plan.buildUnitOrders.single.unitType, 'peasant_levies');
+      expect(plan.recruitOrders, isEmpty);
+      expect(plan.rejected, hasLength(1));
+      expect(plan.rejected.single.reason, kRecruitmentRejectInsufficientWorkers);
+      expect(plan.rejected.single.targetTier, 'apprentice');
+    });
+
+    test('COLONIAL also processes build before recruit (matches EXPAND)', () {
+      final game = _gameWith(playerWithOnePeasant());
+      final view = buildPlayerView(game, _topology, 'gp1');
+      final api = _fakeApi(
+        recruit: const [RecruitWorkerOrder(targetTier: WorkerTier.apprentice)],
+        build: const [
+          BuildUnitOrder(
+            unitType: 'peasant_levies',
+            isMilitary: true,
+            spawnProvinceId: 'oldWorld|P1',
+          ),
+        ],
+      );
+
+      final plan = runRecruitmentPlanner(
+        game: game,
+        view: view,
+        currentOrders: const Orders(),
+        config: _config,
+        seeds: AISeedBundle.fromTurnSeed(0),
+        goalPhase: ObserverGoalPhase.colonial,
+        suggestionApi: api,
+      );
+
+      expect(plan.buildUnitOrders, hasLength(1));
+      expect(plan.recruitOrders, isEmpty);
+    });
+  });
+
+  group('runRecruitmentPlanner — determinism (AC-RP-4)', () {
+    test('two identical invocations return equal plans', () {
+      final game = _gameWith(
+        const Player(
+          id: 'gp1',
+          displayName: 'A',
+          isHuman: false,
+          workerPool: WorkerPool(peasants: 2, apprentices: 1),
+          stockpile: Stockpile(quantities: {'refinedSugar': 5}),
+        ),
+      );
+      final view = buildPlayerView(game, _topology, 'gp1');
+      final api = _fakeApi(
+        recruit: const [
+          RecruitWorkerOrder(targetTier: WorkerTier.peasant),
+          RecruitWorkerOrder(targetTier: WorkerTier.apprentice),
+        ],
+        build: const [
+          BuildUnitOrder(
+            unitType: 'pikemen',
+            isMilitary: true,
+            spawnProvinceId: 'oldWorld|P1',
+          ),
+        ],
+      );
+
+      final plan1 = runRecruitmentPlanner(
+        game: game,
+        view: view,
+        currentOrders: const Orders(),
+        config: _config,
+        seeds: AISeedBundle.fromTurnSeed(42),
+        goalPhase: ObserverGoalPhase.develop,
+        suggestionApi: api,
+      );
+      final plan2 = runRecruitmentPlanner(
+        game: game,
+        view: view,
+        currentOrders: const Orders(),
+        config: _config,
+        seeds: AISeedBundle.fromTurnSeed(42),
+        goalPhase: ObserverGoalPhase.develop,
+        suggestionApi: api,
+      );
+
+      expect(
+        plan1.recruitOrders.map((o) => o.targetTier).toList(),
+        plan2.recruitOrders.map((o) => o.targetTier).toList(),
+      );
+      expect(
+        plan1.buildUnitOrders.map((o) => o.unitType).toList(),
+        plan2.buildUnitOrders.map((o) => o.unitType).toList(),
+      );
+      expect(plan1.rejected, plan2.rejected);
+    });
+  });
+
+  group('runRecruitmentPlanner — edge cases', () {
+    test('returns empty plan when player view targets unknown player', () {
+      final game = _gameWith(
+        const Player(
+          id: 'gp1',
+          displayName: 'A',
+          isHuman: false,
+          workerPool: WorkerPool(peasants: 1),
+        ),
+      );
+      // Reuse gp1's view but resolve against a game without that player.
+      final view = buildPlayerView(game, _topology, 'gp1');
+      final emptyGame = Game(
+        id: 'empty',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+          oldWorld: RegionData(provinces: [], units: []),
+          newWorld: RegionData(provinces: [], units: []),
+        ),
+        players: const [],
+      );
+      final api = _fakeApi(
+        recruit: const [RecruitWorkerOrder(targetTier: WorkerTier.peasant)],
+      );
+
+      final plan = runRecruitmentPlanner(
+        game: emptyGame,
+        view: view,
+        currentOrders: const Orders(),
+        config: _config,
+        seeds: AISeedBundle.fromTurnSeed(0),
+        goalPhase: ObserverGoalPhase.develop,
+        suggestionApi: api,
+      );
+
+      expect(plan.recruitOrders, isEmpty);
+      expect(plan.buildUnitOrders, isEmpty);
+      expect(plan.rejected, isEmpty);
+    });
+
+    test('returns empty plan when suggestion API returns nothing', () {
+      final game = _gameWith(
+        const Player(
+          id: 'gp1',
+          displayName: 'A',
+          isHuman: false,
+          workerPool: WorkerPool(peasants: 5),
+        ),
+      );
+      final view = buildPlayerView(game, _topology, 'gp1');
+      final api = _fakeApi();
+
+      final plan = runRecruitmentPlanner(
+        game: game,
+        view: view,
+        currentOrders: const Orders(),
+        config: _config,
+        seeds: AISeedBundle.fromTurnSeed(0),
+        goalPhase: ObserverGoalPhase.expand,
+        suggestionApi: api,
+      );
+
+      expect(plan.recruitOrders, isEmpty);
+      expect(plan.buildUnitOrders, isEmpty);
+      expect(plan.rejected, isEmpty);
+    });
+
+    test(
+      'multiple peasant-consuming recruits draw down the budget in order',
+      () {
+        // 3 peasants, no pending consumes. Three recruit candidates:
+        // peasant (free), apprentice (consumes 1), journeyman (consumes 1).
+        // sustainable: refinedSugar=10, cigars=10 → both fit.
+        // Result: all 3 emitted, budget after = 1 peasant remaining.
+        final game = _gameWith(
+          const Player(
+            id: 'gp1',
+            displayName: 'A',
+            isHuman: false,
+            workerPool: WorkerPool(peasants: 3),
+            stockpile: Stockpile(
+              quantities: {'refinedSugar': 10, 'cigars': 10},
+            ),
+          ),
+        );
+        final view = buildPlayerView(game, _topology, 'gp1');
+        final api = _fakeApi(
+          recruit: const [
+            RecruitWorkerOrder(targetTier: WorkerTier.peasant),
+            RecruitWorkerOrder(targetTier: WorkerTier.apprentice),
+            RecruitWorkerOrder(targetTier: WorkerTier.journeyman),
+          ],
+        );
+
+        final plan = runRecruitmentPlanner(
+          game: game,
+          view: view,
+          currentOrders: const Orders(),
+          config: _config,
+          seeds: AISeedBundle.fromTurnSeed(0),
+          goalPhase: ObserverGoalPhase.develop,
+          suggestionApi: api,
+        );
+
+        expect(
+          plan.recruitOrders.map((o) => o.targetTier).toList(),
+          const [
+            WorkerTier.peasant,
+            WorkerTier.apprentice,
+            WorkerTier.journeyman,
+          ],
+        );
+        expect(plan.rejected, isEmpty);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Adds the AI **recruitment planner** for issue #2692 S8: a deterministic
module that filters the union of `OrderSuggestionAPI.suggestRecruitWorkerOrders`
and `suggestBuildOrders` outputs by planner-side rules — **peasant
reservation** across recruit + military/naval builds, and the **soft
luxury cap** from `SPEC/game/workers-and-population.md` Requirement #10.
The planner unifies worker recruit/train, regiment, and ship build
decisions for one AI-controlled Great Power per turn under a **stable
signature** so #2509 phase-planner orchestrator churn cannot break the
integration point (Refs #2692 §20).

The planner is **callable** but not yet wired into any phase planner;
integration belongs in the S8 follow-up slice once #2509 orchestrator
work stabilizes, per the issue body.

## Done on this branch

### SPEC

- `SPEC/ai/economy-planner.md` — new **§ Recruitment planner** section:
  - Stable interface (`runRecruitmentPlanner`, `RecruitmentPlan`,
    `RejectedRecruitmentSuggestion`).
  - Inputs (suggestion API, `currentOrders`, `goalPhase`, optional
    `economyPlanHint`).
  - Rules: peasant reservation
    (`availablePeasants = pool − pending consumes − accepted emissions`,
    civilian builds excluded); soft luxury cap with the concrete §10
    rule (no-deficit: reject above `sustainableTrainedCount[T]`;
    deficit: reject above `floor(1.2 × sustainable)`; above the cap the
    planner MUST NOT emit further recruit/train for that tier this
    turn); emit order by `ObserverGoalPhase` (DEVELOP processes recruit
    first; EXPAND / COLONIAL-lite / COLONIAL process build first);
    determinism; suggestion-API integration constraint.
  - 5 testable Given-When-Then acceptance criteria (AC-RP-1 … AC-RP-5)
    covering peasant reservation, soft cap below sustainable, deficit
    override, determinism, and emit order by phase.

### Code

- `packages/colonizethis_ai/lib/src/planning/recruitment_planner.dart`
  (new, ~430 LOC):
  - `runRecruitmentPlanner({game, view, currentOrders, config, seeds,
    goalPhase, suggestionApi, topology?, economyPlanHint?})` returns
    `RecruitmentPlan` with `recruitOrders`, `buildUnitOrders`,
    `rejected`.
  - Stable rejection reason tokens
    (`kRecruitmentRejectInsufficientWorkers`,
    `kRecruitmentRejectSoftLuxuryCap`).
  - Detects peasant-consuming builds via
    `buildUnitCategoryForUnitType` (`military` or `naval`); civilian
    builds bypass the peasant budget (matches
    `SPEC/game/workers-and-population.md` § Peasant reservation).
  - Computes `sustainableTrainedCount[tier]` from
    `stockpile[T-luxury] + projected refinedSugar/cigars/furHats output`
    derived from `economyPlanHint.productionAssignments` (assignedLabour
    ÷ recipe.labourPerOutput → runs × recipe.outputQuantity).
  - Deficit check uses integer comparison
    `effectiveLabour * 10 < targetRecipesLabour * 8` (no doubles).
  - Integer-floor deficit cap: `(sustainable * 12) ~/ 10`.
- `packages/colonizethis_ai/lib/colonizethis_ai.dart`: narrow
  re-exports for the new types plus `ObserverGoalPhase` so phase-planner
  callers can drive the planner without reaching into `src/`.

### Tests

`packages/colonizethis_ai/test/recruitment_planner_test.dart`
(new, 14 tests, **all passing**):

- **Peasant reservation (AC-RP-1)** —
  - Drops both candidates when `pending consumes == workerPool.peasants`.
  - Peasant recruit consumes no peasant (free to emit).
  - Civilian builds bypass the peasant budget alongside a trained
    recruit.
- **Soft luxury cap** —
  - AC-RP-2: rejects apprentice when `sustainable == 0` and no deficit.
  - AC-RP-3: deficit override caps journeyman at `floor(1.2 × 1) == 1`.
  - Accepts apprentice when projected ≤ sustainable.
  - `economyPlanHint` projected refinedSugar raises the cap for
    apprentice.
- **Emit order by phase (AC-RP-5)** — DEVELOP picks recruit before
  build; EXPAND and COLONIAL pick build before recruit.
- **Determinism (AC-RP-4)** — Two identical invocations return equal
  `recruitOrders`, `buildUnitOrders`, and `rejected` lists.
- **Edge cases** — Missing player returns empty plan; empty suggestion
  API returns empty plan; multi-recruit budget draw-down in declared
  order.

## Tests run

- `dart test packages/colonizethis_ai/test/recruitment_planner_test.dart`
  → **14 passed**.
- `dart test` on `packages/colonizethis_ai` → **732 passed, 2 skipped**
  (the 2 skipped are pre-existing and unrelated; no new failures).
- `dart analyze` on the touched files (planner, package barrel, test,
  SPEC) → `No issues found!`.
- `dart analyze packages/colonizethis_ai` → the 24 pre-existing
  warnings/info entries are unchanged; none are introduced by this PR.

## Deferred for #2692 (out of scope for this PR)

- **S8 (phase planner integration)** — `runRecruitmentPlanner` is
  callable from any planner but no existing phase planner invokes it
  yet. Wiring `expand_phase_planner`, `colonial_phase_planner`, and
  `develop_phase_planner` to call the new planner and route its
  emissions into draft orders is a follow-up slice that needs to land
  alongside #2509 orchestrator stabilization.
- **S6** — Production panel Labour UI + disband + orders persistence
  (Flutter widget work).
- **S9** — Additional integration tests once the orchestrator wiring
  lands.
- **S10a / S10** — observer-trace metric finalization and the nightly
  worker-tier / 15-regiment workforce gate.

## Acceptance criteria coverage (from issue #2692)

This PR delivers the planner contract (Requirements #18, #20) and the
soft luxury cap rule with concrete bounds (Requirement #10) backed by
the new SPEC § Recruitment planner ACs:

- **AC-RP-1 (Peasant reservation)** —
  `runRecruitmentPlanner — peasant reservation` test group.
- **AC-RP-2 (Soft cap below sustainable)** —
  `AC-RP-2: rejects apprentice when sustainableTrainedCount == 0 and
  no deficit override`.
- **AC-RP-3 (Soft cap deficit override at 1.2× floor)** —
  `AC-RP-3: deficit override caps journeyman recruit at 1.2 ×
  sustainable (floor)`.
- **AC-RP-4 (Determinism)** —
  `runRecruitmentPlanner — determinism (AC-RP-4)` test group.
- **AC-RP-5 (Emit order by phase)** —
  `runRecruitmentPlanner — emit order by phase (AC-RP-5)` test group.

Issue-level ACs that depend on planner-orchestrator integration (the
DEVELOP-phase end-to-end AC, AC #7a, and AC #7b) remain deferred to
follow-up slices and are explicitly listed under **Deferred** above.

Refs #2692

Tracked by #2692

Made with [Cursor](https://cursor.com)