### PR TITLE
test(e2e): lift _tapMoveOnFirstNonHomeFleet into shared library + pin (Refs #2336)

### DIFF
--- a/app/integration_test/e2e_helpers.dart
+++ b/app/integration_test/e2e_helpers.dart
@@ -174,6 +174,12 @@ Future<void> tapAssignOnCivilianRowWithTitle(
   String unitTypeTitle,
 ) => e2eTapAssignOnCivilianRowWithTitle(tester, unitTypeTitle);
 
+/// Stable public name for [e2eTapMoveOnFirstNonHomeFleet] so fleet scenarios
+/// consume the AC1 barrel only (Refs GitHub #2336 AC1 / AC2). Forwards to
+/// the implementation in `e2e_test_shared_panels.dart`.
+Future<bool> tapMoveOnFirstNonHomeFleet(WidgetTester tester) =>
+    e2eTapMoveOnFirstNonHomeFleet(tester);
+
 Future<void> ensureAllRelocated64pxPngsLoad() =>
     e2eEnsureAllRelocated64pxPngsLoad();
 

--- a/app/integration_test/e2e_test_shared_panels.dart
+++ b/app/integration_test/e2e_test_shared_panels.dart
@@ -562,3 +562,165 @@ Future<void> e2eSplitHomeFleetOnce(
   await e2eExpandEachExpansionTileOnce(tester);
   perf?.timing('fleet_split', phaseSw.elapsed);
 }
+
+/// Taps **Move** on the first non-home human fleet rendered under
+/// [kCtE2ENavalPanelRootKey] and waits for the resulting move dialog to mount.
+///
+/// Lifted from the formerly private `_tapMoveOnFirstNonHomeFleet` in
+/// `new_game_fleet_reaches_new_world_e2e_helpers_part2.dart` (Refs GitHub
+/// #2336 AC1 / AC2). The fleet-reach loop calls this helper through
+/// `_tryNavalMoveSegment` up to `_kMaxNextTurnTapsForNwFleetReach (35)`
+/// times per scenario, so a silent rename / fail-open here would stall the
+/// fleet-reach loop at the 35-turn cap × the dialog wait — Bottleneck 4 in
+/// `SPEC/program/e2e-integration-tests.md` § Determinism.
+///
+/// The integration suite cannot validate this directly today
+/// (`app_e2e_linux` is a no-op per
+/// `SPEC/program/e2e-integration-tests.md` § CI), so the widget-test pin
+/// in `app/test/e2e_tap_move_on_first_non_home_fleet_test.dart` carries the
+/// behavioural contract.
+///
+/// Contract:
+///
+/// - Returns `false` when [kCtE2ENavalPanelRootKey] is not in the tree, or
+///   when no [ExpansionTile] has rendered under it within a 2 s adaptive
+///   wait (`pump_until_naval_expansion_tiles_render`).
+/// - When the panel has exactly one tile and that tile shows a
+///   `Text('Home Fleet')` descendant, returns `false` without tapping
+///   (the fleet split has not yet produced a non-home fleet).
+/// - Iterates non-home fleet tiles in stable tree order; skips tiles that
+///   are themselves the home fleet, and skips tiles that lack a
+///   `Text` whose `data` starts with `'Fleet '`.
+/// - When a candidate tile's `Move` text is not visible, taps the tile's
+///   `Icons.expand_more` icon and waits up to 3 s
+///   (`wait_until_found_move_after_expand`) for the `Move` text to appear.
+/// - **Prefers** tiles whose subtitle reads as a New World location row
+///   (per [e2eTextLooksLikeNewWorldLocationLine]): the first such tile's
+///   hit-testable `Move` button is tapped immediately, the helper waits up
+///   to 3 s for an [AlertDialog] to mount
+///   (`wait_until_found_move_dialog_after_move_tap`), and returns `true`.
+/// - When no NW-preferred tile yields a tap, falls back to the **first**
+///   non-home tile with a hit-testable `Move` button; same
+///   tap-and-wait-for-dialog contract
+///   (`wait_until_found_move_dialog_after_move_tap_fallback`).
+/// - When the first pass finds nothing tappable, calls
+///   [e2eExpandEachExpansionTileOnce] to expand every collapsed tile, then
+///   retries once **without** a further expand fallback so the helper does
+///   not spin past two passes. Returns `false` if even the retry yields
+///   nothing.
+Future<bool> e2eTapMoveOnFirstNonHomeFleet(WidgetTester tester) async {
+  Future<bool> tryTap({required bool allowExpandAllFallback}) async {
+    final navalRoot = find.byKey(kCtE2ENavalPanelRootKey);
+    final tiles = find.descendant(
+      of: navalRoot,
+      matching: find.byType(ExpansionTile),
+    );
+    var n = tiles.evaluate().length;
+    if (n == 0) {
+      // Panel can mount before fleet rows render; poll instead of a fixed delay.
+      await e2ePumpUntilConditionOrIdle(
+        tester,
+        () => tiles.evaluate().isNotEmpty,
+        timeout: const Duration(seconds: 2),
+        phaseName: 'pump_until_naval_expansion_tiles_render',
+      );
+      n = tiles.evaluate().length;
+      if (n == 0) {
+        return false;
+      }
+    }
+    if (n == 1) {
+      final onlyTile = tiles.first;
+      final onlyHome = find.descendant(
+        of: onlyTile,
+        matching: find.text('Home Fleet'),
+      );
+      if (onlyHome.evaluate().isNotEmpty) {
+        return false;
+      }
+    }
+    Finder? fallbackMove;
+    for (var i = 0; i < n; i++) {
+      final sub = tiles.at(i);
+      final home = find.descendant(of: sub, matching: find.text('Home Fleet'));
+      if (home.evaluate().isNotEmpty) {
+        continue;
+      }
+      final fleetTitle = find.descendant(
+        of: sub,
+        matching: find.byWidgetPredicate(
+          (w) => w is Text && (w.data?.startsWith('Fleet ') ?? false),
+        ),
+      );
+      if (fleetTitle.evaluate().isEmpty) {
+        continue;
+      }
+      var move = find.descendant(of: sub, matching: find.text('Move'));
+      if (move.evaluate().isEmpty) {
+        final expandIcon = find.descendant(
+          of: sub,
+          matching: find.byIcon(Icons.expand_more),
+        );
+        if (expandIcon.evaluate().isNotEmpty) {
+          final iconHit = expandIcon.first;
+          await tester.ensureVisible(iconHit);
+          await tester.tap(iconHit, warnIfMissed: false);
+          await e2eWaitUntilFound(
+            tester,
+            find.descendant(of: sub, matching: find.text('Move')),
+            timeout: const Duration(seconds: 3),
+            phaseName: 'wait_until_found_move_after_expand',
+          );
+        }
+        move = find.descendant(of: sub, matching: find.text('Move'));
+      }
+      if (move.evaluate().isEmpty) {
+        continue;
+      }
+      final loc = find.descendant(
+        of: sub,
+        matching: find.byWidgetPredicate(
+          (w) => w is Text && e2eTextLooksLikeNewWorldLocationLine(w.data),
+        ),
+      );
+      final hit = move.hitTestable();
+      if (hit.evaluate().isEmpty) {
+        continue;
+      }
+      if (loc.evaluate().isNotEmpty) {
+        await tester.tap(hit.first, warnIfMissed: false);
+        await e2eWaitUntilFound(
+          tester,
+          find.byType(AlertDialog),
+          timeout: const Duration(seconds: 3),
+          phaseName: 'wait_until_found_move_dialog_after_move_tap',
+        );
+        return true;
+      }
+      fallbackMove ??= hit.first;
+    }
+    if (fallbackMove != null) {
+      await tester.tap(fallbackMove, warnIfMissed: false);
+      await e2eWaitUntilFound(
+        tester,
+        find.byType(AlertDialog),
+        timeout: const Duration(seconds: 3),
+        phaseName: 'wait_until_found_move_dialog_after_move_tap_fallback',
+      );
+      return true;
+    }
+    if (allowExpandAllFallback) {
+      await e2eExpandEachExpansionTileOnce(tester);
+      return false;
+    }
+    return false;
+  }
+
+  if (await tryTap(allowExpandAllFallback: true)) {
+    return true;
+  }
+  if (await tryTap(allowExpandAllFallback: false)) {
+    return true;
+  }
+  return false;
+}

--- a/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers.dart
+++ b/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers.dart
@@ -24,8 +24,18 @@ const Duration _kFleetE2eMaxWallClock = kE2eMaxWallClock;
 /// `kCtE2ERegionTabNewWorldKey` and `CtChoiceChip + region_oldWorld` tap
 /// contracts are shared and unit-pinned (Refs GitHub #2336 AC1 / AC2). Call
 /// sites consume the public names directly; `_tryNavalMoveSegment` below
-/// composes them with [openNavalPanel] / [_tapMoveOnFirstNonHomeFleet]
+/// composes them with [openNavalPanel] / [tapMoveOnFirstNonHomeFleet]
 /// without changing observable behavior.
+
+/// `_tapMoveOnFirstNonHomeFleet` was lifted into
+/// [e2eTapMoveOnFirstNonHomeFleet] (`e2e_test_shared_panels.dart`) so the
+/// non-home Move-tap contract is shared and unit-pinned (Refs GitHub #2336
+/// AC1 / AC2). The fleet-reach loop calls this helper through
+/// `_tryNavalMoveSegment` up to `_kMaxNextTurnTapsForNwFleetReach (35)`
+/// times per scenario; the widget-test pin in
+/// `app/test/e2e_tap_move_on_first_non_home_fleet_test.dart` carries the
+/// behavioural contract because the integration suite cannot validate it
+/// directly today (`SPEC/program/e2e-integration-tests.md` § CI).
 
 /// Generic-instantiation `RadioListTile<…>` lookup inside any mounted
 /// [AlertDialog] moved to [e2eRadioListTilesInAlertDialogs]
@@ -177,7 +187,7 @@ Future<void> _tryNavalMoveSegment(
       bottomSheetCloseTimeout: _kMaxUiResponseWait,
     );
   }
-  final tappedMove = await _tapMoveOnFirstNonHomeFleet(tester);
+  final tappedMove = await tapMoveOnFirstNonHomeFleet(tester);
   if (!tappedMove) {
     perf?.timing(
       'fleet_move_segment',

--- a/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers_part2.dart
+++ b/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers_part2.dart
@@ -1,121 +1,18 @@
 part of 'new_game_fleet_reaches_new_world_e2e_test.dart';
 
-Future<bool> _tapMoveOnFirstNonHomeFleet(WidgetTester tester) async {
-  Future<bool> tryTap({required bool allowExpandAllFallback}) async {
-    final navalRoot = find.byKey(kCtE2ENavalPanelRootKey);
-    final tiles = find.descendant(
-      of: navalRoot,
-      matching: find.byType(ExpansionTile),
-    );
-    var n = tiles.evaluate().length;
-    if (n == 0) {
-      // Panel can mount before fleet rows render; poll instead of a fixed delay.
-      await e2ePumpUntilConditionOrIdle(
-        tester,
-        () => tiles.evaluate().isNotEmpty,
-        timeout: const Duration(seconds: 2),
-        phaseName: 'pump_until_naval_expansion_tiles_render',
-      );
-      n = tiles.evaluate().length;
-      if (n == 0) {
-        return false;
-      }
-    }
-    if (n == 1) {
-      final onlyTile = tiles.first;
-      final onlyHome = find.descendant(
-        of: onlyTile,
-        matching: find.text('Home Fleet'),
-      );
-      if (onlyHome.evaluate().isNotEmpty) {
-        return false;
-      }
-    }
-    Finder? fallbackMove;
-    for (var i = 0; i < n; i++) {
-      final sub = tiles.at(i);
-      final home = find.descendant(of: sub, matching: find.text('Home Fleet'));
-      if (home.evaluate().isNotEmpty) {
-        continue;
-      }
-      final fleetTitle = find.descendant(
-        of: sub,
-        matching: find.byWidgetPredicate(
-          (w) => w is Text && (w.data?.startsWith('Fleet ') ?? false),
-        ),
-      );
-      if (fleetTitle.evaluate().isEmpty) {
-        continue;
-      }
-      var move = find.descendant(of: sub, matching: find.text('Move'));
-      if (move.evaluate().isEmpty) {
-        final expandIcon = find.descendant(
-          of: sub,
-          matching: find.byIcon(Icons.expand_more),
-        );
-        if (expandIcon.evaluate().isNotEmpty) {
-          final iconHit = expandIcon.first;
-          await tester.ensureVisible(iconHit);
-          await tester.tap(iconHit, warnIfMissed: false);
-          await waitUntilFound(
-            tester,
-            find.descendant(of: sub, matching: find.text('Move')),
-            timeout: const Duration(seconds: 3),
-            phaseName: 'wait_until_found_move_after_expand',
-          );
-        }
-        move = find.descendant(of: sub, matching: find.text('Move'));
-      }
-      if (move.evaluate().isEmpty) {
-        continue;
-      }
-      final loc = find.descendant(
-        of: sub,
-        matching: find.byWidgetPredicate(
-          (w) => w is Text && e2eTextLooksLikeNewWorldLocationLine(w.data),
-        ),
-      );
-      final hit = move.hitTestable();
-      if (hit.evaluate().isEmpty) {
-        continue;
-      }
-      if (loc.evaluate().isNotEmpty) {
-        await tester.tap(hit.first, warnIfMissed: false);
-        await waitUntilFound(
-          tester,
-          find.byType(AlertDialog),
-          timeout: const Duration(seconds: 3),
-          phaseName: 'wait_until_found_move_dialog_after_move_tap',
-        );
-        return true;
-      }
-      fallbackMove ??= hit.first;
-    }
-    if (fallbackMove != null) {
-      await tester.tap(fallbackMove, warnIfMissed: false);
-      await waitUntilFound(
-        tester,
-        find.byType(AlertDialog),
-        timeout: const Duration(seconds: 3),
-        phaseName: 'wait_until_found_move_dialog_after_move_tap_fallback',
-      );
-      return true;
-    }
-    if (allowExpandAllFallback) {
-      await expandEachExpansionTileOnce(tester);
-      return false;
-    }
-    return false;
-  }
-
-  if (await tryTap(allowExpandAllFallback: true)) {
-    return true;
-  }
-  if (await tryTap(allowExpandAllFallback: false)) {
-    return true;
-  }
-  return false;
-}
+/// `_tapMoveOnFirstNonHomeFleet` was lifted into the public
+/// [e2eTapMoveOnFirstNonHomeFleet] (`e2e_test_shared_panels.dart`) so the
+/// non-home Move-tap contract is shared and unit-pinned (Refs GitHub
+/// #2336 AC1 / AC2). The fleet-reach loop calls the lifted form through
+/// the AC1 barrel alias `tapMoveOnFirstNonHomeFleet` (`e2e_helpers.dart`).
+/// The widget-test pin in
+/// `app/test/e2e_tap_move_on_first_non_home_fleet_test.dart` guards
+/// against silent regressions (the integration suite cannot validate this
+/// directly today — `app_e2e_linux` is a no-op per
+/// `SPEC/program/e2e-integration-tests.md` § CI). A regression here would
+/// stall the fleet-reach loop at
+/// `_kMaxNextTurnTapsForNwFleetReach (35) × ~5 s` (Bottleneck 4 in
+/// `SPEC/program/e2e-integration-tests.md` § Determinism).
 
 /// Naval-panel location row detection moved to
 /// [e2eTextLooksLikeNewWorldLocationLine] (`e2e_test_shared.dart`) so the

--- a/app/test/e2e_helpers_barrel_test.dart
+++ b/app/test/e2e_helpers_barrel_test.dart
@@ -304,6 +304,45 @@ void main() {
       );
     });
 
+    testWidgets(
+      'tapMoveOnFirstNonHomeFleet is re-exported through the barrel',
+      (tester) async {
+        final Future<bool> Function(WidgetTester) ref =
+            tapMoveOnFirstNonHomeFleet;
+        expect(
+          ref,
+          isNotNull,
+          reason:
+              'The fleet-reach hot path '
+              '(`_tryNavalMoveSegment` in '
+              '`new_game_fleet_reaches_new_world_e2e_helpers.dart`) '
+              'consumes this Move-tap helper via the AC1 barrel up to '
+              '`_kMaxNextTurnTapsForNwFleetReach (35)` times per '
+              'scenario. A regression that dropped the barrel wrapper '
+              'or that flipped the return-type from `Future<bool>` to '
+              '`Future<void>` would break the segment\'s `if (!tappedMove) '
+              'return;` short-circuit and silently re-introduce '
+              'redundant move-dialog probes (Bottleneck 4 in '
+              '`SPEC/program/e2e-integration-tests.md` § Determinism).',
+        );
+        await tester.pumpWidget(
+          const MaterialApp(home: Scaffold(body: SizedBox())),
+        );
+        expect(
+          await ref(tester),
+          isFalse,
+          reason:
+              'Sanity smoke through the barrel: an empty scaffold has no '
+              'naval-panel root key, so the helper must return false '
+              'without tapping. A wrapper that ignored the panel-absent '
+              'guard would either throw on a missing tap target or '
+              'short-circuit to true (masking real fleet-reach '
+              'regressions); pin both the typed tear-off and the '
+              'no-panel return so the contract surfaces here.',
+        );
+      },
+    );
+
     test(
       'e2eTextLooksLikeNewWorldLocationLine is re-exported through the barrel',
       () {

--- a/app/test/e2e_tap_move_on_first_non_home_fleet_test.dart
+++ b/app/test/e2e_tap_move_on_first_non_home_fleet_test.dart
@@ -1,0 +1,341 @@
+/// Pins the widget-tree contract of [e2eTapMoveOnFirstNonHomeFleet]
+/// (`app/integration_test/e2e_test_shared_panels.dart`).
+///
+/// The fleet-reach loop calls this helper through `_tryNavalMoveSegment`
+/// (`new_game_fleet_reaches_new_world_e2e_helpers.dart`) up to
+/// `_kMaxNextTurnTapsForNwFleetReach (35)` times per scenario. A silent
+/// rename / fail-open here would stall the loop at the 35-turn cap × the
+/// per-iteration `Move dialog` wait — Bottleneck 4 in
+/// `SPEC/program/e2e-integration-tests.md` § Determinism — and a regression
+/// that dropped the New World preference would similarly inflate the
+/// wall-clock budget by tapping Move on the wrong (Old World) fleet first.
+///
+/// The integration suite cannot validate this directly today (the
+/// `app_e2e_linux` lane is a no-op per
+/// `SPEC/program/e2e-integration-tests.md` § CI), so this widget-test
+/// layer carries the behavioural pin.
+///
+/// Refs GitHub #2336 AC1 / AC2 / Bottleneck 4.
+library;
+
+import 'package:colonizethis_app/config/ct_e2e.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../integration_test/e2e_test_shared.dart';
+
+/// Mounts a Move row that opens an [AlertDialog] when tapped, mirroring the
+/// production fleet-row Move button surface (`fleet_expansion_tile.dart`).
+class _MoveButton extends StatelessWidget {
+  const _MoveButton({this.onPressedSpy});
+
+  final void Function()? onPressedSpy;
+
+  @override
+  Widget build(BuildContext context) {
+    return Builder(
+      builder: (context) {
+        return TextButton(
+          onPressed: () {
+            onPressedSpy?.call();
+            showDialog<void>(
+              context: context,
+              builder: (_) =>
+                  const AlertDialog(content: Text('Move dialog')),
+            );
+          },
+          child: const Text('Move'),
+        );
+      },
+    );
+  }
+}
+
+/// Builds a non-home fleet [ExpansionTile] with a `Fleet X` title, an
+/// optional subtitle line, and a Move button as the expanded child.
+ExpansionTile _fleetTile({
+  required String title,
+  String? subtitle,
+  bool initiallyExpanded = true,
+  void Function()? onMovePressed,
+}) {
+  return ExpansionTile(
+    title: Text(title),
+    subtitle: subtitle == null ? null : Text(subtitle),
+    initiallyExpanded: initiallyExpanded,
+    children: [_MoveButton(onPressedSpy: onMovePressed)],
+  );
+}
+
+/// Wraps panel children under [kCtE2ENavalPanelRootKey] so the helper's
+/// `find.byKey(kCtE2ENavalPanelRootKey)` lookup matches.
+Widget _navalPanel({required List<Widget> children}) => KeyedSubtree(
+  key: kCtE2ENavalPanelRootKey,
+  child: Column(children: children),
+);
+
+Widget _wrap(Widget body) =>
+    MaterialApp(home: Scaffold(body: SingleChildScrollView(child: body)));
+
+void main() {
+  suppressLogsForTests();
+
+  group('e2eTapMoveOnFirstNonHomeFleet — false / no-tap branches', () {
+    testWidgets('no naval panel root key in tree -> false', (tester) async {
+      await tester.pumpWidget(_wrap(const SizedBox.shrink()));
+      expect(await e2eTapMoveOnFirstNonHomeFleet(tester), isFalse);
+      expect(find.byType(AlertDialog), findsNothing);
+    });
+
+    testWidgets('panel mounted but no ExpansionTile -> false (post-poll)', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _wrap(_navalPanel(children: const [Text('loading')])),
+      );
+      expect(await e2eTapMoveOnFirstNonHomeFleet(tester), isFalse);
+      expect(find.byType(AlertDialog), findsNothing);
+    });
+
+    testWidgets('single tile is the home fleet -> false (no tap)', (
+      tester,
+    ) async {
+      var taps = 0;
+      await tester.pumpWidget(
+        _wrap(
+          _navalPanel(
+            children: [
+              ExpansionTile(
+                title: const Text('Home Fleet'),
+                initiallyExpanded: true,
+                children: [
+                  _MoveButton(onPressedSpy: () => taps++),
+                ],
+              ),
+            ],
+          ),
+        ),
+      );
+      expect(await e2eTapMoveOnFirstNonHomeFleet(tester), isFalse);
+      expect(taps, 0);
+      expect(find.byType(AlertDialog), findsNothing);
+    });
+
+    testWidgets('only tiles without "Fleet " title prefix -> false', (
+      tester,
+    ) async {
+      var taps = 0;
+      await tester.pumpWidget(
+        _wrap(
+          _navalPanel(
+            children: [
+              ExpansionTile(
+                title: const Text('Flotilla 7'),
+                subtitle: const Text('New World — Outer Sea'),
+                initiallyExpanded: true,
+                children: [
+                  _MoveButton(onPressedSpy: () => taps++),
+                ],
+              ),
+            ],
+          ),
+        ),
+      );
+      expect(await e2eTapMoveOnFirstNonHomeFleet(tester), isFalse);
+      expect(taps, 0);
+      expect(find.byType(AlertDialog), findsNothing);
+    });
+  });
+
+  group('e2eTapMoveOnFirstNonHomeFleet — true / tap branches', () {
+    testWidgets('single non-home fleet with NW subtitle -> taps Move + dialog',
+        (tester) async {
+      var taps = 0;
+      await tester.pumpWidget(
+        _wrap(
+          _navalPanel(
+            children: [
+              _fleetTile(
+                title: 'Fleet 2',
+                subtitle: 'New World — Outer Sea',
+                onMovePressed: () => taps++,
+              ),
+            ],
+          ),
+        ),
+      );
+      expect(await e2eTapMoveOnFirstNonHomeFleet(tester), isTrue);
+      expect(taps, 1);
+      expect(find.byType(AlertDialog), findsOneWidget);
+    });
+
+    testWidgets('home fleet skipped; second tile (NW) wins', (tester) async {
+      var homeTaps = 0;
+      var nwTaps = 0;
+      await tester.pumpWidget(
+        _wrap(
+          _navalPanel(
+            children: [
+              ExpansionTile(
+                title: const Text('Home Fleet'),
+                initiallyExpanded: true,
+                children: [
+                  _MoveButton(onPressedSpy: () => homeTaps++),
+                ],
+              ),
+              _fleetTile(
+                title: 'Fleet 3',
+                subtitle: 'New World — Inner Sea',
+                onMovePressed: () => nwTaps++,
+              ),
+            ],
+          ),
+        ),
+      );
+      expect(await e2eTapMoveOnFirstNonHomeFleet(tester), isTrue);
+      expect(homeTaps, 0);
+      expect(nwTaps, 1);
+      expect(find.byType(AlertDialog), findsOneWidget);
+    });
+
+    testWidgets(
+      'NW tile preferred over earlier OW tile (location-line gate)',
+      (tester) async {
+        var owTaps = 0;
+        var nwTaps = 0;
+        await tester.pumpWidget(
+          _wrap(
+            _navalPanel(
+              children: [
+                _fleetTile(
+                  title: 'Fleet 1',
+                  subtitle: 'Old World — Coastal Sea',
+                  onMovePressed: () => owTaps++,
+                ),
+                _fleetTile(
+                  title: 'Fleet 2',
+                  subtitle: 'New World — Outer Sea',
+                  onMovePressed: () => nwTaps++,
+                ),
+              ],
+            ),
+          ),
+        );
+        expect(await e2eTapMoveOnFirstNonHomeFleet(tester), isTrue);
+        expect(
+          owTaps,
+          0,
+          reason: 'NW preference must skip the earlier OW tile so the '
+              'fleet-reach loop progresses toward New World per Bottleneck 4.',
+        );
+        expect(nwTaps, 1);
+        expect(find.byType(AlertDialog), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'no NW location available -> first hit-testable non-home Move tapped',
+      (tester) async {
+        var firstTaps = 0;
+        var secondTaps = 0;
+        await tester.pumpWidget(
+          _wrap(
+            _navalPanel(
+              children: [
+                _fleetTile(
+                  title: 'Fleet 1',
+                  subtitle: 'Old World — Coastal Sea',
+                  onMovePressed: () => firstTaps++,
+                ),
+                _fleetTile(
+                  title: 'Fleet 2',
+                  subtitle: 'Old World — Inner Sea',
+                  onMovePressed: () => secondTaps++,
+                ),
+              ],
+            ),
+          ),
+        );
+        expect(await e2eTapMoveOnFirstNonHomeFleet(tester), isTrue);
+        expect(
+          firstTaps,
+          1,
+          reason: 'When no tile has an NW subtitle the first hit-testable '
+              'Move must be the fallback; pinning this prevents the loop '
+              'silently switching to a later iteration order.',
+        );
+        expect(secondTaps, 0);
+        expect(find.byType(AlertDialog), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'collapsed tile expanded via Icons.expand_more before Move tap',
+      (tester) async {
+        var taps = 0;
+        await tester.pumpWidget(
+          _wrap(
+            _navalPanel(
+              children: [
+                _fleetTile(
+                  title: 'Fleet 4',
+                  subtitle: 'New World — Inner Sea',
+                  initiallyExpanded: false,
+                  onMovePressed: () => taps++,
+                ),
+              ],
+            ),
+          ),
+        );
+        expect(
+          find.text('Move'),
+          findsNothing,
+          reason: 'Sanity: Move text is not mounted while the tile is '
+              'collapsed (children only build after expansion).',
+        );
+        expect(await e2eTapMoveOnFirstNonHomeFleet(tester), isTrue);
+        expect(
+          taps,
+          1,
+          reason: 'The helper must tap the expand-more icon and wait for '
+              'Move text to appear before issuing the Move tap, otherwise '
+              'every collapsed tile would silently fall through (Bottleneck 4).',
+        );
+        expect(find.byType(AlertDialog), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'em-dash, en-dash and hyphen NW subtitles all qualify as preferred',
+      (tester) async {
+        for (final separator in const ['—', '–', '-']) {
+          await tester.pumpWidget(
+            _wrap(
+              _navalPanel(
+                children: [
+                  _fleetTile(
+                    title: 'Fleet 9',
+                    subtitle: 'New World $separator Outer Sea',
+                  ),
+                ],
+              ),
+            ),
+          );
+          expect(
+            await e2eTapMoveOnFirstNonHomeFleet(tester),
+            isTrue,
+            reason: 'Move on a non-home fleet should fire for separator '
+                '"$separator" (e2eTextLooksLikeNewWorldLocationLine '
+                'accepts em / en / hyphen variants).',
+          );
+          expect(find.byType(AlertDialog), findsOneWidget);
+          // Dismiss before the next pumpWidget so showDialog routes do not
+          // leak across the loop iterations.
+          await tester.binding.handlePopRoute();
+          await tester.pumpAndSettle();
+        }
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Continues the issue #2336 AC1 / AC2 helper-lift work by moving the formerly private
`_tapMoveOnFirstNonHomeFleet` (in
`app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers_part2.dart`)
into the public `e2eTapMoveOnFirstNonHomeFleet` in
`app/integration_test/e2e_test_shared_panels.dart`, re-exports it through the
AC1 barrel as `tapMoveOnFirstNonHomeFleet`, and pins the contract via a
new widget-test (`app/test/e2e_tap_move_on_first_non_home_fleet_test.dart`).

This is a **lift + pin** slice — observable behaviour is unchanged; the
fleet-reach hot path (`_tryNavalMoveSegment`) now calls
`tapMoveOnFirstNonHomeFleet` (public alias) instead of the private name,
matching the existing convention used for `openNavalPanel`, `waitUntilFound`,
`expandEachExpansionTileOnce`, and the recently lifted
`e2eTapNewWorldRegionTabIfPresent` / `e2eTapOldWorldRegionTab` neighbours
that compose the same move-segment helper.

## Why this matters (Bottleneck 4)

The fleet-reach loop calls this helper through `_tryNavalMoveSegment` up to
`_kMaxNextTurnTapsForNwFleetReach (35)` times per scenario
(`new_game_fleet_reaches_new_world_e2e_helpers.dart`). A silent rename /
fail-open / preference-loss regression here would stall the loop at the
35-turn cap × the per-iteration Move-dialog wait — Bottleneck 4 in
`SPEC/program/e2e-integration-tests.md` § Determinism — directly inflating
the wall-clock cap that issue #2336 is reducing.

The integration suite cannot validate this directly today
(`app_e2e_linux` is a no-op per `SPEC/program/e2e-integration-tests.md` §
CI), so the widget-test layer carries the behavioural pin.

## Done in this push

- **Lifted helper** — `e2eTapMoveOnFirstNonHomeFleet(WidgetTester) -> Future<bool>`
  added to `app/integration_test/e2e_test_shared_panels.dart` with the same
  observable contract: panel-root absent / no tile / home-only / no
  `Fleet `-prefix tile -> `false`; NW-subtitle preference -> taps and
  returns `true`; OW-only fallback to first hit-testable Move; collapsed
  tile expanded via `Icons.expand_more` before retrying Move; one
  `e2eExpandEachExpansionTileOnce` retry pass before giving up.

- **AC1 barrel re-export** — `tapMoveOnFirstNonHomeFleet(WidgetTester)`
  added to `app/integration_test/e2e_helpers.dart`; the existing
  `import 'e2e_test_shared.dart';` already carries the lifted
  implementation through the panel-shared re-export.

- **Call-site rewire** — `_tryNavalMoveSegment` in
  `new_game_fleet_reaches_new_world_e2e_helpers.dart` now calls
  `tapMoveOnFirstNonHomeFleet`; the private definition in
  `new_game_fleet_reaches_new_world_e2e_helpers_part2.dart` is replaced
  by a doc-comment pointer to the lifted helper and the widget-test pin.

- **Widget-test pin** —
  `app/test/e2e_tap_move_on_first_non_home_fleet_test.dart` (10 tests):
  - **False / no-tap branches** (4): no naval panel root key in tree;
    panel mounted but no `ExpansionTile`; single tile is the home fleet;
    only tiles without a `Fleet `-prefixed title.
  - **True / tap branches** (6): single non-home NW fleet -> taps Move +
    dialog mounts; home fleet skipped + second NW tile wins; NW tile
    preferred over earlier OW tile (location-line gate); no NW available
    -> first hit-testable non-home Move is the fallback; collapsed tile
    expanded via `Icons.expand_more` before Move tap; em-dash / en-dash
    / hyphen NW subtitles all qualify (mirrors
    `e2eTextLooksLikeNewWorldLocationLine` separator contract).
  - Tap counts asserted via per-button `onPressedSpy` callbacks so a
    regression that picked the wrong tile (e.g. dropping the NW
    preference) fails with a concrete spy delta rather than a vague
    timeout.

- **AC1 barrel test extension** — `app/test/e2e_helpers_barrel_test.dart`
  gains a `tapMoveOnFirstNonHomeFleet` typed tear-off pin
  (`Future<bool> Function(WidgetTester)`) plus a no-panel smoke that
  asserts `false` when the scaffold is empty. A barrel that loses the
  wrapper, swaps the return type to `Future<void>`, or short-circuits
  to `true` would fail the tear-off capture or the smoke probe.

## Behavior change

None. The lifted helper is byte-equivalent to the prior private form
(same finder shapes, same timeouts, same NW-preference + fallback +
expand-retry algorithm). Test runs already exercising
`_tryNavalMoveSegment` continue to call into the same logic via the
public alias.

## Local verification

- `flutter analyze integration_test/` — clean.
- `flutter analyze test/e2e_helpers_barrel_test.dart test/e2e_tap_move_on_first_non_home_fleet_test.dart` — clean.
- `flutter test test/e2e_tap_move_on_first_non_home_fleet_test.dart` — 10/10 pass.
- `flutter test test/e2e_tap_move_on_first_non_home_fleet_test.dart test/e2e_naval_panel_shows_non_home_fleet_in_new_world_test.dart test/e2e_text_looks_like_new_world_location_line_test.dart test/e2e_radio_list_tiles_in_alert_dialogs_test.dart test/e2e_expand_expansion_tile_test.dart test/e2e_expansion_tile_is_expanded_boundary_test.dart test/e2e_helpers_barrel_test.dart` — 90/90 pass.

## AC6–AC10 status

Unchanged. This is a refactor + pin slice; AC9 aggregate wall-clock
reduction work continues across the broader #2336 slice queue, and
AC6–AC10 still require maintainer Linux desktop integration_test runs
through `tool/run_e2e_timing.sh` per the issue's Baseline measurement
methodology.

## Label

Leaving as `backlog:implementation` — issue not fully implemented;
AC9 timing evidence and AC6 / AC7 / AC10 pass-evidence are still
outstanding.

Refs #2336

## Test plan

- [x] `flutter analyze integration_test/` clean
- [x] `flutter analyze` for both touched test files clean
- [x] New widget-test green (10 tests)
- [x] Sibling pin tests still green (90 total alongside the new file)
- [ ] CI: `App tests`, `Quality (lint, analyze, observer)`

Made with [Cursor](https://cursor.com)