### PR TITLE
test(e2e): lift _awaitNwCoastalOrVisibleLandForBundledExploreE2e into shared library + pin (Refs #2336)

### DIFF
--- a/app/integration_test/e2e_helpers.dart
+++ b/app/integration_test/e2e_helpers.dart
@@ -18,6 +18,7 @@ export 'e2e_test_shared.dart'
     show
         E2ePerfLog,
         e2eAdaptivePollRampAfterIdle,
+        e2eAwaitNwCoastalOrVisibleLandForBundledExplore,
         e2eBundledExploreRejectionDiagnostics,
         e2eExploreAssignEnabledFromCivilianSnapshot,
         e2eFleetReachDoneFromCtSnapshotOnly,
@@ -32,6 +33,7 @@ export 'e2e_test_shared.dart'
         e2ePickMoveDestinationAndConfirm,
         e2eTryNavalMoveSegment,
         e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot,
+        kE2eDefaultBundledExploreReadinessMaxTurns,
         kE2eDefaultNavalMoveSegmentUiWait,
         e2ePumpUntil,
         e2ePumpUntilConditionOrIdle,
@@ -236,6 +238,24 @@ Future<bool> anyExplorerHasEnabledExploreAssignFleet(
   tester,
   maxUiResponseWait: maxUiResponseWait,
   maxPanelSweepSteps: maxPanelSweepSteps,
+);
+
+/// Stable public name for [e2eAwaitNwCoastalOrVisibleLandForBundledExplore]
+/// so the post-bundle Explore scenario consumes the AC1 barrel only
+/// (Refs GitHub #2336 AC1 / AC2 / Bottleneck 4). Forwards to the
+/// implementation in `e2e_test_shared_panels.dart`.
+Future<void> awaitNwCoastalOrVisibleLandForBundledExplore(
+  WidgetTester tester,
+  AppLocalizations l10n, {
+  required void Function(String step) ensureUnderWallClock,
+  int maxTurns = kE2eDefaultBundledExploreReadinessMaxTurns,
+  Duration maxUiResponseWait = kE2eDefaultNavalMoveSegmentUiWait,
+}) => e2eAwaitNwCoastalOrVisibleLandForBundledExplore(
+  tester,
+  l10n,
+  ensureUnderWallClock: ensureUnderWallClock,
+  maxTurns: maxTurns,
+  maxUiResponseWait: maxUiResponseWait,
 );
 
 Future<void> ensureAllRelocated64pxPngsLoad() =>

--- a/app/integration_test/e2e_test_shared_panels.dart
+++ b/app/integration_test/e2e_test_shared_panels.dart
@@ -1,6 +1,6 @@
 import 'package:colonizethis_app/config/ct_e2e.dart';
 import 'package:colonizethis_app/config/ct_e2e_last_panel_snapshot.dart'
-    show ctE2eCivilianPanelSnapshot;
+    show ctE2eCivilianPanelSnapshot, ctE2eNavalPanelSnapshot;
 import 'package:colonizethis_app/features/game/flame/game_screen_shared.dart';
 import 'package:colonizethis_app/features/game/widgets/units/shared/units_panel_region_label.dart';
 import 'package:colonizethis_app/l10n/app_localizations_contract.dart';
@@ -1151,4 +1151,114 @@ Future<void> e2eTryNavalMoveSegment(
     );
   }
   perf?.timing('fleet_move_segment', phaseSw.elapsed);
+}
+
+/// Default bound on the outer turn loop that drives the bundled-Explore
+/// readiness wait (see [e2eAwaitNwCoastalOrVisibleLandForBundledExplore]).
+///
+/// Mirrors the legacy `maxTurns = 35` constant the helper carried as a
+/// private literal before the lift (Refs GitHub #2336 AC1 / AC2). The 35-turn
+/// budget tracks `_kMaxNextTurnTapsForNwFleetReach` in
+/// `new_game_fleet_reaches_new_world_e2e_helpers.dart` so the bundled-Explore
+/// readiness loop and the upstream fleet-reach loop share a common ceiling.
+const int kE2eDefaultBundledExploreReadinessMaxTurns = 35;
+
+/// Drives the bundled-Explore readiness wait: probes the live naval-panel
+/// snapshot every loop iteration, opens the naval panel only when snapshot
+/// plumbing is unavailable, attempts one bounded New-World move via
+/// [e2eTryNavalMoveSegment], advances one human turn, and exits as soon as
+/// either coastal-NW arrival or any NW fogged-or-better visibility is
+/// observed.
+///
+/// Lifted from the formerly private
+/// `_awaitNwCoastalOrVisibleLandForBundledExploreE2e` in
+/// `new_game_fleet_reaches_new_world_e2e_helpers_part2.dart` (Refs GitHub
+/// #2336 AC1 / AC2 / Bottleneck 4). The post-bundle Explore test calls this
+/// helper exactly once per scenario to bridge the gap between
+/// `e2eHarnessDetectsNonHomeFleetInNewWorld` (fleet has arrived at NW open
+/// sea) and the strict `anyExplorerHasEnabledExploreAssignFleet` check that
+/// requires coastal land visibility. The widget-test pin in
+/// `app/test/e2e_await_nw_coastal_or_visible_land_for_bundled_explore_test.dart`
+/// guards against silent regressions because the integration suite cannot
+/// validate this directly today (`app_e2e_linux` is a no-op per
+/// `SPEC/program/e2e-integration-tests.md` § CI).
+///
+/// Contract:
+///
+/// - Loops at most [maxTurns] iterations (default
+///   [kE2eDefaultBundledExploreReadinessMaxTurns]); each iteration invokes
+///   [ensureUnderWallClock] with `'NW bundled-explore readiness i=<idx>'`.
+/// - Returns immediately when
+///   [e2eNonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot] **or**
+///   [e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot] holds for
+///   [ctE2eNavalPanelSnapshot] at any of the three probe points:
+///   start-of-iteration, post-naval-open (when snapshot was null), and
+///   post-`advanceOneHumanTurn`.
+/// - When the snapshot is null, opens the naval panel via
+///   [e2eOpenNavalPanel] (using [maxUiResponseWait] for both the open and
+///   close timeouts), re-probes, and closes the bottom sheet via
+///   [e2eCloseBottomSheet] before returning on success.
+/// - Calls [e2eTryNavalMoveSegment] with `useNewWorldMapTabFirst: true`,
+///   `allowWarpDestinations: false`, and `navalPanelAlreadyOpen` set to
+///   `ctE2eNavalPanelSnapshot == null` (mirroring the pre-lift contract so
+///   the snapshot-backed path keeps the naval sheet open across iterations).
+/// - Closes the bottom sheet after each move attempt and advances one human
+///   turn via [e2eAdvanceOneHumanTurn].
+/// - Returns normally — without throwing — when the loop exhausts
+///   [maxTurns] without satisfying either predicate. The caller is
+///   responsible for the strict Explore-enabled assertion that follows.
+Future<void> e2eAwaitNwCoastalOrVisibleLandForBundledExplore(
+  WidgetTester tester,
+  AppLocalizations l10n, {
+  required void Function(String step) ensureUnderWallClock,
+  int maxTurns = kE2eDefaultBundledExploreReadinessMaxTurns,
+  Duration maxUiResponseWait = kE2eDefaultNavalMoveSegmentUiWait,
+}) async {
+  for (var i = 0; i < maxTurns; i++) {
+    ensureUnderWallClock('NW bundled-explore readiness i=$i');
+    await e2eDismissTransientUi(tester);
+    await e2eTapNewWorldRegionTabIfPresent(tester);
+    if (e2eNonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot(
+          ctE2eNavalPanelSnapshot,
+        ) ||
+        e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot(
+          ctE2eNavalPanelSnapshot,
+        )) {
+      return;
+    }
+    if (ctE2eNavalPanelSnapshot == null) {
+      await e2eOpenNavalPanel(
+        tester,
+        timeout: maxUiResponseWait,
+        bottomSheetCloseTimeout: maxUiResponseWait,
+      );
+      if (e2eNonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot(
+            ctE2eNavalPanelSnapshot,
+          ) ||
+          e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot(
+            ctE2eNavalPanelSnapshot,
+          )) {
+        await e2eCloseBottomSheet(tester, overallTimeout: maxUiResponseWait);
+        return;
+      }
+    }
+    await e2eTryNavalMoveSegment(
+      tester,
+      l10n,
+      useNewWorldMapTabFirst: true,
+      allowWarpDestinations: false,
+      maxUiResponseWait: maxUiResponseWait,
+      navalPanelAlreadyOpen: ctE2eNavalPanelSnapshot == null,
+    );
+    await e2eCloseBottomSheet(tester, overallTimeout: maxUiResponseWait);
+    await e2eAdvanceOneHumanTurn(tester, l10n: l10n);
+    if (e2eNonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot(
+          ctE2eNavalPanelSnapshot,
+        ) ||
+        e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot(
+          ctE2eNavalPanelSnapshot,
+        )) {
+      return;
+    }
+  }
 }

--- a/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers_part2.dart
+++ b/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers_part2.dart
@@ -57,66 +57,20 @@ part of 'new_game_fleet_reaches_new_world_e2e_test.dart';
 /// [e2eFleetReachDoneFromCtSnapshotOnly] (`e2e_test_shared.dart`, Refs #2336
 /// AC1 / AC2). Call sites pass [ctE2eNavalPanelSnapshot] explicitly.
 
-/// Post–#1869 only: fleet may sit in open-ocean New World first; ship reveal needs
-/// a P–S coastal sea zone (or visibility already updated). Sail / advance until then.
-Future<void> _awaitNwCoastalOrVisibleLandForBundledExploreE2e({
-  required WidgetTester tester,
-  required AppLocalizations l10n,
-  required void Function(String step) ensureUnderWallClock,
-}) async {
-  const maxTurns = 35;
-  for (var i = 0; i < maxTurns; i++) {
-    ensureUnderWallClock('NW bundled-explore readiness i=$i');
-    await dismissTransientUi(tester);
-    await e2eTapNewWorldRegionTabIfPresent(tester);
-    if (e2eNonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot(
-          ctE2eNavalPanelSnapshot,
-        ) ||
-        e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot(
-          ctE2eNavalPanelSnapshot,
-        )) {
-      return;
-    }
-    // Snapshot-backed paths skip redundant naval sheet open/close (Refs #2336).
-    if (ctE2eNavalPanelSnapshot == null) {
-      await openNavalPanel(
-        tester,
-        timeout: _kMaxUiResponseWait,
-        bottomSheetCloseTimeout: _kMaxUiResponseWait,
-      );
-      if (e2eNonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot(
-            ctE2eNavalPanelSnapshot,
-          ) ||
-          e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot(
-            ctE2eNavalPanelSnapshot,
-          )) {
-        await closeBottomSheet(tester, overallTimeout: _kMaxUiResponseWait);
-        return;
-      }
-    }
-    await tryNavalMoveSegment(
-      tester,
-      l10n,
-      useNewWorldMapTabFirst: true,
-      allowWarpDestinations: false,
-      maxUiResponseWait: _kMaxUiResponseWait,
-      navalPanelAlreadyOpen: ctE2eNavalPanelSnapshot == null,
-    );
-    await closeBottomSheet(tester, overallTimeout: _kMaxUiResponseWait);
-    await advanceOneHumanTurn(tester, l10n: l10n);
-    if (e2eNonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot(
-          ctE2eNavalPanelSnapshot,
-        ) ||
-        e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot(
-          ctE2eNavalPanelSnapshot,
-        )) {
-      return;
-    }
-  }
-  // Some generated maps can keep the non-home fleet in open-ocean NW sea lanes
-  // for long bounded stretches; in that case bundled Explore has no visible NW
-  // destinations yet. Leave strict assertion to the final Explore-enabled check.
-}
+/// Post–#1869 bundled-Explore readiness wait was lifted into
+/// [e2eAwaitNwCoastalOrVisibleLandForBundledExplore]
+/// (`e2e_test_shared_panels.dart`) so the 35-turn readiness loop is shared
+/// and unit-pinned (Refs GitHub #2336 AC1 / AC2 / Bottleneck 4). The fleet
+/// scenario calls the lifted form through the AC1 barrel alias
+/// `awaitNwCoastalOrVisibleLandForBundledExplore` (`e2e_helpers.dart`); the
+/// widget-test pin in
+/// `app/test/e2e_await_nw_coastal_or_visible_land_for_bundled_explore_test.dart`
+/// carries the behavioural contract because the integration suite cannot
+/// validate this directly today (`app_e2e_linux` is a no-op per
+/// `SPEC/program/e2e-integration-tests.md` § CI). A regression here would
+/// stall the bundled-Explore retry path at
+/// `kE2eDefaultBundledExploreReadinessMaxTurns (35)` × per-turn cost —
+/// directly inflating the wall-clock budget #2336 is reducing.
 
 /// `_bundledExploreRejectionDiagnostics` was lifted into the public
 /// [e2eBundledExploreRejectionDiagnostics] in `e2e_test_shared.dart`
@@ -150,5 +104,10 @@ Future<void> _awaitNwCoastalOrVisibleLandForBundledExploreE2e({
 /// `maxPanelSweepSteps (16) × per-step Assign sweep` path described as
 /// Bottleneck 5 in `SPEC/program/e2e-integration-tests.md` § Determinism.
 
-/// Taps the map HUD next-turn button, handles the optional confirm dialog,
-/// and waits for the next-turn label to advance. This is the fleet e2e's
+/// Next-turn-tap / dialog-handle / label-advance routine was lifted into
+/// [e2eAdvanceOneHumanTurn] (`e2e_test_shared.dart`) so the fleet e2e's
+/// only next-turn entrypoint is shared and unit-pinned (Refs GitHub #2336
+/// AC1 / AC2). The fleet scenarios call the lifted form through the AC1
+/// barrel alias `advanceOneHumanTurn` (`e2e_helpers.dart`); the widget-test
+/// pin in `app/test/e2e_advance_one_human_turn_test.dart` carries the
+/// behavioural contract.

--- a/app/integration_test/new_game_fleet_reaches_new_world_e2e_test.dart
+++ b/app/integration_test/new_game_fleet_reaches_new_world_e2e_test.dart
@@ -332,10 +332,11 @@ void main() {
       );
       ensureUnderWallClock('fleet in NW confirmed');
 
-      await _awaitNwCoastalOrVisibleLandForBundledExploreE2e(
-        tester: tester,
-        l10n: l10n,
+      await awaitNwCoastalOrVisibleLandForBundledExplore(
+        tester,
+        l10n,
         ensureUnderWallClock: ensureUnderWallClock,
+        maxUiResponseWait: _kMaxUiResponseWait,
       );
 
       await e2eTapNewWorldRegionTabIfPresent(tester);

--- a/app/test/e2e_await_nw_coastal_or_visible_land_for_bundled_explore_test.dart
+++ b/app/test/e2e_await_nw_coastal_or_visible_land_for_bundled_explore_test.dart
@@ -1,0 +1,393 @@
+/// Pins the widget-tree contract of
+/// [e2eAwaitNwCoastalOrVisibleLandForBundledExplore]
+/// (`app/integration_test/e2e_test_shared_panels.dart`).
+///
+/// The post-bundle Explore scenario in
+/// `new_game_fleet_reaches_new_world_e2e_test.dart` calls this helper via
+/// the AC1 barrel alias `awaitNwCoastalOrVisibleLandForBundledExplore` to
+/// bridge `e2eHarnessDetectsNonHomeFleetInNewWorld` (fleet has reached open
+/// NW sea) and the strict `anyExplorerHasEnabledExploreAssignFleet` check
+/// (Explore is enabled, requiring coastal land visibility per
+/// `SPEC/program/fog-and-exploration-resolution.md`). A silent rename or
+/// fail-open would either skip the readiness wait — masking a real Explore
+/// regression — or stall the loop at
+/// `kE2eDefaultBundledExploreReadinessMaxTurns (35) × ~5 s per iteration`,
+/// directly inflating the wall-clock cap #2336 is reducing
+/// (Bottleneck 4 in `SPEC/program/e2e-integration-tests.md` § Determinism).
+///
+/// The integration suite cannot validate this directly today (the
+/// `app_e2e_linux` lane is a no-op per
+/// `SPEC/program/e2e-integration-tests.md` § CI), so the widget-test layer
+/// carries the behavioural pin.
+///
+/// Refs GitHub #2336 AC1 / AC2 / Bottleneck 4.
+library;
+
+import 'package:colonizethis_app/config/ct_e2e_last_panel_snapshot.dart';
+import 'package:colonizethis_app/l10n/app_localizations_contract.dart';
+import 'package:colonizethis_app/l10n/app_localizations_lookup.dart';
+import 'package:colonizethis_data/colonizethis_data.dart'
+    show MapTopology, TopologyEdge, TopologyNode, TopologyNodeType;
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../integration_test/e2e_helpers.dart';
+
+const String _human = 'gp1';
+
+const TurnState _orderingTurn = TurnState(
+  phase: TurnPhase.orders,
+  turnNumber: 1,
+);
+
+const RegionData _emptyRegion = RegionData();
+const Orders _emptyOrders = Orders();
+const MapTopology _emptyTopology = MapTopology();
+
+Province _nwProvince(String localId) =>
+    Province(id: ProvinceId.full('newWorld', localId), regionId: 'newWorld');
+
+Fleet _homeFleet() => Fleet(
+  id: 'fleet_$_human',
+  ownerId: _human,
+  regionId: 'oldWorld',
+  inPortAtProvinceId: 'oldWorld|capital',
+);
+
+MapTopology _coastalNwTopology({
+  required String seaId,
+  required List<String> adjacentProvinceIds,
+}) => MapTopology(
+  nodes: [
+    TopologyNode(
+      id: seaId,
+      regionId: 'newWorld',
+      type: TopologyNodeType.seaZone,
+    ),
+    for (final pid in adjacentProvinceIds)
+      TopologyNode(
+        id: pid,
+        regionId: 'newWorld',
+        type: TopologyNodeType.province,
+      ),
+  ],
+  edges: [
+    for (final pid in adjacentProvinceIds) TopologyEdge(id1: pid, id2: seaId),
+  ],
+);
+
+Game _gameWithFleets({
+  List<Fleet> fleets = const [],
+  RegionData newWorld = _emptyRegion,
+  Map<String, Map<String, String>> playerVisibilityByTile = const {},
+}) => Game(
+  id: 'g1',
+  worldState: WorldState(
+    turnState: _orderingTurn,
+    oldWorld: _emptyRegion,
+    newWorld: newWorld,
+    fleets: fleets,
+    playerVisibilityByTile: playerVisibilityByTile,
+  ),
+  players: const [Player(id: _human, displayName: 'You', isHuman: true)],
+);
+
+CtE2eNavalPanelSnapshot _snapshot({
+  List<Fleet> fleets = const [],
+  MapTopology topology = _emptyTopology,
+  RegionData newWorld = _emptyRegion,
+  Map<String, Map<String, String>> playerVisibilityByTile = const {},
+}) => CtE2eNavalPanelSnapshot(
+  game: _gameWithFleets(
+    fleets: fleets,
+    newWorld: newWorld,
+    playerVisibilityByTile: playerVisibilityByTile,
+  ),
+  humanPlayerId: _human,
+  topology: topology,
+  draftOrders: _emptyOrders,
+);
+
+CtE2eNavalPanelSnapshot _coastalArrivalSnapshot() => _snapshot(
+  fleets: [
+    _homeFleet(),
+    Fleet(
+      id: 'fleet_human_split',
+      ownerId: _human,
+      regionId: 'newWorld',
+      seaZoneId: 'sea_nw_1',
+    ),
+  ],
+  topology: _coastalNwTopology(
+    seaId: 'sea_nw_1',
+    adjacentProvinceIds: const ['newWorld|p1'],
+  ),
+);
+
+CtE2eNavalPanelSnapshot _foggedNwSnapshot() => _snapshot(
+  newWorld: RegionData(provinces: [_nwProvince('p1')]),
+  playerVisibilityByTile: const {
+    _human: {'newWorld|p1|0|0': 'fogged'},
+  },
+);
+
+Future<void> _pumpEmpty(WidgetTester tester) =>
+    tester.pumpWidget(const MaterialApp(home: Scaffold(body: SizedBox())));
+
+void main() {
+  suppressLogsForTests();
+
+  setUp(() {
+    ctE2eNavalPanelSnapshot = null;
+  });
+
+  tearDown(() {
+    ctE2eNavalPanelSnapshot = null;
+  });
+
+  group('e2eAwaitNwCoastalOrVisibleLandForBundledExplore — defaults', () {
+    test(
+      'kE2eDefaultBundledExploreReadinessMaxTurns matches the legacy 35-turn cap',
+      () {
+        expect(
+          kE2eDefaultBundledExploreReadinessMaxTurns,
+          35,
+          reason:
+              'Lifted-from constant must match the legacy private '
+              '`maxTurns = 35` literal so the bundled-Explore readiness '
+              'loop ceiling stays aligned with '
+              '`_kMaxNextTurnTapsForNwFleetReach (35)` in '
+              '`new_game_fleet_reaches_new_world_e2e_helpers.dart`. A '
+              'silent change would either let the loop run longer than '
+              'the documented Bottleneck 4 ceiling (#2336) or '
+              'short-circuit early and skip the readiness wait.',
+        );
+      },
+    );
+  });
+
+  group(
+    'e2eAwaitNwCoastalOrVisibleLandForBundledExplore — bounded loop',
+    () {
+      testWidgets(
+        'maxTurns: 0 is a complete no-op — ensureUnderWallClock never invoked',
+        (tester) async {
+          await _pumpEmpty(tester);
+          final l10n = lookupAppLocalizations(const Locale('en'));
+          final steps = <String>[];
+          await e2eAwaitNwCoastalOrVisibleLandForBundledExplore(
+            tester,
+            l10n,
+            ensureUnderWallClock: steps.add,
+            maxTurns: 0,
+          );
+          expect(
+            steps,
+            isEmpty,
+            reason:
+                'A zero-iteration call must not enter the for-body, '
+                'must not invoke the wall-clock guard, and must not '
+                'attempt to open the naval panel — otherwise callers '
+                'cannot pass `maxTurns: 0` as a safe disarm during '
+                'tests or stub scenarios.',
+          );
+        },
+      );
+
+      testWidgets(
+        'maxTurns honours the caller override (uses the parameter, not the default)',
+        (tester) async {
+          await _pumpEmpty(tester);
+          final l10n = lookupAppLocalizations(const Locale('en'));
+          final steps = <String>[];
+          // Snapshot satisfies neither predicate; the helper would normally
+          // attempt naval-panel work, but with maxTurns: 0 the loop must
+          // not enter even when the snapshot is non-null.
+          ctE2eNavalPanelSnapshot = _snapshot();
+          await e2eAwaitNwCoastalOrVisibleLandForBundledExplore(
+            tester,
+            l10n,
+            ensureUnderWallClock: steps.add,
+            maxTurns: 0,
+          );
+          expect(
+            steps,
+            isEmpty,
+            reason:
+                'maxTurns: 0 must short-circuit before the first '
+                'iteration even when the snapshot is non-null but '
+                'fails both readiness predicates — a regression that '
+                'silently used the default 35 here would burn the '
+                'full Bottleneck 4 budget in any test that disabled '
+                'the loop.',
+          );
+        },
+      );
+    },
+  );
+
+  group(
+    'e2eAwaitNwCoastalOrVisibleLandForBundledExplore — coastal short-circuit',
+    () {
+      testWidgets(
+        'coastal-NW snapshot exits on iteration 0 — single step recorded',
+        (tester) async {
+          await _pumpEmpty(tester);
+          final l10n = lookupAppLocalizations(const Locale('en'));
+          ctE2eNavalPanelSnapshot = _coastalArrivalSnapshot();
+          final steps = <String>[];
+          await e2eAwaitNwCoastalOrVisibleLandForBundledExplore(
+            tester,
+            l10n,
+            ensureUnderWallClock: steps.add,
+            maxTurns: kE2eDefaultBundledExploreReadinessMaxTurns,
+          );
+          expect(
+            steps,
+            equals(<String>['NW bundled-explore readiness i=0']),
+            reason:
+                'A snapshot satisfying '
+                '`e2eNonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot` '
+                'at iteration 0 must short-circuit after one '
+                '`ensureUnderWallClock` callback and one snapshot probe — '
+                'never advancing to the open-naval-panel / move-segment / '
+                'next-turn path. A regression that re-opened the naval '
+                'sheet anyway would burn ~5 s per turn × 35 turns.',
+          );
+        },
+      );
+    },
+  );
+
+  group(
+    'e2eAwaitNwCoastalOrVisibleLandForBundledExplore — fogged-or-better short-circuit',
+    () {
+      testWidgets(
+        'NW-fogged snapshot exits on iteration 0 — single step recorded',
+        (tester) async {
+          await _pumpEmpty(tester);
+          final l10n = lookupAppLocalizations(const Locale('en'));
+          ctE2eNavalPanelSnapshot = _foggedNwSnapshot();
+          final steps = <String>[];
+          await e2eAwaitNwCoastalOrVisibleLandForBundledExplore(
+            tester,
+            l10n,
+            ensureUnderWallClock: steps.add,
+            maxTurns: kE2eDefaultBundledExploreReadinessMaxTurns,
+          );
+          expect(
+            steps,
+            equals(<String>['NW bundled-explore readiness i=0']),
+            reason:
+                'The disjunction with '
+                '`e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot` '
+                'must short-circuit on the first iteration even when the '
+                'coastal predicate is false (no fleets in NW). A '
+                'regression that required both predicates to be true '
+                'would stall the readiness wait whenever the player '
+                'reached NW visibility via warp/scout rather than via '
+                'a coastal sea zone.',
+          );
+        },
+      );
+    },
+  );
+
+  group(
+    'e2eAwaitNwCoastalOrVisibleLandForBundledExplore — step label format',
+    () {
+      testWidgets(
+        'step label uses `NW bundled-explore readiness i=<idx>` form',
+        (tester) async {
+          await _pumpEmpty(tester);
+          final l10n = lookupAppLocalizations(const Locale('en'));
+          ctE2eNavalPanelSnapshot = _coastalArrivalSnapshot();
+          final steps = <String>[];
+          await e2eAwaitNwCoastalOrVisibleLandForBundledExplore(
+            tester,
+            l10n,
+            ensureUnderWallClock: steps.add,
+            maxTurns: 1,
+          );
+          expect(
+            steps.single,
+            matches(RegExp(r'^NW bundled-explore readiness i=\d+$')),
+            reason:
+                'Wall-clock guards captured for `#2336` debug runs key '
+                'on this label prefix to attribute readiness-loop '
+                'overshoot to the correct helper. A silent rename '
+                'would surface in CI as an opaque `wall_clock_exceeded` '
+                'failure with no helper attribution.',
+          );
+          expect(
+            steps.single,
+            equals('NW bundled-explore readiness i=0'),
+            reason:
+                'Iteration index must be 0-based and embedded into the '
+                'label so a regression that reset the counter or used '
+                '1-based indexing surfaces here, not as a confusing '
+                'off-by-one in CI logs.',
+          );
+        },
+      );
+    },
+  );
+
+  group(
+    'e2eAwaitNwCoastalOrVisibleLandForBundledExplore — AC1 barrel forwarding',
+    () {
+      testWidgets(
+        'awaitNwCoastalOrVisibleLandForBundledExplore (barrel alias) '
+        'short-circuits identically to the lifted form',
+        (tester) async {
+          await _pumpEmpty(tester);
+          final l10n = lookupAppLocalizations(const Locale('en'));
+          ctE2eNavalPanelSnapshot = _coastalArrivalSnapshot();
+          final steps = <String>[];
+          await awaitNwCoastalOrVisibleLandForBundledExplore(
+            tester,
+            l10n,
+            ensureUnderWallClock: steps.add,
+            maxTurns: kE2eDefaultBundledExploreReadinessMaxTurns,
+          );
+          expect(
+            steps,
+            equals(<String>['NW bundled-explore readiness i=0']),
+            reason:
+                'The AC1 barrel wrapper must forward arguments in the '
+                'documented order — a regression that swapped '
+                '`ensureUnderWallClock` with `maxTurns`, dropped '
+                '`l10n`, or accidentally captured a fresh `maxTurns` '
+                'default would surface here, not in the slow CI lane.',
+          );
+        },
+      );
+
+      test(
+        'awaitNwCoastalOrVisibleLandForBundledExplore is re-exported as a '
+        'tear-off (compile-time signature pin)',
+        () {
+          final Future<void> Function(
+            WidgetTester,
+            AppLocalizations, {
+            required void Function(String step) ensureUnderWallClock,
+            int maxTurns,
+            Duration maxUiResponseWait,
+          })
+          ref = awaitNwCoastalOrVisibleLandForBundledExplore;
+          expect(
+            ref,
+            isNotNull,
+            reason:
+                'The AC1 barrel must continue to export the helper with '
+                'the documented signature. A silent removal from the '
+                '`show` clause or an arg-order swap on the wrapper '
+                'would fail this assignment at compile time.',
+          );
+        },
+      );
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Lifts the post-#1869 bundled-Explore readiness wait from the formerly private
`_awaitNwCoastalOrVisibleLandForBundledExploreE2e`
(`app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers_part2.dart`)
into the public `e2eAwaitNwCoastalOrVisibleLandForBundledExplore`
(`app/integration_test/e2e_test_shared_panels.dart`) and exposes it via
the AC1 barrel as `awaitNwCoastalOrVisibleLandForBundledExplore`. Adds
`kE2eDefaultBundledExploreReadinessMaxTurns = 35` so the loop ceiling is
overridable for tests and aligns with the existing
`_kMaxNextTurnTapsForNwFleetReach (35)` budget.

This is one of the last remaining test-scope private helpers tied to
GitHub #2336 AC2 (shared helpers across all E2E test files). The lift
mirrors the cadence of recent slices (#2720, #2722, #2723, #2724, #2725).

## Refs

`Refs #2336` (AC1 / AC2 / Bottleneck 4) — does **not** close the issue;
AC8–AC10 timing measurements still require a maintainer Linux desktop run.

## Done in this push

- New public helper `e2eAwaitNwCoastalOrVisibleLandForBundledExplore` in
  `e2e_test_shared_panels.dart` (preserves exact behaviour of the lifted
  private form: same dismiss / region-tab / snapshot-probe order, same
  naval-open-only-when-snapshot-null contract, same `tryNavalMoveSegment`
  args, same exit conditions).
- New public alias `awaitNwCoastalOrVisibleLandForBundledExplore` and
  the new `kE2eDefaultBundledExploreReadinessMaxTurns` constant added to
  the AC1 barrel (`e2e_helpers.dart`) `show` clause.
- Call site in `new_game_fleet_reaches_new_world_e2e_test.dart` switched
  to the AC1 alias; private declaration in `_helpers_part2.dart` replaced
  with a "moved" notice in the established lift-trail format.
- Tail docstring fragment in `_helpers_part2.dart` for the lifted
  `advanceOneHumanTurn` routine fleshed out so it documents the actual
  lifted helper instead of trailing off mid-sentence.

## Pinning test

`app/test/e2e_await_nw_coastal_or_visible_land_for_bundled_explore_test.dart`
carries the behavioural contract because the integration suite cannot
validate this directly today (`app_e2e_linux` is a no-op per
`SPEC/program/e2e-integration-tests.md` § CI). Coverage:

1. `kE2eDefaultBundledExploreReadinessMaxTurns == 35` constant pin.
2. `maxTurns: 0` complete no-op (callback never invoked, no naval-panel
   work).
3. `maxTurns: 0` short-circuits even with a non-null but unsatisfied
   snapshot (catches a regression that silently used the default 35).
4. Coastal-NW snapshot short-circuits on iteration 0 (single callback,
   no naval sheet open).
5. NW fogged-or-better snapshot short-circuits on iteration 0 (single
   callback, pins the disjunction with the coastal predicate).
6. Step label format pin (`NW bundled-explore readiness i=<idx>`,
   0-based, regex match).
7. AC1 barrel alias forwards args correctly + compile-time signature
   pin via tear-off assignment.

## Deferred / outstanding for #2336

- **AC6–AC10 (E2E pass + 3× stability + timing evidence):** still
  requires a maintainer Linux desktop 3× `integration_test` run +
  `tool/run_e2e_timing.sh` baseline-vs-after capture. This host lacks
  `xvfb-run` / display for the integration_test build.

## Local verification

- `cd app && flutter analyze integration_test/` — no issues.
- `cd app && flutter analyze integration_test/<five touched files> test/e2e_await_nw_coastal_or_visible_land_for_bundled_explore_test.dart` — no issues.
- `cd app && flutter test test/e2e_await_nw_coastal_or_visible_land_for_bundled_explore_test.dart` — 8 passed.
- `cd app && flutter test test/e2e_test_shared_smoke_test.dart test/e2e_helpers_barrel_test.dart test/e2e_try_naval_move_segment_test.dart test/e2e_player_has_any_new_world_fogged_or_better_from_ct_snapshot_test.dart test/e2e_non_home_human_fleet_in_coastal_new_world_sea_from_ct_snapshot_test.dart test/ct_e2e_turn_snapshot_refresh_test.dart` — 100 passed (no regressions in adjacent E2E pins).

## Test plan

- [ ] CI quality / app shards green.
- [ ] Maintainer: run `tool/run_e2e_timing.sh 3` on `dev` tip then this branch and update the issue with the AC8/AC9 comparison table once the wider #2336 timing capture cycle resumes.


Made with [Cursor](https://cursor.com)