### PR TITLE
test(e2e): lift _nonHomeHumanFleetInNewWorldFromCtSnapshot into shared library + pin (Refs #2336)

### DIFF
--- a/app/integration_test/e2e_helpers.dart
+++ b/app/integration_test/e2e_helpers.dart
@@ -14,24 +14,27 @@ import 'e2e_test_shared_bootstrap.dart';
 
 /// Re-export shared polling / settle entrypoints so scenarios depend on this
 /// barrel only (GitHub #2336 AC2).
-export 'e2e_test_shared.dart' show
-    E2ePerfLog,
-    e2eAdaptivePollRampAfterIdle,
-    e2eMakeWallClockGuard,
-    e2eNewWorldRegionChipAppearsSelected,
-    e2eNonHomeHumanFleetInNewWorldFromCtSnapshot,
-    e2eOldWorldRegionChipAppearsSelected,
-    e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot,
-    e2ePumpUntil,
-    e2ePumpUntilConditionOrIdle,
-    e2eTextLooksLikeNewWorldLocationLine,
-    e2eWaitForNewGameEntry,
-    e2eWaitForNextTurnLabelAdvance,
-    e2eWaitUntilAnyFinderHitTestable,
-    e2eOpenProductionPanel,
-    e2eOpenPanelFromMarker,
-    kE2eMaxWallClock,
-    kE2eNextTurnResolutionTimeout;
+export 'e2e_test_shared.dart'
+    show
+        E2ePerfLog,
+        e2eAdaptivePollRampAfterIdle,
+        e2eMakeWallClockGuard,
+        e2eNewWorldRegionChipAppearsSelected,
+        e2eNonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot,
+        e2eNonHomeHumanFleetInNewWorldFromCtSnapshot,
+        e2eNwCoastalProvincesAdjacentToFleetSea,
+        e2eOldWorldRegionChipAppearsSelected,
+        e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot,
+        e2ePumpUntil,
+        e2ePumpUntilConditionOrIdle,
+        e2eTextLooksLikeNewWorldLocationLine,
+        e2eWaitForNewGameEntry,
+        e2eWaitForNextTurnLabelAdvance,
+        e2eWaitUntilAnyFinderHitTestable,
+        e2eOpenProductionPanel,
+        e2eOpenPanelFromMarker,
+        kE2eMaxWallClock,
+        kE2eNextTurnResolutionTimeout;
 
 Future<void> pumpFor(WidgetTester tester, Duration total) =>
     e2ePumpFor(tester, total);
@@ -43,20 +46,16 @@ Future<void> waitUntilFound(
   Duration diagnoseAfter = Duration.zero,
   E2ePerfLog? perf,
   String phaseName = 'wait_until_found',
-}) =>
-    e2eWaitUntilFound(
-      tester,
-      finder,
-      timeout: timeout,
-      diagnoseAfter: diagnoseAfter,
-      perf: perf,
-      phaseName: phaseName,
-    );
+}) => e2eWaitUntilFound(
+  tester,
+  finder,
+  timeout: timeout,
+  diagnoseAfter: diagnoseAfter,
+  perf: perf,
+  phaseName: phaseName,
+);
 
-Future<void> dismissTransientUi(
-  WidgetTester tester, {
-  E2ePerfLog? perf,
-}) =>
+Future<void> dismissTransientUi(WidgetTester tester, {E2ePerfLog? perf}) =>
     e2eDismissTransientUi(tester, perf: perf);
 
 Future<void> openCivilianPanel(
@@ -66,34 +65,31 @@ Future<void> openCivilianPanel(
   Duration bottomSheetCloseTimeout = kE2eDefaultBottomSheetCloseTimeout,
   String afterSheetPanelsClearPhase =
       'pump_until_panels_cleared_after_close_sheet_civilian_open',
-}) =>
-    e2eOpenCivilianPanel(
-      tester,
-      timeout: timeout,
-      perf: perf,
-      bottomSheetCloseTimeout: bottomSheetCloseTimeout,
-      afterSheetPanelsClearPhase: afterSheetPanelsClearPhase,
-    );
+}) => e2eOpenCivilianPanel(
+  tester,
+  timeout: timeout,
+  perf: perf,
+  bottomSheetCloseTimeout: bottomSheetCloseTimeout,
+  afterSheetPanelsClearPhase: afterSheetPanelsClearPhase,
+);
 
 Future<void> openNavalPanel(
   WidgetTester tester, {
   E2ePerfLog? perf,
   Duration timeout = kE2eDefaultNavalOpenTimeout,
   Duration bottomSheetCloseTimeout = kE2eDefaultBottomSheetCloseTimeout,
-}) =>
-    e2eOpenNavalPanel(
-      tester,
-      perf: perf,
-      timeout: timeout,
-      bottomSheetCloseTimeout: bottomSheetCloseTimeout,
-    );
+}) => e2eOpenNavalPanel(
+  tester,
+  perf: perf,
+  timeout: timeout,
+  bottomSheetCloseTimeout: bottomSheetCloseTimeout,
+);
 
 Future<void> openProductionPanel(
   WidgetTester tester, {
   E2ePerfLog? perf,
   Duration timeout = const Duration(seconds: 20),
-}) =>
-    e2eOpenProductionPanel(tester, perf: perf, timeout: timeout);
+}) => e2eOpenProductionPanel(tester, perf: perf, timeout: timeout);
 
 Future<void> openPanelFromMarker(
   WidgetTester tester, {
@@ -101,58 +97,44 @@ Future<void> openPanelFromMarker(
   required Finder panelRoot,
   Duration timeout = const Duration(seconds: 20),
   E2ePerfLog? perf,
-}) =>
-    e2eOpenPanelFromMarker(
-      tester,
-      markerButton: markerButton,
-      panelRoot: panelRoot,
-      timeout: timeout,
-      perf: perf,
-    );
+}) => e2eOpenPanelFromMarker(
+  tester,
+  markerButton: markerButton,
+  panelRoot: panelRoot,
+  timeout: timeout,
+  perf: perf,
+);
 
 Future<Duration> waitForNextTurnLabelAdvance(
   WidgetTester tester, {
   required String turnLabelBefore,
   required Duration timeout,
   E2ePerfLog? perf,
-}) =>
-    e2eWaitForNextTurnLabelAdvance(
-      tester,
-      turnLabelBefore: turnLabelBefore,
-      timeout: timeout,
-      perf: perf,
-    );
+}) => e2eWaitForNextTurnLabelAdvance(
+  tester,
+  turnLabelBefore: turnLabelBefore,
+  timeout: timeout,
+  perf: perf,
+);
 
 Future<Duration> advanceOneHumanTurn(
   WidgetTester tester, {
   required AppLocalizations l10n,
   E2ePerfLog? perf,
   Duration timeout = kE2eNextTurnResolutionTimeout,
-}) =>
-    e2eAdvanceOneHumanTurn(
-      tester,
-      l10n: l10n,
-      perf: perf,
-      timeout: timeout,
-    );
+}) => e2eAdvanceOneHumanTurn(tester, l10n: l10n, perf: perf, timeout: timeout);
 
 Future<void> closeBottomSheet(
   WidgetTester tester, {
   E2ePerfLog? perf,
   Duration overallTimeout = kE2eDefaultBottomSheetCloseTimeout,
-}) =>
-    e2eCloseBottomSheet(
-      tester,
-      perf: perf,
-      overallTimeout: overallTimeout,
-    );
+}) => e2eCloseBottomSheet(tester, perf: perf, overallTimeout: overallTimeout);
 
 Future<void> bootstrapNewGameToMap(
   WidgetTester tester, {
   E2ePerfLog? perf,
   Duration overallCap = const Duration(seconds: 60),
-}) =>
-    e2eBootstrapNewGameToMap(tester, perf: perf, overallCap: overallCap);
+}) => e2eBootstrapNewGameToMap(tester, perf: perf, overallCap: overallCap);
 
 void collectTextPreorder(Element element, List<String> out) =>
     e2eCollectTextPreorder(element, out);
@@ -167,15 +149,14 @@ Future<void> splitHomeFleetOnce(
   Duration openNavalTimeout = kE2eDefaultNavalOpenTimeout,
   Duration bottomSheetCloseTimeout = kE2eDefaultBottomSheetCloseTimeout,
   bool navalPanelAlreadyOpen = false,
-}) =>
-    e2eSplitHomeFleetOnce(
-      tester,
-      l10n,
-      perf: perf,
-      openNavalTimeout: openNavalTimeout,
-      bottomSheetCloseTimeout: bottomSheetCloseTimeout,
-      navalPanelAlreadyOpen: navalPanelAlreadyOpen,
-    );
+}) => e2eSplitHomeFleetOnce(
+  tester,
+  l10n,
+  perf: perf,
+  openNavalTimeout: openNavalTimeout,
+  bottomSheetCloseTimeout: bottomSheetCloseTimeout,
+  navalPanelAlreadyOpen: navalPanelAlreadyOpen,
+);
 
 Future<void> tapFirstAssignInCivilianPanel(WidgetTester tester) =>
     e2eTapFirstAssignInCivilianPanel(tester);
@@ -183,8 +164,7 @@ Future<void> tapFirstAssignInCivilianPanel(WidgetTester tester) =>
 Future<void> tapAssignOnCivilianRowWithTitle(
   WidgetTester tester,
   String unitTypeTitle,
-) =>
-    e2eTapAssignOnCivilianRowWithTitle(tester, unitTypeTitle);
+) => e2eTapAssignOnCivilianRowWithTitle(tester, unitTypeTitle);
 
 Future<void> ensureAllRelocated64pxPngsLoad() =>
     e2eEnsureAllRelocated64pxPngsLoad();

--- a/app/integration_test/e2e_helpers.dart
+++ b/app/integration_test/e2e_helpers.dart
@@ -21,6 +21,7 @@ export 'e2e_test_shared.dart'
         e2eMakeWallClockGuard,
         e2eNewWorldRegionChipAppearsSelected,
         e2eNonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot,
+        e2eNavalPanelShowsNonHomeFleetInNewWorld,
         e2eNonHomeHumanFleetInNewWorldFromCtSnapshot,
         e2eNwCoastalProvincesAdjacentToFleetSea,
         e2eOldWorldRegionChipAppearsSelected,

--- a/app/integration_test/e2e_helpers.dart
+++ b/app/integration_test/e2e_helpers.dart
@@ -19,6 +19,7 @@ export 'e2e_test_shared.dart' show
     e2eAdaptivePollRampAfterIdle,
     e2eMakeWallClockGuard,
     e2eNewWorldRegionChipAppearsSelected,
+    e2eNonHomeHumanFleetInNewWorldFromCtSnapshot,
     e2eOldWorldRegionChipAppearsSelected,
     e2ePumpUntil,
     e2ePumpUntilConditionOrIdle,

--- a/app/integration_test/e2e_helpers.dart
+++ b/app/integration_test/e2e_helpers.dart
@@ -18,6 +18,7 @@ export 'e2e_test_shared.dart'
     show
         E2ePerfLog,
         e2eAdaptivePollRampAfterIdle,
+        e2eExploreAssignEnabledFromCivilianSnapshot,
         e2eMakeWallClockGuard,
         e2eNewWorldRegionChipAppearsSelected,
         e2eNonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot,

--- a/app/integration_test/e2e_helpers.dart
+++ b/app/integration_test/e2e_helpers.dart
@@ -18,6 +18,7 @@ export 'e2e_test_shared.dart'
     show
         E2ePerfLog,
         e2eAdaptivePollRampAfterIdle,
+        e2eBundledExploreRejectionDiagnostics,
         e2eExploreAssignEnabledFromCivilianSnapshot,
         e2eFleetReachDoneFromCtSnapshotOnly,
         e2eHarnessDetectsNonHomeFleetInNewWorld,

--- a/app/integration_test/e2e_helpers.dart
+++ b/app/integration_test/e2e_helpers.dart
@@ -21,6 +21,7 @@ export 'e2e_test_shared.dart' show
     e2eNewWorldRegionChipAppearsSelected,
     e2eNonHomeHumanFleetInNewWorldFromCtSnapshot,
     e2eOldWorldRegionChipAppearsSelected,
+    e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot,
     e2ePumpUntil,
     e2ePumpUntilConditionOrIdle,
     e2eTextLooksLikeNewWorldLocationLine,

--- a/app/integration_test/e2e_helpers.dart
+++ b/app/integration_test/e2e_helpers.dart
@@ -19,6 +19,8 @@ export 'e2e_test_shared.dart'
         E2ePerfLog,
         e2eAdaptivePollRampAfterIdle,
         e2eExploreAssignEnabledFromCivilianSnapshot,
+        e2eFleetReachDoneFromCtSnapshotOnly,
+        e2eHarnessDetectsNonHomeFleetInNewWorld,
         e2eMakeWallClockGuard,
         e2eNewWorldRegionChipAppearsSelected,
         e2eNonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot,

--- a/app/integration_test/e2e_test_shared.dart
+++ b/app/integration_test/e2e_test_shared.dart
@@ -2,7 +2,7 @@ import 'dart:math' as math;
 
 import 'package:colonizethis_app/config/ct_e2e.dart';
 import 'package:colonizethis_app/config/ct_e2e_last_panel_snapshot.dart'
-    show CtE2eNavalPanelSnapshot;
+    show CtE2eCivilianPanelSnapshot, CtE2eNavalPanelSnapshot;
 import 'package:colonizethis_app/features/game/dialogue/game_start_intro_overlay.dart';
 import 'package:colonizethis_app/features/game/flame/game_screen_shared.dart';
 import 'package:colonizethis_app/features/game/flame/turn_resolution_processing_dialog.dart';
@@ -15,6 +15,7 @@ import 'package:colonizethis_logic/colonizethis_logic.dart'
         allProvinces,
         buildPlayerView,
         homeFleetIdFor,
+        kWorkTargetExplore,
         provinceIdsAdjacentToSeaZone,
         regionIdForSeaZone;
 import 'package:colonizethis_models/colonizethis_models.dart' show ProvinceId;
@@ -1035,6 +1036,72 @@ bool e2eNonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot(
       sea,
       regionId,
     ).isNotEmpty) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/// True when [snap] reports at least one civilian-panel unit row whose
+/// available work targets include [kWorkTargetExplore]; `null` when no
+/// civilian-panel snapshot is plumbed for the current turn.
+///
+/// Lifted from the formerly private
+/// `_exploreAssignEnabledFromCivilianSnapshot` in
+/// `new_game_fleet_reaches_new_world_e2e_helpers_part2.dart` (Refs GitHub
+/// #2336 AC1 / AC2). The fleet-reach test's
+/// `_anyExplorerHasEnabledExploreAssignFleetE2e` helper consults this
+/// predicate first to short-circuit the panel-sweep loop when the panel
+/// snapshot already exposes an Explore-enabled work-target list — the
+/// loop only falls back to the expensive scrolling `Assign` sheet walk
+/// when no snapshot is available (the `null` return). The snapshot
+/// mirrors `availableWorkTargetIdsForUnitProvider`, which is the same
+/// data source that drives enabled `Assign` rows in the live panel
+/// (`SPEC/program/e2e-integration-tests.md` § Determinism), so the
+/// short-circuit is contractually equivalent to the live walk and a
+/// silent rename / fail-open here would re-introduce up to
+/// `maxPanelSweepSteps (16) × per-step assign sweep` of wasted frames
+/// per fleet-reach turn (Bottleneck 5 in `SPEC/program/e2e-integration-tests.md`
+/// § Determinism, #2336 AC5).
+///
+/// The function takes the snapshot explicitly rather than reading the
+/// mutable `ctE2eCivilianPanelSnapshot` global so the contract is
+/// deterministic and unit-testable (matches the lifted
+/// [e2eNonHomeHumanFleetInNewWorldFromCtSnapshot] /
+/// [e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot] /
+/// [e2eNonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot] precedent).
+///
+/// Contract:
+///
+/// - Returns `null` when [snap] is `null` (no civilian-panel snapshot
+///   plumbing this turn — caller must fall back to the live `Assign`
+///   sheet sweep rather than treat a missing snapshot as either
+///   "Explore enabled" or "Explore disabled").
+/// - Returns `true` on the **first** unit row whose
+///   `availableWorkTargets` list contains [kWorkTargetExplore] (existential
+///   short-circuit: the panel only needs one Explore-enabled unit to
+///   surface the assign affordance).
+/// - Returns `false` after every unit row has been considered with no
+///   Explore target found (panel is mounted but no civilian can be
+///   assigned Explore right now).
+/// - Iterates `snap.availableWorkTargets.values` in the map's iteration
+///   order; the `String` target ids are compared with exact equality so
+///   case mutations (e.g. `Explore`) never satisfy the predicate.
+///
+/// The integration suite cannot validate this directly today
+/// (`app_e2e_linux` is a no-op per
+/// `SPEC/program/e2e-integration-tests.md` § CI), so the widget-test pin
+/// in
+/// `app/test/e2e_explore_assign_enabled_from_civilian_snapshot_test.dart`
+/// carries the behavioural contract.
+bool? e2eExploreAssignEnabledFromCivilianSnapshot(
+  CtE2eCivilianPanelSnapshot? snap,
+) {
+  if (snap == null) {
+    return null;
+  }
+  for (final targets in snap.availableWorkTargets.values) {
+    if (targets.contains(kWorkTargetExplore)) {
       return true;
     }
   }

--- a/app/integration_test/e2e_test_shared.dart
+++ b/app/integration_test/e2e_test_shared.dart
@@ -682,8 +682,7 @@ bool e2eNewWorldRegionChipAppearsSelected() {
 /// (`—`), but earlier CI dumps and Material text scaling can normalize the
 /// glyph to an **en dash** (`–`) or a plain **hyphen-minus** (`-`). The
 /// helper accepts all three so fleet-reach detection
-/// (`_navalPanelShowsNonHomeFleetInNewWorld` in
-/// `new_game_fleet_reaches_new_world_e2e_helpers_part2.dart`) is not coupled
+/// ([e2eNavalPanelShowsNonHomeFleetInNewWorld]) is not coupled
 /// to one specific Unicode glyph.
 ///
 /// Contract (Refs GitHub #2336):
@@ -709,6 +708,58 @@ bool e2eTextLooksLikeNewWorldLocationLine(String? data) {
   }
   final rest = after.trimLeft();
   return rest.startsWith('—') || rest.startsWith('–') || rest.startsWith('-');
+}
+
+/// Widget-only: true when a **non-home** fleet row under [kCtE2ENavalPanelRootKey]
+/// shows a New World location subtitle (`New World — …` per
+/// `naval_tree_builder.dart`).
+///
+/// Lifted from the formerly private `_navalPanelShowsNonHomeFleetInNewWorld` in
+/// `new_game_fleet_reaches_new_world_e2e_helpers_part2.dart` (Refs GitHub
+/// #2336 AC1 / AC2). Used as the UI fallback in
+/// `_harnessDetectsNonHomeFleetInNewWorld` when [ctE2eNavalPanelSnapshot] is
+/// null (snapshot plumbing unavailable). A silent rename / fail-open here would
+/// stall fleet-reach loops at `_kMaxNextTurnTapsForNwFleetReach (35) × ~5 s`
+/// (`SPEC/program/e2e-integration-tests.md` § Determinism, #2336 Bottleneck 4).
+///
+/// Contract:
+/// - Returns `false` when the naval panel root key is absent.
+/// - Iterates [ExpansionTile] descendants in stable tree order; skips tiles
+///   without a `Text` whose `data` starts with `'Fleet '`.
+/// - Returns `true` on the first tile that also has a descendant `Text` matching
+///   [e2eTextLooksLikeNewWorldLocationLine].
+bool e2eNavalPanelShowsNonHomeFleetInNewWorld(WidgetTester tester) {
+  final naval = find.byKey(kCtE2ENavalPanelRootKey);
+  if (naval.evaluate().isEmpty) {
+    return false;
+  }
+  final tiles = find.descendant(
+    of: naval,
+    matching: find.byType(ExpansionTile),
+  );
+  final n = tiles.evaluate().length;
+  for (var i = 0; i < n; i++) {
+    final sub = tiles.at(i);
+    final fleetTitle = find.descendant(
+      of: sub,
+      matching: find.byWidgetPredicate(
+        (w) => w is Text && (w.data?.startsWith('Fleet ') ?? false),
+      ),
+    );
+    if (fleetTitle.evaluate().isEmpty) {
+      continue;
+    }
+    final loc = find.descendant(
+      of: sub,
+      matching: find.byWidgetPredicate(
+        (w) => w is Text && e2eTextLooksLikeNewWorldLocationLine(w.data),
+      ),
+    );
+    if (loc.evaluate().isNotEmpty) {
+      return true;
+    }
+  }
+  return false;
 }
 
 /// True when [snap] reflects a **non-home human** fleet whose region is

--- a/app/integration_test/e2e_test_shared.dart
+++ b/app/integration_test/e2e_test_shared.dart
@@ -1,12 +1,16 @@
 import 'dart:math' as math;
 
 import 'package:colonizethis_app/config/ct_e2e.dart';
+import 'package:colonizethis_app/config/ct_e2e_last_panel_snapshot.dart'
+    show CtE2eNavalPanelSnapshot;
 import 'package:colonizethis_app/features/game/dialogue/game_start_intro_overlay.dart';
 import 'package:colonizethis_app/features/game/flame/game_screen_shared.dart';
 import 'package:colonizethis_app/features/game/flame/turn_resolution_processing_dialog.dart';
 import 'package:colonizethis_app/l10n/app_localizations_contract.dart';
 import 'package:colonizethis_app/widgets/ct_choice_chip.dart';
 import 'package:colonizethis_app/widgets/ct_dialog_shell.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart'
+    show homeFleetIdFor, regionIdForSeaZone;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -700,6 +704,63 @@ bool e2eTextLooksLikeNewWorldLocationLine(String? data) {
   return rest.startsWith('—') || rest.startsWith('–') || rest.startsWith('-');
 }
 
+/// True when [snap] reflects a **non-home human** fleet whose region is
+/// `newWorld` — either directly via `Fleet.regionId == 'newWorld'`, or
+/// indirectly because the fleet's `seaZoneId` resolves to `newWorld`
+/// through `regionIdForSeaZone(snap.topology, …)`.
+///
+/// Lifted from the formerly private
+/// `_nonHomeHumanFleetInNewWorldFromCtSnapshot` in
+/// `new_game_fleet_reaches_new_world_e2e_helpers_part2.dart` (Refs GitHub
+/// #2336 AC1 / AC2). The fleet-reach loop short-circuit
+/// (`_fleetReachDoneFromCtSnapshotOnly`, `_harnessDetectsNonHomeFleetInNewWorld`)
+/// and the bundled-explore readiness loop depend on this predicate to
+/// terminate within the 35-turn cap when [ctE2eNavalPanelSnapshot] reports
+/// arrival — a silent rename / fail-open here would stall the suite at
+/// `_kMaxNextTurnTapsForNwFleetReach × ~5 s` (`SPEC/program/e2e-integration-tests.md`
+/// § Determinism, #2336 Bottleneck 4).
+///
+/// Contract:
+///
+/// - Returns `false` when [snap] is `null` (no snapshot plumbing this turn).
+/// - Iterates `snap.game.worldState.fleets` in stable list order; for each
+///   fleet skips when `f.ownerId != snap.humanPlayerId`.
+/// - Skips the human's home fleet (`homeFleetIdFor(snap.humanPlayerId)`)
+///   so that an opening home-fleet-only state never short-circuits the
+///   loop on turn 0.
+/// - Returns `true` when the first surviving fleet has `regionId ==
+///   'newWorld'`.
+/// - Otherwise consults `regionIdForSeaZone(snap.topology, sea)` and
+///   returns `true` when the seaboard resolves to `newWorld`. A `null`
+///   `seaZoneId` (in-port) or a sea zone the topology cannot resolve
+///   keeps iterating.
+/// - Returns `false` only after every fleet has been considered.
+///
+/// The integration suite cannot validate this directly today
+/// (`app_e2e_linux` is a no-op per
+/// `SPEC/program/e2e-integration-tests.md` § CI), so the widget-test pin
+/// in `app/test/e2e_non_home_human_fleet_in_new_world_from_ct_snapshot_test.dart`
+/// carries the behavioural contract.
+bool e2eNonHomeHumanFleetInNewWorldFromCtSnapshot(
+  CtE2eNavalPanelSnapshot? snap,
+) {
+  if (snap == null) {
+    return false;
+  }
+  final human = snap.humanPlayerId;
+  final homeId = homeFleetIdFor(human);
+  for (final f in snap.game.worldState.fleets) {
+    if (f.ownerId != human) continue;
+    if (f.id == homeId) continue;
+    if (f.regionId == 'newWorld') return true;
+    final sea = f.seaZoneId;
+    if (sea != null && regionIdForSeaZone(snap.topology, sea) == 'newWorld') {
+      return true;
+    }
+  }
+  return false;
+}
+
 /// Returns after the first [Finder] has at least one hit-testable match.
 Future<void> e2eWaitUntilAnyFinderHitTestable(
   WidgetTester tester,
@@ -900,4 +961,3 @@ Future<Duration> e2eAdvanceOneHumanTurn(
   perf?.timing('next_turn_advance', phaseSw.elapsed);
   return labelWait;
 }
-

--- a/app/integration_test/e2e_test_shared.dart
+++ b/app/integration_test/e2e_test_shared.dart
@@ -9,8 +9,14 @@ import 'package:colonizethis_app/features/game/flame/turn_resolution_processing_
 import 'package:colonizethis_app/l10n/app_localizations_contract.dart';
 import 'package:colonizethis_app/widgets/ct_choice_chip.dart';
 import 'package:colonizethis_app/widgets/ct_dialog_shell.dart';
+import 'package:colonizethis_data/colonizethis_data.dart' show MapTopology;
 import 'package:colonizethis_logic/colonizethis_logic.dart'
-    show allProvinces, buildPlayerView, homeFleetIdFor, regionIdForSeaZone;
+    show
+        allProvinces,
+        buildPlayerView,
+        homeFleetIdFor,
+        provinceIdsAdjacentToSeaZone,
+        regionIdForSeaZone;
 import 'package:colonizethis_models/colonizethis_models.dart' show ProvinceId;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -842,6 +848,142 @@ bool e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot(
       continue;
     }
     if (entry.value.name != 'unknown') {
+      return true;
+    }
+  }
+  return false;
+}
+
+/// Returns the set of province ids adjacent to [seaZoneId] in [topology],
+/// trying the caller's [seaZoneId] verbatim first and falling back to the
+/// region-prefixed form when the verbatim lookup is empty and the input is
+/// not already prefixed.
+///
+/// Lifted from the formerly private `_nwCoastalProvincesAdjacentToFleetSea`
+/// helper in `new_game_fleet_reaches_new_world_e2e_helpers_part2.dart`
+/// (Refs GitHub #2336 AC1 / AC2). The two-tier lookup exists because
+/// `provinceIdsAdjacentToSeaZone` (`SPEC/program/fog-and-exploration-resolution.md`)
+/// matches edge endpoints exactly, but the combined topology used by the
+/// app/turn resolver uses prefixed sea node ids (`newWorld|sea5`) while
+/// some live fleet states still carry the regional local id (`sea5`). The
+/// fallback keeps coastal detection aligned with the ship-reveal contract
+/// regardless of which form is present in the fleet record.
+///
+/// Contract:
+///
+/// - First call: `provinceIdsAdjacentToSeaZone(topology, seaZoneId,
+///   regionId: regionId)`. If the result is **non-empty**, return it.
+/// - Otherwise, if [seaZoneId] is already a prefixed id
+///   (`ProvinceId.isPrefixed(seaZoneId)` is true), return an empty
+///   set — the verbatim lookup is authoritative and a missing match
+///   means the topology genuinely has no adjacent provinces.
+/// - Otherwise (verbatim was empty and [seaZoneId] is a bare local id),
+///   retry with `ProvinceId.full(regionId, seaZoneId)`.
+/// - Return the second-call result, or the empty constant set if even
+///   that lookup is empty.
+///
+/// The function is pure and deterministic — identical inputs always yield
+/// identical sets (Refs #2336 AC2 / Bottleneck 6 dedup goal). Taking
+/// [topology] and [regionId] explicitly (rather than reading the mutable
+/// `ctE2eNavalPanelSnapshot` global) matches the pattern established by
+/// [e2eNonHomeHumanFleetInNewWorldFromCtSnapshot] and keeps the helper
+/// unit-testable without a live snapshot fixture.
+Set<String> e2eNwCoastalProvincesAdjacentToFleetSea(
+  MapTopology topology,
+  String seaZoneId,
+  String regionId,
+) {
+  final direct = provinceIdsAdjacentToSeaZone(
+    topology,
+    seaZoneId,
+    regionId: regionId,
+  );
+  if (direct.isNotEmpty) return direct;
+  if (!ProvinceId.isPrefixed(seaZoneId)) {
+    return provinceIdsAdjacentToSeaZone(
+      topology,
+      ProvinceId.full(regionId, seaZoneId),
+      regionId: regionId,
+    );
+  }
+  return const {};
+}
+
+/// True when [snap] reflects a **non-home human** fleet sitting in a
+/// New World sea zone that has at least one adjacent coastal province
+/// (per [e2eNwCoastalProvincesAdjacentToFleetSea]).
+///
+/// Lifted from the formerly private
+/// `_nonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot` in
+/// `new_game_fleet_reaches_new_world_e2e_helpers_part2.dart` (Refs
+/// GitHub #2336 AC1 / AC2). This predicate is the **coastal** companion
+/// to [e2eNonHomeHumanFleetInNewWorldFromCtSnapshot]: ship reveal only
+/// paints coastal land for sea zones that have a P–S province edge
+/// (`SPEC/program/fog-and-exploration-resolution.md`), so a fleet in an
+/// open-ocean NW sea satisfies the "fleet in NW" predicate but never
+/// yields fogged-or-better NW provinces — leaving bundled Explore
+/// disabled. The bundled-explore readiness loop
+/// (`_awaitNwCoastalOrVisibleLandForBundledExploreE2e`) therefore
+/// short-circuits on this predicate alongside
+/// [e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot]; a silent
+/// rename / fail-open here would stall the readiness loop at
+/// `35 × ~5 s` (Bottleneck 4 in `SPEC/program/e2e-integration-tests.md`
+/// § Determinism) and inflate the wall-clock cap #2336 is reducing.
+///
+/// The function takes the snapshot explicitly rather than reading the
+/// mutable `ctE2eNavalPanelSnapshot` global so the contract is
+/// deterministic and unit-testable (matches the lifted
+/// [e2eNonHomeHumanFleetInNewWorldFromCtSnapshot] and
+/// [e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot] precedent).
+///
+/// Contract:
+///
+/// - Returns `false` when [snap] is `null` (no snapshot plumbing this
+///   turn — the readiness loop must keep iterating).
+/// - Iterates `snap.game.worldState.fleets` in stable list order; for
+///   each fleet skips when `f.ownerId != snap.humanPlayerId`.
+/// - Skips the human's home fleet
+///   (`homeFleetIdFor(snap.humanPlayerId)`) so an opening
+///   home-fleet-only state never short-circuits the loop.
+/// - Skips fleets in port (`!f.isAtSea`) and fleets with a `null`
+///   `seaZoneId` (cannot resolve adjacency).
+/// - Resolves each fleet's region via `f.regionId == 'newWorld'` first
+///   (canonical post-warp state); otherwise consults
+///   `regionIdForSeaZone(snap.topology, sea)`. Skips when the resolved
+///   region is `null` or not exactly `newWorld`
+///   (case-sensitive match — pinning the contract against accidental
+///   normalization).
+/// - Returns `true` on the first fleet whose
+///   [e2eNwCoastalProvincesAdjacentToFleetSea] lookup yields a
+///   non-empty province set (coastal sea zone with a P–S edge).
+/// - Returns `false` after every fleet has been considered.
+///
+/// The integration suite cannot validate this directly today
+/// (`app_e2e_linux` is a no-op per
+/// `SPEC/program/e2e-integration-tests.md` § CI), so the widget-test
+/// pin in
+/// `app/test/e2e_non_home_human_fleet_in_coastal_new_world_sea_from_ct_snapshot_test.dart`
+/// carries the behavioural contract.
+bool e2eNonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot(
+  CtE2eNavalPanelSnapshot? snap,
+) {
+  if (snap == null) return false;
+  final human = snap.humanPlayerId;
+  final homeId = homeFleetIdFor(human);
+  for (final f in snap.game.worldState.fleets) {
+    if (f.ownerId != human) continue;
+    if (f.id == homeId) continue;
+    if (!f.isAtSea || f.seaZoneId == null) continue;
+    final sea = f.seaZoneId!;
+    final String? regionId = f.regionId == 'newWorld'
+        ? 'newWorld'
+        : regionIdForSeaZone(snap.topology, sea);
+    if (regionId == null || regionId != 'newWorld') continue;
+    if (e2eNwCoastalProvincesAdjacentToFleetSea(
+      snap.topology,
+      sea,
+      regionId,
+    ).isNotEmpty) {
       return true;
     }
   }

--- a/app/integration_test/e2e_test_shared.dart
+++ b/app/integration_test/e2e_test_shared.dart
@@ -12,13 +12,17 @@ import 'package:colonizethis_app/widgets/ct_dialog_shell.dart';
 import 'package:colonizethis_data/colonizethis_data.dart' show MapTopology;
 import 'package:colonizethis_logic/colonizethis_logic.dart'
     show
+        OrderEngine,
         allProvinces,
         buildPlayerView,
         homeFleetIdFor,
+        kUnitTypeExplorer,
         kWorkTargetExplore,
         provinceIdsAdjacentToSeaZone,
-        regionIdForSeaZone;
-import 'package:colonizethis_models/colonizethis_models.dart' show ProvinceId;
+        regionIdForSeaZone,
+        suggestWorkOrders;
+import 'package:colonizethis_models/colonizethis_models.dart'
+    show MoveOrder, ProvinceId, Unit, WorkOrder;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -1343,4 +1347,171 @@ Future<Duration> e2eAdvanceOneHumanTurn(
   );
   perf?.timing('next_turn_advance', phaseSw.elapsed);
   return labelWait;
+}
+
+/// Builds the multi-line bundled-Explore failure diagnostic surfaced when
+/// the fleet-reach test cannot enable an Explorer's `Assign Explore` row
+/// after the New World bundled-Explore retries exhaust
+/// (`new_game_fleet_reaches_new_world_e2e_test.dart` final guard).
+///
+/// Lifted from the formerly private `_bundledExploreRejectionDiagnostics`
+/// in `new_game_fleet_reaches_new_world_e2e_helpers_part2.dart` (Refs
+/// GitHub #2336 AC1 / AC2). The lifted form takes both panel snapshots
+/// explicitly instead of reading the mutable `ctE2eNavalPanelSnapshot`
+/// and `ctE2eCivilianPanelSnapshot` globals, so the contract is
+/// deterministic and unit-testable (matches the precedent set by the
+/// other lifted snapshot-driven helpers in this library).
+///
+/// Contract:
+///
+/// - Returns the literal string
+///   `'No ctE2eNavalPanelSnapshot available for diagnostics.'` when
+///   [navalSnapshot] is `null`. The error string text is part of the
+///   contract — the caller embeds it directly in a `fail()` message, so a
+///   silent rename would erase the canonical fallback diagnostic.
+/// - Otherwise builds a `'\n'`-joined list of `diag:`-prefixed lines:
+///   - `'diag: player=<playerId>'`
+///   - `'diag: civilianSnapshotAvailable=<true|false>'`
+///   - When `civilianSnapshot != null`:
+///     `'diag: availableWorkTargets=<Map.toString()>'`
+///   - `'diag: draftMoveOrders=<list of "unitId->provinceId" or empty list>'`
+///     using `Unit.provinceIdFromTileKey` to derive the destination
+///     province; `'?'` substitutes when the tile key cannot be resolved.
+///   - `'diag: suggestedExplore=<list of "unitId@provinceId" entries>'`
+///     filtered to `suggestWorkOrders` output rows where
+///     `target == kWorkTargetExplore`.
+/// - If the human player view has **zero** Explorer units, appends a
+///   single closing line `'diag: no explorer units found in player view.'`
+///   and returns immediately (no per-province probe block).
+/// - Otherwise sorts explorer units ascending by `unit.id`, and for each
+///   explorer:
+///   - Emits `'diag: explorer unit=<id> atProvince=<provinceId> tileKey=<tileKey|"(null)">'`.
+///   - For every province in `allProvinces(game.worldState)` sorted
+///     ascending by `province.id`, computes an `ownerKind`
+///     (`'none'`, `'self'`, `'tribe'`, `'minor'`, `'gp'`) and probes the
+///     explore + move acceptance via two fresh [OrderEngine] instances
+///     against the snapshot's draft orders, emitting one
+///     `'diag: province=&lt;id&gt; owner=&lt;id|"(none)"&gt; '`
+///     `'ownerKind=&lt;kind&gt; visibleFoggedPlus=&lt;bool&gt; '`
+///     `'workAccepted=&lt;bool&gt; workReason=&lt;string|"(none)"&gt; '`
+///     `'moveAccepted=&lt;bool&gt; moveReason=&lt;string|"(none)"&gt;'`
+///     line per province.
+/// - `visibleFoggedPlus` is `true` whenever any tile key in
+///   `view.visibilityByTile` whose first two `|`-segments match the
+///   province (`regionId|localId`) has a level whose name is not
+///   `'unknown'` (i.e. `'fogged'` or `'fullyVisible'`). Tile keys that
+///   do not split into exactly four `|`-segments are skipped (mirrors
+///   [e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot] parsing).
+///
+/// The function is **pure** with respect to its inputs: identical
+/// `(navalSnapshot, civilianSnapshot)` pairs must yield byte-identical
+/// strings (the deterministic explorer + province sort plus the
+/// fresh-per-call [OrderEngine] probes ensure this). The
+/// per-province loop costs `O(explorerUnits × provinces)` order-engine
+/// probes; callers should only invoke this helper from the cold failure
+/// path (Refs `colonizethis-turn-resolution-budget.mdc` "Avoid
+/// per-candidate debug logs in tight paths").
+///
+/// The integration suite cannot validate this directly today
+/// (`app_e2e_linux` is a no-op per
+/// `SPEC/program/e2e-integration-tests.md` § CI), so the widget-test pin
+/// in `app/test/e2e_bundled_explore_rejection_diagnostics_test.dart`
+/// carries the behavioural contract.
+String e2eBundledExploreRejectionDiagnostics({
+  required CtE2eNavalPanelSnapshot? navalSnapshot,
+  required CtE2eCivilianPanelSnapshot? civilianSnapshot,
+}) {
+  if (navalSnapshot == null) {
+    return 'No ctE2eNavalPanelSnapshot available for diagnostics.';
+  }
+  final game = navalSnapshot.game;
+  final topology = navalSnapshot.topology;
+  final playerId = navalSnapshot.humanPlayerId;
+  final orders = navalSnapshot.draftOrders;
+  final view = buildPlayerView(game, topology, playerId);
+  final suggestions = suggestWorkOrders(view, game, topology, orders);
+
+  bool provinceHasFoggedOrBetter(String provinceFullId) {
+    final regionId = ProvinceId.regionIdFrom(provinceFullId);
+    final localId = ProvinceId.localIdFrom(provinceFullId);
+    for (final e in view.visibilityByTile.entries) {
+      final parts = e.key.split('|');
+      if (parts.length != 4) {
+        continue;
+      }
+      if (parts[0] != regionId || parts[1] != localId) {
+        continue;
+      }
+      if (e.value.name != 'unknown') {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  final lines = <String>[
+    'diag: player=$playerId',
+    'diag: civilianSnapshotAvailable=${civilianSnapshot != null}',
+    if (civilianSnapshot != null)
+      'diag: availableWorkTargets=${civilianSnapshot.availableWorkTargets}',
+    'diag: draftMoveOrders=${orders.moveOrdersByPlayerId[playerId]?.map((o) => "${o.unitId}->${Unit.provinceIdFromTileKey(o.destinationTileKey) ?? "?"}").toList() ?? const []}',
+    'diag: suggestedExplore=${suggestions.where((o) => o.target == kWorkTargetExplore).map((o) => "${o.unitId}@${Unit.provinceIdFromTileKey(o.targetTileKey) ?? "?"}").toList()}',
+  ];
+
+  final explorerUnits =
+      view.ownUnits.where((u) => u.type == kUnitTypeExplorer).toList()
+        ..sort((a, b) => a.id.compareTo(b.id));
+  if (explorerUnits.isEmpty) {
+    lines.add('diag: no explorer units found in player view.');
+    return lines.join('\n');
+  }
+
+  final provinces = allProvinces(game.worldState).toList()
+    ..sort((a, b) => a.id.compareTo(b.id));
+  final tribeIds = game.tribes.map((t) => t.id).toSet();
+  final minorIds = game.minorNations.map((m) => m.id).toSet();
+  for (final unit in explorerUnits) {
+    lines.add(
+      'diag: explorer unit=${unit.id} atProvince=${unit.locationProvinceId} tileKey=${unit.tileKey ?? "(null)"}',
+    );
+    for (final prov in provinces) {
+      final foggedOrBetter = provinceHasFoggedOrBetter(prov.id);
+      final owner = prov.ownerId;
+      final ownerKind = owner == null
+          ? 'none'
+          : owner == playerId
+          ? 'self'
+          : tribeIds.contains(owner)
+          ? 'tribe'
+          : minorIds.contains(owner)
+          ? 'minor'
+          : 'gp';
+      final targetTileKey = '${prov.id}|0|0';
+      final workRes = OrderEngine(initialOrders: orders)
+          .addWorkOrderWithContext(
+            game,
+            topology,
+            playerId,
+            WorkOrder(
+              unitId: unit.id,
+              target: kWorkTargetExplore,
+              targetTileKey: targetTileKey,
+            ),
+          );
+      final moveRes = OrderEngine(initialOrders: orders)
+          .addMoveOrderWithContext(
+            game,
+            topology,
+            playerId,
+            MoveOrder(unitId: unit.id, destinationTileKey: '${prov.id}|0|0'),
+          );
+      lines.add(
+        'diag: province=${prov.id} owner=${prov.ownerId ?? "(none)"} ownerKind=$ownerKind '
+        'visibleFoggedPlus=$foggedOrBetter '
+        'workAccepted=${workRes.isAccepted} workReason=${workRes.reason ?? "(none)"} '
+        'moveAccepted=${moveRes.isAccepted} moveReason=${moveRes.reason ?? "(none)"}',
+      );
+    }
+  }
+  return lines.join('\n');
 }

--- a/app/integration_test/e2e_test_shared.dart
+++ b/app/integration_test/e2e_test_shared.dart
@@ -10,7 +10,8 @@ import 'package:colonizethis_app/l10n/app_localizations_contract.dart';
 import 'package:colonizethis_app/widgets/ct_choice_chip.dart';
 import 'package:colonizethis_app/widgets/ct_dialog_shell.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart'
-    show homeFleetIdFor, regionIdForSeaZone;
+    show allProvinces, buildPlayerView, homeFleetIdFor, regionIdForSeaZone;
+import 'package:colonizethis_models/colonizethis_models.dart' show ProvinceId;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -755,6 +756,92 @@ bool e2eNonHomeHumanFleetInNewWorldFromCtSnapshot(
     if (f.regionId == 'newWorld') return true;
     final sea = f.seaZoneId;
     if (sea != null && regionIdForSeaZone(snap.topology, sea) == 'newWorld') {
+      return true;
+    }
+  }
+  return false;
+}
+
+/// True when the active player's [PlayerView] reports **at least one** tile
+/// belonging to a New World province whose visibility is above `unknown`
+/// (`fogged` or `fullyVisible`).
+///
+/// Lifted from the formerly private
+/// `_playerHasAnyNewWorldFoggedOrBetterFromCtSnapshot` in
+/// `new_game_fleet_reaches_new_world_e2e_helpers_part2.dart` (Refs GitHub
+/// #2336 AC1 / AC2). The bundled-explore readiness loop short-circuits on
+/// this predicate alongside
+/// `_nonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot` — once either
+/// path reports NW penetration, the explorer-assign affordance is expected
+/// to become enabled within bounded retries. The fleet-reach test's final
+/// guard (`new_game_fleet_reaches_new_world_e2e_test.dart`) also uses
+/// this predicate to skip-rather-than-fail on CI topology/seed runs where
+/// no NW land becomes fogged-or-better within bounded turn retries. A
+/// silent rename or fail-open here would either:
+///
+///   - Stall the bundled-explore readiness loop for the full 35-turn cap
+///     (Bottleneck 4 in `SPEC/program/e2e-integration-tests.md`
+///     § Determinism), inflating wall-clock budget; or
+///   - Convert the strict bundled-explore assertion into a silent skip
+///     (returning `true` always) and mask a real Explore-assign regression.
+///
+/// The function takes the snapshot explicitly rather than reading the
+/// mutable `ctE2eNavalPanelSnapshot` global so the contract is
+/// deterministic and unit-testable (matches the lifted
+/// [e2eNonHomeHumanFleetInNewWorldFromCtSnapshot] precedent).
+///
+/// Contract:
+///
+/// - Returns `false` when [snap] is `null` (no snapshot plumbing this
+///   turn — the readiness loop must keep iterating rather than treat a
+///   missing snapshot as either arrival or "no NW land").
+/// - Returns `false` when the snapshot's game has zero `newWorld|`
+///   provinces (an empty NW region cannot contribute any qualifying
+///   tile; skipping the [PlayerView] build is also a perf safeguard).
+/// - Otherwise builds the human player's [PlayerView] via
+///   [buildPlayerView] and iterates `view.visibilityByTile.entries` in
+///   the map's iteration order.
+/// - For each `(tileKey, level)` entry, skips tiles whose key does not
+///   split into exactly four `|`-delimited parts (`regionId|provinceLocalId|x|y`),
+///   whose first segment is not `newWorld`, or whose second segment
+///   (province local id) is not present in the snapshot's NW province set.
+/// - Returns `true` on the **first** surviving entry whose visibility
+///   level name is anything other than `'unknown'` (i.e. `'fogged'` or
+///   `'fullyVisible'`).
+/// - Returns `false` after every visibility entry has been considered.
+///
+/// The integration suite cannot validate this directly today
+/// (`app_e2e_linux` is a no-op per
+/// `SPEC/program/e2e-integration-tests.md` § CI), so the widget-test pin
+/// in
+/// `app/test/e2e_player_has_any_new_world_fogged_or_better_from_ct_snapshot_test.dart`
+/// carries the behavioural contract.
+bool e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot(
+  CtE2eNavalPanelSnapshot? snap,
+) {
+  if (snap == null) {
+    return false;
+  }
+  final newWorldProvinceLocalIds = allProvinces(snap.game.worldState)
+      .where((p) => ProvinceId.regionIdFrom(p.id) == 'newWorld')
+      .map((p) => ProvinceId.localIdFrom(p.id))
+      .toSet();
+  if (newWorldProvinceLocalIds.isEmpty) {
+    return false;
+  }
+  final view = buildPlayerView(snap.game, snap.topology, snap.humanPlayerId);
+  for (final entry in view.visibilityByTile.entries) {
+    final parts = entry.key.split('|');
+    if (parts.length != 4) {
+      continue;
+    }
+    if (parts[0] != 'newWorld') {
+      continue;
+    }
+    if (!newWorldProvinceLocalIds.contains(parts[1])) {
+      continue;
+    }
+    if (entry.value.name != 'unknown') {
       return true;
     }
   }

--- a/app/integration_test/e2e_test_shared.dart
+++ b/app/integration_test/e2e_test_shared.dart
@@ -820,6 +820,42 @@ bool e2eNonHomeHumanFleetInNewWorldFromCtSnapshot(
   return false;
 }
 
+/// Snapshot-only fleet-reach loop short-circuit (Refs GitHub #2336
+/// Bottleneck 4).
+///
+/// Returns whether [snap] already reports a **non-home human** fleet in the
+/// New World so the fleet-reach turn loop can skip [openNavalPanel] and
+/// redundant widget-tree probes on subsequent iterations. Semantically
+/// identical to [e2eNonHomeHumanFleetInNewWorldFromCtSnapshot] but named for
+/// the call-site contract in `new_game_fleet_reaches_new_world_e2e_test.dart`.
+///
+/// - Returns `false` when [snap] is `null` (keep iterating).
+/// - Does **not** consult the widget tree; use
+///   [e2eHarnessDetectsNonHomeFleetInNewWorld] when a UI fallback is required.
+bool e2eFleetReachDoneFromCtSnapshotOnly(CtE2eNavalPanelSnapshot? snap) =>
+    e2eNonHomeHumanFleetInNewWorldFromCtSnapshot(snap);
+
+/// Fleet-reach / bundled-explore arrival probe with snapshot-first semantics.
+///
+/// Lifted from the formerly private `_harnessDetectsNonHomeFleetInNewWorld`
+/// in `new_game_fleet_reaches_new_world_e2e_helpers_part2.dart` (Refs GitHub
+/// #2336 AC1 / AC2).
+///
+/// Contract:
+///
+/// - Returns `true` when [e2eNonHomeHumanFleetInNewWorldFromCtSnapshot]
+///   reports arrival for [snap] (including when [snap] is non-null and
+///   reports `false` — the widget fallback is **not** consulted in that case).
+/// - When [snap] is `null`, falls back to
+///   [e2eNavalPanelShowsNonHomeFleetInNewWorld] for environments where CT
+///   snapshot plumbing is unavailable.
+bool e2eHarnessDetectsNonHomeFleetInNewWorld(
+  WidgetTester tester,
+  CtE2eNavalPanelSnapshot? snap,
+) =>
+    e2eNonHomeHumanFleetInNewWorldFromCtSnapshot(snap) ||
+    (snap == null && e2eNavalPanelShowsNonHomeFleetInNewWorld(tester));
+
 /// True when the active player's [PlayerView] reports **at least one** tile
 /// belonging to a New World province whose visibility is above `unknown`
 /// (`fogged` or `fullyVisible`).

--- a/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers_part2.dart
+++ b/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers_part2.dart
@@ -126,59 +126,24 @@ Future<bool> _tapMoveOnFirstNonHomeFleet(WidgetTester tester) async {
 /// so the snapshot-driven contract is unit-pinned (Refs GitHub #2336 AC1 /
 /// AC2). Call sites pass [ctE2eNavalPanelSnapshot] explicitly.
 
-/// [provinceIdsAdjacentToSeaZone] matches edge endpoints exactly. Combined game
-/// topology uses prefixed sea node ids (`newWorld|sea5`); some fleet states
-/// still carry the regional local id (`sea5`). Try both so coastal detection
-/// matches logic/ship-reveal (`SPEC/program/fog-and-exploration-resolution.md`).
-Set<String> _nwCoastalProvincesAdjacentToFleetSea(
-  MapTopology topology,
-  String seaZoneId,
-  String regionId,
-) {
-  final direct = provinceIdsAdjacentToSeaZone(
-    topology,
-    seaZoneId,
-    regionId: regionId,
-  );
-  if (direct.isNotEmpty) return direct;
-  if (!ProvinceId.isPrefixed(seaZoneId)) {
-    return provinceIdsAdjacentToSeaZone(
-      topology,
-      ProvinceId.full(regionId, seaZoneId),
-      regionId: regionId,
-    );
-  }
-  return const {};
-}
+/// Coastal sea-zone adjacency lookup with prefixed-id fallback moved to
+/// [e2eNwCoastalProvincesAdjacentToFleetSea] (`e2e_test_shared.dart`) so the
+/// two-tier `provinceIdsAdjacentToSeaZone` contract is unit-pinned and shared
+/// across scenarios (Refs GitHub #2336 AC1 / AC2). The combined topology
+/// uses prefixed sea node ids (`newWorld|sea5`) while some fleet states
+/// still carry the regional local id (`sea5`); the lifted helper tries
+/// both so coastal detection matches logic/ship-reveal
+/// (`SPEC/program/fog-and-exploration-resolution.md`).
 
-/// Ship reveal only paints coastal land for sea zones with a P–S province edge
+/// Non-home human fleet-in-NW-coastal-sea detection moved to
+/// [e2eNonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot]
+/// (`e2e_test_shared.dart`) so the snapshot-driven coastal contract is
+/// unit-pinned (Refs GitHub #2336 AC1 / AC2). Ship reveal only paints
+/// coastal land for sea zones with a P–S province edge
 /// (`SPEC/program/fog-and-exploration-resolution.md`). Open-ocean NW sea
-/// placement satisfies [ _nonHomeHumanFleetInNewWorldFromCtSnapshot ] but never
-/// yields fogged/visible NW provinces, so bundled Explore stays disabled.
-bool _nonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot() {
-  final snap = ctE2eNavalPanelSnapshot;
-  if (snap == null) return false;
-  final human = snap.humanPlayerId;
-  final homeId = homeFleetIdFor(human);
-  for (final f in snap.game.worldState.fleets) {
-    if (f.ownerId != human) continue;
-    if (f.id == homeId) continue;
-    if (!f.isAtSea || f.seaZoneId == null) continue;
-    final sea = f.seaZoneId!;
-    final String? regionId = f.regionId == 'newWorld'
-        ? 'newWorld'
-        : regionIdForSeaZone(snap.topology, sea);
-    if (regionId == null || regionId != 'newWorld') continue;
-    if (_nwCoastalProvincesAdjacentToFleetSea(
-      snap.topology,
-      sea,
-      regionId,
-    ).isNotEmpty) {
-      return true;
-    }
-  }
-  return false;
-}
+/// placement satisfies [e2eNonHomeHumanFleetInNewWorldFromCtSnapshot] but
+/// never yields fogged/visible NW provinces, so bundled Explore stays
+/// disabled. Call sites pass [ctE2eNavalPanelSnapshot] explicitly.
 
 /// NW fogged-or-better detection moved to
 /// [e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot] (`e2e_test_shared.dart`)
@@ -245,7 +210,9 @@ Future<void> _awaitNwCoastalOrVisibleLandForBundledExploreE2e({
     ensureUnderWallClock('NW bundled-explore readiness i=$i');
     await dismissTransientUi(tester);
     await _tapNewWorldRegionTabIfPresent(tester);
-    if (_nonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot() ||
+    if (e2eNonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot(
+          ctE2eNavalPanelSnapshot,
+        ) ||
         e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot(
           ctE2eNavalPanelSnapshot,
         )) {
@@ -258,7 +225,9 @@ Future<void> _awaitNwCoastalOrVisibleLandForBundledExploreE2e({
         timeout: _kMaxUiResponseWait,
         bottomSheetCloseTimeout: _kMaxUiResponseWait,
       );
-      if (_nonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot() ||
+      if (e2eNonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot(
+            ctE2eNavalPanelSnapshot,
+          ) ||
           e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot(
             ctE2eNavalPanelSnapshot,
           )) {
@@ -275,7 +244,9 @@ Future<void> _awaitNwCoastalOrVisibleLandForBundledExploreE2e({
     );
     await closeBottomSheet(tester, overallTimeout: _kMaxUiResponseWait);
     await advanceOneHumanTurn(tester, l10n: l10n);
-    if (_nonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot() ||
+    if (e2eNonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot(
+          ctE2eNavalPanelSnapshot,
+        ) ||
         e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot(
           ctE2eNavalPanelSnapshot,
         )) {

--- a/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers_part2.dart
+++ b/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers_part2.dart
@@ -180,36 +180,10 @@ bool _nonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot() {
   return false;
 }
 
-bool _playerHasAnyNewWorldFoggedOrBetterFromCtSnapshot() {
-  final snap = ctE2eNavalPanelSnapshot;
-  if (snap == null) {
-    return false;
-  }
-  final newWorldProvinceLocalIds = allProvinces(snap.game.worldState)
-      .where((p) => ProvinceId.regionIdFrom(p.id) == 'newWorld')
-      .map((p) => ProvinceId.localIdFrom(p.id))
-      .toSet();
-  if (newWorldProvinceLocalIds.isEmpty) {
-    return false;
-  }
-  final view = buildPlayerView(snap.game, snap.topology, snap.humanPlayerId);
-  for (final entry in view.visibilityByTile.entries) {
-    final parts = entry.key.split('|');
-    if (parts.length != 4) {
-      continue;
-    }
-    if (parts[0] != 'newWorld') {
-      continue;
-    }
-    if (!newWorldProvinceLocalIds.contains(parts[1])) {
-      continue;
-    }
-    if (entry.value.name != 'unknown') {
-      return true;
-    }
-  }
-  return false;
-}
+/// NW fogged-or-better detection moved to
+/// [e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot] (`e2e_test_shared.dart`)
+/// so the [PlayerView]-driven contract is unit-pinned (Refs GitHub #2336
+/// AC1 / AC2). Call sites pass [ctE2eNavalPanelSnapshot] explicitly.
 
 /// Widget-only: a **non–home** fleet row shows [unitsPanelRegionLabel] for New World
 /// in the subtitle location line (`New World — …` per `naval_tree_builder.dart`).
@@ -272,7 +246,9 @@ Future<void> _awaitNwCoastalOrVisibleLandForBundledExploreE2e({
     await dismissTransientUi(tester);
     await _tapNewWorldRegionTabIfPresent(tester);
     if (_nonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot() ||
-        _playerHasAnyNewWorldFoggedOrBetterFromCtSnapshot()) {
+        e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot(
+          ctE2eNavalPanelSnapshot,
+        )) {
       return;
     }
     // Snapshot-backed paths skip redundant naval sheet open/close (Refs #2336).
@@ -283,7 +259,9 @@ Future<void> _awaitNwCoastalOrVisibleLandForBundledExploreE2e({
         bottomSheetCloseTimeout: _kMaxUiResponseWait,
       );
       if (_nonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot() ||
-          _playerHasAnyNewWorldFoggedOrBetterFromCtSnapshot()) {
+          e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot(
+            ctE2eNavalPanelSnapshot,
+          )) {
         await closeBottomSheet(tester, overallTimeout: _kMaxUiResponseWait);
         return;
       }
@@ -298,7 +276,9 @@ Future<void> _awaitNwCoastalOrVisibleLandForBundledExploreE2e({
     await closeBottomSheet(tester, overallTimeout: _kMaxUiResponseWait);
     await advanceOneHumanTurn(tester, l10n: l10n);
     if (_nonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot() ||
-        _playerHasAnyNewWorldFoggedOrBetterFromCtSnapshot()) {
+        e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot(
+          ctE2eNavalPanelSnapshot,
+        )) {
       return;
     }
   }

--- a/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers_part2.dart
+++ b/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers_part2.dart
@@ -220,105 +220,15 @@ Future<void> _awaitNwCoastalOrVisibleLandForBundledExploreE2e({
   // destinations yet. Leave strict assertion to the final Explore-enabled check.
 }
 
-String _bundledExploreRejectionDiagnostics([
-  CtE2eNavalPanelSnapshot? lastKnownNavalSnapshot,
-]) {
-  final navalSnap = lastKnownNavalSnapshot ?? ctE2eNavalPanelSnapshot;
-  final civilianSnap = ctE2eCivilianPanelSnapshot;
-  if (navalSnap == null) {
-    return 'No ctE2eNavalPanelSnapshot available for diagnostics.';
-  }
-  final game = navalSnap.game;
-  final topology = navalSnap.topology;
-  final playerId = navalSnap.humanPlayerId;
-  final orders = navalSnap.draftOrders;
-  final view = buildPlayerView(game, topology, playerId);
-  final suggestions = suggestWorkOrders(view, game, topology, orders);
-
-  bool provinceHasFoggedOrBetter(String provinceFullId) {
-    final regionId = ProvinceId.regionIdFrom(provinceFullId);
-    final localId = ProvinceId.localIdFrom(provinceFullId);
-    for (final e in view.visibilityByTile.entries) {
-      final parts = e.key.split('|');
-      if (parts.length != 4) {
-        continue;
-      }
-      if (parts[0] != regionId || parts[1] != localId) {
-        continue;
-      }
-      if (e.value.name != 'unknown') {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  final lines = <String>[
-    'diag: player=$playerId',
-    'diag: civilianSnapshotAvailable=${civilianSnap != null}',
-    if (civilianSnap != null)
-      'diag: availableWorkTargets=${civilianSnap.availableWorkTargets}',
-    'diag: draftMoveOrders=${orders.moveOrdersByPlayerId[playerId]?.map((o) => "${o.unitId}->${Unit.provinceIdFromTileKey(o.destinationTileKey) ?? "?"}").toList() ?? const []}',
-    'diag: suggestedExplore=${suggestions.where((o) => o.target == kWorkTargetExplore).map((o) => "${o.unitId}@${Unit.provinceIdFromTileKey(o.targetTileKey) ?? "?"}").toList()}',
-  ];
-
-  final explorerUnits =
-      view.ownUnits.where((u) => u.type == kUnitTypeExplorer).toList()
-        ..sort((a, b) => a.id.compareTo(b.id));
-  if (explorerUnits.isEmpty) {
-    lines.add('diag: no explorer units found in player view.');
-    return lines.join('\n');
-  }
-
-  final provinces = allProvinces(game.worldState).toList()
-    ..sort((a, b) => a.id.compareTo(b.id));
-  final tribeIds = game.tribes.map((t) => t.id).toSet();
-  final minorIds = game.minorNations.map((m) => m.id).toSet();
-  for (final unit in explorerUnits) {
-    lines.add(
-      'diag: explorer unit=${unit.id} atProvince=${unit.locationProvinceId} tileKey=${unit.tileKey ?? "(null)"}',
-    );
-    for (final prov in provinces) {
-      final foggedOrBetter = provinceHasFoggedOrBetter(prov.id);
-      final owner = prov.ownerId;
-      final ownerKind = owner == null
-          ? 'none'
-          : owner == playerId
-          ? 'self'
-          : tribeIds.contains(owner)
-          ? 'tribe'
-          : minorIds.contains(owner)
-          ? 'minor'
-          : 'gp';
-      final targetTileKey = '${prov.id}|0|0';
-      final workRes = OrderEngine(initialOrders: orders)
-          .addWorkOrderWithContext(
-            game,
-            topology,
-            playerId,
-            WorkOrder(
-              unitId: unit.id,
-              target: kWorkTargetExplore,
-              targetTileKey: targetTileKey,
-            ),
-          );
-      final moveRes = OrderEngine(initialOrders: orders)
-          .addMoveOrderWithContext(
-            game,
-            topology,
-            playerId,
-            MoveOrder(unitId: unit.id, destinationTileKey: '${prov.id}|0|0'),
-          );
-      lines.add(
-        'diag: province=${prov.id} owner=${prov.ownerId ?? "(none)"} ownerKind=$ownerKind '
-        'visibleFoggedPlus=$foggedOrBetter '
-        'workAccepted=${workRes.isAccepted} workReason=${workRes.reason ?? "(none)"} '
-        'moveAccepted=${moveRes.isAccepted} moveReason=${moveRes.reason ?? "(none)"}',
-      );
-    }
-  }
-  return lines.join('\n');
-}
+/// `_bundledExploreRejectionDiagnostics` was lifted into the public
+/// [e2eBundledExploreRejectionDiagnostics] in `e2e_test_shared.dart`
+/// (Refs GitHub #2336 AC1 / AC2). The lifted form takes both
+/// [CtE2eNavalPanelSnapshot] and [CtE2eCivilianPanelSnapshot] explicitly
+/// rather than reading the global panel snapshots, so the diagnostic
+/// surface is deterministic and unit-pinned in
+/// `app/test/e2e_bundled_explore_rejection_diagnostics_test.dart`. Call
+/// sites compose the global fallback (`x ?? ctE2eNavalPanelSnapshot`)
+/// themselves before delegating to the public helper.
 
 /// _exploreAssignEnabledFromCivilianSnapshot was lifted into the public
 /// [e2eExploreAssignEnabledFromCivilianSnapshot] in `e2e_test_shared.dart`

--- a/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers_part2.dart
+++ b/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers_part2.dart
@@ -121,26 +121,10 @@ Future<bool> _tapMoveOnFirstNonHomeFleet(WidgetTester tester) async {
 /// [e2eTextLooksLikeNewWorldLocationLine] (`e2e_test_shared.dart`) so the
 /// dash-glyph contract is unit-pinned (Refs GitHub #2336).
 
-/// While the naval bottom sheet is open, [ctE2eNavalPanelSnapshot] mirrors the same
-/// [Game] the panel uses (`SPEC/program/e2e-integration-tests.md`). Prefer this on
-/// Linux CI: [ExpansionTile] / [Text] preorder can diverge from macOS while world
-/// state still shows the voyage completed.
-bool _nonHomeHumanFleetInNewWorldFromCtSnapshot() {
-  final snap = ctE2eNavalPanelSnapshot;
-  if (snap == null) return false;
-  final human = snap.humanPlayerId;
-  final homeId = homeFleetIdFor(human);
-  for (final f in snap.game.worldState.fleets) {
-    if (f.ownerId != human) continue;
-    if (f.id == homeId) continue;
-    if (f.regionId == 'newWorld') return true;
-    final sea = f.seaZoneId;
-    if (sea != null && regionIdForSeaZone(snap.topology, sea) == 'newWorld') {
-      return true;
-    }
-  }
-  return false;
-}
+/// Non-home human fleet-in-NW detection moved to
+/// [e2eNonHomeHumanFleetInNewWorldFromCtSnapshot] (`e2e_test_shared.dart`)
+/// so the snapshot-driven contract is unit-pinned (Refs GitHub #2336 AC1 /
+/// AC2). Call sites pass [ctE2eNavalPanelSnapshot] explicitly.
 
 /// [provinceIdsAdjacentToSeaZone] matches edge endpoints exactly. Combined game
 /// topology uses prefixed sea node ids (`newWorld|sea5`); some fleet states
@@ -264,7 +248,7 @@ bool _navalPanelShowsNonHomeFleetInNewWorld(WidgetTester tester) {
 }
 
 bool _harnessDetectsNonHomeFleetInNewWorld(WidgetTester tester) =>
-    _nonHomeHumanFleetInNewWorldFromCtSnapshot() ||
+    e2eNonHomeHumanFleetInNewWorldFromCtSnapshot(ctE2eNavalPanelSnapshot) ||
     // Fallback for environments where ct snapshot plumbing is unavailable.
     (ctE2eNavalPanelSnapshot == null &&
         _navalPanelShowsNonHomeFleetInNewWorld(tester));
@@ -273,7 +257,7 @@ bool _harnessDetectsNonHomeFleetInNewWorld(WidgetTester tester) =>
 /// [refreshCtE2eNavalPanelSnapshotAfterTurnIfEnabled]) lets fleet loops skip
 /// [openNavalPanel] when world state already shows arrival (Refs #2336).
 bool _fleetReachDoneFromCtSnapshotOnly() =>
-    _nonHomeHumanFleetInNewWorldFromCtSnapshot();
+    e2eNonHomeHumanFleetInNewWorldFromCtSnapshot(ctE2eNavalPanelSnapshot);
 
 /// Post–#1869 only: fleet may sit in open-ocean New World first; ship reveal needs
 /// a P–S coastal sea zone (or visibility already updated). Sail / advance until then.

--- a/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers_part2.dart
+++ b/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers_part2.dart
@@ -155,17 +155,10 @@ Future<bool> _tapMoveOnFirstNonHomeFleet(WidgetTester tester) async {
 /// ExpansionTile / location-line contract is unit-pinned (Refs GitHub #2336
 /// AC1 / AC2).
 
-bool _harnessDetectsNonHomeFleetInNewWorld(WidgetTester tester) =>
-    e2eNonHomeHumanFleetInNewWorldFromCtSnapshot(ctE2eNavalPanelSnapshot) ||
-    // Fallback for environments where ct snapshot plumbing is unavailable.
-    (ctE2eNavalPanelSnapshot == null &&
-        e2eNavalPanelShowsNonHomeFleetInNewWorld(tester));
-
-/// Post–next-turn [ctE2eNavalPanelSnapshot] refresh (see
-/// [refreshCtE2eNavalPanelSnapshotAfterTurnIfEnabled]) lets fleet loops skip
-/// [openNavalPanel] when world state already shows arrival (Refs #2336).
-bool _fleetReachDoneFromCtSnapshotOnly() =>
-    e2eNonHomeHumanFleetInNewWorldFromCtSnapshot(ctE2eNavalPanelSnapshot);
+/// `_harnessDetectsNonHomeFleetInNewWorld` and `_fleetReachDoneFromCtSnapshotOnly`
+/// were lifted into [e2eHarnessDetectsNonHomeFleetInNewWorld] and
+/// [e2eFleetReachDoneFromCtSnapshotOnly] (`e2e_test_shared.dart`, Refs #2336
+/// AC1 / AC2). Call sites pass [ctE2eNavalPanelSnapshot] explicitly.
 
 /// Post–#1869 only: fleet may sit in open-ocean New World first; ship reveal needs
 /// a P–S coastal sea zone (or visibility already updated). Sail / advance until then.

--- a/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers_part2.dart
+++ b/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers_part2.dart
@@ -150,47 +150,16 @@ Future<bool> _tapMoveOnFirstNonHomeFleet(WidgetTester tester) async {
 /// so the [PlayerView]-driven contract is unit-pinned (Refs GitHub #2336
 /// AC1 / AC2). Call sites pass [ctE2eNavalPanelSnapshot] explicitly.
 
-/// Widget-only: a **non–home** fleet row shows [unitsPanelRegionLabel] for New World
-/// in the subtitle location line (`New World — …` per `naval_tree_builder.dart`).
-bool _navalPanelShowsNonHomeFleetInNewWorld(WidgetTester tester) {
-  final naval = find.byKey(kCtE2ENavalPanelRootKey);
-  if (naval.evaluate().isEmpty) {
-    return false;
-  }
-  final tiles = find.descendant(
-    of: naval,
-    matching: find.byType(ExpansionTile),
-  );
-  final n = tiles.evaluate().length;
-  for (var i = 0; i < n; i++) {
-    final sub = tiles.at(i);
-    final fleetTitle = find.descendant(
-      of: sub,
-      matching: find.byWidgetPredicate(
-        (w) => w is Text && (w.data?.startsWith('Fleet ') ?? false),
-      ),
-    );
-    if (fleetTitle.evaluate().isEmpty) {
-      continue;
-    }
-    final loc = find.descendant(
-      of: sub,
-      matching: find.byWidgetPredicate(
-        (w) => w is Text && e2eTextLooksLikeNewWorldLocationLine(w.data),
-      ),
-    );
-    if (loc.evaluate().isNotEmpty) {
-      return true;
-    }
-  }
-  return false;
-}
+/// Naval-panel widget fallback for fleet-in-NW detection moved to
+/// [e2eNavalPanelShowsNonHomeFleetInNewWorld] (`e2e_test_shared.dart`) so the
+/// ExpansionTile / location-line contract is unit-pinned (Refs GitHub #2336
+/// AC1 / AC2).
 
 bool _harnessDetectsNonHomeFleetInNewWorld(WidgetTester tester) =>
     e2eNonHomeHumanFleetInNewWorldFromCtSnapshot(ctE2eNavalPanelSnapshot) ||
     // Fallback for environments where ct snapshot plumbing is unavailable.
     (ctE2eNavalPanelSnapshot == null &&
-        _navalPanelShowsNonHomeFleetInNewWorld(tester));
+        e2eNavalPanelShowsNonHomeFleetInNewWorld(tester));
 
 /// Post–next-turn [ctE2eNavalPanelSnapshot] refresh (see
 /// [refreshCtE2eNavalPanelSnapshotAfterTurnIfEnabled]) lets fleet loops skip

--- a/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers_part2.dart
+++ b/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers_part2.dart
@@ -327,26 +327,20 @@ String _bundledExploreRejectionDiagnostics([
   return lines.join('\n');
 }
 
-/// When the civilian panel is open, [ctE2eCivilianPanelSnapshot] mirrors
-/// [availableWorkTargetIdsForUnitProvider] — the same work-target ids that
-/// drive enabled Assign rows. Returns `null` when no snapshot is available.
-bool? _exploreAssignEnabledFromCivilianSnapshot() {
-  final snap = ctE2eCivilianPanelSnapshot;
-  if (snap == null) {
-    return null;
-  }
-  for (final targets in snap.availableWorkTargets.values) {
-    if (targets.contains(kWorkTargetExplore)) {
-      return true;
-    }
-  }
-  return false;
-}
+/// _exploreAssignEnabledFromCivilianSnapshot was lifted into the public
+/// [e2eExploreAssignEnabledFromCivilianSnapshot] in `e2e_test_shared.dart`
+/// (Refs GitHub #2336 AC1 / AC2). Call sites consume the public name and
+/// pass `ctE2eCivilianPanelSnapshot` explicitly; the integration suite
+/// re-exports it through the `e2e_helpers.dart` barrel and pins the
+/// contract via
+/// `app/test/e2e_explore_assign_enabled_from_civilian_snapshot_test.dart`.
 
 Future<bool> _anyExplorerHasEnabledExploreAssignFleetE2e(
   WidgetTester tester,
 ) async {
-  final snapshotHint = _exploreAssignEnabledFromCivilianSnapshot();
+  final snapshotHint = e2eExploreAssignEnabledFromCivilianSnapshot(
+    ctE2eCivilianPanelSnapshot,
+  );
   if (snapshotHint != null) {
     return snapshotHint;
   }

--- a/app/integration_test/new_game_fleet_reaches_new_world_e2e_test.dart
+++ b/app/integration_test/new_game_fleet_reaches_new_world_e2e_test.dart
@@ -81,7 +81,7 @@ void main() {
     ) {
       ensureUnderWallClock('turn loop start turnIdx=$turnIdx');
       perf.bumpCounter('turn_loop_iterations');
-      if (_fleetReachDoneFromCtSnapshotOnly()) {
+      if (e2eFleetReachDoneFromCtSnapshotOnly(ctE2eNavalPanelSnapshot)) {
         perf.timing(
           'test_total',
           testSw.elapsed,
@@ -90,7 +90,7 @@ void main() {
         return;
       }
       await dismissTransientUi(tester, perf: perf);
-      if (_fleetReachDoneFromCtSnapshotOnly()) {
+      if (e2eFleetReachDoneFromCtSnapshotOnly(ctE2eNavalPanelSnapshot)) {
         perf.timing(
           'test_total',
           testSw.elapsed,
@@ -99,7 +99,7 @@ void main() {
         return;
       }
       await _tapNewWorldRegionTabIfPresent(tester);
-      if (_fleetReachDoneFromCtSnapshotOnly()) {
+      if (e2eFleetReachDoneFromCtSnapshotOnly(ctE2eNavalPanelSnapshot)) {
         perf.timing(
           'test_total',
           testSw.elapsed,
@@ -144,7 +144,10 @@ void main() {
         overallTimeout: _kMaxUiResponseWait,
       );
 
-      if (_harnessDetectsNonHomeFleetInNewWorld(tester)) {
+      if (e2eHarnessDetectsNonHomeFleetInNewWorld(
+        tester,
+        ctE2eNavalPanelSnapshot,
+      )) {
         perf.timing(
           'test_total',
           testSw.elapsed,
@@ -154,7 +157,7 @@ void main() {
       }
 
       await advanceOneHumanTurn(tester, l10n: l10n, perf: perf);
-      if (_fleetReachDoneFromCtSnapshotOnly()) {
+      if (e2eFleetReachDoneFromCtSnapshotOnly(ctE2eNavalPanelSnapshot)) {
         perf.timing(
           'test_total',
           testSw.elapsed,
@@ -169,7 +172,7 @@ void main() {
     ensureUnderWallClock('before final naval check');
     await dismissTransientUi(tester, perf: perf);
     await _tapNewWorldRegionTabIfPresent(tester);
-    if (!_fleetReachDoneFromCtSnapshotOnly()) {
+    if (!e2eFleetReachDoneFromCtSnapshotOnly(ctE2eNavalPanelSnapshot)) {
       await openNavalPanel(
         tester,
         perf: perf,
@@ -177,7 +180,10 @@ void main() {
         bottomSheetCloseTimeout: _kMaxUiResponseWait,
       );
     }
-    if (!_harnessDetectsNonHomeFleetInNewWorld(tester)) {
+    if (!e2eHarnessDetectsNonHomeFleetInNewWorld(
+      tester,
+      ctE2eNavalPanelSnapshot,
+    )) {
       fail(
         'After $_kMaxNextTurnTapsForNwFleetReach Next turn resolutions, no non-home human fleet in region '
         'newWorld (ctE2eNavalPanelSnapshot / naval panel UI). '
@@ -248,15 +254,15 @@ void main() {
       ) {
         ensureUnderWallClock('turn loop start turnIdx=$turnIdx');
         perf.bumpCounter('turn_loop_iterations');
-        if (_fleetReachDoneFromCtSnapshotOnly()) {
+        if (e2eFleetReachDoneFromCtSnapshotOnly(ctE2eNavalPanelSnapshot)) {
           break;
         }
         await dismissTransientUi(tester, perf: perf);
-        if (_fleetReachDoneFromCtSnapshotOnly()) {
+        if (e2eFleetReachDoneFromCtSnapshotOnly(ctE2eNavalPanelSnapshot)) {
           break;
         }
         await _tapNewWorldRegionTabIfPresent(tester);
-        if (_fleetReachDoneFromCtSnapshotOnly()) {
+        if (e2eFleetReachDoneFromCtSnapshotOnly(ctE2eNavalPanelSnapshot)) {
           break;
         }
         if (ctE2eNavalPanelSnapshot == null) {
@@ -291,12 +297,15 @@ void main() {
           overallTimeout: _kMaxUiResponseWait,
         );
 
-        if (_harnessDetectsNonHomeFleetInNewWorld(tester)) {
+        if (e2eHarnessDetectsNonHomeFleetInNewWorld(
+          tester,
+          ctE2eNavalPanelSnapshot,
+        )) {
           break;
         }
 
         await advanceOneHumanTurn(tester, l10n: l10n, perf: perf);
-        if (_fleetReachDoneFromCtSnapshotOnly()) {
+        if (e2eFleetReachDoneFromCtSnapshotOnly(ctE2eNavalPanelSnapshot)) {
           break;
         }
         await dismissTransientUi(tester, perf: perf);
@@ -305,7 +314,7 @@ void main() {
 
       await dismissTransientUi(tester, perf: perf);
       await _tapNewWorldRegionTabIfPresent(tester);
-      if (!_fleetReachDoneFromCtSnapshotOnly()) {
+      if (!e2eFleetReachDoneFromCtSnapshotOnly(ctE2eNavalPanelSnapshot)) {
         await openNavalPanel(
           tester,
           perf: perf,
@@ -316,7 +325,10 @@ void main() {
       if (ctE2eNavalPanelSnapshot != null) {
         lastKnownNavalSnapshot = ctE2eNavalPanelSnapshot;
       }
-      if (!_harnessDetectsNonHomeFleetInNewWorld(tester)) {
+      if (!e2eHarnessDetectsNonHomeFleetInNewWorld(
+        tester,
+        ctE2eNavalPanelSnapshot,
+      )) {
         fail(
           'Explorer explore e2e requires a non-home human fleet in New World first. '
           'Last exception: ${tester.takeException()}',

--- a/app/integration_test/new_game_fleet_reaches_new_world_e2e_test.dart
+++ b/app/integration_test/new_game_fleet_reaches_new_world_e2e_test.dart
@@ -362,7 +362,9 @@ void main() {
         exploreEnabled = await checkExploreEnabledFromCivilianPanel();
       }
       if (!exploreEnabled) {
-        if (!_playerHasAnyNewWorldFoggedOrBetterFromCtSnapshot()) {
+        if (!e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot(
+          ctE2eNavalPanelSnapshot,
+        )) {
           // Guard against CI topology/seed runs where no NW land becomes
           // visible within bounded retries, so Explore cannot be enabled.
           return;

--- a/app/integration_test/new_game_fleet_reaches_new_world_e2e_test.dart
+++ b/app/integration_test/new_game_fleet_reaches_new_world_e2e_test.dart
@@ -3,15 +3,6 @@ import 'package:colonizethis_app/config/ct_e2e.dart';
 import 'package:colonizethis_app/config/ct_e2e_last_panel_snapshot.dart';
 import 'package:colonizethis_app/features/game/widgets/units/shared/units_panel_region_label.dart';
 import 'e2e_helpers.dart';
-import 'package:colonizethis_logic/colonizethis_logic.dart'
-    show
-        OrderEngine,
-        allProvinces,
-        buildPlayerView,
-        kWorkTargetExplore,
-        suggestWorkOrders;
-import 'package:colonizethis_models/colonizethis_models.dart'
-    show MoveOrder, ProvinceId, Unit, WorkOrder, kUnitTypeExplorer;
 import 'package:colonizethis_app/l10n/l10n.dart';
 import 'package:colonizethis_app/main.dart' show bootstrapForIntegrationTest;
 import 'package:colonizethis_app/widgets/ct_choice_chip.dart';
@@ -405,8 +396,9 @@ void main() {
           // visible within bounded retries, so Explore cannot be enabled.
           return;
         }
-        final diag = _bundledExploreRejectionDiagnostics(
-          lastKnownNavalSnapshot,
+        final diag = e2eBundledExploreRejectionDiagnostics(
+          navalSnapshot: lastKnownNavalSnapshot ?? ctE2eNavalPanelSnapshot,
+          civilianSnapshot: ctE2eCivilianPanelSnapshot,
         );
         fail(
           'Post-bundle #1869 regression: Explorer Assign never surfaced an enabled '

--- a/app/integration_test/new_game_fleet_reaches_new_world_e2e_test.dart
+++ b/app/integration_test/new_game_fleet_reaches_new_world_e2e_test.dart
@@ -1,4 +1,3 @@
-import 'package:colonizethis_data/colonizethis_data.dart' show MapTopology;
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:colonizethis_app/config/ct_e2e.dart';
 import 'package:colonizethis_app/config/ct_e2e_last_panel_snapshot.dart';
@@ -9,10 +8,7 @@ import 'package:colonizethis_logic/colonizethis_logic.dart'
         OrderEngine,
         allProvinces,
         buildPlayerView,
-        homeFleetIdFor,
         kWorkTargetExplore,
-        provinceIdsAdjacentToSeaZone,
-        regionIdForSeaZone,
         suggestWorkOrders;
 import 'package:colonizethis_models/colonizethis_models.dart'
     show MoveOrder, ProvinceId, Unit, WorkOrder, kUnitTypeExplorer;
@@ -71,7 +67,11 @@ void main() {
       openNavalTimeout: _kMaxUiResponseWait,
       bottomSheetCloseTimeout: _kMaxUiResponseWait,
     );
-    await closeBottomSheet(tester, perf: perf, overallTimeout: _kMaxUiResponseWait);
+    await closeBottomSheet(
+      tester,
+      perf: perf,
+      overallTimeout: _kMaxUiResponseWait,
+    );
     ensureUnderWallClock('after split fleet');
 
     for (
@@ -138,7 +138,11 @@ void main() {
         // Panel was opened above only when snapshot plumbing is unavailable.
         navalPanelAlreadyOpen: ctE2eNavalPanelSnapshot == null,
       );
-      await closeBottomSheet(tester, perf: perf, overallTimeout: _kMaxUiResponseWait);
+      await closeBottomSheet(
+        tester,
+        perf: perf,
+        overallTimeout: _kMaxUiResponseWait,
+      );
 
       if (_harnessDetectsNonHomeFleetInNewWorld(tester)) {
         perf.timing(
@@ -180,7 +184,11 @@ void main() {
         'Last exception: ${tester.takeException()}',
       );
     }
-    await closeBottomSheet(tester, perf: perf, overallTimeout: _kMaxUiResponseWait);
+    await closeBottomSheet(
+      tester,
+      perf: perf,
+      overallTimeout: _kMaxUiResponseWait,
+    );
     ensureUnderWallClock('test complete');
     perf.timing('test_total', testSw.elapsed, meta: 'result=final_check');
   });
@@ -225,7 +233,11 @@ void main() {
         openNavalTimeout: _kMaxUiResponseWait,
         bottomSheetCloseTimeout: _kMaxUiResponseWait,
       );
-      await closeBottomSheet(tester, perf: perf, overallTimeout: _kMaxUiResponseWait);
+      await closeBottomSheet(
+        tester,
+        perf: perf,
+        overallTimeout: _kMaxUiResponseWait,
+      );
       ensureUnderWallClock('after split fleet');
       CtE2eNavalPanelSnapshot? lastKnownNavalSnapshot;
 
@@ -273,7 +285,11 @@ void main() {
           perf: perf,
           navalPanelAlreadyOpen: ctE2eNavalPanelSnapshot == null,
         );
-        await closeBottomSheet(tester, perf: perf, overallTimeout: _kMaxUiResponseWait);
+        await closeBottomSheet(
+          tester,
+          perf: perf,
+          overallTimeout: _kMaxUiResponseWait,
+        );
 
         if (_harnessDetectsNonHomeFleetInNewWorld(tester)) {
           break;
@@ -306,7 +322,11 @@ void main() {
           'Last exception: ${tester.takeException()}',
         );
       }
-      await closeBottomSheet(tester, perf: perf, overallTimeout: _kMaxUiResponseWait);
+      await closeBottomSheet(
+        tester,
+        perf: perf,
+        overallTimeout: _kMaxUiResponseWait,
+      );
       ensureUnderWallClock('fleet in NW confirmed');
 
       await _awaitNwCoastalOrVisibleLandForBundledExploreE2e(
@@ -334,7 +354,11 @@ void main() {
         final enabled = await _anyExplorerHasEnabledExploreAssignFleetE2e(
           tester,
         );
-        await closeBottomSheet(tester, perf: perf, overallTimeout: _kMaxUiResponseWait);
+        await closeBottomSheet(
+          tester,
+          perf: perf,
+          overallTimeout: _kMaxUiResponseWait,
+        );
         perf.timing(
           'bundled_explore_retry_loop',
           phaseSw.elapsed,

--- a/app/integration_test/new_game_fleet_reaches_new_world_e2e_test.dart
+++ b/app/integration_test/new_game_fleet_reaches_new_world_e2e_test.dart
@@ -116,7 +116,7 @@ void main() {
           timeout: _kMaxUiResponseWait,
           bottomSheetCloseTimeout: _kMaxUiResponseWait,
         );
-        if (_navalPanelShowsNonHomeFleetInNewWorld(tester)) {
+        if (e2eNavalPanelShowsNonHomeFleetInNewWorld(tester)) {
           await closeBottomSheet(
             tester,
             perf: perf,
@@ -266,7 +266,7 @@ void main() {
             timeout: _kMaxUiResponseWait,
             bottomSheetCloseTimeout: _kMaxUiResponseWait,
           );
-          if (_navalPanelShowsNonHomeFleetInNewWorld(tester)) {
+          if (e2eNavalPanelShowsNonHomeFleetInNewWorld(tester)) {
             await closeBottomSheet(
               tester,
               perf: perf,

--- a/app/test/e2e_bundled_explore_rejection_diagnostics_test.dart
+++ b/app/test/e2e_bundled_explore_rejection_diagnostics_test.dart
@@ -1,0 +1,517 @@
+/// Pins the snapshot-driven bundled-Explore diagnostic surface of
+/// [e2eBundledExploreRejectionDiagnostics]
+/// (`app/integration_test/e2e_test_shared.dart`).
+///
+/// The fleet-reach test's final guard
+/// (`new_game_fleet_reaches_new_world_e2e_test.dart` line ~408) calls this
+/// helper to build the multi-line diagnostic embedded in the bundled-Explore
+/// failure `fail()` message. The fail-message text is part of the
+/// observable contract (it is grep-able from CI logs by the
+/// `'No ctE2eNavalPanelSnapshot available for diagnostics.'` and `'diag:'`
+/// prefixes) so a silent rename, line-order swap, or accidental
+/// fail-open ("always emit the empty string") here would either:
+///
+///   - Hide the failing fleet-reach `availableWorkTargets` / `suggestedExplore`
+///     details under a generic `fail()` message and erase the per-province
+///     `workReason` / `moveReason` lines reviewers grep for when triaging
+///     post-bundle #1869 regressions; or
+///   - Make the deterministic per-explorer + per-province ordering
+///     `(ascending by unit.id, ascending by province.id)` drift, masking
+///     non-deterministic AI / order-engine state in CI runs where the
+///     diagnostic is the only post-mortem record.
+///
+/// The function takes both [CtE2eNavalPanelSnapshot] and
+/// [CtE2eCivilianPanelSnapshot] explicitly rather than reading the global
+/// `ctE2eNavalPanelSnapshot` / `ctE2eCivilianPanelSnapshot` so the
+/// diagnostic is deterministic and unit-testable (matches the lifted
+/// [e2eNonHomeHumanFleetInNewWorldFromCtSnapshot] /
+/// [e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot] /
+/// [e2eExploreAssignEnabledFromCivilianSnapshot] precedents).
+///
+/// The integration suite cannot validate this directly today
+/// (the `app_e2e_linux` lane is a no-op per
+/// `SPEC/program/e2e-integration-tests.md` § CI), so the widget-test
+/// layer carries the behavioural pin (Refs GitHub #2336 AC1 / AC2).
+library;
+
+import 'package:colonizethis_app/config/ct_e2e_last_panel_snapshot.dart';
+import 'package:colonizethis_data/colonizethis_data.dart' show MapTopology;
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter_test/flutter_test.dart';
+
+import '../integration_test/e2e_test_shared.dart';
+
+const String _human = 'gp1';
+
+const TurnState _orderingTurn = TurnState(
+  phase: TurnPhase.orders,
+  turnNumber: 1,
+);
+
+const MapTopology _emptyTopology = MapTopology();
+
+const Orders _emptyOrders = Orders();
+
+const RegionData _emptyRegion = RegionData();
+
+Unit _explorer({
+  required String id,
+  required String provinceId,
+  String? tileKey,
+}) => Unit(
+  id: id,
+  type: kUnitTypeExplorer,
+  ownerId: _human,
+  locationProvinceId: provinceId,
+  tileKey: tileKey,
+);
+
+WorldState _world({
+  RegionData oldWorld = _emptyRegion,
+  RegionData newWorld = _emptyRegion,
+  Map<String, Map<String, String>> playerVisibilityByTile = const {},
+}) => WorldState(
+  turnState: _orderingTurn,
+  oldWorld: oldWorld,
+  newWorld: newWorld,
+  playerVisibilityByTile: playerVisibilityByTile,
+);
+
+Game _game({
+  RegionData oldWorld = _emptyRegion,
+  RegionData newWorld = _emptyRegion,
+  Map<String, Map<String, String>> playerVisibilityByTile = const {},
+}) => Game(
+  id: 'g1',
+  worldState: _world(
+    oldWorld: oldWorld,
+    newWorld: newWorld,
+    playerVisibilityByTile: playerVisibilityByTile,
+  ),
+  players: const [Player(id: _human, displayName: 'You', isHuman: true)],
+);
+
+CtE2eNavalPanelSnapshot _navalSnapshot({
+  RegionData oldWorld = _emptyRegion,
+  RegionData newWorld = _emptyRegion,
+  Map<String, Map<String, String>> playerVisibilityByTile = const {},
+  Orders draftOrders = _emptyOrders,
+}) => CtE2eNavalPanelSnapshot(
+  game: _game(
+    oldWorld: oldWorld,
+    newWorld: newWorld,
+    playerVisibilityByTile: playerVisibilityByTile,
+  ),
+  humanPlayerId: _human,
+  topology: _emptyTopology,
+  draftOrders: draftOrders,
+);
+
+CtE2eCivilianPanelSnapshot _civilianSnapshot({
+  Map<String, List<String>> availableWorkTargets = const {},
+}) => CtE2eCivilianPanelSnapshot(
+  game: _game(),
+  humanPlayerId: _human,
+  currentOrders: _emptyOrders,
+  availableWorkTargets: availableWorkTargets,
+);
+
+void main() {
+  suppressLogsForTests();
+
+  group('e2eBundledExploreRejectionDiagnostics — fallback string', () {
+    test('null navalSnapshot returns the canonical fallback line', () {
+      // A null navalSnapshot must surface as the literal canonical string
+      // (no `diag:` lines, no joined newlines, no empty string). The fleet
+      // reach test embeds this directly in a `fail()` so a silent rename
+      // or empty-string regression would erase the post-mortem signal CI
+      // grep relies on.
+      expect(
+        e2eBundledExploreRejectionDiagnostics(
+          navalSnapshot: null,
+          civilianSnapshot: null,
+        ),
+        'No ctE2eNavalPanelSnapshot available for diagnostics.',
+        reason:
+            'Null navalSnapshot path returns the canonical fallback string '
+            'verbatim; this is the early-exit contract (#2336 AC1).',
+      );
+    });
+
+    test('null navalSnapshot + non-null civilian still returns fallback', () {
+      // The null-naval branch fires before the civilian snapshot is read.
+      // A regression that swapped argument order or inspected civilian
+      // before naval would emit a different diagnostic and mask the
+      // missing-naval root cause in CI failure messages.
+      expect(
+        e2eBundledExploreRejectionDiagnostics(
+          navalSnapshot: null,
+          civilianSnapshot: _civilianSnapshot(
+            availableWorkTargets: const {
+              'unit-a': <String>['explore'],
+            },
+          ),
+        ),
+        'No ctE2eNavalPanelSnapshot available for diagnostics.',
+        reason:
+            'Civilian snapshot must not be consulted when navalSnapshot is '
+            'null — the canonical fallback line dominates.',
+      );
+    });
+  });
+
+  group('e2eBundledExploreRejectionDiagnostics — header lines', () {
+    test('non-null naval, null civilian → header without availableWorkTargets', () {
+      // The header lines are always emitted in this order:
+      //   1. diag: player=<id>
+      //   2. diag: civilianSnapshotAvailable=<bool>
+      //   3. (optional) diag: availableWorkTargets=<...> — only when civilian
+      //   4. diag: draftMoveOrders=<...>
+      //   5. diag: suggestedExplore=<...>
+      // Followed by an explorer block. Null civilian means line 3 is
+      // omitted but `civilianSnapshotAvailable=false` is still present.
+      final diag = e2eBundledExploreRejectionDiagnostics(
+        navalSnapshot: _navalSnapshot(),
+        civilianSnapshot: null,
+      );
+      expect(
+        diag,
+        contains('diag: player=$_human'),
+        reason: 'Player id header line must appear verbatim.',
+      );
+      expect(
+        diag,
+        contains('diag: civilianSnapshotAvailable=false'),
+        reason:
+            'Civilian-snapshot-presence flag is always emitted; null '
+            'civilian surfaces as "false" (not missing) so reviewers can '
+            'distinguish absence from presence.',
+      );
+      expect(
+        diag,
+        isNot(contains('availableWorkTargets=')),
+        reason:
+            'availableWorkTargets line is conditional on civilian '
+            'snapshot being non-null; omitting it for null civilian keeps '
+            'header noise minimal and preserves the diagnostic contract.',
+      );
+      expect(
+        diag,
+        contains('diag: draftMoveOrders=[]'),
+        reason:
+            'No draft move orders → empty list literal; the prefix '
+            'must remain so consumers can parse the line.',
+      );
+      expect(
+        diag,
+        contains('diag: suggestedExplore=[]'),
+        reason:
+            'No explorer suggestions in an empty game → empty list; '
+            'the prefix anchors the line for grep.',
+      );
+    });
+
+    test('non-null naval + civilian → availableWorkTargets line emitted', () {
+      // The civilian-snapshot-present arm must add the
+      // availableWorkTargets line with the map literal toString form.
+      // A regression that dropped the conditional or inlined a
+      // wrong-format string would diverge from the long-lived contract
+      // surfaced in CI failure messages.
+      final diag = e2eBundledExploreRejectionDiagnostics(
+        navalSnapshot: _navalSnapshot(),
+        civilianSnapshot: _civilianSnapshot(
+          availableWorkTargets: const {
+            'unit-a': <String>['explore', 'prospect'],
+          },
+        ),
+      );
+      expect(
+        diag,
+        contains('diag: civilianSnapshotAvailable=true'),
+        reason: 'Non-null civilian surfaces as "true".',
+      );
+      expect(
+        diag,
+        contains('diag: availableWorkTargets={unit-a: [explore, prospect]}'),
+        reason:
+            'availableWorkTargets serializes via Dart Map.toString(). '
+            'Preserving the exact format lets CI grep on the literal '
+            'tile/target ids.',
+      );
+    });
+  });
+
+  group('e2eBundledExploreRejectionDiagnostics — no explorers branch', () {
+    test('no explorers → ends with the canonical no-explorer line', () {
+      // No explorer units in the human player view → header block plus
+      // the single canonical closing line, with NO per-province probe
+      // lines. A regression that emitted province lines anyway would
+      // run O(provinces) order-engine probes on the cold failure path
+      // for nothing (Refs `colonizethis-turn-resolution-budget.mdc`
+      // "Avoid per-candidate debug logs in tight paths").
+      final diag = e2eBundledExploreRejectionDiagnostics(
+        navalSnapshot: _navalSnapshot(
+          newWorld: const RegionData(
+            provinces: [
+              Province(id: 'newWorld|nwA', regionId: 'newWorld'),
+              Province(id: 'newWorld|nwB', regionId: 'newWorld'),
+            ],
+          ),
+        ),
+        civilianSnapshot: null,
+      );
+      expect(
+        diag,
+        contains('diag: no explorer units found in player view.'),
+        reason:
+            'Closing canonical line for the zero-explorer fast path; '
+            'reviewers grep on this text to confirm the no-explorer arm '
+            'fired vs the per-province probe arm.',
+      );
+      expect(
+        diag,
+        isNot(contains('diag: explorer unit=')),
+        reason:
+            'Per-explorer header line must not appear when no explorer '
+            'is present — confirms the early return prevents per-province '
+            'iteration.',
+      );
+      expect(
+        diag,
+        isNot(contains('diag: province=')),
+        reason:
+            'Per-province probe block must not appear when no explorer '
+            'is present (cold-path cost protection).',
+      );
+    });
+  });
+
+  group('e2eBundledExploreRejectionDiagnostics — per-province probe', () {
+    test('explorer + multiple provinces → sorted per-province lines', () {
+      // Two NW provinces (insertion order nwB, nwA), one OW province
+      // (owA), and one explorer in OW. `allProvinces` walks both regions;
+      // the helper sorts ascending by `province.id`. Expected sort order:
+      //   newWorld|nwA, newWorld|nwB, oldWorld|owA.
+      // A regression that dropped the sort or iterated in insertion order
+      // would surface as `newWorld|nwB` before `newWorld|nwA`.
+      final explorer = _explorer(
+        id: 'ex1',
+        provinceId: 'oldWorld|owA',
+        tileKey: 'oldWorld|owA|0|0',
+      );
+      final diag = e2eBundledExploreRejectionDiagnostics(
+        navalSnapshot: _navalSnapshot(
+          oldWorld: RegionData(
+            provinces: const [Province(id: 'oldWorld|owA', regionId: 'oldWorld')],
+            units: [explorer],
+          ),
+          newWorld: const RegionData(
+            provinces: [
+              Province(id: 'newWorld|nwB', regionId: 'newWorld'),
+              Province(id: 'newWorld|nwA', regionId: 'newWorld'),
+            ],
+          ),
+        ),
+        civilianSnapshot: null,
+      );
+
+      // Explorer header is emitted exactly once.
+      expect(
+        diag,
+        contains(
+          'diag: explorer unit=ex1 atProvince=oldWorld|owA '
+          'tileKey=oldWorld|owA|0|0',
+        ),
+        reason:
+            'Per-explorer header line includes id, provinceId, and the '
+            'resolved tileKey (non-null path renders the tile key '
+            'literal, not the `(null)` fallback).',
+      );
+      // Per-province lines emitted in ascending province.id order.
+      final lines = diag.split('\n');
+      final nwAIndex = lines.indexWhere(
+        (l) => l.startsWith('diag: province=newWorld|nwA '),
+      );
+      final nwBIndex = lines.indexWhere(
+        (l) => l.startsWith('diag: province=newWorld|nwB '),
+      );
+      final owAIndex = lines.indexWhere(
+        (l) => l.startsWith('diag: province=oldWorld|owA '),
+      );
+      expect(
+        nwAIndex,
+        greaterThanOrEqualTo(0),
+        reason: 'NW province nwA probe line must be emitted.',
+      );
+      expect(
+        nwBIndex,
+        greaterThanOrEqualTo(0),
+        reason: 'NW province nwB probe line must be emitted.',
+      );
+      expect(
+        owAIndex,
+        greaterThanOrEqualTo(0),
+        reason: 'OW province owA probe line must be emitted.',
+      );
+      expect(
+        nwAIndex < nwBIndex && nwBIndex < owAIndex,
+        isTrue,
+        reason:
+            'Per-province lines must be emitted in ascending province.id '
+            'order (lexicographic): newWorld|nwA, newWorld|nwB, '
+            'oldWorld|owA. Insertion order in RegionData (nwB before nwA) '
+            'is overridden by the trailing sort — pinning this here keeps '
+            'CI diagnostics deterministic across map-generation reorderings.',
+      );
+    });
+
+    test('tileKey null surfaces as "(null)" in the explorer header', () {
+      // Explorer without a tile key (typical for a freshly-deployed
+      // explorer) must render `tileKey=(null)`. A regression that
+      // emitted the empty string or "null" without the parens would
+      // erase the visual signal CI reviewers use to spot un-deployed
+      // explorers in the failure log.
+      final explorer = _explorer(id: 'ex1', provinceId: 'oldWorld|owA');
+      final diag = e2eBundledExploreRejectionDiagnostics(
+        navalSnapshot: _navalSnapshot(
+          oldWorld: RegionData(
+            provinces: const [Province(id: 'oldWorld|owA', regionId: 'oldWorld')],
+            units: [explorer],
+          ),
+        ),
+        civilianSnapshot: null,
+      );
+      expect(
+        diag,
+        contains(
+          'diag: explorer unit=ex1 atProvince=oldWorld|owA tileKey=(null)',
+        ),
+        reason:
+            'Null tileKey renders as literal "(null)" with parens — that '
+            'rendering is the documented contract and CI grep signal.',
+      );
+    });
+
+    test('province ownerKind classifications cover none / tribe / minor / gp / self', () {
+      // Owner classification:
+      //   ownerId == null            → ownerKind=none
+      //   ownerId == self (gp1)      → ownerKind=self
+      //   ownerId in tribes set      → ownerKind=tribe
+      //   ownerId in minorNations    → ownerKind=minor
+      //   ownerId is GP otherwise    → ownerKind=gp
+      // We construct one province per kind and assert the rendered
+      // `ownerKind=` token. A regression in the precedence (e.g. a
+      // tribe in the minor list would now show as `minor`) would
+      // surface immediately.
+      final explorer = _explorer(id: 'ex1', provinceId: 'oldWorld|none');
+      final game = Game(
+        id: 'g-owner-kinds',
+        worldState: _world(
+          oldWorld: RegionData(
+            provinces: const [
+              Province(id: 'oldWorld|none', regionId: 'oldWorld'),
+              Province(id: 'oldWorld|self', regionId: 'oldWorld', ownerId: _human),
+              Province(id: 'oldWorld|tribe', regionId: 'oldWorld', ownerId: 't1'),
+              Province(id: 'oldWorld|minor', regionId: 'oldWorld', ownerId: 'm1'),
+              Province(id: 'oldWorld|gp', regionId: 'oldWorld', ownerId: 'gp2'),
+            ],
+            units: [explorer],
+          ),
+        ),
+        players: const [
+          Player(id: _human, displayName: 'You', isHuman: true),
+          Player(id: 'gp2', displayName: 'GP2', isHuman: false),
+        ],
+        tribes: const [Tribe(id: 't1', displayName: 'T1')],
+        minorNations: const [MinorNation(id: 'm1', displayName: 'M1')],
+      );
+      final snap = CtE2eNavalPanelSnapshot(
+        game: game,
+        humanPlayerId: _human,
+        topology: _emptyTopology,
+        draftOrders: _emptyOrders,
+      );
+      final diag = e2eBundledExploreRejectionDiagnostics(
+        navalSnapshot: snap,
+        civilianSnapshot: null,
+      );
+      expect(
+        diag,
+        contains(
+          'diag: province=oldWorld|none owner=(none) ownerKind=none ',
+        ),
+        reason: 'Null ownerId surfaces as `(none)` and `ownerKind=none`.',
+      );
+      expect(
+        diag,
+        contains(
+          'diag: province=oldWorld|self owner=$_human ownerKind=self ',
+        ),
+        reason: 'Self-owned province surfaces as `ownerKind=self`.',
+      );
+      expect(
+        diag,
+        contains('diag: province=oldWorld|tribe owner=t1 ownerKind=tribe '),
+        reason: 'Tribe-owned province surfaces as `ownerKind=tribe`.',
+      );
+      expect(
+        diag,
+        contains('diag: province=oldWorld|minor owner=m1 ownerKind=minor '),
+        reason:
+            'Minor-owned province surfaces as `ownerKind=minor` (tribe '
+            'precedence already applied earlier in the cascade).',
+      );
+      expect(
+        diag,
+        contains('diag: province=oldWorld|gp owner=gp2 ownerKind=gp '),
+        reason:
+            'Other-GP province surfaces as `ownerKind=gp` (fall-through '
+            'arm; not classified as tribe/minor/self).',
+      );
+    });
+  });
+
+  group('e2eBundledExploreRejectionDiagnostics — determinism', () {
+    test('identical inputs yield byte-identical strings (pure)', () {
+      // Two adjacent calls with the same snapshots must produce the
+      // same multi-line string. Two fresh OrderEngine instances per
+      // probe + the trailing province sort guarantee this, but the
+      // pin protects against future mutations that leak state across
+      // calls (e.g. a memoizing cache keyed by mutable map identity).
+      final explorer = _explorer(id: 'ex1', provinceId: 'oldWorld|owA');
+      final snap = _navalSnapshot(
+        oldWorld: RegionData(
+          provinces: const [Province(id: 'oldWorld|owA', regionId: 'oldWorld')],
+          units: [explorer],
+        ),
+        newWorld: const RegionData(
+          provinces: [Province(id: 'newWorld|nwA', regionId: 'newWorld')],
+        ),
+      );
+      final civ = _civilianSnapshot(
+        availableWorkTargets: const {
+          'unit-a': <String>['explore'],
+        },
+      );
+      final first = e2eBundledExploreRejectionDiagnostics(
+        navalSnapshot: snap,
+        civilianSnapshot: civ,
+      );
+      final second = e2eBundledExploreRejectionDiagnostics(
+        navalSnapshot: snap,
+        civilianSnapshot: civ,
+      );
+      expect(
+        second,
+        first,
+        reason:
+            'Pure function pin (Refs #2336): identical inputs must yield '
+            'byte-identical multi-line strings. A regression that leaked '
+            'OrderEngine state, used a non-deterministic sort, or read a '
+            'global ctE2e* snapshot mid-call would surface here as a '
+            'string diff.',
+      );
+    });
+  });
+}

--- a/app/test/e2e_bundled_explore_rejection_diagnostics_test.dart
+++ b/app/test/e2e_bundled_explore_rejection_diagnostics_test.dart
@@ -36,6 +36,8 @@ library;
 
 import 'package:colonizethis_app/config/ct_e2e_last_panel_snapshot.dart';
 import 'package:colonizethis_data/colonizethis_data.dart' show MapTopology;
+import 'package:colonizethis_logic/colonizethis_logic.dart'
+    show kWorkTargetExplore, kWorkTargetProspect;
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter_test/flutter_test.dart';
@@ -149,7 +151,7 @@ void main() {
           navalSnapshot: null,
           civilianSnapshot: _civilianSnapshot(
             availableWorkTargets: const {
-              'unit-a': <String>['explore'],
+              'unit-a': <String>[kWorkTargetExplore],
             },
           ),
         ),
@@ -222,7 +224,7 @@ void main() {
         navalSnapshot: _navalSnapshot(),
         civilianSnapshot: _civilianSnapshot(
           availableWorkTargets: const {
-            'unit-a': <String>['explore', 'prospect'],
+            'unit-a': <String>[kWorkTargetExplore, kWorkTargetProspect],
           },
         ),
       );
@@ -233,7 +235,9 @@ void main() {
       );
       expect(
         diag,
-        contains('diag: availableWorkTargets={unit-a: [explore, prospect]}'),
+        contains(
+          'diag: availableWorkTargets={unit-a: [$kWorkTargetExplore, $kWorkTargetProspect]}',
+        ),
         reason:
             'availableWorkTargets serializes via Dart Map.toString(). '
             'Preserving the exact format lets CI grep on the literal '
@@ -491,7 +495,7 @@ void main() {
       );
       final civ = _civilianSnapshot(
         availableWorkTargets: const {
-          'unit-a': <String>['explore'],
+          'unit-a': <String>[kWorkTargetExplore],
         },
       );
       final first = e2eBundledExploreRejectionDiagnostics(

--- a/app/test/e2e_explore_assign_enabled_from_civilian_snapshot_test.dart
+++ b/app/test/e2e_explore_assign_enabled_from_civilian_snapshot_test.dart
@@ -31,6 +31,12 @@
 library;
 
 import 'package:colonizethis_app/config/ct_e2e_last_panel_snapshot.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart'
+    show
+        kWorkTargetBuildImprovement,
+        kWorkTargetBuildRoad,
+        kWorkTargetExplore,
+        kWorkTargetProspect;
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter_test/flutter_test.dart';
@@ -106,7 +112,7 @@ void main() {
         e2eExploreAssignEnabledFromCivilianSnapshot(
           _snapshot(
             availableWorkTargets: const {
-              'unit-1': ['build_road', 'prospect'],
+              'unit-1': [kWorkTargetBuildRoad, kWorkTargetProspect],
             },
           ),
         ),
@@ -124,8 +130,8 @@ void main() {
         e2eExploreAssignEnabledFromCivilianSnapshot(
           _snapshot(
             availableWorkTargets: const {
-              'unit-1': ['build_road'],
-              'unit-2': ['prospect', 'build_improvement'],
+              'unit-1': [kWorkTargetBuildRoad],
+              'unit-2': [kWorkTargetProspect, kWorkTargetBuildImprovement],
               'unit-3': <String>[],
             },
           ),
@@ -164,7 +170,7 @@ void main() {
         e2eExploreAssignEnabledFromCivilianSnapshot(
           _snapshot(
             availableWorkTargets: const {
-              'explorer-1': ['explore'],
+              'explorer-1': [kWorkTargetExplore],
             },
           ),
         ),
@@ -183,7 +189,11 @@ void main() {
           e2eExploreAssignEnabledFromCivilianSnapshot(
             _snapshot(
               availableWorkTargets: const {
-                'explorer-1': ['prospect', 'explore', 'build_road'],
+                'explorer-1': [
+                  kWorkTargetProspect,
+                  kWorkTargetExplore,
+                  kWorkTargetBuildRoad,
+                ],
               },
             ),
           ),
@@ -201,9 +211,9 @@ void main() {
         e2eExploreAssignEnabledFromCivilianSnapshot(
           _snapshot(
             availableWorkTargets: const {
-              'unit-1': ['build_road'],
-              'unit-2': ['prospect'],
-              'explorer-3': ['explore'],
+              'unit-1': [kWorkTargetBuildRoad],
+              'unit-2': [kWorkTargetProspect],
+              'explorer-3': [kWorkTargetExplore],
             },
           ),
         ),
@@ -220,8 +230,8 @@ void main() {
         e2eExploreAssignEnabledFromCivilianSnapshot(
           _snapshot(
             availableWorkTargets: const {
-              'explorer-1': ['explore', 'prospect'],
-              'explorer-2': ['explore'],
+              'explorer-1': [kWorkTargetExplore, kWorkTargetProspect],
+              'explorer-2': [kWorkTargetExplore],
             },
           ),
         ),
@@ -240,7 +250,7 @@ void main() {
             availableWorkTargets: const {
               'unit-1': <String>[],
               'unit-2': <String>[],
-              'explorer-3': ['explore'],
+              'explorer-3': [kWorkTargetExplore],
             },
           ),
         ),
@@ -318,7 +328,7 @@ void main() {
       // (no all-rows reduction, no aggregation).
       final snap = _snapshot(
         availableWorkTargets: const {
-          'explorer-1': ['explore'],
+          'explorer-1': [kWorkTargetExplore],
           'unit-2': ['EXPLORE_ALL_NOT_A_REAL_TARGET'],
         },
       );
@@ -340,14 +350,14 @@ void main() {
     test('identical input snapshots yield identical results', () {
       final snapA = _snapshot(
         availableWorkTargets: const {
-          'unit-1': ['build_road'],
-          'explorer-2': ['explore'],
+          'unit-1': [kWorkTargetBuildRoad],
+          'explorer-2': [kWorkTargetExplore],
         },
       );
       final snapB = _snapshot(
         availableWorkTargets: const {
-          'unit-1': ['build_road'],
-          'explorer-2': ['explore'],
+          'unit-1': [kWorkTargetBuildRoad],
+          'explorer-2': [kWorkTargetExplore],
         },
       );
 
@@ -366,7 +376,7 @@ void main() {
     test('repeated calls on same snapshot yield identical results', () {
       final snap = _snapshot(
         availableWorkTargets: const {
-          'unit-1': ['explore'],
+          'unit-1': [kWorkTargetExplore],
         },
       );
       final first = e2eExploreAssignEnabledFromCivilianSnapshot(snap);

--- a/app/test/e2e_explore_assign_enabled_from_civilian_snapshot_test.dart
+++ b/app/test/e2e_explore_assign_enabled_from_civilian_snapshot_test.dart
@@ -1,0 +1,384 @@
+/// Pins the snapshot-driven Explore-Assign contract of
+/// [e2eExploreAssignEnabledFromCivilianSnapshot]
+/// (`app/integration_test/e2e_test_shared.dart`).
+///
+/// The fleet-reach test's `_anyExplorerHasEnabledExploreAssignFleetE2e`
+/// short-circuits on this predicate before scrolling the civilian panel
+/// `Assign` sheet (`new_game_fleet_reaches_new_world_e2e_helpers_part2.dart`).
+/// A silent rename / fail-open here would either:
+///
+///   - Force the panel-sweep loop to fall through to the
+///     `maxPanelSweepSteps (16) × per-step Assign sweep` slow path on every
+///     fleet-reach turn — burning frames on a deterministic short-circuit
+///     the snapshot already provides (Bottleneck 5 in
+///     `SPEC/program/e2e-integration-tests.md` § Determinism, #2336 AC5); or
+///   - Convert the strict Explore-Assign affordance assertion into a silent
+///     "always enabled" / "always disabled" verdict and mask a real
+///     bundled-Explore regression.
+///
+/// The `null` return path is contractually distinct from the `false` return
+/// path: the caller treats `null` as "no civilian-panel snapshot plumbed for
+/// this turn — fall back to the live walk" while `false` is the definitive
+/// "panel mounted but no civilian can be assigned Explore right now"
+/// verdict. Conflating the two would either skip the slow-path fallback
+/// when the snapshot is missing (false negative) or trigger the slow-path
+/// fallback when the snapshot already says `false` (wasted frames).
+///
+/// The integration suite cannot validate this directly today
+/// (the `app_e2e_linux` lane is a no-op per
+/// `SPEC/program/e2e-integration-tests.md` § CI), so the widget-test layer
+/// carries the behavioural pin (Refs GitHub #2336 AC1 / AC2).
+library;
+
+import 'package:colonizethis_app/config/ct_e2e_last_panel_snapshot.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter_test/flutter_test.dart';
+
+import '../integration_test/e2e_test_shared.dart';
+
+const String _human = 'gp1';
+
+const TurnState _orderingTurn = TurnState(
+  phase: TurnPhase.orders,
+  turnNumber: 1,
+);
+
+const Orders _emptyOrders = Orders();
+
+WorldState _world() => const WorldState(
+  turnState: _orderingTurn,
+  oldWorld: RegionData(),
+  newWorld: RegionData(),
+);
+
+Game _game() => Game(
+  id: 'g1',
+  worldState: _world(),
+  players: const [Player(id: _human, displayName: 'You', isHuman: true)],
+);
+
+CtE2eCivilianPanelSnapshot _snapshot({
+  Map<String, List<String>> availableWorkTargets = const {},
+}) => CtE2eCivilianPanelSnapshot(
+  game: _game(),
+  humanPlayerId: _human,
+  currentOrders: _emptyOrders,
+  availableWorkTargets: availableWorkTargets,
+);
+
+void main() {
+  suppressLogsForTests();
+
+  group('e2eExploreAssignEnabledFromCivilianSnapshot — null branch', () {
+    test('null snapshot returns null (NOT false)', () {
+      expect(
+        e2eExploreAssignEnabledFromCivilianSnapshot(null),
+        isNull,
+        reason:
+            'No civilian-panel snapshot plumbing this turn must surface '
+            'as `null` so the caller (`_anyExplorerHasEnabledExploreAssignFleetE2e`) '
+            'falls back to the live panel walk instead of treating the '
+            'missing snapshot as a definitive "enabled" / "disabled" '
+            'verdict. Returning `false` here would silently skip the '
+            'slow-path fallback and surface a false bundled-Explore '
+            '"disabled" reading whenever the panel is mid-mount.',
+      );
+    });
+  });
+
+  group('e2eExploreAssignEnabledFromCivilianSnapshot — false branches', () {
+    test('empty availableWorkTargets returns false', () {
+      expect(
+        e2eExploreAssignEnabledFromCivilianSnapshot(_snapshot()),
+        isFalse,
+        reason:
+            'A mounted civilian panel with zero unit rows is a definitive '
+            '"panel mounted but no civilian can be assigned anything" '
+            'verdict — the caller skips the slow-path Assign sweep. '
+            'Returning `null` here would force an unnecessary panel-sweep '
+            'on every fleet-reach turn.',
+      );
+    });
+
+    test('single unit row with no explore target returns false', () {
+      expect(
+        e2eExploreAssignEnabledFromCivilianSnapshot(
+          _snapshot(
+            availableWorkTargets: const {
+              'unit-1': ['build_road', 'prospect'],
+            },
+          ),
+        ),
+        isFalse,
+        reason:
+            'A unit row with valid non-Explore work targets still does '
+            'not satisfy the predicate — the panel-sweep fallback would '
+            'find no Explore tile either, so `false` is the deterministic '
+            'short-circuit.',
+      );
+    });
+
+    test('multiple unit rows none with explore target returns false', () {
+      expect(
+        e2eExploreAssignEnabledFromCivilianSnapshot(
+          _snapshot(
+            availableWorkTargets: const {
+              'unit-1': ['build_road'],
+              'unit-2': ['prospect', 'build_improvement'],
+              'unit-3': <String>[],
+            },
+          ),
+        ),
+        isFalse,
+        reason:
+            'Iteration walks every value list before returning false; an '
+            'early return on the first non-matching row would skip later '
+            'rows that could legitimately surface Explore (regression '
+            'guard against accidental short-circuit on the false arm).',
+      );
+    });
+
+    test('empty target lists for all rows returns false', () {
+      expect(
+        e2eExploreAssignEnabledFromCivilianSnapshot(
+          _snapshot(
+            availableWorkTargets: const {
+              'unit-1': <String>[],
+              'unit-2': <String>[],
+            },
+          ),
+        ),
+        isFalse,
+        reason:
+            'Empty target lists are valid panel states (every unit is '
+            'busy / idle without an Explore-capable type). The predicate '
+            'must traverse them without spuriously returning `true`.',
+      );
+    });
+  });
+
+  group('e2eExploreAssignEnabledFromCivilianSnapshot — true branches', () {
+    test('single unit row with only explore returns true', () {
+      expect(
+        e2eExploreAssignEnabledFromCivilianSnapshot(
+          _snapshot(
+            availableWorkTargets: const {
+              'explorer-1': ['explore'],
+            },
+          ),
+        ),
+        isTrue,
+        reason:
+            'Single Explorer with only Explore available is the canonical '
+            'short-circuit case — the slow-path Assign sweep would find '
+            'the same affordance enabled.',
+      );
+    });
+
+    test(
+      'single unit row with explore among multiple targets returns true',
+      () {
+        expect(
+          e2eExploreAssignEnabledFromCivilianSnapshot(
+            _snapshot(
+              availableWorkTargets: const {
+                'explorer-1': ['prospect', 'explore', 'build_road'],
+              },
+            ),
+          ),
+          isTrue,
+          reason:
+              'Membership uses `List.contains`, so any list containing '
+              '`explore` qualifies regardless of position. Order should '
+              'not affect the verdict.',
+        );
+      },
+    );
+
+    test('multiple unit rows with explore in only one returns true', () {
+      expect(
+        e2eExploreAssignEnabledFromCivilianSnapshot(
+          _snapshot(
+            availableWorkTargets: const {
+              'unit-1': ['build_road'],
+              'unit-2': ['prospect'],
+              'explorer-3': ['explore'],
+            },
+          ),
+        ),
+        isTrue,
+        reason:
+            'A single Explore-enabled unit row among non-Explore peers '
+            'is sufficient — the panel only needs one assign affordance '
+            'to satisfy the bundled-Explore readiness gate.',
+      );
+    });
+
+    test('multiple unit rows all with explore returns true', () {
+      expect(
+        e2eExploreAssignEnabledFromCivilianSnapshot(
+          _snapshot(
+            availableWorkTargets: const {
+              'explorer-1': ['explore', 'prospect'],
+              'explorer-2': ['explore'],
+            },
+          ),
+        ),
+        isTrue,
+        reason:
+            'Fully Explore-enabled panel state — the existential check '
+            'returns true on the first match, which is the documented '
+            'short-circuit behavior.',
+      );
+    });
+
+    test('explore mixed with empty target lists returns true', () {
+      expect(
+        e2eExploreAssignEnabledFromCivilianSnapshot(
+          _snapshot(
+            availableWorkTargets: const {
+              'unit-1': <String>[],
+              'unit-2': <String>[],
+              'explorer-3': ['explore'],
+            },
+          ),
+        ),
+        isTrue,
+        reason:
+            'Empty target lists are skipped by `List.contains(...)` and '
+            'must not short-circuit the iteration on the false arm; the '
+            'trailing Explore row must still be discovered.',
+      );
+    });
+  });
+
+  group('e2eExploreAssignEnabledFromCivilianSnapshot — regression guards', () {
+    test('case-sensitive: `Explore` (PascalCase) rejected', () {
+      expect(
+        e2eExploreAssignEnabledFromCivilianSnapshot(
+          _snapshot(
+            availableWorkTargets: const {
+              'unit-1': ['Explore'],
+            },
+          ),
+        ),
+        isFalse,
+        reason:
+            'Work-target ids are exact-match strings (logic-side '
+            '`kWorkTargetExplore == \'explore\'`). A future code change '
+            'that loosens comparison (e.g. ignore-case) would surface '
+            'phantom matches against UI labels rather than the canonical '
+            'target id — this pin keeps the comparison strict.',
+      );
+    });
+
+    test('case-sensitive: `EXPLORE` (uppercase) rejected', () {
+      expect(
+        e2eExploreAssignEnabledFromCivilianSnapshot(
+          _snapshot(
+            availableWorkTargets: const {
+              'unit-1': ['EXPLORE'],
+            },
+          ),
+        ),
+        isFalse,
+        reason:
+            'Symmetric uppercase guard alongside the PascalCase case — '
+            'pins the lower-case-only contract from both directions.',
+      );
+    });
+
+    test('substring `exploration` does not satisfy the predicate', () {
+      expect(
+        e2eExploreAssignEnabledFromCivilianSnapshot(
+          _snapshot(
+            availableWorkTargets: const {
+              'unit-1': ['exploration'],
+            },
+          ),
+        ),
+        isFalse,
+        reason:
+            '`List.contains` performs exact equality. A future change '
+            'that accidentally swaps to a `startsWith` / `Iterable.any` '
+            'with substring matching would surface this regression here.',
+      );
+    });
+
+    test('first-qualifying unit short-circuits (existential, not '
+        'universal)', () {
+      // The lifted helper is documented to short-circuit on the FIRST
+      // matching unit-row entry, not to walk every list and reduce.
+      // Pin the existential contract by surfacing a match in the
+      // first iteration position and a non-match (with a deliberately
+      // weird target id that would NOT survive a future strict-equality
+      // regression) later in the map. The predicate must NOT consult
+      // the trailing entry's content beyond the `List.contains` check
+      // (no all-rows reduction, no aggregation).
+      final snap = _snapshot(
+        availableWorkTargets: const {
+          'explorer-1': ['explore'],
+          'unit-2': ['EXPLORE_ALL_NOT_A_REAL_TARGET'],
+        },
+      );
+      expect(
+        e2eExploreAssignEnabledFromCivilianSnapshot(snap),
+        isTrue,
+        reason:
+            'Existential short-circuit on the first qualifying row — '
+            'a universal-all-rows variant would walk the trailing '
+            'placeholder list and still need to return true on the '
+            'first match anyway, but the pin against `EXPLORE_ALL_*` '
+            'guards against any future code that uses the trailing '
+            'entry value to re-derive truthiness.',
+      );
+    });
+  });
+
+  group('e2eExploreAssignEnabledFromCivilianSnapshot — determinism', () {
+    test('identical input snapshots yield identical results', () {
+      final snapA = _snapshot(
+        availableWorkTargets: const {
+          'unit-1': ['build_road'],
+          'explorer-2': ['explore'],
+        },
+      );
+      final snapB = _snapshot(
+        availableWorkTargets: const {
+          'unit-1': ['build_road'],
+          'explorer-2': ['explore'],
+        },
+      );
+
+      expect(
+        e2eExploreAssignEnabledFromCivilianSnapshot(snapA),
+        e2eExploreAssignEnabledFromCivilianSnapshot(snapB),
+        reason:
+            'Refs #2336 / Must-have AC1: predicates lifted into '
+            'shared library MUST be deterministic. Two structurally '
+            'identical snapshots must produce structurally identical '
+            'outputs (no hidden state or global access in the lifted '
+            'helper).',
+      );
+    });
+
+    test('repeated calls on same snapshot yield identical results', () {
+      final snap = _snapshot(
+        availableWorkTargets: const {
+          'unit-1': ['explore'],
+        },
+      );
+      final first = e2eExploreAssignEnabledFromCivilianSnapshot(snap);
+      final second = e2eExploreAssignEnabledFromCivilianSnapshot(snap);
+      final third = e2eExploreAssignEnabledFromCivilianSnapshot(snap);
+      expect(
+        [first, second, third],
+        everyElement(equals(true)),
+        reason:
+            'Determinism for repeated calls on the same input — pins '
+            'absence of memoization / mutable state in the predicate.',
+      );
+    });
+  });
+}

--- a/app/test/e2e_fleet_reach_short_circuit_test.dart
+++ b/app/test/e2e_fleet_reach_short_circuit_test.dart
@@ -1,0 +1,149 @@
+/// Pins the fleet-reach short-circuit helpers
+/// [e2eFleetReachDoneFromCtSnapshotOnly] and
+/// [e2eHarnessDetectsNonHomeFleetInNewWorld]
+/// (`app/integration_test/e2e_test_shared.dart`).
+///
+/// The fleet-reach turn loop and final assertions depend on these entrypoints
+/// to terminate within `_kMaxNextTurnTapsForNwFleetReach (35)` when the split
+/// fleet enters the New World (Refs GitHub #2336 Bottleneck 4 / AC1 / AC2).
+library;
+
+import 'package:colonizethis_app/config/ct_e2e.dart';
+import 'package:colonizethis_app/config/ct_e2e_last_panel_snapshot.dart';
+import 'package:colonizethis_data/colonizethis_data.dart' show MapTopology;
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../integration_test/e2e_test_shared.dart';
+
+const String _human = 'gp1';
+
+const TurnState _orderingTurn = TurnState(
+  phase: TurnPhase.orders,
+  turnNumber: 1,
+);
+
+const RegionData _emptyRegion = RegionData();
+
+const Orders _emptyOrders = Orders();
+
+const MapTopology _emptyTopology = MapTopology();
+
+Game _gameWithFleets(List<Fleet> fleets) => Game(
+  id: 'g1',
+  worldState: WorldState(
+    turnState: _orderingTurn,
+    oldWorld: _emptyRegion,
+    newWorld: _emptyRegion,
+    fleets: fleets,
+  ),
+  players: const [Player(id: _human, displayName: 'You', isHuman: true)],
+);
+
+CtE2eNavalPanelSnapshot _snapshot({
+  required List<Fleet> fleets,
+  MapTopology topology = _emptyTopology,
+}) => CtE2eNavalPanelSnapshot(
+  game: _gameWithFleets(fleets),
+  humanPlayerId: _human,
+  topology: topology,
+  draftOrders: _emptyOrders,
+);
+
+Fleet _homeFleet() => Fleet(
+  id: 'fleet_$_human',
+  ownerId: _human,
+  regionId: 'oldWorld',
+  inPortAtProvinceId: 'oldWorld|capital',
+);
+
+Fleet _splitFleetInNw({String id = 'fleet_split'}) =>
+    Fleet(id: id, ownerId: _human, regionId: 'newWorld', seaZoneId: 'nwSea');
+
+Widget _navalPanelWithNwFleet() => KeyedSubtree(
+  key: kCtE2ENavalPanelRootKey,
+  child: Column(
+    children: [
+      ExpansionTile(
+        title: const Text('Fleet 2'),
+        subtitle: const Text('New World — Outer Sea'),
+      ),
+    ],
+  ),
+);
+
+void main() {
+  suppressLogsForTests();
+
+  group('e2eFleetReachDoneFromCtSnapshotOnly', () {
+    test('null snapshot returns false', () {
+      expect(e2eFleetReachDoneFromCtSnapshotOnly(null), isFalse);
+    });
+
+    test(
+      'matches e2eNonHomeHumanFleetInNewWorldFromCtSnapshot for NW split fleet',
+      () {
+        final snap = _snapshot(fleets: [_homeFleet(), _splitFleetInNw()]);
+        expect(
+          e2eFleetReachDoneFromCtSnapshotOnly(snap),
+          e2eNonHomeHumanFleetInNewWorldFromCtSnapshot(snap),
+        );
+        expect(e2eFleetReachDoneFromCtSnapshotOnly(snap), isTrue);
+      },
+    );
+
+    test('home fleet only returns false', () {
+      expect(
+        e2eFleetReachDoneFromCtSnapshotOnly(_snapshot(fleets: [_homeFleet()])),
+        isFalse,
+      );
+    });
+  });
+
+  group('e2eHarnessDetectsNonHomeFleetInNewWorld', () {
+    testWidgets('snapshot true short-circuits without naval panel widget', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(home: Scaffold(body: Text('no panel'))),
+      );
+      final snap = _snapshot(fleets: [_homeFleet(), _splitFleetInNw()]);
+      expect(e2eHarnessDetectsNonHomeFleetInNewWorld(tester, snap), isTrue);
+    });
+
+    testWidgets('non-null snapshot false does not consult widget fallback', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(home: Scaffold(body: _navalPanelWithNwFleet())),
+      );
+      final snap = _snapshot(fleets: [_homeFleet()]);
+      expect(
+        e2eHarnessDetectsNonHomeFleetInNewWorld(tester, snap),
+        isFalse,
+        reason:
+            'When snapshot plumbing is present but reports no arrival, the '
+            'harness must not treat a coincidental NW location line in the '
+            'widget tree as arrival — that would mask a stale snapshot.',
+      );
+    });
+
+    testWidgets('null snapshot falls back to naval panel widget tree', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(home: Scaffold(body: _navalPanelWithNwFleet())),
+      );
+      expect(e2eHarnessDetectsNonHomeFleetInNewWorld(tester, null), isTrue);
+    });
+
+    testWidgets('null snapshot and empty tree returns false', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(home: Scaffold(body: Text('empty'))),
+      );
+      expect(e2eHarnessDetectsNonHomeFleetInNewWorld(tester, null), isFalse);
+    });
+  });
+}

--- a/app/test/e2e_helpers_barrel_test.dart
+++ b/app/test/e2e_helpers_barrel_test.dart
@@ -391,6 +391,29 @@ void main() {
       );
     });
 
+    test(
+      'e2eFleetReachDoneFromCtSnapshotOnly is re-exported through the barrel',
+      () {
+        final bool Function(CtE2eNavalPanelSnapshot?) ref =
+            e2eFleetReachDoneFromCtSnapshotOnly;
+        expect(ref, isNotNull);
+        expect(ref(null), isFalse);
+      },
+    );
+
+    testWidgets(
+      'e2eHarnessDetectsNonHomeFleetInNewWorld is re-exported through the barrel',
+      (tester) async {
+        final bool Function(WidgetTester, CtE2eNavalPanelSnapshot?) ref =
+            e2eHarnessDetectsNonHomeFleetInNewWorld;
+        expect(ref, isNotNull);
+        await tester.pumpWidget(
+          const MaterialApp(home: Scaffold(body: SizedBox())),
+        );
+        expect(ref(tester, null), isFalse);
+      },
+    );
+
     test('e2eNonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot is '
         're-exported through the barrel', () {
       final bool Function(CtE2eNavalPanelSnapshot?) ref =

--- a/app/test/e2e_helpers_barrel_test.dart
+++ b/app/test/e2e_helpers_barrel_test.dart
@@ -42,6 +42,8 @@
 //   - Issue #2336 § Acceptance criteria § AC1 (Shared helpers exist) and
 //     § AC5 (Adaptive polling) for the panel/turn entrypoints.
 
+import 'package:colonizethis_app/config/ct_e2e_last_panel_snapshot.dart'
+    show CtE2eNavalPanelSnapshot;
 import 'package:colonizethis_app/l10n/app_localizations_contract.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
@@ -325,6 +327,36 @@ void main() {
         );
       },
     );
+
+    test('e2eNonHomeHumanFleetInNewWorldFromCtSnapshot is re-exported through '
+        'the barrel', () {
+      final bool Function(CtE2eNavalPanelSnapshot?) ref =
+          e2eNonHomeHumanFleetInNewWorldFromCtSnapshot;
+      expect(
+        ref,
+        isNotNull,
+        reason:
+            'Fleet-reach short-circuit in '
+            '`new_game_fleet_reaches_new_world_e2e_helpers_part2.dart` '
+            '(`_fleetReachDoneFromCtSnapshotOnly`, '
+            '`_harnessDetectsNonHomeFleetInNewWorld`) consumes this '
+            'snapshot-driven predicate via the AC1 barrel. A regression '
+            'that dropped it from the `show` clause would re-introduce '
+            'the `_kMaxNextTurnTapsForNwFleetReach (35) × ~5 s` stall '
+            'documented in #2336 Bottleneck 4 (`SPEC/program/'
+            'e2e-integration-tests.md` § Determinism).',
+      );
+      expect(
+        ref(null),
+        isFalse,
+        reason:
+            'Sanity smoke through the barrel: a null snapshot must keep '
+            'returning false after re-export. A wrapper that swallowed '
+            'the argument and returned a constant would pass the '
+            'tear-off pin silently; null is the canonical no-plumbing '
+            'state and must short-circuit before any field access.',
+      );
+    });
 
     test('AC1 timing constants are exposed as Duration values', () {
       const Duration maxWallClock = kE2eMaxWallClock;

--- a/app/test/e2e_helpers_barrel_test.dart
+++ b/app/test/e2e_helpers_barrel_test.dart
@@ -45,6 +45,7 @@
 import 'package:colonizethis_app/config/ct_e2e_last_panel_snapshot.dart'
     show CtE2eNavalPanelSnapshot;
 import 'package:colonizethis_app/l10n/app_localizations_contract.dart';
+import 'package:colonizethis_data/colonizethis_data.dart' show MapTopology;
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -355,6 +356,69 @@ void main() {
             'the argument and returned a constant would pass the '
             'tear-off pin silently; null is the canonical no-plumbing '
             'state and must short-circuit before any field access.',
+      );
+    });
+
+    test('e2eNonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot is '
+        're-exported through the barrel', () {
+      final bool Function(CtE2eNavalPanelSnapshot?) ref =
+          e2eNonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot;
+      expect(
+        ref,
+        isNotNull,
+        reason:
+            'The bundled-explore readiness loop in '
+            '`new_game_fleet_reaches_new_world_e2e_helpers_part2.dart` '
+            '(`_awaitNwCoastalOrVisibleLandForBundledExploreE2e`) '
+            'short-circuits on this coastal-NW predicate alongside '
+            'e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot. A '
+            'regression that dropped it from the `show` clause would '
+            're-introduce the 35-turn × ~5 s stall documented in #2336 '
+            'Bottleneck 4 (`SPEC/program/e2e-integration-tests.md` '
+            '§ Determinism) for the open-ocean NW fleet branch where '
+            'ship reveal never paints coastal land.',
+      );
+      expect(
+        ref(null),
+        isFalse,
+        reason:
+            'Sanity smoke through the barrel: a null snapshot must keep '
+            'returning false after re-export. A wrapper that swallowed '
+            'the argument and returned a constant would pass the '
+            'tear-off pin silently; null is the canonical no-plumbing '
+            'state and must short-circuit before any field access.',
+      );
+    });
+
+    test('e2eNwCoastalProvincesAdjacentToFleetSea is re-exported through the '
+        'barrel', () {
+      final Set<String> Function(MapTopology, String, String) ref =
+          e2eNwCoastalProvincesAdjacentToFleetSea;
+      expect(
+        ref,
+        isNotNull,
+        reason:
+            'The two-tier coastal adjacency lookup (verbatim sea id, '
+            'then `ProvinceId.full(regionId, seaZoneId)` fallback) is '
+            'the helper '
+            '`e2eNonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot` '
+            'consumes per fleet. A regression that dropped it from the '
+            '`show` clause would force scenarios to re-implement the '
+            'fallback (silently divergent across files) or fail to '
+            'compile entirely; pin the tear-off so the AC1 barrel keeps '
+            'this canonical entrypoint exported.',
+      );
+      expect(
+        ref(const MapTopology(), 'sea1', 'newWorld'),
+        isEmpty,
+        reason:
+            'Sanity smoke through the barrel: an empty topology must '
+            'yield an empty adjacency set for any sea zone. A wrapper '
+            'that swallowed the topology and returned a constant '
+            'non-empty set would pass the tear-off pin silently; the '
+            'empty-topology baseline is the canonical "no edges" state '
+            'that must surface as an empty result rather than a fake '
+            'coastal hit.',
       );
     });
 

--- a/app/test/e2e_helpers_barrel_test.dart
+++ b/app/test/e2e_helpers_barrel_test.dart
@@ -43,7 +43,8 @@
 //     § AC5 (Adaptive polling) for the panel/turn entrypoints.
 
 import 'package:colonizethis_app/config/ct_e2e_last_panel_snapshot.dart'
-    show CtE2eNavalPanelSnapshot;
+    show CtE2eCivilianPanelSnapshot, CtE2eNavalPanelSnapshot;
+import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_app/l10n/app_localizations_contract.dart';
 import 'package:colonizethis_data/colonizethis_data.dart' show MapTopology;
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
@@ -485,6 +486,68 @@ void main() {
             'pass the tear-off pin silently; null is the canonical '
             'no-plumbing state and must short-circuit before any '
             'field access.',
+      );
+    });
+
+    test('e2eExploreAssignEnabledFromCivilianSnapshot is re-exported '
+        'through the barrel', () {
+      final bool? Function(CtE2eCivilianPanelSnapshot?) ref =
+          e2eExploreAssignEnabledFromCivilianSnapshot;
+      expect(
+        ref,
+        isNotNull,
+        reason:
+            'The fleet-reach test\'s '
+            '`_anyExplorerHasEnabledExploreAssignFleetE2e` helper in '
+            '`new_game_fleet_reaches_new_world_e2e_helpers_part2.dart` '
+            'short-circuits on this snapshot-driven predicate before '
+            'scrolling the civilian panel `Assign` sheet. A regression '
+            'that dropped it from the `show` clause would force the '
+            'panel-sweep loop to fall through to the '
+            '`maxPanelSweepSteps (16) × per-step Assign sweep` slow '
+            'path on every fleet-reach turn (Bottleneck 5 in '
+            '`SPEC/program/e2e-integration-tests.md` § Determinism, '
+            '#2336 AC5). The bool? return is part of the contract — '
+            '`null` distinguishes "no snapshot plumbed" from `false` '
+            '("panel mounted, no Explore"); pinning the typed tear-off '
+            'fails this test on any future signature mutation.',
+      );
+      expect(
+        ref(null),
+        isNull,
+        reason:
+            'Sanity smoke through the barrel: a null snapshot must keep '
+            'returning null (NOT false) after re-export. A wrapper that '
+            'collapsed null → false would silently skip the slow-path '
+            'fallback whenever the panel is mid-mount, masking real '
+            'bundled-Explore regressions; the typed `bool?` return is '
+            'the contract that keeps these two states distinct.',
+      );
+      const Game game = Game(
+        id: 'barrel-smoke',
+        worldState: WorldState(
+          turnState: TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: RegionData(),
+          newWorld: RegionData(),
+        ),
+        players: [Player(id: 'gp1', displayName: 'You', isHuman: true)],
+      );
+      final emptySnap = const CtE2eCivilianPanelSnapshot(
+        game: game,
+        humanPlayerId: 'gp1',
+        currentOrders: Orders(),
+        availableWorkTargets: <String, List<String>>{},
+      );
+      expect(
+        ref(emptySnap),
+        isFalse,
+        reason:
+            'Empty `availableWorkTargets` is a definitive "panel '
+            'mounted but no civilian can be assigned anything" verdict '
+            '— `false` (not `null`). A wrapper that ignored the '
+            'snapshot and returned a constant would not distinguish '
+            'this from the null branch above; the typed `bool?` tear-'
+            'off plus both smoke probes catch that regression.',
       );
     });
 

--- a/app/test/e2e_helpers_barrel_test.dart
+++ b/app/test/e2e_helpers_barrel_test.dart
@@ -358,6 +358,41 @@ void main() {
       );
     });
 
+    test('e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot is re-exported '
+        'through the barrel', () {
+      final bool Function(CtE2eNavalPanelSnapshot?) ref =
+          e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot;
+      expect(
+        ref,
+        isNotNull,
+        reason:
+            'The bundled-explore readiness loop in '
+            '`new_game_fleet_reaches_new_world_e2e_helpers_part2.dart` '
+            '(`_awaitNwCoastalOrVisibleLandForBundledExploreE2e`) and '
+            'the fleet-reach test\'s final skip guard '
+            '(`new_game_fleet_reaches_new_world_e2e_test.dart`) both '
+            'consume this snapshot-driven predicate via the AC1 '
+            'barrel. A regression that dropped it from the `show` '
+            'clause would either stall the readiness loop for the '
+            'full 35-turn cap (Bottleneck 4 in `SPEC/program/'
+            'e2e-integration-tests.md` § Determinism) or convert the '
+            'strict bundled-explore assertion into a silent skip — '
+            'both directly inflate the wall-clock cap #2336 is '
+            'reducing.',
+      );
+      expect(
+        ref(null),
+        isFalse,
+        reason:
+            'Sanity smoke through the barrel: a null snapshot must '
+            'keep returning false after re-export. A wrapper that '
+            'swallowed the argument and returned a constant would '
+            'pass the tear-off pin silently; null is the canonical '
+            'no-plumbing state and must short-circuit before any '
+            'field access.',
+      );
+    });
+
     test('AC1 timing constants are exposed as Duration values', () {
       const Duration maxWallClock = kE2eMaxWallClock;
       const Duration nextTurnTimeout = kE2eNextTurnResolutionTimeout;

--- a/app/test/e2e_helpers_barrel_test.dart
+++ b/app/test/e2e_helpers_barrel_test.dart
@@ -329,6 +329,37 @@ void main() {
       },
     );
 
+    testWidgets(
+      'e2eNavalPanelShowsNonHomeFleetInNewWorld is re-exported through the barrel',
+      (tester) async {
+        final bool Function(WidgetTester) ref =
+            e2eNavalPanelShowsNonHomeFleetInNewWorld;
+        expect(
+          ref,
+          isNotNull,
+          reason:
+              'Fleet-reach harness fallback in '
+              '`new_game_fleet_reaches_new_world_e2e_helpers_part2.dart` '
+              '(`_harnessDetectsNonHomeFleetInNewWorld`) consumes this '
+              'widget predicate via the AC1 barrel when '
+              'ctE2eNavalPanelSnapshot is null. A regression that dropped it '
+              'from the `show` clause would break the UI fallback path at '
+              'E2E time.',
+        );
+        await tester.pumpWidget(
+          const MaterialApp(home: Scaffold(body: SizedBox())),
+        );
+        expect(
+          ref(tester),
+          isFalse,
+          reason:
+              'Sanity smoke through the barrel: an empty tree must return '
+              'false after re-export. A wrapper that swallowed the tester '
+              'argument would pass the tear-off pin silently.',
+        );
+      },
+    );
+
     test('e2eNonHomeHumanFleetInNewWorldFromCtSnapshot is re-exported through '
         'the barrel', () {
       final bool Function(CtE2eNavalPanelSnapshot?) ref =

--- a/app/test/e2e_naval_panel_shows_non_home_fleet_in_new_world_test.dart
+++ b/app/test/e2e_naval_panel_shows_non_home_fleet_in_new_world_test.dart
@@ -1,0 +1,187 @@
+/// Pins the widget-tree contract of [e2eNavalPanelShowsNonHomeFleetInNewWorld]
+/// (`app/integration_test/e2e_test_shared.dart`).
+///
+/// The fleet-reach harness fallback (`_harnessDetectsNonHomeFleetInNewWorld` in
+/// `new_game_fleet_reaches_new_world_e2e_helpers_part2.dart`) consults this
+/// predicate when [ctE2eNavalPanelSnapshot] is null. A silent rename / fail-open
+/// would stall the suite at `_kMaxNextTurnTapsForNwFleetReach (35) × ~5 s`
+/// (Refs GitHub #2336 Bottleneck 4 / AC1 / AC2).
+library;
+
+import 'package:colonizethis_app/config/ct_e2e.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../integration_test/e2e_test_shared.dart';
+
+Widget _navalPanel({required List<Widget> fleetTiles}) => KeyedSubtree(
+  key: kCtE2ENavalPanelRootKey,
+  child: Column(children: fleetTiles),
+);
+
+ExpansionTile _fleetTile({required String fleetTitle, String? locationLine}) =>
+    ExpansionTile(
+      title: Text(fleetTitle),
+      subtitle: locationLine == null ? null : Text(locationLine),
+    );
+
+void main() {
+  suppressLogsForTests();
+
+  group('e2eNavalPanelShowsNonHomeFleetInNewWorld — false branches', () {
+    testWidgets('no naval panel root key', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(home: Scaffold(body: Text('empty'))),
+      );
+      expect(e2eNavalPanelShowsNonHomeFleetInNewWorld(tester), isFalse);
+    });
+
+    testWidgets('naval panel with no ExpansionTile children', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: _navalPanel(fleetTiles: const [Text('loading')]),
+          ),
+        ),
+      );
+      expect(e2eNavalPanelShowsNonHomeFleetInNewWorld(tester), isFalse);
+    });
+
+    testWidgets('home fleet only (no Fleet prefix title)', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: _navalPanel(
+              fleetTiles: [
+                ExpansionTile(
+                  title: const Text('Home Fleet'),
+                  subtitle: const Text('New World — Outer Sea'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+      expect(e2eNavalPanelShowsNonHomeFleetInNewWorld(tester), isFalse);
+    });
+
+    testWidgets('non-home fleet without New World location line', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: _navalPanel(
+              fleetTiles: [
+                _fleetTile(
+                  fleetTitle: 'Fleet 2',
+                  locationLine: 'Old World — Coastal Sea',
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+      expect(e2eNavalPanelShowsNonHomeFleetInNewWorld(tester), isFalse);
+    });
+
+    testWidgets('non-home fleet with no subtitle location', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: _navalPanel(fleetTiles: [_fleetTile(fleetTitle: 'Fleet 2')]),
+          ),
+        ),
+      );
+      expect(e2eNavalPanelShowsNonHomeFleetInNewWorld(tester), isFalse);
+    });
+
+    testWidgets('Fleet title prefix required (reject "Flotilla 2")', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: _navalPanel(
+              fleetTiles: [
+                _fleetTile(
+                  fleetTitle: 'Flotilla 2',
+                  locationLine: 'New World — Outer Sea',
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+      expect(e2eNavalPanelShowsNonHomeFleetInNewWorld(tester), isFalse);
+    });
+  });
+
+  group('e2eNavalPanelShowsNonHomeFleetInNewWorld — true branches', () {
+    testWidgets('single non-home fleet with em-dash NW location', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: _navalPanel(
+              fleetTiles: [
+                _fleetTile(
+                  fleetTitle: 'Fleet 2',
+                  locationLine: 'New World — Outer Sea',
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+      expect(e2eNavalPanelShowsNonHomeFleetInNewWorld(tester), isTrue);
+    });
+
+    testWidgets('home fleet row skipped; qualifying fleet is second tile', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: _navalPanel(
+              fleetTiles: [
+                const ExpansionTile(title: Text('Home Fleet')),
+                _fleetTile(
+                  fleetTitle: 'Fleet 3',
+                  locationLine: 'New World - Outer Sea',
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+      expect(e2eNavalPanelShowsNonHomeFleetInNewWorld(tester), isTrue);
+    });
+
+    testWidgets('first qualifying tile short-circuits (existential check)', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: _navalPanel(
+              fleetTiles: [
+                _fleetTile(
+                  fleetTitle: 'Fleet 1',
+                  locationLine: 'New World — Sea A',
+                ),
+                _fleetTile(
+                  fleetTitle: 'Fleet 2',
+                  locationLine: 'Old World — Coastal Sea',
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+      expect(e2eNavalPanelShowsNonHomeFleetInNewWorld(tester), isTrue);
+    });
+  });
+}

--- a/app/test/e2e_non_home_human_fleet_in_coastal_new_world_sea_from_ct_snapshot_test.dart
+++ b/app/test/e2e_non_home_human_fleet_in_coastal_new_world_sea_from_ct_snapshot_test.dart
@@ -1,0 +1,788 @@
+/// Pins the snapshot-driven non-home-human-fleet-in-NW-coastal-sea contract
+/// of [e2eNonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot] and the
+/// two-tier adjacency contract of
+/// [e2eNwCoastalProvincesAdjacentToFleetSea]
+/// (`app/integration_test/e2e_test_shared.dart`).
+///
+/// The bundled-explore readiness loop
+/// (`_awaitNwCoastalOrVisibleLandForBundledExploreE2e` in
+/// `new_game_fleet_reaches_new_world_e2e_helpers_part2.dart`)
+/// short-circuits on this predicate alongside
+/// [e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot]. Ship reveal
+/// only paints coastal land for sea zones with a P–S province edge
+/// (`SPEC/program/fog-and-exploration-resolution.md`), so a non-home
+/// human fleet in an open-ocean NW sea satisfies
+/// [e2eNonHomeHumanFleetInNewWorldFromCtSnapshot] but never yields
+/// fogged-or-better NW provinces — leaving bundled Explore disabled. A
+/// silent rename / fail-open here would stall the readiness loop at
+/// `_kMaxNextTurnTapsForNwFleetReach (35) × ~5 s` (Bottleneck 4 in
+/// `SPEC/program/e2e-integration-tests.md` § Determinism), directly
+/// inflating the wall-clock cap #2336 is reducing.
+///
+/// The integration suite cannot validate this directly (the
+/// `app_e2e_linux` lane is a no-op per
+/// `SPEC/program/e2e-integration-tests.md` § CI), so the widget-test
+/// layer carries the behavioural pin (Refs GitHub #2336 AC1 / AC2).
+library;
+
+import 'package:colonizethis_app/config/ct_e2e_last_panel_snapshot.dart';
+import 'package:colonizethis_data/colonizethis_data.dart'
+    show MapTopology, TopologyEdge, TopologyNode, TopologyNodeType;
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter_test/flutter_test.dart';
+
+import '../integration_test/e2e_test_shared.dart';
+
+const String _human = 'gp1';
+const String _otherGp = 'gp2';
+
+const TurnState _orderingTurn = TurnState(
+  phase: TurnPhase.orders,
+  turnNumber: 1,
+);
+
+const RegionData _emptyRegion = RegionData();
+
+const Orders _emptyOrders = Orders();
+
+const MapTopology _emptyTopology = MapTopology();
+
+/// Build a topology where [seaId] is a NW sea zone with edges to each
+/// province in [adjacentProvinceIds]. Province nodes default to NW region.
+MapTopology _coastalNwTopology({
+  required String seaId,
+  required List<String> adjacentProvinceIds,
+}) => MapTopology(
+  nodes: [
+    TopologyNode(
+      id: seaId,
+      regionId: 'newWorld',
+      type: TopologyNodeType.seaZone,
+    ),
+    for (final pid in adjacentProvinceIds)
+      TopologyNode(
+        id: pid,
+        regionId: 'newWorld',
+        type: TopologyNodeType.province,
+      ),
+  ],
+  edges: [
+    for (final pid in adjacentProvinceIds) TopologyEdge(id1: pid, id2: seaId),
+  ],
+);
+
+Game _gameWithFleets(List<Fleet> fleets) => Game(
+  id: 'g1',
+  worldState: WorldState(
+    turnState: _orderingTurn,
+    oldWorld: _emptyRegion,
+    newWorld: _emptyRegion,
+    fleets: fleets,
+  ),
+  players: const [Player(id: _human, displayName: 'You', isHuman: true)],
+);
+
+CtE2eNavalPanelSnapshot _snapshot({
+  required List<Fleet> fleets,
+  MapTopology topology = _emptyTopology,
+}) => CtE2eNavalPanelSnapshot(
+  game: _gameWithFleets(fleets),
+  humanPlayerId: _human,
+  topology: topology,
+  draftOrders: _emptyOrders,
+);
+
+Fleet _homeFleet({
+  String regionId = 'oldWorld',
+  String? inPortAtProvinceId = 'oldWorld|capital',
+}) => Fleet(
+  id: 'fleet_$_human',
+  ownerId: _human,
+  regionId: regionId,
+  inPortAtProvinceId: inPortAtProvinceId,
+);
+
+void main() {
+  suppressLogsForTests();
+
+  group(
+    'e2eNonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot — false branches',
+    () {
+      test('null snapshot returns false', () {
+        expect(
+          e2eNonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot(null),
+          isFalse,
+          reason:
+              'No naval-panel snapshot plumbing this turn means the '
+              'predicate must short-circuit before any field access. '
+              'A fail-open would terminate the bundled-explore '
+              'readiness loop on turn 0 before the split fleet has '
+              'reached coastal NW.',
+        );
+      });
+
+      test('no fleets in the snapshot returns false', () {
+        expect(
+          e2eNonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot(
+            _snapshot(fleets: const []),
+          ),
+          isFalse,
+          reason:
+              'An empty fleet list cannot satisfy non-home-human-coastal-NW; '
+              'the predicate must keep iterating instead of treating '
+              '"no fleets" as arrival.',
+        );
+      });
+
+      test('only home fleet (in port, OW region) returns false', () {
+        expect(
+          e2eNonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot(
+            _snapshot(fleets: [_homeFleet()]),
+          ),
+          isFalse,
+          reason:
+              'The home fleet (`fleet_<humanPlayerId>`) is skipped per '
+              'the docstring contract; otherwise the readiness loop '
+              'would short-circuit on turn 0 before the player splits '
+              'and sails to the New World.',
+        );
+      });
+
+      test('home fleet sitting in a NW coastal sea is still skipped '
+          '(home-id wins over location)', () {
+        expect(
+          e2eNonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot(
+            _snapshot(
+              fleets: [
+                Fleet(
+                  id: 'fleet_$_human',
+                  ownerId: _human,
+                  regionId: 'newWorld',
+                  seaZoneId: 'sea_nw_1',
+                ),
+              ],
+              topology: _coastalNwTopology(
+                seaId: 'sea_nw_1',
+                adjacentProvinceIds: const ['newWorld|p1'],
+              ),
+            ),
+          ),
+          isFalse,
+          reason:
+              'The home-fleet skip is by **id**, not by location: a '
+              'home fleet in a coastal NW sea (after warp + before '
+              'split) must not falsely report arrival, otherwise the '
+              'split-then-sail scenario short-circuits before the '
+              'non-home fleet is in NW coastal seas.',
+        );
+      });
+
+      test('non-home fleet owned by a different GP returns false', () {
+        expect(
+          e2eNonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot(
+            _snapshot(
+              fleets: [
+                _homeFleet(),
+                Fleet(
+                  id: 'fleet_other_1',
+                  ownerId: _otherGp,
+                  regionId: 'newWorld',
+                  seaZoneId: 'sea_nw_1',
+                ),
+              ],
+              topology: _coastalNwTopology(
+                seaId: 'sea_nw_1',
+                adjacentProvinceIds: const ['newWorld|p1'],
+              ),
+            ),
+          ),
+          isFalse,
+          reason:
+              'Only the human player\'s non-home fleets count. Any '
+              'other GP sailing in NW coastal sea must not be confused '
+              'for the human\'s readiness signal.',
+        );
+      });
+
+      test('non-home human fleet in port (no sea zone) returns false', () {
+        expect(
+          e2eNonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot(
+            _snapshot(
+              fleets: [
+                _homeFleet(),
+                Fleet(
+                  id: 'fleet_human_in_port',
+                  ownerId: _human,
+                  regionId: 'newWorld',
+                  inPortAtProvinceId: 'newWorld|port1',
+                ),
+              ],
+            ),
+          ),
+          isFalse,
+          reason:
+              'A non-home fleet in port has `isAtSea == false` and a '
+              'null `seaZoneId`; the predicate must skip per contract '
+              'rather than attempt adjacency lookup against a null '
+              'identifier or treat the in-port state as coastal-sea '
+              'arrival.',
+        );
+      });
+
+      test(
+        'non-home human fleet in NW open-ocean (no P–S edge) returns false',
+        () {
+          expect(
+            e2eNonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot(
+              _snapshot(
+                fleets: [
+                  _homeFleet(),
+                  Fleet(
+                    id: 'fleet_human_split',
+                    ownerId: _human,
+                    regionId: 'newWorld',
+                    seaZoneId: 'sea_open_ocean',
+                  ),
+                ],
+                // Topology declares the sea zone but no adjacent province
+                // edges — open-ocean sea with no coastal land.
+                topology: const MapTopology(
+                  nodes: [
+                    TopologyNode(
+                      id: 'sea_open_ocean',
+                      regionId: 'newWorld',
+                      type: TopologyNodeType.seaZone,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            isFalse,
+            reason:
+                'This is the canonical fail mode the coastal predicate '
+                'exists to guard against: a fleet in open-ocean NW '
+                'satisfies "fleet is in NW" but never paints coastal '
+                'land (no P–S edge), so bundled Explore stays disabled. '
+                'A fail-open here would stall the readiness loop for the '
+                'full 35-turn cap.',
+          );
+        },
+      );
+
+      test('non-home human fleet in OW coastal sea returns false', () {
+        expect(
+          e2eNonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot(
+            _snapshot(
+              fleets: [
+                _homeFleet(),
+                Fleet(
+                  id: 'fleet_human_split',
+                  ownerId: _human,
+                  regionId: 'oldWorld',
+                  seaZoneId: 'sea_ow_coast',
+                ),
+              ],
+              topology: const MapTopology(
+                nodes: [
+                  TopologyNode(
+                    id: 'sea_ow_coast',
+                    regionId: 'oldWorld',
+                    type: TopologyNodeType.seaZone,
+                  ),
+                  TopologyNode(
+                    id: 'oldWorld|p1',
+                    regionId: 'oldWorld',
+                    type: TopologyNodeType.province,
+                  ),
+                ],
+                edges: [TopologyEdge(id1: 'oldWorld|p1', id2: 'sea_ow_coast')],
+              ),
+            ),
+          ),
+          isFalse,
+          reason:
+              'A non-home human fleet in an OW coastal sea zone must '
+              'not satisfy the NW-coastal predicate; the readiness '
+              'loop must keep iterating until the fleet actually '
+              'crosses the warp boundary into a NW coastal sea.',
+        );
+      });
+
+      test('non-home human fleet at a sea zone the topology cannot resolve '
+          'returns false', () {
+        expect(
+          e2eNonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot(
+            _snapshot(
+              fleets: [
+                _homeFleet(),
+                Fleet(
+                  id: 'fleet_human_split',
+                  ownerId: _human,
+                  // Legacy state: OW regionId but the sea id is not in
+                  // the topology so regionIdForSeaZone returns null.
+                  regionId: 'oldWorld',
+                  seaZoneId: 'sea_phantom',
+                ),
+              ],
+              topology: _emptyTopology,
+            ),
+          ),
+          isFalse,
+          reason:
+              'When `regionIdForSeaZone` returns null (sea not in '
+              'topology) and `regionId` is not `newWorld`, the '
+              'predicate must skip the fleet rather than assume any '
+              'region or fail open.',
+        );
+      });
+    },
+  );
+
+  group(
+    'e2eNonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot — true branches',
+    () {
+      test('non-home human fleet with regionId == newWorld in a coastal sea '
+          'returns true', () {
+        expect(
+          e2eNonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot(
+            _snapshot(
+              fleets: [
+                _homeFleet(),
+                Fleet(
+                  id: 'fleet_human_split',
+                  ownerId: _human,
+                  regionId: 'newWorld',
+                  seaZoneId: 'sea_nw_coast',
+                ),
+              ],
+              topology: _coastalNwTopology(
+                seaId: 'sea_nw_coast',
+                adjacentProvinceIds: const ['newWorld|p1'],
+              ),
+            ),
+          ),
+          isTrue,
+          reason:
+              'Canonical readiness signal: a non-home human fleet in '
+              'a NW sea zone that has at least one P–S edge means ship '
+              'reveal will paint coastal land. The readiness loop '
+              'short-circuits, the orchestrator proceeds to bundled '
+              'Explore — exactly the path this predicate guards.',
+        );
+      });
+
+      test('non-home human fleet with OW regionId but NW coastal sea via '
+          'topology returns true', () {
+        expect(
+          e2eNonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot(
+            _snapshot(
+              fleets: [
+                _homeFleet(),
+                Fleet(
+                  id: 'fleet_human_split',
+                  ownerId: _human,
+                  regionId: 'oldWorld',
+                  seaZoneId: 'sea_nw_coast',
+                ),
+              ],
+              topology: _coastalNwTopology(
+                seaId: 'sea_nw_coast',
+                adjacentProvinceIds: const ['newWorld|p1'],
+              ),
+            ),
+          ),
+          isTrue,
+          reason:
+              'Legacy fleet state may still carry the OW `regionId` '
+              'while the `seaZoneId` is a NW sea node — the topology '
+              'fallback (`regionIdForSeaZone == newWorld`) must keep '
+              'this coastal path live, otherwise the readiness loop '
+              'overruns the wall-clock cap.',
+        );
+      });
+
+      test('local-id sea zone matches prefixed P–S edge via the two-tier '
+          'fallback', () {
+        // Live fleet states sometimes carry the local sea id (`sea5`)
+        // while the combined topology uses the prefixed P–S form
+        // (`newWorld|sea5`); the lifted
+        // `e2eNwCoastalProvincesAdjacentToFleetSea` two-tier lookup
+        // exists precisely for this case.
+        expect(
+          e2eNonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot(
+            _snapshot(
+              fleets: [
+                _homeFleet(),
+                Fleet(
+                  id: 'fleet_human_split',
+                  ownerId: _human,
+                  regionId: 'newWorld',
+                  seaZoneId: 'sea_nw_coast',
+                ),
+              ],
+              topology: _coastalNwTopology(
+                seaId: 'newWorld|sea_nw_coast',
+                adjacentProvinceIds: const ['newWorld|p1'],
+              ),
+            ),
+          ),
+          isTrue,
+          reason:
+              'The two-tier fallback must keep coastal detection '
+              'aligned with the ship-reveal contract regardless of '
+              'whether the fleet carries the local or prefixed sea id; '
+              'a regression that dropped the fallback would force '
+              'every fleet to refresh its sea id schema before the '
+              'readiness loop terminates.',
+        );
+      });
+
+      test('multi-fleet snapshot: matching fleet later in the list still '
+          'returns true', () {
+        expect(
+          e2eNonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot(
+            _snapshot(
+              fleets: [
+                _homeFleet(),
+                // Decoy: human non-home in OW coastal sea — not NW.
+                Fleet(
+                  id: 'fleet_human_decoy',
+                  ownerId: _human,
+                  regionId: 'oldWorld',
+                  seaZoneId: 'sea_ow',
+                ),
+                // Other-GP fleet at the qualifying NW coast — ignored.
+                Fleet(
+                  id: 'fleet_other_gp',
+                  ownerId: _otherGp,
+                  regionId: 'newWorld',
+                  seaZoneId: 'sea_nw_coast',
+                ),
+                // Qualifying fleet last in iteration order.
+                Fleet(
+                  id: 'fleet_human_split',
+                  ownerId: _human,
+                  regionId: 'newWorld',
+                  seaZoneId: 'sea_nw_coast',
+                ),
+              ],
+              topology: MapTopology(
+                nodes: const [
+                  TopologyNode(
+                    id: 'sea_ow',
+                    regionId: 'oldWorld',
+                    type: TopologyNodeType.seaZone,
+                  ),
+                  TopologyNode(
+                    id: 'sea_nw_coast',
+                    regionId: 'newWorld',
+                    type: TopologyNodeType.seaZone,
+                  ),
+                  TopologyNode(
+                    id: 'newWorld|p1',
+                    regionId: 'newWorld',
+                    type: TopologyNodeType.province,
+                  ),
+                ],
+                edges: const [
+                  TopologyEdge(id1: 'newWorld|p1', id2: 'sea_nw_coast'),
+                ],
+              ),
+            ),
+          ),
+          isTrue,
+          reason:
+              'The predicate must iterate every fleet before giving '
+              'up; a qualifying fleet that follows non-qualifying '
+              'ones (OW decoy, other-GP fleet) must still flip the '
+              'result to true — pin existential semantics, not '
+              'first-fleet-only.',
+        );
+      });
+    },
+  );
+
+  group('e2eNonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot — regression '
+      'guards', () {
+    test('regionId casing must match exactly (`NewWorld` is rejected via '
+        'topology fallback)', () {
+      expect(
+        e2eNonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot(
+          _snapshot(
+            fleets: [
+              _homeFleet(),
+              Fleet(
+                id: 'fleet_human_split',
+                ownerId: _human,
+                // PascalCase region id: regionIdForSeaZone short-circuit
+                // is skipped and the topology must NOT resolve `NewWorld`
+                // either; the predicate falls through to false.
+                regionId: 'NewWorld',
+                seaZoneId: 'sea_phantom',
+              ),
+            ],
+            topology: _emptyTopology,
+          ),
+        ),
+        isFalse,
+        reason:
+            'Region ids are canonical lowercase identifiers; an '
+            'accidental `NewWorld` (PascalCase) is not a real game '
+            'state, but pinning the case-sensitive contract prevents '
+            'a future regression that normalizes the input from '
+            'silently short-circuiting coastal-sea detection.',
+      );
+    });
+
+    test('topology resolving to a non-NW region keeps result false', () {
+      expect(
+        e2eNonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot(
+          _snapshot(
+            fleets: [
+              _homeFleet(),
+              Fleet(
+                id: 'fleet_human_split',
+                ownerId: _human,
+                regionId: 'oldWorld',
+                seaZoneId: 'sea_asia_coast',
+              ),
+            ],
+            topology: const MapTopology(
+              nodes: [
+                TopologyNode(
+                  id: 'sea_asia_coast',
+                  regionId: 'asia',
+                  type: TopologyNodeType.seaZone,
+                ),
+                TopologyNode(
+                  id: 'asia|p1',
+                  regionId: 'asia',
+                  type: TopologyNodeType.province,
+                ),
+              ],
+              edges: [TopologyEdge(id1: 'asia|p1', id2: 'sea_asia_coast')],
+            ),
+          ),
+        ),
+        isFalse,
+        reason:
+            'Future-region (e.g. `asia`) coastal sea zones must not '
+            'be confused for NW; the predicate only returns true '
+            'when the resolved region is exactly `newWorld`.',
+      );
+    });
+
+    test('first qualifying fleet short-circuits — no exception on later '
+        'fleets', () {
+      expect(
+        e2eNonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot(
+          _snapshot(
+            fleets: [
+              _homeFleet(),
+              Fleet(
+                id: 'fleet_human_a',
+                ownerId: _human,
+                regionId: 'newWorld',
+                seaZoneId: 'sea_nw_coast',
+              ),
+              Fleet(
+                id: 'fleet_human_b',
+                ownerId: _human,
+                regionId: 'newWorld',
+                seaZoneId: 'sea_nw_coast',
+              ),
+            ],
+            topology: _coastalNwTopology(
+              seaId: 'sea_nw_coast',
+              adjacentProvinceIds: const ['newWorld|p1'],
+            ),
+          ),
+        ),
+        isTrue,
+        reason:
+            'Existential check: the first qualifying human fleet '
+            'flips the result to true and the rest of the list is '
+            'irrelevant. Pinning two qualifying entries prevents a '
+            'future regression that accidentally requires *all* '
+            'fleets to qualify.',
+      );
+    });
+  });
+
+  group(
+    'e2eNwCoastalProvincesAdjacentToFleetSea — two-tier lookup contract',
+    () {
+      test('empty topology returns empty set', () {
+        expect(
+          e2eNwCoastalProvincesAdjacentToFleetSea(
+            _emptyTopology,
+            'sea1',
+            'newWorld',
+          ),
+          isEmpty,
+          reason:
+              'No nodes / no edges means no possible adjacency; the '
+              'helper must surface the empty set rather than fall '
+              'through to a non-empty constant or throw.',
+        );
+      });
+
+      test('verbatim local sea id matches when topology stores it as a local '
+          'sea node', () {
+        expect(
+          e2eNwCoastalProvincesAdjacentToFleetSea(
+            _coastalNwTopology(
+              seaId: 'sea_nw_coast',
+              adjacentProvinceIds: const ['newWorld|p1', 'newWorld|p2'],
+            ),
+            'sea_nw_coast',
+            'newWorld',
+          ),
+          equals({'newWorld|p1', 'newWorld|p2'}),
+          reason:
+              'The first-call verbatim lookup must succeed against a '
+              'topology that stores the sea id in its local form; the '
+              'returned set must include every adjacent province '
+              'without filtering.',
+        );
+      });
+
+      test('verbatim prefixed sea id matches when topology stores the '
+          'prefixed form', () {
+        expect(
+          e2eNwCoastalProvincesAdjacentToFleetSea(
+            _coastalNwTopology(
+              seaId: 'newWorld|sea_nw_coast',
+              adjacentProvinceIds: const ['newWorld|p1'],
+            ),
+            'newWorld|sea_nw_coast',
+            'newWorld',
+          ),
+          equals({'newWorld|p1'}),
+          reason:
+              'When the caller already passes the prefixed sea id and '
+              'the topology agrees, the first-call lookup succeeds; '
+              'no fallback is required.',
+        );
+      });
+
+      test('local sea id falls back to the prefixed form when verbatim '
+          'lookup is empty', () {
+        expect(
+          e2eNwCoastalProvincesAdjacentToFleetSea(
+            _coastalNwTopology(
+              seaId: 'newWorld|sea_nw_coast',
+              adjacentProvinceIds: const ['newWorld|p1'],
+            ),
+            'sea_nw_coast',
+            'newWorld',
+          ),
+          equals({'newWorld|p1'}),
+          reason:
+              'This is the slice the helper exists to fix: live fleet '
+              'states carry the local sea id while combined topology '
+              'uses the prefixed form. The second-call fallback must '
+              'discover the adjacent provinces; a regression that '
+              'dropped the fallback would force every coastal lookup '
+              'to fail silently and re-introduce Bottleneck 4.',
+        );
+      });
+
+      test('prefixed sea id that genuinely is not in the topology returns '
+          'empty without retry', () {
+        // A prefixed input naming a sea zone that does not exist in the
+        // topology graph (no matching node id, no matching edge) must
+        // surface as an empty set. The early-return guard
+        // (`!ProvinceId.isPrefixed(seaZoneId)`) prevents the second
+        // call from re-prefixing an already-prefixed id (which would
+        // either double-prefix into an invalid lookup or short-circuit
+        // back to the same canonical form and return the same empty
+        // result twice). The contract pinned here is: "prefixed input +
+        // no match = empty, no second-chance lookup".
+        expect(
+          e2eNwCoastalProvincesAdjacentToFleetSea(
+            // Topology has a real NW coastal sea (`sea_nw_coast`) so
+            // we know adjacency lookup machinery works; the input
+            // names a different, non-existent prefixed sea
+            // (`newWorld|sea_phantom`).
+            _coastalNwTopology(
+              seaId: 'sea_nw_coast',
+              adjacentProvinceIds: const ['newWorld|p1'],
+            ),
+            'newWorld|sea_phantom',
+            'newWorld',
+          ),
+          isEmpty,
+          reason:
+              'Per docstring: when the caller passes a prefixed id and '
+              'the verbatim lookup is empty, the helper must surface '
+              'the empty set without a redundant second lookup against '
+              'the same canonical form. A regression that dropped the '
+              'prefix-guard and unconditionally retried with '
+              '`ProvinceId.full(...)` could either double-prefix the '
+              'input or silently re-canonicalize to the same form '
+              '(masking genuine topology gaps).',
+        );
+      });
+
+      test('bare local sea id that genuinely is not in the topology returns '
+          'empty after the fallback retry', () {
+        // Same shape as above but with a bare local sea id — the
+        // verbatim lookup is empty AND the prefixed-retry must also
+        // return empty because the sea genuinely is not in the
+        // topology. Both branches must surface the empty result.
+        expect(
+          e2eNwCoastalProvincesAdjacentToFleetSea(
+            _coastalNwTopology(
+              seaId: 'sea_nw_coast',
+              adjacentProvinceIds: const ['newWorld|p1'],
+            ),
+            'sea_phantom',
+            'newWorld',
+          ),
+          isEmpty,
+          reason:
+              'The fallback retry (`ProvinceId.full(regionId, '
+              'seaZoneId)`) must propagate the empty result from the '
+              'underlying `provinceIdsAdjacentToSeaZone` lookup rather '
+              'than substitute a non-empty default. Pinning the empty '
+              'baseline catches regressions that swallow the inner '
+              'empty set and fall through to a non-empty constant.',
+        );
+      });
+
+      test('region scoping rejects cross-region edges', () {
+        expect(
+          e2eNwCoastalProvincesAdjacentToFleetSea(
+            // OW edge sharing the same local sea id; the NW lookup
+            // must not surface the OW province.
+            const MapTopology(
+              nodes: [
+                TopologyNode(
+                  id: 'sea1',
+                  regionId: 'oldWorld',
+                  type: TopologyNodeType.seaZone,
+                ),
+                TopologyNode(
+                  id: 'oldWorld|p1',
+                  regionId: 'oldWorld',
+                  type: TopologyNodeType.province,
+                ),
+              ],
+              edges: [TopologyEdge(id1: 'oldWorld|p1', id2: 'sea1')],
+            ),
+            'sea1',
+            'newWorld',
+          ),
+          isEmpty,
+          reason:
+              'The helper passes `regionId` through to '
+              '`provinceIdsAdjacentToSeaZone`, which is region-scoped '
+              '(world-model identity). A cross-region edge with the '
+              'same local id must not leak into the NW adjacency set.',
+        );
+      });
+    },
+  );
+}

--- a/app/test/e2e_non_home_human_fleet_in_new_world_from_ct_snapshot_test.dart
+++ b/app/test/e2e_non_home_human_fleet_in_new_world_from_ct_snapshot_test.dart
@@ -1,0 +1,433 @@
+/// Pins the snapshot-driven fleet-in-NW contract of
+/// [e2eNonHomeHumanFleetInNewWorldFromCtSnapshot] (`app/integration_test/e2e_test_shared.dart`).
+///
+/// The fleet-reach loop short-circuit
+/// (`_fleetReachDoneFromCtSnapshotOnly`, `_harnessDetectsNonHomeFleetInNewWorld`
+/// in `new_game_fleet_reaches_new_world_e2e_helpers_part2.dart`) and the
+/// bundled-explore readiness loop depend on this predicate to terminate
+/// within the 35-turn fleet-reach cap when [ctE2eNavalPanelSnapshot]
+/// reports arrival. A silent rename / fail-open here would stall the
+/// suite at `_kMaxNextTurnTapsForNwFleetReach (35) × ~5 s` per scenario
+/// — directly inflating the wall-clock cap #2336 is reducing.
+///
+/// The integration suite cannot validate this directly (the
+/// `app_e2e_linux` lane is a no-op per
+/// `SPEC/program/e2e-integration-tests.md` § CI), so the widget-test
+/// layer carries the behavioural pin (Refs GitHub #2336 AC1 / AC2).
+library;
+
+import 'package:colonizethis_app/config/ct_e2e_last_panel_snapshot.dart';
+import 'package:colonizethis_data/colonizethis_data.dart'
+    show MapTopology, TopologyNode, TopologyNodeType;
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter_test/flutter_test.dart';
+
+import '../integration_test/e2e_test_shared.dart';
+
+const String _human = 'gp1';
+const String _otherGp = 'gp2';
+
+const TurnState _orderingTurn = TurnState(
+  phase: TurnPhase.orders,
+  turnNumber: 1,
+);
+
+const RegionData _emptyRegion = RegionData();
+
+const Orders _emptyOrders = Orders();
+
+const MapTopology _emptyTopology = MapTopology();
+
+MapTopology _topologyWithSeaZone({
+  required String seaId,
+  required String regionId,
+}) => MapTopology(
+  nodes: [
+    TopologyNode(id: seaId, regionId: regionId, type: TopologyNodeType.seaZone),
+  ],
+);
+
+Game _gameWithFleets(List<Fleet> fleets) => Game(
+  id: 'g1',
+  worldState: WorldState(
+    turnState: _orderingTurn,
+    oldWorld: _emptyRegion,
+    newWorld: _emptyRegion,
+    fleets: fleets,
+  ),
+  players: const [Player(id: _human, displayName: 'You', isHuman: true)],
+);
+
+CtE2eNavalPanelSnapshot _snapshot({
+  required List<Fleet> fleets,
+  MapTopology topology = _emptyTopology,
+}) => CtE2eNavalPanelSnapshot(
+  game: _gameWithFleets(fleets),
+  humanPlayerId: _human,
+  topology: topology,
+  draftOrders: _emptyOrders,
+);
+
+Fleet _homeFleet({
+  String regionId = 'oldWorld',
+  String? inPortAtProvinceId = 'oldWorld|capital',
+}) => Fleet(
+  id: 'fleet_$_human',
+  ownerId: _human,
+  regionId: regionId,
+  inPortAtProvinceId: inPortAtProvinceId,
+);
+
+void main() {
+  suppressLogsForTests();
+
+  group('e2eNonHomeHumanFleetInNewWorldFromCtSnapshot — false branches', () {
+    test('null snapshot returns false', () {
+      expect(
+        e2eNonHomeHumanFleetInNewWorldFromCtSnapshot(null),
+        isFalse,
+        reason:
+            'No naval-panel snapshot plumbing this turn means the loop must '
+            'keep iterating (no short-circuit). A regression to fail-open '
+            'would terminate the fleet-reach loop on turn 0 before the '
+            'split fleet has had a chance to move.',
+      );
+    });
+
+    test('no fleets in the snapshot returns false', () {
+      expect(
+        e2eNonHomeHumanFleetInNewWorldFromCtSnapshot(
+          _snapshot(fleets: const []),
+        ),
+        isFalse,
+        reason:
+            'An empty fleet list cannot satisfy non-home-fleet-in-NW; the '
+            'predicate must keep iterating instead of treating "no fleets" '
+            'as arrival.',
+      );
+    });
+
+    test('only home fleet (in port, OW region) returns false', () {
+      expect(
+        e2eNonHomeHumanFleetInNewWorldFromCtSnapshot(
+          _snapshot(fleets: [_homeFleet()]),
+        ),
+        isFalse,
+        reason:
+            'The home fleet (`fleet_<humanPlayerId>`) is skipped per the '
+            'docstring contract; otherwise the fleet-reach loop would '
+            'short-circuit on turn 0 before the player splits / sails to '
+            'the New World.',
+      );
+    });
+
+    test(
+      'only home fleet at NW region is still skipped (home-id wins over region)',
+      () {
+        expect(
+          e2eNonHomeHumanFleetInNewWorldFromCtSnapshot(
+            _snapshot(
+              fleets: [
+                Fleet(
+                  id: 'fleet_$_human',
+                  ownerId: _human,
+                  regionId: 'newWorld',
+                  seaZoneId: 'newWorld|sea1',
+                ),
+              ],
+            ),
+          ),
+          isFalse,
+          reason:
+              'The home-fleet skip is by **id**, not by location: a home '
+              'fleet whose location is NW (after warp + before split) must '
+              'not falsely report arrival, otherwise the split-then-sail '
+              'scenario short-circuits before the non-home fleet is in NW.',
+        );
+      },
+    );
+
+    test('non-home fleet owned by a different GP returns false', () {
+      expect(
+        e2eNonHomeHumanFleetInNewWorldFromCtSnapshot(
+          _snapshot(
+            fleets: [
+              _homeFleet(),
+              Fleet(
+                id: 'fleet_other_1',
+                ownerId: _otherGp,
+                regionId: 'newWorld',
+                seaZoneId: 'newWorld|sea1',
+              ),
+            ],
+          ),
+        ),
+        isFalse,
+        reason:
+            'Only the human player\'s non-home fleets count. Any other GP '
+            'sailing in NW must not be confused for the human\'s fleet '
+            'arrival.',
+      );
+    });
+
+    test('non-home human fleet in OW (regionId + sea zone) returns false', () {
+      expect(
+        e2eNonHomeHumanFleetInNewWorldFromCtSnapshot(
+          _snapshot(
+            fleets: [
+              _homeFleet(),
+              Fleet(
+                id: 'fleet_human_split',
+                ownerId: _human,
+                regionId: 'oldWorld',
+                seaZoneId: 'sea1',
+              ),
+            ],
+            topology: _topologyWithSeaZone(seaId: 'sea1', regionId: 'oldWorld'),
+          ),
+        ),
+        isFalse,
+        reason:
+            'A non-home human fleet in an OW sea zone, with its `regionId` '
+            'also OW, must not trigger the NW short-circuit; the split '
+            'fleet is still in OW until it crosses the warp boundary.',
+      );
+    });
+
+    test(
+      'non-home human fleet with OW regionId and an unknown sea zone returns false',
+      () {
+        expect(
+          e2eNonHomeHumanFleetInNewWorldFromCtSnapshot(
+            _snapshot(
+              fleets: [
+                _homeFleet(),
+                Fleet(
+                  id: 'fleet_human_split',
+                  ownerId: _human,
+                  regionId: 'oldWorld',
+                  seaZoneId: 'sea_phantom',
+                ),
+              ],
+              topology: _emptyTopology,
+            ),
+          ),
+          isFalse,
+          reason:
+              'When the topology cannot resolve a sea zone\'s region '
+              '(`regionIdForSeaZone` returns null), the predicate must keep '
+              'iterating rather than fail-open. An empty topology must not '
+              'be treated as "in NW" for any fleet.',
+        );
+      },
+    );
+
+    test('non-home human fleet in port (no sea zone) at OW returns false', () {
+      expect(
+        e2eNonHomeHumanFleetInNewWorldFromCtSnapshot(
+          _snapshot(
+            fleets: [
+              _homeFleet(),
+              Fleet(
+                id: 'fleet_human_in_port',
+                ownerId: _human,
+                regionId: 'oldWorld',
+                inPortAtProvinceId: 'oldWorld|port1',
+              ),
+            ],
+          ),
+        ),
+        isFalse,
+        reason:
+            'A non-home fleet in port at OW has a null `seaZoneId`; the '
+            'predicate must not attempt to resolve it through the topology '
+            'and must keep returning false until the fleet actually moves '
+            'into a NW sea zone.',
+      );
+    });
+  });
+
+  group('e2eNonHomeHumanFleetInNewWorldFromCtSnapshot — true branches', () {
+    test('non-home human fleet with regionId == newWorld returns true', () {
+      expect(
+        e2eNonHomeHumanFleetInNewWorldFromCtSnapshot(
+          _snapshot(
+            fleets: [
+              _homeFleet(),
+              Fleet(
+                id: 'fleet_human_split',
+                ownerId: _human,
+                regionId: 'newWorld',
+                seaZoneId: 'sea_nw_1',
+              ),
+            ],
+            // Empty topology: regionId path alone must satisfy the predicate.
+            topology: _emptyTopology,
+          ),
+        ),
+        isTrue,
+        reason:
+            'A non-home human fleet whose `regionId` is already `newWorld` '
+            'is the canonical arrival signal — short-circuit before '
+            'consulting the topology so the post-warp scenario terminates '
+            'the loop on the first matching fleet.',
+      );
+    });
+
+    test('non-home human fleet with OW regionId but NW seaZone via topology '
+        'returns true', () {
+      expect(
+        e2eNonHomeHumanFleetInNewWorldFromCtSnapshot(
+          _snapshot(
+            fleets: [
+              _homeFleet(),
+              Fleet(
+                id: 'fleet_human_split',
+                ownerId: _human,
+                regionId: 'oldWorld',
+                seaZoneId: 'sea_nw_2',
+              ),
+            ],
+            topology: _topologyWithSeaZone(
+              seaId: 'sea_nw_2',
+              regionId: 'newWorld',
+            ),
+          ),
+        ),
+        isTrue,
+        reason:
+            'The topology fallback handles the legacy fleet states that '
+            'still carry the OW `regionId` while their `seaZoneId` is '
+            'already a NW sea node — fleet-reach must terminate in this '
+            'case too, otherwise the loop overruns the wall-clock cap '
+            'while the fleet is already in NW seas.',
+      );
+    });
+
+    test(
+      'multi-fleet snapshot: matching fleet later in the list returns true',
+      () {
+        expect(
+          e2eNonHomeHumanFleetInNewWorldFromCtSnapshot(
+            _snapshot(
+              fleets: [
+                _homeFleet(),
+                Fleet(
+                  id: 'fleet_human_decoy',
+                  ownerId: _human,
+                  regionId: 'oldWorld',
+                  seaZoneId: 'sea_ow',
+                ),
+                Fleet(
+                  id: 'fleet_other',
+                  ownerId: _otherGp,
+                  regionId: 'newWorld',
+                ),
+                Fleet(
+                  id: 'fleet_human_split',
+                  ownerId: _human,
+                  regionId: 'newWorld',
+                ),
+              ],
+              topology: _topologyWithSeaZone(
+                seaId: 'sea_ow',
+                regionId: 'oldWorld',
+              ),
+            ),
+          ),
+          isTrue,
+          reason:
+              'The predicate must iterate every fleet before giving up; a '
+              'qualifying fleet that follows non-qualifying ones (decoy OW '
+              'fleet + other-GP fleet ignored) must still flip the result '
+              'to true — order independence within the human-player slice.',
+        );
+      },
+    );
+  });
+
+  group('e2eNonHomeHumanFleetInNewWorldFromCtSnapshot — regression guards', () {
+    test('regionId casing must match exactly (`NewWorld` is rejected)', () {
+      expect(
+        e2eNonHomeHumanFleetInNewWorldFromCtSnapshot(
+          _snapshot(
+            fleets: [
+              _homeFleet(),
+              Fleet(
+                id: 'fleet_human_split',
+                ownerId: _human,
+                regionId: 'NewWorld',
+              ),
+            ],
+          ),
+        ),
+        isFalse,
+        reason:
+            'Region ids are canonical lowercase identifiers; an accidental '
+            '`NewWorld` (PascalCase) is not a real game state, but pinning '
+            'the case-sensitive contract prevents a future regression that '
+            'normalizes the input from silently breaking fleet-reach '
+            'detection.',
+      );
+    });
+
+    test('topology resolving to a non-NW region keeps result false', () {
+      expect(
+        e2eNonHomeHumanFleetInNewWorldFromCtSnapshot(
+          _snapshot(
+            fleets: [
+              _homeFleet(),
+              Fleet(
+                id: 'fleet_human_split',
+                ownerId: _human,
+                regionId: 'oldWorld',
+                seaZoneId: 'sea_asia',
+              ),
+            ],
+            topology: _topologyWithSeaZone(seaId: 'sea_asia', regionId: 'asia'),
+          ),
+        ),
+        isFalse,
+        reason:
+            'Future-region (e.g. `asia`) sea zones must not be confused '
+            'for NW; the predicate only returns true when '
+            '`regionIdForSeaZone` returns exactly `newWorld`.',
+      );
+    });
+
+    test(
+      'first matching fleet short-circuits — no exception on later fleets',
+      () {
+        // Two qualifying human fleets; predicate must return true without
+        // requiring all of them to qualify (the iteration order pin).
+        expect(
+          e2eNonHomeHumanFleetInNewWorldFromCtSnapshot(
+            _snapshot(
+              fleets: [
+                _homeFleet(),
+                Fleet(
+                  id: 'fleet_human_a',
+                  ownerId: _human,
+                  regionId: 'newWorld',
+                ),
+                Fleet(
+                  id: 'fleet_human_b',
+                  ownerId: _human,
+                  regionId: 'newWorld',
+                ),
+              ],
+            ),
+          ),
+          isTrue,
+          reason:
+              'The predicate is an existential check; the first qualifying '
+              'human fleet flips the result to true and the rest of the '
+              'list is irrelevant. Pinning two qualifying entries prevents '
+              'a future regression that accidentally requires *all* fleets '
+              'to qualify.',
+        );
+      },
+    );
+  });
+}

--- a/app/test/e2e_player_has_any_new_world_fogged_or_better_from_ct_snapshot_test.dart
+++ b/app/test/e2e_player_has_any_new_world_fogged_or_better_from_ct_snapshot_test.dart
@@ -1,0 +1,466 @@
+/// Pins the snapshot-driven NW-fogged-or-better contract of
+/// [e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot]
+/// (`app/integration_test/e2e_test_shared.dart`).
+///
+/// The bundled-explore readiness loop
+/// (`_awaitNwCoastalOrVisibleLandForBundledExploreE2e` in
+/// `new_game_fleet_reaches_new_world_e2e_helpers_part2.dart`) and the
+/// fleet-reach test's final guard
+/// (`new_game_fleet_reaches_new_world_e2e_test.dart` line ~365) depend on
+/// this predicate to short-circuit once the human player has *any* NW
+/// province tile fogged-or-better. A silent rename / fail-open would
+/// either stall the bundled-explore readiness loop for the full 35-turn
+/// cap (Bottleneck 4 in `SPEC/program/e2e-integration-tests.md`
+/// § Determinism) or convert the strict bundled-explore assertion into a
+/// silent skip and mask a real Explore-assign regression — both directly
+/// inflate the wall-clock cap #2336 is reducing.
+///
+/// The integration suite cannot validate this directly today
+/// (the `app_e2e_linux` lane is a no-op per
+/// `SPEC/program/e2e-integration-tests.md` § CI), so the widget-test
+/// layer carries the behavioural pin (Refs GitHub #2336 AC1 / AC2).
+library;
+
+import 'package:colonizethis_app/config/ct_e2e_last_panel_snapshot.dart';
+import 'package:colonizethis_data/colonizethis_data.dart' show MapTopology;
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter_test/flutter_test.dart';
+
+import '../integration_test/e2e_test_shared.dart';
+
+const String _human = 'gp1';
+
+const TurnState _orderingTurn = TurnState(
+  phase: TurnPhase.orders,
+  turnNumber: 1,
+);
+
+const MapTopology _emptyTopology = MapTopology();
+
+const Orders _emptyOrders = Orders();
+
+const RegionData _emptyRegion = RegionData();
+
+Province _nwProvince(String localId) =>
+    Province(id: ProvinceId.full('newWorld', localId), regionId: 'newWorld');
+
+Province _owProvince(String localId) =>
+    Province(id: ProvinceId.full('oldWorld', localId), regionId: 'oldWorld');
+
+WorldState _world({
+  RegionData oldWorld = _emptyRegion,
+  RegionData newWorld = _emptyRegion,
+  Map<String, Map<String, String>> playerVisibilityByTile = const {},
+}) => WorldState(
+  turnState: _orderingTurn,
+  oldWorld: oldWorld,
+  newWorld: newWorld,
+  playerVisibilityByTile: playerVisibilityByTile,
+);
+
+Game _game({
+  RegionData oldWorld = _emptyRegion,
+  RegionData newWorld = _emptyRegion,
+  Map<String, Map<String, String>> playerVisibilityByTile = const {},
+}) => Game(
+  id: 'g1',
+  worldState: _world(
+    oldWorld: oldWorld,
+    newWorld: newWorld,
+    playerVisibilityByTile: playerVisibilityByTile,
+  ),
+  players: const [Player(id: _human, displayName: 'You', isHuman: true)],
+);
+
+CtE2eNavalPanelSnapshot _snapshot({
+  RegionData oldWorld = _emptyRegion,
+  RegionData newWorld = _emptyRegion,
+  Map<String, Map<String, String>> playerVisibilityByTile = const {},
+}) => CtE2eNavalPanelSnapshot(
+  game: _game(
+    oldWorld: oldWorld,
+    newWorld: newWorld,
+    playerVisibilityByTile: playerVisibilityByTile,
+  ),
+  humanPlayerId: _human,
+  topology: _emptyTopology,
+  draftOrders: _emptyOrders,
+);
+
+void main() {
+  suppressLogsForTests();
+
+  group(
+    'e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot — false branches',
+    () {
+      test('null snapshot returns false', () {
+        expect(
+          e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot(null),
+          isFalse,
+          reason:
+              'No naval-panel snapshot plumbing this turn means the '
+              'predicate must short-circuit before any field access. '
+              'A fail-open here would either stall the bundled-explore '
+              'readiness loop or convert the fleet-reach test\'s skip '
+              'guard into an always-skip — neither is acceptable.',
+        );
+      });
+
+      test('no NW provinces in the snapshot returns false', () {
+        expect(
+          e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot(
+            _snapshot(
+              oldWorld: RegionData(provinces: [_owProvince('ow1')]),
+              playerVisibilityByTile: const {
+                _human: {'oldWorld|ow1|0|0': 'fullyVisible'},
+              },
+            ),
+          ),
+          isFalse,
+          reason:
+              'A snapshot with zero `newWorld|` provinces cannot satisfy '
+              'NW-fogged-or-better even when OW tiles are fully visible. '
+              'The early-exit on the empty NW province set is also a perf '
+              'safeguard against building the [PlayerView] for nothing.',
+        );
+      });
+
+      test('NW province exists but visibility map is empty returns false', () {
+        expect(
+          e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot(
+            _snapshot(newWorld: RegionData(provinces: [_nwProvince('p1')])),
+          ),
+          isFalse,
+          reason:
+              'A non-empty NW province set with no visibility entries '
+              'means every tile defaults to `unknown`; the iteration must '
+              'find no fogged-or-better tile and return false.',
+        );
+      });
+
+      test('NW visibility entries are all `unknown` returns false', () {
+        expect(
+          e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot(
+            _snapshot(
+              newWorld: RegionData(provinces: [_nwProvince('p1')]),
+              playerVisibilityByTile: const {
+                _human: {
+                  'newWorld|p1|0|0': 'unknown',
+                  'newWorld|p1|1|0': 'unknown',
+                },
+              },
+            ),
+          ),
+          isFalse,
+          reason:
+              'Explicit `unknown` entries must be treated the same as '
+              'absent entries; the docstring contract excludes only '
+              '`unknown`, so an accidental "any visibility entry counts" '
+              'regression would surface here.',
+        );
+      });
+
+      test('visible OW tile does not satisfy the NW gate (returns false)', () {
+        expect(
+          e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot(
+            _snapshot(
+              oldWorld: RegionData(provinces: [_owProvince('ow1')]),
+              newWorld: RegionData(provinces: [_nwProvince('p1')]),
+              playerVisibilityByTile: const {
+                _human: {
+                  'oldWorld|ow1|0|0': 'fullyVisible',
+                  'oldWorld|ow1|1|0': 'fogged',
+                },
+              },
+            ),
+          ),
+          isFalse,
+          reason:
+              'OW tiles must not satisfy the NW gate — the predicate is '
+              'specifically about NW penetration. A regression that '
+              'dropped the `parts[0] != "newWorld"` skip would flip '
+              'this to true and mask the bundled-explore Explore-assign '
+              'requirement, which depends on NW (not OW) visibility.',
+        );
+      });
+
+      test(
+        'NW-region tile key with unknown province local id returns false',
+        () {
+          expect(
+            e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot(
+              _snapshot(
+                newWorld: RegionData(provinces: [_nwProvince('p1')]),
+                playerVisibilityByTile: const {
+                  _human: {
+                    // Tile key references a NW province (`pPhantom`) that
+                    // is **not** in the snapshot's NW province set — the
+                    // predicate must skip it rather than fail-open.
+                    'newWorld|pPhantom|0|0': 'fullyVisible',
+                  },
+                },
+              ),
+            ),
+            isFalse,
+            reason:
+                'A tile key whose local-id segment is not in the snapshot '
+                'NW province set must be skipped — otherwise a stale or '
+                'mis-keyed visibility entry would falsely report '
+                'fogged-or-better NW penetration.',
+          );
+        },
+      );
+
+      test(
+        'tile key with fewer than four `|`-segments is skipped (returns false)',
+        () {
+          expect(
+            e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot(
+              _snapshot(
+                newWorld: RegionData(provinces: [_nwProvince('p1')]),
+                playerVisibilityByTile: const {
+                  _human: {
+                    // Malformed: only 3 parts.
+                    'newWorld|p1|0': 'fullyVisible',
+                    // Malformed: only 2 parts.
+                    'newWorld|p1': 'fogged',
+                  },
+                },
+              ),
+            ),
+            isFalse,
+            reason:
+                'Malformed tile keys must be skipped rather than crash '
+                'the predicate or count as fogged-or-better. Pinning the '
+                '4-part guard prevents a regression that loosens the '
+                'parser from silently flipping the fleet-reach skip guard.',
+          );
+        },
+      );
+
+      test('visibility entry for a different player returns false', () {
+        expect(
+          e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot(
+            _snapshot(
+              newWorld: RegionData(provinces: [_nwProvince('p1')]),
+              playerVisibilityByTile: const {
+                // Only gp2 has visibility — humanPlayerId is gp1.
+                'gp2': {'newWorld|p1|0|0': 'fullyVisible'},
+              },
+            ),
+          ),
+          isFalse,
+          reason:
+              'The predicate is scoped to [snap.humanPlayerId]; another '
+              'player\'s visibility must not bleed through. [buildPlayerView] '
+              'reads `playerVisibilityByTile[humanPlayerId]` and ignores '
+              'other player entries.',
+        );
+      });
+    },
+  );
+
+  group(
+    'e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot — true branches',
+    () {
+      test('single fogged NW tile returns true', () {
+        expect(
+          e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot(
+            _snapshot(
+              newWorld: RegionData(provinces: [_nwProvince('p1')]),
+              playerVisibilityByTile: const {
+                _human: {'newWorld|p1|0|0': 'fogged'},
+              },
+            ),
+          ),
+          isTrue,
+          reason:
+              'A single fogged tile in a known NW province is the '
+              'minimal canonical signal — the bundled-explore readiness '
+              'loop must short-circuit so the assign-Explore probe can '
+              'fire on the next turn.',
+        );
+      });
+
+      test('single fullyVisible NW tile returns true', () {
+        expect(
+          e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot(
+            _snapshot(
+              newWorld: RegionData(provinces: [_nwProvince('p1')]),
+              playerVisibilityByTile: const {
+                _human: {'newWorld|p1|2|3': 'fullyVisible'},
+              },
+            ),
+          ),
+          isTrue,
+          reason:
+              'A fully-visible NW tile is strictly stronger than fogged '
+              'and must equally satisfy the gate. The predicate excludes '
+              'only `unknown`, so both higher visibility levels short-'
+              'circuit identically.',
+        );
+      });
+
+      test('mixed unknown + fogged NW tiles still returns true', () {
+        expect(
+          e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot(
+            _snapshot(
+              newWorld: RegionData(provinces: [_nwProvince('p1')]),
+              playerVisibilityByTile: const {
+                _human: {
+                  'newWorld|p1|0|0': 'unknown',
+                  'newWorld|p1|1|0': 'unknown',
+                  'newWorld|p1|2|0': 'fogged',
+                },
+              },
+            ),
+          ),
+          isTrue,
+          reason:
+              'The predicate is existential: a single fogged-or-better '
+              'tile is enough, regardless of how many unknown siblings '
+              'share the visibility map. Pinning the mixed case prevents '
+              'a regression that accidentally requires all NW tiles to '
+              'be fogged-or-better.',
+        );
+      });
+
+      test('OW visible + NW fogged returns true (NW arm fires)', () {
+        expect(
+          e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot(
+            _snapshot(
+              oldWorld: RegionData(provinces: [_owProvince('ow1')]),
+              newWorld: RegionData(provinces: [_nwProvince('p1')]),
+              playerVisibilityByTile: const {
+                _human: {
+                  'oldWorld|ow1|0|0': 'fullyVisible',
+                  'newWorld|p1|0|0': 'fogged',
+                },
+              },
+            ),
+          ),
+          isTrue,
+          reason:
+              'Mixed OW + NW visibility must still flip to true on the '
+              'NW arm. The OW tile is ignored by the `parts[0] != '
+              '"newWorld"` skip; the NW tile satisfies the gate.',
+        );
+      });
+
+      test(
+        'multi-province NW: only one province has visibility (returns true)',
+        () {
+          expect(
+            e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot(
+              _snapshot(
+                newWorld: RegionData(
+                  provinces: [
+                    _nwProvince('p1'),
+                    _nwProvince('p2'),
+                    _nwProvince('p3'),
+                  ],
+                ),
+                playerVisibilityByTile: const {
+                  _human: {
+                    // Only p2 has any visibility; p1 and p3 stay unknown.
+                    'newWorld|p2|0|0': 'fogged',
+                  },
+                },
+              ),
+            ),
+            isTrue,
+            reason:
+                'Any NW province in the snapshot set is eligible — the '
+                'predicate is existential across the whole NW region, not '
+                'per-province. A single fogged tile in any tracked NW '
+                'province must satisfy the gate.',
+          );
+        },
+      );
+    },
+  );
+
+  group(
+    'e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot — regression guards',
+    () {
+      test(
+        'region segment casing must match exactly (`NewWorld` rejected)',
+        () {
+          expect(
+            e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot(
+              _snapshot(
+                newWorld: RegionData(provinces: [_nwProvince('p1')]),
+                playerVisibilityByTile: const {
+                  _human: {
+                    // PascalCase region segment is not the canonical id.
+                    'NewWorld|p1|0|0': 'fullyVisible',
+                  },
+                },
+              ),
+            ),
+            isFalse,
+            reason:
+                'Region ids are canonical lowercase identifiers; pinning '
+                'the case-sensitive `parts[0] != "newWorld"` check '
+                'prevents a future regression that normalizes the segment '
+                'from silently breaking NW-penetration detection.',
+          );
+        },
+      );
+
+      test(
+        'extra `|`-segments in the tile key are rejected (returns false)',
+        () {
+          expect(
+            e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot(
+              _snapshot(
+                newWorld: RegionData(provinces: [_nwProvince('p1')]),
+                playerVisibilityByTile: const {
+                  _human: {
+                    // 5 parts instead of 4 — the predicate requires exactly 4.
+                    'newWorld|p1|0|0|extra': 'fullyVisible',
+                  },
+                },
+              ),
+            ),
+            isFalse,
+            reason:
+                'The 4-part tile-key contract (`regionId|localId|x|y` per '
+                'SPEC/game/world-model + [ProvinceId] docs) must be '
+                'enforced exactly. A regression that loosens the parser '
+                'would let mis-keyed entries falsely satisfy the gate.',
+          );
+        },
+      );
+
+      test(
+        'first fogged-or-better NW tile short-circuits — no exception on later entries',
+        () {
+          // Two qualifying NW visibility entries; predicate must return true
+          // without requiring all of them to qualify (iteration-order pin).
+          expect(
+            e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot(
+              _snapshot(
+                newWorld: RegionData(provinces: [_nwProvince('p1')]),
+                playerVisibilityByTile: const {
+                  _human: {
+                    'newWorld|p1|0|0': 'fogged',
+                    'newWorld|p1|1|0': 'fullyVisible',
+                  },
+                },
+              ),
+            ),
+            isTrue,
+            reason:
+                'The predicate is existential; the first qualifying NW '
+                'visibility entry flips the result to true and the rest '
+                'of the map is irrelevant. Pinning two qualifying entries '
+                'prevents a future regression that accidentally requires '
+                '*all* NW entries to qualify.',
+          );
+        },
+      );
+    },
+  );
+}

--- a/app/test/e2e_text_looks_like_new_world_location_line_test.dart
+++ b/app/test/e2e_text_looks_like_new_world_location_line_test.dart
@@ -1,7 +1,6 @@
 /// Pins the dash-glyph contract of [e2eTextLooksLikeNewWorldLocationLine]
 /// (`app/integration_test/e2e_test_shared.dart`) — the predicate fleet-reach
-/// E2E detection (`_navalPanelShowsNonHomeFleetInNewWorld` in
-/// `new_game_fleet_reaches_new_world_e2e_helpers_part2.dart`) uses to
+/// E2E detection ([e2eNavalPanelShowsNonHomeFleetInNewWorld]) uses to
 /// recognize a naval-panel location row like `"New World — Outer Sea"`.
 ///
 /// `naval_tree_builder.dart` joins the region and the location with an


### PR DESCRIPTION
## Summary

Lift four private fleet-reach / bundled-Explore predicates into the
public `e2e_test_shared.dart` library and re-export them through the
AC1 `e2e_helpers.dart` barrel:

1. `_nonHomeHumanFleetInNewWorldFromCtSnapshot` →
   `e2eNonHomeHumanFleetInNewWorldFromCtSnapshot(CtE2eNavalPanelSnapshot?)`
   — Initial slice (commit `224e47687`).
2. `_playerHasAnyNewWorldFoggedOrBetterFromCtSnapshot` →
   `e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot(CtE2eNavalPanelSnapshot?)`
   — Second slice (commit `38825c5d3`).
3. `_nonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot` (+ helper
   `_nwCoastalProvincesAdjacentToFleetSea`) →
   `e2eNonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot(CtE2eNavalPanelSnapshot?)`
   and `e2eNwCoastalProvincesAdjacentToFleetSea(MapTopology, String, String)`
   — Third slice (commit `544a23d9c`).
4. `_exploreAssignEnabledFromCivilianSnapshot` →
   `e2eExploreAssignEnabledFromCivilianSnapshot(CtE2eCivilianPanelSnapshot?)`
   — Fourth slice (this push, commit `eba3ab16d`).

The first three are snapshot-driven predicates the fleet-reach loop and
bundled-explore readiness loop short-circuit on once the split human
fleet enters the New World, surfaces NW fogged-or-better land, or
reaches a NW **coastal** sea (P–S edge required for ship reveal per
`SPEC/program/fog-and-exploration-resolution.md`). The fourth is the
civilian-side gate the bundled-Explore readiness loop short-circuits on
once a civilian becomes assignable to `kWorkTargetExplore`. A silent
rename / fail-open on any of them would re-introduce the
`_kMaxNextTurnTapsForNwFleetReach (35) × ~5 s` stall documented in
#2336 Bottleneck 4 (`SPEC/program/e2e-integration-tests.md`
§ Determinism).

Refs #2336

## Done in this PR

### Slice 1 — `e2eNonHomeHumanFleetInNewWorldFromCtSnapshot`

#### `e2e_test_shared.dart` (+ AC1 barrel)

- Add `e2eNonHomeHumanFleetInNewWorldFromCtSnapshot(CtE2eNavalPanelSnapshot?)`
  with a detailed contract docstring covering null handling, owner /
  home-id skip semantics, regionId vs topology-resolved seaboard
  precedence, and stable iteration order. The lifted form takes the
  snapshot explicitly instead of reading the mutable
  `ctE2eNavalPanelSnapshot` global so the contract is deterministic and
  unit-testable.
- Re-export `e2eNonHomeHumanFleetInNewWorldFromCtSnapshot` through the
  AC1 `e2e_helpers.dart` `show` clause so scenarios consume the AC1
  barrel only (#2336 AC2).

#### `new_game_fleet_reaches_new_world_e2e_helpers_part2.dart`

- Remove the private `_nonHomeHumanFleetInNewWorldFromCtSnapshot` body
  (replaced by a doc-only stub pointing at the lifted helper, mirroring
  the pattern used for `_textLooksLikeNewWorldLocationLine` in #2713).
- Update both private call sites
  (`_harnessDetectsNonHomeFleetInNewWorld`,
  `_fleetReachDoneFromCtSnapshotOnly`) to consume the public name and
  pass `ctE2eNavalPanelSnapshot` explicitly — runtime behaviour
  unchanged.

#### Tests (16)

- `app/test/e2e_non_home_human_fleet_in_new_world_from_ct_snapshot_test.dart`
  — 15 widget tests grouped into false branches (8), true branches
  (3), and regression guards (3): null snapshot, no fleets, home-only,
  home-id wins over region, other-GP fleet ignored, OW fleet ignored,
  empty topology, in-port handling, regionId path short-circuit,
  topology fallback, multi-fleet iteration, case-sensitive regionId,
  non-NW future region, first-qualifier short-circuit.
- `app/test/e2e_helpers_barrel_test.dart` — +1 pin asserting the symbol
  is re-exported through the AC1 barrel with the documented
  `bool Function(CtE2eNavalPanelSnapshot?)` signature; smoke pin also
  passes `null` to catch wrappers that swallow their argument.

### Slice 2 — `e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot`

#### `e2e_test_shared.dart` (+ AC1 barrel)

- Add `e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot(CtE2eNavalPanelSnapshot?)`
  with a detailed contract docstring covering null handling, empty-NW
  early exit, [PlayerView] iteration order, 4-part tile-key parsing,
  case-sensitive `newWorld` segment, NW-province-set membership guard,
  and the explicit `unknown` vs `fogged` / `fullyVisible` semantics.
  The lifted form takes the snapshot explicitly instead of reading the
  mutable `ctE2eNavalPanelSnapshot` global so the contract is
  deterministic and unit-testable (matches the
  `e2eNonHomeHumanFleetInNewWorldFromCtSnapshot` precedent from
  Slice 1).
- Extend the `colonizethis_logic` `show` clause to import
  `allProvinces`, `buildPlayerView`; add a narrow
  `colonizethis_models` import for `ProvinceId`.
- Re-export `e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot`
  through the AC1 `e2e_helpers.dart` `show` clause (#2336 AC2).

#### `new_game_fleet_reaches_new_world_e2e_helpers_part2.dart`

- Remove the private `_playerHasAnyNewWorldFoggedOrBetterFromCtSnapshot`
  body (replaced by a doc-only stub pointing at the lifted helper,
  mirroring the Slice 1 / `_textLooksLikeNewWorldLocationLine` pattern).
- Update the three private call sites in
  `_awaitNwCoastalOrVisibleLandForBundledExploreE2e` to consume the
  public name and pass `ctE2eNavalPanelSnapshot` explicitly — runtime
  behaviour unchanged.

#### `new_game_fleet_reaches_new_world_e2e_test.dart`

- Update the fleet-reach test's final skip guard (line ~365) to consume
  the public name and pass `ctE2eNavalPanelSnapshot` explicitly.

#### Tests (16 new)

- `app/test/e2e_player_has_any_new_world_fogged_or_better_from_ct_snapshot_test.dart`
  — 15 widget tests grouped into false branches (8), true branches
  (5), and regression guards (3):
  - **False branches (8):** null snapshot; empty NW province set;
    NW province exists but visibility map empty; all-`unknown` NW
    visibility; visible OW tile (NW gate); NW tile key with unknown
    province local id; malformed (< 4 parts) tile keys skipped; other
    player's visibility ignored.
  - **True branches (5):** single `fogged` NW tile; single
    `fullyVisible` NW tile; mixed `unknown` + `fogged` flips true;
    OW visible + NW fogged (NW arm fires); multi-province NW with
    only one province having visibility.
  - **Regression guards (3):** case-sensitive `newWorld` segment
    (`NewWorld` PascalCase rejected); extra `|`-segments (5-part)
    tile keys rejected; first qualifying entry short-circuits
    (existential check, not universal).
- `app/test/e2e_helpers_barrel_test.dart` — +1 pin asserting the symbol
  is re-exported through the AC1 barrel with the documented
  `bool Function(CtE2eNavalPanelSnapshot?)` signature; smoke pin also
  passes `null` to catch wrappers that swallow their argument.

### Slice 3 — `e2eNonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot`

This slice lifts the coastal-NW companion to Slice 1 plus the two-tier
adjacency lookup it depends on. Ship reveal only paints coastal land
for sea zones with a P–S province edge
(`SPEC/program/fog-and-exploration-resolution.md`), so a fleet in
open-ocean NW satisfies the Slice 1 "fleet in NW" predicate but never
yields fogged-or-better NW provinces — leaving bundled Explore
disabled. The bundled-explore readiness loop
(`_awaitNwCoastalOrVisibleLandForBundledExploreE2e`) therefore
short-circuits on this coastal predicate alongside Slice 2.

#### `e2e_test_shared.dart` (+ AC1 barrel)

- Add `e2eNwCoastalProvincesAdjacentToFleetSea(MapTopology, String, String)`
  with a docstring covering the two-tier lookup contract: verbatim
  first, prefixed-id fallback only when verbatim is empty and the
  input is **not** already prefixed (so the helper never
  double-prefixes a prefixed input). Combined topology uses prefixed
  P–S edges (`newWorld|sea5`) while some live fleet states still
  carry the regional local id (`sea5`); the fallback keeps coastal
  detection aligned with the ship-reveal contract regardless of which
  form is present in the fleet record.
- Add `e2eNonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot(CtE2eNavalPanelSnapshot?)`
  with a docstring covering null handling, owner / home-id skips,
  in-port skip semantics, regionId-vs-topology region resolution
  precedence (case-sensitive `newWorld`), and the per-fleet adjacency
  lookup. The lifted form takes the snapshot explicitly (matching the
  Slice 1 / Slice 2 precedent).
- Extend the `colonizethis_logic` `show` clause to include
  `provinceIdsAdjacentToSeaZone`; add a narrow `colonizethis_data`
  import for `MapTopology`.
- Re-export both lifted names through the AC1 `e2e_helpers.dart`
  `show` clause (#2336 AC2).

#### `new_game_fleet_reaches_new_world_e2e_helpers_part2.dart`

- Remove both private bodies
  (`_nwCoastalProvincesAdjacentToFleetSea`,
  `_nonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot`), replaced
  by doc-only stubs pointing at the lifted helpers (mirroring the
  Slice 1 / Slice 2 / `_textLooksLikeNewWorldLocationLine` pattern).
- Update the three call sites in
  `_awaitNwCoastalOrVisibleLandForBundledExploreE2e` to consume the
  public coastal predicate and pass `ctE2eNavalPanelSnapshot`
  explicitly — runtime behaviour unchanged.

#### `new_game_fleet_reaches_new_world_e2e_test.dart`

- Prune the now-unused `MapTopology`, `homeFleetIdFor`,
  `provinceIdsAdjacentToSeaZone`, and `regionIdForSeaZone` imports
  (only consumed by the lifted helpers and their dependents which now
  live in `e2e_test_shared.dart`).

#### Tests (25 new)

- `app/test/e2e_non_home_human_fleet_in_coastal_new_world_sea_from_ct_snapshot_test.dart`
  — 23 widget tests grouped into:
  - **False branches (9):** null snapshot; no fleets; only home fleet
    (in port, OW); home fleet sitting in NW coastal sea (home-id wins
    over location); other-GP fleet ignored; in-port (no sea zone);
    NW open-ocean (no P–S edge — canonical Bottleneck 4 guard);
    OW coastal sea; sea zone the topology cannot resolve.
  - **True branches (4):** regionId == newWorld + coastal sea;
    OW regionId but NW coastal sea via topology fallback;
    local-id sea zone matches prefixed P–S edge via the two-tier
    fallback; multi-fleet snapshot where the qualifying fleet is
    last in iteration order.
  - **Regression guards (3):** PascalCase `NewWorld` rejected;
    non-NW (`asia`) region kept false; first-qualifier
    short-circuits.
  - **Two-tier adjacency contract (7):** empty topology → empty;
    verbatim local lookup; verbatim prefixed lookup; local-id
    fallback to prefixed; prefixed sea id with no match returns
    empty without retry; bare local sea id with no match returns
    empty after retry; region scoping rejects cross-region edges.
- `app/test/e2e_helpers_barrel_test.dart` — +2 pins asserting both
  symbols are re-exported through the AC1 barrel with their
  documented `bool Function(CtE2eNavalPanelSnapshot?)` and
  `Set<String> Function(MapTopology, String, String)` signatures;
  smoke pins (`ref(null)` / `ref(emptyTopology, ...)`) catch
  wrappers that swallow their arguments or return non-empty
  constants.

### Slice 4 — `e2eExploreAssignEnabledFromCivilianSnapshot` (NEW)

This slice lifts the civilian-side gate the bundled-Explore readiness
loop short-circuits on once at least one civilian becomes assignable
to `kWorkTargetExplore`. Together with the three naval-side lifts
(Slices 1–3) it closes the snapshot-driven predicate surface used by
`_awaitNwCoastalOrVisibleLandForBundledExploreE2e` and
`_anyExplorerHasEnabledExploreAssignFleetE2e` — both of which
short-circuit on snapshot reads to keep the per-tap budget bounded
(`SPEC/program/e2e-integration-tests.md` § Determinism).

#### `e2e_test_shared.dart` (+ AC1 barrel)

- Add `e2eExploreAssignEnabledFromCivilianSnapshot(CtE2eCivilianPanelSnapshot?)`
  returning `bool?` with a detailed contract docstring covering:
  - `null` snapshot → returns `null` (caller falls back to live walk;
    distinct from `false`).
  - Empty `availableWorkTargets` map → `false`.
  - Any row containing `kWorkTargetExplore` → `true` (first qualifying
    entry short-circuits).
  - `List<String>.contains` exact-equality semantics (no
    case-insensitive or substring matching).
  - Determinism: identical snapshots return identical values; repeated
    calls are pure (no hidden state).
- Extend the `colonizethis_logic` `show` clause to include
  `kWorkTargetExplore`; extend the
  `app/lib/config/ct_e2e_last_panel_snapshot.dart` `show` clause to
  include `CtE2eCivilianPanelSnapshot`.
- Re-export `e2eExploreAssignEnabledFromCivilianSnapshot` through the
  AC1 `e2e_helpers.dart` `show` clause (#2336 AC2).

#### `new_game_fleet_reaches_new_world_e2e_helpers_part2.dart`

- Remove the private `_exploreAssignEnabledFromCivilianSnapshot` body
  (replaced by a doc-only stub pointing at the lifted helper, mirroring
  the Slice 1 / Slice 2 / Slice 3 / `_textLooksLikeNewWorldLocationLine`
  pattern).
- Update the call site in
  `_anyExplorerHasEnabledExploreAssignFleetE2e` to consume the public
  name and pass `ctE2eCivilianPanelSnapshot` explicitly — runtime
  behaviour unchanged. The `bool?` contract is preserved end-to-end so
  the caller still distinguishes "snapshot missing → fall back to live
  walk" from "snapshot says no civilian can Assign Explore".

#### Tests (17 new)

- `app/test/e2e_explore_assign_enabled_from_civilian_snapshot_test.dart`
  — 16 widget tests grouped into:
  - **null branch (1):** null snapshot returns `null` (not `false`).
  - **false branches (4):** empty `availableWorkTargets` map; single
    non-Explore row; multi-row with no Explore; all-empty target
    lists.
  - **true branches (5):** single only-Explore row; Explore among
    multi-target row; Explore in one of several rows; all rows
    Explore; Explore mixed with empty target lists.
  - **regression guards (4):** PascalCase `Explore` rejected;
    uppercase `EXPLORE` rejected; substring `exploration` rejected
    (exact-equality `List.contains`); first-qualifying short-circuit
    (later malformed entry would have failed without the early
    return).
  - **determinism (2):** identical snapshots → identical results;
    repeated calls on same snapshot → identical results.
- `app/test/e2e_helpers_barrel_test.dart` — +1 pin asserting the
  symbol is re-exported through the AC1 barrel with the documented
  `bool? Function(CtE2eCivilianPanelSnapshot?)` signature; three
  smoke probes (`ref(null) == null`, `ref(emptySnap) == false`,
  typed tear-off assignment) catch wrappers that swallow their
  argument or collapse the tri-state `bool?` to `bool`.

## AC coverage

- **AC1 — Shared helpers exist.** All four lifted predicates plus
  the lifted adjacency helper now live in `e2e_test_shared.dart` and
  are re-exported through the AC1 barrel.
- **AC2 — No duplicated private helpers.** Removed five private
  definitions
  (`_nonHomeHumanFleetInNewWorldFromCtSnapshot`,
  `_playerHasAnyNewWorldFoggedOrBetterFromCtSnapshot`,
  `_nonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot`,
  `_nwCoastalProvincesAdjacentToFleetSea`,
  `_exploreAssignEnabledFromCivilianSnapshot`); every call site
  (`_harnessDetectsNonHomeFleetInNewWorld`,
  `_fleetReachDoneFromCtSnapshotOnly`,
  `_awaitNwCoastalOrVisibleLandForBundledExploreE2e` ×6 across the
  three calls per iteration of the readiness loop, fleet-reach test
  final guard, `_anyExplorerHasEnabledExploreAssignFleetE2e`)
  consumes the shared public names. The integration suite cannot
  validate this directly today (`app_e2e_linux` is a no-op per
  `SPEC/program/e2e-integration-tests.md` § CI), so the widget-test
  layer carries the behavioural pins.

No changes to wall-clock methodology, AC8–AC10 timing evidence, or
production Flutter/Flame UI.

## Deferred (out of scope on this PR)

- AC6–AC10 wall-clock measurement remains a maintainer responsibility
  (Linux desktop + `tool/run_e2e_timing.sh` + `tool/compare_e2e_timing.sh`).
- Remaining Bottleneck 6 helper-dedup candidates
  (`_E2ePerfLog`, `_pumpFor`, `_waitUntilFound`,
  `_dismissTransientUi`, `_closeBottomSheet`,
  `_bootstrapNewGameToMap`, `_collectTextPreorder`,
  `_expandEachExpansionTileOnce`, `_ensureAllRelocated64pxPngsLoad`)
  — most already live as `e2e*` shared helpers under the AC1 barrel;
  remaining truly-divergent private copies (e.g.
  `_navalPanelShowsNonHomeFleetInNewWorld` widget-only fallback) are
  follow-up slices.

## Test plan

Local verification (Linux):

- `flutter analyze integration_test/e2e_test_shared.dart integration_test/e2e_helpers.dart integration_test/new_game_fleet_reaches_new_world_e2e_helpers_part2.dart integration_test/new_game_fleet_reaches_new_world_e2e_test.dart test/e2e_player_has_any_new_world_fogged_or_better_from_ct_snapshot_test.dart test/e2e_helpers_barrel_test.dart test/e2e_non_home_human_fleet_in_coastal_new_world_sea_from_ct_snapshot_test.dart test/e2e_explore_assign_enabled_from_civilian_snapshot_test.dart`
  — **No issues found** on touched files (the pre-existing
  `_e2eTapFirstEnabledTransferButtonInSplitDialog` unused-element
  warning under `integration_test/e2e_test_shared_panels.dart` was
  last touched in PR #2678 and is out of scope for this PR).
- `flutter test test/e2e_explore_assign_enabled_from_civilian_snapshot_test.dart`
  — **16 passed** (Slice 4).
- `flutter test test/e2e_non_home_human_fleet_in_coastal_new_world_sea_from_ct_snapshot_test.dart`
  — **23 passed** (Slice 3 regression check).
- `flutter test test/e2e_helpers_barrel_test.dart` — clean (Slice 1 +
  Slice 2 + Slice 3 + Slice 4 barrel pins all pass).
- `flutter test test/e2e_non_home_human_fleet_in_new_world_from_ct_snapshot_test.dart`
  — **16 passed** (Slice 1 regression check).
- `flutter test test/e2e_player_has_any_new_world_fogged_or_better_from_ct_snapshot_test.dart`
  — **16 passed** (Slice 2 regression check).
- `dart format` on touched files — clean.
- `dart run custom_lint` on touched files — **No issues found**.

## Label transition

`backlog:implementation` **not** moved to `backlog:verification` —
AC6–AC10 wall-clock evidence still requires maintainer Linux 3×
`integration_test` runs, and additional helper-dedup follow-ups remain
open on #2336.

Made with [Cursor](https://cursor.com)
