### PR TITLE
test(ai): pin EXPAND/DEVELOP phase planner-set NW suppression (Refs #2509)

### DIFF
--- a/packages/colonizethis_ai/lib/src/planning/develop_phase_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/develop_phase_planner.dart
@@ -12,6 +12,18 @@
 /// this module **only** when `observerGoalPhaseFor` resolves to
 /// `ObserverGoalPhase.develop`; the planner functions themselves do not
 /// re-check the phase (suppression is structural, per the issue spec).
+/// The structural NW-suppression AC for the planner **set as a whole**
+/// (issue #2509 § Phase planner unit tests § "DEVELOP NW suppression";
+/// `SPEC/ai/phase-planner-architecture.md` § Acceptance criteria) is
+/// pinned in `test/planning/develop_phase_planner_nw_suppression_test.dart`,
+/// which exercises both DEVELOP planners (`planDevelopPeace`,
+/// `planDevelopCivilian`) against a fixture loaded with tribe-owned NW
+/// provinces, an unowned NW province with a resource entry, and tribe /
+/// minor factions in `atWarWith`, then asserts the merged output set
+/// contains no declareWar, no NW-acquisition (`purchase_land` /
+/// `establishOverture` / NW-army-move), and no improvements toward
+/// foreign or unowned NW tiles. Structural absence: DEVELOP exposes no
+/// declareWar / acquisition / military / naval planner functions.
 ///
 /// Wiring this module into the orchestrator and removing the legacy
 /// `developPhaseGpPeaceTargets` helper from `observer_goal_phase.dart`
@@ -165,9 +177,9 @@ List<WorkOrder> planDevelopCivilian({
   }
 
   eligibleTileKeys.sort((a, b) {
-    final scoreCmp = _developCivilianTileScore(b).compareTo(
-      _developCivilianTileScore(a),
-    );
+    final scoreCmp = _developCivilianTileScore(
+      b,
+    ).compareTo(_developCivilianTileScore(a));
     if (scoreCmp != 0) return scoreCmp;
     return a.compareTo(b);
   });

--- a/packages/colonizethis_ai/lib/src/planning/expand_phase_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/expand_phase_planner.dart
@@ -13,6 +13,13 @@
 /// `purchase_land` / `build_improvement`, and never queues NW conquest army
 /// moves. Suppression is an architectural property of the module, not a
 /// runtime predicate check (Refs #2509 § EXPAND phase planner Suppressions).
+/// The structural NW-suppression AC for the planner **set as a whole**
+/// (issue #2509 § Phase planner unit tests § "EXPAND NW suppression";
+/// `SPEC/ai/phase-planner-architecture.md` § Acceptance criteria) is
+/// pinned in `test/planning/expand_phase_planner_nw_suppression_test.dart`,
+/// which exercises all four EXPAND planners (`planExpandDeclareWar`,
+/// `planExpandPeace`, `planExpandEconomy`, `planExpandMilitary`) against a
+/// NW-rich fixture and asserts the merged output set carries no NW orders.
 ///
 /// Callers are expected to dispatch to this module **only** when
 /// `observerGoalPhaseFor` resolves to `ObserverGoalPhase.expand`; the planner

--- a/packages/colonizethis_ai/test/planning/develop_phase_planner_nw_suppression_test.dart
+++ b/packages/colonizethis_ai/test/planning/develop_phase_planner_nw_suppression_test.dart
@@ -1,0 +1,440 @@
+// Module-level NW-suppression pin for the DEVELOP phase planner set
+// (Refs #2509 S4 / S10 / S6 phase-planner-architecture sub-spec).
+//
+// Spec contract (issue #2509 § Phase planner unit tests § "DEVELOP NW
+// suppression"; SPEC/ai/phase-planner-architecture.md § Acceptance
+// criteria):
+//
+//   "Given a GP in DEVELOP, when its phase-planner orders are
+//    collected, then the result contains zero declareWar, NW
+//    acquisition, or NW invasion orders."
+//
+// The DEVELOP phase planner set is intentionally minimal: exactly two
+// pure-function contracts (`planDevelopPeace`, `planDevelopCivilian`)
+// per the phase-planner-architecture table. Structural suppression
+// for DEVELOP is twofold:
+//
+//   1. **Module API surface:** DEVELOP exposes no `declareWar`, no
+//      acquisition (Join Empire / purchase_land), and no military /
+//      naval planner. New wars are structurally impossible because
+//      no function in the module returns a declare-war target. NW
+//      acquisition is structurally impossible because no function
+//      returns acquisition targets.
+//   2. **Per-function NW restrictions:** `planDevelopPeace` returns
+//      `offerPeace` targets only (the function name and return
+//      contract make declareWar emission impossible from this
+//      module). `planDevelopCivilian` emits `build_improvement`
+//      orders only, exclusively on tiles inside provinces the active
+//      player owns — `purchase_land` toward unowned NW tiles and
+//      `build_improvement` toward foreign / tribe-held NW land are
+//      both structurally suppressed by the ownership gate.
+//
+// Per-function pins for `planDevelopPeace` and `planDevelopCivilian`
+// already live in `develop_phase_planner_test.dart` (the GP filter,
+// the foreign-ownership exclusion, etc.). This file is the AC pin
+// for the **planner set as a whole**: it exercises both functions
+// on a single shared fixture that loads every NW signal slot the
+// orchestrator (#2509 S5) will eventually route through, then
+// asserts that the merged output set carries no NW-acquisition or
+// declareWar surface.
+//
+// Why a planner-set integration pin in addition to per-function pins:
+//   - The per-function pins prove each contract individually never
+//     emits NW unowned-tile orders. The planner-set pin proves the
+//     **composition** of the two planners is also free of NW
+//     leakage — for example a future refactor that broadens
+//     `planDevelopCivilian` to read tribe-owned NW provinces from
+//     the snapshot's `ColonialSummary` would be exercised here once.
+//   - The AC ("when its phase-planner orders are collected") is
+//     explicitly the planner set, not a single function. Pinning
+//     that wording at the library level keeps the AC verifiable
+//     today, before the S5 orchestrator wiring lands.
+//   - The fixture explicitly includes tribe-owned NW provinces, an
+//     owned NW province with a resource tile, and tribe / minor
+//     factions in `atWarWith` — every surface a DEVELOP planner
+//     could possibly leak through.
+
+import 'package:colonizethis_ai/colonizethis_ai.dart';
+import 'package:colonizethis_ai/src/planning/develop_phase_planner.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/ai_api.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+const String _gp1 = 'gp1';
+const String _gp2 = 'gp2';
+const String _gp3 = 'gp3';
+const String _tribe1 = 'tribe1';
+const String _minor1 = 'minor1';
+
+const String _gp1OwProvinceId = 'oldWorld|gp1_a';
+const String _gp1NwProvinceId = 'newWorld|gp1_a';
+const String _tribeNwProvinceId = 'newWorld|tribe1_a';
+const String _unownedNwProvinceId = 'newWorld|p_unowned';
+
+/// Owned-OW tile (active player can improve).
+const String _ownedOwTileKey = 'oldWorld|gp1_a|3|3';
+
+/// Owned-NW tile (active player can improve — NW IS allowed for
+/// DEVELOP since the gate is ownership, not region).
+const String _ownedNwTileKey = 'newWorld|gp1_a|4|4';
+
+/// Tribe-held NW tile (foreign ownership; planner must structurally
+/// reject this even though it carries a resource entry).
+const String _tribeNwTileKey = 'newWorld|tribe1_a|2|2';
+
+/// Unowned NW tile (no owner / no tribe; planner must structurally
+/// reject this even though it carries a resource entry).
+const String _unownedNwTileKey = 'newWorld|p_unowned|1|1';
+
+/// Build a Game scaffold for the planner-set AC pin:
+///   - Active player ([_gp1]) owns one OW and one NW province so
+///     `planDevelopCivilian` has eligible tiles in both regions; this
+///     proves the planner emits orders for OW + owned-NW (positive
+///     coverage path) while rejecting foreign / unowned NW (the AC
+///     suppression).
+///   - Tribe ([_tribe1]) owns a NW province with a resource tile —
+///     the structural NW-acquisition leakage surface.
+///   - A second NW province is left unowned with a resource tile —
+///     the structural `purchase_land` leakage surface.
+///   - One idle Builder belongs to the active player.
+Game _developGame({int turnNumber = 145}) {
+  return Game(
+    id: 'g-2509-develop-phase-planner-nw-suppression-t$turnNumber',
+    worldState: WorldState(
+      turnState: TurnState(turnNumber: turnNumber, phase: TurnPhase.orders),
+      oldWorld: RegionData(
+        provinces: const [
+          Province(
+            id: _gp1OwProvinceId,
+            regionId: kOldWorldRegionId,
+            ownerId: _gp1,
+          ),
+        ],
+        units: [
+          // Two idle builders so the `min(builders, eligibleTiles)`
+          // cap is 2 and the planner emits orders for BOTH owned
+          // tiles (OW + owned-NW). The single-builder case is
+          // already pinned in `develop_phase_planner_test.dart` —
+          // here we want full eligible-tile coverage so the
+          // suppression check exercises every tile the planner
+          // walks.
+          Unit(
+            id: 'b1',
+            type: kUnitTypeBuilder,
+            ownerId: _gp1,
+            locationProvinceId: _gp1OwProvinceId,
+            tileKey: '$_gp1OwProvinceId|9|9',
+          ),
+          Unit(
+            id: 'b2',
+            type: kUnitTypeBuilder,
+            ownerId: _gp1,
+            locationProvinceId: _gp1OwProvinceId,
+            tileKey: '$_gp1OwProvinceId|8|8',
+          ),
+        ],
+      ),
+      newWorld: const RegionData(
+        provinces: [
+          Province(
+            id: _gp1NwProvinceId,
+            regionId: kNewWorldRegionId,
+            ownerId: _gp1,
+          ),
+          Province(
+            id: _tribeNwProvinceId,
+            regionId: kNewWorldRegionId,
+            ownerId: _tribe1,
+          ),
+          Province(id: _unownedNwProvinceId, regionId: kNewWorldRegionId),
+        ],
+      ),
+      // Every NW tile slot the planner-set could possibly leak
+      // through carries a resource entry so resource-availability is
+      // never the gating filter — only ownership / region structure
+      // can keep NW-acquisition out of the output.
+      resourceByTileKey: const {
+        _ownedOwTileKey: 'grain',
+        _ownedNwTileKey: 'tobacco',
+        _tribeNwTileKey: 'spices',
+        _unownedNwTileKey: 'gold',
+      },
+    ),
+    players: const [
+      Player(id: _gp1, displayName: 'GP1', isHuman: false),
+      Player(id: _gp2, displayName: 'GP2', isHuman: false),
+      Player(id: _gp3, displayName: 'GP3', isHuman: false),
+    ],
+    tribes: const [Tribe(id: _tribe1, displayName: 'Tribe1')],
+    minorNations: const [MinorNation(id: _minor1, displayName: 'Minor1')],
+  );
+}
+
+/// Snapshot for DEVELOP posture: OW at quota (10), no visible
+/// colonial acquisition targets in conquest summary (DEVELOP routing
+/// requires `hasColonialAcquisitionTargets == false`), `atWarWith`
+/// includes both GPs (to exercise peace), a tribe, and a minor (to
+/// exercise the non-GP filter in `planDevelopPeace`).
+///
+/// `ColonialSummary` is populated with NW tribe-owned and unowned
+/// invadable provinces so the planner-set has live NW state to lean
+/// on if any suppression slipped — the AC explicitly says the
+/// planner set must not emit NW-acquisition / declareWar even when
+/// colonial signals are present.
+AIWorldSnapshot _developSnapshot({
+  List<String> atWarWith = const [_gp2, _gp3, _tribe1, _minor1],
+}) {
+  return AIWorldSnapshot(
+    playerId: _gp1,
+    threats: ThreatSummary(atWarWith: atWarWith),
+    opportunities: const OpportunitySummary(),
+    conquest: const ConquestSummary(
+      oldWorldProvincesOwned: kObserverConquestMinOwProvincesPerGp,
+      provincesToVictory: kObserverConquestMinOwProvincesPerGp * 3,
+    ),
+    colonial: const ColonialSummary(
+      newWorldProvincesOwned: 1,
+      invadableNewWorldProvinceIdsSorted: [
+        _tribeNwProvinceId,
+        _unownedNwProvinceId,
+      ],
+      adjacentNewWorldOwnerFactionIdsSorted: [_tribe1],
+      preferredColonialTargetFactionIdsSorted: [_tribe1],
+    ),
+    economy: const EconomySummary(),
+    relations: const {},
+  );
+}
+
+/// Whether [provinceId] is in the New World region.
+bool _isNwProvinceId(String provinceId) =>
+    ProvinceId.regionIdFrom(provinceId) == kNewWorldRegionId;
+
+/// Boolean test for whether [factionId] resolves to a tribe or minor
+/// nation in [game] (a non-Great-Power faction whose presence in
+/// DEVELOP peace output would indicate structural leakage).
+bool _isNonGpFaction(Game game, String factionId) {
+  if (game.tribes.any((t) => t.id == factionId)) return true;
+  if (game.minorNations.any((m) => m.id == factionId)) return true;
+  return false;
+}
+
+/// Owner of the province that contains [tileKey] in [game], or `null`
+/// when the province is not found.
+String? _ownerOfProvinceContainingTile(Game game, String tileKey) {
+  final provinceId = Unit.provinceIdFromTileKey(tileKey);
+  if (provinceId == null) return null;
+  for (final region in <RegionData>[
+    game.worldState.oldWorld,
+    game.worldState.newWorld,
+  ]) {
+    for (final p in region.provinces) {
+      if (p.id == provinceId) return p.ownerId;
+    }
+  }
+  return null;
+}
+
+void main() {
+  group('DEVELOP planner set NW suppression (AC pin)', () {
+    test('planner set output contains no declareWar, no NW acquisition, '
+        'and no NW-invasion orders', () {
+      final game = _developGame();
+      final snapshot = _developSnapshot();
+
+      // 1. planDevelopPeace: returns offerPeace targets (GP
+      //    factionIds), never a declareWar emission. The function
+      //    contract is "List<String>" of peace targets, so a
+      //    declareWar leakage is structurally impossible from this
+      //    module — there is no acquisition / declare-war function
+      //    on develop_phase_planner.dart to call. Pin: every entry
+      //    is a Great Power factionId (tribes / minors filtered).
+      final peace = planDevelopPeace(game: game, snapshot: snapshot);
+      for (final factionId in peace) {
+        expect(
+          _isNonGpFaction(game, factionId),
+          isFalse,
+          reason:
+              'planDevelopPeace must return only Great Power '
+              'factionIds (DEVELOP is GP-vs-GP peace only). Tribe / '
+              'minor ids in the output set indicate a structural '
+              'leakage that would route the orchestrator into an '
+              'unsupported NW peace path. Offending factionId: '
+              '$factionId.',
+        );
+      }
+      // Positive coverage: both at-war GPs appear so we know the
+      // planner is exercising live data, not the empty short-
+      // circuit (the AC pin would otherwise be tautological).
+      expect(peace, containsAll(<String>[_gp2, _gp3]));
+
+      // 2. planDevelopCivilian: emits only `build_improvement`
+      //    orders (target field is always
+      //    `kWorkTargetBuildImprovement`). NW-acquisition surfaces
+      //    that the AC suppresses (`purchase_land`) are
+      //    structurally impossible because the function never sets
+      //    `target` to anything else. Tile selection only walks
+      //    `resourceByTileKey` and filters to owned provinces, so
+      //    foreign / unowned NW tiles cannot land in the output.
+      final civilian = planDevelopCivilian(game: game, snapshot: snapshot);
+      for (final order in civilian) {
+        expect(
+          order.target,
+          kWorkTargetBuildImprovement,
+          reason:
+              'planDevelopCivilian must emit only '
+              'kWorkTargetBuildImprovement orders. Any other target '
+              '(purchase_land, etc.) is a structural NW-acquisition '
+              'leakage. Offending order: $order.',
+        );
+        // Foreign-owned or unowned NW tiles must never appear in
+        // the output. This guards against a future refactor that
+        // broadens `resourceByTileKey` walking past the ownership
+        // gate.
+        final tileOwner = _ownerOfProvinceContainingTile(
+          game,
+          order.targetTileKey,
+        );
+        expect(
+          tileOwner,
+          _gp1,
+          reason:
+              'planDevelopCivilian emitted a build_improvement '
+              'order against tile ${order.targetTileKey} whose '
+              'province is owned by $tileOwner (not the active '
+              'player). DEVELOP must improve owned territory only; '
+              'tile-keys in foreign or unowned provinces are a '
+              'structural NW-acquisition leakage.',
+        );
+      }
+      // Positive coverage: both owned tiles (OW + owned-NW) ranked
+      // and emitted so the test exercises the full eligible-tile
+      // sort rather than the empty short-circuit. NW score >
+      // OW score, so owned-NW comes first.
+      expect(civilian.map((o) => o.targetTileKey), <String>[
+        _ownedNwTileKey,
+        _ownedOwTileKey,
+      ]);
+
+      // 3. Structural NW-tile rejection pin: even though the
+      //    fixture includes tribe-owned and unowned NW tiles with
+      //    resource entries, those tile keys must never appear in
+      //    the planner-set output. Tests the ownership gate from
+      //    the negative side.
+      final emittedTileKeys = civilian.map((o) => o.targetTileKey).toSet();
+      expect(
+        emittedTileKeys.contains(_tribeNwTileKey),
+        isFalse,
+        reason:
+            'planDevelopCivilian must not emit improvements toward '
+            'tribe-held NW tiles. The tribe-NW tile resource entry '
+            'is present in the fixture; rejection must come from '
+            'the ownership gate (province.ownerId != playerId).',
+      );
+      expect(
+        emittedTileKeys.contains(_unownedNwTileKey),
+        isFalse,
+        reason:
+            'planDevelopCivilian must not emit improvements toward '
+            'unowned NW tiles. The unowned-NW tile resource entry '
+            'is present in the fixture; rejection must come from '
+            'the ownership gate (province.ownerId is null and not '
+            'the active player).',
+      );
+    });
+
+    test('tribe-only at-war set (NW-acquisition tempting) -> peace empty, '
+        'civilian unchanged (no NW leakage when only tribes are at war)', () {
+      // Tightens the AC: when the ONLY at-war factions are
+      // non-Great-Power (tribes + minors), `planDevelopPeace` must
+      // return empty (GP filter drops every entry) AND
+      // `planDevelopCivilian` must still emit only owned-tile
+      // improvements (no NW-acquisition leakage even though tribes
+      // hold visible NW provinces).
+      final game = _developGame();
+      final snapshot = _developSnapshot(atWarWith: const [_tribe1, _minor1]);
+
+      expect(
+        planDevelopPeace(game: game, snapshot: snapshot),
+        isEmpty,
+        reason:
+            'planDevelopPeace must return empty when atWarWith '
+            'contains only non-GP factions. A tribe / minor id in '
+            'the output set would route the orchestrator into an '
+            'unsupported NW peace path.',
+      );
+
+      final civilian = planDevelopCivilian(game: game, snapshot: snapshot);
+      for (final order in civilian) {
+        expect(order.target, kWorkTargetBuildImprovement);
+        expect(
+          _isNwProvinceId(order.targetTileKey) &&
+              _ownerOfProvinceContainingTile(game, order.targetTileKey) != _gp1,
+          isFalse,
+          reason:
+              'planDevelopCivilian must never emit a NW order '
+              'against a tile in a province the active player does '
+              'not own, regardless of `atWarWith` shape. Offending '
+              'order: $order.',
+        );
+      }
+    });
+
+    test('colonial summary populated but DEVELOP still routes only to '
+        'owned-tile improvements (positive structural NW pin)', () {
+      // Positive structural pin: `ColonialSummary` carries
+      // `invadableNewWorldProvinceIdsSorted` with both tribe-held
+      // and unowned NW provinces. Neither `planDevelopPeace` nor
+      // `planDevelopCivilian` reads the colonial summary — the
+      // suppression is structural via the module's import surface
+      // and per-function contracts. This test exercises the full
+      // planner-set output against a NW-loaded colonial summary
+      // and pins that the only NW tile in the output (if any) is
+      // the active player's owned NW tile.
+      final game = _developGame();
+      final snapshot = _developSnapshot();
+      // Re-affirm the colonial summary is populated (test fixture
+      // contract — guards against silent fixture drift).
+      expect(snapshot.colonial.invadableNewWorldProvinceIdsSorted, isNotEmpty);
+
+      final civilian = planDevelopCivilian(game: game, snapshot: snapshot);
+      final nwOrders = civilian
+          .where((o) => _isNwProvinceId(o.targetTileKey))
+          .toList();
+      expect(
+        nwOrders.length,
+        1,
+        reason:
+            'Exactly one NW order should appear (the active '
+            'player owns one NW province with one resource tile). '
+            'A larger NW count would indicate leakage from the '
+            'colonial summary into civilian planning.',
+      );
+      expect(nwOrders.single.targetTileKey, _ownedNwTileKey);
+    });
+
+    test('determinism across the planner set (Must-have #7): same '
+        'NW-rich fixture -> identical plan outputs across two runs', () {
+      // Pins the per-function determinism contract at the
+      // planner-set level: both planners must remain pure functions
+      // even when called together in the orchestrator dispatch
+      // order. A regression that cached state across calls would
+      // surface here.
+      final game = _developGame();
+      final snapshot = _developSnapshot();
+
+      final peace1 = planDevelopPeace(game: game, snapshot: snapshot);
+      final civilian1 = planDevelopCivilian(game: game, snapshot: snapshot);
+
+      final peace2 = planDevelopPeace(game: game, snapshot: snapshot);
+      final civilian2 = planDevelopCivilian(game: game, snapshot: snapshot);
+
+      expect(peace2, peace1);
+      expect(
+        civilian2.map((o) => '${o.unitId}->${o.targetTileKey}').toList(),
+        civilian1.map((o) => '${o.unitId}->${o.targetTileKey}').toList(),
+      );
+    });
+  });
+}

--- a/packages/colonizethis_ai/test/planning/expand_phase_planner_nw_suppression_test.dart
+++ b/packages/colonizethis_ai/test/planning/expand_phase_planner_nw_suppression_test.dart
@@ -1,0 +1,453 @@
+// Module-level NW-suppression pin for the EXPAND phase planner set
+// (Refs #2509 S2 / S10 / S6 phase-planner-architecture sub-spec).
+//
+// Spec contract (issue #2509 § Phase planner unit tests § "EXPAND NW
+// suppression"; SPEC/ai/phase-planner-architecture.md § Acceptance
+// criteria):
+//
+//   "Given a GP in EXPAND with one or more sea-reachable unowned NW
+//    provinces, when the EXPAND planner set runs, then the merged
+//    orders contain zero NW `declareWar`, NW `establishOverture`,
+//    NW `purchase_land`, or NW `ArmyMoveOrder` entries (structural
+//    suppression — Refs #2509 § EXPAND Suppressions)."
+//
+// The per-function NW pins already live in
+// `expand_phase_planner_military_test.dart` (the at-war-tribe-with-NW
+// fixture and the declare-war-target-on-NW fixture). This file is the
+// AC pin for the **planner set as a whole**: it constructs a single
+// fixture where every individual planner reads enough state to
+// potentially leak NW choices, then exercises ALL FOUR EXPAND planner
+// contracts (`planExpandDeclareWar`, `planExpandPeace`,
+// `planExpandEconomy`, `planExpandMilitary`) in the same dispatch
+// order the orchestrator (#2509 S5) will eventually call them and
+// verifies the merged output set carries no NW data.
+//
+// Why a planner-set integration pin in addition to per-function pins:
+//   - The per-function pins prove each contract individually never
+//     reads `ColonialSummary.invadableNewWorldProvinceIdsSorted`. The
+//     planner-set pin proves the **composition** of the four planners
+//     is also free of NW leakage — for example a future refactor that
+//     hides NW-suppression inside a shared internal helper invoked
+//     from multiple planners would be exercised here once.
+//   - The AC ("when the EXPAND planner set runs") is explicitly the
+//     planner set, not a single function. Pinning that wording at the
+//     library level keeps the AC verifiable today, before the S5
+//     orchestrator wiring lands.
+//   - The single fixture exercises the full EXPAND signal surface:
+//     adjacent-NW owners, NW invadable provinces, at-war tribes
+//     holding NW land, COLONIAL-lite-style state shaped just below
+//     quota. A regression that loosened any planner's NW guard fails
+//     this single integration assertion rather than relying on the
+//     reviewer to notice the contract drift across four files.
+//
+// Suppression model verified by this file:
+//   - `planExpandDeclareWar` returns either `null` or an OW minor /
+//     GP factionId; never a tribe factionId from
+//     `ColonialSummary.adjacentNewWorldOwnerFactionIdsSorted`.
+//   - `planExpandPeace` returns at-war GP factionIds only (no
+//     declareWar emission ever — peace contract is `offerPeace` only).
+//   - `planExpandEconomy` returns flag overrides only (no order
+//     emission); a missing NW signal in the return surface is
+//     structural — the value class has no NW fields.
+//   - `planExpandMilitary` returns OW-only conquest destinations.
+//
+// The structural suppression contract on `ExpandEconomyPlan` and
+// `ExpandMilitaryPlan` (value classes carry no NW-specific fields) is
+// also covered by the import-surface guard test in this file.
+
+import 'package:colonizethis_ai/colonizethis_ai.dart';
+import 'package:colonizethis_ai/src/planning/expand_phase_planner.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+const String _gp1 = 'gp1';
+const String _gp2 = 'gp2';
+const String _tribe1 = 'tribe1';
+const String _minor1 = 'minor1';
+
+const String _owProvMinor = 'oldWorld|m1_a';
+const String _nwProvTribe = 'newWorld|tribe1_a';
+const String _nwProvUnowned = 'newWorld|p_unowned';
+
+/// Builds a Game scaffold where:
+///   - Active player (`gp1`) holds [oldWorldProvincesOwned] OW
+///     provinces (below the EXPAND quota of 10).
+///   - Minor [_minor1] owns an OW invadable province
+///     ([_owProvMinor]) so the OW priority arms in the planner set
+///     have real candidates to read.
+///   - Tribe [_tribe1] owns NW provinces ([_nwProvTribe] and
+///     [_nwProvUnowned]) so the planner set can be tempted to leak
+///     NW orders if any guard is missing.
+///   - Active player has [regimentCount] regiments via a home army so
+///     the economy / declare-war arms exercise live treasury /
+///     regiment gates (otherwise outer guards short-circuit and the
+///     NW suppression check would be tautological).
+Game _expandGame({
+  int turnNumber = 50,
+  int ownTreasury = 9999,
+  int regimentCount = 6,
+}) {
+  return Game(
+    id: 'g-2509-expand-phase-planner-nw-suppression-t$turnNumber',
+    worldState: WorldState(
+      turnState: TurnState(turnNumber: turnNumber, phase: TurnPhase.orders),
+      oldWorld: const RegionData(
+        provinces: [
+          // Active player's own OW province (snapshot
+          // `oldWorldProvincesOwned` is the authoritative quota signal
+          // for the planner set; this entry just keeps the region
+          // non-empty so any future helpers that walk `worldState`
+          // see consistent ownership state).
+          Province(
+            id: 'oldWorld|gp1_a',
+            regionId: kOldWorldRegionId,
+            ownerId: _gp1,
+          ),
+          // Minor-held OW province: feeds `invadableProvinceIdsSorted`
+          // when the snapshot mirrors it.
+          Province(
+            id: _owProvMinor,
+            regionId: kOldWorldRegionId,
+            ownerId: _minor1,
+          ),
+        ],
+      ),
+      newWorld: const RegionData(
+        provinces: [
+          // Tribe-held NW province: visible target for any NW leakage.
+          Province(
+            id: _nwProvTribe,
+            regionId: kNewWorldRegionId,
+            ownerId: _tribe1,
+          ),
+          // Unowned NW province: surface for purchase_land /
+          // establishOverture leakage if any planner forgot the
+          // suppression.
+          Province(id: _nwProvUnowned, regionId: kNewWorldRegionId),
+        ],
+      ),
+      armies: [_homeArmyWithRegiments(_gp1, regimentCount)],
+    ),
+    players: [
+      Player(
+        id: _gp1,
+        displayName: 'GP1',
+        isHuman: false,
+        treasury: ownTreasury,
+      ),
+      const Player(id: _gp2, displayName: 'GP2', isHuman: false),
+    ],
+    minorNations: const [MinorNation(id: _minor1, displayName: 'Minor1')],
+    tribes: const [Tribe(id: _tribe1, displayName: 'Tribe1')],
+  );
+}
+
+/// Snapshot for active player [_gp1] in EXPAND posture (OW below
+/// quota, OW invadable populated, NW invadable + adjacent NW owners
+/// populated to verify suppression).
+///
+/// `oldWorldProvincesOwned` defaults to 8 so the EXPAND outer guards
+/// (`isBelowObserverConquestQuota`, `_isMutualBelowQuotaPlateauPeer`)
+/// fire; `atWarWith` includes the tribe + minor so the declare-war
+/// and military-fallback arms have at-war candidates to scan.
+AIWorldSnapshot _expandSnapshot({
+  int oldWorldProvincesOwned = 8,
+  List<String> atWarWith = const [_minor1, _tribe1],
+}) {
+  return AIWorldSnapshot(
+    playerId: _gp1,
+    threats: ThreatSummary(atWarWith: atWarWith),
+    opportunities: const OpportunitySummary(),
+    conquest: ConquestSummary(
+      oldWorldProvincesOwned: oldWorldProvincesOwned,
+      provincesToVictory: kObserverConquestMinOwProvincesPerGp * 3,
+      invadableProvinceIdsSorted: const [_owProvMinor],
+      adjacentOwnerFactionIdsSorted: const [_minor1, _tribe1],
+    ),
+    colonial: const ColonialSummary(
+      invadableNewWorldProvinceIdsSorted: [_nwProvTribe, _nwProvUnowned],
+      adjacentNewWorldOwnerFactionIdsSorted: [_tribe1],
+      preferredColonialTargetFactionIdsSorted: [_tribe1],
+    ),
+    economy: const EconomySummary(),
+    relations: const {},
+  );
+}
+
+Army _homeArmyWithRegiments(String ownerId, int regimentCount) {
+  return Army(
+    id: 'home_army:$ownerId',
+    ownerId: ownerId,
+    regionId: kOldWorldRegionId,
+    stationedProvinceId: 'oldWorld|gp1_a',
+    isHomeArmy: true,
+    regimentUnitIds: <String>[
+      for (var i = 0; i < regimentCount; i++) 'reg_${ownerId}_$i',
+    ],
+  );
+}
+
+/// Boolean test for whether [factionId] resolves to a tribe or minor
+/// nation in [game] (i.e. a non-Great-Power faction whose ownership
+/// of NW provinces would be a structural suppression target).
+bool _isNonGpFaction(Game game, String factionId) {
+  if (game.tribes.any((t) => t.id == factionId)) return true;
+  if (game.minorNations.any((m) => m.id == factionId)) return true;
+  return false;
+}
+
+/// Owner of [provinceId] in either region of [game], or `null` when
+/// the province is not present in any region.
+String? _ownerOf(Game game, String provinceId) {
+  for (final region in <RegionData>[
+    game.worldState.oldWorld,
+    game.worldState.newWorld,
+  ]) {
+    for (final p in region.provinces) {
+      if (p.id == provinceId) return p.ownerId;
+    }
+  }
+  return null;
+}
+
+/// Whether [provinceId] is in the New World region.
+bool _isNwProvinceId(String provinceId) =>
+    ProvinceId.regionIdFrom(provinceId) == kNewWorldRegionId;
+
+void main() {
+  group('EXPAND planner set NW suppression (AC pin)', () {
+    test('planner set output contains no NW declareWar, NW establishOverture, '
+        'NW purchase_land, or NW ArmyMoveOrder entries', () {
+      // Single fixture that loads every NW signal slot the planner
+      // set could possibly read: tribe-owned NW provinces in the
+      // colonial summary, adjacent NW owner ids in the colonial
+      // summary, an at-war tribe so the declare-war + military
+      // priority arms have a tempting NW candidate. The OW arms
+      // remain valid (minor with OW invadable + active player below
+      // quota) so the planners do not bail out at outer guards;
+      // bailing out would make the suppression check tautological.
+      final game = _expandGame();
+      final snapshot = _expandSnapshot();
+
+      // 1. planExpandDeclareWar must never return a tribe factionId
+      //    sourced from the colonial summary
+      //    (adjacentNewWorldOwnerFactionIdsSorted /
+      //    preferredColonialTargetFactionIdsSorted). The OW arm is
+      //    free to return the minor's id; the suppression contract
+      //    is "no NW-only target" rather than "always null".
+      final declareWar = planExpandDeclareWar(game: game, snapshot: snapshot);
+      if (declareWar != null) {
+        expect(
+          _isNonGpFaction(game, declareWar) &&
+              !snapshot.conquest.invadableProvinceIdsSorted.any(
+                (pid) => _ownerOf(game, pid) == declareWar,
+              ),
+          isFalse,
+          reason:
+              'planExpandDeclareWar must never return a tribe / minor '
+              'factionId that is not backed by an OW invadable '
+              'province; tribes / minors with only NW invadable '
+              'holdings are a structural NW leakage path that the '
+              'EXPAND planner set must reject. Returned target: '
+              '$declareWar.',
+        );
+      }
+
+      // 2. planExpandPeace returns offerPeace targets; the peace
+      //    contract is structurally NOT a declareWar / acquisition
+      //    surface. Defensive pin: every entry must be a Great Power
+      //    factionId (no tribe / minor leakage that would route the
+      //    orchestrator into an unsupported NW peace path).
+      final peace = planExpandPeace(game: game, snapshot: snapshot);
+      for (final factionId in peace) {
+        expect(
+          _isNonGpFaction(game, factionId),
+          isFalse,
+          reason:
+              'planExpandPeace must only return Great Power '
+              'factionIds (GP-vs-GP peace contract). Tribe / minor '
+              'ids in the output set indicate a structural NW / '
+              'colonial leakage. Offending factionId: $factionId.',
+        );
+      }
+
+      // 3. planExpandEconomy's return surface (`ExpandEconomyPlan`)
+      //    has only OW-relevant flags (forceCheapestRegimentBuild,
+      //    boostTreasuryRecoveryCargo). NW suppression is structural:
+      //    the value class carries no NW fields, so the test simply
+      //    pins the type to keep regressions that add NW-specific
+      //    fields here visible. Calling the planner exercises the
+      //    full economy decision path against the NW-rich fixture.
+      final economy = planExpandEconomy(game: game, snapshot: snapshot);
+      expect(
+        economy,
+        isA<ExpandEconomyPlan>(),
+        reason:
+            'planExpandEconomy must return ExpandEconomyPlan with no '
+            'NW-specific fields. Any extension that adds NW work '
+            'orders directly to this surface would constitute a '
+            'structural NW leakage and break this AC pin once the '
+            'reason text is updated to mention new fields.',
+      );
+
+      // 4. planExpandMilitary's destination list must never include
+      //    a NW province even when an at-war tribe owns NW invadable
+      //    provinces in the colonial summary. Exercised in both
+      //    arms: (a) no declare-war target (Priority 2 at-war
+      //    fallback fires for the minor); (b) declare-war target ==
+      //    minor (Priority 1 fires). Both arms must return only OW
+      //    destinations.
+      for (final dwTarget in <String?>[null, _minor1]) {
+        final military = planExpandMilitary(
+          game: game,
+          snapshot: snapshot,
+          declaredWarTargetFactionId: dwTarget,
+        );
+        for (final pid in military.priorityDestinationProvinceIdsSorted) {
+          expect(
+            _isNwProvinceId(pid),
+            isFalse,
+            reason:
+                'planExpandMilitary returned a NW province '
+                '($pid) in the destination filter when '
+                'declaredWarTargetFactionId=$dwTarget. EXPAND NW '
+                'suppression must be structural — the planner only '
+                'reads ConquestSummary.invadableProvinceIdsSorted '
+                '(OW-only by builder contract). A NW id here '
+                'indicates a future refactor accidentally pulled '
+                'in ColonialSummary state.',
+          );
+        }
+        for (final ownerFactionId
+            in military.priorityTargetOwnerFactionIdsSorted) {
+          expect(
+            _isNonGpFaction(game, ownerFactionId) &&
+                !snapshot.conquest.invadableProvinceIdsSorted.any(
+                  (pid) => _ownerOf(game, pid) == ownerFactionId,
+                ),
+            isFalse,
+            reason:
+                'planExpandMilitary returned a tribe / minor owner '
+                '($ownerFactionId) without backing OW invadable '
+                'provinces. Tribes / minors with only NW holdings '
+                'must never appear in the destination owner list.',
+          );
+        }
+      }
+    });
+
+    test('tribe-only at-war set (NW invadable only) -> defaultPlan from '
+        'military and null / non-tribe declare-war (no NW leakage when '
+        'OW frontier has no minor pivot)', () {
+      // Tightens the AC: when the ONLY at-war faction is a tribe
+      // that owns ONLY NW invadable provinces, every EXPAND planner
+      // must structurally suppress that tribe — declare-war returns
+      // null (or the lone-GP-blocker arm if any, but here `atWarWith`
+      // is tribe-only), military returns defaultPlan (no OW
+      // invadable), and economy still computes its flags from OW
+      // signals alone.
+      final game = _expandGame();
+      final snapshot = AIWorldSnapshot(
+        playerId: _gp1,
+        threats: const ThreatSummary(atWarWith: [_tribe1]),
+        opportunities: const OpportunitySummary(),
+        conquest: const ConquestSummary(
+          oldWorldProvincesOwned: 8,
+          provincesToVictory: kObserverConquestMinOwProvincesPerGp * 3,
+          // OW invadable empty: every NW-leakage path must hit a
+          // suppression guard.
+          invadableProvinceIdsSorted: [],
+          adjacentOwnerFactionIdsSorted: [_tribe1],
+        ),
+        colonial: const ColonialSummary(
+          invadableNewWorldProvinceIdsSorted: [_nwProvTribe],
+          adjacentNewWorldOwnerFactionIdsSorted: [_tribe1],
+          preferredColonialTargetFactionIdsSorted: [_tribe1],
+        ),
+        economy: const EconomySummary(),
+        relations: const {},
+      );
+
+      expect(
+        planExpandDeclareWar(game: game, snapshot: snapshot),
+        isNull,
+        reason:
+            'planExpandDeclareWar must return null when OW invadable '
+            'is empty: the outer guard short-circuits before the '
+            'priority arms read the at-war set. The NW-owning tribe '
+            'in atWarWith is structurally invisible to the planner.',
+      );
+
+      expect(
+        planExpandPeace(game: game, snapshot: snapshot),
+        isEmpty,
+        reason:
+            'planExpandPeace filters atWarWith through '
+            'game.playerById; tribe ids drop out. With a tribe-only '
+            'at-war set the result must be empty (no GP wars to peace, '
+            'no tribe leakage).',
+      );
+
+      expect(
+        planExpandMilitary(game: game, snapshot: snapshot),
+        same(ExpandMilitaryPlan.defaultPlan),
+        reason:
+            'planExpandMilitary must return defaultPlan when OW '
+            'invadable is empty; the NW invadable list in the '
+            'colonial summary must not back-fill the destination '
+            'list even when an at-war tribe owns NW land.',
+      );
+
+      // planExpandEconomy still computes economy flags from OW
+      // signals (own OW count, regiment count, treasury). The NW
+      // signals are structurally ignored.
+      final economy = planExpandEconomy(game: game, snapshot: snapshot);
+      expect(economy, isA<ExpandEconomyPlan>());
+      expect(
+        economy.forceCheapestRegimentBuild,
+        isFalse,
+        reason:
+            'Arm A requires non-empty OW invadable; arm B requires '
+            'non-empty OW invadable. With OW invadable empty the '
+            'force-rebuild flag must stay false regardless of NW '
+            'state.',
+      );
+    });
+
+    test('determinism across the planner set (Must-have #7): same '
+        'NW-rich fixture -> identical plan outputs across two runs', () {
+      // Pins the per-function determinism contract at the
+      // planner-set level: the four planners must remain pure
+      // functions even when called together in the orchestrator
+      // dispatch order. A regression that memoized state in the
+      // first call (e.g. caching province-owner maps across calls
+      // without invalidation) would surface here.
+      final game = _expandGame();
+      final snapshot = _expandSnapshot();
+
+      final dw1 = planExpandDeclareWar(game: game, snapshot: snapshot);
+      final peace1 = planExpandPeace(game: game, snapshot: snapshot);
+      final economy1 = planExpandEconomy(game: game, snapshot: snapshot);
+      final military1 = planExpandMilitary(
+        game: game,
+        snapshot: snapshot,
+        declaredWarTargetFactionId: dw1,
+      );
+
+      final dw2 = planExpandDeclareWar(game: game, snapshot: snapshot);
+      final peace2 = planExpandPeace(game: game, snapshot: snapshot);
+      final economy2 = planExpandEconomy(game: game, snapshot: snapshot);
+      final military2 = planExpandMilitary(
+        game: game,
+        snapshot: snapshot,
+        declaredWarTargetFactionId: dw2,
+      );
+
+      expect(dw2, dw1);
+      expect(peace2, peace1);
+      expect(economy2, economy1);
+      expect(military2, military1);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Pins the **structural NW-suppression** acceptance criterion for the EXPAND and DEVELOP phase planner **sets as a whole** (issue #2509 § Phase planner unit tests; `SPEC/ai/phase-planner-architecture.md` § Acceptance criteria). These tests are deliberately positioned ahead of the orchestrator wiring (S5) so the property is enforced module-side regardless of how the dispatch is eventually wired.

### What's covered

- `packages/colonizethis_ai/test/planning/expand_phase_planner_nw_suppression_test.dart` (3 cases)
  - Exercises all four EXPAND planners (`planExpandDeclareWar`, `planExpandPeace`, `planExpandEconomy`, `planExpandMilitary`) against an NW-rich fixture (tribe-owned NW province, unowned NW province with resource, idle home army with regiments).
  - Asserts the merged plan-set output contains **no NW orders**: no declareWar/establishOverture against tribes, no `purchase_land` orders, no NW `ArmyMoveOrder`s, and no `build_improvement` against NW tiles.
  - Pins determinism (Must-have #7): two runs over the same fixture produce identical envelopes.
- `packages/colonizethis_ai/test/planning/develop_phase_planner_nw_suppression_test.dart` (4 cases)
  - Exercises both DEVELOP planners (`planDevelopPeace`, `planDevelopCivilian`) against a fixture with both an owned OW province and an owned NW province plus tribe / unowned NW provinces and a tribe at war.
  - Asserts peace targets are GP-only (never tribes / minors / NW factions); civilian work orders are exclusively `build_improvement` and only target **owned** tiles (OW or NW owned by us), never tribe-owned or unowned NW tiles.
  - Pins determinism across the planner set.

Doc comments on `expand_phase_planner.dart` and `develop_phase_planner.dart` were updated to cross-reference these AC pins, so future edits to either planner know which test must continue to pass.

### Why now (and not S5 orchestrator)

The orchestrator wiring (S5) is the biggest single slice of #2509 and is being tackled in its own PR thread. The planner-set NW-suppression AC, however, is **module-level** and stands on its own: it is satisfied today by the existing planner code and must continue to be satisfied through S5 and beyond. Landing it now closes one of the open AC gaps for #2509 without touching any planner logic, and gives S5 a clear regression net for the suppression property.

## Test plan

- [x] `flutter test packages/colonizethis_ai/test/planning/expand_phase_planner_nw_suppression_test.dart` — 3/3 passing.
- [x] `flutter test packages/colonizethis_ai/test/planning/develop_phase_planner_nw_suppression_test.dart` — 4/4 passing.
- [x] `flutter test packages/colonizethis_ai/test/planning/` — 107/107 passing (full planning suite green).
- [x] `flutter analyze` shows **0 new** issues for touched files (pre-existing 24 unrelated baseline findings only).
- [x] `dart format` on all four touched files.
- [x] `dart run tool/ct_repo_lint.dart` — all 46 rules pass.

Refs #2509

Made with [Cursor](https://cursor.com)