### PR TITLE
feat(observer): --verify-workforce CLI + nightly wiring (Refs #2692 S10)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -43,11 +43,12 @@ jobs:
       - name: Resolve dependencies (workspace)
         run: dart pub get
 
-      - name: Run observer game with conquest and colonial verification
+      - name: Run observer game with conquest, colonial, and workforce verification
         run: |
           dart run tool/run_observer_game/bin/run_observer_game.dart \
             --seed 42 \
             --max-turns 150 \
             --verify-conquest \
             --verify-colonial-expansion \
+            --verify-workforce \
             --output /tmp/observer_nightly

--- a/SPEC/program/observer-workforce-verify.md
+++ b/SPEC/program/observer-workforce-verify.md
@@ -2,18 +2,21 @@
 
 **SPEC/program** — Verifier for the **15-regiment workforce sustain** metric from issue **#2692** Requirement §21. Lives in `tool/run_observer_game/lib/observer_workforce_verify.dart`. Consumes the `workerPool` block added to player rollups in `ObserverSnapshot` v3 (see [run_observer_game-tool.md](run_observer_game-tool.md)). Stakeholder decisions: GitHub **#2692**.
 
-## Scope (this slice, S10a)
+## Scope
 
-In scope:
+In scope (landed across **S10a** and **S10**):
 
-- Schema reader: `WorkerPoolCounts workerPoolCountsForPlayer(Map snapshotJson, String playerId)` returns the player's pool counts or `WorkerPoolCounts.zero` for missing / malformed / v2 rollups.
-- Per-GP verifier: `List<String> verifyPerGpWorkforceSustain({...})` checks each canonical Great Power (`gp1`–`gp6`) against the provisional thresholds and returns one human-readable failure line per failing threshold per GP.
-- Disk reader: `List<String> verifyObserverWorkforceFromTraceDir(String tracesGameDir, {int endTurn = 100, ...})` loads `turn-<endTurn>.snapshot.json` and delegates to the per-GP verifier; reports a single `missing end snapshot: <path>` line when the file is absent.
+- **Verifier library (S10a)**
+  - Schema reader: `WorkerPoolCounts workerPoolCountsForPlayer(Map snapshotJson, String playerId)` returns the player's pool counts or `WorkerPoolCounts.zero` for missing / malformed / v2 rollups.
+  - Per-GP verifier: `List<String> verifyPerGpWorkforceSustain({...})` checks each canonical Great Power (`gp1`–`gp6`) against the provisional thresholds and returns one human-readable failure line per failing threshold per GP.
+  - Disk reader: `List<String> verifyObserverWorkforceFromTraceDir(String tracesGameDir, {int endTurn = 100, ...})` loads `turn-<endTurn>.snapshot.json` and delegates to the per-GP verifier; reports a single `missing end snapshot: <path>` line when the file is absent.
+- **CLI + nightly wiring (S10)**
+  - `--verify-workforce` flag in `tool/run_observer_game/lib/run_observer_game_cli.dart`. Requires `--max-turns >= kObserverWorkforceCanonicalTurn` (or no cap). On verification failure the CLI exits with code **`kExitWorkforceVerifyFailed` (8)** and emits one `workforce_verify: …` line on stderr per failure. On pass, the CLI emits a single confirmation line on stdout.
+  - When `--verify-workforce` is the only active verify flag the runner enters minimal trace mode (no merged trace, no HTML) and writes only `turn-000100.snapshot.json` plus `run-summary.json` (Refs #2534). Combined verify flags union their canonical turns via `requiredObserverSnapshotTurns(...)` in `observer_minimal_trace.dart`.
+  - `.github/workflows/nightly.yml` job `observer_conquest_verify` runs `--verify-workforce` alongside `--verify-conquest` and `--verify-colonial-expansion` daily at **23:00 Asia/Hong_Kong** (`0 15 * * *` UTC).
 
-Out of scope for this slice (tracked under #2692 S10 follow-up):
+Out of scope (tracked as #2692 follow-ups):
 
-- `--verify-workforce` CLI flag wiring in `run_observer_game_cli.dart`.
-- Nightly workflow integration in `.github/workflows/nightly.yml`.
 - Food production (`grain + meat`) and luxury production (`refinedSugar` / `cigars` / `furHats`) checks from Requirement §21 bullets 3–4. These require new snapshot fields (production / stockpile rollups) and are gated by `kObserverWorkforceFoodLuxuryDeferred` in the verifier so future work can grep the marker.
 
 ## Provisional thresholds (v1; tunable in S10a)
@@ -54,3 +57,15 @@ S10a observer-trace analysis on **seed 42** (issue #2692 AC #7a) may revise thes
 - Given a trace directory containing a `turn-000050.snapshot.json` where every `gp1`–`gp6` has `peasants == 8` and `apprentices == 1`  
   When the System invokes `verifyObserverWorkforceFromTraceDir(tracesGameDir: dir, endTurn: 50)`  
   Then the System returns at least one failure line containing `peasants=8` and at least one containing `trained=1`.
+
+- Given CLI arguments `--output <dir> --max-turns 50 --verify-workforce`  
+  When the System invokes `runObserverGameCli(arguments: [...])`  
+  Then the System exits with code `kExitUsage` and writes a stderr line that mentions `--verify-workforce` and `>= kObserverWorkforceCanonicalTurn`.
+
+- Given the CLI ran a successful observer session with `--verify-workforce` and the resulting `turn-000100.snapshot.json` contains every Great Power `gp1`–`gp6` with `peasants < 15`  
+  When the System runs the workforce verification block in `runObserverGameCli`  
+  Then the System exits with code `kExitWorkforceVerifyFailed` (8) and writes one `workforce_verify: <gpId> peasants=<n> …` line to stderr per failing threshold per GP.
+
+- Given the nightly workflow `.github/workflows/nightly.yml` job `observer_conquest_verify`  
+  When the System renders the rendered `dart run …/run_observer_game.dart …` command line  
+  Then the command line contains `--verify-conquest`, `--verify-colonial-expansion`, **and** `--verify-workforce`, plus `--seed 42` and `--max-turns 150`.

--- a/SPEC/program/run_observer_game-tool.md
+++ b/SPEC/program/run_observer_game-tool.md
@@ -21,6 +21,7 @@ melos run run_observer_game -- [options]
 | `--config <path>` | Optional JSON `GameSetupConfig` consistent with **`init_game`**. |
 | `--verify-conquest` | After success: turn-1 vs turn-100 OW per-GP net +3 provinces (exit **5** on failure; requires `--max-turns >= 100` or no cap). |
 | `--verify-colonial-expansion` | After success: turn-150 snapshot checks NW GP ownership and extractable improvement ratio (exit **6** on failure; requires `--max-turns >= 150` or no cap). |
+| `--verify-workforce` | After success: turn-100 snapshot checks every Great Power `gp1`–`gp6` has `peasants >= 15` AND `apprentices + journeymen + masters >= 8` (exit **8** on failure; requires `--max-turns >= 100` or no cap; Refs #2692 S10). |
 
 **Errors:** Diagnostics via `logger`; user-facing failures → **stderr** and non-zero exit; no raw stack traces by default (match `init_game`).
 
@@ -38,13 +39,14 @@ Active when **no** `--verify-*` flag is set.
 
 ### Minimal trace mode (auto when `--verify-*` is set)
 
-Active when **`--verify-conquest` and/or `--verify-colonial-expansion`** is passed (no separate nightly flag). Refs **#2534**.
+Active when **`--verify-conquest`, `--verify-colonial-expansion`, and/or `--verify-workforce`** is passed (no separate nightly flag). Refs **#2534**, **#2692 S10**.
 
 - **No** merged turn-trace JSON, **no** `.html`, **no** in-memory phase tracing (`onTurnTracePhase` / `turnTraceRuntime` off).
 - **ObserverSnapshot** JSON only on turns required by the active verify flags (union):
   - `--verify-conquest` → `turn-000001.snapshot.json`, `turn-000100.snapshot.json`
   - `--verify-colonial-expansion` → `turn-000150.snapshot.json`
-  - Both (nightly) → those **three** snapshots plus `run-summary.json` only.
+  - `--verify-workforce` → `turn-000100.snapshot.json`
+  - All three (nightly) → those **three** distinct snapshots (turns 1, 100, 150) plus `run-summary.json` only.
 - **`run-summary.json`** always written at end (`minimal_trace_mode: true` in summary when minimal mode ran).
 - **Artifact size cap:** cumulative bytes under the game trace directory must stay **strictly below 300 MB** (`300 * 1024 * 1024`); if a write would exceed the cap, the run aborts with exit **7** (`artifact_size_cap_exceeded`). Canonical nightly verify inputs are expected to be far below the cap; the cap guards regressions that reintroduce large artifacts.
 
@@ -92,11 +94,11 @@ Each **resolved turn** in the session loop measures the same segment as the app 
 
 Pass **`--verify-colonial-expansion`** after a successful run (exit **6** on failure; requires `--max-turns >= 150` or no turn cap). Rollup computation: `lib/observer_extractable_rollup.dart` (init static resource grid ∩ GP-owned provinces at verify turn; excludes capital and province town tiles per [extraction-and-improvements.md](../game/extraction-and-improvements.md)).
 
-Unit tests cover parsers; full observer runs are slow and are **not** in the default `quality` gate. **Nightly:** `.github/workflows/nightly.yml` job `observer_conquest_verify` runs seed **42**, **150** turns, **`--verify-conquest`**, and **`--verify-colonial-expansion`** daily at **23:00 Asia/Hong_Kong** (`0 15 * * *` UTC; `workflow_dispatch` supported).
+Unit tests cover parsers; full observer runs are slow and are **not** in the default `quality` gate. **Nightly:** `.github/workflows/nightly.yml` job `observer_conquest_verify` runs seed **42**, **150** turns, **`--verify-conquest`**, **`--verify-colonial-expansion`**, and **`--verify-workforce`** daily at **23:00 Asia/Hong_Kong** (`0 15 * * *` UTC; `workflow_dispatch` supported).
 
-## Workforce sustain verification (Refs #2692 S10a)
+## Workforce sustain verification (Refs #2692 S10)
 
-`lib/observer_workforce_verify.dart` reads `turn-000100.snapshot.json` and, per `gp1`–`gp6`, asserts `peasants >= 15` AND `apprentices + journeymen + masters >= 8`. Thresholds, parser contract, food/luxury follow-ups, and the deferred `--verify-workforce` CLI wiring (S10) are in [observer-workforce-verify.md](observer-workforce-verify.md).
+`lib/observer_workforce_verify.dart` reads `turn-000100.snapshot.json` and, per `gp1`–`gp6`, asserts `peasants >= 15` AND `apprentices + journeymen + masters >= 8`. Pass **`--verify-workforce`** after a successful run (exit **8** on failure; requires `--max-turns >= 100` or no turn cap). Food / luxury sustain checks (Requirement §21 bullets 3–4 of issue #2692) remain deferred behind `kObserverWorkforceFoodLuxuryDeferred`; thresholds, parser contract, and the deferral marker live in [observer-workforce-verify.md](observer-workforce-verify.md).
 
 ## Coverage
 

--- a/tool/run_observer_game/lib/observer_minimal_trace.dart
+++ b/tool/run_observer_game/lib/observer_minimal_trace.dart
@@ -1,5 +1,6 @@
 import 'observer_colonial_verify.dart';
 import 'observer_conquest_verify.dart';
+import 'observer_workforce_verify.dart';
 
 /// Exit code when verify-run artifact writes would exceed [kObserverVerifyArtifactSizeCapBytes].
 const int kExitArtifactSizeCapExceeded = 7;
@@ -8,9 +9,14 @@ const int kExitArtifactSizeCapExceeded = 7;
 const int kObserverVerifyArtifactSizeCapBytes = 300 * 1024 * 1024;
 
 /// Turn numbers for which [ObserverSnapshot] JSON is written in minimal trace mode.
+///
+/// The set unions the canonical turns required by every active verify flag so a
+/// single run can satisfy multiple downstream verifiers without re-running
+/// the campaign (Refs #2509, #2692 S10).
 Set<int> requiredObserverSnapshotTurns({
   required bool verifyConquest,
   required bool verifyColonialExpansion,
+  bool verifyWorkforce = false,
 }) {
   final turns = <int>{};
   if (verifyConquest) {
@@ -19,6 +25,9 @@ Set<int> requiredObserverSnapshotTurns({
   }
   if (verifyColonialExpansion) {
     turns.add(kObserverColonialCanonicalTurn);
+  }
+  if (verifyWorkforce) {
+    turns.add(kObserverWorkforceCanonicalTurn);
   }
   return turns;
 }

--- a/tool/run_observer_game/lib/observer_session_runner.dart
+++ b/tool/run_observer_game/lib/observer_session_runner.dart
@@ -27,6 +27,7 @@ Future<int> runObserverSession({
   int? maxTurnsCap,
   bool verifyConquest = false,
   bool verifyColonialExpansion = false,
+  bool verifyWorkforce = false,
   int verifyArtifactCapBytes = kObserverVerifyArtifactSizeCapBytes,
 }) async {
   late final InitGameResult init;
@@ -44,11 +45,13 @@ Future<int> runObserverSession({
     return 2;
   }
 
-  final minimalTraceMode = verifyConquest || verifyColonialExpansion;
+  final minimalTraceMode =
+      verifyConquest || verifyColonialExpansion || verifyWorkforce;
   final requiredSnapshotTurns = minimalTraceMode
       ? requiredObserverSnapshotTurns(
           verifyConquest: verifyConquest,
           verifyColonialExpansion: verifyColonialExpansion,
+          verifyWorkforce: verifyWorkforce,
         )
       : null;
 

--- a/tool/run_observer_game/lib/run_observer_game_cli.dart
+++ b/tool/run_observer_game/lib/run_observer_game_cli.dart
@@ -6,6 +6,7 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'observer_colonial_verify.dart';
 import 'observer_conquest_verify.dart';
 import 'observer_session_runner.dart';
+import 'observer_workforce_verify.dart';
 import 'setup_config_parser.dart';
 
 /// Exit code for usage / argument errors (sysexits.h EX_USAGE).
@@ -16,6 +17,9 @@ const int kExitConquestVerifyFailed = 5;
 
 /// Exit code when `--verify-colonial-expansion` fails (Refs #2509).
 const int kExitColonialVerifyFailed = 6;
+
+/// Exit code when `--verify-workforce` fails (Refs #2692 S10).
+const int kExitWorkforceVerifyFailed = 8;
 
 String _usage(ArgParser parser) {
   final buf = StringBuffer()
@@ -95,6 +99,16 @@ Future<int> runObserverGameCli(
           'snapshot: all newWorld| provinces owned by gp1–gp6 and >=70% of '
           'extractable GP resource tiles improved (requires --max-turns >= '
           '$kObserverColonialCanonicalTurn or omit cap).',
+    )
+    ..addFlag(
+      'verify-workforce',
+      help:
+          'After a successful run, verify the turn-'
+          '$kObserverWorkforceCanonicalTurn snapshot: each Great Power gp1–gp6 '
+          'has peasants >= $kObserverWorkforceMinPeasants AND '
+          'apprentices+journeymen+masters >= $kObserverWorkforceMinTrained '
+          '(requires --max-turns >= $kObserverWorkforceCanonicalTurn or omit '
+          'cap).',
     );
 
   late final ArgResults results;
@@ -167,6 +181,7 @@ Future<int> runObserverGameCli(
 
   final verifyConquest = results['verify-conquest'] == true;
   final verifyColonial = results['verify-colonial-expansion'] == true;
+  final verifyWorkforce = results['verify-workforce'] == true;
 
   if (verifyConquest &&
       maxTurnsCap != null &&
@@ -186,6 +201,15 @@ Future<int> runObserverGameCli(
     );
     return kExitUsage;
   }
+  if (verifyWorkforce &&
+      maxTurnsCap != null &&
+      maxTurnsCap < kObserverWorkforceCanonicalTurn) {
+    emitStderr(
+      'Error: --verify-workforce requires --max-turns >= '
+      '$kObserverWorkforceCanonicalTurn (got $maxTurnsCap).',
+    );
+    return kExitUsage;
+  }
 
   final sessionCode = await runObserverSession(
     outputRoot: outputRoot,
@@ -193,12 +217,13 @@ Future<int> runObserverGameCli(
     maxTurnsCap: maxTurnsCap,
     verifyConquest: verifyConquest,
     verifyColonialExpansion: verifyColonial,
+    verifyWorkforce: verifyWorkforce,
   );
   if (sessionCode != 0) {
     return sessionCode;
   }
 
-  if (!verifyConquest && !verifyColonial) {
+  if (!verifyConquest && !verifyColonial && !verifyWorkforce) {
     return 0;
   }
 
@@ -242,6 +267,26 @@ Future<int> runObserverGameCli(
       'turn $kObserverColonialCanonicalTurn, all newWorld| GP-owned, '
       'extractable improvement >= '
       '${(kObserverColonialMinImprovementRatio * 100).round()}%).',
+    );
+  }
+
+  if (verifyWorkforce) {
+    final failures = verifyObserverWorkforceFromTraceDir(
+      gameDir,
+      endTurn: kObserverWorkforceCanonicalTurn,
+    );
+    if (failures.isNotEmpty) {
+      for (final line in failures) {
+        emitStderr('workforce_verify: $line');
+      }
+      return kExitWorkforceVerifyFailed;
+    }
+    emitStdout(
+      'Workforce verification passed (seed=${setup.seed}, '
+      'turn $kObserverWorkforceCanonicalTurn, '
+      'peasants >= $kObserverWorkforceMinPeasants AND '
+      'apprentices+journeymen+masters >= $kObserverWorkforceMinTrained '
+      'per gp1–gp6).',
     );
   }
 

--- a/tool/run_observer_game/test/nightly_observer_workflow_pin_test.dart
+++ b/tool/run_observer_game/test/nightly_observer_workflow_pin_test.dart
@@ -81,7 +81,7 @@ void main() {
       );
     });
 
-    test('invokes run_observer_game with both verify flags and seed 42', () {
+    test('invokes run_observer_game with all verify flags and seed 42', () {
       expect(
         yaml,
         contains('dart run tool/run_observer_game/bin/run_observer_game.dart'),
@@ -91,6 +91,14 @@ void main() {
       expect(yaml, contains('--max-turns 150'));
       expect(yaml, contains('--verify-conquest'));
       expect(yaml, contains('--verify-colonial-expansion'));
+      expect(
+        yaml,
+        contains('--verify-workforce'),
+        reason:
+            'Issue #2692 S10 wires the workforce sustain gate into the '
+            'nightly observer campaign alongside conquest and colonial '
+            'verification.',
+      );
     });
 
     test('allows enough wall-clock budget for the 150-turn campaign', () {
@@ -139,6 +147,13 @@ void main() {
         reason:
             'quality.yml must not run --verify-colonial-expansion; that gate '
             'is reserved for the nightly job (Refs #2509).',
+      );
+      expect(
+        yaml.contains('--verify-workforce'),
+        isFalse,
+        reason:
+            'quality.yml must not run --verify-workforce; that gate is '
+            'reserved for the nightly job (Refs #2692 S10).',
       );
       // The CLI binary path must not appear as a "run:" step. Allow path
       // references that gate test scope ("tool/run_observer_game/**") but

--- a/tool/run_observer_game/test/observer_minimal_trace_test.dart
+++ b/tool/run_observer_game/test/observer_minimal_trace_test.dart
@@ -1,9 +1,20 @@
 import 'package:colonizethis_test/test.dart';
 
 import 'package:run_observer_game/observer_minimal_trace.dart';
+import 'package:run_observer_game/observer_workforce_verify.dart';
 
 void main() {
   group('requiredObserverSnapshotTurns', () {
+    test('no flags returns empty set (defensive)', () {
+      expect(
+        requiredObserverSnapshotTurns(
+          verifyConquest: false,
+          verifyColonialExpansion: false,
+        ),
+        isEmpty,
+      );
+    });
+
     test('conquest only requires turns 1 and 100', () {
       expect(
         requiredObserverSnapshotTurns(
@@ -24,6 +35,31 @@ void main() {
       );
     });
 
+    test('workforce only requires the canonical workforce turn', () {
+      expect(
+        requiredObserverSnapshotTurns(
+          verifyConquest: false,
+          verifyColonialExpansion: false,
+          verifyWorkforce: true,
+        ),
+        {kObserverWorkforceCanonicalTurn},
+      );
+    });
+
+    test('verifyWorkforce defaults to false', () {
+      expect(
+        requiredObserverSnapshotTurns(
+          verifyConquest: false,
+          verifyColonialExpansion: false,
+        ),
+        requiredObserverSnapshotTurns(
+          verifyConquest: false,
+          verifyColonialExpansion: false,
+          verifyWorkforce: false,
+        ),
+      );
+    });
+
     test('both verify flags require turns 1, 100, and 150', () {
       expect(
         requiredObserverSnapshotTurns(
@@ -33,6 +69,31 @@ void main() {
         {1, 100, 150},
       );
     });
+
+    test('conquest + workforce de-duplicates turn 100', () {
+      expect(
+        requiredObserverSnapshotTurns(
+          verifyConquest: true,
+          verifyColonialExpansion: false,
+          verifyWorkforce: true,
+        ),
+        {1, 100},
+      );
+    });
+
+    test(
+      'all three verify flags request distinct snapshot turns 1, 100, 150',
+      () {
+        expect(
+          requiredObserverSnapshotTurns(
+            verifyConquest: true,
+            verifyColonialExpansion: true,
+            verifyWorkforce: true,
+          ),
+          {1, 100, 150},
+        );
+      },
+    );
   });
 
   group('ObserverArtifactBudget', () {

--- a/tool/run_observer_game/test/run_observer_game_cli_test.dart
+++ b/tool/run_observer_game/test/run_observer_game_cli_test.dart
@@ -7,6 +7,7 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 
 import 'package:run_observer_game/observer_minimal_trace.dart';
 import 'package:run_observer_game/observer_session_runner.dart';
+import 'package:run_observer_game/observer_workforce_verify.dart';
 import 'package:run_observer_game/run_observer_game_cli.dart';
 
 /// Decodes `<pre>` text produced by `HtmlEscape` (snapshot HTML wrapper).
@@ -106,6 +107,47 @@ void main() {
       );
       expect(code, kExitUsage);
       expect(err.join('\n'), contains('verify-conquest'));
+    });
+
+    test('verify-workforce with low max-turns yields EX_USAGE', () async {
+      final out = <String>[];
+      final err = <String>[];
+      final tmp = Directory.systemTemp.createTempSync('roc_workforce_');
+      addTearDown(() => tmp.deleteSync(recursive: true));
+      final code = await runObserverGameCli(
+        [
+          '--output',
+          tmp.path,
+          '--max-turns',
+          '50',
+          '--verify-workforce',
+        ],
+        emitStdout: out.add,
+        emitStderr: err.add,
+      );
+      expect(code, kExitUsage);
+      final stderr = err.join('\n');
+      expect(stderr, contains('--verify-workforce'));
+      expect(
+        stderr,
+        contains('$kObserverWorkforceCanonicalTurn'),
+        reason:
+            'CLI usage error must surface the canonical workforce turn so '
+            'callers can fix --max-turns without spelunking SPEC.',
+      );
+    });
+
+    test('--help mentions --verify-workforce', () async {
+      final out = <String>[];
+      final err = <String>[];
+      final code = await runObserverGameCli(
+        ['--help'],
+        emitStdout: out.add,
+        emitStderr: err.add,
+      );
+      expect(code, 0);
+      expect(err, isEmpty);
+      expect(out.join('\n'), contains('verify-workforce'));
     });
 
     test('negative --max-turns yields EX_USAGE', () async {
@@ -342,6 +384,66 @@ void main() {
         );
 
         expect(code, kExitArtifactSizeCapExceeded);
+      },
+      timeout: const Timeout(Duration(minutes: 15)),
+    );
+
+    test(
+      'minimal trace mode honours verifyWorkforce union (turn-100 snapshot)',
+      () async {
+        final tmp = Directory.systemTemp.createTempSync('run_observer_wf_');
+        addTearDown(() => tmp.deleteSync(recursive: true));
+
+        final setup = GameSetupConfig(
+          selectedGreatPowerIds: const ['england', 'france'],
+          continentCount: 4,
+          minorNationCount: 2,
+          tribeCount: 2,
+          numProvincesOldWorld: 14,
+          numProvincesNewWorld: 6,
+          minProvincesPerMinor: 2,
+          seed: 11,
+        );
+
+        final code = await runObserverSession(
+          outputRoot: tmp.path,
+          setupConfig: setup,
+          maxTurnsCap: 1,
+          verifyWorkforce: true,
+        );
+
+        expect(code, 0);
+
+        final gameDir = Directory('${tmp.path}/observer-traces')
+            .listSync()
+            .whereType<Directory>()
+            .single;
+        final names = gameDir
+            .listSync()
+            .whereType<File>()
+            .map((f) => f.uri.pathSegments.last)
+            .toList()
+          ..sort();
+
+        expect(
+          names,
+          ['run-summary.json'],
+          reason:
+              '--verify-workforce + maxTurns=1 must not produce a turn-1 '
+              'snapshot (workforce only needs turn 100). The session ends '
+              'before turn 100 so no snapshot is written; only '
+              'run-summary.json remains.',
+        );
+        expect(names.where((n) => n.endsWith('.html')), isEmpty);
+
+        final summary = jsonDecode(
+              File('${gameDir.path}/run-summary.json').readAsStringSync(),
+            ) as Map<String, Object?>;
+        expect(summary['minimal_trace_mode'], isTrue);
+
+        final failures = verifyObserverWorkforceFromTraceDir(gameDir.path);
+        expect(failures, hasLength(1));
+        expect(failures.single, contains('missing end snapshot'));
       },
       timeout: const Timeout(Duration(minutes: 15)),
     );


### PR DESCRIPTION
## Scope

S10 slice for #2692: wires the S10a workforce sustain verifier (landed
in PR #2715) into the `run_observer_game` CLI and the nightly GitHub
workflow.

This is **partial** scope for issue #2692 S10. The CLI flag + nightly
gate ship in this PR; food / luxury sustain checks remain a follow-up
slice (see Deferred section).

## What lands

- **CLI**: `--verify-workforce` flag in
  `tool/run_observer_game/lib/run_observer_game_cli.dart`.
  - Requires `--max-turns >= 100` (or no cap); otherwise exits
    `kExitUsage` with a stderr line that mentions the canonical turn.
  - On verifier failure, exits new `kExitWorkforceVerifyFailed = 8`
    and emits one `workforce_verify: …` line on stderr per failure.
  - On success, emits a single confirmation line on stdout.
- **Session runner**:
  `runObserverSession(...)` accepts `verifyWorkforce: bool` and
  enables minimal trace mode + the canonical workforce turn (100)
  alongside conquest (1, 100) and colonial (150).
- **Required snapshot turns helper**:
  `requiredObserverSnapshotTurns(...)` adds an optional
  `verifyWorkforce` parameter; the set unions canonical turns so a
  three-flag nightly run still writes only three distinct snapshots
  (turns 1, 100, 150).
- **Nightly workflow**: `.github/workflows/nightly.yml` job
  `observer_conquest_verify` now passes `--verify-workforce` alongside
  the existing two verify flags. No timeout change.
- **SPEC**:
  - `SPEC/program/run_observer_game-tool.md`: CLI surface table gains
    a `--verify-workforce` row; § Workforce sustain verification
    upgraded from S10a (library-only) to S10 (CLI + nightly).
  - `SPEC/program/observer-workforce-verify.md`: Scope reorganised
    into a landed-across-S10a-and-S10 section; new ACs cover the
    EX_USAGE gate, verifier-failure stderr / exit contract, and the
    nightly workflow command line.

## Tests

- `observer_minimal_trace_test.dart` — new cases pin the
  `verifyWorkforce` parameter behaviour:
  - workforce-only → `{kObserverWorkforceCanonicalTurn}`
  - `verifyWorkforce` defaults to `false`
  - conquest + workforce de-duplicates turn 100 → `{1, 100}`
  - all three flags → distinct `{1, 100, 150}`
  - explicit empty-set defensive case
- `run_observer_game_cli_test.dart` — new cases:
  - `--help` surfaces the new flag
  - `--verify-workforce` with `--max-turns 50` yields `kExitUsage`
    and stderr mentions both the flag and the canonical turn (100)
  - Session smoke test: `verifyWorkforce: true, maxTurnsCap: 1`
    enters minimal trace mode, writes no snapshots (turn 100 never
    reached), and the verifier returns a single
    `missing end snapshot:` failure line.
- `nightly_observer_workflow_pin_test.dart`:
  - `nightly.yml` invokes `--verify-workforce` alongside conquest +
    colonial verify
  - `quality.yml` does not invoke `--verify-workforce` (gate stays
    nightly-only)

Local verification:

- `dart analyze tool/run_observer_game/lib tool/run_observer_game/test` — clean.
- `dart run custom_lint` (in `tool/run_observer_game`) — clean.
- `dart test` (in `tool/run_observer_game`) — **92 passed**, including
  all new minimal-trace, CLI, nightly-pin, and existing
  conquest/colonial/workforce verifier suites.

## AC mapping (#2692)

This slice begins satisfying issue #2692 § Acceptance criteria
**AC #7b (S10)** by enabling the workforce gate to run in nightly
verification with the S10a-finalized provisional thresholds
(`peasants >= 15`, `apprentices + journeymen + masters >= 8`). The
gate's first canonical run will be on the next scheduled nightly
campaign. Closing AC #7b also requires food / luxury production
checks — those remain a follow-up slice (see Deferred).

## Deferred (separate slice on #2692)

- Food production (`grain + meat`) and luxury production
  (`refinedSugar` / `cigars` / `furHats`) gates from Requirement §21
  bullets 3-4. Those require new `ObserverSnapshot` rollup fields and
  remain gated by `kObserverWorkforceFoodLuxuryDeferred = true` in
  `observer_workforce_verify.dart`.
- Any threshold revisions following observer-trace analysis on seed
  42 if the provisional thresholds prove too tight or too loose; the
  thresholds remain parameterised via
  `kObserverWorkforceMinPeasants` / `kObserverWorkforceMinTrained`
  constants for a quick follow-up bump if needed.

Refs #2692

Made with [Cursor](https://cursor.com)