### PR TITLE
feat(workers): Production panel Labour UI — recruit/train steppers + disband (Refs #2692 S6)

### DIFF
--- a/SPEC/ui/production-panel.md
+++ b/SPEC/ui/production-panel.md
@@ -68,6 +68,51 @@ Asset filenames and style for commodities and workers appear in [game-toolbar-ic
 - **Breakdown live update:** Given the breakdown dialog is open, when the player changes any allocation (**slider**, **±** steppers, **maximize**, **clear**, or header **Reset**) on the main panel, then phase and total cells refresh to match the new preview without closing the dialog.
 - **Breakdown commodity icons:** Given the breakdown dialog open, when a data row for a commodity renders, then the **Commodity** cell shows a **leading** `ResourceIcon` for that commodity id (16px, 4dp gap before the name) like the Available grid; long names truncate with ellipsis without breaking table layout.
 
+## Labour Controls (12-A)
+
+The Available subpanel's Workers section is extended with **Labour controls** that let the Great Power human player queue worker recruit / train orders and apply immediate disband actions per [workers-and-population.md](../game/workers-and-population.md) § Recruiting, Training, and Disbanding. Controls are visible only when the viewed player is the human-controlled GP and the panel is in editable mode (`canEdit`).
+
+### Per-tier row layout
+
+- One row per [worker tier](../game/workers-and-population.md#worker-tiers) (peasant, apprentice, journeyman, master), rendered immediately below the existing tier count row inside the Workers section, in the same tier order as the count grid.
+- Each row contains, left to right: a **tier label** (reuses `production_workers_*` strings), a **pending counter** (`Queued: N` when `N > 0`, hidden when `N == 0`), a **decrement (−)** stepper, an **increment (+)** stepper, and — for trained tiers (`apprentice`, `journeyman`, `master`) — a **disband** button. Peasant rows have **no** disband control.
+- Stepper icons reuse the same `StrictAssetIcon` size and asset family as the per-recipe allocation steppers (`ui_icon_production_alloc_increment.png`, `ui_icon_production_alloc_decrement.png`). The disband control is a `CtNinePatchButton` with text `Disband` (single localizable string).
+
+### Recruit / train queue semantics
+
+- **+** appends one `RecruitWorkerOrder(targetTier: <tier>)` to the viewed player's slot in `currentOrders.recruitWorkerOrdersByPlayerId`, preserving previously-queued orders (matches `train_unit_dialog_helper.dart` queue model). One stepper press = exactly one order appended.
+- **−** removes the **last** queued `RecruitWorkerOrder` for that tier (LIFO) from the viewed player's slot. Disabled when the per-tier queued count is zero.
+- The Production panel **does not** distinguish "Recruit" from "Train" in the queue; both verbs produce the same `RecruitWorkerOrder` per the worker SPEC § Train. UI may surface separate tooltips per tier (peasant tooltip uses "Recruit"; trained tiers use "Train"), but the underlying order type is identical.
+- Pending queue counts and economy deltas remain reflected in the existing **Net Changes** preview pipeline (`previewStockpileNetDeltaByCommodityForPlayer`), since recruit worker orders are already deducted in the preview sequence per the Behaviour § Net Changes table.
+
+### Affordance rules (per-tier enabled flags)
+
+For each tier `t` and the running peasant ledger `availablePeasants = pool.peasants − sum(pending peasant consumes from all queued recruit worker + queued military / naval build orders for the viewed player, including the candidate order)`:
+
+- **+** is enabled iff **all** of:
+  1. The viewed player has every required tech for tier `t` unlocked (peasant has no tech gate).
+  2. After applying the cumulative cost of all already-queued recruit worker orders + the candidate, the player still affords the cost row (treasury + materials) per `canAffordRecruitWorker`.
+  3. For trained tiers, `availablePeasants ≥ 1` after the candidate is reserved (peasant reservation per workers-and-population.md § Peasant reservation).
+- **−** is enabled iff the per-tier queued count for the viewed player is ≥ 1.
+- **Disband** is enabled iff `pool.<tier>` ≥ 1 (excluding peasant) **and** the panel is in editable mode. Disband acts on the live `WorkerPool`, not on queued orders, so it is independent of the queue counters.
+
+### Disband (immediate)
+
+- Tapping **Disband** for tier `t` immediately decrements `pool.t` by 1 and increments `pool.peasants` by 1 on the viewed player. The mutation does **not** enqueue any order; it is applied to the live `Game` state during the Orders phase exactly as specified in workers-and-population.md § Disband.
+- Disband has **no** treasury, stockpile, or material refund — the cost row is forfeit.
+- After disband, the **+** stepper for the player's available trained tiers immediately reflects the new `availablePeasants` and may become enabled for tiers that were previously blocked by the peasant ledger.
+
+### Acceptance Criteria — Labour Controls
+
+- Given the viewed player is the human Great Power in Orders phase and the panel is editable, when the Workers section renders, then one Labour row appears for each of the four worker tiers in the order peasant → apprentice → journeyman → master, each with **+** / **−** steppers, and trained tiers additionally show a **Disband** control.
+- Given the viewed player has `peasant_workers` tech (none required), `fabric ≥ 2` in the stockpile, and the panel is editable, when the player taps **+** once on the peasant row, then exactly one `RecruitWorkerOrder(targetTier: peasant)` is appended to `currentOrders.recruitWorkerOrdersByPlayerId[viewedPlayer.id]` and the row's `Queued:` counter reads `1`.
+- Given the viewed player has at least one queued `RecruitWorkerOrder(targetTier: apprentice)`, when the player taps **−** on the apprentice row, then exactly one apprentice-tier order is removed (LIFO) from the viewed player's `recruitWorkerOrdersByPlayerId` slot and the queued counter decrements by 1.
+- Given the viewed player does not have all tech ids for tier `t` in `techUnlocked`, when the Workers section renders, then the **+** stepper for tier `t` is disabled and the row label remains visible (no row hidden).
+- Given `pool.peasants = 0` and no pending peasant-producing recruit orders for the viewed player, when the Workers section renders, then the **+** stepper for every trained tier is disabled and the **+** for peasant remains enabled iff fabric ≥ 2.
+- Given `pool.peasants = 2` and the viewed player already has one queued `RecruitWorkerOrder(targetTier: apprentice)` plus one queued `BuildUnitOrder` whose unit type consumes one peasant, when the player attempts a second apprentice **+**, then the **+** stepper for every trained tier is disabled (peasant ledger exhausted by the two pending consumes).
+- Given the viewed player has `pool.journeymen ≥ 1`, when the player taps **Disband** on the journeyman row, then `pool.journeymen` decrements by 1, `pool.peasants` increments by 1, no entry is added to `currentOrders.recruitWorkerOrdersByPlayerId`, and treasury / paper / fabric remain unchanged.
+- Given the panel is in non-editable view (e.g. observe mode), when the Workers section renders, then **+**, **−**, and **Disband** controls do not appear (or are completely disabled and have no effect on tap).
+
 ## Integration
 
 - Shown from the in-game shell (e.g. bottom toolbar). Game screen passes current game and human player; panel reads/writes allocation via app state (e.g. Riverpod provider) so nextTurn can pass `defaultAssignmentsByPlayerId`.

--- a/app/lib/features/game/screens/production_screen.dart
+++ b/app/lib/features/game/screens/production_screen.dart
@@ -15,6 +15,7 @@ import '../shell_player_context.dart';
 import '../widgets/observe_mode_not_defined_panel.dart';
 import '../../../widgets/ct_game_feature_screen_shell.dart';
 import '../widgets/production_commodity_breakdown_dialog.dart';
+import '../widgets/production_labour_helpers.dart';
 import '../widgets/production_panel.dart';
 
 class ProductionScreen extends ConsumerWidget {
@@ -91,11 +92,44 @@ class ProductionScreen extends ConsumerWidget {
               },
             );
         final canEdit = shellRef.read(shellPlayerContextProvider).canMutateViaUi;
+        final labourCallbacks = ProductionLabourCallbacks(
+          onAppendRecruitOrder: (tier) {
+            if (!canEdit) return;
+            final next = ordersWithAppendedRecruitWorkerOrder(
+              currentOrders: shellRef.read(currentOrdersProvider),
+              playerId: displayPlayer.id,
+              tier: tier,
+            );
+            shellRef.read(currentOrdersProvider.notifier).replaceAll(next);
+          },
+          onPopLastRecruitOrder: (tier) {
+            if (!canEdit) return;
+            final next = ordersWithLastRecruitWorkerOrderRemoved(
+              currentOrders: shellRef.read(currentOrdersProvider),
+              playerId: displayPlayer.id,
+              tier: tier,
+            );
+            shellRef.read(currentOrdersProvider.notifier).replaceAll(next);
+          },
+          onDisband: (tier) {
+            if (!canEdit) return;
+            final nextGame = gameWithImmediateDisband(
+              game: shellRef.read(currentGameProvider) ?? displayGame,
+              playerId: displayPlayer.id,
+              tier: tier,
+            );
+            if (nextGame == null) return;
+            shellRef.read(currentGameProvider.notifier).setGame(nextGame);
+          },
+        );
         final productionPanel = ProductionPanel(
           game: displayGame,
           player: displayPlayer,
           desiredOutputByRecipe: desiredOutputByRecipe,
           netDeltasByCommodity: netDeltasByCommodity,
+          currentOrders: currentOrders,
+          labourCallbacks: labourCallbacks,
+          canEditLabour: canEdit,
           onOpenCommodityBreakdown: canEdit
               ? () {
                   showDialog<void>(

--- a/app/lib/features/game/widgets/production_allocation_row.dart
+++ b/app/lib/features/game/widgets/production_allocation_row.dart
@@ -1,0 +1,202 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:flutter/material.dart';
+
+import '../../../l10n/l10n.dart';
+import '../../../widgets/ct_slider.dart';
+import '../production_recipe_affordance.dart';
+import 'production_allocation_mutations.dart';
+import 'production_allocation_row_buttons.dart';
+
+const _uiIconProductionAllocDecrement =
+    'ui_icon_production_alloc_decrement.png';
+const _uiIconProductionAllocIncrement =
+    'ui_icon_production_alloc_increment.png';
+const _uiIconProductionAllocMaximize = 'ui_icon_production_alloc_maximize.png';
+const _uiIconProductionAllocClear = 'ui_icon_production_alloc_clear.png';
+
+/// One row in the Production allocation list: recipe label + affordance,
+/// slider, and the four step/action buttons. Extracted from
+/// `production_panel.dart` so `_AvailableSubpanel` and `_AllocationSubpanel`
+/// stay within the `app/lib/features/game/widgets` file-size budget.
+class ProductionAllocationRow extends StatelessWidget {
+  const ProductionAllocationRow({
+    super.key,
+    required this.recipe,
+    required this.player,
+    required this.effectiveLabour,
+    required this.desiredOutputByRecipe,
+    required this.onDesiredOutputChanged,
+    required this.buildRecipeLabel,
+    required this.l10n,
+    required this.theme,
+  });
+
+  final ProductionRecipe recipe;
+  final Player player;
+  final int effectiveLabour;
+  final Map<String, int> desiredOutputByRecipe;
+  final ValueChanged<Map<String, int>> onDesiredOutputChanged;
+  final Widget Function(ProductionRecipe recipe) buildRecipeLabel;
+  final AppLocalizations l10n;
+  final ThemeData theme;
+
+  int get _desired => desiredOutputByRecipe[recipe.id] ?? 0;
+
+  RecipeAffordance get _affordance => computeRecipeAffordance(
+    recipe: recipe,
+    stockpile: player.stockpile,
+    desiredOutputByRecipe: desiredOutputByRecipe,
+    effectiveLabour: effectiveLabour,
+  );
+
+  bool get _comfortHeadroom => recipeAllocationComfortHeadroomActive(
+    recipe: recipe,
+    desiredOutput: _desired,
+    maxDesiredOutput: _affordance.maxDesiredOutput,
+    stockpile: player.stockpile,
+    desiredOutputByRecipe: desiredOutputByRecipe,
+    effectiveLabour: effectiveLabour,
+  );
+
+  Widget _buildSlider(int maxAchievable) {
+    final sliderMax = maxAchievable == 0
+        ? 0.0
+        : maxAchievable.clamp(1, kProductionAllocationSliderCap).toDouble();
+    return CtSlider(
+      value: _desired.clamp(0, maxAchievable).toDouble(),
+      min: 0,
+      max: sliderMax,
+      divisions: maxAchievable == 0
+          ? 1
+          : maxAchievable.clamp(1, kProductionAllocationSliderCap),
+      comfortHeadroomActive: _comfortHeadroom,
+      onChanged: (value) {
+        final next = Map<String, int>.from(desiredOutputByRecipe);
+        final rounded = value.round().clamp(0, maxAchievable);
+        if (rounded == 0) {
+          next.remove(recipe.id);
+        } else {
+          next[recipe.id] = rounded;
+        }
+        onDesiredOutputChanged(next);
+      },
+    );
+  }
+
+  Widget _buildActionButtons(int maxAchievable) {
+    final canDecrement = _desired > 0;
+    final canIncrement = maxAchievable > 0 && _desired < maxAchievable;
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        SizedBox(
+          width: 30,
+          child: Text(
+            _desired.toString(),
+            textAlign: TextAlign.right,
+            style: theme.textTheme.bodySmall,
+          ),
+        ),
+        ProductionAllocationStepButton(
+          enabled: canDecrement,
+          readDesired: () => desiredOutputByRecipe,
+          tryStepFromCurrent: (cur) => applyProductionRecipeDecrement(
+            recipe: recipe,
+            player: player,
+            effectiveLabour: effectiveLabour,
+            current: cur,
+            onDesiredOutputChanged: onDesiredOutputChanged,
+          ),
+          semanticLabel: l10n.production_allocationDecrementRecipe,
+          tooltip: l10n.production_allocationDecrementRecipe,
+          assetFileName: _uiIconProductionAllocDecrement,
+        ),
+        ProductionAllocationStepButton(
+          enabled: canIncrement,
+          readDesired: () => desiredOutputByRecipe,
+          tryStepFromCurrent: (cur) => applyProductionRecipeIncrement(
+            recipe: recipe,
+            player: player,
+            effectiveLabour: effectiveLabour,
+            current: cur,
+            onDesiredOutputChanged: onDesiredOutputChanged,
+          ),
+          semanticLabel: l10n.production_allocationIncrementRecipe,
+          tooltip: l10n.production_allocationIncrementRecipe,
+          assetFileName: _uiIconProductionAllocIncrement,
+        ),
+        ProductionAllocationActionIconButton(
+          enabled: canIncrement,
+          readDesired: () => desiredOutputByRecipe,
+          onPressedFromCurrent: (cur) => applyProductionRecipeMaximize(
+            recipe: recipe,
+            player: player,
+            effectiveLabour: effectiveLabour,
+            current: cur,
+            onDesiredOutputChanged: onDesiredOutputChanged,
+          ),
+          semanticLabel: l10n.production_allocationMaximizeRecipe,
+          tooltip: l10n.production_allocationMaximizeRecipe,
+          assetFileName: _uiIconProductionAllocMaximize,
+        ),
+        ProductionAllocationActionIconButton(
+          enabled: _desired > 0,
+          readDesired: () => desiredOutputByRecipe,
+          onPressedFromCurrent: (cur) => applyProductionRecipeClear(
+            recipe: recipe,
+            current: cur,
+            onDesiredOutputChanged: onDesiredOutputChanged,
+          ),
+          semanticLabel: l10n.production_allocationClearRecipe,
+          tooltip: l10n.production_allocationClearRecipe,
+          assetFileName: _uiIconProductionAllocClear,
+        ),
+      ],
+    );
+  }
+
+  Widget _buildHeader(RecipeAffordance affordance) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Expanded(flex: 2, child: buildRecipeLabel(recipe)),
+        Expanded(
+          flex: 1,
+          child: Text(
+            l10n.production_recipeAffordance(
+              affordance.maxDesiredOutput,
+              affordance.limitingLabel,
+            ),
+            textAlign: TextAlign.right,
+            style: theme.textTheme.labelSmall,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ),
+      ],
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final affordance = _affordance;
+    final maxAchievable = affordance.maxDesiredOutput;
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _buildHeader(affordance),
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              Expanded(child: _buildSlider(maxAchievable)),
+              _buildActionButtons(maxAchievable),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/app/lib/features/game/widgets/production_labour_helpers.dart
+++ b/app/lib/features/game/widgets/production_labour_helpers.dart
@@ -1,0 +1,375 @@
+// Pure helpers for the Production panel Labour controls section.
+// SPEC/ui/production-panel.md § Labour Controls, SPEC/game/workers-and-population.md.
+
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+/// Render order for the four Labour rows. Peasant first, then trained tiers
+/// in tech-tier order — matches the Workers grid above and the worker tier
+/// table in SPEC/game/workers-and-population.md § Worker Tiers.
+const List<WorkerTier> kProductionLabourTierOrder = <WorkerTier>[
+  WorkerTier.peasant,
+  WorkerTier.apprentice,
+  WorkerTier.journeyman,
+  WorkerTier.master,
+];
+
+/// Callbacks emitted by Labour controls. The screen wires these to
+/// `currentOrdersProvider` (recruit queue) and `currentGameProvider`
+/// (immediate disband).
+class ProductionLabourCallbacks {
+  const ProductionLabourCallbacks({
+    required this.onAppendRecruitOrder,
+    required this.onPopLastRecruitOrder,
+    required this.onDisband,
+  });
+
+  /// Append one [RecruitWorkerOrder] at [tier] to the viewed player's queue.
+  final void Function(WorkerTier tier) onAppendRecruitOrder;
+
+  /// Remove the last queued [RecruitWorkerOrder] at [tier] (LIFO).
+  final void Function(WorkerTier tier) onPopLastRecruitOrder;
+
+  /// Immediately apply disband on one [tier] worker. Peasant is invalid
+  /// per SPEC § Disband; callers must filter trained tiers only.
+  final void Function(WorkerTier tier) onDisband;
+}
+
+/// Inputs needed to render one tier row's stepper + disband controls.
+class ProductionLabourTierRowData {
+  const ProductionLabourTierRowData({
+    required this.tier,
+    required this.poolCount,
+    required this.queuedCount,
+    required this.canAppend,
+    required this.canPop,
+    required this.canDisband,
+  });
+
+  final WorkerTier tier;
+  final int poolCount;
+  final int queuedCount;
+  final bool canAppend;
+  final bool canPop;
+  final bool canDisband;
+}
+
+/// Pure builder that maps a [Player] + [Orders] snapshot to one row data
+/// per tier in canonical render order. Kept side-effect-free so tests can
+/// assert affordance and queue counts without mounting the widget.
+List<ProductionLabourTierRowData> buildProductionLabourRowData({
+  required Player player,
+  required Orders currentOrders,
+  required bool canEdit,
+}) {
+  final queued = queuedRecruitWorkerCountsByTier(
+    currentOrders: currentOrders,
+    playerId: player.id,
+  );
+  final rows = <ProductionLabourTierRowData>[];
+  for (final tier in kProductionLabourTierOrder) {
+    final poolCount = workerPoolTierCount(player.workerPool, tier);
+    final queuedCount = queued[tier] ?? 0;
+    final canAppend = canEdit &&
+        canAppendRecruitWorkerOrder(
+          player: player,
+          currentOrders: currentOrders,
+          candidateTier: tier,
+        );
+    final canPop = canEdit && queuedCount > 0;
+    final canDisband =
+        canEdit && tier != WorkerTier.peasant && poolCount > 0;
+    rows.add(
+      ProductionLabourTierRowData(
+        tier: tier,
+        poolCount: poolCount,
+        queuedCount: queuedCount,
+        canAppend: canAppend,
+        canPop: canPop,
+        canDisband: canDisband,
+      ),
+    );
+  }
+  return rows;
+}
+
+/// Per-tier queued recruit-worker counts for [playerId] from [currentOrders].
+///
+/// Returns a dense map for every [WorkerTier] (zero when absent) so callers
+/// can render rows without nullable lookups.
+Map<WorkerTier, int> queuedRecruitWorkerCountsByTier({
+  required Orders currentOrders,
+  required String playerId,
+}) {
+  final counts = <WorkerTier, int>{
+    for (final tier in WorkerTier.values) tier: 0,
+  };
+  final orders =
+      currentOrders.recruitWorkerOrdersByPlayerId[playerId] ??
+      const <RecruitWorkerOrder>[];
+  for (final order in orders) {
+    counts[order.targetTier] = (counts[order.targetTier] ?? 0) + 1;
+  }
+  return counts;
+}
+
+/// Pending peasant consumes from the human player's queued orders for
+/// peasant-reservation gating. Matches the AI recruitment planner's
+/// `_pendingPeasantConsumes` (SPEC/game/workers-and-population.md
+/// § Peasant reservation): every queued non-peasant [RecruitWorkerOrder]
+/// plus every queued military/naval [BuildUnitOrder] reserves one peasant.
+int pendingPeasantConsumesForPlayer({
+  required Orders currentOrders,
+  required String playerId,
+}) {
+  var count = 0;
+  final recruits =
+      currentOrders.recruitWorkerOrdersByPlayerId[playerId] ??
+      const <RecruitWorkerOrder>[];
+  for (final order in recruits) {
+    final row = WorkerActionEconomyCatalog.forTier(order.targetTier);
+    if (row.consumesPeasant) count += 1;
+  }
+  final builds =
+      currentOrders.buildUnitOrdersByPlayerId[playerId] ??
+      const <BuildUnitOrder>[];
+  for (final order in builds) {
+    final category = buildUnitCategoryForUnitType(order.unitType);
+    if (category == BuildUnitCategory.military ||
+        category == BuildUnitCategory.naval) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+/// Returns the worker pool snapshot after applying every queued
+/// recruit-worker order for [playerId] in submission order, so the
+/// affordance helper can probe whether **one more** order at [candidateTier]
+/// would still be acceptable against the projected economy.
+///
+/// Defensively skips queued orders that are no longer affordable against
+/// the running snapshot (mirrors the resolver's per-order validation chain
+/// in `RecruitWorkerOrderValidator`). This guards UI affordance lookups
+/// when external state changes (e.g. debug treasury credit, prior turn
+/// failure) leave a queued order in a state the resolver would reject.
+({WorkerPool workers, Stockpile stockpile, int treasury})
+projectedEconomyAfterQueuedRecruitWorkerOrders({
+  required Player player,
+  required Orders currentOrders,
+}) {
+  var workers = player.workerPool;
+  var stockpile = player.stockpile;
+  var treasury = player.treasury;
+  final queued =
+      currentOrders.recruitWorkerOrdersByPlayerId[player.id] ??
+      const <RecruitWorkerOrder>[];
+  for (final order in queued) {
+    final check = canAffordRecruitWorker(
+      player,
+      order,
+      workers,
+      stockpile,
+      treasury,
+    );
+    if (!check.canAfford) continue;
+    final after = applyRecruitWorkerCostDeduction(
+      order,
+      workers,
+      stockpile,
+      treasury,
+    );
+    workers = after.workers;
+    stockpile = after.stockpile;
+    treasury = after.treasury;
+  }
+  return (workers: workers, stockpile: stockpile, treasury: treasury);
+}
+
+/// True when appending one more [RecruitWorkerOrder] at [candidateTier] for
+/// [player] would be accepted by [canAffordRecruitWorker] after every
+/// already-queued recruit order has been deducted, **and** after applying
+/// the pending peasant reservation for military/naval builds for that
+/// player (peasant consumes counted on top of the projected pool).
+///
+/// Returns `false` when tech gates, treasury, materials, or the peasant
+/// ledger would reject the candidate.
+bool canAppendRecruitWorkerOrder({
+  required Player player,
+  required Orders currentOrders,
+  required WorkerTier candidateTier,
+}) {
+  final projected = projectedEconomyAfterQueuedRecruitWorkerOrders(
+    player: player,
+    currentOrders: currentOrders,
+  );
+  final row = WorkerActionEconomyCatalog.forTier(candidateTier);
+  if (row.consumesPeasant) {
+    final militaryNavalConsumes = _militaryAndNavalPeasantConsumes(
+      currentOrders: currentOrders,
+      playerId: player.id,
+    );
+    if (projected.workers.peasants - militaryNavalConsumes < 1) {
+      return false;
+    }
+  }
+  final candidate = RecruitWorkerOrder(targetTier: candidateTier);
+  final check = canAffordRecruitWorker(
+    player,
+    candidate,
+    projected.workers,
+    projected.stockpile,
+    projected.treasury,
+  );
+  return check.canAfford;
+}
+
+int _militaryAndNavalPeasantConsumes({
+  required Orders currentOrders,
+  required String playerId,
+}) {
+  final builds =
+      currentOrders.buildUnitOrdersByPlayerId[playerId] ??
+      const <BuildUnitOrder>[];
+  var count = 0;
+  for (final order in builds) {
+    final category = buildUnitCategoryForUnitType(order.unitType);
+    if (category == BuildUnitCategory.military ||
+        category == BuildUnitCategory.naval) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+/// Returns the value of `WorkerPool.<tier>` for the given enum without
+/// switching at each call site.
+int workerPoolTierCount(WorkerPool pool, WorkerTier tier) {
+  switch (tier) {
+    case WorkerTier.peasant:
+      return pool.peasants;
+    case WorkerTier.apprentice:
+      return pool.apprentices;
+    case WorkerTier.journeyman:
+      return pool.journeymen;
+    case WorkerTier.master:
+      return pool.masters;
+  }
+}
+
+/// Appends one [RecruitWorkerOrder] at [tier] for [playerId] and returns
+/// the new [Orders] value. Preserves the prior order list ordering.
+Orders ordersWithAppendedRecruitWorkerOrder({
+  required Orders currentOrders,
+  required String playerId,
+  required WorkerTier tier,
+}) {
+  final next =
+      Map<String, List<RecruitWorkerOrder>>.from(
+        currentOrders.recruitWorkerOrdersByPlayerId,
+      );
+  final existing = List<RecruitWorkerOrder>.from(
+    next[playerId] ?? const <RecruitWorkerOrder>[],
+  );
+  existing.add(RecruitWorkerOrder(targetTier: tier));
+  next[playerId] = existing;
+  return currentOrders.copyWith(recruitWorkerOrdersByPlayerId: next);
+}
+
+/// Removes the **last** queued [RecruitWorkerOrder] of [tier] for
+/// [playerId] (LIFO) and returns the new [Orders] value. Returns
+/// [currentOrders] unchanged when no matching order exists.
+Orders ordersWithLastRecruitWorkerOrderRemoved({
+  required Orders currentOrders,
+  required String playerId,
+  required WorkerTier tier,
+}) {
+  final existing =
+      currentOrders.recruitWorkerOrdersByPlayerId[playerId] ??
+      const <RecruitWorkerOrder>[];
+  if (existing.isEmpty) return currentOrders;
+  final lastIndex = _lastIndexWhereTier(existing, tier);
+  if (lastIndex < 0) return currentOrders;
+  final updated = List<RecruitWorkerOrder>.from(existing)
+    ..removeAt(lastIndex);
+  final next =
+      Map<String, List<RecruitWorkerOrder>>.from(
+        currentOrders.recruitWorkerOrdersByPlayerId,
+      );
+  if (updated.isEmpty) {
+    next.remove(playerId);
+  } else {
+    next[playerId] = updated;
+  }
+  return currentOrders.copyWith(recruitWorkerOrdersByPlayerId: next);
+}
+
+int _lastIndexWhereTier(List<RecruitWorkerOrder> orders, WorkerTier tier) {
+  for (var i = orders.length - 1; i >= 0; i--) {
+    if (orders[i].targetTier == tier) return i;
+  }
+  return -1;
+}
+
+/// Applies an immediate disband action for [tier] on [player]: returns a
+/// new [Player] with `pool.tier` decremented by 1 and `pool.peasants`
+/// incremented by 1. Returns `null` when [tier] is `peasant` (no disband
+/// row per SPEC § Disband) or when the pool count is zero.
+Player? playerWithImmediateDisband({
+  required Player player,
+  required WorkerTier tier,
+}) {
+  if (tier == WorkerTier.peasant) return null;
+  final pool = player.workerPool;
+  if (workerPoolTierCount(pool, tier) <= 0) return null;
+  final nextPool = _applyDisbandToPool(pool, tier);
+  return player.copyWith(workerPool: nextPool);
+}
+
+WorkerPool _applyDisbandToPool(WorkerPool pool, WorkerTier tier) {
+  switch (tier) {
+    case WorkerTier.peasant:
+      return pool;
+    case WorkerTier.apprentice:
+      return pool.copyWith(
+        apprentices: pool.apprentices - 1,
+        peasants: pool.peasants + 1,
+      );
+    case WorkerTier.journeyman:
+      return pool.copyWith(
+        journeymen: pool.journeymen - 1,
+        peasants: pool.peasants + 1,
+      );
+    case WorkerTier.master:
+      return pool.copyWith(
+        masters: pool.masters - 1,
+        peasants: pool.peasants + 1,
+      );
+  }
+}
+
+/// Returns a new [Game] where the viewed player's [workerPool] reflects
+/// an immediate disband of one [tier] worker. Returns `null` (no change)
+/// when the player cannot be found or the disband would underflow.
+Game? gameWithImmediateDisband({
+  required Game game,
+  required String playerId,
+  required WorkerTier tier,
+}) {
+  final players = game.players;
+  Player? found;
+  for (final p in players) {
+    if (p.id == playerId) {
+      found = p;
+      break;
+    }
+  }
+  if (found == null) return null;
+  final updated = playerWithImmediateDisband(player: found, tier: tier);
+  if (updated == null) return null;
+  final nextPlayers = players
+      .map((p) => p.id == playerId ? updated : p)
+      .toList(growable: false);
+  return game.copyWith(players: nextPlayers);
+}

--- a/app/lib/features/game/widgets/production_labour_section.dart
+++ b/app/lib/features/game/widgets/production_labour_section.dart
@@ -96,18 +96,49 @@ class _ProductionLabourTierRow extends StatelessWidget {
         : l10n.production_labourTrainTier(label);
   }
 
+  Widget _buildQueuedSegment() {
+    if (data.queuedCount <= 0) {
+      return const SizedBox.shrink();
+    }
+    return Padding(
+      padding: const EdgeInsets.only(left: 8),
+      child: Text(
+        l10n.production_labourQueued(data.queuedCount),
+        style: theme.textTheme.labelSmall,
+      ),
+    );
+  }
+
+  List<Widget> _buildEditActions(String tierLabel) {
+    return [
+      _LabourIconButton(
+        enabled: data.canPop,
+        semanticLabel: l10n.production_labourDequeueTier(tierLabel),
+        tooltip: l10n.production_labourDequeueTier(tierLabel),
+        assetFileName: _uiIconLabourDecrement,
+        onPressed: () => callbacks.onPopLastRecruitOrder(data.tier),
+      ),
+      _LabourIconButton(
+        enabled: data.canAppend,
+        semanticLabel: _appendTooltip(),
+        tooltip: _appendTooltip(),
+        assetFileName: _uiIconLabourIncrement,
+        onPressed: () => callbacks.onAppendRecruitOrder(data.tier),
+      ),
+      if (data.tier != WorkerTier.peasant)
+        _DisbandTierButton(
+          tier: data.tier,
+          enabled: data.canDisband,
+          disbandLabel: l10n.production_labourDisband,
+          tooltip: l10n.production_labourDisbandTier(tierLabel),
+          onDisband: callbacks.onDisband,
+        ),
+    ];
+  }
+
   @override
   Widget build(BuildContext context) {
     final tierLabel = _tierLabel();
-    final queuedSegment = data.queuedCount > 0
-        ? Padding(
-            padding: const EdgeInsets.only(left: 8),
-            child: Text(
-              l10n.production_labourQueued(data.queuedCount),
-              style: theme.textTheme.labelSmall,
-            ),
-          )
-        : const SizedBox.shrink();
     return Row(
       mainAxisSize: MainAxisSize.max,
       children: [
@@ -118,48 +149,48 @@ class _ProductionLabourTierRow extends StatelessWidget {
             overflow: TextOverflow.ellipsis,
           ),
         ),
-        queuedSegment,
+        _buildQueuedSegment(),
         const Spacer(),
-        if (canEdit) ...[
-          _LabourIconButton(
-            enabled: data.canPop,
-            semanticLabel: l10n.production_labourDequeueTier(tierLabel),
-            tooltip: l10n.production_labourDequeueTier(tierLabel),
-            assetFileName: _uiIconLabourDecrement,
-            onPressed: () => callbacks.onPopLastRecruitOrder(data.tier),
-          ),
-          _LabourIconButton(
-            enabled: data.canAppend,
-            semanticLabel: _appendTooltip(),
-            tooltip: _appendTooltip(),
-            assetFileName: _uiIconLabourIncrement,
-            onPressed: () => callbacks.onAppendRecruitOrder(data.tier),
-          ),
-          if (data.tier != WorkerTier.peasant)
-            Padding(
-              padding: const EdgeInsets.only(left: 6),
-              child: MergeSemantics(
-                child: Semantics(
-                  button: true,
-                  enabled: data.canDisband,
-                  label: l10n.production_labourDisbandTier(tierLabel),
-                  child: Tooltip(
-                    message: l10n.production_labourDisbandTier(tierLabel),
-                    child: CtNinePatchButton(
-                      key: ValueKey<String>(
-                        'production_labour_disband_${data.tier.id}',
-                      ),
-                      onPressed: data.canDisband
-                          ? () => callbacks.onDisband(data.tier)
-                          : null,
-                      child: Text(l10n.production_labourDisband),
-                    ),
-                  ),
-                ),
-              ),
-            ),
-        ],
+        if (canEdit) ..._buildEditActions(tierLabel),
       ],
+    );
+  }
+}
+
+class _DisbandTierButton extends StatelessWidget {
+  const _DisbandTierButton({
+    required this.tier,
+    required this.enabled,
+    required this.disbandLabel,
+    required this.tooltip,
+    required this.onDisband,
+  });
+
+  final WorkerTier tier;
+  final bool enabled;
+  final String disbandLabel;
+  final String tooltip;
+  final void Function(WorkerTier tier) onDisband;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(left: 6),
+      child: MergeSemantics(
+        child: Semantics(
+          button: true,
+          enabled: enabled,
+          label: tooltip,
+          child: Tooltip(
+            message: tooltip,
+            child: CtNinePatchButton(
+              key: ValueKey<String>('production_labour_disband_${tier.id}'),
+              onPressed: enabled ? () => onDisband(tier) : null,
+              child: Text(disbandLabel),
+            ),
+          ),
+        ),
+      ),
     );
   }
 }

--- a/app/lib/features/game/widgets/production_labour_section.dart
+++ b/app/lib/features/game/widgets/production_labour_section.dart
@@ -1,0 +1,214 @@
+// Production panel Labour controls (per-tier recruit/train steppers +
+// immediate disband). SPEC/ui/production-panel.md § Labour Controls,
+// SPEC/game/workers-and-population.md.
+
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:flutter/material.dart';
+
+import '../../../config/app_assets.dart';
+import '../../../l10n/l10n.dart';
+import '../../../widgets/ct_nine_patch_button.dart';
+import '../../../widgets/strict_asset_icon.dart';
+import 'production_labour_helpers.dart';
+
+const _uiIconLabourIncrement = 'ui_icon_production_alloc_increment.png';
+const _uiIconLabourDecrement = 'ui_icon_production_alloc_decrement.png';
+
+/// Labour controls section appended to the Workers section of the
+/// Available subpanel. Renders one row per worker tier with recruit/train
+/// steppers and (for trained tiers) a disband button.
+class ProductionLabourSection extends StatelessWidget {
+  const ProductionLabourSection({
+    super.key,
+    required this.player,
+    required this.currentOrders,
+    required this.canEdit,
+    required this.callbacks,
+  });
+
+  final Player player;
+  final Orders currentOrders;
+  final bool canEdit;
+  final ProductionLabourCallbacks callbacks;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = appL10n(context);
+    final rows = buildProductionLabourRowData(
+      player: player,
+      currentOrders: currentOrders,
+      canEdit: canEdit,
+    );
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        for (final row in rows)
+          Padding(
+            key: ValueKey<String>('production_labour_row_${row.tier.id}'),
+            padding: const EdgeInsets.only(top: 4),
+            child: _ProductionLabourTierRow(
+              data: row,
+              callbacks: callbacks,
+              canEdit: canEdit,
+              l10n: l10n,
+              theme: theme,
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _ProductionLabourTierRow extends StatelessWidget {
+  const _ProductionLabourTierRow({
+    required this.data,
+    required this.callbacks,
+    required this.canEdit,
+    required this.l10n,
+    required this.theme,
+  });
+
+  final ProductionLabourTierRowData data;
+  final ProductionLabourCallbacks callbacks;
+  final bool canEdit;
+  final AppLocalizations l10n;
+  final ThemeData theme;
+
+  String _tierLabel() {
+    switch (data.tier) {
+      case WorkerTier.peasant:
+        return l10n.production_workers_peasants;
+      case WorkerTier.apprentice:
+        return l10n.production_workers_apprentices;
+      case WorkerTier.journeyman:
+        return l10n.production_workers_journeymen;
+      case WorkerTier.master:
+        return l10n.production_workers_masters;
+    }
+  }
+
+  String _appendTooltip() {
+    final label = _tierLabel();
+    return data.tier == WorkerTier.peasant
+        ? l10n.production_labourRecruitTier(label)
+        : l10n.production_labourTrainTier(label);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final tierLabel = _tierLabel();
+    final queuedSegment = data.queuedCount > 0
+        ? Padding(
+            padding: const EdgeInsets.only(left: 8),
+            child: Text(
+              l10n.production_labourQueued(data.queuedCount),
+              style: theme.textTheme.labelSmall,
+            ),
+          )
+        : const SizedBox.shrink();
+    return Row(
+      mainAxisSize: MainAxisSize.max,
+      children: [
+        Flexible(
+          child: Text(
+            tierLabel,
+            style: theme.textTheme.bodySmall,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ),
+        queuedSegment,
+        const Spacer(),
+        if (canEdit) ...[
+          _LabourIconButton(
+            enabled: data.canPop,
+            semanticLabel: l10n.production_labourDequeueTier(tierLabel),
+            tooltip: l10n.production_labourDequeueTier(tierLabel),
+            assetFileName: _uiIconLabourDecrement,
+            onPressed: () => callbacks.onPopLastRecruitOrder(data.tier),
+          ),
+          _LabourIconButton(
+            enabled: data.canAppend,
+            semanticLabel: _appendTooltip(),
+            tooltip: _appendTooltip(),
+            assetFileName: _uiIconLabourIncrement,
+            onPressed: () => callbacks.onAppendRecruitOrder(data.tier),
+          ),
+          if (data.tier != WorkerTier.peasant)
+            Padding(
+              padding: const EdgeInsets.only(left: 6),
+              child: MergeSemantics(
+                child: Semantics(
+                  button: true,
+                  enabled: data.canDisband,
+                  label: l10n.production_labourDisbandTier(tierLabel),
+                  child: Tooltip(
+                    message: l10n.production_labourDisbandTier(tierLabel),
+                    child: CtNinePatchButton(
+                      key: ValueKey<String>(
+                        'production_labour_disband_${data.tier.id}',
+                      ),
+                      onPressed: data.canDisband
+                          ? () => callbacks.onDisband(data.tier)
+                          : null,
+                      child: Text(l10n.production_labourDisband),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+        ],
+      ],
+    );
+  }
+}
+
+class _LabourIconButton extends StatelessWidget {
+  const _LabourIconButton({
+    required this.enabled,
+    required this.semanticLabel,
+    required this.tooltip,
+    required this.assetFileName,
+    required this.onPressed,
+  });
+
+  static const double _iconSize = 15;
+
+  final bool enabled;
+  final String semanticLabel;
+  final String tooltip;
+  final String assetFileName;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final path = '$kAppIconAssetPrefix$assetFileName';
+    final icon = Opacity(
+      opacity: enabled ? 1 : 0.35,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 2, vertical: 4),
+        child: StrictAssetIcon(
+          assetPath: path,
+          width: _iconSize,
+          height: _iconSize,
+        ),
+      ),
+    );
+    return Semantics(
+      button: true,
+      enabled: enabled,
+      label: semanticLabel,
+      child: Tooltip(
+        message: tooltip,
+        child: Material(
+          color: Colors.transparent,
+          child: InkWell(
+            onTap: enabled ? onPressed : null,
+            child: icon,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/features/game/widgets/production_panel.dart
+++ b/app/lib/features/game/widgets/production_panel.dart
@@ -12,6 +12,8 @@ import '../../../widgets/resource_icon.dart';
 import '../production_recipe_affordance.dart';
 import 'production_allocation_mutations.dart';
 import 'production_allocation_row_buttons.dart';
+import 'production_labour_helpers.dart';
+import 'production_labour_section.dart';
 
 const _uiIconProductionAllocDecrement =
     'ui_icon_production_alloc_decrement.png';
@@ -29,6 +31,9 @@ class ProductionPanel extends StatelessWidget {
     required this.netDeltasByCommodity,
     required this.onDesiredOutputChanged,
     this.onOpenCommodityBreakdown,
+    this.currentOrders,
+    this.labourCallbacks,
+    this.canEditLabour = false,
   });
 
   final Game game;
@@ -39,6 +44,18 @@ class ProductionPanel extends StatelessWidget {
 
   /// When set, Available header shows a text button that opens the breakdown dialog.
   final VoidCallback? onOpenCommodityBreakdown;
+
+  /// Required for the Labour controls to display queued counts. When `null`
+  /// the Labour section renders read-only with zero pending counts.
+  final Orders? currentOrders;
+
+  /// Callbacks bound to the screen's providers. When `null`, the Labour
+  /// controls render in read-only mode (no +/-/Disband buttons).
+  final ProductionLabourCallbacks? labourCallbacks;
+
+  /// True when the viewed player may mutate orders or pool via the Labour
+  /// controls. Combined with [labourCallbacks] presence to gate buttons.
+  final bool canEditLabour;
 
   static Set<String> get _inputCommodityIds {
     final inputIds = <String>{};
@@ -77,6 +94,9 @@ class ProductionPanel extends StatelessWidget {
       netDeltasByCommodity: netDeltasByCommodity,
       l10n: l10n,
       onOpenCommodityBreakdown: onOpenCommodityBreakdown,
+      currentOrders: currentOrders,
+      labourCallbacks: labourCallbacks,
+      canEditLabour: canEditLabour,
     );
     final allocationSubpanel = _AllocationSubpanel(
       player: player,
@@ -159,6 +179,9 @@ class _AvailableSubpanel extends StatelessWidget {
     required this.netDeltasByCommodity,
     required this.l10n,
     this.onOpenCommodityBreakdown,
+    this.currentOrders,
+    this.labourCallbacks,
+    this.canEditLabour = false,
   });
 
   final Player player;
@@ -168,6 +191,9 @@ class _AvailableSubpanel extends StatelessWidget {
   final Map<String, int> netDeltasByCommodity;
   final AppLocalizations l10n;
   final VoidCallback? onOpenCommodityBreakdown;
+  final Orders? currentOrders;
+  final ProductionLabourCallbacks? labourCallbacks;
+  final bool canEditLabour;
 
   Widget _buildCommodityRow(Commodity c, int qty, int change, ThemeData theme) {
     final name = c.displayName ?? c.id;
@@ -280,7 +306,7 @@ class _AvailableSubpanel extends StatelessWidget {
   }
 
   List<Widget> _buildWorkerSection(ThemeData theme) {
-    return <Widget>[
+    final children = <Widget>[
       const SizedBox(height: 12),
       Text(l10n.production_workers, style: theme.textTheme.labelMedium),
       const SizedBox(height: 4),
@@ -296,12 +322,26 @@ class _AvailableSubpanel extends StatelessWidget {
           _buildWorkerRow('master', player.workerPool.masters, theme),
         ],
       ),
+    ];
+    if (currentOrders != null && labourCallbacks != null) {
+      children.addAll(<Widget>[
+        const SizedBox(height: 8),
+        ProductionLabourSection(
+          player: player,
+          currentOrders: currentOrders!,
+          canEdit: canEditLabour,
+          callbacks: labourCallbacks!,
+        ),
+      ]);
+    }
+    children.addAll(<Widget>[
       const SizedBox(height: 8),
       Text(
         l10n.production_effectiveLabour(effectiveLabour),
         style: theme.textTheme.bodySmall?.copyWith(fontWeight: FontWeight.w600),
       ),
-    ];
+    ]);
+    return children;
   }
 
   @override

--- a/app/lib/features/game/widgets/production_panel.dart
+++ b/app/lib/features/game/widgets/production_panel.dart
@@ -7,20 +7,10 @@ import '../../../config/constants.dart';
 import '../../../l10n/l10n.dart';
 import '../../../widgets/ct_nine_patch_button.dart';
 import '../../../widgets/ct_panel.dart';
-import '../../../widgets/ct_slider.dart';
 import '../../../widgets/resource_icon.dart';
-import '../production_recipe_affordance.dart';
-import 'production_allocation_mutations.dart';
-import 'production_allocation_row_buttons.dart';
+import 'production_allocation_row.dart';
 import 'production_labour_helpers.dart';
 import 'production_labour_section.dart';
-
-const _uiIconProductionAllocDecrement =
-    'ui_icon_production_alloc_decrement.png';
-const _uiIconProductionAllocIncrement =
-    'ui_icon_production_alloc_increment.png';
-const _uiIconProductionAllocMaximize = 'ui_icon_production_alloc_maximize.png';
-const _uiIconProductionAllocClear = 'ui_icon_production_alloc_clear.png';
 
 class ProductionPanel extends StatelessWidget {
   const ProductionPanel({
@@ -480,7 +470,7 @@ class _AllocationSubpanel extends StatelessWidget {
 
   Iterable<Widget> _buildAllocationRows(ThemeData theme) {
     return ProductionRecipesCatalog.all.map(
-      (recipe) => _ProductionAllocationRow(
+      (recipe) => ProductionAllocationRow(
         key: ValueKey<String>('production_alloc_row_${recipe.id}'),
         recipe: recipe,
         player: player,
@@ -549,184 +539,3 @@ class _AllocationSubpanel extends StatelessWidget {
   }
 }
 
-class _ProductionAllocationRow extends StatelessWidget {
-  const _ProductionAllocationRow({
-    super.key,
-    required this.recipe,
-    required this.player,
-    required this.effectiveLabour,
-    required this.desiredOutputByRecipe,
-    required this.onDesiredOutputChanged,
-    required this.buildRecipeLabel,
-    required this.l10n,
-    required this.theme,
-  });
-
-  final ProductionRecipe recipe;
-  final Player player;
-  final int effectiveLabour;
-  final Map<String, int> desiredOutputByRecipe;
-  final ValueChanged<Map<String, int>> onDesiredOutputChanged;
-  final Widget Function(ProductionRecipe recipe) buildRecipeLabel;
-  final AppLocalizations l10n;
-  final ThemeData theme;
-
-  int get _desired => desiredOutputByRecipe[recipe.id] ?? 0;
-
-  RecipeAffordance get _affordance => computeRecipeAffordance(
-    recipe: recipe,
-    stockpile: player.stockpile,
-    desiredOutputByRecipe: desiredOutputByRecipe,
-    effectiveLabour: effectiveLabour,
-  );
-
-  bool get _comfortHeadroom => recipeAllocationComfortHeadroomActive(
-    recipe: recipe,
-    desiredOutput: _desired,
-    maxDesiredOutput: _affordance.maxDesiredOutput,
-    stockpile: player.stockpile,
-    desiredOutputByRecipe: desiredOutputByRecipe,
-    effectiveLabour: effectiveLabour,
-  );
-
-  Widget _buildSlider(int maxAchievable) {
-    final sliderMax = maxAchievable == 0
-        ? 0.0
-        : maxAchievable.clamp(1, kProductionAllocationSliderCap).toDouble();
-    return CtSlider(
-      value: _desired.clamp(0, maxAchievable).toDouble(),
-      min: 0,
-      max: sliderMax,
-      divisions: maxAchievable == 0
-          ? 1
-          : maxAchievable.clamp(1, kProductionAllocationSliderCap),
-      comfortHeadroomActive: _comfortHeadroom,
-      onChanged: (value) {
-        final next = Map<String, int>.from(desiredOutputByRecipe);
-        final rounded = value.round().clamp(0, maxAchievable);
-        if (rounded == 0) {
-          next.remove(recipe.id);
-        } else {
-          next[recipe.id] = rounded;
-        }
-        onDesiredOutputChanged(next);
-      },
-    );
-  }
-
-  Widget _buildActionButtons(int maxAchievable) {
-    final canDecrement = _desired > 0;
-    final canIncrement = maxAchievable > 0 && _desired < maxAchievable;
-    return Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        SizedBox(
-          width: 30,
-          child: Text(
-            _desired.toString(),
-            textAlign: TextAlign.right,
-            style: theme.textTheme.bodySmall,
-          ),
-        ),
-        ProductionAllocationStepButton(
-          enabled: canDecrement,
-          readDesired: () => desiredOutputByRecipe,
-          tryStepFromCurrent: (cur) => applyProductionRecipeDecrement(
-            recipe: recipe,
-            player: player,
-            effectiveLabour: effectiveLabour,
-            current: cur,
-            onDesiredOutputChanged: onDesiredOutputChanged,
-          ),
-          semanticLabel: l10n.production_allocationDecrementRecipe,
-          tooltip: l10n.production_allocationDecrementRecipe,
-          assetFileName: _uiIconProductionAllocDecrement,
-        ),
-        ProductionAllocationStepButton(
-          enabled: canIncrement,
-          readDesired: () => desiredOutputByRecipe,
-          tryStepFromCurrent: (cur) => applyProductionRecipeIncrement(
-            recipe: recipe,
-            player: player,
-            effectiveLabour: effectiveLabour,
-            current: cur,
-            onDesiredOutputChanged: onDesiredOutputChanged,
-          ),
-          semanticLabel: l10n.production_allocationIncrementRecipe,
-          tooltip: l10n.production_allocationIncrementRecipe,
-          assetFileName: _uiIconProductionAllocIncrement,
-        ),
-        ProductionAllocationActionIconButton(
-          enabled: canIncrement,
-          readDesired: () => desiredOutputByRecipe,
-          onPressedFromCurrent: (cur) => applyProductionRecipeMaximize(
-            recipe: recipe,
-            player: player,
-            effectiveLabour: effectiveLabour,
-            current: cur,
-            onDesiredOutputChanged: onDesiredOutputChanged,
-          ),
-          semanticLabel: l10n.production_allocationMaximizeRecipe,
-          tooltip: l10n.production_allocationMaximizeRecipe,
-          assetFileName: _uiIconProductionAllocMaximize,
-        ),
-        ProductionAllocationActionIconButton(
-          enabled: _desired > 0,
-          readDesired: () => desiredOutputByRecipe,
-          onPressedFromCurrent: (cur) => applyProductionRecipeClear(
-            recipe: recipe,
-            current: cur,
-            onDesiredOutputChanged: onDesiredOutputChanged,
-          ),
-          semanticLabel: l10n.production_allocationClearRecipe,
-          tooltip: l10n.production_allocationClearRecipe,
-          assetFileName: _uiIconProductionAllocClear,
-        ),
-      ],
-    );
-  }
-
-  Widget _buildHeader(RecipeAffordance affordance) {
-    return Row(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Expanded(flex: 2, child: buildRecipeLabel(recipe)),
-        Expanded(
-          flex: 1,
-          child: Text(
-            l10n.production_recipeAffordance(
-              affordance.maxDesiredOutput,
-              affordance.limitingLabel,
-            ),
-            textAlign: TextAlign.right,
-            style: theme.textTheme.labelSmall,
-            overflow: TextOverflow.ellipsis,
-          ),
-        ),
-      ],
-    );
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final affordance = _affordance;
-    final maxAchievable = affordance.maxDesiredOutput;
-    return Padding(
-      padding: const EdgeInsets.only(bottom: 12),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          _buildHeader(affordance),
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: [
-              Expanded(child: _buildSlider(maxAchievable)),
-              _buildActionButtons(maxAchievable),
-            ],
-          ),
-        ],
-      ),
-    );
-  }
-}

--- a/app/lib/l10n/app_localizations_contract.dart
+++ b/app/lib/l10n/app_localizations_contract.dart
@@ -1183,6 +1183,24 @@ abstract class AppLocalizations {
   /// Warning when allocated labour exceeds effective labour.
   String get production_labourInsufficient;
 
+  /// Pending recruit-worker order count shown on a tier row in the Labour controls.
+  String production_labourQueued(int count);
+
+  /// Tooltip and semantics label for the + stepper on the peasant row.
+  String production_labourRecruitTier(String tier);
+
+  /// Tooltip and semantics label for the + stepper on a trained-tier row.
+  String production_labourTrainTier(String tier);
+
+  /// Tooltip and semantics label for the − stepper on any tier row.
+  String production_labourDequeueTier(String tier);
+
+  /// Tooltip and semantics label for the Disband control on a trained-tier row.
+  String production_labourDisbandTier(String tier);
+
+  /// Visible label for the Disband button on trained-tier rows.
+  String get production_labourDisband;
+
   /// Worker type and count in production panel.
   String production_workerCount(String name, int count);
 

--- a/app/lib/l10n/app_localizations_en_part3.dart
+++ b/app/lib/l10n/app_localizations_en_part3.dart
@@ -484,6 +484,34 @@ mixin _AppLocalizationsEnStrings3 on AppLocalizations {
       'Insufficient labour — production will be capped next turn';
 
   @override
+  String production_labourQueued(int count) {
+    return 'Queued: $count';
+  }
+
+  @override
+  String production_labourRecruitTier(String tier) {
+    return 'Recruit $tier';
+  }
+
+  @override
+  String production_labourTrainTier(String tier) {
+    return 'Train $tier';
+  }
+
+  @override
+  String production_labourDequeueTier(String tier) {
+    return 'Cancel last queued $tier';
+  }
+
+  @override
+  String production_labourDisbandTier(String tier) {
+    return 'Disband $tier';
+  }
+
+  @override
+  String get production_labourDisband => 'Disband';
+
+  @override
   String production_workerCount(String name, int count) {
     return '$name: $count';
   }

--- a/app/lib/l10n/arb/app_en.arb
+++ b/app/lib/l10n/arb/app_en.arb
@@ -2211,6 +2211,55 @@
   "@production_labourInsufficient": {
     "description": "Warning when allocated labour exceeds effective labour."
   },
+  "production_labourQueued": "Queued: {count}",
+  "@production_labourQueued": {
+    "description": "Pending recruit-worker order count shown on a tier row in the Labour controls.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "production_labourRecruitTier": "Recruit {tier}",
+  "@production_labourRecruitTier": {
+    "description": "Tooltip and semantics label for the + stepper on the peasant row.",
+    "placeholders": {
+      "tier": {
+        "type": "String"
+      }
+    }
+  },
+  "production_labourTrainTier": "Train {tier}",
+  "@production_labourTrainTier": {
+    "description": "Tooltip and semantics label for the + stepper on a trained-tier row.",
+    "placeholders": {
+      "tier": {
+        "type": "String"
+      }
+    }
+  },
+  "production_labourDequeueTier": "Cancel last queued {tier}",
+  "@production_labourDequeueTier": {
+    "description": "Tooltip and semantics label for the − stepper on any tier row.",
+    "placeholders": {
+      "tier": {
+        "type": "String"
+      }
+    }
+  },
+  "production_labourDisbandTier": "Disband {tier}",
+  "@production_labourDisbandTier": {
+    "description": "Tooltip and semantics label for the Disband control on a trained-tier row.",
+    "placeholders": {
+      "tier": {
+        "type": "String"
+      }
+    }
+  },
+  "production_labourDisband": "Disband",
+  "@production_labourDisband": {
+    "description": "Visible label for the Disband button on trained-tier rows."
+  },
   "production_workerCount": "{name}: {count}",
   "@production_workerCount": {
     "description": "Worker type and count in production panel.",

--- a/app/test/production_labour_helpers_test.dart
+++ b/app/test/production_labour_helpers_test.dart
@@ -1,0 +1,453 @@
+// Pure-logic tests for production labour helpers (S6, Refs #2692).
+// SPEC/ui/production-panel.md § Labour Controls, SPEC/game/workers-and-population.md.
+
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:colonizethis_app/features/game/widgets/production_labour_helpers.dart';
+
+const _playerId = 'gp_labour_test';
+
+Player _gpWithPool({
+  int peasants = 0,
+  int apprentices = 0,
+  int journeymen = 0,
+  int masters = 0,
+  int treasury = 0,
+  Map<String, int> stockpile = const {},
+  Map<String, bool>? techUnlocked,
+}) {
+  return Player(
+    id: _playerId,
+    displayName: 'Labour test GP',
+    isHuman: true,
+    workerPool: WorkerPool(
+      peasants: peasants,
+      apprentices: apprentices,
+      journeymen: journeymen,
+      masters: masters,
+    ),
+    stockpile: Stockpile(quantities: Map<String, int>.from(stockpile)),
+    treasury: treasury,
+    techUnlocked: techUnlocked,
+  );
+}
+
+Orders _ordersWithRecruits(List<WorkerTier> tiers, {String id = _playerId}) {
+  if (tiers.isEmpty) return const Orders();
+  return Orders(
+    recruitWorkerOrdersByPlayerId: {
+      id: [for (final t in tiers) RecruitWorkerOrder(targetTier: t)],
+    },
+  );
+}
+
+Orders _ordersWithMilitaryBuilds(int count, {String id = _playerId}) {
+  if (count <= 0) return const Orders();
+  // Pick a regiment unit type from the catalog so peasant-cost classification is real.
+  final militaryUnitType =
+      RegimentEconomyCatalog.byId.keys.first;
+  return Orders(
+    buildUnitOrdersByPlayerId: {
+      id: [
+        for (var i = 0; i < count; i++)
+          BuildUnitOrder(
+            unitType: militaryUnitType,
+            isMilitary: true,
+            spawnProvinceId: 'province_x',
+          ),
+      ],
+    },
+  );
+}
+
+void main() {
+  suppressLogsForTests();
+
+  group('queuedRecruitWorkerCountsByTier', () {
+    test('returns zero counts for every tier when no orders queued', () {
+      final counts = queuedRecruitWorkerCountsByTier(
+        currentOrders: const Orders(),
+        playerId: _playerId,
+      );
+      expect(counts.keys.toSet(), WorkerTier.values.toSet());
+      for (final tier in WorkerTier.values) {
+        expect(counts[tier], 0, reason: 'tier ${tier.id}');
+      }
+    });
+
+    test('counts queued orders per tier', () {
+      final orders = _ordersWithRecruits([
+        WorkerTier.peasant,
+        WorkerTier.apprentice,
+        WorkerTier.apprentice,
+        WorkerTier.master,
+      ]);
+      final counts = queuedRecruitWorkerCountsByTier(
+        currentOrders: orders,
+        playerId: _playerId,
+      );
+      expect(counts[WorkerTier.peasant], 1);
+      expect(counts[WorkerTier.apprentice], 2);
+      expect(counts[WorkerTier.journeyman], 0);
+      expect(counts[WorkerTier.master], 1);
+    });
+
+    test('ignores orders for other players', () {
+      final orders = _ordersWithRecruits([WorkerTier.master], id: 'other_gp');
+      final counts = queuedRecruitWorkerCountsByTier(
+        currentOrders: orders,
+        playerId: _playerId,
+      );
+      expect(counts.values.every((v) => v == 0), isTrue);
+    });
+  });
+
+  group('pendingPeasantConsumesForPlayer', () {
+    test('counts non-peasant recruit orders + military builds only', () {
+      final recruits = _ordersWithRecruits([
+        WorkerTier.peasant, // does not consume peasant per cost row
+        WorkerTier.journeyman, // consumes peasant
+        WorkerTier.master, // consumes peasant
+      ]);
+      final builds = _ordersWithMilitaryBuilds(3);
+      final combined = recruits.copyWith(
+        buildUnitOrdersByPlayerId: builds.buildUnitOrdersByPlayerId,
+      );
+      expect(
+        pendingPeasantConsumesForPlayer(
+          currentOrders: combined,
+          playerId: _playerId,
+        ),
+        2 + 3,
+      );
+    });
+
+    test('zero when only peasant recruit orders queued', () {
+      final orders = _ordersWithRecruits([WorkerTier.peasant, WorkerTier.peasant]);
+      expect(
+        pendingPeasantConsumesForPlayer(
+          currentOrders: orders,
+          playerId: _playerId,
+        ),
+        0,
+      );
+    });
+  });
+
+  group('canAppendRecruitWorkerOrder', () {
+    test('peasant recruit succeeds when fabric ≥ 2', () {
+      final player = _gpWithPool(
+        peasants: 0,
+        stockpile: {CommodityCatalog.fabric.id: 2},
+      );
+      expect(
+        canAppendRecruitWorkerOrder(
+          player: player,
+          currentOrders: const Orders(),
+          candidateTier: WorkerTier.peasant,
+        ),
+        isTrue,
+      );
+    });
+
+    test('peasant recruit fails when fabric < 2', () {
+      final player = _gpWithPool(stockpile: {CommodityCatalog.fabric.id: 1});
+      expect(
+        canAppendRecruitWorkerOrder(
+          player: player,
+          currentOrders: const Orders(),
+          candidateTier: WorkerTier.peasant,
+        ),
+        isFalse,
+      );
+    });
+
+    test('apprentice train fails when tech locked', () {
+      final player = _gpWithPool(
+        peasants: 1,
+        treasury: 200,
+        stockpile: {CommodityCatalog.paper.id: 2},
+      );
+      expect(
+        canAppendRecruitWorkerOrder(
+          player: player,
+          currentOrders: const Orders(),
+          candidateTier: WorkerTier.apprentice,
+        ),
+        isFalse,
+      );
+    });
+
+    test('apprentice train succeeds with full tech + cost coverage', () {
+      final player = _gpWithPool(
+        peasants: 1,
+        treasury: 200,
+        stockpile: {CommodityCatalog.paper.id: 2},
+        techUnlocked: const {
+          kTechIdApprenticeWorkers: true,
+          kTechIdSugarRefining: true,
+        },
+      );
+      expect(
+        canAppendRecruitWorkerOrder(
+          player: player,
+          currentOrders: const Orders(),
+          candidateTier: WorkerTier.apprentice,
+        ),
+        isTrue,
+      );
+    });
+
+    test('apprentice train fails when peasant ledger exhausted by pending military builds', () {
+      final player = _gpWithPool(
+        peasants: 1,
+        treasury: 200,
+        stockpile: {CommodityCatalog.paper.id: 2},
+        techUnlocked: const {
+          kTechIdApprenticeWorkers: true,
+          kTechIdSugarRefining: true,
+        },
+      );
+      final orders = _ordersWithMilitaryBuilds(1);
+      expect(
+        canAppendRecruitWorkerOrder(
+          player: player,
+          currentOrders: orders,
+          candidateTier: WorkerTier.apprentice,
+        ),
+        isFalse,
+      );
+    });
+
+    test('second apprentice train fails when only one peasant available', () {
+      final player = _gpWithPool(
+        peasants: 1,
+        treasury: 1000,
+        stockpile: {CommodityCatalog.paper.id: 20},
+        techUnlocked: const {
+          kTechIdApprenticeWorkers: true,
+          kTechIdSugarRefining: true,
+        },
+      );
+      final orders = _ordersWithRecruits([WorkerTier.apprentice]);
+      expect(
+        canAppendRecruitWorkerOrder(
+          player: player,
+          currentOrders: orders,
+          candidateTier: WorkerTier.apprentice,
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('orders mutation helpers', () {
+    test('append adds one order at end and preserves prior list', () {
+      final orders = _ordersWithRecruits([WorkerTier.peasant]);
+      final next = ordersWithAppendedRecruitWorkerOrder(
+        currentOrders: orders,
+        playerId: _playerId,
+        tier: WorkerTier.master,
+      );
+      final list = next.recruitWorkerOrdersByPlayerId[_playerId]!;
+      expect(list.length, 2);
+      expect(list.last.targetTier, WorkerTier.master);
+      expect(list.first.targetTier, WorkerTier.peasant);
+    });
+
+    test('pop removes last matching tier (LIFO) and leaves others', () {
+      final orders = _ordersWithRecruits([
+        WorkerTier.apprentice,
+        WorkerTier.master,
+        WorkerTier.apprentice,
+      ]);
+      final next = ordersWithLastRecruitWorkerOrderRemoved(
+        currentOrders: orders,
+        playerId: _playerId,
+        tier: WorkerTier.apprentice,
+      );
+      final list = next.recruitWorkerOrdersByPlayerId[_playerId]!;
+      expect(list.length, 2);
+      expect(
+        list.map((o) => o.targetTier).toList(),
+        [WorkerTier.apprentice, WorkerTier.master],
+      );
+    });
+
+    test('pop returns unchanged orders when no matching tier', () {
+      final orders = _ordersWithRecruits([WorkerTier.peasant]);
+      final next = ordersWithLastRecruitWorkerOrderRemoved(
+        currentOrders: orders,
+        playerId: _playerId,
+        tier: WorkerTier.master,
+      );
+      expect(
+        next.recruitWorkerOrdersByPlayerId[_playerId]!.length,
+        1,
+      );
+    });
+
+    test('pop removes player entry when list becomes empty', () {
+      final orders = _ordersWithRecruits([WorkerTier.peasant]);
+      final next = ordersWithLastRecruitWorkerOrderRemoved(
+        currentOrders: orders,
+        playerId: _playerId,
+        tier: WorkerTier.peasant,
+      );
+      expect(
+        next.recruitWorkerOrdersByPlayerId.containsKey(_playerId),
+        isFalse,
+      );
+    });
+  });
+
+  group('disband helpers', () {
+    test('disband journeyman increments peasants and decrements journeymen', () {
+      final player = _gpWithPool(peasants: 0, journeymen: 1, treasury: 500);
+      final updated = playerWithImmediateDisband(
+        player: player,
+        tier: WorkerTier.journeyman,
+      );
+      expect(updated, isNotNull);
+      expect(updated!.workerPool.peasants, 1);
+      expect(updated.workerPool.journeymen, 0);
+      expect(updated.treasury, 500, reason: 'disband has no treasury refund');
+    });
+
+    test('disband peasant returns null (not allowed)', () {
+      final player = _gpWithPool(peasants: 3);
+      final updated = playerWithImmediateDisband(
+        player: player,
+        tier: WorkerTier.peasant,
+      );
+      expect(updated, isNull);
+    });
+
+    test('disband returns null when no worker of the tier exists', () {
+      final player = _gpWithPool(peasants: 1, masters: 0);
+      final updated = playerWithImmediateDisband(
+        player: player,
+        tier: WorkerTier.master,
+      );
+      expect(updated, isNull);
+    });
+
+    test('gameWithImmediateDisband updates the matching player only', () {
+      final p1 = _gpWithPool(masters: 1).copyWith(id: 'gp_a');
+      final p2 = _gpWithPool(masters: 1).copyWith(id: 'gp_b');
+      final game = Game(
+        id: 'g',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+        ),
+        players: [p1, p2],
+      );
+      final next = gameWithImmediateDisband(
+        game: game,
+        playerId: 'gp_a',
+        tier: WorkerTier.master,
+      );
+      expect(next, isNotNull);
+      final updatedA = next!.players.firstWhere((p) => p.id == 'gp_a');
+      final unchangedB = next.players.firstWhere((p) => p.id == 'gp_b');
+      expect(updatedA.workerPool.masters, 0);
+      expect(updatedA.workerPool.peasants, 1);
+      expect(unchangedB.workerPool.masters, 1);
+      expect(unchangedB.workerPool.peasants, 0);
+    });
+
+    test('gameWithImmediateDisband returns null for unknown player', () {
+      final game = Game(
+        id: 'g',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+        ),
+        players: const [],
+      );
+      final next = gameWithImmediateDisband(
+        game: game,
+        playerId: 'missing',
+        tier: WorkerTier.master,
+      );
+      expect(next, isNull);
+    });
+  });
+
+  group('buildProductionLabourRowData', () {
+    test('returns one row per tier in canonical order', () {
+      final player = _gpWithPool();
+      final rows = buildProductionLabourRowData(
+        player: player,
+        currentOrders: const Orders(),
+        canEdit: true,
+      );
+      expect(
+        rows.map((r) => r.tier).toList(),
+        kProductionLabourTierOrder,
+      );
+    });
+
+    test('canEdit=false disables every append, pop, and disband action', () {
+      final player = _gpWithPool(
+        peasants: 5,
+        masters: 3,
+        treasury: 5000,
+        stockpile: {
+          CommodityCatalog.fabric.id: 10,
+          CommodityCatalog.paper.id: 50,
+        },
+        techUnlocked: const {
+          kTechIdApprenticeWorkers: true,
+          kTechIdSugarRefining: true,
+          kTechIdTrainedJourneymen: true,
+          kTechIdCigarProduction: true,
+          kTechIdMasterArtisans: true,
+          kTechIdHatProduction: true,
+        },
+      );
+      final orders = _ordersWithRecruits([WorkerTier.master]);
+      final rows = buildProductionLabourRowData(
+        player: player,
+        currentOrders: orders,
+        canEdit: false,
+      );
+      for (final row in rows) {
+        expect(row.canAppend, isFalse, reason: 'tier ${row.tier.id}');
+        expect(row.canPop, isFalse, reason: 'tier ${row.tier.id}');
+        expect(row.canDisband, isFalse, reason: 'tier ${row.tier.id}');
+      }
+    });
+
+    test('disband is never enabled for peasant row even with peasants > 0', () {
+      final player = _gpWithPool(peasants: 5);
+      final rows = buildProductionLabourRowData(
+        player: player,
+        currentOrders: const Orders(),
+        canEdit: true,
+      );
+      final peasantRow = rows.firstWhere((r) => r.tier == WorkerTier.peasant);
+      expect(peasantRow.canDisband, isFalse);
+    });
+
+    test('canPop reflects queued count, canDisband reflects pool count', () {
+      final player = _gpWithPool(journeymen: 2);
+      final orders = _ordersWithRecruits([WorkerTier.journeyman]);
+      final rows = buildProductionLabourRowData(
+        player: player,
+        currentOrders: orders,
+        canEdit: true,
+      );
+      final jmRow = rows.firstWhere((r) => r.tier == WorkerTier.journeyman);
+      expect(jmRow.queuedCount, 1);
+      expect(jmRow.canPop, isTrue);
+      expect(jmRow.canDisband, isTrue);
+    });
+  });
+}

--- a/app/test/production_labour_section_test.dart
+++ b/app/test/production_labour_section_test.dart
@@ -1,0 +1,274 @@
+// Widget tests for ProductionLabourSection. SPEC/ui/production-panel.md
+// § Labour Controls, SPEC/game/workers-and-population.md.
+
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:colonizethis_app/features/game/widgets/production_labour_helpers.dart';
+import 'package:colonizethis_app/features/game/widgets/production_labour_section.dart';
+import 'package:colonizethis_app/l10n/l10n.dart';
+
+import 'widget_test_pumps.dart';
+
+const _playerId = 'gp_labour_widget_test';
+
+Player _gpWithPool({
+  int peasants = 0,
+  int apprentices = 0,
+  int journeymen = 0,
+  int masters = 0,
+  int treasury = 0,
+  Map<String, int> stockpile = const {},
+  Map<String, bool>? techUnlocked,
+}) {
+  return Player(
+    id: _playerId,
+    displayName: 'Labour widget GP',
+    isHuman: true,
+    workerPool: WorkerPool(
+      peasants: peasants,
+      apprentices: apprentices,
+      journeymen: journeymen,
+      masters: masters,
+    ),
+    stockpile: Stockpile(quantities: Map<String, int>.from(stockpile)),
+    treasury: treasury,
+    techUnlocked: techUnlocked,
+  );
+}
+
+class _Capture {
+  final List<WorkerTier> appended = [];
+  final List<WorkerTier> popped = [];
+  final List<WorkerTier> disbanded = [];
+
+  ProductionLabourCallbacks asCallbacks() {
+    return ProductionLabourCallbacks(
+      onAppendRecruitOrder: appended.add,
+      onPopLastRecruitOrder: popped.add,
+      onDisband: disbanded.add,
+    );
+  }
+}
+
+Widget _mount({
+  required Player player,
+  Orders currentOrders = const Orders(),
+  bool canEdit = true,
+  ProductionLabourCallbacks? callbacks,
+}) {
+  return MaterialApp(
+    localizationsDelegates:
+        AppLocalizationsBinding.localizationsDelegates,
+    supportedLocales: const [Locale('en')],
+    home: Scaffold(
+      body: SizedBox(
+        width: 800,
+        height: 600,
+        child: ProductionLabourSection(
+          player: player,
+          currentOrders: currentOrders,
+          canEdit: canEdit,
+          callbacks: callbacks ?? _Capture().asCallbacks(),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  suppressLogsForTests();
+
+  group('ProductionLabourSection', () {
+    testWidgets('renders one row per tier (peasant + 3 trained) with disband only on trained tiers', (
+      WidgetTester tester,
+    ) async {
+      final player = _gpWithPool(peasants: 1, apprentices: 1, journeymen: 1, masters: 1);
+      await tester.pumpWidget(_mount(player: player));
+      await pumpSettleCapped(tester);
+
+      // All four tier rows present.
+      for (final tier in kProductionLabourTierOrder) {
+        expect(
+          find.byKey(ValueKey<String>('production_labour_row_${tier.id}')),
+          findsOneWidget,
+          reason: 'expected row for ${tier.id}',
+        );
+      }
+
+      // Disband button on each trained tier (3) but not on peasant.
+      expect(find.text('Disband'), findsNWidgets(3));
+    });
+
+    testWidgets('tapping + on peasant invokes onAppendRecruitOrder with peasant', (
+      WidgetTester tester,
+    ) async {
+      final capture = _Capture();
+      final player = _gpWithPool(
+        stockpile: {CommodityCatalog.fabric.id: 2},
+      );
+      await tester.pumpWidget(
+        _mount(player: player, callbacks: capture.asCallbacks()),
+      );
+      await pumpSettleCapped(tester);
+
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      await tester.tap(
+        find.bySemanticsLabel(
+          l10n.production_labourRecruitTier(l10n.production_workers_peasants),
+        ),
+      );
+      await pumpSyncFrames(tester);
+
+      expect(capture.appended, [WorkerTier.peasant]);
+    });
+
+    testWidgets('tapping − dequeues last matching tier order', (
+      WidgetTester tester,
+    ) async {
+      final capture = _Capture();
+      final player = _gpWithPool(
+        peasants: 1,
+        treasury: 500,
+        stockpile: {CommodityCatalog.paper.id: 5},
+        techUnlocked: const {
+          kTechIdTrainedJourneymen: true,
+          kTechIdCigarProduction: true,
+        },
+      );
+      final orders = Orders(
+        recruitWorkerOrdersByPlayerId: {
+          _playerId: const [RecruitWorkerOrder(targetTier: WorkerTier.journeyman)],
+        },
+      );
+      await tester.pumpWidget(
+        _mount(
+          player: player,
+          currentOrders: orders,
+          callbacks: capture.asCallbacks(),
+        ),
+      );
+      await pumpSettleCapped(tester);
+
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      await tester.tap(
+        find.bySemanticsLabel(
+          l10n.production_labourDequeueTier(l10n.production_workers_journeymen),
+        ),
+      );
+      await pumpSyncFrames(tester);
+
+      expect(capture.popped, [WorkerTier.journeyman]);
+    });
+
+    testWidgets('Queued: N badge appears only when count > 0', (
+      WidgetTester tester,
+    ) async {
+      final player = _gpWithPool(peasants: 1);
+      final orders = Orders(
+        recruitWorkerOrdersByPlayerId: {
+          _playerId: const [
+            RecruitWorkerOrder(targetTier: WorkerTier.peasant),
+            RecruitWorkerOrder(targetTier: WorkerTier.peasant),
+          ],
+        },
+      );
+      await tester.pumpWidget(
+        _mount(player: player, currentOrders: orders),
+      );
+      await pumpSettleCapped(tester);
+
+      expect(find.text('Queued: 2'), findsOneWidget);
+      // Other tiers have no queued orders so no badge appears for them.
+      expect(find.text('Queued: 0'), findsNothing);
+    });
+
+    testWidgets('+ stepper for tech-locked apprentice tier is disabled (no callback on tap)', (
+      WidgetTester tester,
+    ) async {
+      final capture = _Capture();
+      final player = _gpWithPool(
+        peasants: 5,
+        treasury: 5000,
+        stockpile: {CommodityCatalog.paper.id: 50},
+      );
+      await tester.pumpWidget(
+        _mount(player: player, callbacks: capture.asCallbacks()),
+      );
+      await pumpSettleCapped(tester);
+
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      await tester.tap(
+        find.bySemanticsLabel(
+          l10n.production_labourTrainTier(l10n.production_workers_apprentices),
+        ),
+        warnIfMissed: false,
+      );
+      await pumpSyncFrames(tester);
+
+      expect(capture.appended, isEmpty);
+    });
+
+    testWidgets('disband control fires onDisband with the trained tier', (
+      WidgetTester tester,
+    ) async {
+      final capture = _Capture();
+      // Three Disband buttons (one per trained tier); only journeyman enabled.
+      final player = _gpWithPool(journeymen: 1);
+      await tester.pumpWidget(
+        _mount(player: player, callbacks: capture.asCallbacks()),
+      );
+      await pumpSettleCapped(tester);
+
+      await tester.tap(
+        find.byKey(const ValueKey<String>('production_labour_disband_journeymen')),
+      );
+      await pumpSyncFrames(tester);
+
+      expect(capture.disbanded, [WorkerTier.journeyman]);
+    });
+
+    testWidgets('disband is disabled when no worker of that tier (no callback)', (
+      WidgetTester tester,
+    ) async {
+      final capture = _Capture();
+      // No trained workers at all — all three disband buttons rendered, disabled.
+      final player = _gpWithPool(peasants: 1);
+      await tester.pumpWidget(
+        _mount(player: player, callbacks: capture.asCallbacks()),
+      );
+      await pumpSettleCapped(tester);
+
+      await tester.tap(
+        find.byKey(const ValueKey<String>('production_labour_disband_masters')),
+        warnIfMissed: false,
+      );
+      await pumpSyncFrames(tester);
+
+      expect(capture.disbanded, isEmpty);
+    });
+
+    testWidgets('canEdit=false hides all action buttons', (
+      WidgetTester tester,
+    ) async {
+      final player = _gpWithPool(peasants: 2, journeymen: 1);
+      await tester.pumpWidget(_mount(player: player, canEdit: false));
+      await pumpSettleCapped(tester);
+
+      // No disband buttons rendered when read-only.
+      expect(find.text('Disband'), findsNothing);
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      // Append/dequeue semantic labels do not appear because read-only mode
+      // skips emitting any action button.
+      expect(
+        find.bySemanticsLabel(
+          l10n.production_labourRecruitTier(l10n.production_workers_peasants),
+        ),
+        findsNothing,
+      );
+    });
+  });
+}

--- a/packages/colonizethis_logic/lib/colonizethis_logic.dart
+++ b/packages/colonizethis_logic/lib/colonizethis_logic.dart
@@ -62,6 +62,7 @@ export 'src/economy/economy_preview_stockpile_phase.dart';
 export 'src/economy/economy_riches_to_treasury.dart';
 export 'src/economy/resource_extractor.dart';
 export 'src/economy/sea_transport.dart';
+export 'src/economy/worker_action_cost.dart';
 export 'src/economy/worker_economy.dart';
 
 // Orders


### PR DESCRIPTION
## Summary

Implements **S6** (Production panel Labour UI + disband + orders persistence) for #2692.

Refs #2692

## Done in this PR

### SPEC
- `SPEC/ui/production-panel.md` — new **Labour Controls (12-A)** section with per-tier row layout, queue semantics, affordance rules, disband behaviour, and 8 Given–When–Then ACs.

### App UI
- `production_labour_helpers.dart` — pure helpers: queued counts, peasant reservation ledger, projected economy after queued orders, `canAppendRecruitWorkerOrder`, order append/pop (LIFO), immediate disband on `Player`/`Game`.
- `production_labour_section.dart` — `ProductionLabourSection` widget: one row per tier with **+** / **−** steppers and **Disband** (trained tiers only); `buildProductionLabourRowData` for testable affordance.
- `production_panel.dart` — wires Labour section into Workers subpanel when `currentOrders` + `labourCallbacks` provided.
- `production_screen.dart` — binds callbacks to `currentOrdersProvider` (recruit queue) and `currentGameProvider` (immediate disband).

### Logic export
- `colonizethis_logic.dart` — exports `worker_action_cost.dart` (`canAffordRecruitWorker`, `applyRecruitWorkerCostDeduction`) for app affordance checks.

### L10n
- `production_labourQueued`, `production_labourRecruitTier`, `production_labourTrainTier`, `production_labourDequeueTier`, `production_labourDisbandTier`, `production_labourDisband`.

### Tests (32 new)
- `production_labour_helpers_test.dart` — 24 unit tests: queue counts, peasant ledger, affordance (tech/cost/peasant), order mutations, disband.
- `production_labour_section_test.dart` — 8 widget tests: row render, +/− callbacks, Queued badge, tech-lock disable, disband, read-only mode.
- Existing `production_panel_test.dart` (28) and `production_screen_integration_test.dart` (4) pass unchanged.

## AC coverage (this PR)

| AC | Status |
|----|--------|
| Given GP in Orders phase with fabric ≥ 2, tap + on peasant → one `RecruitWorkerOrder` queued | Covered (helper + widget tests) |
| Given queued apprentice order, tap − → LIFO remove | Covered |
| Given tech locked, + disabled for that tier | Covered |
| Given peasant ledger exhausted, + disabled for trained tiers | Covered |
| Given journeymen ≥ 1, Disband → pool update, no order queued | Covered |
| Given non-editable panel, no action buttons | Covered |
| Production Breakdown pending worker costs parity | **Already covered** by S5 merged PRs; Labour controls feed same `currentOrders` |
| Full AI / observer gates (AC #7a/#7b) | Deferred (S10a/S10) |

## Deferred (follow-up on same issue)

- **S9** — broader cross-layer / AI determinism tests for worker orders.
- **S10a / S10** — observer trace analysis + nightly worker tier / 15-regiment gate.
- **Widgetbook** Labour section stories (nice-to-have per issue).
- **E2E** — update `production_panel_e2e_expected_lines.dart` when e2e exercises Labour controls.

## Label transition

`backlog:implementation` **not** moved to `backlog:verification` — S9, S10a, S10 remain open on #2692.

Made with [Cursor](https://cursor.com)