### PR TITLE
test(e2e): lift _anyExplorerHasEnabledExploreAssignFleetE2e into shared library + pin (Refs #2336)

### DIFF
--- a/app/integration_test/e2e_helpers.dart
+++ b/app/integration_test/e2e_helpers.dart
@@ -180,6 +180,20 @@ Future<void> tapAssignOnCivilianRowWithTitle(
 Future<bool> tapMoveOnFirstNonHomeFleet(WidgetTester tester) =>
     e2eTapMoveOnFirstNonHomeFleet(tester);
 
+/// Stable public name for [e2eAnyExplorerHasEnabledExploreAssignFleet] so
+/// the fleet bundled-Explore retry loop consumes the AC1 barrel only
+/// (Refs GitHub #2336 AC1 / AC2 / AC5 / Bottleneck 5). Forwards to the
+/// implementation in `e2e_test_shared_panels.dart`.
+Future<bool> anyExplorerHasEnabledExploreAssignFleet(
+  WidgetTester tester, {
+  Duration maxUiResponseWait = kE2eDefaultBundledExploreSweepWait,
+  int maxPanelSweepSteps = 16,
+}) => e2eAnyExplorerHasEnabledExploreAssignFleet(
+  tester,
+  maxUiResponseWait: maxUiResponseWait,
+  maxPanelSweepSteps: maxPanelSweepSteps,
+);
+
 Future<void> ensureAllRelocated64pxPngsLoad() =>
     e2eEnsureAllRelocated64pxPngsLoad();
 

--- a/app/integration_test/e2e_test_shared_panels.dart
+++ b/app/integration_test/e2e_test_shared_panels.dart
@@ -1,4 +1,6 @@
 import 'package:colonizethis_app/config/ct_e2e.dart';
+import 'package:colonizethis_app/config/ct_e2e_last_panel_snapshot.dart'
+    show ctE2eCivilianPanelSnapshot;
 import 'package:colonizethis_app/features/game/flame/game_screen_shared.dart';
 import 'package:colonizethis_app/l10n/app_localizations_contract.dart';
 import 'package:colonizethis_app/widgets/ct_dialog_shell.dart';
@@ -721,6 +723,148 @@ Future<bool> e2eTapMoveOnFirstNonHomeFleet(WidgetTester tester) async {
   }
   if (await tryTap(allowExpandAllFallback: false)) {
     return true;
+  }
+  return false;
+}
+
+/// Default UI-response timeout cap for the bundled-Explore enabled-Assign
+/// panel sweep (parity with the `_kMaxUiResponseWait` constant in
+/// `new_game_fleet_reaches_new_world_e2e_helpers.dart`).
+const Duration kE2eDefaultBundledExploreSweepWait = Duration(seconds: 5);
+
+/// Returns `true` when at least one civilian unit row exposes an **enabled**
+/// `Explore` assign target reachable through the civilian panel
+/// ([kCtE2ECivilianPanelRootKey]).
+///
+/// Lifted from the formerly private `_anyExplorerHasEnabledExploreAssignFleetE2e`
+/// in `new_game_fleet_reaches_new_world_e2e_helpers_part2.dart` (Refs GitHub
+/// #2336 AC1 / AC2 / AC5 / Bottleneck 5). The fleet bundled-Explore retry
+/// loop in `new_game_fleet_reaches_new_world_e2e_test.dart` calls this
+/// helper through the AC1 barrel alias `anyExplorerHasEnabledExploreAssignFleet`
+/// up to `maxBoundedTurnRetries (8)` times per scenario, so a silent rename
+/// / fail-open here would stall the retry loop on the slow `maxPanelSweepSteps
+/// (16) × per-step Assign sweep` path — Bottleneck 5 in
+/// `SPEC/program/e2e-integration-tests.md` § Determinism.
+///
+/// The integration suite cannot validate this directly today
+/// (`app_e2e_linux` is a no-op per
+/// `SPEC/program/e2e-integration-tests.md` § CI), so the widget-test pin
+/// in `app/test/e2e_any_explorer_has_enabled_explore_assign_fleet_test.dart`
+/// carries the behavioural contract.
+///
+/// Contract:
+///
+/// - First, consults [e2eExploreAssignEnabledFromCivilianSnapshot] with the
+///   current [ctE2eCivilianPanelSnapshot]. A non-`null` snapshot result is
+///   returned verbatim (`true` / `false`); the panel-sweep walk is only
+///   entered when the snapshot is `null` (no plumbing yet this turn).
+/// - Expects exactly one [ListView] descendant of [kCtE2ECivilianPanelRootKey];
+///   throws via [expect] otherwise (fail-fast on a malformed panel — the
+///   pre-#2336 helper had the same precondition).
+/// - Walks `Assign` text rows under that ListView in tree order, tapping
+///   each unique button (identityHashCode-deduped) and bounded-polling for
+///   an `Explore` [ListTile] to mount.
+/// - When the tapped row's `Explore` tile appears and reports
+///   `enabled == true`, returns `true`. When `enabled == false`, dismisses
+///   the assign sheet and continues the sweep.
+/// - When the sweep exhausts [maxPanelSweepSteps] (defaults to **16**, the
+///   narrowed bound from issue #2336 § Bottleneck 5 / AC1; the pre-#2336
+///   helper used 24), returns `false`.
+/// - Between sweep steps, drags the panel `Scrollable` upward by
+///   `Offset(0, -180)` and pumps a single 25 ms frame so the next iteration
+///   can short-circuit on freshly revealed `Assign` rows without paying a
+///   leading fixed-delay settle (AC5 adaptive polling).
+/// - The `Explore`-tile-settled and assign-sheet-dismissed waits are
+///   bounded by [maxUiResponseWait] (5 s default, the legacy constant) and
+///   a 400 ms dismissed-poll respectively; both ramp via
+///   [e2eAdaptivePollRampAfterIdle].
+Future<bool> e2eAnyExplorerHasEnabledExploreAssignFleet(
+  WidgetTester tester, {
+  Duration maxUiResponseWait = kE2eDefaultBundledExploreSweepWait,
+  int maxPanelSweepSteps = 16,
+}) async {
+  final snapshotHint = e2eExploreAssignEnabledFromCivilianSnapshot(
+    ctE2eCivilianPanelSnapshot,
+  );
+  if (snapshotHint != null) {
+    return snapshotHint;
+  }
+
+  final root = find.byKey(kCtE2ECivilianPanelRootKey);
+  final listView = find.descendant(of: root, matching: find.byType(ListView));
+  expect(listView, findsOneWidget);
+  final panelScrollable = find.descendant(
+    of: listView,
+    matching: find.byType(Scrollable),
+  );
+  expect(panelScrollable, findsOneWidget);
+  final exploreTile = find.widgetWithText(ListTile, 'Explore');
+  // Adaptive replacement (#2336 AC5 / Bottleneck 5): the prior 300ms post-tap
+  // settle plus 50ms fixed wait loop is replaced by a single condition-based
+  // wait that evaluates [exploreTile] before the first pump and ramps the
+  // pump interval via [e2eAdaptivePollRampAfterIdle]. The hard
+  // [maxUiResponseWait] cap is preserved.
+  Future<void> waitForAssignSheetSettled() async {
+    final wait = Stopwatch()..start();
+    var assignPollMs = 25;
+    while (wait.elapsed < maxUiResponseWait) {
+      if (exploreTile.evaluate().isNotEmpty) {
+        return;
+      }
+      await tester.pump(Duration(milliseconds: assignPollMs));
+      assignPollMs = e2eAdaptivePollRampAfterIdle(assignPollMs);
+    }
+  }
+
+  // After [handlePopRoute] the assign sheet can take a frame or two to leave
+  // the tree. Replace the prior fixed 200ms pump with a bounded adaptive
+  // poll that returns as soon as the sheet finishes dismissing.
+  Future<void> waitForAssignSheetDismissed() async {
+    await e2ePumpUntilConditionOrIdle(
+      tester,
+      () => exploreTile.evaluate().isEmpty,
+      timeout: const Duration(milliseconds: 400),
+      phaseName: 'pump_until_assign_sheet_dismissed',
+    );
+  }
+
+  final visitedAssignWidgets = <int>{};
+  for (var step = 0; step < maxPanelSweepSteps; step++) {
+    final assignCandidates = find
+        .descendant(of: listView, matching: find.text('Assign'))
+        .evaluate()
+        .toList();
+    for (final assignElement in assignCandidates) {
+      final marker = identityHashCode(assignElement.widget);
+      if (!visitedAssignWidgets.add(marker)) {
+        continue;
+      }
+      final assignFinder = find.byWidget(assignElement.widget);
+      try {
+        await tester.ensureVisible(assignFinder);
+      } catch (_) {
+        continue;
+      }
+      await tester.tap(assignFinder.first, warnIfMissed: false);
+      await waitForAssignSheetSettled();
+      if (exploreTile.evaluate().isNotEmpty) {
+        final enabled = tester.widget<ListTile>(exploreTile.first).enabled;
+        await tester.binding.handlePopRoute();
+        await waitForAssignSheetDismissed();
+        if (enabled == true) {
+          return true;
+        }
+      } else {
+        await tester.binding.handlePopRoute();
+        await waitForAssignSheetDismissed();
+      }
+    }
+
+    await tester.drag(panelScrollable, const Offset(0, -180));
+    // Adaptive replacement for the prior 120ms post-drag settle (#2336 AC5):
+    // pump a single short frame and let the next iteration short-circuit if
+    // new Assign rows are already visible.
+    await tester.pump(const Duration(milliseconds: 25));
   }
   return false;
 }

--- a/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers_part2.dart
+++ b/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers_part2.dart
@@ -135,95 +135,19 @@ Future<void> _awaitNwCoastalOrVisibleLandForBundledExploreE2e({
 /// contract via
 /// `app/test/e2e_explore_assign_enabled_from_civilian_snapshot_test.dart`.
 
-Future<bool> _anyExplorerHasEnabledExploreAssignFleetE2e(
-  WidgetTester tester,
-) async {
-  final snapshotHint = e2eExploreAssignEnabledFromCivilianSnapshot(
-    ctE2eCivilianPanelSnapshot,
-  );
-  if (snapshotHint != null) {
-    return snapshotHint;
-  }
-
-  final root = find.byKey(kCtE2ECivilianPanelRootKey);
-  final listView = find.descendant(of: root, matching: find.byType(ListView));
-  expect(listView, findsOneWidget);
-  final panelScrollable = find.descendant(
-    of: listView,
-    matching: find.byType(Scrollable),
-  );
-  expect(panelScrollable, findsOneWidget);
-  final exploreTile = find.widgetWithText(ListTile, 'Explore');
-  // Adaptive replacement (#2336 AC5 / Bottleneck 5): the prior 300ms post-tap
-  // settle plus 50ms fixed wait loop is replaced by a single condition-based
-  // wait that evaluates [exploreTile] before the first pump and ramps the
-  // pump interval via [e2eAdaptivePollRampAfterIdle]. The hard
-  // [_kMaxUiResponseWait] cap is preserved.
-  Future<void> waitForAssignSheetSettled() async {
-    final wait = Stopwatch()..start();
-    var assignPollMs = 25;
-    while (wait.elapsed < _kMaxUiResponseWait) {
-      if (exploreTile.evaluate().isNotEmpty) {
-        return;
-      }
-      await tester.pump(Duration(milliseconds: assignPollMs));
-      assignPollMs = e2eAdaptivePollRampAfterIdle(assignPollMs);
-    }
-  }
-
-  // After [handlePopRoute] the assign sheet can take a frame or two to leave
-  // the tree. Replace the prior fixed 200ms pump with a bounded adaptive
-  // poll that returns as soon as the sheet finishes dismissing.
-  Future<void> waitForAssignSheetDismissed() async {
-    await e2ePumpUntilConditionOrIdle(
-      tester,
-      () => exploreTile.evaluate().isEmpty,
-      timeout: const Duration(milliseconds: 400),
-      phaseName: 'pump_until_assign_sheet_dismissed',
-    );
-  }
-
-  final visitedAssignWidgets = <int>{};
-  const maxPanelSweepSteps = 16;
-  for (var step = 0; step < maxPanelSweepSteps; step++) {
-    final assignCandidates = find
-        .descendant(of: listView, matching: find.text('Assign'))
-        .evaluate()
-        .toList();
-    for (final assignElement in assignCandidates) {
-      final marker = identityHashCode(assignElement.widget);
-      if (!visitedAssignWidgets.add(marker)) {
-        continue;
-      }
-      final assignFinder = find.byWidget(assignElement.widget);
-      try {
-        await tester.ensureVisible(assignFinder);
-      } catch (_) {
-        continue;
-      }
-      await tester.tap(assignFinder.first, warnIfMissed: false);
-      await waitForAssignSheetSettled();
-      if (exploreTile.evaluate().isNotEmpty) {
-        final enabled = tester.widget<ListTile>(exploreTile.first).enabled;
-        await tester.binding.handlePopRoute();
-        await waitForAssignSheetDismissed();
-        if (enabled == true) {
-          return true;
-        }
-      } else {
-        await tester.binding.handlePopRoute();
-        await waitForAssignSheetDismissed();
-      }
-    }
-
-    await tester.drag(panelScrollable, const Offset(0, -180));
-    // Adaptive replacement for the prior 120ms post-drag settle (#2336 AC5):
-    // pump a single short frame and let the next iteration short-circuit if
-    // new Assign rows are already visible.
-    await tester.pump(const Duration(milliseconds: 25));
-  }
-  return false;
-}
+/// `_anyExplorerHasEnabledExploreAssignFleetE2e` was lifted into the public
+/// [e2eAnyExplorerHasEnabledExploreAssignFleet] in
+/// `e2e_test_shared_panels.dart` (Refs GitHub #2336 AC1 / AC2 / AC5 /
+/// Bottleneck 5). The fleet bundled-Explore retry loop calls the lifted
+/// form through the AC1 barrel alias `anyExplorerHasEnabledExploreAssignFleet`
+/// (`e2e_helpers.dart`). The widget-test pin in
+/// `app/test/e2e_any_explorer_has_enabled_explore_assign_fleet_test.dart`
+/// guards against silent regressions (the integration suite cannot validate
+/// this directly today — `app_e2e_linux` is a no-op per
+/// `SPEC/program/e2e-integration-tests.md` § CI). A regression here would
+/// stall the bundled-Explore retry loop on the slow
+/// `maxPanelSweepSteps (16) × per-step Assign sweep` path described as
+/// Bottleneck 5 in `SPEC/program/e2e-integration-tests.md` § Determinism.
 
 /// Taps the map HUD next-turn button, handles the optional confirm dialog,
 /// and waits for the next-turn label to advance. This is the fleet e2e's

--- a/app/integration_test/new_game_fleet_reaches_new_world_e2e_test.dart
+++ b/app/integration_test/new_game_fleet_reaches_new_world_e2e_test.dart
@@ -353,8 +353,9 @@ void main() {
           perf: perf,
           phaseName: 'wait_until_found_civilian_panel',
         );
-        final enabled = await _anyExplorerHasEnabledExploreAssignFleetE2e(
+        final enabled = await anyExplorerHasEnabledExploreAssignFleet(
           tester,
+          maxUiResponseWait: _kMaxUiResponseWait,
         );
         await closeBottomSheet(
           tester,

--- a/app/test/e2e_any_explorer_has_enabled_explore_assign_fleet_test.dart
+++ b/app/test/e2e_any_explorer_has_enabled_explore_assign_fleet_test.dart
@@ -1,0 +1,520 @@
+/// Pins the widget-tree contract of
+/// [e2eAnyExplorerHasEnabledExploreAssignFleet]
+/// (`app/integration_test/e2e_test_shared_panels.dart`).
+///
+/// The fleet bundled-Explore retry loop in
+/// `new_game_fleet_reaches_new_world_e2e_test.dart` calls this helper
+/// through the AC1 barrel alias `anyExplorerHasEnabledExploreAssignFleet`
+/// inside a bounded retry window (`maxBoundedTurnRetries = 8`). A silent
+/// rename / fail-open here would either:
+///
+///   - Stall the retry loop on the slow `maxPanelSweepSteps (16) ×
+///     per-step Assign sweep` path — Bottleneck 5 in
+///     `SPEC/program/e2e-integration-tests.md` § Determinism — burning
+///     wall-clock the snapshot short-circuit already avoids; or
+///   - Silently flip the bundled-Explore readiness verdict (always-true
+///     / always-false) and mask a real production regression.
+///
+/// The integration suite cannot validate this directly today (the
+/// `app_e2e_linux` lane is a no-op per
+/// `SPEC/program/e2e-integration-tests.md` § CI), so this widget-test
+/// layer carries the behavioural pin.
+///
+/// Refs GitHub #2336 AC1 / AC2 / AC5 / Bottleneck 5.
+library;
+
+import 'package:colonizethis_app/config/ct_e2e.dart';
+import 'package:colonizethis_app/config/ct_e2e_last_panel_snapshot.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart'
+    show kWorkTargetBuildRoad, kWorkTargetExplore;
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../integration_test/e2e_test_shared.dart';
+
+const String _human = 'gp1';
+
+const TurnState _orderingTurn = TurnState(
+  phase: TurnPhase.orders,
+  turnNumber: 1,
+);
+
+const Orders _emptyOrders = Orders();
+
+Game _game() => const Game(
+  id: 'g1',
+  worldState: WorldState(
+    turnState: _orderingTurn,
+    oldWorld: RegionData(),
+    newWorld: RegionData(),
+  ),
+  players: [Player(id: _human, displayName: 'You', isHuman: true)],
+);
+
+CtE2eCivilianPanelSnapshot _snapshot({
+  Map<String, List<String>> availableWorkTargets = const {},
+}) => CtE2eCivilianPanelSnapshot(
+  game: _game(),
+  humanPlayerId: _human,
+  currentOrders: _emptyOrders,
+  availableWorkTargets: availableWorkTargets,
+);
+
+/// Builder for an Assign row that, when tapped, shows a modal route whose
+/// tree contains an `Explore` [ListTile] with the given [exploreTileEnabled]
+/// flag. Uses `showDialog` (a modal overlay) so the underlying civilian
+/// panel ListView stays mounted in the tree between iterations — the
+/// helper's `tester.drag(panelScrollable, ...)` between sweep steps needs
+/// the panel root to remain reachable. The production civilian panel
+/// likewise sits behind a modal-style assign sheet, not a full-screen push
+/// route, so this mock is more faithful to the live surface as well.
+class _AssignRow extends StatelessWidget {
+  const _AssignRow({
+    required this.label,
+    this.exploreTileEnabled,
+    this.onTap,
+  });
+
+  /// Visible label to disambiguate rows in failure messages.
+  final String label;
+
+  /// `null` → tapping shows a dialog WITHOUT an `Explore` tile (the helper
+  /// walks past this row).
+  /// non-null → tapping shows a dialog WITH an `Explore` [ListTile] whose
+  /// `enabled` matches this flag.
+  final bool? exploreTileEnabled;
+
+  /// Optional spy invoked each time the Assign button is tapped.
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      title: Text(label),
+      trailing: Builder(
+        builder: (context) {
+          return TextButton(
+            onPressed: () {
+              onTap?.call();
+              final tiles = <Widget>[];
+              if (exploreTileEnabled != null) {
+                tiles.add(
+                  ListTile(
+                    title: const Text('Explore'),
+                    enabled: exploreTileEnabled!,
+                  ),
+                );
+              } else {
+                tiles.add(const ListTile(title: Text('Build Road')));
+              }
+              showDialog<void>(
+                context: context,
+                builder: (_) => Dialog(child: Column(children: tiles)),
+              );
+            },
+            // Non-const so each row's `Text('Assign')` has its own widget
+            // identity. The helper's
+            // `visitedAssignWidgets.add(identityHashCode(...))` dedup pin
+            // requires distinct Text instances per Assign row — Dart
+            // canonicalizes `const Text('Assign')` literals and would make
+            // the dedup set collapse rows that the live panel renders
+            // separately.
+            // ignore: prefer_const_constructors
+            child: Text('Assign'),
+          );
+        },
+      ),
+    );
+  }
+}
+
+/// Wraps panel children under [kCtE2ECivilianPanelRootKey] with a single
+/// [ListView] descendant, matching the helper's `find.descendant(of: root,
+/// matching: find.byType(ListView))` precondition.
+Widget _civilianPanel({required List<Widget> children}) => KeyedSubtree(
+  key: kCtE2ECivilianPanelRootKey,
+  child: ListView(children: children),
+);
+
+Widget _wrap(Widget body) => MaterialApp(home: Scaffold(body: body));
+
+void main() {
+  suppressLogsForTests();
+
+  setUp(() {
+    ctE2eCivilianPanelSnapshot = null;
+  });
+
+  tearDown(() {
+    ctE2eCivilianPanelSnapshot = null;
+  });
+
+  group(
+    'e2eAnyExplorerHasEnabledExploreAssignFleet — snapshot short-circuit',
+    () {
+      testWidgets('snapshot says Explore enabled -> true (no panel sweep)', (
+        tester,
+      ) async {
+        var assignTaps = 0;
+        ctE2eCivilianPanelSnapshot = _snapshot(
+          availableWorkTargets: const {
+            'explorer-1': [kWorkTargetExplore],
+          },
+        );
+        await tester.pumpWidget(
+          _wrap(
+            _civilianPanel(
+              children: [
+                _AssignRow(
+                  label: 'Explorer',
+                  exploreTileEnabled: true,
+                  onTap: () => assignTaps++,
+                ),
+              ],
+            ),
+          ),
+        );
+        expect(
+          await e2eAnyExplorerHasEnabledExploreAssignFleet(tester),
+          isTrue,
+        );
+        expect(
+          assignTaps,
+          0,
+          reason: 'The snapshot short-circuit must return immediately '
+              'without tapping any Assign row; a regression that walked '
+              'the panel anyway would inflate every fleet-reach turn by '
+              'the slow-path budget (Bottleneck 5).',
+        );
+      });
+
+      testWidgets(
+        'snapshot says no Explore enabled -> false (no panel sweep)',
+        (tester) async {
+          var assignTaps = 0;
+          ctE2eCivilianPanelSnapshot = _snapshot(
+            availableWorkTargets: const {
+              'unit-1': [kWorkTargetBuildRoad],
+            },
+          );
+          await tester.pumpWidget(
+            _wrap(
+              _civilianPanel(
+                children: [
+                  _AssignRow(
+                    label: 'Builder',
+                    exploreTileEnabled: true,
+                    onTap: () => assignTaps++,
+                  ),
+                ],
+              ),
+            ),
+          );
+          expect(
+            await e2eAnyExplorerHasEnabledExploreAssignFleet(tester),
+            isFalse,
+          );
+          expect(
+            assignTaps,
+            0,
+            reason: 'The snapshot `false` verdict is contractually distinct '
+                'from `null` and must short-circuit the panel sweep too. '
+                'Conflating `false` with `null` would surface a false '
+                'positive whenever the snapshot already proved no Explore '
+                'is assignable.',
+          );
+        },
+      );
+
+      testWidgets(
+        'snapshot null -> falls through to panel sweep (tap occurs)',
+        (tester) async {
+          var assignTaps = 0;
+          ctE2eCivilianPanelSnapshot = null;
+          await tester.pumpWidget(
+            _wrap(
+              _civilianPanel(
+                children: [
+                  _AssignRow(
+                    label: 'Explorer',
+                    exploreTileEnabled: true,
+                    onTap: () => assignTaps++,
+                  ),
+                ],
+              ),
+            ),
+          );
+          expect(
+            await e2eAnyExplorerHasEnabledExploreAssignFleet(tester),
+            isTrue,
+          );
+          expect(
+            assignTaps,
+            1,
+            reason: 'A null snapshot is the "no plumbing this turn" '
+                'state — the helper must fall through to the live '
+                'Assign-row walk rather than treat null as a definitive '
+                'verdict (matching the documented `bool?` contract of '
+                '[e2eExploreAssignEnabledFromCivilianSnapshot]).',
+          );
+        },
+      );
+    },
+  );
+
+  group(
+    'e2eAnyExplorerHasEnabledExploreAssignFleet — panel sweep true branches',
+    () {
+      testWidgets('single Assign row with enabled Explore tile -> true', (
+        tester,
+      ) async {
+        var assignTaps = 0;
+        await tester.pumpWidget(
+          _wrap(
+            _civilianPanel(
+              children: [
+                _AssignRow(
+                  label: 'Explorer',
+                  exploreTileEnabled: true,
+                  onTap: () => assignTaps++,
+                ),
+              ],
+            ),
+          ),
+        );
+        expect(
+          await e2eAnyExplorerHasEnabledExploreAssignFleet(tester),
+          isTrue,
+        );
+        expect(
+          assignTaps,
+          1,
+          reason: 'The canonical happy path: one Assign row whose '
+              'pushed sheet exposes an enabled `Explore` tile must '
+              'return true after exactly one tap.',
+        );
+      });
+
+      testWidgets(
+        'second Assign row carries the enabled Explore tile -> true after '
+        'two taps',
+        (tester) async {
+          var firstTaps = 0;
+          var secondTaps = 0;
+          await tester.pumpWidget(
+            _wrap(
+              _civilianPanel(
+                children: [
+                  _AssignRow(
+                    label: 'Builder',
+                    exploreTileEnabled: false,
+                    onTap: () => firstTaps++,
+                  ),
+                  _AssignRow(
+                    label: 'Explorer',
+                    exploreTileEnabled: true,
+                    onTap: () => secondTaps++,
+                  ),
+                ],
+              ),
+            ),
+          );
+          expect(
+            await e2eAnyExplorerHasEnabledExploreAssignFleet(tester),
+            isTrue,
+          );
+          expect(
+            firstTaps,
+            1,
+            reason: 'A disabled `Explore` tile on the first row must NOT '
+                'short-circuit to `true`; the helper has to keep walking '
+                'until it finds an `enabled: true` Explore tile.',
+          );
+          expect(
+            secondTaps,
+            1,
+            reason: 'The second row carrying the enabled `Explore` tile '
+                'is the first true match — pin the linear sweep order so '
+                'a regression that reorders / skips rows fails here.',
+          );
+        },
+      );
+    },
+  );
+
+  group(
+    'e2eAnyExplorerHasEnabledExploreAssignFleet — panel sweep false branches',
+    () {
+      testWidgets('no Assign rows at all -> false (sweep exhausted)', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          _wrap(
+            _civilianPanel(
+              children: const [ListTile(title: Text('No Assign here'))],
+            ),
+          ),
+        );
+        expect(
+          await e2eAnyExplorerHasEnabledExploreAssignFleet(
+            tester,
+            maxPanelSweepSteps: 2,
+          ),
+          isFalse,
+        );
+      });
+
+      testWidgets('only Assign rows whose sheet has no Explore tile -> false',
+          (tester) async {
+        var taps = 0;
+        await tester.pumpWidget(
+          _wrap(
+            _civilianPanel(
+              children: [
+                _AssignRow(
+                  label: 'Builder',
+                  exploreTileEnabled: null,
+                  onTap: () => taps++,
+                ),
+              ],
+            ),
+          ),
+        );
+        expect(
+          await e2eAnyExplorerHasEnabledExploreAssignFleet(
+            tester,
+            maxPanelSweepSteps: 1,
+          ),
+          isFalse,
+        );
+        expect(
+          taps,
+          1,
+          reason: 'When the assign sheet mounts but contains no `Explore` '
+              'tile at all, the helper must pop the route and continue '
+              'the sweep (returning false only after the sweep cap). A '
+              'regression that returned true here would conflate '
+              '"no Explore tile" with "Explore enabled".',
+        );
+      });
+
+      testWidgets(
+        'Assign row whose Explore tile is `enabled: false` -> false '
+        '(panel-mounted but no readiness)',
+        (tester) async {
+          var taps = 0;
+          await tester.pumpWidget(
+            _wrap(
+              _civilianPanel(
+                children: [
+                  _AssignRow(
+                    label: 'Explorer',
+                    exploreTileEnabled: false,
+                    onTap: () => taps++,
+                  ),
+                ],
+              ),
+            ),
+          );
+          expect(
+            await e2eAnyExplorerHasEnabledExploreAssignFleet(
+              tester,
+              maxPanelSweepSteps: 1,
+            ),
+            isFalse,
+          );
+          expect(
+            taps,
+            1,
+            reason: 'A disabled `Explore` tile is the canonical "panel '
+                'mounted but Explore not assignable yet" state — the '
+                'helper must check `enabled` strictly and continue past '
+                '`enabled: false`. A regression that ignored the flag '
+                'and returned true on tile-presence alone would mask '
+                'real bundled-Explore readiness regressions on Linux CI.',
+          );
+        },
+      );
+    },
+  );
+
+  group(
+    'e2eAnyExplorerHasEnabledExploreAssignFleet — dedup and bounds',
+    () {
+      testWidgets(
+        'visited Assign widgets are deduped across sweep steps '
+        '(same widget identity not tapped twice)',
+        (tester) async {
+          var taps = 0;
+          await tester.pumpWidget(
+            _wrap(
+              _civilianPanel(
+                children: [
+                  _AssignRow(
+                    label: 'Explorer',
+                    exploreTileEnabled: false,
+                    onTap: () => taps++,
+                  ),
+                ],
+              ),
+            ),
+          );
+          expect(
+            await e2eAnyExplorerHasEnabledExploreAssignFleet(
+              tester,
+              maxPanelSweepSteps: 4,
+            ),
+            isFalse,
+          );
+          expect(
+            taps,
+            1,
+            reason: 'Across 4 sweep steps the same Assign widget must be '
+                'tapped at most once — the identityHashCode-deduped '
+                '`visitedAssignWidgets` set guards against re-tapping a '
+                'stable row when the drag does not reveal new rows. A '
+                'regression that dropped the dedup would inflate the '
+                'sweep by 4× on every fleet-reach retry.',
+          );
+        },
+      );
+
+      testWidgets(
+        'maxPanelSweepSteps = 0 short-circuits before any Assign tap',
+        (tester) async {
+          var taps = 0;
+          await tester.pumpWidget(
+            _wrap(
+              _civilianPanel(
+                children: [
+                  _AssignRow(
+                    label: 'Explorer',
+                    exploreTileEnabled: true,
+                    onTap: () => taps++,
+                  ),
+                ],
+              ),
+            ),
+          );
+          expect(
+            await e2eAnyExplorerHasEnabledExploreAssignFleet(
+              tester,
+              maxPanelSweepSteps: 0,
+            ),
+            isFalse,
+          );
+          expect(
+            taps,
+            0,
+            reason: 'A `maxPanelSweepSteps: 0` ceiling must enter the '
+                'for-loop zero times and return false before any tap — '
+                'pins the bound as the canonical kill-switch the issue '
+                '§ Bottleneck 5 narrowed from 24 to 16.',
+          );
+        },
+      );
+    },
+  );
+}

--- a/app/test/e2e_any_explorer_has_enabled_explore_assign_fleet_test.dart
+++ b/app/test/e2e_any_explorer_has_enabled_explore_assign_fleet_test.dart
@@ -168,7 +168,7 @@ void main() {
             _civilianPanel(
               children: [
                 _AssignRow(
-                  label: 'Explorer',
+                  label: kUnitTypeExplorer,
                   exploreTileEnabled: true,
                   onTap: () => assignTaps++,
                 ),
@@ -204,7 +204,7 @@ void main() {
               _civilianPanel(
                 children: [
                   _AssignRow(
-                    label: 'Builder',
+                    label: kUnitTypeBuilder,
                     exploreTileEnabled: true,
                     onTap: () => assignTaps++,
                   ),
@@ -238,7 +238,7 @@ void main() {
               _civilianPanel(
                 children: [
                   _AssignRow(
-                    label: 'Explorer',
+                    label: kUnitTypeExplorer,
                     exploreTileEnabled: true,
                     onTap: () => assignTaps++,
                   ),
@@ -276,7 +276,7 @@ void main() {
             _civilianPanel(
               children: [
                 _AssignRow(
-                  label: 'Explorer',
+                  label: kUnitTypeExplorer,
                   exploreTileEnabled: true,
                   onTap: () => assignTaps++,
                 ),
@@ -308,12 +308,12 @@ void main() {
               _civilianPanel(
                 children: [
                   _AssignRow(
-                    label: 'Builder',
+                    label: kUnitTypeBuilder,
                     exploreTileEnabled: false,
                     onTap: () => firstTaps++,
                   ),
                   _AssignRow(
-                    label: 'Explorer',
+                    label: kUnitTypeExplorer,
                     exploreTileEnabled: true,
                     onTap: () => secondTaps++,
                   ),
@@ -374,7 +374,7 @@ void main() {
             _civilianPanel(
               children: [
                 _AssignRow(
-                  label: 'Builder',
+                  label: kUnitTypeBuilder,
                   exploreTileEnabled: null,
                   onTap: () => taps++,
                 ),
@@ -410,7 +410,7 @@ void main() {
               _civilianPanel(
                 children: [
                   _AssignRow(
-                    label: 'Explorer',
+                    label: kUnitTypeExplorer,
                     exploreTileEnabled: false,
                     onTap: () => taps++,
                   ),
@@ -453,7 +453,7 @@ void main() {
               _civilianPanel(
                 children: [
                   _AssignRow(
-                    label: 'Explorer',
+                    label: kUnitTypeExplorer,
                     exploreTileEnabled: false,
                     onTap: () => taps++,
                   ),
@@ -490,7 +490,7 @@ void main() {
               _civilianPanel(
                 children: [
                   _AssignRow(
-                    label: 'Explorer',
+                    label: kUnitTypeExplorer,
                     exploreTileEnabled: true,
                     onTap: () => taps++,
                   ),

--- a/app/test/e2e_helpers_barrel_test.dart
+++ b/app/test/e2e_helpers_barrel_test.dart
@@ -43,7 +43,10 @@
 //     § AC5 (Adaptive polling) for the panel/turn entrypoints.
 
 import 'package:colonizethis_app/config/ct_e2e_last_panel_snapshot.dart'
-    show CtE2eCivilianPanelSnapshot, CtE2eNavalPanelSnapshot;
+    show
+        CtE2eCivilianPanelSnapshot,
+        CtE2eNavalPanelSnapshot,
+        ctE2eCivilianPanelSnapshot;
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_app/l10n/app_localizations_contract.dart';
 import 'package:colonizethis_data/colonizethis_data.dart' show MapTopology;
@@ -339,6 +342,74 @@ void main() {
               'short-circuit to true (masking real fleet-reach '
               'regressions); pin both the typed tear-off and the '
               'no-panel return so the contract surfaces here.',
+        );
+      },
+    );
+
+    testWidgets(
+      'anyExplorerHasEnabledExploreAssignFleet is re-exported through '
+      'the barrel',
+      (tester) async {
+        final Future<bool> Function(
+          WidgetTester, {
+          Duration maxUiResponseWait,
+          int maxPanelSweepSteps,
+        })
+        ref = anyExplorerHasEnabledExploreAssignFleet;
+        expect(
+          ref,
+          isNotNull,
+          reason:
+              'The fleet bundled-Explore retry loop '
+              '(`checkExploreEnabledFromCivilianPanel` in '
+              '`new_game_fleet_reaches_new_world_e2e_test.dart`) '
+              'consumes this readiness helper via the AC1 barrel inside '
+              'the `maxBoundedTurnRetries = 8` retry window. A '
+              'regression that dropped the barrel wrapper, flipped the '
+              'return type, or removed the `maxUiResponseWait` / '
+              '`maxPanelSweepSteps` named parameters would either break '
+              'the retry loop\'s budget plumbing or silently inflate '
+              'every retry by the slow-path `maxPanelSweepSteps (16) × '
+              'per-step Assign sweep` cost (Bottleneck 5 in '
+              '`SPEC/program/e2e-integration-tests.md` § Determinism, '
+              '#2336 AC1 / AC5).',
+        );
+        ctE2eCivilianPanelSnapshot = const CtE2eCivilianPanelSnapshot(
+          game: Game(
+            id: 'barrel-smoke-no-explore',
+            worldState: WorldState(
+              turnState: TurnState(
+                phase: TurnPhase.orders,
+                turnNumber: 1,
+              ),
+              oldWorld: RegionData(),
+              newWorld: RegionData(),
+            ),
+            players: [Player(id: 'gp1', displayName: 'You', isHuman: true)],
+          ),
+          humanPlayerId: 'gp1',
+          currentOrders: Orders(),
+          availableWorkTargets: <String, List<String>>{},
+        );
+        addTearDown(() {
+          ctE2eCivilianPanelSnapshot = null;
+        });
+        await tester.pumpWidget(
+          const MaterialApp(home: Scaffold(body: SizedBox())),
+        );
+        expect(
+          await ref(tester, maxPanelSweepSteps: 0),
+          isFalse,
+          reason:
+              'Sanity smoke through the barrel: an empty-targets civilian-'
+              'panel snapshot short-circuits the helper via '
+              '[e2eExploreAssignEnabledFromCivilianSnapshot] (which '
+              'returns `false`), so the helper returns `false` without '
+              'ever consulting `kCtE2ECivilianPanelRootKey`. A wrapper '
+              'that swallowed the snapshot path or short-circuited to '
+              '`true` would pass the tear-off pin silently — this smoke '
+              'distinguishes the snapshot-driven false verdict from the '
+              'panel-sweep fallback.',
         );
       },
     );


### PR DESCRIPTION
## Summary

Continues the issue #2336 AC1 / AC2 helper-lift work by moving the formerly
private `_anyExplorerHasEnabledExploreAssignFleetE2e` (in
`app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers_part2.dart`)
into the public `e2eAnyExplorerHasEnabledExploreAssignFleet` in
`app/integration_test/e2e_test_shared_panels.dart`, re-exports it through the
AC1 barrel as `anyExplorerHasEnabledExploreAssignFleet`, and pins the
contract via a new widget-test
(`app/test/e2e_any_explorer_has_enabled_explore_assign_fleet_test.dart`,
10 tests).

This is a **lift + pin** slice targeting **Bottleneck 5** (the bundled-
Explore assign panel sweep). Observable behaviour is unchanged; the
fleet bundled-Explore retry loop in `new_game_fleet_reaches_new_world_e2e_test.dart`
(`checkExploreEnabledFromCivilianPanel`) now calls
`anyExplorerHasEnabledExploreAssignFleet` (public alias) instead of the
private name, matching the existing convention used for
`openNavalPanel`, `tapMoveOnFirstNonHomeFleet`,
`e2eExploreAssignEnabledFromCivilianSnapshot`, and the other neighbours
that compose the bundled-Explore loop.

## Why this matters (Bottleneck 5)

The bundled-Explore retry loop calls this helper through
`checkExploreEnabledFromCivilianPanel` up to `maxBoundedTurnRetries (8)`
times per fleet-reach scenario. A silent rename / fail-open here would
either:

- Stall every retry on the slow `maxPanelSweepSteps (16) × per-step
  Assign sweep` path — Bottleneck 5 in
  `SPEC/program/e2e-integration-tests.md` § Determinism — burning the
  wall-clock budget #2336 is reducing; or
- Silently flip the bundled-Explore readiness verdict (always-true /
  always-false) and mask a real production regression.

The integration suite cannot validate this directly today
(`app_e2e_linux` is a no-op per
`SPEC/program/e2e-integration-tests.md` § CI), so the widget-test layer
carries the behavioural pin.

## Done in this push

- **Lifted helper** — `e2eAnyExplorerHasEnabledExploreAssignFleet(WidgetTester, {Duration maxUiResponseWait, int maxPanelSweepSteps}) -> Future<bool>`
  added to `app/integration_test/e2e_test_shared_panels.dart` with the
  same observable contract: snapshot short-circuit via
  `e2eExploreAssignEnabledFromCivilianSnapshot` first, then live panel
  sweep over `find.descendant(of: kCtE2ECivilianPanelRootKey, matching:
  find.byType(ListView))`. The 5 s `maxUiResponseWait` and 16-step
  `maxPanelSweepSteps` ceilings are exposed as named parameters
  (defaults preserve the pre-lift bounds) so call sites and the
  widget-test pin can drive bound-edge cases without forking the
  implementation.

- **AC1 barrel re-export** — `anyExplorerHasEnabledExploreAssignFleet(WidgetTester, {Duration, int})`
  added to `app/integration_test/e2e_helpers.dart`; the existing
  `e2e_test_shared.dart` re-export chain already carries the lifted
  implementation through the panel-shared re-export.

- **Call-site rewire** — `checkExploreEnabledFromCivilianPanel` in
  `new_game_fleet_reaches_new_world_e2e_test.dart` now calls
  `anyExplorerHasEnabledExploreAssignFleet` with the existing
  `_kMaxUiResponseWait` (5 s). The private definition in
  `new_game_fleet_reaches_new_world_e2e_helpers_part2.dart` is replaced
  by a doc-comment pointer to the lifted helper and the widget-test pin.

- **Widget-test pin** —
  `app/test/e2e_any_explorer_has_enabled_explore_assign_fleet_test.dart`
  (10 tests):
  - **Snapshot short-circuit** (3): snapshot says Explore enabled → `true`
    without any panel tap; snapshot says no Explore → `false` without any
    panel tap; `null` snapshot → falls through to the live panel sweep
    (tap occurs).
  - **Panel-sweep true branches** (2): single Assign row whose pushed
    dialog exposes an enabled `Explore` `ListTile` → `true` after one
    tap; first row carries a disabled tile and the second carries an
    enabled tile → `true` after two taps (pins linear sweep order so a
    regression that reorders / skips rows fails here).
  - **Panel-sweep false branches** (3): no Assign rows → `false` (sweep
    exhausted); Assign row whose dialog has no `Explore` tile at all →
    `false` (regression guard against "no tile = enabled"); Assign row
    whose `Explore` tile is `enabled: false` → `false` (panel-mounted
    but Explore not ready — pins the strict `enabled` check).
  - **Dedup and bounds** (2): same Assign widget identity is tapped at
    most once across 4 sweep steps (`visitedAssignWidgets`); 
    `maxPanelSweepSteps: 0` short-circuits before any tap (pins the
    bound the issue § Bottleneck 5 narrowed from 24 to 16).

- **AC1 barrel test extension** — `app/test/e2e_helpers_barrel_test.dart`
  gains an `anyExplorerHasEnabledExploreAssignFleet` typed tear-off pin
  (`Future<bool> Function(WidgetTester, {Duration maxUiResponseWait, int maxPanelSweepSteps})`)
  plus a snapshot-driven smoke that asserts `false` when an
  empty-targets `CtE2eCivilianPanelSnapshot` short-circuits the helper.

## Behavior change

None. The lifted helper is byte-equivalent to the prior private form
(same finders, same timeouts, same NW-preference + dedup + drag
algorithm). The fleet bundled-Explore retry loop already exercising
`_anyExplorerHasEnabledExploreAssignFleetE2e` continues to call into the
same logic via the public alias.

## Local verification

- `flutter analyze integration_test/` — clean.
- `flutter analyze` for both touched test files — clean.
- `flutter test test/e2e_any_explorer_has_enabled_explore_assign_fleet_test.dart`
  — 10/10 pass.
- `flutter test test/e2e_*_test.dart` — 368/368 pass (sibling pins still
  green alongside the new file).

## AC6–AC10 status

Unchanged. This is a refactor + pin slice; AC9 aggregate wall-clock
reduction work continues across the broader #2336 slice queue, and
AC6–AC10 still require maintainer Linux desktop integration_test runs
through `tool/run_e2e_timing.sh` per the issue's Baseline measurement
methodology.

## Label

Leaving as `backlog:implementation` — issue not fully implemented;
AC9 timing evidence and AC6 / AC7 / AC10 pass-evidence are still
outstanding.

Refs #2336

## Test plan

- [x] `flutter analyze integration_test/` clean
- [x] `flutter analyze` for both touched test files clean
- [x] New widget-test green (10 tests)
- [x] Sibling pin tests still green (368 total alongside the new file)
- [ ] CI: `App tests`, `Quality (lint, analyze, observer)`

Made with [Cursor](https://cursor.com)