### PR TITLE
feat(observer): ObserverSnapshot v3 workerPool + workforce sustain verifier (Refs #2692 S10a)

### DIFF
--- a/SPEC/program/observer-workforce-verify.md
+++ b/SPEC/program/observer-workforce-verify.md
@@ -1,0 +1,56 @@
+# Observer workforce sustain verifier
+
+**SPEC/program** — Verifier for the **15-regiment workforce sustain** metric from issue **#2692** Requirement §21. Lives in `tool/run_observer_game/lib/observer_workforce_verify.dart`. Consumes the `workerPool` block added to player rollups in `ObserverSnapshot` v3 (see [run_observer_game-tool.md](run_observer_game-tool.md)). Stakeholder decisions: GitHub **#2692**.
+
+## Scope (this slice, S10a)
+
+In scope:
+
+- Schema reader: `WorkerPoolCounts workerPoolCountsForPlayer(Map snapshotJson, String playerId)` returns the player's pool counts or `WorkerPoolCounts.zero` for missing / malformed / v2 rollups.
+- Per-GP verifier: `List<String> verifyPerGpWorkforceSustain({...})` checks each canonical Great Power (`gp1`–`gp6`) against the provisional thresholds and returns one human-readable failure line per failing threshold per GP.
+- Disk reader: `List<String> verifyObserverWorkforceFromTraceDir(String tracesGameDir, {int endTurn = 100, ...})` loads `turn-<endTurn>.snapshot.json` and delegates to the per-GP verifier; reports a single `missing end snapshot: <path>` line when the file is absent.
+
+Out of scope for this slice (tracked under #2692 S10 follow-up):
+
+- `--verify-workforce` CLI flag wiring in `run_observer_game_cli.dart`.
+- Nightly workflow integration in `.github/workflows/nightly.yml`.
+- Food production (`grain + meat`) and luxury production (`refinedSugar` / `cigars` / `furHats`) checks from Requirement §21 bullets 3–4. These require new snapshot fields (production / stockpile rollups) and are gated by `kObserverWorkforceFoodLuxuryDeferred` in the verifier so future work can grep the marker.
+
+## Provisional thresholds (v1; tunable in S10a)
+
+Per Requirement §21 of issue **#2692**, recorded here as the source of truth for the verifier constants:
+
+| Constant | Default | Meaning |
+|----------|---------|---------|
+| `kObserverWorkforceCanonicalTurn` | `100` | Turn whose snapshot is read by `verifyObserverWorkforceFromTraceDir`. |
+| `kObserverWorkforceMinPeasants` | `15` | Lower bound on `peasants` per Great Power; covers one full 15-regiment build cycle plus a reservation buffer per `SPEC/game/workers-and-population.md` § Peasant reservation. |
+| `kObserverWorkforceMinTrained` | `8` | Lower bound on `apprentices + journeymen + masters` per Great Power; effective-labour buffer for production chains. |
+| `kObserverWorkforceFoodLuxuryDeferred` | `true` | Documents that food / luxury sustain checks are not enforced yet. |
+
+S10a observer-trace analysis on **seed 42** (issue #2692 AC #7a) may revise these constants before the nightly gate (S10) is wired; the defaults above are the starting point.
+
+## Acceptance
+
+- Given an `ObserverSnapshot` v3 player rollup with `workerPool = {peasants: P, apprentices: A, journeymen: J, masters: M}`  
+  When the System invokes `workerPoolCountsForPlayer(snapshot, playerId)` with that rollup's `playerId`  
+  Then the System returns `WorkerPoolCounts(peasants: P, apprentices: A, journeymen: J, masters: M)` and `WorkerPoolCounts.trained == A + J + M`.
+
+- Given a snapshot whose `players` list is missing, is not a list, or contains no entry for `playerId`  
+  When the System invokes `workerPoolCountsForPlayer(snapshot, playerId)`  
+  Then the System returns `WorkerPoolCounts.zero`.
+
+- Given a snapshot where every `gp1`–`gp6` player rollup contains `peasants >= 15` and `apprentices + journeymen + masters >= 8`  
+  When the System invokes `verifyPerGpWorkforceSustain(turnEndSnapshot: snapshot)` with default thresholds  
+  Then the System returns an empty `List<String>`.
+
+- Given a snapshot where exactly one Great Power (`gpX`) has `peasants < 15` AND `apprentices + journeymen + masters < 8` and all other Great Powers meet both thresholds  
+  When the System invokes `verifyPerGpWorkforceSustain(turnEndSnapshot: snapshot)` with default thresholds  
+  Then the System returns exactly **two** failure lines: one starting with `gpX peasants=` and one starting with `gpX trained=`, and no failure lines for any other Great Power.
+
+- Given a trace directory containing no `turn-000100.snapshot.json`  
+  When the System invokes `verifyObserverWorkforceFromTraceDir(tracesGameDir: dir)` with the default `endTurn`  
+  Then the System returns a single failure line containing `missing end snapshot:` followed by the expected snapshot path.
+
+- Given a trace directory containing a `turn-000050.snapshot.json` where every `gp1`–`gp6` has `peasants == 8` and `apprentices == 1`  
+  When the System invokes `verifyObserverWorkforceFromTraceDir(tracesGameDir: dir, endTurn: 50)`  
+  Then the System returns at least one failure line containing `peasants=8` and at least one containing `trained=1`.

--- a/SPEC/program/run_observer_game-tool.md
+++ b/SPEC/program/run_observer_game-tool.md
@@ -48,18 +48,18 @@ Active when **`--verify-conquest` and/or `--verify-colonial-expansion`** is pass
 - **`run-summary.json`** always written at end (`minimal_trace_mode: true` in summary when minimal mode ran).
 - **Artifact size cap:** cumulative bytes under the game trace directory must stay **strictly below 300 MB** (`300 * 1024 * 1024`); if a write would exceed the cap, the run aborts with exit **7** (`artifact_size_cap_exceeded`). Canonical nightly verify inputs are expected to be far below the cap; the cap guards regressions that reintroduce large artifacts.
 
-## ObserverSnapshot (`ObserverSnapshot` v2)
+## ObserverSnapshot (`ObserverSnapshot` v3)
 
-Versioned map written to `turn-<nnnnnn>.snapshot.json` and embedded (escaped) in paired `turn-<nnnnnn>.html`. **`observerSnapshotSchemaVersion` is `2`.**
+Versioned map written to `turn-<nnnnnn>.snapshot.json` and embedded (escaped) in paired `turn-<nnnnnn>.html`. **`observerSnapshotSchemaVersion` is `3`** (Refs **#2692** S10a; v3 adds per-player `workerPool`).
 
 | Field | Meaning |
 |-------|---------|
-| `observerSnapshotSchemaVersion` | Always `2` for this shape (v1 lacked extraction rollups). |
+| `observerSnapshotSchemaVersion` | `3` (v2 lacked `workerPool`; v1 lacked extraction rollups). |
 | `gameId` | Game id string. |
 | `turnNumber` | Post-resolution turn index (`Game.worldState.turnState.turnNumber`). |
 | `calendarYearAtTurnStart` | `yearAtTurn(turnNumber)` using the game's active `TurnTimeMapping` (if `turnNumber` is below 1, the lookup uses 1). |
 | `calendarCampaignHalted` | Mirrors `Game.calendarCampaignHalted`. |
-| `players` | One object per `game.players`: ids, display name, human flag, GP power score, treasury, military strength / fleet hints, sorted tech unlock ids. |
+| `players` | One object per `game.players`: ids, display name, human flag, GP power score, treasury, military strength / fleet hints, sorted tech unlock ids, **`workerPool`** (peasants / apprentices / journeymen / masters mirroring `Player.workerPool`). |
 | `provinceOwnershipSorted` | Sorted list of `{ id, ownerId }` for every province (`allProvinces`), ids prefixed per world model. |
 | `diplomacyRelationSummariesSorted` | Stable string lines summarizing each `diplomacyRelations` row (pair, score, level, war/peace). |
 | `militaryArmySummariesSorted` | One string per land army (id, owner, region, regiment count). |
@@ -93,6 +93,10 @@ Each **resolved turn** in the session loop measures the same segment as the app 
 Pass **`--verify-colonial-expansion`** after a successful run (exit **6** on failure; requires `--max-turns >= 150` or no turn cap). Rollup computation: `lib/observer_extractable_rollup.dart` (init static resource grid ∩ GP-owned provinces at verify turn; excludes capital and province town tiles per [extraction-and-improvements.md](../game/extraction-and-improvements.md)).
 
 Unit tests cover parsers; full observer runs are slow and are **not** in the default `quality` gate. **Nightly:** `.github/workflows/nightly.yml` job `observer_conquest_verify` runs seed **42**, **150** turns, **`--verify-conquest`**, and **`--verify-colonial-expansion`** daily at **23:00 Asia/Hong_Kong** (`0 15 * * *` UTC; `workflow_dispatch` supported).
+
+## Workforce sustain verification (Refs #2692 S10a)
+
+`lib/observer_workforce_verify.dart` reads `turn-000100.snapshot.json` and, per `gp1`–`gp6`, asserts `peasants >= 15` AND `apprentices + journeymen + masters >= 8`. Thresholds, parser contract, food/luxury follow-ups, and the deferred `--verify-workforce` CLI wiring (S10) are in [observer-workforce-verify.md](observer-workforce-verify.md).
 
 ## Coverage
 

--- a/tool/run_observer_game/lib/observer_snapshot_v1.dart
+++ b/tool/run_observer_game/lib/observer_snapshot_v1.dart
@@ -8,7 +8,12 @@ import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'observer_extractable_rollup.dart';
 
 /// Observer canonical snapshot (SPEC/program/run_observer_game-tool.md).
-const int observerSnapshotSchemaVersion = 2;
+///
+/// **v3 (Refs #2692 S10a):** Adds `workerPool` per player rollup
+/// (`peasants`, `apprentices`, `journeymen`, `masters`) so workforce
+/// growth and 15-regiment sustain can be verified from snapshots at
+/// turn 100 without rerunning the campaign.
+const int observerSnapshotSchemaVersion = 3;
 
 Map<String, Object?> buildObserverSnapshotJson(
   Game game, {
@@ -28,6 +33,7 @@ Map<String, Object?> buildObserverSnapshotJson(
     final techKeys =
         (p.techUnlocked?.keys.map((k) => k.toString()).toList() ?? <String>[])
           ..sort();
+    final pool = p.workerPool;
     playerRollups.add(<String, Object?>{
       'playerId': p.id,
       'displayName': p.displayName,
@@ -40,6 +46,12 @@ Map<String, Object?> buildObserverSnapshotJson(
       ).round(),
       'fleetShipCountHint': shipCountForFaction(game, p.id),
       'techUnlockedIds': techKeys,
+      'workerPool': <String, Object?>{
+        'peasants': pool.peasants,
+        'apprentices': pool.apprentices,
+        'journeymen': pool.journeymen,
+        'masters': pool.masters,
+      },
     });
   }
 

--- a/tool/run_observer_game/lib/observer_workforce_verify.dart
+++ b/tool/run_observer_game/lib/observer_workforce_verify.dart
@@ -1,0 +1,155 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'observer_conquest_verify.dart';
+
+/// Workforce sustain verifier (Refs #2692 S10a).
+///
+/// Reads per-player `workerPool` from a turn-100 `ObserverSnapshot` v3 and
+/// checks the provisional 15-regiment workforce sustain metric for each
+/// canonical Great Power (`gp1`–`gp6`):
+///
+/// 1. **Peasant buffer** — `peasants >= kObserverWorkforceMinPeasants`
+///    (default `15`, sufficient for one full 15-regiment build cycle
+///    plus reservation headroom per `SPEC/game/workers-and-population.md`
+///    § Peasant reservation).
+/// 2. **Trained-tier buffer** — `apprentices + journeymen + masters >=
+///    kObserverWorkforceMinTrained` (default `8`, effective-labour buffer
+///    for production chains per Requirement §21 of issue #2692).
+///
+/// The food/luxury sustain checks listed in Requirement §21 are deferred
+/// to a follow-up slice: `ObserverSnapshot` v3 exposes worker counts only
+/// — `stockpile`, `food production`, and per-tier luxury production
+/// summaries are not in scope here. `kObserverWorkforceFoodLuxuryDeferred`
+/// documents the deferral as a value developers can grep for when the
+/// next slice lands.
+const int kObserverWorkforceCanonicalTurn = 100;
+
+/// Minimum peasants per Great Power on the turn-100 snapshot.
+const int kObserverWorkforceMinPeasants = 15;
+
+/// Minimum combined trained-tier workers (apprentices + journeymen +
+/// masters) per Great Power on the turn-100 snapshot.
+const int kObserverWorkforceMinTrained = 8;
+
+/// Deferral marker: food and luxury sustain checks (§21 bullets 3 and 4)
+/// are NOT enforced by this verifier yet. The marker exists so future
+/// work can surface every gated check in one search.
+const bool kObserverWorkforceFoodLuxuryDeferred = true;
+
+/// Per-Great-Power worker pool counts parsed from an
+/// `ObserverSnapshot` v3 player rollup.
+class WorkerPoolCounts {
+  const WorkerPoolCounts({
+    required this.peasants,
+    required this.apprentices,
+    required this.journeymen,
+    required this.masters,
+  });
+
+  final int peasants;
+  final int apprentices;
+  final int journeymen;
+  final int masters;
+
+  int get trained => apprentices + journeymen + masters;
+
+  static const WorkerPoolCounts zero = WorkerPoolCounts(
+    peasants: 0,
+    apprentices: 0,
+    journeymen: 0,
+    masters: 0,
+  );
+}
+
+int _readInt(Object? value) {
+  if (value is int) return value;
+  if (value is num) return value.toInt();
+  return int.tryParse(value?.toString() ?? '') ?? 0;
+}
+
+/// Returns the `WorkerPoolCounts` for [playerId] in [snapshotJson], or
+/// [WorkerPoolCounts.zero] when the player row is missing or has no
+/// `workerPool` block (older v2 snapshots).
+WorkerPoolCounts workerPoolCountsForPlayer(
+  Map<String, Object?> snapshotJson,
+  String playerId,
+) {
+  final players = snapshotJson['players'];
+  if (players is! List<Object?>) {
+    return WorkerPoolCounts.zero;
+  }
+  for (final row in players) {
+    if (row is! Map<String, Object?>) continue;
+    if (row['playerId']?.toString() != playerId) continue;
+    final pool = row['workerPool'];
+    if (pool is! Map<String, Object?>) {
+      return WorkerPoolCounts.zero;
+    }
+    return WorkerPoolCounts(
+      peasants: _readInt(pool['peasants']),
+      apprentices: _readInt(pool['apprentices']),
+      journeymen: _readInt(pool['journeymen']),
+      masters: _readInt(pool['masters']),
+    );
+  }
+  return WorkerPoolCounts.zero;
+}
+
+/// Returns human-readable failure lines; empty when every Great Power
+/// in [kObserverGreatPowerIds] meets both thresholds.
+List<String> verifyPerGpWorkforceSustain({
+  required Map<String, Object?> turnEndSnapshot,
+  int minPeasants = kObserverWorkforceMinPeasants,
+  int minTrained = kObserverWorkforceMinTrained,
+}) {
+  final failures = <String>[];
+  for (final gpId in kObserverGreatPowerIds) {
+    final counts = workerPoolCountsForPlayer(turnEndSnapshot, gpId);
+    if (counts.peasants < minPeasants) {
+      failures.add(
+        '$gpId peasants=${counts.peasants} (need >= $minPeasants)',
+      );
+    }
+    if (counts.trained < minTrained) {
+      failures.add(
+        '$gpId trained=${counts.trained} '
+        '(apprentices=${counts.apprentices} journeymen=${counts.journeymen} '
+        'masters=${counts.masters}; need apprentices+journeymen+masters '
+        '>= $minTrained)',
+      );
+    }
+  }
+  return failures;
+}
+
+Map<String, Object?> _loadSnapshot(String path) {
+  final text = File(path).readAsStringSync();
+  final decoded = jsonDecode(text);
+  if (decoded is! Map<String, Object?>) {
+    throw FormatException('Observer snapshot root must be a JSON object: $path');
+  }
+  return decoded;
+}
+
+/// Verifies the turn-[endTurn] snapshot under [tracesGameDir] meets the
+/// workforce sustain thresholds for every Great Power.
+List<String> verifyObserverWorkforceFromTraceDir(
+  String tracesGameDir, {
+  int endTurn = kObserverWorkforceCanonicalTurn,
+  int minPeasants = kObserverWorkforceMinPeasants,
+  int minTrained = kObserverWorkforceMinTrained,
+}) {
+  final endPath = observerTurnSnapshotPath(
+    tracesGameDir: tracesGameDir,
+    turnNumber: endTurn,
+  );
+  if (!File(endPath).existsSync()) {
+    return ['missing end snapshot: $endPath'];
+  }
+  return verifyPerGpWorkforceSustain(
+    turnEndSnapshot: _loadSnapshot(endPath),
+    minPeasants: minPeasants,
+    minTrained: minTrained,
+  );
+}

--- a/tool/run_observer_game/test/observer_snapshot_worker_pool_test.dart
+++ b/tool/run_observer_game/test/observer_snapshot_worker_pool_test.dart
@@ -1,0 +1,130 @@
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+import 'package:run_observer_game/observer_snapshot_v1.dart';
+
+/// Refs #2692 S10a: `ObserverSnapshot` v3 must surface per-player
+/// `workerPool` counts so the workforce sustain verifier can read
+/// peasants and trained-tier counts directly from the snapshot.
+void main() {
+  Game _gameWithPools(Map<String, WorkerPool> poolByPlayerId) {
+    return Game(
+      id: 'g-workforce',
+      worldState: WorldState(
+        turnState: const TurnState(phase: TurnPhase.endOfTurn, turnNumber: 100),
+        oldWorld: const RegionData(),
+        newWorld: const RegionData(),
+      ),
+      players: [
+        for (final entry in poolByPlayerId.entries)
+          Player(
+            id: entry.key,
+            displayName: entry.key.toUpperCase(),
+            isHuman: false,
+            workerPool: entry.value,
+          ),
+      ],
+    );
+  }
+
+  group('ObserverSnapshot v3 worker pool exposure', () {
+    test('schema version is 3', () {
+      expect(observerSnapshotSchemaVersion, 3);
+    });
+
+    test('player rollups include a workerPool block with all four tiers', () {
+      final game = _gameWithPools({
+        'gp1': const WorkerPool(
+          peasants: 17,
+          apprentices: 4,
+          journeymen: 3,
+          masters: 1,
+        ),
+      });
+
+      final snapshot = buildObserverSnapshotJson(
+        game,
+        postResolutionTurnNumber: 100,
+      );
+
+      expect(snapshot['observerSnapshotSchemaVersion'], 3);
+      final players = snapshot['players'] as List<Object?>;
+      final gp1 = players.cast<Map<String, Object?>>().single;
+      expect(gp1['playerId'], 'gp1');
+
+      final pool = gp1['workerPool'] as Map<String, Object?>;
+      expect(pool['peasants'], 17);
+      expect(pool['apprentices'], 4);
+      expect(pool['journeymen'], 3);
+      expect(pool['masters'], 1);
+    });
+
+    test('empty pool serialises to zeros (does not omit fields)', () {
+      final game = _gameWithPools({'gp1': WorkerPool.empty});
+
+      final snapshot = buildObserverSnapshotJson(
+        game,
+        postResolutionTurnNumber: 1,
+      );
+
+      final pool = (snapshot['players'] as List<Object?>)
+          .cast<Map<String, Object?>>()
+          .single['workerPool'] as Map<String, Object?>;
+      expect(pool['peasants'], 0);
+      expect(pool['apprentices'], 0);
+      expect(pool['journeymen'], 0);
+      expect(pool['masters'], 0);
+    });
+
+    test('every player rollup carries its own workerPool block', () {
+      final game = _gameWithPools({
+        'gp1': const WorkerPool(peasants: 5),
+        'gp2': const WorkerPool(peasants: 0, masters: 2),
+        'gp3': const WorkerPool(apprentices: 1, journeymen: 1),
+      });
+
+      final snapshot = buildObserverSnapshotJson(
+        game,
+        postResolutionTurnNumber: 100,
+      );
+
+      final players = (snapshot['players'] as List<Object?>)
+          .cast<Map<String, Object?>>();
+      expect(players, hasLength(3));
+      for (final row in players) {
+        expect(row['workerPool'], isA<Map<String, Object?>>());
+        final pool = row['workerPool'] as Map<String, Object?>;
+        expect(pool.keys.toList()..sort(), <String>[
+          'apprentices',
+          'journeymen',
+          'masters',
+          'peasants',
+        ]);
+      }
+    });
+
+    test('player rollup keeps existing v2 fields alongside workerPool', () {
+      final game = _gameWithPools({
+        'gp1': const WorkerPool(peasants: 10),
+      });
+
+      final snapshot = buildObserverSnapshotJson(
+        game,
+        postResolutionTurnNumber: 100,
+      );
+
+      final gp1 = (snapshot['players'] as List<Object?>)
+          .cast<Map<String, Object?>>()
+          .single;
+
+      expect(gp1.containsKey('playerId'), isTrue);
+      expect(gp1.containsKey('displayName'), isTrue);
+      expect(gp1.containsKey('greatPowerPowerScore'), isTrue);
+      expect(gp1.containsKey('treasuryPounds'), isTrue);
+      expect(gp1.containsKey('regimentLikeUnitCountHint'), isTrue);
+      expect(gp1.containsKey('fleetShipCountHint'), isTrue);
+      expect(gp1.containsKey('techUnlockedIds'), isTrue);
+      expect(gp1.containsKey('workerPool'), isTrue);
+    });
+  });
+}

--- a/tool/run_observer_game/test/observer_workforce_verify_test.dart
+++ b/tool/run_observer_game/test/observer_workforce_verify_test.dart
@@ -1,0 +1,280 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:colonizethis_test/test.dart';
+
+import 'package:run_observer_game/observer_conquest_verify.dart'
+    show kObserverGreatPowerIds, observerTurnSnapshotPath;
+import 'package:run_observer_game/observer_workforce_verify.dart';
+
+Map<String, Object?> _snapshotWithWorkerPools(
+  Map<String, WorkerPoolCounts> byGp,
+) {
+  final players = <Map<String, Object?>>[];
+  for (final entry in byGp.entries) {
+    players.add(<String, Object?>{
+      'playerId': entry.key,
+      'displayName': entry.key.toUpperCase(),
+      'isHuman': false,
+      'workerPool': <String, Object?>{
+        'peasants': entry.value.peasants,
+        'apprentices': entry.value.apprentices,
+        'journeymen': entry.value.journeymen,
+        'masters': entry.value.masters,
+      },
+    });
+  }
+  return <String, Object?>{'players': players};
+}
+
+WorkerPoolCounts _meetsBoth() => const WorkerPoolCounts(
+      peasants: 20,
+      apprentices: 5,
+      journeymen: 3,
+      masters: 1,
+    );
+
+void _writeSnapshot(
+  String dir,
+  int turnNumber,
+  Map<String, Object?> snapshot,
+) {
+  final path = observerTurnSnapshotPath(
+    tracesGameDir: dir,
+    turnNumber: turnNumber,
+  );
+  File(path).writeAsStringSync(jsonEncode(snapshot));
+}
+
+void main() {
+  group('workerPoolCountsForPlayer', () {
+    test('returns counts when player rollup contains workerPool', () {
+      final snap = _snapshotWithWorkerPools({
+        'gp1': const WorkerPoolCounts(
+          peasants: 12,
+          apprentices: 3,
+          journeymen: 2,
+          masters: 1,
+        ),
+      });
+      final got = workerPoolCountsForPlayer(snap, 'gp1');
+      expect(got.peasants, 12);
+      expect(got.apprentices, 3);
+      expect(got.journeymen, 2);
+      expect(got.masters, 1);
+      expect(got.trained, 6);
+    });
+
+    test('returns zero when players list is missing or wrong type', () {
+      expect(workerPoolCountsForPlayer(<String, Object?>{}, 'gp1').peasants, 0);
+      expect(
+        workerPoolCountsForPlayer(
+          <String, Object?>{'players': 'not-a-list'},
+          'gp1',
+        ).peasants,
+        0,
+      );
+    });
+
+    test('returns zero when player rollup has no workerPool block (v2)', () {
+      final snap = <String, Object?>{
+        'players': <Object?>[
+          <String, Object?>{'playerId': 'gp1', 'displayName': 'GP1'},
+        ],
+      };
+      final got = workerPoolCountsForPlayer(snap, 'gp1');
+      expect(got.peasants, 0);
+      expect(got.trained, 0);
+    });
+
+    test('returns zero when player id is absent', () {
+      final snap = _snapshotWithWorkerPools({
+        'gp1': const WorkerPoolCounts(
+          peasants: 5,
+          apprentices: 0,
+          journeymen: 0,
+          masters: 0,
+        ),
+      });
+      expect(workerPoolCountsForPlayer(snap, 'gp9').peasants, 0);
+    });
+
+    test('coerces numeric strings and num values', () {
+      final snap = <String, Object?>{
+        'players': <Object?>[
+          <String, Object?>{
+            'playerId': 'gp1',
+            'workerPool': <String, Object?>{
+              'peasants': '14',
+              'apprentices': 4.0,
+              'journeymen': '2',
+              'masters': 1,
+            },
+          },
+        ],
+      };
+      final got = workerPoolCountsForPlayer(snap, 'gp1');
+      expect(got.peasants, 14);
+      expect(got.apprentices, 4);
+      expect(got.journeymen, 2);
+      expect(got.masters, 1);
+    });
+  });
+
+  group('verifyPerGpWorkforceSustain', () {
+    test('passes when every GP meets both thresholds', () {
+      final snap = _snapshotWithWorkerPools({
+        for (final gp in kObserverGreatPowerIds) gp: _meetsBoth(),
+      });
+      expect(verifyPerGpWorkforceSustain(turnEndSnapshot: snap), isEmpty);
+    });
+
+    test('emits one failure line per failing threshold per GP', () {
+      final snap = _snapshotWithWorkerPools({
+        for (final gp in kObserverGreatPowerIds) gp: _meetsBoth(),
+      });
+      (snap['players'] as List<Object?>)
+          .cast<Map<String, Object?>>()
+          .firstWhere((r) => r['playerId'] == 'gp3')['workerPool'] =
+          <String, Object?>{
+        'peasants': 5,
+        'apprentices': 0,
+        'journeymen': 0,
+        'masters': 0,
+      };
+
+      final failures = verifyPerGpWorkforceSustain(turnEndSnapshot: snap);
+      expect(failures, hasLength(2));
+      expect(failures.any((f) => f.startsWith('gp3 peasants=5')), isTrue);
+      expect(failures.any((f) => f.startsWith('gp3 trained=0')), isTrue);
+    });
+
+    test('reports missing rollups as zero counts (worst-case fail)', () {
+      final snap = <String, Object?>{'players': <Object?>[]};
+      final failures = verifyPerGpWorkforceSustain(turnEndSnapshot: snap);
+      expect(failures.length, kObserverGreatPowerIds.length * 2);
+      for (final gp in kObserverGreatPowerIds) {
+        expect(failures.any((f) => f.startsWith('$gp peasants=0')), isTrue);
+        expect(failures.any((f) => f.startsWith('$gp trained=0')), isTrue);
+      }
+    });
+
+    test('thresholds are overridable for tuning', () {
+      final snap = _snapshotWithWorkerPools({
+        for (final gp in kObserverGreatPowerIds)
+          gp: const WorkerPoolCounts(
+            peasants: 5,
+            apprentices: 1,
+            journeymen: 0,
+            masters: 0,
+          ),
+      });
+      expect(
+        verifyPerGpWorkforceSustain(
+          turnEndSnapshot: snap,
+          minPeasants: 5,
+          minTrained: 1,
+        ),
+        isEmpty,
+      );
+    });
+
+    test('default thresholds match documented v1 metric (15 / 8)', () {
+      expect(kObserverWorkforceMinPeasants, 15);
+      expect(kObserverWorkforceMinTrained, 8);
+      expect(kObserverWorkforceCanonicalTurn, 100);
+      expect(kObserverWorkforceFoodLuxuryDeferred, isTrue);
+    });
+
+    test('peasant-only failure surfaces only the peasant line for that GP', () {
+      final snap = _snapshotWithWorkerPools({
+        for (final gp in kObserverGreatPowerIds) gp: _meetsBoth(),
+      });
+      (snap['players'] as List<Object?>)
+          .cast<Map<String, Object?>>()
+          .firstWhere((r) => r['playerId'] == 'gp2')['workerPool'] =
+          <String, Object?>{
+        'peasants': 14,
+        'apprentices': 5,
+        'journeymen': 3,
+        'masters': 1,
+      };
+
+      final failures = verifyPerGpWorkforceSustain(turnEndSnapshot: snap);
+      expect(failures, hasLength(1));
+      expect(failures.single, startsWith('gp2 peasants=14'));
+    });
+
+    test('trained-only failure surfaces only the trained line for that GP', () {
+      final snap = _snapshotWithWorkerPools({
+        for (final gp in kObserverGreatPowerIds) gp: _meetsBoth(),
+      });
+      (snap['players'] as List<Object?>)
+          .cast<Map<String, Object?>>()
+          .firstWhere((r) => r['playerId'] == 'gp4')['workerPool'] =
+          <String, Object?>{
+        'peasants': 20,
+        'apprentices': 4,
+        'journeymen': 2,
+        'masters': 1,
+      };
+
+      final failures = verifyPerGpWorkforceSustain(turnEndSnapshot: snap);
+      expect(failures, hasLength(1));
+      expect(failures.single, startsWith('gp4 trained=7'));
+    });
+  });
+
+  group('verifyObserverWorkforceFromTraceDir', () {
+    test('returns failures when end snapshot is missing', () {
+      final tmp = Directory.systemTemp.createTempSync('obs_workforce_missing_');
+      addTearDown(() => tmp.deleteSync(recursive: true));
+
+      final failures = verifyObserverWorkforceFromTraceDir(tmp.path);
+      expect(failures, hasLength(1));
+      expect(failures.single, contains('missing end snapshot'));
+    });
+
+    test('passes when turn-100 snapshot meets thresholds for every GP', () {
+      final tmp = Directory.systemTemp.createTempSync('obs_workforce_pass_');
+      addTearDown(() => tmp.deleteSync(recursive: true));
+
+      _writeSnapshot(
+        tmp.path,
+        kObserverWorkforceCanonicalTurn,
+        _snapshotWithWorkerPools({
+          for (final gp in kObserverGreatPowerIds) gp: _meetsBoth(),
+        }),
+      );
+
+      expect(verifyObserverWorkforceFromTraceDir(tmp.path), isEmpty);
+    });
+
+    test('honours endTurn override and surfaces threshold failures', () {
+      final tmp = Directory.systemTemp.createTempSync('obs_workforce_alt_');
+      addTearDown(() => tmp.deleteSync(recursive: true));
+
+      _writeSnapshot(
+        tmp.path,
+        50,
+        _snapshotWithWorkerPools({
+          for (final gp in kObserverGreatPowerIds)
+            gp: const WorkerPoolCounts(
+              peasants: 8,
+              apprentices: 1,
+              journeymen: 0,
+              masters: 0,
+            ),
+        }),
+      );
+
+      final failures = verifyObserverWorkforceFromTraceDir(
+        tmp.path,
+        endTurn: 50,
+      );
+      expect(failures, isNotEmpty);
+      expect(failures.any((f) => f.contains('peasants=8')), isTrue);
+      expect(failures.any((f) => f.contains('trained=1')), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Scaffolding for issue #2692 S10a (workforce sustain verification). Two
moving parts:

1. **ObserverSnapshot v3** — `observerSnapshotSchemaVersion` is bumped
   from `2` to `3` and each `players[i]` rollup gains a `workerPool`
   block (`peasants`, `apprentices`, `journeymen`, `masters`) mirroring
   `Player.workerPool`. No other v2 fields change.
2. **Workforce sustain verifier (library-only)** —
   `tool/run_observer_game/lib/observer_workforce_verify.dart` reads
   `turn-000100.snapshot.json` and, for each canonical Great Power
   (`gp1`–`gp6`), checks the provisional turn-100 metric from issue
   #2692 Requirement §21: `peasants >= 15` AND
   `apprentices + journeymen + masters >= 8`. Returns one
   human-readable failure line per failing threshold per GP, plus a
   `verifyObserverWorkforceFromTraceDir` disk reader that surfaces a
   `missing end snapshot: <path>` line when the snapshot file is
   absent.

The verifier intentionally **does not** wire a `--verify-workforce`
CLI flag, nightly workflow integration, or food / luxury production
checks in this PR — those follow-ups (S10) are documented in the new
sub-spec `SPEC/program/observer-workforce-verify.md` and the
`kObserverWorkforceFoodLuxuryDeferred` constant in the Dart library so
the next slice can grep for the gate.

## Done in this PR

### SPEC

- `SPEC/program/run_observer_game-tool.md` — Bump
  `ObserverSnapshot` to v3, add `workerPool` to the `players` row,
  add a short § *Workforce sustain verification* pointing at the new
  sub-spec.
- `SPEC/program/observer-workforce-verify.md` *(NEW, 598 words)* —
  Verifier scope, constants, deferral, and six Given–When–Then ACs
  (parser happy path, parser missing-rows, all-pass, per-GP
  dual-failure, missing snapshot file, `endTurn` override + failure
  surfacing).

### Code

- `tool/run_observer_game/lib/observer_snapshot_v1.dart` — Schema
  version bump 2 → 3 and per-player `workerPool` block in the player
  rollup builder.
- `tool/run_observer_game/lib/observer_workforce_verify.dart` *(NEW)* —
  `WorkerPoolCounts` value class, `workerPoolCountsForPlayer`,
  `verifyPerGpWorkforceSustain`, `verifyObserverWorkforceFromTraceDir`,
  plus public constants
  (`kObserverWorkforceCanonicalTurn = 100`,
  `kObserverWorkforceMinPeasants = 15`,
  `kObserverWorkforceMinTrained = 8`,
  `kObserverWorkforceFoodLuxuryDeferred = true`).

### Tests (19 new)

- `tool/run_observer_game/test/observer_snapshot_worker_pool_test.dart` *(NEW, 5 tests)* —
  Pins schema version 3; asserts every player rollup carries a full
  `workerPool` block with all four tiers (no field omission for zero
  counts); asserts existing v2 fields (`playerId`, `displayName`,
  `greatPowerPowerScore`, `treasuryPounds`, `regimentLikeUnitCountHint`,
  `fleetShipCountHint`, `techUnlockedIds`) remain alongside.
- `tool/run_observer_game/test/observer_workforce_verify_test.dart` *(NEW, 14 tests)* —
  Covers `workerPoolCountsForPlayer` (happy path, missing players list,
  v2-style rollup without `workerPool`, missing player id, numeric-string
  / num coercion), `verifyPerGpWorkforceSustain` (all-pass, per-GP
  single-threshold and dual-threshold failures, all-missing rollups,
  threshold overrides, default constant pinning), and
  `verifyObserverWorkforceFromTraceDir` (missing snapshot file, pass,
  `endTurn` override + failure surfacing).

## AC coverage

From issue #2692 Requirement §21 / AC #7a:

- **Per-GP workforce sustain at turn 100** — Provisional v1 metric
  (`peasants >= 15`, `apprentices + journeymen + masters >= 8`)
  encoded as default constants and pinned by the verifier tests.
- **Per-GP failure reporting** — One failure line per failing
  threshold per GP, with the offending counts surfaced for tuning.
- **Snapshot-driven (no campaign rerun)** — `ObserverSnapshot` v3
  carries the data the verifier needs; no in-memory game required.

Food / luxury bullets of §21 (food production, fur-hat / cigar /
refined-sugar sustain) are **deferred** to S10 follow-up because the
v3 snapshot does not yet expose production / stockpile rollups.

## Deferred for #2692 (out of scope on this PR)

- **S10a metric finalization** — Observer-trace analysis on seed 42
  to turn 100 with the worker feature enabled, then revise (or
  confirm) the constants and record the final metric in
  `SPEC/program/run_observer_game-tool.md` and AC #7b. This PR ships
  the scaffolding the analysis will consume.
- **S10 nightly gate** — `--verify-workforce` CLI flag wiring in
  `run_observer_game_cli.dart`, nightly workflow integration in
  `.github/workflows/nightly.yml`, and the food / luxury checks (with
  any `ObserverSnapshot` v3 extensions they need).
- **S9 cross-slice test polish** — Any remaining integration coverage
  across S4-S8 that the per-slice PRs (#2693, #2694, #2698, #2699,
  #2709, #2710, #2711, #2712) did not already pick up.

## Test plan

- `dart analyze` of touched files: clean.
- `dart test` for the `run_observer_game` package: **84 passed** locally.
- Line coverage on touched libs:
  `observer_snapshot_v1.dart` **100 %**, `observer_workforce_verify.dart`
  **97.6 %** — both well above the 80 % gate for the package.

## Label transition

`backlog:implementation` **not** moved to `backlog:verification` —
S9, S10a (metric finalization from real observer traces), and S10
(CLI flag + nightly wiring + food / luxury checks) remain open on
#2692.

Refs #2692

Made with [Cursor](https://cursor.com)