### PR TITLE
test(e2e): lift _pickMoveDestinationAndConfirm into shared library + pin (Refs #2336)

### DIFF
--- a/app/integration_test/e2e_helpers.dart
+++ b/app/integration_test/e2e_helpers.dart
@@ -29,6 +29,7 @@ export 'e2e_test_shared.dart'
         e2eNonHomeHumanFleetInNewWorldFromCtSnapshot,
         e2eNwCoastalProvincesAdjacentToFleetSea,
         e2eOldWorldRegionChipAppearsSelected,
+        e2ePickMoveDestinationAndConfirm,
         e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot,
         e2ePumpUntil,
         e2ePumpUntilConditionOrIdle,
@@ -41,6 +42,8 @@ export 'e2e_test_shared.dart'
         e2eWaitUntilAnyFinderHitTestable,
         e2eOpenProductionPanel,
         e2eOpenPanelFromMarker,
+        kE2eDefaultMoveFleetDialogBudget,
+        kE2eDefaultMoveFleetWarpDragProbes,
         kE2eMaxWallClock,
         kE2eNextTurnResolutionTimeout;
 
@@ -179,6 +182,24 @@ Future<void> tapAssignOnCivilianRowWithTitle(
 /// the implementation in `e2e_test_shared_panels.dart`.
 Future<bool> tapMoveOnFirstNonHomeFleet(WidgetTester tester) =>
     e2eTapMoveOnFirstNonHomeFleet(tester);
+
+/// Stable public name for [e2ePickMoveDestinationAndConfirm] so fleet
+/// scenarios consume the AC1 barrel only (Refs GitHub #2336 AC1 / AC2 / AC4 /
+/// Bottleneck 4 / H4). Forwards to the implementation in
+/// `e2e_test_shared_panels.dart`.
+Future<void> pickMoveDestinationAndConfirm(
+  WidgetTester tester,
+  AppLocalizations l10n, {
+  bool allowWarpDestinations = true,
+  Duration moveDialogBudget = kE2eDefaultMoveFleetDialogBudget,
+  int maxWarpDragProbes = kE2eDefaultMoveFleetWarpDragProbes,
+}) => e2ePickMoveDestinationAndConfirm(
+  tester,
+  l10n,
+  allowWarpDestinations: allowWarpDestinations,
+  moveDialogBudget: moveDialogBudget,
+  maxWarpDragProbes: maxWarpDragProbes,
+);
 
 /// Stable public name for [e2eAnyExplorerHasEnabledExploreAssignFleet] so
 /// the fleet bundled-Explore retry loop consumes the AC1 barrel only

--- a/app/integration_test/e2e_helpers.dart
+++ b/app/integration_test/e2e_helpers.dart
@@ -30,7 +30,9 @@ export 'e2e_test_shared.dart'
         e2eNwCoastalProvincesAdjacentToFleetSea,
         e2eOldWorldRegionChipAppearsSelected,
         e2ePickMoveDestinationAndConfirm,
+        e2eTryNavalMoveSegment,
         e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot,
+        kE2eDefaultNavalMoveSegmentUiWait,
         e2ePumpUntil,
         e2ePumpUntilConditionOrIdle,
         e2eRadioListTilesInAlertDialogs,
@@ -199,6 +201,27 @@ Future<void> pickMoveDestinationAndConfirm(
   allowWarpDestinations: allowWarpDestinations,
   moveDialogBudget: moveDialogBudget,
   maxWarpDragProbes: maxWarpDragProbes,
+);
+
+/// Stable public name for [e2eTryNavalMoveSegment] so fleet scenarios consume
+/// the AC1 barrel only (Refs GitHub #2336 AC1 / AC2 / Bottleneck 4 / H1–H4).
+/// Forwards to the implementation in `e2e_test_shared_panels.dart`.
+Future<void> tryNavalMoveSegment(
+  WidgetTester tester,
+  AppLocalizations l10n, {
+  bool useNewWorldMapTabFirst = false,
+  bool allowWarpDestinations = true,
+  bool navalPanelAlreadyOpen = false,
+  E2ePerfLog? perf,
+  Duration maxUiResponseWait = kE2eDefaultNavalMoveSegmentUiWait,
+}) => e2eTryNavalMoveSegment(
+  tester,
+  l10n,
+  useNewWorldMapTabFirst: useNewWorldMapTabFirst,
+  allowWarpDestinations: allowWarpDestinations,
+  navalPanelAlreadyOpen: navalPanelAlreadyOpen,
+  perf: perf,
+  maxUiResponseWait: maxUiResponseWait,
 );
 
 /// Stable public name for [e2eAnyExplorerHasEnabledExploreAssignFleet] so

--- a/app/integration_test/e2e_test_shared_panels.dart
+++ b/app/integration_test/e2e_test_shared_panels.dart
@@ -1043,3 +1043,112 @@ Future<void> e2ePickMoveDestinationAndConfirm(
   );
   ensureBudget('after confirm');
 }
+
+/// Default per-call UI wait for [e2eTryNavalMoveSegment] (naval panel open,
+/// move-dialog picker budget). Matches the pre-lift private
+/// `_kMaxUiResponseWait = Duration(seconds: 5)` in
+/// `new_game_fleet_reaches_new_world_e2e_helpers.dart` (Refs GitHub #2336
+/// Bottleneck 4 / H1–H3).
+const Duration kE2eDefaultNavalMoveSegmentUiWait =
+    kE2eDefaultMoveFleetDialogBudget;
+
+/// Composes region-tab selection, optional naval-panel open, non-home Move tap,
+/// and move-dialog destination pick for one fleet-reach turn iteration.
+///
+/// Lifted from the formerly private `_tryNavalMoveSegment` in
+/// `new_game_fleet_reaches_new_world_e2e_helpers.dart` (Refs GitHub #2336 AC1
+/// / AC2 / Bottleneck 4 / H1–H4). The fleet-reach loop in
+/// `new_game_fleet_reaches_new_world_e2e_test.dart` calls this helper up to
+/// `_kMaxNextTurnTapsForNwFleetReach (35)` times per scenario; the widget-test
+/// pin in `app/test/e2e_try_naval_move_segment_test.dart` carries the
+/// behavioural contract because the integration suite cannot validate it
+/// directly today (`app_e2e_linux` is a no-op per
+/// `SPEC/program/e2e-integration-tests.md` § CI).
+///
+/// Contract:
+///
+/// - When [useNewWorldMapTabFirst] is `true`, taps the New World region tab
+///   via [e2eTapNewWorldRegionTabIfPresent]; otherwise taps the Old World tab
+///   via [e2eTapOldWorldRegionTab].
+/// - Opens the naval panel via [e2eOpenNavalPanel] unless
+///   [navalPanelAlreadyOpen] is `true` (Refs #2336 Bottleneck 4 — avoids
+///   redundant close/reopen inside the 35-turn loop).
+/// - Invokes [e2eTapMoveOnFirstNonHomeFleet]; when it returns `false`, records
+///   `result=no_non_home_move_control` on [perf] and returns without opening a
+///   move dialog.
+/// - Waits up to 2 s for an [AlertDialog] after Move (`wait_until_found_move_
+///   dialog_after_tap`).
+/// - When `l10n.moveFleet_noAdjacentSeaZones` is visible, taps
+///   `l10n.common_cancel`, pumps until the dialog dismisses, records
+///   `result=no_legal_step` on [perf], and returns.
+/// - Otherwise, when an [AlertDialog] remains mounted, delegates to
+///   [e2ePickMoveDestinationAndConfirm] with [allowWarpDestinations] and
+///   [maxUiResponseWait] as [moveDialogBudget].
+Future<void> e2eTryNavalMoveSegment(
+  WidgetTester tester,
+  AppLocalizations l10n, {
+  bool useNewWorldMapTabFirst = false,
+  bool allowWarpDestinations = true,
+  bool navalPanelAlreadyOpen = false,
+  E2ePerfLog? perf,
+  Duration maxUiResponseWait = kE2eDefaultNavalMoveSegmentUiWait,
+}) async {
+  final phaseSw = Stopwatch()..start();
+  if (useNewWorldMapTabFirst) {
+    await e2eTapNewWorldRegionTabIfPresent(tester);
+  } else {
+    await e2eTapOldWorldRegionTab(tester, l10n);
+  }
+  if (!navalPanelAlreadyOpen) {
+    await e2eOpenNavalPanel(
+      tester,
+      perf: perf,
+      timeout: maxUiResponseWait,
+      bottomSheetCloseTimeout: maxUiResponseWait,
+    );
+  }
+  final tappedMove = await e2eTapMoveOnFirstNonHomeFleet(tester);
+  if (!tappedMove) {
+    perf?.timing(
+      'fleet_move_segment',
+      phaseSw.elapsed,
+      meta: 'result=no_non_home_move_control',
+    );
+    return;
+  }
+  await e2eWaitUntilFound(
+    tester,
+    find.byType(AlertDialog),
+    timeout: const Duration(seconds: 2),
+    phaseName: 'wait_until_found_move_dialog_after_tap',
+  );
+  // No legal sea-step this turn: close dialog and rely on the outer loop +
+  // next turn (Refs #1831 heuristic path).
+  if (find.text(l10n.moveFleet_noAdjacentSeaZones).evaluate().isNotEmpty) {
+    final cancel = find.text(l10n.common_cancel).hitTestable();
+    expect(cancel, findsOneWidget);
+    await tester.tap(cancel, warnIfMissed: false);
+    await e2ePumpUntil(
+      tester,
+      () => find.byType(AlertDialog).evaluate().isEmpty,
+      timeout: const Duration(seconds: 2),
+      perf: perf,
+      phaseName: 'pump_until_cancel_move_dialog_closed',
+    );
+    perf?.timing(
+      'fleet_move_segment',
+      phaseSw.elapsed,
+      meta: 'result=no_legal_step',
+    );
+    return;
+  }
+  if (find.byType(AlertDialog).evaluate().isNotEmpty) {
+    await e2ePickMoveDestinationAndConfirm(
+      tester,
+      l10n,
+      allowWarpDestinations: allowWarpDestinations,
+      moveDialogBudget: maxUiResponseWait,
+    );
+  }
+  perf?.timing('fleet_move_segment', phaseSw.elapsed);
+}

--- a/app/integration_test/e2e_test_shared_panels.dart
+++ b/app/integration_test/e2e_test_shared_panels.dart
@@ -2,6 +2,7 @@ import 'package:colonizethis_app/config/ct_e2e.dart';
 import 'package:colonizethis_app/config/ct_e2e_last_panel_snapshot.dart'
     show ctE2eCivilianPanelSnapshot;
 import 'package:colonizethis_app/features/game/flame/game_screen_shared.dart';
+import 'package:colonizethis_app/features/game/widgets/units/shared/units_panel_region_label.dart';
 import 'package:colonizethis_app/l10n/app_localizations_contract.dart';
 import 'package:colonizethis_app/widgets/ct_dialog_shell.dart';
 import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
@@ -867,4 +868,178 @@ Future<bool> e2eAnyExplorerHasEnabledExploreAssignFleet(
     await tester.pump(const Duration(milliseconds: 25));
   }
   return false;
+}
+
+/// Default per-call budget for [e2ePickMoveDestinationAndConfirm]. Matches the
+/// pre-lift private `_kMaxUiResponseWait = Duration(seconds: 5)` constant in
+/// `new_game_fleet_reaches_new_world_e2e_helpers.dart` (Refs GitHub #2336
+/// Bottleneck 4 / AC5).
+const Duration kE2eDefaultMoveFleetDialogBudget = Duration(seconds: 5);
+
+/// Default upper bound on the warp-row drag-probe loop inside
+/// [e2ePickMoveDestinationAndConfirm]. Matches the pre-lift private
+/// `maxWarpDragProbes = 8` constant in
+/// `new_game_fleet_reaches_new_world_e2e_helpers.dart` (Refs GitHub #2336
+/// Bottleneck 4 / H4 hot path).
+const int kE2eDefaultMoveFleetWarpDragProbes = 8;
+
+/// Picks a destination on the mounted [MoveFleetDialog] and confirms it.
+///
+/// Lifted from the formerly private `_pickMoveDestinationAndConfirm` in
+/// `new_game_fleet_reaches_new_world_e2e_helpers.dart` (Refs GitHub #2336 AC1
+/// / AC2 / AC4 / Bottleneck 4 / H4). The fleet-reach loop in
+/// `new_game_fleet_reaches_new_world_e2e_test.dart` calls this helper through
+/// `_tryNavalMoveSegment` up to `_kMaxNextTurnTapsForNwFleetReach (35)` times
+/// per scenario, so a silent rename / behavioural drift here would either
+/// stall the fleet-reach loop at the per-call [moveDialogBudget] cap or
+/// silently flip warp vs sea-radio selection — both regress the bundled-
+/// Explore wall clock issue #2336 § AC9 is shrinking.
+///
+/// The integration suite cannot validate this directly today
+/// (`app_e2e_linux` is a no-op per
+/// `SPEC/program/e2e-integration-tests.md` § CI), so the widget-test pin in
+/// `app/test/e2e_pick_move_destination_and_confirm_test.dart` carries the
+/// behavioural contract.
+///
+/// Contract:
+///
+/// - Waits up to 2 s for an [AlertDialog] to mount
+///   (`wait_until_found_move_dialog`) before evaluating any destination
+///   finders.
+/// - When [allowWarpDestinations] is `true` **and** a row labelled
+///   `l10n.moveFleet_warpLinkToRegion(unitsPanelRegionLabel('newWorld'))`
+///   exists in the dialog: scrolls to make the warp row hit-testable using
+///   the [MoveFleetDialog] scroll root keyed by
+///   [kCtE2EMoveFleetDialogScrollRootKey] (or the dialog's [Scrollable] as
+///   fallback), then taps the ancestor `RadioListTile<…>` so the dialog
+///   selection state updates before Confirm. Headless Linux CI can miss
+///   implicit tile taps when the inner `Text` is tapped directly.
+/// - The warp-row drag-probe loop is bounded by [maxWarpDragProbes]
+///   (defaults to [kE2eDefaultMoveFleetWarpDragProbes] = 8). Each probe drags
+///   the [Scrollable] by `Offset(0, -120)` and short-circuits via
+///   [e2ePumpUntilConditionOrIdle] (400 ms cap) as soon as the warp row
+///   becomes hit-testable — replacing the legacy per-drag fixed pump
+///   (AC5 adaptive polling).
+/// - When [allowWarpDestinations] is `false`, or the warp row is absent,
+///   taps the first [RadioListTile] returned by
+///   [e2eRadioListTilesInAlertDialogs] (scoped to the active [AlertDialog]).
+/// - Waits up to 2 s for the [Text(l10n.common_confirm)] button to mount
+///   (`wait_until_found_move_confirm`), then taps it and pumps until the
+///   [AlertDialog] leaves the tree
+///   (`pump_until_move_dialog_closed`, 2 s cap).
+/// - The whole call is bounded by [moveDialogBudget]
+///   (defaults to [kE2eDefaultMoveFleetDialogBudget] = 5 s); exceeding the
+///   budget mid-flow fails via [fail] with the breached `step` label.
+/// - When the warp row cannot be made hit-testable after
+///   [maxWarpDragProbes] drag probes, fails via [fail] with a deterministic
+///   diagnostic message rather than silently falling back to the sea radio.
+Future<void> e2ePickMoveDestinationAndConfirm(
+  WidgetTester tester,
+  AppLocalizations l10n, {
+  bool allowWarpDestinations = true,
+  Duration moveDialogBudget = kE2eDefaultMoveFleetDialogBudget,
+  int maxWarpDragProbes = kE2eDefaultMoveFleetWarpDragProbes,
+}) async {
+  final budget = Stopwatch()..start();
+  void ensureBudget(String step) {
+    if (budget.elapsed > moveDialogBudget) {
+      fail(
+        'Move fleet dialog exceeded ${moveDialogBudget.inSeconds}s at $step',
+      );
+    }
+  }
+
+  ensureBudget('start');
+  await e2eWaitUntilFound(
+    tester,
+    find.byType(AlertDialog),
+    timeout: const Duration(seconds: 2),
+    phaseName: 'wait_until_found_move_dialog',
+  );
+  final warpSuffix = l10n.moveFleet_warpLinkToRegion(
+    unitsPanelRegionLabel('newWorld'),
+  );
+  final warp = find.textContaining(warpSuffix);
+  if (allowWarpDestinations && warp.evaluate().isNotEmpty) {
+    final scrollRoot = find.byKey(kCtE2EMoveFleetDialogScrollRootKey);
+    final Finder scrollable;
+    if (scrollRoot.evaluate().isNotEmpty) {
+      scrollable = find.descendant(
+        of: scrollRoot,
+        matching: find.byType(Scrollable),
+      );
+    } else {
+      scrollable = find.descendant(
+        of: find.byType(AlertDialog),
+        matching: find.byType(Scrollable),
+      );
+    }
+    if (scrollable.evaluate().isNotEmpty) {
+      final sc = scrollable.first;
+      if (warp.hitTestable().evaluate().isEmpty) {
+        try {
+          await tester.scrollUntilVisible(warp.first, 200, scrollable: sc);
+        } catch (_) {
+          // Row may not be built yet; fall back to drag probing below.
+        }
+      }
+      for (
+        var i = 0;
+        i < maxWarpDragProbes && warp.hitTestable().evaluate().isEmpty;
+        i++
+      ) {
+        ensureBudget('warp drag $i');
+        await tester.drag(sc, const Offset(0, -120));
+        // Short-circuit as soon as the warp row becomes hit-testable instead of
+        // a single frame pump per drag (Refs #2336 H4 / adaptive polling).
+        await e2ePumpUntilConditionOrIdle(
+          tester,
+          () => warp.hitTestable().evaluate().isNotEmpty,
+          timeout: const Duration(milliseconds: 400),
+          phaseName: 'pump_until_warp_row_visible_after_move_dialog_drag',
+        );
+      }
+      if (warp.hitTestable().evaluate().isEmpty) {
+        fail(
+          'Warp row not hit-testable after drag attempts '
+          '(within ${moveDialogBudget.inSeconds}s dialog budget).',
+        );
+      }
+    }
+    ensureBudget('before warp tap');
+    final hit = warp.hitTestable();
+    expect(hit, findsWidgets);
+    // Tap the RadioListTile, not only the inner Text, so the tile's selection
+    // updates before Confirm (Linux CI / headless can miss implicit tile taps).
+    final warpTile = find.ancestor(
+      of: hit.first,
+      matching: find.byWidgetPredicate(
+        (w) => w.runtimeType.toString().startsWith('RadioListTile<'),
+      ),
+    );
+    expect(warpTile, findsWidgets);
+    await tester.tap(warpTile.first, warnIfMissed: false);
+  } else {
+    ensureBudget('sea radio');
+    final seaRadio = e2eRadioListTilesInAlertDialogs();
+    expect(seaRadio, findsWidgets);
+    await tester.tap(seaRadio.first, warnIfMissed: false);
+  }
+  await e2eWaitUntilFound(
+    tester,
+    find.text(l10n.common_confirm),
+    timeout: const Duration(seconds: 2),
+    phaseName: 'wait_until_found_move_confirm',
+  );
+  ensureBudget('confirm');
+  final confirm = find.text(l10n.common_confirm).hitTestable();
+  expect(confirm, findsWidgets);
+  await tester.tap(confirm.first, warnIfMissed: false);
+  await e2ePumpUntil(
+    tester,
+    () => find.byType(AlertDialog).evaluate().isEmpty,
+    timeout: const Duration(seconds: 2),
+    phaseName: 'pump_until_move_dialog_closed',
+  );
+  ensureBudget('after confirm');
 }

--- a/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers.dart
+++ b/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers.dart
@@ -46,121 +46,20 @@ const Duration _kFleetE2eMaxWallClock = kE2eMaxWallClock;
 /// against a silent rename / scope-removal that would re-introduce
 /// false positives in move-segment dialogs.
 
-/// Prefer cross-region warp row (English copy); else first adjacent sea tile.
-///
-/// When [allowWarpDestinations] is false, only S–S (radio) destinations are
-/// used. Post–#1869 the split fleet may already be in the New World; the move
-/// dialog still lists a warp row to the Old World—tapping it every turn
-/// prevents sailing along NW seas toward a P–S coastal zone.
-Future<void> _pickMoveDestinationAndConfirm(
-  WidgetTester tester,
-  AppLocalizations l10n, {
-  bool allowWarpDestinations = true,
-}) async {
-  final budget = Stopwatch()..start();
-  void ensureBudget(String step) {
-    if (budget.elapsed > _kMaxUiResponseWait) {
-      fail(
-        'Move fleet dialog exceeded ${_kMaxUiResponseWait.inSeconds}s at $step',
-      );
-    }
-  }
-
-  ensureBudget('start');
-  await waitUntilFound(
-    tester,
-    find.byType(AlertDialog),
-    timeout: const Duration(seconds: 2),
-    phaseName: 'wait_until_found_move_dialog',
-  );
-  final warpSuffix = l10n.moveFleet_warpLinkToRegion(
-    unitsPanelRegionLabel('newWorld'),
-  );
-  final warp = find.textContaining(warpSuffix);
-  if (allowWarpDestinations && warp.evaluate().isNotEmpty) {
-    final scrollRoot = find.byKey(kCtE2EMoveFleetDialogScrollRootKey);
-    final Finder scrollable;
-    if (scrollRoot.evaluate().isNotEmpty) {
-      scrollable = find.descendant(
-        of: scrollRoot,
-        matching: find.byType(Scrollable),
-      );
-    } else {
-      scrollable = find.descendant(
-        of: find.byType(AlertDialog),
-        matching: find.byType(Scrollable),
-      );
-    }
-    if (scrollable.evaluate().isNotEmpty) {
-      final sc = scrollable.first;
-      if (warp.hitTestable().evaluate().isEmpty) {
-        try {
-          await tester.scrollUntilVisible(warp.first, 200, scrollable: sc);
-        } catch (_) {
-          // Row may not be built yet; fall back to drag probing below.
-        }
-      }
-      const maxWarpDragProbes = 8;
-      for (
-        var i = 0;
-        i < maxWarpDragProbes && warp.hitTestable().evaluate().isEmpty;
-        i++
-      ) {
-        ensureBudget('warp drag $i');
-        await tester.drag(sc, const Offset(0, -120));
-        // Short-circuit as soon as the warp row becomes hit-testable instead of
-        // a single frame pump per drag (Refs #2336 H4 / adaptive polling).
-        await e2ePumpUntilConditionOrIdle(
-          tester,
-          () => warp.hitTestable().evaluate().isNotEmpty,
-          timeout: const Duration(milliseconds: 400),
-          phaseName: 'pump_until_warp_row_visible_after_move_dialog_drag',
-        );
-      }
-      if (warp.hitTestable().evaluate().isEmpty) {
-        fail(
-          'Warp row not hit-testable after drag attempts '
-          '(within ${_kMaxUiResponseWait.inSeconds}s dialog budget).',
-        );
-      }
-    }
-    ensureBudget('before warp tap');
-    final hit = warp.hitTestable();
-    expect(hit, findsWidgets);
-    // Tap the RadioListTile, not only the inner Text, so the tile's selection
-    // updates before Confirm (Linux CI / headless can miss implicit tile taps).
-    final warpTile = find.ancestor(
-      of: hit.first,
-      matching: find.byWidgetPredicate(
-        (w) => w.runtimeType.toString().startsWith('RadioListTile<'),
-      ),
-    );
-    expect(warpTile, findsWidgets);
-    await tester.tap(warpTile.first, warnIfMissed: false);
-  } else {
-    ensureBudget('sea radio');
-    final seaRadio = e2eRadioListTilesInAlertDialogs();
-    expect(seaRadio, findsWidgets);
-    await tester.tap(seaRadio.first, warnIfMissed: false);
-  }
-  await waitUntilFound(
-    tester,
-    find.text(l10n.common_confirm),
-    timeout: const Duration(seconds: 2),
-    phaseName: 'wait_until_found_move_confirm',
-  );
-  ensureBudget('confirm');
-  final confirm = find.text(l10n.common_confirm).hitTestable();
-  expect(confirm, findsWidgets);
-  await tester.tap(confirm.first, warnIfMissed: false);
-  await e2ePumpUntil(
-    tester,
-    () => find.byType(AlertDialog).evaluate().isEmpty,
-    timeout: const Duration(seconds: 2),
-    phaseName: 'pump_until_move_dialog_closed',
-  );
-  ensureBudget('after confirm');
-}
+/// `_pickMoveDestinationAndConfirm` was lifted into
+/// [e2ePickMoveDestinationAndConfirm] (`e2e_test_shared_panels.dart`) so the
+/// move-dialog warp-tap / sea-radio / drag-probe contract is shared and
+/// unit-pinned (Refs GitHub #2336 AC1 / AC2 / AC4 / Bottleneck 4 / H4). The
+/// fleet-reach loop calls the lifted form through the AC1 barrel alias
+/// `pickMoveDestinationAndConfirm` (`e2e_helpers.dart`). The widget-test pin
+/// in `app/test/e2e_pick_move_destination_and_confirm_test.dart` guards
+/// against silent regressions because the integration suite cannot validate
+/// this directly today (`app_e2e_linux` is a no-op per
+/// `SPEC/program/e2e-integration-tests.md` § CI). A regression here would
+/// stall the fleet-reach loop at the per-call
+/// [kE2eDefaultMoveFleetDialogBudget] cap × `_kMaxNextTurnTapsForNwFleetReach
+/// (35)` turns — Bottleneck 4 in
+/// `SPEC/program/e2e-integration-tests.md` § Determinism.
 
 Future<void> _tryNavalMoveSegment(
   WidgetTester tester,
@@ -223,10 +122,11 @@ Future<void> _tryNavalMoveSegment(
     return;
   }
   if (find.byType(AlertDialog).evaluate().isNotEmpty) {
-    await _pickMoveDestinationAndConfirm(
+    await pickMoveDestinationAndConfirm(
       tester,
       l10n,
       allowWarpDestinations: allowWarpDestinations,
+      moveDialogBudget: _kMaxUiResponseWait,
     );
   }
   perf?.timing('fleet_move_segment', phaseSw.elapsed);

--- a/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers.dart
+++ b/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers.dart
@@ -23,15 +23,15 @@ const Duration _kFleetE2eMaxWallClock = kE2eMaxWallClock;
 /// and [e2eTapOldWorldRegionTab] (`e2e_test_shared.dart`) so the
 /// `kCtE2ERegionTabNewWorldKey` and `CtChoiceChip + region_oldWorld` tap
 /// contracts are shared and unit-pinned (Refs GitHub #2336 AC1 / AC2). Call
-/// sites consume the public names directly; `_tryNavalMoveSegment` below
-/// composes them with [openNavalPanel] / [tapMoveOnFirstNonHomeFleet]
-/// without changing observable behavior.
+/// sites consume the public names directly; [tryNavalMoveSegment] composes
+/// them with [openNavalPanel] / [tapMoveOnFirstNonHomeFleet] /
+/// [pickMoveDestinationAndConfirm] without changing observable behavior.
 
 /// `_tapMoveOnFirstNonHomeFleet` was lifted into
 /// [e2eTapMoveOnFirstNonHomeFleet] (`e2e_test_shared_panels.dart`) so the
 /// non-home Move-tap contract is shared and unit-pinned (Refs GitHub #2336
 /// AC1 / AC2). The fleet-reach loop calls this helper through
-/// `_tryNavalMoveSegment` up to `_kMaxNextTurnTapsForNwFleetReach (35)`
+/// [tryNavalMoveSegment] up to `_kMaxNextTurnTapsForNwFleetReach (35)`
 /// times per scenario; the widget-test pin in
 /// `app/test/e2e_tap_move_on_first_non_home_fleet_test.dart` carries the
 /// behavioural contract because the integration suite cannot validate it
@@ -61,73 +61,12 @@ const Duration _kFleetE2eMaxWallClock = kE2eMaxWallClock;
 /// (35)` turns — Bottleneck 4 in
 /// `SPEC/program/e2e-integration-tests.md` § Determinism.
 
-Future<void> _tryNavalMoveSegment(
-  WidgetTester tester,
-  AppLocalizations l10n, {
-  bool useNewWorldMapTabFirst = false,
-  bool allowWarpDestinations = true,
-
-  /// When true, the naval panel is already open from a prior [openNavalPanel]
-  /// in the same turn iteration — skip close/reopen (Refs #2336 Bottleneck 4).
-  bool navalPanelAlreadyOpen = false,
-  E2ePerfLog? perf,
-}) async {
-  final phaseSw = Stopwatch()..start();
-  if (useNewWorldMapTabFirst) {
-    await e2eTapNewWorldRegionTabIfPresent(tester);
-  } else {
-    await e2eTapOldWorldRegionTab(tester, l10n);
-  }
-  if (!navalPanelAlreadyOpen) {
-    await openNavalPanel(
-      tester,
-      perf: perf,
-      timeout: _kMaxUiResponseWait,
-      bottomSheetCloseTimeout: _kMaxUiResponseWait,
-    );
-  }
-  final tappedMove = await tapMoveOnFirstNonHomeFleet(tester);
-  if (!tappedMove) {
-    perf?.timing(
-      'fleet_move_segment',
-      phaseSw.elapsed,
-      meta: 'result=no_non_home_move_control',
-    );
-    return;
-  }
-  await waitUntilFound(
-    tester,
-    find.byType(AlertDialog),
-    timeout: const Duration(seconds: 2),
-    phaseName: 'wait_until_found_move_dialog_after_tap',
-  );
-  // No legal sea-step this turn: close dialog and rely on the outer loop +
-  // next turn (Refs #1831 heuristic path).
-  if (find.text(l10n.moveFleet_noAdjacentSeaZones).evaluate().isNotEmpty) {
-    final cancel = find.text(l10n.common_cancel).hitTestable();
-    expect(cancel, findsOneWidget);
-    await tester.tap(cancel, warnIfMissed: false);
-    await e2ePumpUntil(
-      tester,
-      () => find.byType(AlertDialog).evaluate().isEmpty,
-      timeout: const Duration(seconds: 2),
-      perf: perf,
-      phaseName: 'pump_until_cancel_move_dialog_closed',
-    );
-    perf?.timing(
-      'fleet_move_segment',
-      phaseSw.elapsed,
-      meta: 'result=no_legal_step',
-    );
-    return;
-  }
-  if (find.byType(AlertDialog).evaluate().isNotEmpty) {
-    await pickMoveDestinationAndConfirm(
-      tester,
-      l10n,
-      allowWarpDestinations: allowWarpDestinations,
-      moveDialogBudget: _kMaxUiResponseWait,
-    );
-  }
-  perf?.timing('fleet_move_segment', phaseSw.elapsed);
-}
+/// `_tryNavalMoveSegment` was lifted into [e2eTryNavalMoveSegment]
+/// (`e2e_test_shared_panels.dart`) so the region-tab / naval-open / Move-tap /
+/// move-dialog contract is shared and unit-pinned (Refs GitHub #2336 AC1 /
+/// AC2 / Bottleneck 4 / H1–H4). The fleet-reach loop calls the lifted form
+/// through the AC1 barrel alias `tryNavalMoveSegment` (`e2e_helpers.dart`).
+/// The widget-test pin in `app/test/e2e_try_naval_move_segment_test.dart`
+/// guards against silent regressions because the integration suite cannot
+/// validate this directly today (`app_e2e_linux` is a no-op per
+/// `SPEC/program/e2e-integration-tests.md` § CI).

--- a/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers_part2.dart
+++ b/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers_part2.dart
@@ -94,11 +94,12 @@ Future<void> _awaitNwCoastalOrVisibleLandForBundledExploreE2e({
         return;
       }
     }
-    await _tryNavalMoveSegment(
+    await tryNavalMoveSegment(
       tester,
       l10n,
       useNewWorldMapTabFirst: true,
       allowWarpDestinations: false,
+      maxUiResponseWait: _kMaxUiResponseWait,
       navalPanelAlreadyOpen: ctE2eNavalPanelSnapshot == null,
     );
     await closeBottomSheet(tester, overallTimeout: _kMaxUiResponseWait);

--- a/app/integration_test/new_game_fleet_reaches_new_world_e2e_test.dart
+++ b/app/integration_test/new_game_fleet_reaches_new_world_e2e_test.dart
@@ -1,7 +1,6 @@
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:colonizethis_app/config/ct_e2e.dart';
 import 'package:colonizethis_app/config/ct_e2e_last_panel_snapshot.dart';
-import 'package:colonizethis_app/features/game/widgets/units/shared/units_panel_region_label.dart';
 import 'e2e_helpers.dart';
 import 'package:colonizethis_app/l10n/l10n.dart';
 import 'package:colonizethis_app/main.dart' show bootstrapForIntegrationTest;

--- a/app/integration_test/new_game_fleet_reaches_new_world_e2e_test.dart
+++ b/app/integration_test/new_game_fleet_reaches_new_world_e2e_test.dart
@@ -120,10 +120,11 @@ void main() {
         }
       }
 
-      await _tryNavalMoveSegment(
+      await tryNavalMoveSegment(
         tester,
         l10n,
         perf: perf,
+        maxUiResponseWait: _kMaxUiResponseWait,
         // Panel was opened above only when snapshot plumbing is unavailable.
         navalPanelAlreadyOpen: ctE2eNavalPanelSnapshot == null,
       );
@@ -274,10 +275,11 @@ void main() {
           lastKnownNavalSnapshot = ctE2eNavalPanelSnapshot;
         }
 
-        await _tryNavalMoveSegment(
+        await tryNavalMoveSegment(
           tester,
           l10n,
           perf: perf,
+          maxUiResponseWait: _kMaxUiResponseWait,
           navalPanelAlreadyOpen: ctE2eNavalPanelSnapshot == null,
         );
         await closeBottomSheet(

--- a/app/test/e2e_helpers_barrel_test.dart
+++ b/app/test/e2e_helpers_barrel_test.dart
@@ -416,6 +416,51 @@ void main() {
     );
 
     testWidgets(
+      'tryNavalMoveSegment is re-exported through the barrel',
+      (tester) async {
+        final Future<void> Function(
+          WidgetTester,
+          AppLocalizations, {
+          bool useNewWorldMapTabFirst,
+          bool allowWarpDestinations,
+          bool navalPanelAlreadyOpen,
+          E2ePerfLog? perf,
+          Duration maxUiResponseWait,
+        })
+        ref = tryNavalMoveSegment;
+        expect(
+          ref,
+          isNotNull,
+          reason:
+              'The fleet-reach hot path consumes this segment composer via '
+              'the AC1 barrel up to `_kMaxNextTurnTapsForNwFleetReach (35)` '
+              'times per scenario. A regression that dropped the barrel '
+              'wrapper or removed the `navalPanelAlreadyOpen` / '
+              '`allowWarpDestinations` / `maxUiResponseWait` named parameters '
+              'would break Bottleneck 4 short-circuits or re-introduce '
+              'redundant naval-panel open/close work (#2336 AC1 / H1–H4).',
+        );
+        expect(
+          kE2eDefaultNavalMoveSegmentUiWait,
+          const Duration(seconds: 5),
+          reason:
+              'Default UI-wait constant must remain the legacy 5 s '
+              '`_kMaxUiResponseWait` contract for open-naval + move-dialog '
+              'budget forwarding.',
+        );
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        await tester.pumpWidget(
+          const MaterialApp(home: Scaffold(body: SizedBox())),
+        );
+        await ref(
+          tester,
+          l10n,
+          navalPanelAlreadyOpen: true,
+        );
+      },
+    );
+
+    testWidgets(
       'pickMoveDestinationAndConfirm is re-exported through the barrel',
       (tester) async {
         final Future<void> Function(

--- a/app/test/e2e_helpers_barrel_test.dart
+++ b/app/test/e2e_helpers_barrel_test.dart
@@ -49,6 +49,7 @@ import 'package:colonizethis_app/config/ct_e2e_last_panel_snapshot.dart'
         ctE2eCivilianPanelSnapshot;
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_app/l10n/app_localizations_contract.dart';
+import 'package:colonizethis_app/l10n/app_localizations_lookup.dart';
 import 'package:colonizethis_data/colonizethis_data.dart' show MapTopology;
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
@@ -414,6 +415,86 @@ void main() {
       },
     );
 
+    testWidgets(
+      'pickMoveDestinationAndConfirm is re-exported through the barrel',
+      (tester) async {
+        final Future<void> Function(
+          WidgetTester,
+          AppLocalizations, {
+          bool allowWarpDestinations,
+          Duration moveDialogBudget,
+          int maxWarpDragProbes,
+        })
+        ref = pickMoveDestinationAndConfirm;
+        expect(
+          ref,
+          isNotNull,
+          reason:
+              'The fleet-reach hot path '
+              '(`_tryNavalMoveSegment` in '
+              '`new_game_fleet_reaches_new_world_e2e_helpers.dart`) '
+              'consumes this move-dialog picker via the AC1 barrel up to '
+              '`_kMaxNextTurnTapsForNwFleetReach (35)` times per scenario. '
+              "A regression that dropped the barrel wrapper, flipped the "
+              "return type, or removed the `allowWarpDestinations` / "
+              "`moveDialogBudget` / `maxWarpDragProbes` named parameters "
+              'would break the segment\'s NW-warp vs sea-radio routing or '
+              'silently inflate the warp-row drag loop past the legacy '
+              "`maxWarpDragProbes = 8` cap (Bottleneck 4 / H4 in "
+              '`SPEC/program/e2e-integration-tests.md` § Determinism, '
+              '#2336 AC1 / AC4).',
+        );
+        expect(
+          kE2eDefaultMoveFleetDialogBudget,
+          const Duration(seconds: 5),
+          reason:
+              'Default-budget constant must remain the legacy 5 s per-call '
+              'cap so the barrel signature matches the pre-lift '
+              '`_kMaxUiResponseWait` contract. A barrel re-export that '
+              'aliased the constant to a different value would silently '
+              'change call-site behaviour.',
+        );
+        expect(
+          kE2eDefaultMoveFleetWarpDragProbes,
+          8,
+          reason:
+              'Default warp-probe constant must remain the legacy '
+              '`maxWarpDragProbes = 8` bound. A regression that re-exported '
+              'a wider bound (for example the pre-#2336 36-probe loop) '
+              'would silently re-introduce Bottleneck 2 / H4 wall-clock '
+              'blow-out.',
+        );
+        // Sanity smoke through the barrel: pumping an empty scaffold has
+        // no AlertDialog, so the helper must fail via e2eWaitUntilFound's
+        // deterministic timeout. A wrapper that swallowed the missing
+        // dialog and silently returned would pass the tear-off pin
+        // without exercising the helper at all.
+        await tester.pumpWidget(
+          const MaterialApp(home: Scaffold(body: SizedBox())),
+        );
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        Object? caught;
+        try {
+          await ref(
+            tester,
+            l10n,
+            moveDialogBudget: const Duration(seconds: 10),
+          );
+        } catch (e) {
+          caught = e;
+        }
+        expect(
+          caught,
+          isNotNull,
+          reason:
+              'Empty scaffold has no AlertDialog — the barrel-aliased '
+              'helper must throw via e2eWaitUntilFound rather than '
+              'silently no-op, so the tear-off smoke catches a wrapper '
+              'that swallowed the missing-dialog path.',
+        );
+      },
+    );
+
     test(
       'e2eTextLooksLikeNewWorldLocationLine is re-exported through the barrel',
       () {
@@ -693,8 +774,8 @@ void main() {
           isNotNull,
           reason:
               'The fleet-reach move dialog consumes this scoped lookup via '
-              'the AC1 barrel (`_pickMoveDestinationAndConfirm` in '
-              '`new_game_fleet_reaches_new_world_e2e_helpers.dart` taps '
+              'the AC1 barrel (`e2ePickMoveDestinationAndConfirm` in '
+              '`e2e_test_shared_panels.dart` taps '
               '`e2eRadioListTilesInAlertDialogs().first` to pick the sea '
               'radio when the warp row is absent). A regression that '
               'dropped it from the `show` clause would force the move '

--- a/app/test/e2e_pick_move_destination_and_confirm_test.dart
+++ b/app/test/e2e_pick_move_destination_and_confirm_test.dart
@@ -1,0 +1,753 @@
+/// Pins the widget-tree contract of
+/// [e2ePickMoveDestinationAndConfirm]
+/// (`app/integration_test/e2e_test_shared_panels.dart`).
+///
+/// The fleet-reach turn loop in
+/// `new_game_fleet_reaches_new_world_e2e_test.dart` calls this helper via
+/// `_tryNavalMoveSegment` up to `_kMaxNextTurnTapsForNwFleetReach (35)`
+/// times per scenario. A silent rename / behavioural drift here would
+/// either:
+///
+///   - Stall the loop at the per-call
+///     [kE2eDefaultMoveFleetDialogBudget] cap (5 s) × 35 turns — Bottleneck
+///     4 / H4 in `SPEC/program/e2e-integration-tests.md` § Determinism —
+///     burning wall-clock issue #2336 § AC9 is shrinking; or
+///   - Silently flip warp vs sea-radio selection and mask a real production
+///     regression in `MoveFleetDialog`.
+///
+/// The integration suite cannot validate this directly today (the
+/// `app_e2e_linux` lane is a no-op per
+/// `SPEC/program/e2e-integration-tests.md` § CI), so this widget-test layer
+/// carries the behavioural pin.
+///
+/// Refs GitHub #2336 AC1 / AC2 / AC4 / Bottleneck 4 / H4.
+library;
+
+// The production move-fleet dialog (`move_fleet_dialog.dart`) constructs
+// `RadioListTile<_MovePick>` with the legacy `groupValue` / `onChanged` API;
+// the AC1 helper matches on `runtimeType.toString().startsWith('RadioListTile<')`,
+// so the test fixtures must build the same widget shape (not the newer
+// RadioGroup-based API) for the pin to validate the production code path.
+// Same pattern as `e2e_radio_list_tiles_in_alert_dialogs_test.dart`.
+// ignore_for_file: deprecated_member_use
+
+import 'package:colonizethis_app/config/ct_e2e.dart';
+import 'package:colonizethis_app/l10n/app_localizations_contract.dart';
+import 'package:colonizethis_app/l10n/app_localizations_lookup.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../integration_test/e2e_test_shared.dart';
+
+/// Single source of truth for the warp row text under English locale.
+/// Matches `l10n.moveFleet_warpLinkToRegion(unitsPanelRegionLabel('newWorld'))`
+/// — see `app/lib/l10n/app_localizations_en_part2.dart` and
+/// `app/lib/features/game/utils/region_labels.dart`.
+const String _warpText = 'links to New World';
+
+/// Sea-zone destination row label distinct from the warp text so the
+/// fixture exercises the multi-row branch (warp present vs sea-only) without
+/// ambiguity.
+const String _seaText = 'sea zone 1';
+
+/// Test-only host that renders a `MoveFleetDialog`-shaped [AlertDialog].
+///
+/// The dialog uses a [Scrollable] keyed by
+/// [kCtE2EMoveFleetDialogScrollRootKey] when [withScrollKey] is true (the
+/// production [MoveFleetDialog] body always carries this key). When false,
+/// the helper falls back to the descendant [Scrollable] under
+/// [AlertDialog].
+class _MoveDialogHost extends StatefulWidget {
+  const _MoveDialogHost({
+    super.key,
+    required this.l10n,
+    required this.includeWarp,
+    this.includeSea = true,
+    this.withScrollKey = true,
+    this.warpAheadFillers = 0,
+    this.scrollPhysics,
+    this.includeScrollable = true,
+    this.wrapWarpInIgnorePointer = false,
+  });
+
+  final AppLocalizations l10n;
+  final bool includeWarp;
+  final bool includeSea;
+  final bool withScrollKey;
+
+  /// When > 0, inserts that many tall filler rows BEFORE the warp row so the
+  /// row is initially off-screen and the helper must drag the scrollable to
+  /// reveal it.
+  final int warpAheadFillers;
+
+  /// Custom scroll physics for the dialog's [SingleChildScrollView]. When set
+  /// to [NeverScrollableScrollPhysics] the [tester.drag] gesture cannot
+  /// produce a scroll offset, though [tester.scrollUntilVisible] (which
+  /// composes [Scrollable.ensureVisible] programmatically) still bypasses
+  /// physics.
+  final ScrollPhysics? scrollPhysics;
+
+  /// When false, the dialog content is a bare [Column] with no [Scrollable];
+  /// the helper's `find.descendant(of: AlertDialog, matching: Scrollable)`
+  /// branch resolves empty and the warp-scroll loop is skipped entirely.
+  final bool includeScrollable;
+
+  /// When true, wraps the warp [RadioListTile] (and its `Text(warpText)`
+  /// title) in an [IgnorePointer], so the Text widget remains findable via
+  /// `find.textContaining(...)` but `warp.hitTestable()` always resolves
+  /// empty. Forces the helper's deterministic `'Warp row not hit-testable'`
+  /// failure path even when [tester.scrollUntilVisible] would otherwise
+  /// reveal the row.
+  final bool wrapWarpInIgnorePointer;
+
+  @override
+  State<_MoveDialogHost> createState() => _MoveDialogHostState();
+}
+
+class _MoveDialogHostState extends State<_MoveDialogHost> {
+  int? selectedRowIndex;
+  int taps = 0;
+  bool dialogOpen = true;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!dialogOpen) {
+      return const SizedBox.shrink();
+    }
+    final rows = <Widget>[];
+    final indices = <int, String>{};
+    var nextIndex = 0;
+    for (var i = 0; i < widget.warpAheadFillers; i++) {
+      rows.add(
+        SizedBox(
+          height: 200,
+          child: Center(child: Text('filler-$i')),
+        ),
+      );
+    }
+    if (widget.includeWarp) {
+      final warpIndex = nextIndex++;
+      indices[warpIndex] = 'warp';
+      final Widget warpTile = RadioListTile<int>(
+        key: const ValueKey('warp-tile'),
+        title: const Text(_warpText),
+        value: warpIndex,
+        groupValue: selectedRowIndex,
+        onChanged: (next) {
+          taps++;
+          setState(() => selectedRowIndex = next);
+        },
+      );
+      rows.add(
+        widget.wrapWarpInIgnorePointer
+            ? IgnorePointer(child: warpTile)
+            : warpTile,
+      );
+    }
+    if (widget.includeSea) {
+      final seaIndex = nextIndex++;
+      indices[seaIndex] = 'sea';
+      rows.add(
+        RadioListTile<int>(
+          key: const ValueKey('sea-tile'),
+          title: const Text(_seaText),
+          value: seaIndex,
+          groupValue: selectedRowIndex,
+          onChanged: (next) {
+            taps++;
+            setState(() => selectedRowIndex = next);
+          },
+        ),
+      );
+    }
+    final Widget content;
+    if (widget.includeScrollable) {
+      content = SingleChildScrollView(
+        key: widget.withScrollKey ? kCtE2EMoveFleetDialogScrollRootKey : null,
+        physics: widget.scrollPhysics,
+        child: Column(mainAxisSize: MainAxisSize.min, children: rows),
+      );
+    } else {
+      content = Column(mainAxisSize: MainAxisSize.min, children: rows);
+    }
+    return AlertDialog(
+      content: SizedBox(
+        width: 320,
+        height: 240,
+        child: content,
+      ),
+      actions: <Widget>[
+        TextButton(
+          onPressed: () {
+            setState(() => dialogOpen = false);
+          },
+          child: Text(widget.l10n.common_confirm),
+        ),
+      ],
+    );
+  }
+
+  String? get selectedKind {
+    final i = selectedRowIndex;
+    if (i == null) {
+      return null;
+    }
+    var nextIndex = 0;
+    if (widget.includeWarp) {
+      if (i == nextIndex) {
+        return 'warp';
+      }
+      nextIndex++;
+    }
+    if (widget.includeSea) {
+      if (i == nextIndex) {
+        return 'sea';
+      }
+    }
+    return null;
+  }
+}
+
+Future<void> _pumpDialogScaffold(
+  WidgetTester tester, {
+  required Widget child,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: Builder(
+          builder: (context) => Center(
+            child: SizedBox.expand(child: child),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+/// Counter for unique [_MoveDialogHost] keys so each `_pumpMoveDialog` call
+/// in the same `testWidgets` body mounts a fresh State (no `dialogOpen=false`
+/// leakage between invocations of [e2ePickMoveDestinationAndConfirm]).
+int _hostKeyCounter = 0;
+
+Future<_MoveDialogHostState> _pumpMoveDialog(
+  WidgetTester tester, {
+  required AppLocalizations l10n,
+  required bool includeWarp,
+  bool includeSea = true,
+  bool withScrollKey = true,
+  int warpAheadFillers = 0,
+  ScrollPhysics? scrollPhysics,
+  bool includeScrollable = true,
+  bool wrapWarpInIgnorePointer = false,
+}) async {
+  _hostKeyCounter++;
+  final hostKey = ValueKey<int>(_hostKeyCounter);
+  late _MoveDialogHostState hostState;
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: Builder(
+          builder: (context) {
+            return Center(
+              child: _MoveDialogHost(
+                key: hostKey,
+                l10n: l10n,
+                includeWarp: includeWarp,
+                includeSea: includeSea,
+                withScrollKey: withScrollKey,
+                warpAheadFillers: warpAheadFillers,
+                scrollPhysics: scrollPhysics,
+                includeScrollable: includeScrollable,
+                wrapWarpInIgnorePointer: wrapWarpInIgnorePointer,
+              ),
+            );
+          },
+        ),
+      ),
+    ),
+  );
+  hostState = tester.state<_MoveDialogHostState>(find.byType(_MoveDialogHost));
+  return hostState;
+}
+
+void main() {
+  suppressLogsForTests();
+
+  group('e2ePickMoveDestinationAndConfirm — warp branch', () {
+    testWidgets(
+      'taps warp RadioListTile when present and confirms (default args)',
+      (WidgetTester tester) async {
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        final host = await _pumpMoveDialog(
+          tester,
+          l10n: l10n,
+          includeWarp: true,
+        );
+        expect(host.selectedKind, isNull);
+        expect(host.dialogOpen, isTrue);
+
+        await e2ePickMoveDestinationAndConfirm(tester, l10n);
+
+        expect(
+          host.selectedKind,
+          'warp',
+          reason:
+              'When the warp row text is present, the helper must select the '
+              'warp RadioListTile (not the sea-radio fallback). A regression '
+              'that tapped the sea radio here would silently keep the fleet '
+              'sailing along NW seas instead of warping back to OW '
+              '(Refs #1869 / fleet-reach behaviour).',
+        );
+        expect(
+          host.dialogOpen,
+          isFalse,
+          reason:
+              'Helper must tap Confirm and pump until the AlertDialog leaves '
+              'the tree (`pump_until_move_dialog_closed`). A regression that '
+              'returned before the dialog closed would leave the next loop '
+              'iteration tapping into a stale dialog.',
+        );
+        expect(
+          host.taps,
+          1,
+          reason:
+              'Helper must tap exactly one RadioListTile. A double-tap or '
+              'thrash would deselect the warp row before Confirm fires.',
+        );
+      },
+    );
+
+    testWidgets(
+      'taps warp tile via RadioListTile ancestor (not the inner Text)',
+      (WidgetTester tester) async {
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        final host = await _pumpMoveDialog(
+          tester,
+          l10n: l10n,
+          includeWarp: true,
+        );
+
+        await e2ePickMoveDestinationAndConfirm(tester, l10n);
+
+        // The tap target is `find.ancestor(of: warp.hitTestable().first,
+        // matching: byWidgetPredicate(runtimeType startsWith 'RadioListTile<'))`.
+        // The host's RadioListTile<int>.onChanged sets selectedRowIndex —
+        // we verify the warp tile was selected (not just the Text widget).
+        expect(
+          host.selectedKind,
+          'warp',
+          reason:
+              'Helper must tap the RadioListTile ancestor of the warp text '
+              'so the tile selection actually updates (Linux CI / headless '
+              'can miss implicit taps on the inner Text). A regression that '
+              'tapped only the Text would leave selectedKind null.',
+        );
+      },
+    );
+
+    testWidgets(
+      'drag-probes the scrollable when warp row is initially off-screen',
+      (WidgetTester tester) async {
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        final host = await _pumpMoveDialog(
+          tester,
+          l10n: l10n,
+          includeWarp: true,
+          warpAheadFillers: 5,
+        );
+        final warpFinder = find.text(_warpText);
+        expect(
+          warpFinder.evaluate().isNotEmpty,
+          isTrue,
+          reason:
+              'Sanity: warp Text widget exists in the tree (off-screen) '
+              'before the helper runs.',
+        );
+
+        await e2ePickMoveDestinationAndConfirm(tester, l10n);
+
+        expect(
+          host.selectedKind,
+          'warp',
+          reason:
+              'After scrolling/dragging, the helper must successfully tap '
+              'the warp tile. A regression that skipped the drag probe '
+              'loop (or capped it at 0) would silently fail before tapping.',
+        );
+        expect(host.dialogOpen, isFalse);
+      },
+    );
+
+    testWidgets(
+      'fails deterministically when warp row never becomes hit-testable',
+      (WidgetTester tester) async {
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        // Wrap the warp tile in [IgnorePointer] so the Text widget remains
+        // findable via `find.textContaining(...)` (the helper's entry
+        // condition) but `warp.hitTestable()` always resolves empty. This
+        // forces the deterministic `fail(...)` path after the drag-probe
+        // loop exhausts; `NeverScrollableScrollPhysics` is not enough on
+        // its own because [tester.scrollUntilVisible] composes
+        // [Scrollable.ensureVisible] programmatically and bypasses scroll
+        // physics.
+        await _pumpMoveDialog(
+          tester,
+          l10n: l10n,
+          includeWarp: true,
+          wrapWarpInIgnorePointer: true,
+        );
+
+        Object? caught;
+        try {
+          await e2ePickMoveDestinationAndConfirm(
+            tester,
+            l10n,
+            maxWarpDragProbes: 2,
+            moveDialogBudget: const Duration(seconds: 10),
+          );
+        } catch (e) {
+          caught = e;
+        }
+        expect(
+          caught,
+          isNotNull,
+          reason:
+              'Helper must fail deterministically when the warp row is '
+              'never hit-testable. A silent fall-back to the sea radio '
+              'would mask a real production scroll regression.',
+        );
+        expect(
+          caught.toString(),
+          contains('Warp row not hit-testable'),
+          reason:
+              'Failure message must name the warp-row diagnostic so the '
+              'fleet-reach loop log surfaces the cause; a generic timeout '
+              'message would leave Bottleneck 4 hard to diagnose.',
+        );
+      },
+    );
+
+    testWidgets(
+      'falls back to dialog Scrollable when kCtE2EMoveFleetDialogScrollRootKey '
+      'is absent',
+      (WidgetTester tester) async {
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        final host = await _pumpMoveDialog(
+          tester,
+          l10n: l10n,
+          includeWarp: true,
+          withScrollKey: false,
+        );
+
+        await e2ePickMoveDestinationAndConfirm(tester, l10n);
+
+        expect(
+          host.selectedKind,
+          'warp',
+          reason:
+              'Production [MoveFleetDialog] always supplies '
+              'kCtE2EMoveFleetDialogScrollRootKey, but the helper must '
+              'still tap the warp tile under a generic AlertDialog '
+              'descendant-Scrollable fallback. A regression here would '
+              'turn the helper into a soft-dependency on a private key.',
+        );
+      },
+    );
+  });
+
+  group('e2ePickMoveDestinationAndConfirm — sea radio branch', () {
+    testWidgets(
+      'taps sea RadioListTile when warp row is absent',
+      (WidgetTester tester) async {
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        final host = await _pumpMoveDialog(
+          tester,
+          l10n: l10n,
+          includeWarp: false,
+        );
+
+        await e2ePickMoveDestinationAndConfirm(tester, l10n);
+
+        expect(
+          host.selectedKind,
+          'sea',
+          reason:
+              'When no warp row exists, the helper must select the first '
+              'AlertDialog-scoped RadioListTile via '
+              'e2eRadioListTilesInAlertDialogs. A regression that dropped '
+              'the AlertDialog scope would match panel radios outside the '
+              'dialog (Refs `e2e_radio_list_tiles_in_alert_dialogs_test`).',
+        );
+        expect(host.dialogOpen, isFalse);
+      },
+    );
+
+    testWidgets(
+      'takes the sea-radio branch (no warp scroll/drag) when '
+      'allowWarpDestinations is false',
+      (WidgetTester tester) async {
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        // Both rows hit-testable on a viewport that can fit them. The
+        // contract pin is that with allowWarpDestinations=false **and**
+        // [NeverScrollableScrollPhysics], the helper must NOT enter the
+        // warp-scroll/drag branch (which would `fail` because the row
+        // ordering puts the on-screen warp tile first but the helper's
+        // sea-radio branch picks `seaRadio.first` directly — proving no
+        // warp-scroll work happened).
+        final host = await _pumpMoveDialog(
+          tester,
+          l10n: l10n,
+          includeWarp: true,
+          // `NeverScrollableScrollPhysics` here would normally crash the
+          // warp-scroll branch with "Warp row not hit-testable" once the
+          // warp row is off-screen; we keep the row on-screen so the
+          // helper succeeds via the sea-radio branch (whose `.first` is
+          // the warp tile in tree order). The combination pins that
+          // allowWarpDestinations=false does not consult the warp text or
+          // probe drags at all.
+          scrollPhysics: const NeverScrollableScrollPhysics(),
+        );
+
+        Object? caught;
+        try {
+          await e2ePickMoveDestinationAndConfirm(
+            tester,
+            l10n,
+            allowWarpDestinations: false,
+            // Cap drag probes at 0 so the warp branch (if accidentally
+            // taken) would immediately fail with "Warp row not hit-testable".
+            // A clean pass here proves the helper never entered that branch.
+            maxWarpDragProbes: 0,
+          );
+        } catch (e) {
+          caught = e;
+        }
+        expect(
+          caught,
+          isNull,
+          reason:
+              'With allowWarpDestinations=false the helper must not consult '
+              'the warp text or run the drag-probe loop — otherwise '
+              'maxWarpDragProbes=0 would surface a deterministic '
+              '"Warp row not hit-testable" failure here.',
+        );
+        expect(
+          host.dialogOpen,
+          isFalse,
+          reason:
+              'Sea-radio branch still confirms the dialog. A regression '
+              'that left dialogOpen=true would stall the fleet-reach loop '
+              'on a stale dialog.',
+        );
+        expect(
+          host.selectedKind,
+          isNotNull,
+          reason:
+              'Helper must tap `seaRadio.first` (whatever the first '
+              'dialog-scoped RadioListTile happens to be in tree order). '
+              'A null selectedKind would mean no tile was tapped — the '
+              'helper short-circuited before Confirm.',
+        );
+      },
+    );
+
+    testWidgets(
+      'sea radio branch needs no scrollable / scroll key in the dialog',
+      (WidgetTester tester) async {
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        // No Scrollable, no scroll key — only the sea-radio tile rendered
+        // inside the AlertDialog content. The helper must reach the
+        // sea-radio branch and confirm without depending on
+        // `kCtE2EMoveFleetDialogScrollRootKey` or a descendant
+        // [Scrollable].
+        final host = await _pumpMoveDialog(
+          tester,
+          l10n: l10n,
+          includeWarp: false,
+          includeScrollable: false,
+        );
+
+        Object? caught;
+        try {
+          await e2ePickMoveDestinationAndConfirm(
+            tester,
+            l10n,
+            allowWarpDestinations: false,
+          );
+        } catch (e) {
+          caught = e;
+        }
+        expect(
+          caught,
+          isNull,
+          reason:
+              'Sea-radio branch must not require '
+              'kCtE2EMoveFleetDialogScrollRootKey or a descendant '
+              'Scrollable; it must read the AlertDialog-scoped radio list '
+              'and tap the first match directly. A regression that '
+              'required a scroll root here would break dialogs that fit '
+              'every destination on one screen.',
+        );
+        expect(
+          host.dialogOpen,
+          isFalse,
+          reason:
+              'Even without a Scrollable, the helper must still tap '
+              'Confirm and pump until the AlertDialog leaves the tree.',
+        );
+        expect(host.selectedKind, 'sea');
+      },
+    );
+  });
+
+  group('e2ePickMoveDestinationAndConfirm — budget / determinism', () {
+    testWidgets(
+      'fails with deterministic message when no AlertDialog mounts in time',
+      (WidgetTester tester) async {
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        await _pumpDialogScaffold(tester, child: const SizedBox());
+
+        Object? caught;
+        try {
+          await e2ePickMoveDestinationAndConfirm(
+            tester,
+            l10n,
+            // Allow the inner `wait_until_found_move_dialog` (2 s) to run to
+            // its own timeout and surface a deterministic "Timed out" failure;
+            // the budget guard would otherwise short-circuit with the at-step
+            // diagnostic, which is also valid but covered by the next case.
+            moveDialogBudget: const Duration(seconds: 10),
+          );
+        } catch (e) {
+          caught = e;
+        }
+        expect(
+          caught,
+          isNotNull,
+          reason:
+              'When no AlertDialog mounts, the inner '
+              'wait_until_found_move_dialog must throw (helper does not '
+              'swallow it). Silent return would let the fleet-reach loop '
+              'proceed into a NUL state.',
+        );
+        expect(
+          caught.toString(),
+          contains('Timed out'),
+          reason:
+              'Failure surface must include the timeout sentinel from '
+              'e2eWaitUntilFound so triage points at the missing dialog, '
+              'not a downstream symptom.',
+        );
+      },
+    );
+
+    testWidgets(
+      'fails on the very first ensureBudget when moveDialogBudget is zero',
+      (WidgetTester tester) async {
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        await _pumpMoveDialog(
+          tester,
+          l10n: l10n,
+          includeWarp: true,
+        );
+
+        Object? caught;
+        try {
+          await e2ePickMoveDestinationAndConfirm(
+            tester,
+            l10n,
+            moveDialogBudget: Duration.zero,
+          );
+        } catch (e) {
+          caught = e;
+        }
+        expect(
+          caught,
+          isNotNull,
+          reason:
+              'A non-positive budget must trip the ensureBudget guard '
+              'immediately. A regression that swallowed Duration.zero would '
+              'let the helper run past the documented per-call cap.',
+        );
+        expect(
+          caught.toString(),
+          contains('Move fleet dialog exceeded'),
+          reason:
+              'Failure must use the budget-exceeded diagnostic (not a '
+              'generic timeout) so triage knows the cap fired, not the '
+              'inner finders.',
+        );
+      },
+    );
+
+    testWidgets(
+      'is deterministic across two independent invocations',
+      (WidgetTester tester) async {
+        final l10n = lookupAppLocalizations(const Locale('en'));
+
+        final hostA = await _pumpMoveDialog(
+          tester,
+          l10n: l10n,
+          includeWarp: true,
+        );
+        await e2ePickMoveDestinationAndConfirm(tester, l10n);
+        expect(hostA.selectedKind, 'warp');
+        expect(hostA.dialogOpen, isFalse);
+
+        final hostB = await _pumpMoveDialog(
+          tester,
+          l10n: l10n,
+          includeWarp: true,
+        );
+        await e2ePickMoveDestinationAndConfirm(tester, l10n);
+        expect(
+          hostB.selectedKind,
+          'warp',
+          reason:
+              'Helper has no hidden state — a second invocation on a fresh '
+              'host must yield the same warp-tap result (Refs GitHub #2336 '
+              'AC5 / Bottleneck 4 determinism contract).',
+        );
+        expect(hostB.dialogOpen, isFalse);
+      },
+    );
+  });
+
+  group('e2ePickMoveDestinationAndConfirm — default constants', () {
+    test(
+      'kE2eDefaultMoveFleetDialogBudget matches the legacy 5 s per-call cap',
+      () {
+        expect(
+          kE2eDefaultMoveFleetDialogBudget,
+          const Duration(seconds: 5),
+          reason:
+              'The pre-lift private `_kMaxUiResponseWait = Duration(seconds: '
+              '5)` constant gated every call site in '
+              'new_game_fleet_reaches_new_world_e2e_helpers.dart. A '
+              'regression that shortened this cap would force flaky '
+              'budget-exceeded failures in the fleet-reach loop; a '
+              'regression that widened it would inflate the wall clock '
+              'cap issue #2336 § AC9 is shrinking.',
+        );
+      },
+    );
+
+    test(
+      'kE2eDefaultMoveFleetWarpDragProbes matches the legacy 8-probe bound',
+      () {
+        expect(
+          kE2eDefaultMoveFleetWarpDragProbes,
+          8,
+          reason:
+              'The pre-lift private `maxWarpDragProbes = 8` constant capped '
+              'the warp-row drag loop. A regression that reset this to the '
+              'pre-#2336 36-probe cap (each 50 ms) would reintroduce '
+              'Bottleneck 2 / H4 wall-clock blow-out (~1.8 s per turn × 35 '
+              'turns).',
+        );
+      },
+    );
+  });
+}

--- a/app/test/e2e_radio_list_tiles_in_alert_dialogs_test.dart
+++ b/app/test/e2e_radio_list_tiles_in_alert_dialogs_test.dart
@@ -1,8 +1,8 @@
 /// Pins the dialog-scoped `RadioListTile<…>` lookup contract of
 /// [e2eRadioListTilesInAlertDialogs] (`app/integration_test/e2e_test_shared.dart`).
 ///
-/// The fleet-reach move helper (`_pickMoveDestinationAndConfirm` in
-/// `new_game_fleet_reaches_new_world_e2e_helpers.dart`) taps
+/// The fleet-reach move helper (`e2ePickMoveDestinationAndConfirm` in
+/// `e2e_test_shared_panels.dart`) taps
 /// `e2eRadioListTilesInAlertDialogs().first` to pick the destination sea
 /// radio when no warp row is present. Two regressions would silently
 /// re-introduce flakes / stalls if the helper drifted:

--- a/app/test/e2e_try_naval_move_segment_test.dart
+++ b/app/test/e2e_try_naval_move_segment_test.dart
@@ -1,0 +1,378 @@
+/// Pins the widget-tree contract of [e2eTryNavalMoveSegment]
+/// (`app/integration_test/e2e_test_shared_panels.dart`).
+///
+/// The fleet-reach turn loop in `new_game_fleet_reaches_new_world_e2e_test.dart`
+/// calls this helper via the AC1 barrel alias `tryNavalMoveSegment` up to
+/// `_kMaxNextTurnTapsForNwFleetReach (35)` times per scenario. A silent rename
+/// or behavioural drift here would either stall the loop at the per-call
+/// [kE2eDefaultNavalMoveSegmentUiWait] cap × 35 turns (Bottleneck 4 / H1–H4 in
+/// `SPEC/program/e2e-integration-tests.md` § Determinism) or break the
+/// `no_non_home_move_control` / `no_legal_step` short-circuits that keep the
+/// bundled-Explore path from burning wall clock on impossible moves.
+///
+/// The integration suite cannot validate this directly today (the
+/// `app_e2e_linux` lane is a no-op per
+/// `SPEC/program/e2e-integration-tests.md` § CI), so this widget-test layer
+/// carries the behavioural pin.
+///
+/// Refs GitHub #2336 AC1 / AC2 / Bottleneck 4 / H1–H4.
+library;
+
+// ignore_for_file: deprecated_member_use
+
+import 'package:colonizethis_app/config/ct_e2e.dart';
+import 'package:colonizethis_app/l10n/app_localizations_contract.dart';
+import 'package:colonizethis_app/l10n/app_localizations_lookup.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../integration_test/e2e_test_shared.dart';
+
+const String _seaText = 'sea zone 1';
+
+class _MoveButton extends StatelessWidget {
+  const _MoveButton({this.onPressedSpy, this.dialogBuilder});
+
+  final void Function()? onPressedSpy;
+  final Widget Function(BuildContext context)? dialogBuilder;
+
+  @override
+  Widget build(BuildContext context) {
+    return Builder(
+      builder: (context) {
+        return TextButton(
+          onPressed: () {
+            onPressedSpy?.call();
+            showDialog<void>(
+              context: context,
+              builder: dialogBuilder ??
+                  (_) => const AlertDialog(content: Text('Move dialog')),
+            );
+          },
+          child: const Text('Move'),
+        );
+      },
+    );
+  }
+}
+
+ExpansionTile _fleetTile({
+  required String title,
+  String? subtitle,
+  void Function()? onMovePressed,
+  Widget Function(BuildContext context)? dialogBuilder,
+}) {
+  return ExpansionTile(
+    title: Text(title),
+    subtitle: subtitle == null ? null : Text(subtitle),
+    initiallyExpanded: true,
+    children: [
+      _MoveButton(
+        onPressedSpy: onMovePressed,
+        dialogBuilder: dialogBuilder,
+      ),
+    ],
+  );
+}
+
+Widget _navalPanel({required List<Widget> children}) => KeyedSubtree(
+  key: kCtE2ENavalPanelRootKey,
+  child: Column(children: children),
+);
+
+Widget _wrap(Widget body) =>
+    MaterialApp(home: Scaffold(body: SingleChildScrollView(child: body)));
+
+class _DismissibleSeaDialog extends StatefulWidget {
+  const _DismissibleSeaDialog({required this.l10n});
+
+  final AppLocalizations l10n;
+
+  @override
+  State<_DismissibleSeaDialog> createState() => _DismissibleSeaDialogState();
+}
+
+class _DismissibleSeaDialogState extends State<_DismissibleSeaDialog> {
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      content: SingleChildScrollView(
+        key: kCtE2EMoveFleetDialogScrollRootKey,
+        child: RadioListTile<int>(
+          title: const Text(_seaText),
+          value: 0,
+          groupValue: 0,
+          onChanged: (_) {},
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: Text(widget.l10n.common_confirm),
+        ),
+      ],
+    );
+  }
+}
+
+void main() {
+  suppressLogsForTests();
+
+  group('e2eTryNavalMoveSegment — early exit branches', () {
+    testWidgets('no non-home Move control -> no dialog (naval panel open)', (
+      tester,
+    ) async {
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      await tester.pumpWidget(
+        _wrap(
+          _navalPanel(
+            children: [
+              ExpansionTile(
+                title: const Text('Home Fleet'),
+                initiallyExpanded: true,
+                children: [_MoveButton(onPressedSpy: () {})],
+              ),
+            ],
+          ),
+        ),
+      );
+      await e2eTryNavalMoveSegment(
+        tester,
+        l10n,
+        navalPanelAlreadyOpen: true,
+      );
+      expect(find.byType(AlertDialog), findsNothing);
+    });
+
+    testWidgets(
+      'no adjacent sea zones message -> Cancel dismisses dialog',
+      (tester) async {
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        await tester.pumpWidget(
+          _wrap(
+            _navalPanel(
+              children: [
+                _fleetTile(
+                  title: 'Fleet 2',
+                  subtitle: 'New World — Outer Sea',
+                  dialogBuilder: (context) => AlertDialog(
+                    content: Text(l10n.moveFleet_noAdjacentSeaZones),
+                    actions: [
+                      TextButton(
+                        onPressed: () => Navigator.of(context).pop(),
+                        child: Text(l10n.common_cancel),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+        await e2eTryNavalMoveSegment(
+          tester,
+          l10n,
+          navalPanelAlreadyOpen: true,
+        );
+        expect(find.byType(AlertDialog), findsNothing);
+      },
+    );
+  });
+
+  group('e2eTryNavalMoveSegment — happy path', () {
+    testWidgets(
+      'sea-radio move dialog confirmed when panel already open',
+      (tester) async {
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        await tester.pumpWidget(
+          _wrap(
+            _navalPanel(
+              children: [
+                _fleetTile(
+                  title: 'Fleet 2',
+                  subtitle: 'New World — Outer Sea',
+                  dialogBuilder: (_) => _DismissibleSeaDialog(l10n: l10n),
+                ),
+              ],
+            ),
+          ),
+        );
+        await e2eTryNavalMoveSegment(
+          tester,
+          l10n,
+          navalPanelAlreadyOpen: true,
+        );
+        expect(find.byType(AlertDialog), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'allowWarpDestinations false reaches sea-radio branch on warp+sea dialog',
+      (tester) async {
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        await tester.pumpWidget(
+          _wrap(
+            _navalPanel(
+              children: [
+                _fleetTile(
+                  title: 'Fleet 2',
+                  subtitle: 'New World — Outer Sea',
+                  dialogBuilder: (_) => AlertDialog(
+                    content: SingleChildScrollView(
+                      key: kCtE2EMoveFleetDialogScrollRootKey,
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          RadioListTile<int>(
+                            title: const Text('links to New World'),
+                            value: 0,
+                            groupValue: null,
+                            onChanged: (_) {},
+                          ),
+                          RadioListTile<int>(
+                            title: const Text(_seaText),
+                            value: 1,
+                            groupValue: null,
+                            onChanged: (_) {},
+                          ),
+                        ],
+                      ),
+                    ),
+                    actions: [
+                      Builder(
+                        builder: (context) => TextButton(
+                          onPressed: () => Navigator.of(context).pop(),
+                          child: Text(l10n.common_confirm),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+        Object? caught;
+        try {
+          await e2eTryNavalMoveSegment(
+            tester,
+            l10n,
+            navalPanelAlreadyOpen: true,
+            allowWarpDestinations: false,
+            maxUiResponseWait: const Duration(seconds: 10),
+          );
+        } catch (e) {
+          caught = e;
+        }
+        expect(
+          caught,
+          isNull,
+          reason:
+              'allowWarpDestinations=false must delegate to the sea-radio '
+              'branch without entering the warp drag-probe fail path.',
+        );
+        expect(find.byType(AlertDialog), findsNothing);
+      },
+    );
+  });
+
+  group('e2eTryNavalMoveSegment — perf markers', () {
+    testWidgets('records no_non_home_move_control when Move not tapped', (
+      tester,
+    ) async {
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      final perf = E2ePerfLog('no_non_home_move');
+      await tester.pumpWidget(
+        _wrap(
+          _navalPanel(
+            children: const [Text('loading fleets')],
+          ),
+        ),
+      );
+      final lines = <String>[];
+      final original = debugPrint;
+      debugPrint = (String? message, {int? wrapWidth}) {
+        lines.add(message ?? '');
+      };
+      try {
+        await e2eTryNavalMoveSegment(
+          tester,
+          l10n,
+          navalPanelAlreadyOpen: true,
+          perf: perf,
+        );
+      } finally {
+        debugPrint = original;
+      }
+      expect(
+        lines.any(
+          (line) =>
+              line.contains('fleet_move_segment') &&
+              line.contains('no_non_home_move_control'),
+        ),
+        isTrue,
+      );
+    });
+
+    testWidgets('records no_legal_step when adjacent-sea message shown', (
+      tester,
+    ) async {
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      final perf = E2ePerfLog('no_legal_step');
+      await tester.pumpWidget(
+        _wrap(
+          _navalPanel(
+            children: [
+              _fleetTile(
+                title: 'Fleet 2',
+                subtitle: 'New World — Outer Sea',
+                dialogBuilder: (context) => AlertDialog(
+                  content: Text(l10n.moveFleet_noAdjacentSeaZones),
+                  actions: [
+                    TextButton(
+                      onPressed: () => Navigator.of(context).pop(),
+                      child: Text(l10n.common_cancel),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+      final lines = <String>[];
+      final original = debugPrint;
+      debugPrint = (String? message, {int? wrapWidth}) {
+        lines.add(message ?? '');
+      };
+      try {
+        await e2eTryNavalMoveSegment(
+          tester,
+          l10n,
+          navalPanelAlreadyOpen: true,
+          perf: perf,
+        );
+      } finally {
+        debugPrint = original;
+      }
+      expect(
+        lines.any(
+          (line) =>
+              line.contains('fleet_move_segment') &&
+              line.contains('no_legal_step'),
+        ),
+        isTrue,
+      );
+    });
+  });
+
+  group('e2eTryNavalMoveSegment — default constants', () {
+    test('kE2eDefaultNavalMoveSegmentUiWait matches legacy 5 s cap', () {
+      expect(
+        kE2eDefaultNavalMoveSegmentUiWait,
+        const Duration(seconds: 5),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Lifts the formerly private `_pickMoveDestinationAndConfirm` (in
`app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers.dart`)
into the public `e2ePickMoveDestinationAndConfirm` in
`app/integration_test/e2e_test_shared_panels.dart`, re-exports it through
the AC1 barrel (`e2e_helpers.dart`) as `pickMoveDestinationAndConfirm`, and
pins the contract via a new widget test (13 cases).

This is a lift + pin slice for issue #2336 § Bottleneck 4 / H4 (the
move-fleet dialog warp / sea-radio / drag-probe contract). The fleet-reach
loop in `new_game_fleet_reaches_new_world_e2e_test.dart` calls this helper
via `_tryNavalMoveSegment` up to `_kMaxNextTurnTapsForNwFleetReach (35)`
times per scenario — a silent rename or behavioural drift would stall the
loop at the per-call budget cap × 35 turns or silently flip warp vs
sea-radio routing.

## What this PR does

- Adds public `e2ePickMoveDestinationAndConfirm(tester, l10n,
  {allowWarpDestinations, moveDialogBudget, maxWarpDragProbes})` to
  `e2e_test_shared_panels.dart` so the move-dialog contract is shared and
  unit-pinned.
- Surfaces the legacy bounds as public constants:
  - `kE2eDefaultMoveFleetDialogBudget` = `Duration(seconds: 5)` (legacy
    `_kMaxUiResponseWait`).
  - `kE2eDefaultMoveFleetWarpDragProbes` = `8` (legacy private
    `maxWarpDragProbes`).
- Re-exports the helper and constants through the AC1 barrel and adds a
  stable public alias `pickMoveDestinationAndConfirm` per the AC1
  checklist.
- Replaces the private declaration in
  `new_game_fleet_reaches_new_world_e2e_helpers.dart` with a doc-comment
  pointer (same pattern as the recently merged region-tab /
  `tapMoveOnFirstNonHomeFleet` /
  `anyExplorerHasEnabledExploreAssignFleet` lifts).
- Updates the in-file call site in `_tryNavalMoveSegment` to consume the
  AC1 barrel alias and forwards `_kMaxUiResponseWait` explicitly as the
  per-call budget so wall-clock contract stays identical.
- Removes the now-unused import of
  `units_panel_region_label.dart` from the integration test file.
- Adds widget-test pin `app/test/e2e_pick_move_destination_and_confirm_test.dart`
  covering: warp tap happy path, warp tap via `RadioListTile` ancestor,
  drag-probe scroll-to-reveal, deterministic `'Warp row not hit-testable'`
  failure path (via `IgnorePointer`), `kCtE2EMoveFleetDialogScrollRootKey`
  absent fallback, sea-radio branch when warp absent, sea-radio branch
  with `allowWarpDestinations: false` (verified via `maxWarpDragProbes: 0`
  not failing), sea-radio branch without any scrollable in the dialog,
  AlertDialog-missing failure, zero-budget short-circuit, determinism
  across two invocations, and default-constant values.
- Refreshes stale doc references to the pre-lift private name in
  `e2e_radio_list_tiles_in_alert_dialogs_test.dart` and the
  `e2eRadioListTilesInAlertDialogs` barrel pin reason to point at the
  lifted public helper.
- Adds a typed tear-off pin (with all three named parameters) for
  `pickMoveDestinationAndConfirm` in `e2e_helpers_barrel_test.dart` plus
  an empty-scaffold smoke that surfaces the helper's missing-dialog
  throw.

## Done in this push

Issue #2336 AC1 / AC2 (shared helper) for `_pickMoveDestinationAndConfirm`
and a widget-test pin gating the behavioural contract for AC4 / Bottleneck
4 / H4. Production behaviour is unchanged.

## Remaining for #2336

Remaining private helpers in the fleet-reach integration suite (to be
lifted in follow-up PRs):

- `_tryNavalMoveSegment` (composes the just-lifted picker with
  `openNavalPanel` / `tapMoveOnFirstNonHomeFleet` /
  region-tab helpers).
- `_awaitNwCoastalOrVisibleLandForBundledExploreE2e`.

AC8 baseline measurement / AC9 25% aggregate-suite reduction work remains
the broader convergence target on the issue.

## Behavior change

None. The lifted helper is byte-equivalent to the prior private form
(same finders, same waits, same scroll/drag algorithm, same fail
diagnostics, same default bounds; `_tryNavalMoveSegment` passes
`_kMaxUiResponseWait` as `moveDialogBudget` so the live budget is
identical).

## Test plan

- `cd app && flutter analyze integration_test/e2e_test_shared_panels.dart
  integration_test/e2e_helpers.dart
  integration_test/new_game_fleet_reaches_new_world_e2e_helpers.dart
  integration_test/new_game_fleet_reaches_new_world_e2e_test.dart
  test/e2e_pick_move_destination_and_confirm_test.dart
  test/e2e_helpers_barrel_test.dart
  test/e2e_radio_list_tiles_in_alert_dialogs_test.dart` -> No issues
  found.
- `cd app && flutter test
  test/e2e_pick_move_destination_and_confirm_test.dart` -> 13/13 pass.
- `cd app && flutter test test/e2e_helpers_barrel_test.dart
  test/e2e_radio_list_tiles_in_alert_dialogs_test.dart` -> 46/46 pass.
- `cd app && flutter test \$(ls test/e2e_*_test.dart)` -> 382/382 pass
  (full e2e widget-test suite green).
- CI: relies on `App test cache (deps + l10n + analyze)`, `App tests
  (shard …)`, and `Quality (lint, analyze, observer)` workflows; the
  `app_e2e_linux` lane remains a no-op per
  `SPEC/program/e2e-integration-tests.md` § CI, so the new
  widget-test pin carries the behavioural contract.

Refs #2336

Made with [Cursor](https://cursor.com)