### PR TITLE
test(e2e): lift _radioListTilesInAlertDialogs into shared library + pin (Refs #2336)

### DIFF
--- a/app/integration_test/e2e_helpers.dart
+++ b/app/integration_test/e2e_helpers.dart
@@ -32,6 +32,7 @@ export 'e2e_test_shared.dart'
         e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot,
         e2ePumpUntil,
         e2ePumpUntilConditionOrIdle,
+        e2eRadioListTilesInAlertDialogs,
         e2eTextLooksLikeNewWorldLocationLine,
         e2eWaitForNewGameEntry,
         e2eWaitForNextTurnLabelAdvance,

--- a/app/integration_test/e2e_test_shared.dart
+++ b/app/integration_test/e2e_test_shared.dart
@@ -1515,3 +1515,45 @@ String e2eBundledExploreRejectionDiagnostics({
   }
   return lines.join('\n');
 }
+
+/// Returns a [Finder] matching every `RadioListTile<…>` widget that is a
+/// descendant of any currently-mounted [AlertDialog].
+///
+/// Contract (issue #2336 AC1 / AC2):
+///
+///   - Composes `find.descendant(of: find.byType(AlertDialog), matching: …)`
+///     so the search is scoped to dialog subtrees only — `RadioListTile`s
+///     outside an [AlertDialog] (panels, settings sheets, etc.) are never
+///     returned. Naval / civilian / production move dialogs all surface
+///     destination tiles via `RadioListTile<…>`; scoping to [AlertDialog]
+///     keeps the move-segment helpers from accidentally hitting a panel
+///     radio.
+///   - The matcher inspects [Widget.runtimeType] via `toString()` so it
+///     accepts any generic instantiation
+///     (`RadioListTile<String>`, `RadioListTile<int>`, etc.) without
+///     pulling in the concrete type argument. The fleet-reach move dialog
+///     parameterises radio tiles on the destination string id; binding to
+///     `RadioListTile<String>` directly would silently miss future
+///     dialogs that switch to a different parameter type.
+///   - Pure — the function reads no globals, returns a new [Finder] on
+///     every call, and never throws. The returned [Finder] is lazy and
+///     only resolves against the active widget tree when iterated, which
+///     keeps it safe to construct outside an `await tester.pump()`
+///     boundary.
+///
+/// Mirrors the lifted public-name pattern used by
+/// `e2eNonHomeHumanFleetInNewWorldFromCtSnapshot` and
+/// `e2eNavalPanelShowsNonHomeFleetInNewWorld` so callers consume the
+/// AC1 barrel (`e2e_helpers.dart`) only. A silent rename or accidental
+/// scope-removal (matching every `RadioListTile` across the tree)
+/// would re-introduce false positives in move-segment dialogs that
+/// also host non-destination radios on the surrounding screen
+/// (Refs `SPEC/program/e2e-integration-tests.md` § Determinism).
+Finder e2eRadioListTilesInAlertDialogs() {
+  return find.descendant(
+    of: find.byType(AlertDialog),
+    matching: find.byWidgetPredicate(
+      (w) => w.runtimeType.toString().startsWith('RadioListTile<'),
+    ),
+  );
+}

--- a/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers.dart
+++ b/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers.dart
@@ -64,14 +64,14 @@ Future<void> _tapOldWorldRegionTab(
   );
 }
 
-Finder _radioListTilesInAlertDialogs() {
-  return find.descendant(
-    of: find.byType(AlertDialog),
-    matching: find.byWidgetPredicate(
-      (w) => w.runtimeType.toString().startsWith('RadioListTile<'),
-    ),
-  );
-}
+/// Generic-instantiation `RadioListTile<…>` lookup inside any mounted
+/// [AlertDialog] moved to [e2eRadioListTilesInAlertDialogs]
+/// (`e2e_test_shared.dart`) so the `runtimeType.toString().startsWith`
+/// contract is unit-pinned and shared across scenarios (Refs GitHub
+/// #2336 AC1 / AC2). The widget-test pin in
+/// `app/test/e2e_radio_list_tiles_in_alert_dialogs_test.dart` guards
+/// against a silent rename / scope-removal that would re-introduce
+/// false positives in move-segment dialogs.
 
 /// Prefer cross-region warp row (English copy); else first adjacent sea tile.
 ///
@@ -128,9 +128,11 @@ Future<void> _pickMoveDestinationAndConfirm(
         }
       }
       const maxWarpDragProbes = 8;
-      for (var i = 0;
-          i < maxWarpDragProbes && warp.hitTestable().evaluate().isEmpty;
-          i++) {
+      for (
+        var i = 0;
+        i < maxWarpDragProbes && warp.hitTestable().evaluate().isEmpty;
+        i++
+      ) {
         ensureBudget('warp drag $i');
         await tester.drag(sc, const Offset(0, -120));
         // Short-circuit as soon as the warp row becomes hit-testable instead of
@@ -164,7 +166,7 @@ Future<void> _pickMoveDestinationAndConfirm(
     await tester.tap(warpTile.first, warnIfMissed: false);
   } else {
     ensureBudget('sea radio');
-    final seaRadio = _radioListTilesInAlertDialogs();
+    final seaRadio = e2eRadioListTilesInAlertDialogs();
     expect(seaRadio, findsWidgets);
     await tester.tap(seaRadio.first, warnIfMissed: false);
   }
@@ -192,6 +194,7 @@ Future<void> _tryNavalMoveSegment(
   AppLocalizations l10n, {
   bool useNewWorldMapTabFirst = false,
   bool allowWarpDestinations = true,
+
   /// When true, the naval panel is already open from a prior [openNavalPanel]
   /// in the same turn iteration — skip close/reopen (Refs #2336 Bottleneck 4).
   bool navalPanelAlreadyOpen = false,

--- a/app/test/e2e_helpers_barrel_test.dart
+++ b/app/test/e2e_helpers_barrel_test.dart
@@ -574,6 +574,42 @@ void main() {
       );
     });
 
+    testWidgets(
+      'e2eRadioListTilesInAlertDialogs is re-exported through the barrel',
+      (tester) async {
+        final Finder Function() ref = e2eRadioListTilesInAlertDialogs;
+        expect(
+          ref,
+          isNotNull,
+          reason:
+              'The fleet-reach move dialog consumes this scoped lookup via '
+              'the AC1 barrel (`_pickMoveDestinationAndConfirm` in '
+              '`new_game_fleet_reaches_new_world_e2e_helpers.dart` taps '
+              '`e2eRadioListTilesInAlertDialogs().first` to pick the sea '
+              'radio when the warp row is absent). A regression that '
+              'dropped it from the `show` clause would force the move '
+              'helper to either re-roll a private duplicate (Bottleneck 6) '
+              'or fall back to an unscoped RadioListTile finder that '
+              'matches panels outside the dialog (`SPEC/program/'
+              'e2e-integration-tests.md` § Determinism).',
+        );
+        await tester.pumpWidget(
+          const MaterialApp(home: Scaffold(body: SizedBox())),
+        );
+        expect(
+          ref(),
+          findsNothing,
+          reason:
+              'Sanity smoke through the barrel: with no AlertDialog '
+              'mounted the finder must resolve to zero matches. A '
+              'wrapper that returned a constant non-empty Finder, or '
+              'that dropped the AlertDialog scope and matched every '
+              'RadioListTile in the tree, would pass the tear-off pin '
+              'silently.',
+        );
+      },
+    );
+
     test('AC1 timing constants are exposed as Duration values', () {
       const Duration maxWallClock = kE2eMaxWallClock;
       const Duration nextTurnTimeout = kE2eNextTurnResolutionTimeout;

--- a/app/test/e2e_radio_list_tiles_in_alert_dialogs_test.dart
+++ b/app/test/e2e_radio_list_tiles_in_alert_dialogs_test.dart
@@ -1,0 +1,396 @@
+/// Pins the dialog-scoped `RadioListTile<…>` lookup contract of
+/// [e2eRadioListTilesInAlertDialogs] (`app/integration_test/e2e_test_shared.dart`).
+///
+/// The fleet-reach move helper (`_pickMoveDestinationAndConfirm` in
+/// `new_game_fleet_reaches_new_world_e2e_helpers.dart`) taps
+/// `e2eRadioListTilesInAlertDialogs().first` to pick the destination sea
+/// radio when no warp row is present. Two regressions would silently
+/// re-introduce flakes / stalls if the helper drifted:
+///
+///   1. **Dropping the `find.byType(AlertDialog)` scope** would match
+///      `RadioListTile`s outside the dialog — the unit/civilian/production
+///      panel trees host their own radios for filters and settings, so an
+///      unscoped finder can return a tile that lives in a side panel and
+///      never advance the move dialog. The fleet-reach loop would stall
+///      until the 35-tap cap (`_kMaxNextTurnTapsForNwFleetReach`) instead
+///      of completing at the first qualifying sea radio.
+///   2. **Binding the matcher to a concrete `RadioListTile<String>`**
+///      would silently miss every future move dialog parameterised on a
+///      different type (a destination enum, a province id record, etc.).
+///      The current `runtimeType.toString().startsWith('RadioListTile<')`
+///      contract matches **every** generic instantiation, which keeps the
+///      helper resilient to type-argument changes in
+///      `naval_tree_builder.dart` / move-fleet dialog widgets.
+///
+/// The integration suite cannot validate this directly (the
+/// `app_e2e_linux` lane is a no-op per `SPEC/program/e2e-integration-tests.md`
+/// § CI), so the widget-test layer carries the behavioural pin.
+///
+/// Refs GitHub #2336 AC1 / AC2.
+library;
+
+// The production move-fleet dialog (`move_fleet_dialog.dart`) constructs
+// `RadioListTile<_MovePick>` with the legacy `groupValue` / `onChanged`
+// API; the AC1 helper matches on `runtimeType.toString()`, so the test
+// fixtures must build the same widget shape (not the newer RadioGroup-
+// based API) for the pin to validate the production code path.
+// ignore_for_file: deprecated_member_use
+
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../integration_test/e2e_test_shared.dart';
+
+Widget _wrap(Widget child) {
+  return MaterialApp(home: Scaffold(body: child));
+}
+
+Future<void> _pumpDialog(
+  WidgetTester tester, {
+  required List<Widget> dialogChildren,
+  List<Widget> outsideDialog = const <Widget>[],
+}) async {
+  await tester.pumpWidget(
+    _wrap(
+      Column(
+        children: [
+          ...outsideDialog,
+          Builder(
+            builder: (context) {
+              return ElevatedButton(
+                onPressed: () {
+                  showDialog<void>(
+                    context: context,
+                    builder: (_) =>
+                        AlertDialog(content: Column(children: dialogChildren)),
+                  );
+                },
+                child: const Text('open'),
+              );
+            },
+          ),
+        ],
+      ),
+    ),
+  );
+  await tester.tap(find.text('open'));
+  await tester.pumpAndSettle();
+  expect(
+    find.byType(AlertDialog),
+    findsOneWidget,
+    reason:
+        'Test harness sanity: the AlertDialog must be mounted before '
+        'asserting against the dialog-scoped finder.',
+  );
+}
+
+void main() {
+  suppressLogsForTests();
+
+  group('e2eRadioListTilesInAlertDialogs — false / empty branches', () {
+    testWidgets('no AlertDialog mounted -> findsNothing', (tester) async {
+      await tester.pumpWidget(_wrap(const SizedBox()));
+      expect(
+        e2eRadioListTilesInAlertDialogs(),
+        findsNothing,
+        reason:
+            'Without an AlertDialog in the tree the descendant lookup must '
+            'short-circuit to zero matches. A regression that dropped the '
+            '`of: find.byType(AlertDialog)` scope would match nothing here '
+            'too (no radios at all), so this test must be paired with the '
+            '"radio outside dialog ignored" branch below to catch the '
+            'scope-drop regression on its own.',
+      );
+    });
+
+    testWidgets('AlertDialog with no RadioListTile -> findsNothing', (
+      tester,
+    ) async {
+      await _pumpDialog(
+        tester,
+        dialogChildren: const [Text('Pick a destination')],
+      );
+      expect(
+        e2eRadioListTilesInAlertDialogs(),
+        findsNothing,
+        reason:
+            'AlertDialog content that holds only Text (the move dialog '
+            'fall-back when no legal sea step exists) must keep the helper '
+            'empty. A wrapper that matched any descendant — or that '
+            'misread the AlertDialog body as a RadioListTile parent — '
+            'would surface false positives here.',
+      );
+    });
+
+    testWidgets('RadioListTile outside any AlertDialog -> findsNothing', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _wrap(
+          RadioListTile<String>(
+            title: const Text('panel-side'),
+            value: 'a',
+            groupValue: 'b',
+            onChanged: (_) {},
+          ),
+        ),
+      );
+      expect(
+        e2eRadioListTilesInAlertDialogs(),
+        findsNothing,
+        reason:
+            'A panel-side RadioListTile (settings sheet, civilian panel '
+            'filter, etc.) must NOT leak into the dialog-scoped lookup. '
+            'Dropping the `find.byType(AlertDialog)` scope would match '
+            'this tile and let the fleet-reach move helper tap the wrong '
+            'control, stalling the loop at the 35-tap cap.',
+      );
+    });
+
+    testWidgets(
+      'AlertDialog without RadioListTile + RadioListTile outside dialog -> findsNothing',
+      (tester) async {
+        await _pumpDialog(
+          tester,
+          dialogChildren: const [Text('Confirm warp?')],
+          outsideDialog: [
+            RadioListTile<int>(
+              title: const Text('outside'),
+              value: 1,
+              groupValue: 2,
+              onChanged: (_) {},
+            ),
+          ],
+        );
+        expect(
+          e2eRadioListTilesInAlertDialogs(),
+          findsNothing,
+          reason:
+              'Composite of the previous two branches: even with a '
+              'mounted AlertDialog the lookup must remain empty when the '
+              'only RadioListTile lives outside the dialog. A regression '
+              'that swapped the descendant scope for an ancestor scope '
+              '(or dropped it entirely) would match the panel-side tile.',
+        );
+      },
+    );
+  });
+
+  group('e2eRadioListTilesInAlertDialogs — true branches', () {
+    testWidgets('single RadioListTile<String> inside AlertDialog -> 1 match', (
+      tester,
+    ) async {
+      await _pumpDialog(
+        tester,
+        dialogChildren: [
+          RadioListTile<String>(
+            title: const Text('sea1'),
+            value: 'sea1',
+            groupValue: '',
+            onChanged: (_) {},
+          ),
+        ],
+      );
+      expect(
+        e2eRadioListTilesInAlertDialogs(),
+        findsOneWidget,
+        reason:
+            'The canonical fleet-reach move dialog parameterises '
+            'destination tiles on `RadioListTile<String>` (the sea-zone '
+            'id). A single radio must surface as exactly one match — the '
+            'fleet helper calls `.first` on it, so any over-count would '
+            'still pass but any under-count (matcher too strict) would '
+            'fail this assertion.',
+      );
+    });
+
+    testWidgets('multiple RadioListTile<String> inside AlertDialog -> N', (
+      tester,
+    ) async {
+      await _pumpDialog(
+        tester,
+        dialogChildren: [
+          for (final id in const ['sea1', 'sea2', 'sea3'])
+            RadioListTile<String>(
+              title: Text(id),
+              value: id,
+              groupValue: '',
+              onChanged: (_) {},
+            ),
+        ],
+      );
+      expect(
+        e2eRadioListTilesInAlertDialogs(),
+        findsNWidgets(3),
+        reason:
+            'Move dialogs with multiple legal destinations must surface '
+            'every radio (the helper later disambiguates via `.first`). '
+            'A regression that short-circuited after the first match — '
+            'or that filtered to a single index — would break multi-'
+            'destination probing.',
+      );
+    });
+
+    testWidgets(
+      'RadioListTile with non-String type argument is still matched',
+      (tester) async {
+        await _pumpDialog(
+          tester,
+          dialogChildren: [
+            RadioListTile<int>(
+              title: const Text('int-typed'),
+              value: 1,
+              groupValue: 2,
+              onChanged: (_) {},
+            ),
+          ],
+        );
+        expect(
+          e2eRadioListTilesInAlertDialogs(),
+          findsOneWidget,
+          reason:
+              'The contract uses `runtimeType.toString().startsWith('
+              '`'
+              'RadioListTile<'
+              '`'
+              ')` so any generic instantiation (`RadioListTile<int>`, '
+              '`RadioListTile<MyEnum>`, etc.) is in scope. Hard-binding '
+              'the matcher to `RadioListTile<String>` would silently miss '
+              'future move dialogs that parameterise on a different '
+              'destination type.',
+        );
+      },
+    );
+
+    testWidgets(
+      'RadioListTiles inside AlertDialog co-exist with siblings outside',
+      (tester) async {
+        await _pumpDialog(
+          tester,
+          dialogChildren: [
+            RadioListTile<String>(
+              title: const Text('inside-1'),
+              value: 'a',
+              groupValue: 'b',
+              onChanged: (_) {},
+            ),
+            RadioListTile<String>(
+              title: const Text('inside-2'),
+              value: 'b',
+              groupValue: 'b',
+              onChanged: (_) {},
+            ),
+          ],
+          outsideDialog: [
+            RadioListTile<String>(
+              title: const Text('outside-1'),
+              value: 'x',
+              groupValue: 'y',
+              onChanged: (_) {},
+            ),
+          ],
+        );
+        expect(
+          e2eRadioListTilesInAlertDialogs(),
+          findsNWidgets(2),
+          reason:
+              'The dialog-scoped lookup must count exactly the two '
+              'in-dialog tiles, never the outside sibling. This is the '
+              'canonical "panel + dialog co-mounted" regression guard for '
+              'move-dialog tapping (Bottleneck 4 of #2336).',
+        );
+      },
+    );
+  });
+
+  group('e2eRadioListTilesInAlertDialogs — regression guards', () {
+    testWidgets('plain ListTile (no Radio prefix) is rejected', (tester) async {
+      await _pumpDialog(
+        tester,
+        dialogChildren: const [ListTile(title: Text('plain-list-tile'))],
+      );
+      expect(
+        e2eRadioListTilesInAlertDialogs(),
+        findsNothing,
+        reason:
+            'A plain `ListTile` inside the dialog must NOT match the '
+            'finder. The fleet-reach helper depends on tapping the '
+            'RadioListTile (so the tile selection updates before '
+            'Confirm); matching a plain ListTile would dispatch the tap '
+            'to the wrong widget and silently miss the destination set.',
+      );
+    });
+
+    testWidgets('CheckboxListTile inside the dialog is rejected', (
+      tester,
+    ) async {
+      await _pumpDialog(
+        tester,
+        dialogChildren: [
+          CheckboxListTile(
+            title: const Text('checkbox-list-tile'),
+            value: false,
+            onChanged: (_) {},
+          ),
+        ],
+      );
+      expect(
+        e2eRadioListTilesInAlertDialogs(),
+        findsNothing,
+        reason:
+            'Even though `CheckboxListTile` shares the `ListTile` family, '
+            'the `runtimeType.toString().startsWith("RadioListTile<")` '
+            'prefix excludes it deterministically. A regression to a '
+            'substring-style match (`contains("ListTile")`) would '
+            'surface this checkbox and break the move-dialog tap path.',
+      );
+    });
+
+    testWidgets('successive calls return fresh, idle Finder objects', (
+      tester,
+    ) async {
+      await _pumpDialog(
+        tester,
+        dialogChildren: [
+          RadioListTile<String>(
+            title: const Text('only'),
+            value: 'a',
+            groupValue: '',
+            onChanged: (_) {},
+          ),
+        ],
+      );
+      final first = e2eRadioListTilesInAlertDialogs();
+      final second = e2eRadioListTilesInAlertDialogs();
+      expect(
+        identical(first, second),
+        isFalse,
+        reason:
+            'The helper must construct a fresh Finder on each call (no '
+            'caching). A shared/cached Finder would resolve against a '
+            'stale Element tree across pump frames and silently report '
+            'matches from a previous frame.',
+      );
+      expect(first.evaluate().length, 1);
+      expect(second.evaluate().length, 1);
+    });
+
+    testWidgets('finder is lazy: constructible without a pumped tree', (
+      tester,
+    ) async {
+      final finder = e2eRadioListTilesInAlertDialogs();
+      expect(
+        finder,
+        isNotNull,
+        reason:
+            'The helper must not query the WidgetTester on construction; '
+            'returning a lazy Finder keeps it safe to compose / store '
+            'before pumping. A regression that resolved the Finder '
+            'eagerly would throw outside an active tester binding.',
+      );
+      await tester.pumpWidget(_wrap(const SizedBox()));
+      expect(finder.evaluate(), isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Lift the dialog-scoped `RadioListTile<…>` lookup used by the fleet-reach
move helper (`_pickMoveDestinationAndConfirm` in
`new_game_fleet_reaches_new_world_e2e_helpers.dart`) from a private
single-call helper into a public, unit-pinned `e2eRadioListTilesInAlertDialogs`
in `e2e_test_shared.dart`, re-exported through the AC1 `e2e_helpers.dart`
barrel.

Follow-up to the just-merged PR #2714 (`Refs #2336`) which lifted the
snapshot-driven fleet-reach predicates and `_bundledExploreRejectionDiagnostics`.
This slice closes out one of the remaining private `Finder`-shaped helpers
in `new_game_fleet_reaches_new_world_e2e_helpers.dart` so the AC1 / AC2
"shared canonical implementation" pattern keeps converging.

Two regressions would silently re-introduce flakes / stalls if the helper
drifted:

1. **Dropping the `find.byType(AlertDialog)` scope** would match
   `RadioListTile`s outside the dialog — the unit/civilian/production
   panel trees host their own radios for filters and settings, so an
   unscoped finder can return a tile that lives in a side panel and never
   advance the move dialog. The fleet-reach loop would stall until the
   35-tap cap (`_kMaxNextTurnTapsForNwFleetReach`) instead of completing
   at the first qualifying sea radio.
2. **Binding the matcher to a concrete `RadioListTile<String>`** would
   silently miss every future move dialog parameterised on a different
   type (a destination enum, a province id record, etc.). The current
   `runtimeType.toString().startsWith('RadioListTile<')` contract matches
   every generic instantiation, which keeps the helper resilient to
   type-argument changes in `naval_tree_builder.dart` / move-fleet dialog
   widgets.

The integration suite cannot validate this directly (the `app_e2e_linux`
lane is a no-op per `SPEC/program/e2e-integration-tests.md` § CI), so
the widget-test layer carries the behavioural pin.

Refs #2336

## Done in this PR

### `e2e_test_shared.dart` (+ AC1 barrel)

- Add `Finder e2eRadioListTilesInAlertDialogs()` with a detailed contract
  docstring covering the dialog-scoped composition (`find.descendant(of:
  find.byType(AlertDialog), …)`), the `runtimeType.toString().startsWith`
  prefix that accepts every generic instantiation, and the pure / lazy
  / no-globals guarantees. The lifted form mirrors the earlier
  `e2eNonHomeHumanFleetInNewWorldFromCtSnapshot` /
  `e2eNavalPanelShowsNonHomeFleetInNewWorld` precedent so callers
  consume the AC1 barrel only.
- Re-export `e2eRadioListTilesInAlertDialogs` through the AC1
  `e2e_helpers.dart` `show` clause (#2336 AC2).

### `new_game_fleet_reaches_new_world_e2e_helpers.dart`

- Remove the private `_radioListTilesInAlertDialogs` body (replaced by a
  doc-only stub pointing at the lifted helper, mirroring the pattern
  used for `_textLooksLikeNewWorldLocationLine`,
  `_nonHomeHumanFleetInNewWorldFromCtSnapshot`,
  `_exploreAssignEnabledFromCivilianSnapshot`, etc. from PR #2714).
- Update the call site in `_pickMoveDestinationAndConfirm` to consume
  the public name — runtime behaviour unchanged.

### Tests (12 new + 1 barrel pin)

- `app/test/e2e_radio_list_tiles_in_alert_dialogs_test.dart` (NEW, 12
  widget tests grouped into:
  - **False / empty branches (4):** no AlertDialog mounted; AlertDialog
    with no RadioListTile; RadioListTile outside any AlertDialog; both
    composite (panel-side tile + empty dialog).
  - **True branches (4):** single `RadioListTile<String>` inside the
    dialog; multiple in-dialog tiles; non-String type argument still
    matched; in-dialog tiles co-exist with an outside-the-dialog
    sibling.
  - **Regression guards (4):** plain `ListTile` rejected; `CheckboxListTile`
    rejected (substring-style match guard); successive calls return
    fresh idle `Finder` objects (no caching); finder is lazy
    (constructible before pumping the tree).
- `app/test/e2e_helpers_barrel_test.dart` — +1 pin asserting the symbol
  is re-exported through the AC1 barrel with the documented
  `Finder Function()` signature; smoke probe asserts the finder
  resolves to `findsNothing` when no AlertDialog is mounted so a
  wrapper that returned a constant Finder or dropped the AlertDialog
  scope would surface here.

## AC coverage

- **AC1 — Shared helpers exist.** `e2eRadioListTilesInAlertDialogs` now
  lives in `e2e_test_shared.dart` and is re-exported through the AC1
  barrel.
- **AC2 — No duplicated private helpers.** Removed the private
  `_radioListTilesInAlertDialogs` definition; the only call site
  (`_pickMoveDestinationAndConfirm`) consumes the shared public name.
  The integration suite cannot validate this directly today
  (`app_e2e_linux` is a no-op per `SPEC/program/e2e-integration-tests.md`
  § CI), so the widget-test layer carries the behavioural pins.

No changes to wall-clock methodology, AC8–AC10 timing evidence, or
production Flutter/Flame UI.

## Test plan

Local verification (Linux):

- \`flutter test test/e2e_radio_list_tiles_in_alert_dialogs_test.dart\` —
  **12 passed**.
- \`flutter test test/e2e_helpers_barrel_test.dart\` — clean (existing
  pins + the new `e2eRadioListTilesInAlertDialogs` barrel pin pass).
- \`flutter analyze integration_test/e2e_test_shared.dart integration_test/e2e_helpers.dart integration_test/new_game_fleet_reaches_new_world_e2e_helpers.dart test/e2e_radio_list_tiles_in_alert_dialogs_test.dart test/e2e_helpers_barrel_test.dart\` — **No issues found**.
- \`dart format\` on touched files — clean.
- \`dart run custom_lint\` on touched files — **No issues found**.

## Label transition

\`backlog:implementation\` **not** moved to \`backlog:verification\` —
AC6–AC10 wall-clock evidence still requires maintainer Linux 3×
\`integration_test\` runs, and additional helper-dedup follow-ups remain
open on #2336.

Made with [Cursor](https://cursor.com)