### PR TITLE
chore(e2e): remove dead split-transfer helper + pin expansion-tile rotation boundary (Refs #2336)

### DIFF
--- a/app/integration_test/e2e_test_shared_panels.dart
+++ b/app/integration_test/e2e_test_shared_panels.dart
@@ -8,24 +8,13 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'e2e_test_shared.dart';
 
-Future<void> _e2eTapFirstEnabledTransferButtonInSplitDialog(
-  WidgetTester tester,
-  bool Function(ValueKey<String> key) keyMatches,
-) async {
-  final shell = find.byType(CtDialogShell);
-  final buttons = find.descendant(
-    of: shell,
-    matching: find.byWidgetPredicate((w) {
-      if (w is! CtNinePatchButton || !w.enabled) {
-        return false;
-      }
-      final key = w.key;
-      return key is ValueKey<String> && keyMatches(key);
-    }),
-  );
-  expect(buttons, findsWidgets);
-  await tester.tap(buttons.first, warnIfMissed: false);
-}
+// `_e2eTapFirstEnabledTransferButtonInSplitDialog` previously lived here as a
+// helper for split-fleet transfer-row taps but was never wired into any caller
+// (`e2eSplitHomeFleetOnce` inlines its own `enabledLeftNudge` finder for the
+// `>>` / `>` transfer keys). Static analysis flagged the symbol with
+// `unused_element` since at least PR #2596. The dead declaration is removed
+// here rather than carried forward so the shared-helpers surface only ships
+// reachable code (Refs GitHub #2336 AC1 / AC2 shared-helper hygiene).
 
 /// Opens the civilian units panel from the empire rail or the first civilian
 /// marker, closing a conflicting naval/civilian sheet first when needed.
@@ -525,15 +514,15 @@ Future<void> e2eSplitHomeFleetOnce(
   }
 
   Finder enabledLeftNudge(String prefix) => find.descendant(
-        of: find.byType(CtDialogShell),
-        matching: find.byWidgetPredicate((w) {
-          if (w is! CtNinePatchButton || !w.enabled) {
-            return false;
-          }
-          final key = w.key;
-          return key is ValueKey<String> && key.value.startsWith(prefix);
-        }),
-      );
+    of: find.byType(CtDialogShell),
+    matching: find.byWidgetPredicate((w) {
+      if (w is! CtNinePatchButton || !w.enabled) {
+        return false;
+      }
+      final key = w.key;
+      return key is ValueKey<String> && key.value.startsWith(prefix);
+    }),
+  );
 
   for (var attempt = 0; attempt < 6 && !splitConfirmEnabled(); attempt++) {
     final moveAll = enabledLeftNudge('ctTransfer.left.>>');

--- a/app/test/e2e_expansion_tile_is_expanded_boundary_test.dart
+++ b/app/test/e2e_expansion_tile_is_expanded_boundary_test.dart
@@ -1,0 +1,267 @@
+// Pins the boundary contract of `e2eExpansionTileIsExpanded`: the helper
+// inspects the subtree rooted at the given [Element] for any `RotationTransition`
+// whose `turns.value > 0.4` and returns true on the first match. The existing
+// `e2e_expand_expansion_tile_test.dart` only pins the two ends of a real
+// Material `ExpansionTile` (collapsed → false, `initiallyExpanded: true`
+// → true), which never exercises the `> 0.4` threshold, the in-flight
+// animation interval, the no-`RotationTransition` subtree, or the early-exit
+// short-circuit on the first crossing transition.
+//
+// The threshold is load-bearing: Material's `ExpansionTile` animates its
+// chevron from `turns = 0.0` (collapsed) to `turns = 0.5` (expanded), and
+// `e2eExpandEachExpansionTileOnce` polls `e2eExpansionTileIsExpanded` to
+// decide when the per-tile expand is done. If the threshold drifted upward
+// past 0.5 the helper would never accept a finished animation; if it drifted
+// downward toward 0.0 the helper could accept a mid-animation frame and
+// resume tapping before children are laid out. Both regressions present as
+// runtime cost rather than test failure (Refs GitHub #2336 H10 / Bottleneck 6
+// — the icon-presence pre-fix already burned ~26 s per call without any test
+// failing), so each boundary needs an explicit pin here.
+
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../integration_test/e2e_test_shared.dart';
+
+/// Mounts a single child rooted under a stable `Center` so the test can
+/// resolve a deterministic `Element` to hand to `e2eExpansionTileIsExpanded`.
+Future<Element> _pumpAndResolveRoot(WidgetTester tester, Widget child) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(body: Center(child: child)),
+    ),
+  );
+  final centerFinder = find.byType(Center);
+  // `MaterialApp` and `Scaffold` mount their own `Center` descendants, so
+  // anchor on the outermost user-supplied `Center` deterministically by
+  // taking the first `Center` element found via pre-order traversal.
+  return centerFinder.evaluate().first;
+}
+
+void main() {
+  suppressLogsForTests();
+
+  group('e2eExpansionTileIsExpanded threshold boundary', () {
+    testWidgets(
+      'returns false when no RotationTransition exists in the subtree',
+      (WidgetTester tester) async {
+        final root = await _pumpAndResolveRoot(
+          tester,
+          const Text('no-rotation-here'),
+        );
+        expect(
+          e2eExpansionTileIsExpanded(root),
+          isFalse,
+          reason:
+              'A subtree without any RotationTransition must read as not '
+              'expanded so the helper does not falsely advance past a tile '
+              'whose chevron is missing or replaced by a non-rotating icon.',
+        );
+      },
+    );
+
+    testWidgets('returns false at exactly the threshold (turns == 0.4)', (
+      WidgetTester tester,
+    ) async {
+      final root = await _pumpAndResolveRoot(
+        tester,
+        RotationTransition(
+          turns: const AlwaysStoppedAnimation<double>(0.4),
+          child: const Icon(Icons.expand_more),
+        ),
+      );
+      expect(
+        e2eExpansionTileIsExpanded(root),
+        isFalse,
+        reason:
+            'The threshold uses a strict greater-than (`> 0.4`); a tile '
+            'whose chevron is parked exactly at the threshold must read as '
+            'not yet expanded so the polling loop keeps waiting for the '
+            'animation to complete past 0.4 → 0.5.',
+      );
+    });
+
+    testWidgets('returns true just above the threshold (turns == 0.41)', (
+      WidgetTester tester,
+    ) async {
+      final root = await _pumpAndResolveRoot(
+        tester,
+        RotationTransition(
+          turns: const AlwaysStoppedAnimation<double>(0.41),
+          child: const Icon(Icons.expand_more),
+        ),
+      );
+      expect(
+        e2eExpansionTileIsExpanded(root),
+        isTrue,
+        reason:
+            'Any RotationTransition.turns strictly greater than 0.4 must '
+            'count as expanded so the helper stops polling once the chevron '
+            'is past the half-rotated midpoint — even before it parks at '
+            'the canonical 0.5 endpoint.',
+      );
+    });
+
+    testWidgets(
+      'returns true at the canonical fully-expanded value (turns == 0.5)',
+      (WidgetTester tester) async {
+        final root = await _pumpAndResolveRoot(
+          tester,
+          RotationTransition(
+            turns: const AlwaysStoppedAnimation<double>(0.5),
+            child: const Icon(Icons.expand_more),
+          ),
+        );
+        expect(
+          e2eExpansionTileIsExpanded(root),
+          isTrue,
+          reason:
+              'The canonical Material ExpansionTile expanded endpoint (0.5) '
+              'must read as expanded; this is the value the real animation '
+              'parks on once the tile is open (Refs `expansion_tile.dart`).',
+        );
+      },
+    );
+
+    testWidgets(
+      'returns false at the canonical collapsed value (turns == 0.0)',
+      (WidgetTester tester) async {
+        final root = await _pumpAndResolveRoot(
+          tester,
+          RotationTransition(
+            turns: const AlwaysStoppedAnimation<double>(0.0),
+            child: const Icon(Icons.expand_more),
+          ),
+        );
+        expect(
+          e2eExpansionTileIsExpanded(root),
+          isFalse,
+          reason:
+              'A chevron parked at the canonical collapsed endpoint (0.0) '
+              'must read as not expanded so the outer helper still taps it.',
+        );
+      },
+    );
+
+    testWidgets(
+      'returns false on a mid-animation value below the threshold (turns == 0.25)',
+      (WidgetTester tester) async {
+        final root = await _pumpAndResolveRoot(
+          tester,
+          RotationTransition(
+            turns: const AlwaysStoppedAnimation<double>(0.25),
+            child: const Icon(Icons.expand_more),
+          ),
+        );
+        expect(
+          e2eExpansionTileIsExpanded(root),
+          isFalse,
+          reason:
+              'A mid-flight chevron rotation (between collapsed 0.0 and the '
+              'threshold 0.4) must not be accepted as expanded — the polling '
+              'loop must wait until the animation has crossed the threshold '
+              'so the tile children are actually laid out before further '
+              'interaction.',
+        );
+      },
+    );
+  });
+
+  group('e2eExpansionTileIsExpanded subtree traversal', () {
+    testWidgets(
+      'returns true when at least one nested RotationTransition is past the '
+      'threshold',
+      (WidgetTester tester) async {
+        final root = await _pumpAndResolveRoot(
+          tester,
+          Column(
+            children: const [
+              RotationTransition(
+                turns: AlwaysStoppedAnimation<double>(0.0),
+                child: Icon(Icons.chevron_left),
+              ),
+              RotationTransition(
+                turns: AlwaysStoppedAnimation<double>(0.5),
+                child: Icon(Icons.expand_more),
+              ),
+            ],
+          ),
+        );
+        expect(
+          e2eExpansionTileIsExpanded(root),
+          isTrue,
+          reason:
+              'When the subtree contains multiple RotationTransitions, any '
+              'one past the threshold must flip the result — the helper is '
+              'an existential check, not a universal one.',
+        );
+      },
+    );
+
+    testWidgets(
+      'returns false when every nested RotationTransition is below the threshold',
+      (WidgetTester tester) async {
+        final root = await _pumpAndResolveRoot(
+          tester,
+          Column(
+            children: const [
+              RotationTransition(
+                turns: AlwaysStoppedAnimation<double>(0.0),
+                child: Icon(Icons.chevron_left),
+              ),
+              RotationTransition(
+                turns: AlwaysStoppedAnimation<double>(0.4),
+                child: Icon(Icons.expand_more),
+              ),
+              RotationTransition(
+                turns: AlwaysStoppedAnimation<double>(0.1),
+                child: Icon(Icons.refresh),
+              ),
+            ],
+          ),
+        );
+        expect(
+          e2eExpansionTileIsExpanded(root),
+          isFalse,
+          reason:
+              'With every RotationTransition at or below the threshold the '
+              'helper must report not expanded; a regression that returned '
+              'true here would let the outer loop accept tiles whose chevron '
+              'has not yet crossed the expand midpoint.',
+        );
+      },
+    );
+
+    testWidgets(
+      'reads `RotationTransition` descendants beneath unrelated wrappers',
+      (WidgetTester tester) async {
+        final root = await _pumpAndResolveRoot(
+          tester,
+          Padding(
+            padding: const EdgeInsets.all(8),
+            child: SizedBox(
+              width: 120,
+              height: 120,
+              child: Opacity(
+                opacity: 1,
+                child: RotationTransition(
+                  turns: const AlwaysStoppedAnimation<double>(0.5),
+                  child: const Icon(Icons.expand_more),
+                ),
+              ),
+            ),
+          ),
+        );
+        expect(
+          e2eExpansionTileIsExpanded(root),
+          isTrue,
+          reason:
+              'The depth-first subtree walk must reach a RotationTransition '
+              'no matter how many non-transition wrappers (Padding, SizedBox, '
+              'Opacity, …) sit between the input element and the chevron.',
+        );
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Two small, focused E2E shared-helper hygiene changes for #2336, with
no production code touched and no behavioural changes to existing
helpers:

1. **Remove dead `_e2eTapFirstEnabledTransferButtonInSplitDialog`** in
   `app/integration_test/e2e_test_shared_panels.dart`. No call site
   exists anywhere in the repo (`rg` returns the declaration line
   only); `e2eSplitHomeFleetOnce` builds its own `enabledLeftNudge`
   finder for the `>>` / `>` transfer keys. The dead declaration has
   been flagged with `unused_element` since at least PR #2596
   (\"the pre-existing `unused_element` warning on
   `_e2eTapFirstEnabledTransferButtonInSplitDialog` is unrelated\").
   Removing it keeps the shared-helpers surface reachable only
   (#2336 AC1 / AC2 shared-helper hygiene).

2. **Pin the `> 0.4` rotation threshold of `e2eExpansionTileIsExpanded`**
   in a new `app/test/e2e_expansion_tile_is_expanded_boundary_test.dart`
   suite (9 tests, no production code changes). The existing
   `e2e_expand_expansion_tile_test.dart` only pins the two endpoints
   of a real Material `ExpansionTile` (`initiallyExpanded: false`
   → `false`, `initiallyExpanded: true` → `true`), which never
   exercises the strict-greater-than threshold the helper relies on.

   The threshold is load-bearing for `e2eExpandEachExpansionTileOnce`:
   a drift upward past 0.5 would make the polling loop never accept a
   finished animation, and a drift downward toward 0.0 would let the
   helper accept a mid-animation frame before children are laid out.
   Both regressions present as wall-clock inflation rather than test
   failure (#2336 H10 / Bottleneck 6 — the icon-presence pre-fix
   burned ~26 s per call without any test failing).

   The new boundary suite pins:

   - subtree without any `RotationTransition` reads as not expanded
   - exact threshold (`turns == 0.4`) reads as not expanded (strict `>`)
   - just above threshold (`turns == 0.41`) reads as expanded
   - canonical fully-expanded endpoint (`turns == 0.5`) reads as expanded
   - canonical collapsed endpoint (`turns == 0.0`) reads as not expanded
   - mid-animation value below threshold (`turns == 0.25`) reads as not expanded
   - nested transitions: any one past threshold flips the result (existential)
   - nested transitions: every transition at or below threshold reads as not expanded
   - `RotationTransition` reachable beneath unrelated wrappers (Padding / SizedBox / Opacity)

Refs #2336

## AC coverage

- **AC1 — Shared helpers exist** / **AC2 — No duplicated private helpers.**
  The dead `_e2eTapFirstEnabledTransferButtonInSplitDialog` is a stray
  private helper in the shared library that no test or scenario ever
  consumed. Removing it tightens AC2's \"no duplicated private helpers\"
  guarantee in the strongest form (no dead private helpers either) and
  resolves the `unused_element` warning that has been documented as
  pre-existing on the helper since PR #2596.

- **AC6–AC10 — Tests pass / stability / timing evidence.** Not
  re-measured here. The H10 / Bottleneck 6 regression that motivated
  the existing `e2eExpansionTileIsExpanded` helper presented as
  ~26 s of silent wall-clock inflation per call. The new boundary
  pins protect the precise rotation threshold the helper relies on;
  any future regression (threshold drift, no-`RotationTransition`
  short-circuit removal, depth-first early-exit removal) will fail
  these widget tests in CI rather than reappear as a silent
  wall-clock cost in maintainer Linux runs.

## Test plan

Local verification:

- \`flutter analyze integration_test/e2e_test_shared_panels.dart
  test/e2e_expansion_tile_is_expanded_boundary_test.dart\` — clean
  (resolves the pre-existing `unused_element` warning on
  `_e2eTapFirstEnabledTransferButtonInSplitDialog`).
- \`flutter test test/e2e_expansion_tile_is_expanded_boundary_test.dart
  test/e2e_expand_expansion_tile_test.dart\` — **15 / 15 pass**
  (9 new boundary tests + 6 existing expand-each tests).
- \`flutter test test/e2e_expand_expansion_tile_test.dart
  test/e2e_expansion_tile_is_expanded_boundary_test.dart
  test/e2e_split_home_fleet_test.dart
  test/e2e_helpers_barrel_test.dart\` — **49 / 49 pass** (verifies the
  removal of the dead helper did not regress `e2eSplitHomeFleetOnce`
  or the barrel re-exports).
- \`dart format\` of touched files — clean.

## Label transition

\`backlog:implementation\` **not** moved to \`backlog:verification\` —
AC6–AC10 wall-clock evidence still requires maintainer Linux 3×
\`integration_test\` runs and additional helper-dedup follow-ups remain
open on #2336.

Made with [Cursor](https://cursor.com)