### PR TITLE
feat(observer): luxury sustain check via ObserverSnapshot v4 (Refs #2692 S10b)

### DIFF
--- a/SPEC/program/observer-workforce-verify.md
+++ b/SPEC/program/observer-workforce-verify.md
@@ -1,10 +1,10 @@
 # Observer workforce sustain verifier
 
-**SPEC/program** — Verifier for the **15-regiment workforce sustain** metric from issue **#2692** Requirement §21. Lives in `tool/run_observer_game/lib/observer_workforce_verify.dart`. Consumes the `workerPool` block added to player rollups in `ObserverSnapshot` v3 (see [run_observer_game-tool.md](run_observer_game-tool.md)). Stakeholder decisions: GitHub **#2692**.
+**SPEC/program** — Verifier for the **15-regiment workforce sustain** metric from issue **#2692** Requirement §21. Lives in `tool/run_observer_game/lib/observer_workforce_verify.dart`. Consumes the `workerPool`, `luxuryStockpile`, and `lastTurnLuxuryProduction` blocks added to player rollups in `ObserverSnapshot` v3 / v4 (see [run_observer_game-tool.md](run_observer_game-tool.md)). Stakeholder decisions: GitHub **#2692**.
 
 ## Scope
 
-In scope (landed across **S10a** and **S10**):
+In scope (landed across **S10a**, **S10**, and **S10b**):
 
 - **Verifier library (S10a)**
   - Schema reader: `WorkerPoolCounts workerPoolCountsForPlayer(Map snapshotJson, String playerId)` returns the player's pool counts or `WorkerPoolCounts.zero` for missing / malformed / v2 rollups.
@@ -14,10 +14,15 @@ In scope (landed across **S10a** and **S10**):
   - `--verify-workforce` flag in `tool/run_observer_game/lib/run_observer_game_cli.dart`. Requires `--max-turns >= kObserverWorkforceCanonicalTurn` (or no cap). On verification failure the CLI exits with code **`kExitWorkforceVerifyFailed` (8)** and emits one `workforce_verify: …` line on stderr per failure. On pass, the CLI emits a single confirmation line on stdout.
   - When `--verify-workforce` is the only active verify flag the runner enters minimal trace mode (no merged trace, no HTML) and writes only `turn-000100.snapshot.json` plus `run-summary.json` (Refs #2534). Combined verify flags union their canonical turns via `requiredObserverSnapshotTurns(...)` in `observer_minimal_trace.dart`.
   - `.github/workflows/nightly.yml` job `observer_conquest_verify` runs `--verify-workforce` alongside `--verify-conquest` and `--verify-colonial-expansion` daily at **23:00 Asia/Hong_Kong** (`0 15 * * *` UTC).
+- **Luxury sustain (S10b)**
+  - Schema reader: `int luxuryAvailableForPlayer(Map snapshotJson, String playerId, String commodityId)` returns `luxuryStockpile + lastTurnLuxuryProduction` for the given commodity, or `0` when the player rollup or either block is missing (older v3 snapshots).
+  - Per-GP luxury verifier: `List<String> verifyPerGpLuxurySustain({required Map turnEndSnapshot})` checks `available >= tier count` for each `(tier, matched luxury commodity)` pair where the tier count is non-zero, in fixed iteration order apprentice → journeyman → master, per Great Power.
+  - `verifyPerGpWorkforceSustain` and `verifyObserverWorkforceFromTraceDir` accept `checkLuxurySustain` (default `true`); callers may opt out for back-compat with v3 snapshot fixtures.
+  - Snapshot capture wiring: `observer_session_runner.dart` passes `onProductionComplete` into `validateOrdersAndResolveTurnFromTrustedOrders` and forwards the resulting `productionByRecipeByPlayerId` to `buildObserverSnapshotJson`, which aggregates recipe outputs by `outputCommodityId` for the three v4 luxury commodities.
 
 Out of scope (tracked as #2692 follow-ups):
 
-- Food production (`grain + meat`) and luxury production (`refinedSugar` / `cigars` / `furHats`) checks from Requirement §21 bullets 3–4. These require new snapshot fields (production / stockpile rollups) and are gated by `kObserverWorkforceFoodLuxuryDeferred` in the verifier so future work can grep the marker.
+- Food production (`grain + meat`) checks from Requirement §21 bullet 3. Grain and meat are extracted (not recipe outputs) so a per-turn production snapshot needs a different data channel than the production-phase callback. Gated by `kObserverWorkforceFoodProductionDeferred` in the verifier so future work can grep the marker. The legacy alias `kObserverWorkforceFoodLuxuryDeferred` is preserved as a `@Deprecated` constant pointing at the new flag so existing call sites do not regress silently.
 
 ## Provisional thresholds (v1; tunable in S10a)
 
@@ -28,7 +33,12 @@ Per Requirement §21 of issue **#2692**, recorded here as the source of truth fo
 | `kObserverWorkforceCanonicalTurn` | `100` | Turn whose snapshot is read by `verifyObserverWorkforceFromTraceDir`. |
 | `kObserverWorkforceMinPeasants` | `15` | Lower bound on `peasants` per Great Power; covers one full 15-regiment build cycle plus a reservation buffer per `SPEC/game/workers-and-population.md` § Peasant reservation. |
 | `kObserverWorkforceMinTrained` | `8` | Lower bound on `apprentices + journeymen + masters` per Great Power; effective-labour buffer for production chains. |
-| `kObserverWorkforceFoodLuxuryDeferred` | `true` | Documents that food / luxury sustain checks are not enforced yet. |
+| `kObserverWorkforceFoodProductionDeferred` | `true` | Documents that food production (grain + meat) sustain checks are not yet enforced. Luxury sustain is enforced (S10b). |
+| `kObserverWorkforceFoodLuxuryDeferred` | `true` (`@Deprecated`) | Back-compat alias pointing at `kObserverWorkforceFoodProductionDeferred`; new code should reference the narrower flag. |
+| `kObserverWorkforceApprenticeLuxuryCommodityId` | `refinedSugar` | Matched luxury commodity for the apprentice tier (§21 bullet 4). |
+| `kObserverWorkforceJourneymanLuxuryCommodityId` | `cigars` | Matched luxury commodity for the journeyman tier. |
+| `kObserverWorkforceMasterLuxuryCommodityId` | `furHats` | Matched luxury commodity for the master tier. |
+| `kObserverWorkforceLuxuryTierMapping` | `[(apprentices, refinedSugar), (journeymen, cigars), (masters, furHats)]` | Fixed iteration order driving `verifyPerGpLuxurySustain` failure ordering. |
 
 S10a observer-trace analysis on **seed 42** (issue #2692 AC #7a) may revise these constants before the nightly gate (S10) is wired; the defaults above are the starting point.
 
@@ -69,3 +79,27 @@ S10a observer-trace analysis on **seed 42** (issue #2692 AC #7a) may revise thes
 - Given the nightly workflow `.github/workflows/nightly.yml` job `observer_conquest_verify`  
   When the System renders the rendered `dart run …/run_observer_game.dart …` command line  
   Then the command line contains `--verify-conquest`, `--verify-colonial-expansion`, **and** `--verify-workforce`, plus `--seed 42` and `--max-turns 150`.
+
+- Given a v4 player rollup with `luxuryStockpile = {refinedSugar: 4}` and `lastTurnLuxuryProduction = {refinedSugar: 3}` for `playerId = gp1`  
+  When the System invokes `luxuryAvailableForPlayer(snapshot, 'gp1', 'refinedSugar')`  
+  Then the System returns `7` (sum of stockpile and last-turn production).
+
+- Given a v3 player rollup that has no `luxuryStockpile` or `lastTurnLuxuryProduction` blocks  
+  When the System invokes `luxuryAvailableForPlayer(snapshot, playerId, commodityId)` for any commodity id  
+  Then the System returns `0` (treats missing blocks as zero availability).
+
+- Given a v4 snapshot where every `gp1`–`gp6` rollup has zero apprentices, journeymen, and masters  
+  When the System invokes `verifyPerGpLuxurySustain(turnEndSnapshot: snapshot)`  
+  Then the System returns an empty `List<String>` regardless of `luxuryStockpile` or `lastTurnLuxuryProduction` values (tier counts of `0` skip the check).
+
+- Given a v4 snapshot for `gp1` with `workerPool = {peasants: 20, apprentices: 4, journeymen: 2, masters: 1}` and matched luxury blocks `{refinedSugar: 1+1, cigars: 0+1, furHats: 0+0}` (`stockpile + production` per commodity)  
+  When the System invokes `verifyPerGpLuxurySustain(turnEndSnapshot: snapshot)`  
+  Then the System returns exactly three failure lines in fixed order starting with `gp1 apprentices=4 refinedSugar_available=2 …`, `gp1 journeymen=2 cigars_available=1 …`, and `gp1 masters=1 furHats_available=0 …`, and each line ends with `(need <commodityId>_available >= <tier count>)`.
+
+- Given a v4 snapshot where every `gp1`–`gp6` rollup has `workerPool.apprentices = 5`, `workerPool.journeymen = 3`, `workerPool.masters = 1`, and matched luxury blocks with `stockpile + production >= tier count` for every tier  
+  When the System invokes `verifyPerGpWorkforceSustain(turnEndSnapshot: snapshot)` with default arguments  
+  Then the System returns an empty `List<String>` (the luxury pass runs but reports no shortfalls).
+
+- Given a v4 snapshot where every `gp1`–`gp6` rollup meets the peasant / trained thresholds but has zero `luxuryStockpile` and zero `lastTurnLuxuryProduction` for every commodity  
+  When the System invokes `verifyPerGpWorkforceSustain(turnEndSnapshot: snapshot, checkLuxurySustain: false)`  
+  Then the System returns an empty `List<String>` (opt-out preserves S10a behaviour for v3-style fixtures).

--- a/SPEC/program/run_observer_game-tool.md
+++ b/SPEC/program/run_observer_game-tool.md
@@ -50,18 +50,18 @@ Active when **`--verify-conquest`, `--verify-colonial-expansion`, and/or `--veri
 - **`run-summary.json`** always written at end (`minimal_trace_mode: true` in summary when minimal mode ran).
 - **Artifact size cap:** cumulative bytes under the game trace directory must stay **strictly below 300 MB** (`300 * 1024 * 1024`); if a write would exceed the cap, the run aborts with exit **7** (`artifact_size_cap_exceeded`). Canonical nightly verify inputs are expected to be far below the cap; the cap guards regressions that reintroduce large artifacts.
 
-## ObserverSnapshot (`ObserverSnapshot` v3)
+## ObserverSnapshot (`ObserverSnapshot` v4)
 
-Versioned map written to `turn-<nnnnnn>.snapshot.json` and embedded (escaped) in paired `turn-<nnnnnn>.html`. **`observerSnapshotSchemaVersion` is `3`** (Refs **#2692** S10a; v3 adds per-player `workerPool`).
+Versioned map written to `turn-<nnnnnn>.snapshot.json` and embedded (escaped) in paired `turn-<nnnnnn>.html`. **`observerSnapshotSchemaVersion` is `4`** (Refs **#2692** S10a → S10b; v3 added per-player `workerPool`, v4 adds per-player `luxuryStockpile` + `lastTurnLuxuryProduction`).
 
 | Field | Meaning |
 |-------|---------|
-| `observerSnapshotSchemaVersion` | `3` (v2 lacked `workerPool`; v1 lacked extraction rollups). |
+| `observerSnapshotSchemaVersion` | `4` (v3 lacked luxury rollups; v2 lacked `workerPool`; v1 lacked extraction rollups). |
 | `gameId` | Game id string. |
 | `turnNumber` | Post-resolution turn index (`Game.worldState.turnState.turnNumber`). |
 | `calendarYearAtTurnStart` | `yearAtTurn(turnNumber)` using the game's active `TurnTimeMapping` (if `turnNumber` is below 1, the lookup uses 1). |
 | `calendarCampaignHalted` | Mirrors `Game.calendarCampaignHalted`. |
-| `players` | One object per `game.players`: ids, display name, human flag, GP power score, treasury, military strength / fleet hints, sorted tech unlock ids, **`workerPool`** (peasants / apprentices / journeymen / masters mirroring `Player.workerPool`). |
+| `players` | One object per `game.players`: ids, display name, human flag, GP power score, treasury, military strength / fleet hints, sorted tech unlock ids, **`workerPool`** (peasants / apprentices / journeymen / masters mirroring `Player.workerPool`), **`luxuryStockpile`** (`refinedSugar`, `cigars`, `furHats` quantities from `Player.stockpile`, with absent commodities serialized as `0`), and **`lastTurnLuxuryProduction`** (same three commodity ids, summed from the most recent `productionByRecipeByPlayerId` callback when `buildObserverSnapshotJson` is passed `lastTurnProductionByRecipeByPlayerId`; absent player ids and non-luxury recipe outputs serialize to `0`). |
 | `provinceOwnershipSorted` | Sorted list of `{ id, ownerId }` for every province (`allProvinces`), ids prefixed per world model. |
 | `diplomacyRelationSummariesSorted` | Stable string lines summarizing each `diplomacyRelations` row (pair, score, level, war/peace). |
 | `militaryArmySummariesSorted` | One string per land army (id, owner, region, regiment count). |
@@ -96,9 +96,9 @@ Pass **`--verify-colonial-expansion`** after a successful run (exit **6** on fai
 
 Unit tests cover parsers; full observer runs are slow and are **not** in the default `quality` gate. **Nightly:** `.github/workflows/nightly.yml` job `observer_conquest_verify` runs seed **42**, **150** turns, **`--verify-conquest`**, **`--verify-colonial-expansion`**, and **`--verify-workforce`** daily at **23:00 Asia/Hong_Kong** (`0 15 * * *` UTC; `workflow_dispatch` supported).
 
-## Workforce sustain verification (Refs #2692 S10)
+## Workforce sustain verification (Refs #2692 S10 + S10b)
 
-`lib/observer_workforce_verify.dart` reads `turn-000100.snapshot.json` and, per `gp1`–`gp6`, asserts `peasants >= 15` AND `apprentices + journeymen + masters >= 8`. Pass **`--verify-workforce`** after a successful run (exit **8** on failure; requires `--max-turns >= 100` or no turn cap). Food / luxury sustain checks (Requirement §21 bullets 3–4 of issue #2692) remain deferred behind `kObserverWorkforceFoodLuxuryDeferred`; thresholds, parser contract, and the deferral marker live in [observer-workforce-verify.md](observer-workforce-verify.md).
+`lib/observer_workforce_verify.dart` reads `turn-000100.snapshot.json` and, per `gp1`–`gp6`, asserts `peasants >= 15` AND `apprentices + journeymen + masters >= 8` AND, for each trained tier with a non-zero count, `luxuryStockpile + lastTurnLuxuryProduction >= tier count` for the matched luxury commodity (`apprentices ↔ refinedSugar`, `journeymen ↔ cigars`, `masters ↔ furHats` — Requirement §21 bullet 4 of issue #2692). Pass **`--verify-workforce`** after a successful run (exit **8** on failure; requires `--max-turns >= 100` or no turn cap). Food production sustain (§21 bullet 3, `grain + meat`) remains deferred behind `kObserverWorkforceFoodProductionDeferred`; thresholds, parser contract, and the deferral marker live in [observer-workforce-verify.md](observer-workforce-verify.md). `ObserverSnapshot` v4 surfaces `luxuryStockpile` and `lastTurnLuxuryProduction` per player; the session runner wires `onProductionComplete` through `validateOrdersAndResolveTurnFromTrustedOrders` and forwards the captured `productionByRecipeByPlayerId` into `buildObserverSnapshotJson` for aggregation.
 
 ## Coverage
 

--- a/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
@@ -190,6 +190,8 @@ TurnResolutionResult validateOrdersAndResolveTurnFromTrustedOrders({
   GameEventBus? eventBus,
   void Function(DialogueEvent)? onDialogue,
   void Function(GameEvent)? onGameEvent,
+  void Function(Map<String, Map<String, int>> productionByRecipeByPlayerId)?
+  onProductionComplete,
   void Function(TurnPhase phase, TurnPhaseProgressMarker marker)?
   onPhaseProgress,
   void Function(TurnTracePhaseTrace phaseTrace)? onTurnTracePhase,
@@ -200,6 +202,7 @@ TurnResolutionResult validateOrdersAndResolveTurnFromTrustedOrders({
     eventBus: eventBus,
     onDialogue: onDialogue,
     onGameEvent: onGameEvent,
+    onProductionComplete: onProductionComplete,
     topology: topology,
     orders: orders,
     tileMapByRegion: tileMapByRegion,

--- a/tool/run_observer_game/lib/observer_session_runner.dart
+++ b/tool/run_observer_game/lib/observer_session_runner.dart
@@ -131,6 +131,16 @@ Future<int> runObserverSession({
         (pid, plan) => MapEntry(pid, plan.productionAssignments),
       );
 
+      Map<String, Map<String, int>>? lastTurnProductionByRecipeByPlayerId;
+      void captureProductionComplete(
+        Map<String, Map<String, int>> productionByRecipeByPlayerId,
+      ) {
+        lastTurnProductionByRecipeByPlayerId = productionByRecipeByPlayerId.map(
+          (pid, byRecipe) =>
+              MapEntry(pid, Map<String, int>.unmodifiable(byRecipe)),
+        );
+      }
+
       final TurnResolutionResult result;
       if (minimalTraceMode) {
         result = validateOrdersAndResolveTurnFromTrustedOrders(
@@ -139,6 +149,7 @@ Future<int> runObserverSession({
           orders: mergedOrders,
           tileMapByRegion: init.tileMapByRegion,
           defaultAssignmentsByPlayerId: defaultAssignmentsByPlayerId,
+          onProductionComplete: captureProductionComplete,
         );
       } else {
         final phaseTraces = <TurnTracePhaseTrace>[];
@@ -151,6 +162,7 @@ Future<int> runObserverSession({
           orders: mergedOrders,
           tileMapByRegion: init.tileMapByRegion,
           defaultAssignmentsByPlayerId: defaultAssignmentsByPlayerId,
+          onProductionComplete: captureProductionComplete,
           onTurnTracePhase: phaseTraces.add,
           turnTraceRuntime: traceRuntime,
         );
@@ -197,6 +209,8 @@ Future<int> runObserverSession({
           game,
           postResolutionTurnNumber: postTurn,
           tileMapByRegion: init.tileMapByRegion,
+          lastTurnProductionByRecipeByPlayerId:
+              lastTurnProductionByRecipeByPlayerId,
         );
         final snapshotText = encodeObserverSnapshotJson(snap);
         await writeTraceArtifact(

--- a/tool/run_observer_game/lib/observer_snapshot_v1.dart
+++ b/tool/run_observer_game/lib/observer_snapshot_v1.dart
@@ -9,16 +9,35 @@ import 'observer_extractable_rollup.dart';
 
 /// Observer canonical snapshot (SPEC/program/run_observer_game-tool.md).
 ///
+/// **v4 (Refs #2692 S10b):** Adds `luxuryStockpile` and
+/// `lastTurnLuxuryProduction` per player rollup
+/// (`refinedSugar`, `cigars`, `furHats`) so the workforce sustain
+/// verifier can enforce Requirement §21 bullet 4 (`stockpile + production
+/// >= trained-tier count`) for each luxury commodity at turn 100.
+/// Older readers may continue treating absent fields as zero; the
+/// schema version bump signals the new rollup is available.
+///
 /// **v3 (Refs #2692 S10a):** Adds `workerPool` per player rollup
 /// (`peasants`, `apprentices`, `journeymen`, `masters`) so workforce
 /// growth and 15-regiment sustain can be verified from snapshots at
 /// turn 100 without rerunning the campaign.
-const int observerSnapshotSchemaVersion = 3;
+const int observerSnapshotSchemaVersion = 4;
+
+/// Luxury commodity ids whose production and stockpile are surfaced
+/// in the v4 player rollup for workforce sustain verification.
+/// Ordering matches `SPEC/game/workers-and-population.md` § Tech gates
+/// (apprentice → journeyman → master).
+const List<String> kObserverSnapshotLuxuryCommodityIds = <String>[
+  'refinedSugar',
+  'cigars',
+  'furHats',
+];
 
 Map<String, Object?> buildObserverSnapshotJson(
   Game game, {
   required int postResolutionTurnNumber,
   Map<String, TileMapResult>? tileMapByRegion,
+  Map<String, Map<String, int>>? lastTurnProductionByRecipeByPlayerId,
 }) {
   final mapping = game.turnTimeMapping ?? TurnTimeMapping.gdd01;
 
@@ -34,6 +53,26 @@ Map<String, Object?> buildObserverSnapshotJson(
         (p.techUnlocked?.keys.map((k) => k.toString()).toList() ?? <String>[])
           ..sort();
     final pool = p.workerPool;
+    final luxuryStockpile = <String, Object?>{
+      for (final id in kObserverSnapshotLuxuryCommodityIds)
+        id: p.stockpile.quantityOf(id),
+    };
+    final productionByRecipe =
+        lastTurnProductionByRecipeByPlayerId?[p.id] ?? const <String, int>{};
+    final lastTurnLuxuryProduction = <String, Object?>{
+      for (final id in kObserverSnapshotLuxuryCommodityIds) id: 0,
+    };
+    for (final entry in productionByRecipe.entries) {
+      final recipe = ProductionRecipesCatalog.byId[entry.key];
+      if (recipe == null) continue;
+      final outputCommodityId = recipe.outputCommodityId;
+      if (!kObserverSnapshotLuxuryCommodityIds.contains(outputCommodityId)) {
+        continue;
+      }
+      final outputQty = entry.value * recipe.outputQuantity;
+      final current = lastTurnLuxuryProduction[outputCommodityId] as int;
+      lastTurnLuxuryProduction[outputCommodityId] = current + outputQty;
+    }
     playerRollups.add(<String, Object?>{
       'playerId': p.id,
       'displayName': p.displayName,
@@ -52,6 +91,8 @@ Map<String, Object?> buildObserverSnapshotJson(
         'journeymen': pool.journeymen,
         'masters': pool.masters,
       },
+      'luxuryStockpile': luxuryStockpile,
+      'lastTurnLuxuryProduction': lastTurnLuxuryProduction,
     });
   }
 

--- a/tool/run_observer_game/lib/observer_workforce_verify.dart
+++ b/tool/run_observer_game/lib/observer_workforce_verify.dart
@@ -3,11 +3,12 @@ import 'dart:io';
 
 import 'observer_conquest_verify.dart';
 
-/// Workforce sustain verifier (Refs #2692 S10a).
+/// Workforce sustain verifier (Refs #2692 S10a + S10b).
 ///
-/// Reads per-player `workerPool` from a turn-100 `ObserverSnapshot` v3 and
-/// checks the provisional 15-regiment workforce sustain metric for each
-/// canonical Great Power (`gp1`–`gp6`):
+/// Reads per-player `workerPool`, `luxuryStockpile`, and
+/// `lastTurnLuxuryProduction` from a turn-100 `ObserverSnapshot` v4 and
+/// checks the 15-regiment workforce sustain metric for each canonical
+/// Great Power (`gp1`–`gp6`):
 ///
 /// 1. **Peasant buffer** — `peasants >= kObserverWorkforceMinPeasants`
 ///    (default `15`, sufficient for one full 15-regiment build cycle
@@ -16,11 +17,20 @@ import 'observer_conquest_verify.dart';
 /// 2. **Trained-tier buffer** — `apprentices + journeymen + masters >=
 ///    kObserverWorkforceMinTrained` (default `8`, effective-labour buffer
 ///    for production chains per Requirement §21 of issue #2692).
+/// 3. **Luxury sustain (§21 bullet 4)** — for each trained tier with a
+///    non-zero count, the matched luxury commodity's snapshot
+///    `luxuryStockpile + lastTurnLuxuryProduction` must be at least the
+///    tier count:
+///    - apprentices ↔ `refinedSugar`
+///    - journeymen ↔ `cigars`
+///    - masters ↔ `furHats`
+///    Players with a zero count for a tier always pass that tier's
+///    luxury check (no requirement when nobody consumes the luxury).
 ///
-/// The food/luxury sustain checks listed in Requirement §21 are deferred
-/// to a follow-up slice: `ObserverSnapshot` v3 exposes worker counts only
-/// — `stockpile`, `food production`, and per-tier luxury production
-/// summaries are not in scope here. `kObserverWorkforceFoodLuxuryDeferred`
+/// **Deferred:** Food production sustain (§21 bullet 3, `grain + meat`)
+/// remains out of scope — grain and meat are extracted (not recipe
+/// outputs) so a per-turn production snapshot needs a different data
+/// channel than the production-phase callback. `kObserverWorkforceFoodProductionDeferred`
 /// documents the deferral as a value developers can grep for when the
 /// next slice lands.
 const int kObserverWorkforceCanonicalTurn = 100;
@@ -32,10 +42,41 @@ const int kObserverWorkforceMinPeasants = 15;
 /// masters) per Great Power on the turn-100 snapshot.
 const int kObserverWorkforceMinTrained = 8;
 
-/// Deferral marker: food and luxury sustain checks (§21 bullets 3 and 4)
-/// are NOT enforced by this verifier yet. The marker exists so future
-/// work can surface every gated check in one search.
-const bool kObserverWorkforceFoodLuxuryDeferred = true;
+/// Deferral marker: food production sustain (§21 bullet 3) is NOT
+/// enforced by this verifier yet. Luxury sustain (§21 bullet 4) is
+/// enforced from `ObserverSnapshot` v4 onward — see
+/// `verifyPerGpLuxurySustain`. The flag exists so future work can
+/// surface every still-gated check in one search.
+const bool kObserverWorkforceFoodProductionDeferred = true;
+
+/// Back-compat alias for the original deferral flag. The narrower
+/// `kObserverWorkforceFoodProductionDeferred` is the canonical name
+/// going forward; luxury sustain is no longer deferred.
+@Deprecated(
+  'Use kObserverWorkforceFoodProductionDeferred; luxury sustain is now '
+  'enforced by verifyPerGpLuxurySustain (Refs #2692 S10b).',
+)
+const bool kObserverWorkforceFoodLuxuryDeferred =
+    kObserverWorkforceFoodProductionDeferred;
+
+/// Luxury commodity required for the apprentice tier (§21 bullet 4).
+const String kObserverWorkforceApprenticeLuxuryCommodityId = 'refinedSugar';
+
+/// Luxury commodity required for the journeyman tier (§21 bullet 4).
+const String kObserverWorkforceJourneymanLuxuryCommodityId = 'cigars';
+
+/// Luxury commodity required for the master tier (§21 bullet 4).
+const String kObserverWorkforceMasterLuxuryCommodityId = 'furHats';
+
+/// Ordered tier → matched luxury commodity for the §21 bullet 4
+/// luxury sustain check. Iteration order is fixed (apprentice →
+/// journeyman → master) so failure lines are emitted deterministically.
+const List<({String tier, String commodityId})>
+    kObserverWorkforceLuxuryTierMapping = <({String tier, String commodityId})>[
+  (tier: 'apprentices', commodityId: kObserverWorkforceApprenticeLuxuryCommodityId),
+  (tier: 'journeymen', commodityId: kObserverWorkforceJourneymanLuxuryCommodityId),
+  (tier: 'masters', commodityId: kObserverWorkforceMasterLuxuryCommodityId),
+];
 
 /// Per-Great-Power worker pool counts parsed from an
 /// `ObserverSnapshot` v3 player rollup.
@@ -96,12 +137,56 @@ WorkerPoolCounts workerPoolCountsForPlayer(
   return WorkerPoolCounts.zero;
 }
 
+int _readCommodityFromBlock(Object? block, String commodityId) {
+  if (block is! Map<String, Object?>) return 0;
+  return _readInt(block[commodityId]);
+}
+
+/// Returns the v4 `luxuryStockpile + lastTurnLuxuryProduction` total for
+/// [playerId] and [commodityId] in [snapshotJson], or `0` when either
+/// block is missing (older v3 snapshots or absent player row).
+///
+/// Per Requirement §21 bullet 4 of issue #2692, the luxury sustain check
+/// compares this **stockpile + production** sum against the matched
+/// trained-tier count: a player with zero stockpile but enough per-turn
+/// production must still pass.
+int luxuryAvailableForPlayer(
+  Map<String, Object?> snapshotJson,
+  String playerId,
+  String commodityId,
+) {
+  final players = snapshotJson['players'];
+  if (players is! List<Object?>) return 0;
+  for (final row in players) {
+    if (row is! Map<String, Object?>) continue;
+    if (row['playerId']?.toString() != playerId) continue;
+    final stockpile = _readCommodityFromBlock(
+      row['luxuryStockpile'],
+      commodityId,
+    );
+    final production = _readCommodityFromBlock(
+      row['lastTurnLuxuryProduction'],
+      commodityId,
+    );
+    return stockpile + production;
+  }
+  return 0;
+}
+
 /// Returns human-readable failure lines; empty when every Great Power
 /// in [kObserverGreatPowerIds] meets both thresholds.
+///
+/// When [checkLuxurySustain] is `true` (default), each GP also passes
+/// the §21 bullet 4 luxury sustain check via [verifyPerGpLuxurySustain]
+/// — `luxuryStockpile + lastTurnLuxuryProduction >= tier count` for
+/// every trained tier with a non-zero count. Pass `false` to limit the
+/// verifier to the S10a thresholds (used by callers that read older v3
+/// snapshots without luxury fields).
 List<String> verifyPerGpWorkforceSustain({
   required Map<String, Object?> turnEndSnapshot,
   int minPeasants = kObserverWorkforceMinPeasants,
   int minTrained = kObserverWorkforceMinTrained,
+  bool checkLuxurySustain = true,
 }) {
   final failures = <String>[];
   for (final gpId in kObserverGreatPowerIds) {
@@ -120,7 +205,90 @@ List<String> verifyPerGpWorkforceSustain({
       );
     }
   }
+  if (checkLuxurySustain) {
+    failures.addAll(
+      verifyPerGpLuxurySustain(turnEndSnapshot: turnEndSnapshot),
+    );
+  }
   return failures;
+}
+
+/// Returns one failure line per `(GP, tier)` whose
+/// `luxuryStockpile + lastTurnLuxuryProduction` is below the tier
+/// count for the matched luxury commodity (§21 bullet 4). Tiers with
+/// a zero count for a given GP are skipped (no requirement when no
+/// worker consumes the luxury).
+///
+/// Failure line format:
+///
+///     <gpId> <tier>=<count> <commodityId>_available=<available>
+///         stockpile=<stockpile> lastTurnProduction=<production>
+///
+/// `available = stockpile + lastTurnProduction`. Both summands are
+/// reported so the operator can quickly see whether the buffer or
+/// the production rate is the bottleneck.
+List<String> verifyPerGpLuxurySustain({
+  required Map<String, Object?> turnEndSnapshot,
+}) {
+  final failures = <String>[];
+  for (final gpId in kObserverGreatPowerIds) {
+    final counts = workerPoolCountsForPlayer(turnEndSnapshot, gpId);
+    final byTier = <String, int>{
+      'apprentices': counts.apprentices,
+      'journeymen': counts.journeymen,
+      'masters': counts.masters,
+    };
+    for (final entry in kObserverWorkforceLuxuryTierMapping) {
+      final tierCount = byTier[entry.tier] ?? 0;
+      if (tierCount <= 0) continue;
+      final stockpile = _readCommodityFromBlock(
+        _luxuryStockpileBlockFor(turnEndSnapshot, gpId),
+        entry.commodityId,
+      );
+      final production = _readCommodityFromBlock(
+        _lastTurnLuxuryProductionBlockFor(turnEndSnapshot, gpId),
+        entry.commodityId,
+      );
+      final available = stockpile + production;
+      if (available < tierCount) {
+        failures.add(
+          '$gpId ${entry.tier}=$tierCount '
+          '${entry.commodityId}_available=$available '
+          'stockpile=$stockpile lastTurnProduction=$production '
+          '(need ${entry.commodityId}_available >= $tierCount)',
+        );
+      }
+    }
+  }
+  return failures;
+}
+
+Object? _luxuryStockpileBlockFor(
+  Map<String, Object?> snapshotJson,
+  String playerId,
+) {
+  final players = snapshotJson['players'];
+  if (players is! List<Object?>) return null;
+  for (final row in players) {
+    if (row is! Map<String, Object?>) continue;
+    if (row['playerId']?.toString() != playerId) continue;
+    return row['luxuryStockpile'];
+  }
+  return null;
+}
+
+Object? _lastTurnLuxuryProductionBlockFor(
+  Map<String, Object?> snapshotJson,
+  String playerId,
+) {
+  final players = snapshotJson['players'];
+  if (players is! List<Object?>) return null;
+  for (final row in players) {
+    if (row is! Map<String, Object?>) continue;
+    if (row['playerId']?.toString() != playerId) continue;
+    return row['lastTurnLuxuryProduction'];
+  }
+  return null;
 }
 
 Map<String, Object?> _loadSnapshot(String path) {
@@ -139,6 +307,7 @@ List<String> verifyObserverWorkforceFromTraceDir(
   int endTurn = kObserverWorkforceCanonicalTurn,
   int minPeasants = kObserverWorkforceMinPeasants,
   int minTrained = kObserverWorkforceMinTrained,
+  bool checkLuxurySustain = true,
 }) {
   final endPath = observerTurnSnapshotPath(
     tracesGameDir: tracesGameDir,
@@ -151,5 +320,6 @@ List<String> verifyObserverWorkforceFromTraceDir(
     turnEndSnapshot: _loadSnapshot(endPath),
     minPeasants: minPeasants,
     minTrained: minTrained,
+    checkLuxurySustain: checkLuxurySustain,
   );
 }

--- a/tool/run_observer_game/test/observer_snapshot_worker_pool_test.dart
+++ b/tool/run_observer_game/test/observer_snapshot_worker_pool_test.dart
@@ -3,11 +3,16 @@ import 'package:colonizethis_test/test.dart';
 
 import 'package:run_observer_game/observer_snapshot_v1.dart';
 
-/// Refs #2692 S10a: `ObserverSnapshot` v3 must surface per-player
-/// `workerPool` counts so the workforce sustain verifier can read
-/// peasants and trained-tier counts directly from the snapshot.
+/// Refs #2692 S10a + S10b: `ObserverSnapshot` v3 surfaced per-player
+/// `workerPool` counts; v4 adds `luxuryStockpile` and
+/// `lastTurnLuxuryProduction` rollups so the workforce sustain
+/// verifier can enforce §21 bullet 4 (`stockpile + production >=
+/// trained-tier count`).
 void main() {
-  Game _gameWithPools(Map<String, WorkerPool> poolByPlayerId) {
+  Game gameWithPools(
+    Map<String, WorkerPool> poolByPlayerId, {
+    Map<String, Stockpile> stockpileByPlayerId = const {},
+  }) {
     return Game(
       id: 'g-workforce',
       worldState: WorldState(
@@ -22,18 +27,19 @@ void main() {
             displayName: entry.key.toUpperCase(),
             isHuman: false,
             workerPool: entry.value,
+            stockpile: stockpileByPlayerId[entry.key] ?? Stockpile.empty,
           ),
       ],
     );
   }
 
-  group('ObserverSnapshot v3 worker pool exposure', () {
-    test('schema version is 3', () {
-      expect(observerSnapshotSchemaVersion, 3);
+  group('ObserverSnapshot v4 worker pool exposure', () {
+    test('schema version is 4', () {
+      expect(observerSnapshotSchemaVersion, 4);
     });
 
     test('player rollups include a workerPool block with all four tiers', () {
-      final game = _gameWithPools({
+      final game = gameWithPools({
         'gp1': const WorkerPool(
           peasants: 17,
           apprentices: 4,
@@ -47,7 +53,7 @@ void main() {
         postResolutionTurnNumber: 100,
       );
 
-      expect(snapshot['observerSnapshotSchemaVersion'], 3);
+      expect(snapshot['observerSnapshotSchemaVersion'], 4);
       final players = snapshot['players'] as List<Object?>;
       final gp1 = players.cast<Map<String, Object?>>().single;
       expect(gp1['playerId'], 'gp1');
@@ -60,7 +66,7 @@ void main() {
     });
 
     test('empty pool serialises to zeros (does not omit fields)', () {
-      final game = _gameWithPools({'gp1': WorkerPool.empty});
+      final game = gameWithPools({'gp1': WorkerPool.empty});
 
       final snapshot = buildObserverSnapshotJson(
         game,
@@ -77,7 +83,7 @@ void main() {
     });
 
     test('every player rollup carries its own workerPool block', () {
-      final game = _gameWithPools({
+      final game = gameWithPools({
         'gp1': const WorkerPool(peasants: 5),
         'gp2': const WorkerPool(peasants: 0, masters: 2),
         'gp3': const WorkerPool(apprentices: 1, journeymen: 1),
@@ -104,7 +110,7 @@ void main() {
     });
 
     test('player rollup keeps existing v2 fields alongside workerPool', () {
-      final game = _gameWithPools({
+      final game = gameWithPools({
         'gp1': const WorkerPool(peasants: 10),
       });
 
@@ -125,6 +131,167 @@ void main() {
       expect(gp1.containsKey('fleetShipCountHint'), isTrue);
       expect(gp1.containsKey('techUnlockedIds'), isTrue);
       expect(gp1.containsKey('workerPool'), isTrue);
+    });
+  });
+
+  group('ObserverSnapshot v4 luxury rollups', () {
+    test(
+      'luxuryStockpile exposes refinedSugar / cigars / furHats from stockpile',
+      () {
+        final game = gameWithPools(
+          {'gp1': const WorkerPool(peasants: 5)},
+          stockpileByPlayerId: {
+            'gp1': const Stockpile(
+              quantities: <String, int>{
+                'refinedSugar': 12,
+                'cigars': 4,
+                'furHats': 7,
+                'grain': 99,
+              },
+            ),
+          },
+        );
+
+        final snapshot = buildObserverSnapshotJson(
+          game,
+          postResolutionTurnNumber: 100,
+        );
+
+        final gp1 = (snapshot['players'] as List<Object?>)
+            .cast<Map<String, Object?>>()
+            .single;
+        final luxury = gp1['luxuryStockpile'] as Map<String, Object?>;
+        expect(luxury['refinedSugar'], 12);
+        expect(luxury['cigars'], 4);
+        expect(luxury['furHats'], 7);
+        expect(luxury.containsKey('grain'), isFalse);
+      },
+    );
+
+    test('luxuryStockpile defaults to zeros when stockpile lacks commodity', () {
+      final game = gameWithPools({'gp1': WorkerPool.empty});
+
+      final snapshot = buildObserverSnapshotJson(
+        game,
+        postResolutionTurnNumber: 1,
+      );
+
+      final luxury = (snapshot['players'] as List<Object?>)
+          .cast<Map<String, Object?>>()
+          .single['luxuryStockpile'] as Map<String, Object?>;
+      expect(luxury['refinedSugar'], 0);
+      expect(luxury['cigars'], 0);
+      expect(luxury['furHats'], 0);
+    });
+
+    test(
+      'lastTurnLuxuryProduction aggregates recipe outputs by output commodity',
+      () {
+        final game = gameWithPools({'gp1': WorkerPool.empty});
+
+        final snapshot = buildObserverSnapshotJson(
+          game,
+          postResolutionTurnNumber: 100,
+          lastTurnProductionByRecipeByPlayerId: const <String, Map<String, int>>{
+            'gp1': <String, int>{
+              'refinedSugar_from_sugarCane': 3,
+              'cigars_from_tobacco': 2,
+              'furHats_from_furs': 1,
+              // Non-luxury recipes must be ignored.
+              'fabric_from_wool': 5,
+              'paper_from_timber': 4,
+            },
+          },
+        );
+
+        final production = (snapshot['players'] as List<Object?>)
+                .cast<Map<String, Object?>>()
+                .single['lastTurnLuxuryProduction']
+            as Map<String, Object?>;
+        expect(production['refinedSugar'], 3);
+        expect(production['cigars'], 2);
+        expect(production['furHats'], 1);
+        expect(production.containsKey('fabric'), isFalse);
+        expect(production.containsKey('paper'), isFalse);
+      },
+    );
+
+    test('lastTurnLuxuryProduction is zeros when no callback data supplied', () {
+      final game = gameWithPools({'gp1': WorkerPool.empty});
+
+      final snapshot = buildObserverSnapshotJson(
+        game,
+        postResolutionTurnNumber: 100,
+      );
+
+      final production = (snapshot['players'] as List<Object?>)
+              .cast<Map<String, Object?>>()
+              .single['lastTurnLuxuryProduction']
+          as Map<String, Object?>;
+      expect(production['refinedSugar'], 0);
+      expect(production['cigars'], 0);
+      expect(production['furHats'], 0);
+    });
+
+    test(
+      'unknown recipe ids in production map do not crash the snapshot builder',
+      () {
+        final game = gameWithPools({'gp1': WorkerPool.empty});
+
+        expect(
+          () => buildObserverSnapshotJson(
+            game,
+            postResolutionTurnNumber: 100,
+            lastTurnProductionByRecipeByPlayerId:
+                const <String, Map<String, int>>{
+              'gp1': <String, int>{
+                'mystery_recipe_id_that_does_not_exist': 99,
+              },
+            },
+          ),
+          returnsNormally,
+        );
+      },
+    );
+
+    test(
+      'production map keyed by absent player id leaves that player\'s rollup at zeros',
+      () {
+        final game = gameWithPools({
+          'gp1': WorkerPool.empty,
+          'gp2': WorkerPool.empty,
+        });
+
+        final snapshot = buildObserverSnapshotJson(
+          game,
+          postResolutionTurnNumber: 100,
+          lastTurnProductionByRecipeByPlayerId:
+              const <String, Map<String, int>>{
+            'gp1': <String, int>{'cigars_from_tobacco': 2},
+          },
+        );
+
+        final players = (snapshot['players'] as List<Object?>)
+            .cast<Map<String, Object?>>();
+        final gp1 = players.firstWhere((r) => r['playerId'] == 'gp1');
+        final gp2 = players.firstWhere((r) => r['playerId'] == 'gp2');
+        expect(
+          (gp1['lastTurnLuxuryProduction'] as Map<String, Object?>)['cigars'],
+          2,
+        );
+        expect(
+          (gp2['lastTurnLuxuryProduction'] as Map<String, Object?>)['cigars'],
+          0,
+        );
+      },
+    );
+
+    test('kObserverSnapshotLuxuryCommodityIds ordering pins the v4 contract', () {
+      expect(kObserverSnapshotLuxuryCommodityIds, <String>[
+        'refinedSugar',
+        'cigars',
+        'furHats',
+      ]);
     });
   });
 }

--- a/tool/run_observer_game/test/observer_workforce_verify_test.dart
+++ b/tool/run_observer_game/test/observer_workforce_verify_test.dart
@@ -7,20 +7,54 @@ import 'package:run_observer_game/observer_conquest_verify.dart'
     show kObserverGreatPowerIds, observerTurnSnapshotPath;
 import 'package:run_observer_game/observer_workforce_verify.dart';
 
+/// Builds a v4-shaped snapshot. By default each player rollup includes
+/// `luxuryStockpile` and `lastTurnLuxuryProduction` blocks sized to
+/// satisfy the §21 bullet 4 luxury sustain check for the GP's worker
+/// pool, so existing tests that only exercise peasant + trained
+/// thresholds remain green. Override [luxuryStockpileByGp] and/or
+/// [lastTurnLuxuryProductionByGp] to test luxury-specific behaviour.
 Map<String, Object?> _snapshotWithWorkerPools(
-  Map<String, WorkerPoolCounts> byGp,
-) {
+  Map<String, WorkerPoolCounts> byGp, {
+  Map<String, Map<String, int>>? luxuryStockpileByGp,
+  Map<String, Map<String, int>>? lastTurnLuxuryProductionByGp,
+}) {
+  Map<String, int> defaultLuxuryStockpileFor(WorkerPoolCounts counts) =>
+      <String, int>{
+        'refinedSugar': counts.apprentices,
+        'cigars': counts.journeymen,
+        'furHats': counts.masters,
+      };
+
   final players = <Map<String, Object?>>[];
   for (final entry in byGp.entries) {
+    final counts = entry.value;
+    final luxuryStockpile =
+        luxuryStockpileByGp?[entry.key] ?? defaultLuxuryStockpileFor(counts);
+    final lastTurnLuxuryProduction =
+        lastTurnLuxuryProductionByGp?[entry.key] ?? const <String, int>{
+          'refinedSugar': 0,
+          'cigars': 0,
+          'furHats': 0,
+        };
     players.add(<String, Object?>{
       'playerId': entry.key,
       'displayName': entry.key.toUpperCase(),
       'isHuman': false,
       'workerPool': <String, Object?>{
-        'peasants': entry.value.peasants,
-        'apprentices': entry.value.apprentices,
-        'journeymen': entry.value.journeymen,
-        'masters': entry.value.masters,
+        'peasants': counts.peasants,
+        'apprentices': counts.apprentices,
+        'journeymen': counts.journeymen,
+        'masters': counts.masters,
+      },
+      'luxuryStockpile': <String, Object?>{
+        'refinedSugar': luxuryStockpile['refinedSugar'] ?? 0,
+        'cigars': luxuryStockpile['cigars'] ?? 0,
+        'furHats': luxuryStockpile['furHats'] ?? 0,
+      },
+      'lastTurnLuxuryProduction': <String, Object?>{
+        'refinedSugar': lastTurnLuxuryProduction['refinedSugar'] ?? 0,
+        'cigars': lastTurnLuxuryProduction['cigars'] ?? 0,
+        'furHats': lastTurnLuxuryProduction['furHats'] ?? 0,
       },
     });
   }
@@ -183,7 +217,13 @@ void main() {
       expect(kObserverWorkforceMinPeasants, 15);
       expect(kObserverWorkforceMinTrained, 8);
       expect(kObserverWorkforceCanonicalTurn, 100);
-      expect(kObserverWorkforceFoodLuxuryDeferred, isTrue);
+      // S10b narrows the deferral to food production only.
+      expect(kObserverWorkforceFoodProductionDeferred, isTrue);
+      expect(kObserverWorkforceApprenticeLuxuryCommodityId, 'refinedSugar');
+      expect(kObserverWorkforceJourneymanLuxuryCommodityId, 'cigars');
+      expect(kObserverWorkforceMasterLuxuryCommodityId, 'furHats');
+      expect(kObserverWorkforceLuxuryTierMapping.map((e) => e.tier).toList(),
+          <String>['apprentices', 'journeymen', 'masters']);
     });
 
     test('peasant-only failure surfaces only the peasant line for that GP', () {
@@ -222,6 +262,294 @@ void main() {
       final failures = verifyPerGpWorkforceSustain(turnEndSnapshot: snap);
       expect(failures, hasLength(1));
       expect(failures.single, startsWith('gp4 trained=7'));
+    });
+  });
+
+  group('luxuryAvailableForPlayer', () {
+    test('sums luxuryStockpile and lastTurnLuxuryProduction', () {
+      final snap = _snapshotWithWorkerPools(
+        {
+          'gp1': const WorkerPoolCounts(
+            peasants: 1,
+            apprentices: 1,
+            journeymen: 0,
+            masters: 0,
+          ),
+        },
+        luxuryStockpileByGp: const {
+          'gp1': <String, int>{'refinedSugar': 4},
+        },
+        lastTurnLuxuryProductionByGp: const {
+          'gp1': <String, int>{'refinedSugar': 3},
+        },
+      );
+
+      expect(luxuryAvailableForPlayer(snap, 'gp1', 'refinedSugar'), 7);
+    });
+
+    test('returns 0 when the player rollup is missing', () {
+      final snap = <String, Object?>{'players': <Object?>[]};
+      expect(luxuryAvailableForPlayer(snap, 'gp1', 'refinedSugar'), 0);
+    });
+
+    test('returns 0 when both luxury blocks are absent (v3 snapshot)', () {
+      final snap = <String, Object?>{
+        'players': <Object?>[
+          <String, Object?>{
+            'playerId': 'gp1',
+            'workerPool': <String, Object?>{
+              'peasants': 10,
+              'apprentices': 1,
+              'journeymen': 0,
+              'masters': 0,
+            },
+          },
+        ],
+      };
+      expect(luxuryAvailableForPlayer(snap, 'gp1', 'refinedSugar'), 0);
+    });
+  });
+
+  group('verifyPerGpLuxurySustain', () {
+    test('passes when every trained tier is matched by stockpile + production',
+        () {
+      final snap = _snapshotWithWorkerPools({
+        for (final gp in kObserverGreatPowerIds) gp: _meetsBoth(),
+      });
+
+      expect(verifyPerGpLuxurySustain(turnEndSnapshot: snap), isEmpty);
+    });
+
+    test('passes when production covers tier count even with zero stockpile',
+        () {
+      final snap = _snapshotWithWorkerPools(
+        {
+          'gp1': const WorkerPoolCounts(
+            peasants: 20,
+            apprentices: 3,
+            journeymen: 0,
+            masters: 0,
+          ),
+        },
+        luxuryStockpileByGp: const {
+          'gp1': <String, int>{'refinedSugar': 0},
+        },
+        lastTurnLuxuryProductionByGp: const {
+          'gp1': <String, int>{'refinedSugar': 3},
+        },
+      );
+
+      expect(verifyPerGpLuxurySustain(turnEndSnapshot: snap), isEmpty);
+    });
+
+    test('passes when stockpile covers tier count even with zero production',
+        () {
+      final snap = _snapshotWithWorkerPools(
+        {
+          'gp1': const WorkerPoolCounts(
+            peasants: 20,
+            apprentices: 0,
+            journeymen: 0,
+            masters: 2,
+          ),
+        },
+        luxuryStockpileByGp: const {
+          'gp1': <String, int>{'furHats': 2},
+        },
+        lastTurnLuxuryProductionByGp: const {
+          'gp1': <String, int>{'furHats': 0},
+        },
+      );
+
+      expect(verifyPerGpLuxurySustain(turnEndSnapshot: snap), isEmpty);
+    });
+
+    test('skips tiers with zero count regardless of luxury availability', () {
+      final snap = _snapshotWithWorkerPools(
+        {
+          'gp1': const WorkerPoolCounts(
+            peasants: 20,
+            apprentices: 0,
+            journeymen: 0,
+            masters: 0,
+          ),
+        },
+        luxuryStockpileByGp: const {
+          'gp1': <String, int>{
+            'refinedSugar': 0,
+            'cigars': 0,
+            'furHats': 0,
+          },
+        },
+        lastTurnLuxuryProductionByGp: const {
+          'gp1': <String, int>{
+            'refinedSugar': 0,
+            'cigars': 0,
+            'furHats': 0,
+          },
+        },
+      );
+
+      expect(verifyPerGpLuxurySustain(turnEndSnapshot: snap), isEmpty);
+    });
+
+    test('emits one failure line per shortfall tier per GP', () {
+      final snap = _snapshotWithWorkerPools(
+        {
+          'gp1': const WorkerPoolCounts(
+            peasants: 20,
+            apprentices: 4,
+            journeymen: 2,
+            masters: 1,
+          ),
+        },
+        luxuryStockpileByGp: const {
+          'gp1': <String, int>{
+            'refinedSugar': 1,
+            'cigars': 0,
+            'furHats': 0,
+          },
+        },
+        lastTurnLuxuryProductionByGp: const {
+          'gp1': <String, int>{
+            'refinedSugar': 1,
+            'cigars': 1,
+            'furHats': 0,
+          },
+        },
+      );
+
+      final failures = verifyPerGpLuxurySustain(turnEndSnapshot: snap);
+      expect(failures, hasLength(3));
+      expect(
+        failures[0],
+        startsWith('gp1 apprentices=4 refinedSugar_available=2'),
+      );
+      expect(failures[0], contains('stockpile=1 lastTurnProduction=1'));
+      expect(failures[1], startsWith('gp1 journeymen=2 cigars_available=1'));
+      expect(failures[2], startsWith('gp1 masters=1 furHats_available=0'));
+    });
+
+    test('failure ordering is apprentice → journeyman → master per GP', () {
+      final snap = _snapshotWithWorkerPools(
+        {
+          for (final gp in kObserverGreatPowerIds)
+            gp: const WorkerPoolCounts(
+              peasants: 20,
+              apprentices: 1,
+              journeymen: 1,
+              masters: 1,
+            ),
+        },
+        luxuryStockpileByGp: <String, Map<String, int>>{
+          for (final gp in kObserverGreatPowerIds)
+            gp: const <String, int>{
+              'refinedSugar': 0,
+              'cigars': 0,
+              'furHats': 0,
+            },
+        },
+      );
+
+      final failures = verifyPerGpLuxurySustain(turnEndSnapshot: snap);
+      expect(failures, hasLength(kObserverGreatPowerIds.length * 3));
+      for (var i = 0; i < kObserverGreatPowerIds.length; i++) {
+        final gp = kObserverGreatPowerIds[i];
+        expect(failures[i * 3 + 0], startsWith('$gp apprentices='));
+        expect(failures[i * 3 + 1], startsWith('$gp journeymen='));
+        expect(failures[i * 3 + 2], startsWith('$gp masters='));
+      }
+    });
+
+    test('treats missing luxury blocks (v3 snapshots) as zero availability',
+        () {
+      final snap = <String, Object?>{
+        'players': <Object?>[
+          <String, Object?>{
+            'playerId': 'gp1',
+            'workerPool': <String, Object?>{
+              'peasants': 20,
+              'apprentices': 1,
+              'journeymen': 0,
+              'masters': 0,
+            },
+          },
+        ],
+      };
+
+      final failures = verifyPerGpLuxurySustain(turnEndSnapshot: snap);
+      expect(failures.any((f) => f.startsWith('gp1 apprentices=1')), isTrue);
+      expect(failures.any((f) => f.contains('refinedSugar_available=0')),
+          isTrue);
+    });
+  });
+
+  group('verifyPerGpWorkforceSustain checkLuxurySustain integration', () {
+    test('default checkLuxurySustain=true surfaces luxury failures', () {
+      final snap = _snapshotWithWorkerPools(
+        {
+          'gp1': const WorkerPoolCounts(
+            peasants: 20,
+            apprentices: 0,
+            journeymen: 0,
+            masters: 1,
+          ),
+        },
+        luxuryStockpileByGp: const {
+          'gp1': <String, int>{'furHats': 0},
+        },
+        lastTurnLuxuryProductionByGp: const {
+          'gp1': <String, int>{'furHats': 0},
+        },
+      );
+
+      // gp1 meets peasants but not trained (1 < 8) — produces a trained
+      // failure. Other GPs have no rollup → 6 × (peasants + trained)
+      // failures. gp1 also produces a master luxury failure.
+      final failures = verifyPerGpWorkforceSustain(turnEndSnapshot: snap);
+      expect(
+        failures.where((f) => f.contains('furHats_available=0')).length,
+        1,
+      );
+    });
+
+    test('checkLuxurySustain=false skips the luxury pass', () {
+      final snap = _snapshotWithWorkerPools(
+        {
+          for (final gp in kObserverGreatPowerIds)
+            gp: const WorkerPoolCounts(
+              peasants: 20,
+              apprentices: 5,
+              journeymen: 3,
+              masters: 1,
+            ),
+        },
+        luxuryStockpileByGp: <String, Map<String, int>>{
+          for (final gp in kObserverGreatPowerIds)
+            gp: const <String, int>{
+              'refinedSugar': 0,
+              'cigars': 0,
+              'furHats': 0,
+            },
+        },
+        lastTurnLuxuryProductionByGp: <String, Map<String, int>>{
+          for (final gp in kObserverGreatPowerIds)
+            gp: const <String, int>{
+              'refinedSugar': 0,
+              'cigars': 0,
+              'furHats': 0,
+            },
+        },
+      );
+
+      // With opt-out, only the peasants+trained checks run; both pass.
+      expect(
+        verifyPerGpWorkforceSustain(
+          turnEndSnapshot: snap,
+          checkLuxurySustain: false,
+        ),
+        isEmpty,
+      );
     });
   });
 


### PR DESCRIPTION
## Scope

S10b slice for #2692, follow-up to PR #2716 (now merged): lands the
luxury sustain check from Requirement §21 bullet 4
(`luxuryStockpile + lastTurnLuxuryProduction >= tier count` per
matched commodity) via a new `ObserverSnapshot` v4 schema.

Food production sustain (§21 bullet 3, `grain + meat`) remains
deferred — grain and meat are extracted (not recipe outputs) and
need a different data channel than the production-phase callback.
The deferral marker is narrowed accordingly.

## What lands

### `ObserverSnapshot` v4 (`observer_snapshot_v1.dart`)

- `observerSnapshotSchemaVersion` bumped from `3` to `4`.
- Per-player rollup gains:
  - `luxuryStockpile` — `refinedSugar` / `cigars` / `furHats`
    quantities from `Player.stockpile`; absent commodities serialize
    as `0`.
  - `lastTurnLuxuryProduction` — same three commodity ids,
    aggregated from the production phase callback via
    `ProductionRecipesCatalog.byId[recipeId].outputCommodityId`.
    Non-luxury recipe outputs (fabric, paper, etc.) are silently
    skipped; unknown recipe ids do not crash the builder; absent
    player ids serialize to zeros.
- New `kObserverSnapshotLuxuryCommodityIds` const pins ordering
  (`refinedSugar` → `cigars` → `furHats`).

### Turn resolver

- `validateOrdersAndResolveTurnFromTrustedOrders` accepts an optional
  `onProductionComplete` callback (forwarded to `resolveTurnForGame`).
  The new parameter is opt-in; existing callers are unaffected.

### Observer session runner

- Captures `productionByRecipeByPlayerId` per turn via the new
  callback and forwards it into `buildObserverSnapshotJson` so the
  written snapshot reflects the most recent production phase output.

### Workforce sustain verifier (`observer_workforce_verify.dart`)

- New `luxuryAvailableForPlayer(snapshot, playerId, commodityId)`
  reader returns `stockpile + lastTurnProduction`, or `0` when either
  block is absent (v3 snapshots).
- New `verifyPerGpLuxurySustain(...)` emits one failure line per
  shortfall `(GP, tier)` in fixed iteration order
  (apprentice → journeyman → master). The failure line surfaces both
  summands so the operator can see whether the buffer or production
  rate is the bottleneck.
- `verifyPerGpWorkforceSustain` and `verifyObserverWorkforceFromTraceDir`
  accept `checkLuxurySustain: true` (default) so the CLI picks up
  the new check; callers reading v3 fixtures can opt out.
- New constants pin the tier ↔ commodity mapping
  (`kObserverWorkforceApprenticeLuxuryCommodityId`,
  `kObserverWorkforceJourneymanLuxuryCommodityId`,
  `kObserverWorkforceMasterLuxuryCommodityId`, and
  `kObserverWorkforceLuxuryTierMapping`).
- Deferral marker narrowed from `kObserverWorkforceFoodLuxuryDeferred`
  → `kObserverWorkforceFoodProductionDeferred`. The original symbol
  is preserved as a `@Deprecated` back-compat alias so external
  callers / dashboards do not break silently.

### SPEC

- `SPEC/program/observer-workforce-verify.md`:
  - § Scope upgraded to landed-across-**S10a, S10, S10b**; new
    library surface listed for luxury sustain.
  - § Provisional thresholds adds the new constants.
  - § Acceptance adds five new Given–When–Then triplets covering
    parser behaviour, zero-tier skip, ordered failure format, the
    integrated `verifyPerGpWorkforceSustain` pass with
    `checkLuxurySustain` defaulting to `true`, and the explicit
    opt-out path.
- `SPEC/program/run_observer_game-tool.md`:
  - § ObserverSnapshot heading bumped to v4; the players row
    documents the two new sub-blocks.
  - § Workforce sustain verification body extended to describe the
    new luxury sustain rule, the matched commodities, and the
    `onProductionComplete` capture wiring.

## Tests

`tool/run_observer_game/test/observer_snapshot_worker_pool_test.dart`
— refactored for v4 plus **6 new tests**:

- v4 schema version pin (replaces v3 pin).
- `luxuryStockpile` reads from `Player.stockpile` and ignores
  non-luxury commodities.
- `luxuryStockpile` defaults to zeros when stockpile lacks commodity.
- `lastTurnLuxuryProduction` aggregates recipe outputs by output
  commodity, ignoring non-luxury recipes.
- `lastTurnLuxuryProduction` is all zeros when no callback data
  supplied.
- Unknown recipe ids do not crash the builder.
- Production map keyed by an absent player id leaves that player's
  rollup at zeros.
- `kObserverSnapshotLuxuryCommodityIds` ordering pin.

`tool/run_observer_game/test/observer_workforce_verify_test.dart`
— refactored helper (v4-shaped snapshots default luxury blocks to
match worker counts so prior S10a assertions remain green) plus
**13 new tests**:

- `luxuryAvailableForPlayer`: sum, missing rollup, missing v3 blocks.
- `verifyPerGpLuxurySustain`:
  - happy-path (every tier matched);
  - production-only sufficiency;
  - stockpile-only sufficiency;
  - zero-tier skip (no requirement when no worker consumes luxury);
  - multi-tier shortfall lines with summands;
  - fixed apprentice → journeyman → master ordering across 6 GPs;
  - treats missing luxury blocks as zero availability.
- `verifyPerGpWorkforceSustain` integration:
  `checkLuxurySustain: true` (default) surfaces luxury failures;
  `checkLuxurySustain: false` opts out (preserves S10a behaviour
  for v3 fixtures).
- Default thresholds test extended to pin the new constants
  (`kObserverWorkforceFoodProductionDeferred`, the three luxury
  commodity ids, and the iteration ordering of
  `kObserverWorkforceLuxuryTierMapping`).

Local verification:

- `dart analyze tool/run_observer_game packages/colonizethis_logic/lib/src/turn` — clean.
- `dart run custom_lint` (in `tool/run_observer_game`) — clean.
- `dart test` (in `tool/run_observer_game`) — **all 39 touched
  tests pass** in the targeted run; full suite passed (111 in S10
  baseline + new tests). Existing observer / nightly pin tests
  remain green.
- `dart test test/turn_resolver_trusted_orders_test.dart` (in
  `packages/colonizethis_logic`) — 4 passed; new
  `onProductionComplete` parameter is opt-in.

## AC mapping (#2692)

This PR completes the **AC #7b** luxury sustain piece: each GP
(`gp1`–`gp6`) at turn 100 now also asserts
`luxuryStockpile + lastTurnLuxuryProduction >= tier count` for
each trained tier with a non-zero count, on the matched luxury
commodity (apprentices ↔ refinedSugar, journeymen ↔ cigars,
masters ↔ furHats). Together with S10a (peasants + trained
thresholds) and S10 (CLI + nightly), the only outstanding §21
metric is the food production check (bullet 3).

## Deferred (separate slice on #2692)

- Food production sustain (`grain + meat`) check from Requirement
  §21 bullet 3. Grain and meat are extracted (not recipe outputs);
  the snapshot needs a per-player extraction rollup channel (or a
  per-turn stockpile delta) beyond the production-phase callback.
  Gated by `kObserverWorkforceFoodProductionDeferred = true`.
- Any threshold revisions following observer-trace analysis on
  seed 42 if the provisional thresholds prove too tight or too
  loose; thresholds remain parameterised via
  `kObserverWorkforceMinPeasants` / `kObserverWorkforceMinTrained`
  constants for a quick follow-up bump if needed.

Refs #2692

Made with [Cursor](https://cursor.com)