### PR TITLE
test(e2e): lift checkExploreEnabledFromCivilianPanel into shared library + pin (Refs #2336)

### DIFF
--- a/app/integration_test/e2e_helpers.dart
+++ b/app/integration_test/e2e_helpers.dart
@@ -20,6 +20,7 @@ export 'e2e_test_shared.dart'
         e2eAdaptivePollRampAfterIdle,
         e2eAwaitNwCoastalOrVisibleLandForBundledExplore,
         e2eBundledExploreRejectionDiagnostics,
+        e2eCheckExploreEnabledFromCivilianPanel,
         e2eExploreAssignEnabledFromCivilianSnapshot,
         e2eFleetReachDoneFromCtSnapshotOnly,
         e2eHarnessDetectsNonHomeFleetInNewWorld,
@@ -34,6 +35,9 @@ export 'e2e_test_shared.dart'
         e2eTryNavalMoveSegment,
         e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot,
         kE2eDefaultBundledExploreReadinessMaxTurns,
+        kE2eDefaultBundledExploreRetryLoopPhase,
+        kE2eDefaultBundledExploreSweepWait,
+        kE2eDefaultFleetCivilianOpenAfterSheetClearPhase,
         kE2eDefaultNavalMoveSegmentUiWait,
         e2ePumpUntil,
         e2ePumpUntilConditionOrIdle,
@@ -256,6 +260,25 @@ Future<void> awaitNwCoastalOrVisibleLandForBundledExplore(
   ensureUnderWallClock: ensureUnderWallClock,
   maxTurns: maxTurns,
   maxUiResponseWait: maxUiResponseWait,
+);
+
+/// Stable public name for [e2eCheckExploreEnabledFromCivilianPanel] so the
+/// post-bundle Explore scenario consumes the AC1 barrel only (Refs GitHub
+/// #2336 AC1 / AC2 / AC5 / Bottleneck 5). Forwards to the implementation
+/// in `e2e_test_shared_panels.dart`.
+Future<bool> checkExploreEnabledFromCivilianPanel(
+  WidgetTester tester, {
+  E2ePerfLog? perf,
+  Duration maxUiResponseWait = kE2eDefaultBundledExploreSweepWait,
+  String afterSheetPanelsClearPhase =
+      kE2eDefaultFleetCivilianOpenAfterSheetClearPhase,
+  String phaseTimingLabel = kE2eDefaultBundledExploreRetryLoopPhase,
+}) => e2eCheckExploreEnabledFromCivilianPanel(
+  tester,
+  perf: perf,
+  maxUiResponseWait: maxUiResponseWait,
+  afterSheetPanelsClearPhase: afterSheetPanelsClearPhase,
+  phaseTimingLabel: phaseTimingLabel,
 );
 
 Future<void> ensureAllRelocated64pxPngsLoad() =>

--- a/app/integration_test/e2e_test_shared_panels.dart
+++ b/app/integration_test/e2e_test_shared_panels.dart
@@ -1262,3 +1262,104 @@ Future<void> e2eAwaitNwCoastalOrVisibleLandForBundledExplore(
     }
   }
 }
+
+/// Default `perf.timing` phase label emitted by
+/// [e2eCheckExploreEnabledFromCivilianPanel].
+///
+/// Mirrors the pre-lift inline-closure literal in
+/// `new_game_fleet_reaches_new_world_e2e_test.dart` so downstream
+/// `E2E_TIMING|phase=...` log scrapers and dashboards remain stable across
+/// the lift (Refs GitHub #2336 AC1 / AC2 / AC5 / Bottleneck 5). A silent
+/// rename would orphan any existing telemetry keyed on this phase name.
+const String kE2eDefaultBundledExploreRetryLoopPhase =
+    'bundled_explore_retry_loop';
+
+/// Default `afterSheetPanelsClearPhase` override forwarded into
+/// [e2eOpenCivilianPanel] by [e2eCheckExploreEnabledFromCivilianPanel].
+///
+/// Mirrors the pre-lift fleet-scenario literal so the
+/// `pump_until_panels_cleared_after_close_sheet_fleet_civilian_open` phase
+/// label keeps attributing post-sheet-close settle time to the fleet
+/// scenario rather than to the generic civilian-open path. The full-turn
+/// scenario keeps the default `_civilian_open` label by going through
+/// [e2eOpenCivilianPanel] directly (Refs GitHub #2336 AC1 / AC2).
+const String kE2eDefaultFleetCivilianOpenAfterSheetClearPhase =
+    'pump_until_panels_cleared_after_close_sheet_fleet_civilian_open';
+
+/// Opens the civilian panel from the fleet bundled-Explore retry context and
+/// returns `true` when at least one civilian unit row exposes an enabled
+/// `Explore` assign target.
+///
+/// Lifted from the formerly inline `checkExploreEnabledFromCivilianPanel`
+/// closure in `new_game_fleet_reaches_new_world_e2e_test.dart` (Refs GitHub
+/// #2336 AC1 / AC2 / AC5 / Bottleneck 5). The post-bundle Explore scenario
+/// invokes this helper inside a bounded `maxBoundedTurnRetries (8)` retry
+/// loop, so a silent rename / fail-open would either inflate the bundled-
+/// Explore wall clock or mask a real Explore regression. The widget-test
+/// pin in
+/// `app/test/e2e_check_explore_enabled_from_civilian_panel_test.dart`
+/// guards against silent regressions because the integration suite cannot
+/// validate this directly today (`app_e2e_linux` is a no-op per
+/// `SPEC/program/e2e-integration-tests.md` § CI).
+///
+/// Contract:
+///
+/// - Starts a fresh stopwatch and forwards [perf] / [maxUiResponseWait]
+///   into [e2eOpenCivilianPanel]; the `afterSheetPanelsClearPhase` default
+///   ([kE2eDefaultFleetCivilianOpenAfterSheetClearPhase]) preserves the
+///   pre-lift fleet-scenario attribution label.
+/// - Calls [e2eWaitUntilFound] on [kCtE2ECivilianPanelRootKey] with
+///   `phaseName: 'wait_until_found_civilian_panel'` before evaluating any
+///   Assign rows, matching the pre-lift closure exactly.
+/// - Delegates to [e2eAnyExplorerHasEnabledExploreAssignFleet] for the
+///   actual sweep, forwarding [maxUiResponseWait]. The Assign-sweep is the
+///   only place where snapshot short-circuit / panel-walk semantics are
+///   defined (Bottleneck 5).
+/// - Calls [e2eCloseBottomSheet] with [maxUiResponseWait] regardless of
+///   the Explore-enabled outcome so the next retry iteration starts from a
+///   clean panel state. A regression that skipped the close would stall
+///   the retry loop on a stale Assign sheet.
+/// - When [perf] is non-`null`, emits a single `perf.timing(...)` event on
+///   return with phase [phaseTimingLabel] (default
+///   [kE2eDefaultBundledExploreRetryLoopPhase]) and
+///   `meta: 'result=enabled'` or `meta: 'result=not_enabled'`.
+/// - Returns the boolean reported by
+///   [e2eAnyExplorerHasEnabledExploreAssignFleet] verbatim.
+Future<bool> e2eCheckExploreEnabledFromCivilianPanel(
+  WidgetTester tester, {
+  E2ePerfLog? perf,
+  Duration maxUiResponseWait = kE2eDefaultBundledExploreSweepWait,
+  String afterSheetPanelsClearPhase =
+      kE2eDefaultFleetCivilianOpenAfterSheetClearPhase,
+  String phaseTimingLabel = kE2eDefaultBundledExploreRetryLoopPhase,
+}) async {
+  final phaseSw = Stopwatch()..start();
+  await e2eOpenCivilianPanel(
+    tester,
+    perf: perf,
+    afterSheetPanelsClearPhase: afterSheetPanelsClearPhase,
+    bottomSheetCloseTimeout: maxUiResponseWait,
+  );
+  await e2eWaitUntilFound(
+    tester,
+    find.byKey(kCtE2ECivilianPanelRootKey),
+    timeout: maxUiResponseWait,
+    perf: perf,
+    phaseName: 'wait_until_found_civilian_panel',
+  );
+  final enabled = await e2eAnyExplorerHasEnabledExploreAssignFleet(
+    tester,
+    maxUiResponseWait: maxUiResponseWait,
+  );
+  await e2eCloseBottomSheet(
+    tester,
+    perf: perf,
+    overallTimeout: maxUiResponseWait,
+  );
+  perf?.timing(
+    phaseTimingLabel,
+    phaseSw.elapsed,
+    meta: 'result=${enabled ? "enabled" : "not_enabled"}',
+  );
+  return enabled;
+}

--- a/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers_part2.dart
+++ b/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers_part2.dart
@@ -111,3 +111,21 @@ part of 'new_game_fleet_reaches_new_world_e2e_test.dart';
 /// barrel alias `advanceOneHumanTurn` (`e2e_helpers.dart`); the widget-test
 /// pin in `app/test/e2e_advance_one_human_turn_test.dart` carries the
 /// behavioural contract.
+
+/// The bundled-Explore "check Explore enabled from civilian panel" inline
+/// closure was lifted into [e2eCheckExploreEnabledFromCivilianPanel]
+/// (`e2e_test_shared_panels.dart`) so the open-civilian → wait-root →
+/// Assign-sweep → close-sheet → perf-timing recipe is shared and
+/// unit-pinned (Refs GitHub #2336 AC1 / AC2 / AC5 / Bottleneck 5). The
+/// post-bundle Explore scenario calls the lifted form through the AC1
+/// barrel alias `checkExploreEnabledFromCivilianPanel`
+/// (`e2e_helpers.dart`) inside a bounded `maxBoundedTurnRetries (8)` retry
+/// loop. The widget-test pin in
+/// `app/test/e2e_check_explore_enabled_from_civilian_panel_test.dart`
+/// guards against silent regressions (the integration suite cannot
+/// validate this directly today — `app_e2e_linux` is a no-op per
+/// `SPEC/program/e2e-integration-tests.md` § CI). A regression that
+/// dropped the `closeBottomSheet` call would stall the retry loop on a
+/// stale Assign sheet; one that swapped `bottomSheetCloseTimeout` for the
+/// default 30 s would inflate the per-iteration wall clock past the
+/// `_kMaxUiResponseWait (5s)` cap #2336 is reducing.

--- a/app/integration_test/new_game_fleet_reaches_new_world_e2e_test.dart
+++ b/app/integration_test/new_game_fleet_reaches_new_world_e2e_test.dart
@@ -340,39 +340,12 @@ void main() {
       );
 
       await e2eTapNewWorldRegionTabIfPresent(tester);
-      Future<bool> checkExploreEnabledFromCivilianPanel() async {
-        final phaseSw = Stopwatch()..start();
-        await openCivilianPanel(
-          tester,
-          afterSheetPanelsClearPhase:
-              'pump_until_panels_cleared_after_close_sheet_fleet_civilian_open',
-          bottomSheetCloseTimeout: _kMaxUiResponseWait,
-        );
-        await waitUntilFound(
-          tester,
-          find.byKey(kCtE2ECivilianPanelRootKey),
-          timeout: _kMaxUiResponseWait,
-          perf: perf,
-          phaseName: 'wait_until_found_civilian_panel',
-        );
-        final enabled = await anyExplorerHasEnabledExploreAssignFleet(
-          tester,
-          maxUiResponseWait: _kMaxUiResponseWait,
-        );
-        await closeBottomSheet(
-          tester,
-          perf: perf,
-          overallTimeout: _kMaxUiResponseWait,
-        );
-        perf.timing(
-          'bundled_explore_retry_loop',
-          phaseSw.elapsed,
-          meta: 'result=${enabled ? "enabled" : "not_enabled"}',
-        );
-        return enabled;
-      }
 
-      var exploreEnabled = await checkExploreEnabledFromCivilianPanel();
+      var exploreEnabled = await checkExploreEnabledFromCivilianPanel(
+        tester,
+        perf: perf,
+        maxUiResponseWait: _kMaxUiResponseWait,
+      );
       // Linux CI can require more than three post-reveal turns before the
       // Assign list surfaces an enabled Explore row for at least one explorer.
       // Keep strict failure semantics, but widen the bounded retry window.
@@ -388,7 +361,11 @@ void main() {
         await advanceOneHumanTurn(tester, l10n: l10n, perf: perf);
         await dismissTransientUi(tester, perf: perf);
         await e2eTapNewWorldRegionTabIfPresent(tester);
-        exploreEnabled = await checkExploreEnabledFromCivilianPanel();
+        exploreEnabled = await checkExploreEnabledFromCivilianPanel(
+          tester,
+          perf: perf,
+          maxUiResponseWait: _kMaxUiResponseWait,
+        );
       }
       if (!exploreEnabled) {
         if (!e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot(

--- a/app/test/e2e_check_explore_enabled_from_civilian_panel_test.dart
+++ b/app/test/e2e_check_explore_enabled_from_civilian_panel_test.dart
@@ -1,0 +1,362 @@
+/// Pins the widget-tree contract of
+/// [e2eCheckExploreEnabledFromCivilianPanel]
+/// (`app/integration_test/e2e_test_shared_panels.dart`).
+///
+/// The post-bundle Explore scenario in
+/// `new_game_fleet_reaches_new_world_e2e_test.dart` calls this helper via
+/// the AC1 barrel alias `checkExploreEnabledFromCivilianPanel` inside a
+/// bounded `maxBoundedTurnRetries (8)` retry loop. The helper composes
+/// four sub-steps (`open civilian panel`, `wait for root`, `Assign sweep`,
+/// `close bottom sheet`) and emits a single `perf.timing(...)` entry per
+/// invocation under the canonical
+/// `kE2eDefaultBundledExploreRetryLoopPhase` ('bundled_explore_retry_loop')
+/// phase label.
+///
+/// A silent regression here would either:
+///
+///   - Skip the `closeBottomSheet` call and stall the next retry
+///     iteration on a stale Assign sheet — burning wall-clock the
+///     bottom-sheet-close timeout already caps.
+///   - Drop the `perf.timing(...)` invocation and orphan any telemetry /
+///     dashboards keyed on the `bundled_explore_retry_loop` phase, hiding
+///     Bottleneck 5 regressions.
+///   - Forward the wrong [maxUiResponseWait] into either
+///     [e2eAnyExplorerHasEnabledExploreAssignFleet] or
+///     [e2eCloseBottomSheet] — inflating the per-iteration wall clock
+///     past the `_kMaxUiResponseWait (5s)` cap #2336 is reducing.
+///   - Flip the `meta=` payload between `result=enabled` /
+///     `result=not_enabled`, masking a real Explore-enabled regression as
+///     a steady-state pass.
+///
+/// The integration suite cannot validate this directly today (the
+/// `app_e2e_linux` lane is a no-op per
+/// `SPEC/program/e2e-integration-tests.md` § CI), so this widget-test
+/// layer carries the behavioural pin.
+///
+/// Refs GitHub #2336 AC1 / AC2 / AC5 / Bottleneck 5.
+library;
+
+import 'package:colonizethis_app/config/ct_e2e.dart';
+import 'package:colonizethis_app/config/ct_e2e_last_panel_snapshot.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart'
+    show kWorkTargetBuildRoad, kWorkTargetExplore;
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../integration_test/e2e_helpers.dart';
+import '../integration_test/e2e_test_shared.dart' as shared;
+
+const String _human = 'gp1';
+
+const TurnState _orderingTurn = TurnState(
+  phase: TurnPhase.orders,
+  turnNumber: 1,
+);
+
+const Orders _emptyOrders = Orders();
+
+Game _game() => const Game(
+  id: 'g1',
+  worldState: WorldState(
+    turnState: _orderingTurn,
+    oldWorld: RegionData(),
+    newWorld: RegionData(),
+  ),
+  players: [Player(id: _human, displayName: 'You', isHuman: true)],
+);
+
+CtE2eCivilianPanelSnapshot _civilianSnapshot({
+  Map<String, List<String>> availableWorkTargets = const {},
+}) => CtE2eCivilianPanelSnapshot(
+  game: _game(),
+  humanPlayerId: _human,
+  currentOrders: _emptyOrders,
+  availableWorkTargets: availableWorkTargets,
+);
+
+/// Mounts a hit-testable civilian panel root with the given children so
+/// [e2eOpenCivilianPanel] short-circuits on its
+/// `civilianPanel.hitTestable().evaluate().isNotEmpty` precondition. The
+/// helper exits before attempting to open the empire rail / marker
+/// triggers, isolating the contract under test to the wait/sweep/close
+/// composition only.
+Widget _wrap({required List<Widget> children}) => MaterialApp(
+  home: Scaffold(
+    body: KeyedSubtree(
+      key: kCtE2ECivilianPanelRootKey,
+      child: ListView(children: children),
+    ),
+  ),
+);
+
+/// Captures every `debugPrint` line emitted while [body] runs and restores
+/// the original printer afterwards (defensive in `finally` so a thrown
+/// expectation does not leak the override into later tests).
+Future<List<String>> _captureDebugPrints(Future<void> Function() body) async {
+  final captured = <String>[];
+  final original = debugPrint;
+  debugPrint = (String? message, {int? wrapWidth}) {
+    captured.add(message ?? '');
+  };
+  try {
+    await body();
+  } finally {
+    debugPrint = original;
+  }
+  return captured;
+}
+
+void main() {
+  suppressLogsForTests();
+
+  setUp(() {
+    ctE2eCivilianPanelSnapshot = null;
+  });
+
+  tearDown(() {
+    ctE2eCivilianPanelSnapshot = null;
+  });
+
+  group('e2eCheckExploreEnabledFromCivilianPanel — default constants', () {
+    test('kE2eDefaultBundledExploreRetryLoopPhase preserves the legacy '
+        'inline-closure phase literal', () {
+      expect(
+        kE2eDefaultBundledExploreRetryLoopPhase,
+        'bundled_explore_retry_loop',
+        reason:
+            'Pre-lift `perf.timing("bundled_explore_retry_loop", ...)` '
+            'callers (and downstream `E2E_TIMING|phase=...` scrapers) '
+            'must keep seeing the same canonical phase name; a silent '
+            'rename would orphan every dashboard/key keyed on '
+            '`bundled_explore_retry_loop` and hide Bottleneck 5 '
+            'regressions.',
+      );
+    });
+
+    test('kE2eDefaultFleetCivilianOpenAfterSheetClearPhase preserves the '
+        'legacy fleet-scenario attribution label', () {
+      expect(
+        kE2eDefaultFleetCivilianOpenAfterSheetClearPhase,
+        'pump_until_panels_cleared_after_close_sheet_fleet_civilian_open',
+        reason:
+            'The fleet-scenario override label is distinct from the '
+            'generic `_civilian_open` default used by '
+            '[e2eOpenCivilianPanel] callers in the full-turn scenario; '
+            'collapsing the two would attribute fleet retry-loop '
+            'post-sheet-close pumps to the wrong scenario in AC8 '
+            'timing tables.',
+      );
+    });
+  });
+
+  group('e2eCheckExploreEnabledFromCivilianPanel — snapshot short-circuit', () {
+    testWidgets('snapshot says Explore enabled -> returns true and emits '
+        'result=enabled timing event', (tester) async {
+      ctE2eCivilianPanelSnapshot = _civilianSnapshot(
+        availableWorkTargets: const {
+          'explorer-1': [kWorkTargetExplore],
+        },
+      );
+      await tester.pumpWidget(
+        _wrap(children: const [ListTile(title: Text('Stub'))]),
+      );
+      final perf = shared.E2ePerfLog('check_explore_pin');
+      late bool result;
+      final lines = await _captureDebugPrints(() async {
+        result = await e2eCheckExploreEnabledFromCivilianPanel(
+          tester,
+          perf: perf,
+          maxUiResponseWait: const Duration(seconds: 5),
+        );
+      });
+      expect(result, isTrue);
+      final timingLines = lines
+          .where((line) => line.startsWith('E2E_TIMING|'))
+          .toList();
+      expect(
+        timingLines.any(
+          (line) =>
+              line.contains('|phase=$kE2eDefaultBundledExploreRetryLoopPhase|'),
+        ),
+        isTrue,
+        reason:
+            'A successful return must emit exactly one `E2E_TIMING` '
+            'marker keyed on `bundled_explore_retry_loop` — the '
+            'phase name AC8 / Bottleneck 5 dashboards key on.',
+      );
+      expect(
+        timingLines.any((line) => line.endsWith('|meta=result=enabled')),
+        isTrue,
+        reason:
+            'The `meta=result=enabled` payload distinguishes successful '
+            'Explore detection from the `not_enabled` exhaustion path; '
+            'a regression that flipped the boolean encoding would '
+            'silently invert AC8 success/fail attribution.',
+      );
+    });
+
+    testWidgets('snapshot says no Explore enabled -> returns false and emits '
+        'result=not_enabled timing event', (tester) async {
+      ctE2eCivilianPanelSnapshot = _civilianSnapshot(
+        availableWorkTargets: const {
+          'unit-1': [kWorkTargetBuildRoad],
+        },
+      );
+      await tester.pumpWidget(
+        _wrap(children: const [ListTile(title: Text('Stub'))]),
+      );
+      final perf = shared.E2ePerfLog('check_explore_pin');
+      late bool result;
+      final lines = await _captureDebugPrints(() async {
+        result = await e2eCheckExploreEnabledFromCivilianPanel(
+          tester,
+          perf: perf,
+        );
+      });
+      expect(result, isFalse);
+      final timingLines = lines
+          .where((line) => line.startsWith('E2E_TIMING|'))
+          .toList();
+      expect(
+        timingLines.any((line) => line.endsWith('|meta=result=not_enabled')),
+        isTrue,
+        reason:
+            'A snapshot `false` verdict must still emit a timing '
+            'event so dashboards counting retry iterations (every '
+            'iteration of the bounded retry window) attribute the '
+            'exhaustion path correctly; dropping the marker on '
+            '`false` would skew Bottleneck 5 cost attribution.',
+      );
+    });
+
+    testWidgets(
+      'perf parameter is optional — no E2E_TIMING marker emitted when '
+      'perf is null',
+      (tester) async {
+        ctE2eCivilianPanelSnapshot = _civilianSnapshot(
+          availableWorkTargets: const {
+            'explorer-1': [kWorkTargetExplore],
+          },
+        );
+        await tester.pumpWidget(
+          _wrap(children: const [ListTile(title: Text('Stub'))]),
+        );
+        late bool result;
+        final lines = await _captureDebugPrints(() async {
+          result = await e2eCheckExploreEnabledFromCivilianPanel(tester);
+        });
+        expect(result, isTrue);
+        expect(
+          lines.where((line) => line.startsWith('E2E_TIMING|')),
+          isEmpty,
+          reason:
+              'Callers that opt out of perf logging (no shared '
+              '`E2ePerfLog`) must not trigger spurious markers; the '
+              'helper must guard the `perf?.timing(...)` call with a '
+              'null check so unit tests / future stand-alone callers '
+              'can use the helper without instantiating a perf log.',
+        );
+      },
+    );
+  });
+
+  group(
+    'e2eCheckExploreEnabledFromCivilianPanel — phaseTimingLabel override',
+    () {
+      testWidgets(
+        'phaseTimingLabel overrides the default phase= field while keeping '
+        'meta=result=...',
+        (tester) async {
+          ctE2eCivilianPanelSnapshot = _civilianSnapshot(
+            availableWorkTargets: const {
+              'explorer-1': [kWorkTargetExplore],
+            },
+          );
+          await tester.pumpWidget(
+            _wrap(children: const [ListTile(title: Text('Stub'))]),
+          );
+          final perf = shared.E2ePerfLog('check_explore_pin');
+          final lines = await _captureDebugPrints(() async {
+            await e2eCheckExploreEnabledFromCivilianPanel(
+              tester,
+              perf: perf,
+              phaseTimingLabel: 'pin_custom_phase',
+            );
+          });
+          final timingLines = lines
+              .where((line) => line.startsWith('E2E_TIMING|'))
+              .toList();
+          expect(
+            timingLines.any(
+              (line) =>
+                  line.contains('|phase=pin_custom_phase|') &&
+                  line.endsWith('|meta=result=enabled'),
+            ),
+            isTrue,
+            reason:
+                'Callers (for example a future develop-phase retry loop '
+                'reusing the same composition) must be able to attribute '
+                'their timing under a distinct phase label without '
+                'forking the helper implementation. A regression that '
+                'hard-coded the default would silently merge attribution '
+                'across scenarios.',
+          );
+        },
+      );
+    },
+  );
+
+  group('e2eCheckExploreEnabledFromCivilianPanel — AC1 barrel forwarding', () {
+    testWidgets(
+      'checkExploreEnabledFromCivilianPanel (barrel alias) returns the '
+      'same boolean as the lifted form',
+      (tester) async {
+        ctE2eCivilianPanelSnapshot = _civilianSnapshot(
+          availableWorkTargets: const {
+            'explorer-1': [kWorkTargetExplore],
+          },
+        );
+        await tester.pumpWidget(
+          _wrap(children: const [ListTile(title: Text('Stub'))]),
+        );
+        final result = await checkExploreEnabledFromCivilianPanel(tester);
+        expect(
+          result,
+          isTrue,
+          reason:
+              'The AC1 barrel wrapper must forward all named arguments '
+              'in the documented order and preserve the boolean return '
+              'value. A regression that dropped `tester` from the '
+              'signature, swapped `perf` with `maxUiResponseWait`, or '
+              'fail-opened to `false` would surface here, not in the '
+              'slow CI lane.',
+        );
+      },
+    );
+
+    test('checkExploreEnabledFromCivilianPanel is re-exported as a tear-off '
+        '(compile-time signature pin)', () {
+      final Future<bool> Function(
+        WidgetTester, {
+        shared.E2ePerfLog? perf,
+        Duration maxUiResponseWait,
+        String afterSheetPanelsClearPhase,
+        String phaseTimingLabel,
+      })
+      ref = checkExploreEnabledFromCivilianPanel;
+      expect(
+        ref,
+        isNotNull,
+        reason:
+            'The AC1 barrel must continue to export the helper with '
+            'the documented signature. A silent removal from the '
+            '`show` clause, an arg-order swap on the wrapper, or a '
+            'changed default for `maxUiResponseWait` / '
+            '`afterSheetPanelsClearPhase` / `phaseTimingLabel` '
+            'would fail this assignment at compile time.',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Lifts the previously inline `checkExploreEnabledFromCivilianPanel`
closure from `new_game_fleet_reaches_new_world_e2e_test.dart` into the
public `e2eCheckExploreEnabledFromCivilianPanel`
(`e2e_test_shared_panels.dart`) and exposes it via the AC1 barrel as
`checkExploreEnabledFromCivilianPanel` (`e2e_helpers.dart`). The post-
bundle Explore scenario consumed the closure twice (initial check +
bounded retry loop), so a regression in the open-civilian → wait-root
→ Assign-sweep → close-sheet → perf-timing recipe — for example a
dropped `closeBottomSheet`, an inflated `bottomSheetCloseTimeout`, or
a flipped `meta=result=...` payload — would not have been caught
anywhere because the `app_e2e_linux` lane is a no-op
(`SPEC/program/e2e-integration-tests.md` § CI).

Mirrors the slice cadence of #2720 / #2722 / #2723 / #2724 / #2725 /
#2726.

## Done in this push

### `e2e_test_shared_panels.dart`

- `e2eCheckExploreEnabledFromCivilianPanel(...)` — composes
  `e2eOpenCivilianPanel` (with the legacy fleet-scenario
  `afterSheetPanelsClearPhase` override), `e2eWaitUntilFound` on
  `kCtE2ECivilianPanelRootKey`, `e2eAnyExplorerHasEnabledExploreAssignFleet`,
  and `e2eCloseBottomSheet`. Emits one `perf.timing(...)` event per
  invocation when `perf` is non-null with phase
  `kE2eDefaultBundledExploreRetryLoopPhase` and `meta=result=enabled`
  / `meta=result=not_enabled`.
- New public constants
  `kE2eDefaultBundledExploreRetryLoopPhase = 'bundled_explore_retry_loop'`
  and `kE2eDefaultFleetCivilianOpenAfterSheetClearPhase =
  'pump_until_panels_cleared_after_close_sheet_fleet_civilian_open'`
  preserve the legacy literals so a silent rename surfaces
  immediately in the test pin.

### `e2e_helpers.dart` (AC1 barrel)

- Adds `e2eCheckExploreEnabledFromCivilianPanel`,
  `kE2eDefaultBundledExploreRetryLoopPhase`,
  `kE2eDefaultBundledExploreSweepWait`, and
  `kE2eDefaultFleetCivilianOpenAfterSheetClearPhase` to the `show`
  clause.
- AC1 barrel alias `checkExploreEnabledFromCivilianPanel(...)`
  forwards every named argument with the documented defaults.

### `new_game_fleet_reaches_new_world_e2e_test.dart`

- Removes the 33-line inline closure; both call sites now consume the
  AC1 alias with explicit `perf: perf, maxUiResponseWait:
  _kMaxUiResponseWait` so the legacy 5 s cap is preserved.

### `new_game_fleet_reaches_new_world_e2e_helpers_part2.dart`

- Adds a docstring entry documenting the lift (matches the prior
  slice pattern of leaving the file as a record of what moved
  where).

### `app/test/e2e_check_explore_enabled_from_civilian_panel_test.dart` (NEW, 8 tests)

1. `kE2eDefaultBundledExploreRetryLoopPhase` matches the legacy
   `'bundled_explore_retry_loop'` literal.
2. `kE2eDefaultFleetCivilianOpenAfterSheetClearPhase` matches the
   legacy fleet-scenario `pump_until_panels_cleared_after_close_sheet_fleet_civilian_open`
   override.
3. Snapshot says Explore enabled → returns `true` and emits exactly
   one `E2E_TIMING|...|phase=bundled_explore_retry_loop|...|meta=result=enabled`.
4. Snapshot says no Explore enabled → returns `false` and emits
   `meta=result=not_enabled` (proves `false` is not silently dropped).
5. `perf` parameter is optional — no `E2E_TIMING` marker emitted
   when `perf` is `null` (guards the `perf?.timing(...)` null check).
6. `phaseTimingLabel` override emits under the custom phase name
   while keeping the `meta=result=...` payload (proves the
   override does not leak into `meta`).
7. AC1 barrel wrapper returns the same boolean as the lifted form.
8. AC1 barrel wrapper is re-exported as a tear-off with the
   documented signature (compile-time pin).

## Local verification

- `cd app && flutter analyze integration_test/
  test/e2e_check_explore_enabled_from_civilian_panel_test.dart` →
  no issues.
- `cd app && flutter test
  test/e2e_check_explore_enabled_from_civilian_panel_test.dart` →
  8/8 pass.
- `cd app && flutter test test/e2e_any_explorer_has_enabled_explore_assign_fleet_test.dart
  test/e2e_helpers_barrel_test.dart
  test/e2e_await_nw_coastal_or_visible_land_for_bundled_explore_test.dart
  test/e2e_test_shared_smoke_test.dart test/e2e_perf_log_markers_test.dart` →
  82/82 pass (no adjacent regressions).
- `dart format` of touched files → clean.
- `dart run tool/ct_repo_lint.dart` with `CT_REPO_LINT_INCLUDE_APP=true`,
  `GITHUB_BASE_REF=dev`, `CT_REPO_LINT_BASE_SHA=\$(git merge-base HEAD
  origin/dev)` → all 47 rules pass.

## Acceptance criteria coverage (#2336)

- **AC1** (canonical public-name surface for shared E2E helpers):
  satisfied — `e2eCheckExploreEnabledFromCivilianPanel` is the
  single public implementation; `checkExploreEnabledFromCivilianPanel`
  is the only stable alias.
- **AC2** (test files import only the AC1 barrel for shared
  helpers): satisfied — the fleet test now consumes the alias only;
  no inline closure remains.
- **AC5** (adaptive polling / no wasted fixed-delay budget):
  satisfied structurally — the new helper composes existing
  Bottleneck-5-adapted helpers and introduces no new fixed pumps.

## Deferred / out of scope on this PR

- AC6–AC10 (aggregate wall-clock baseline/post-refactor table on a
  Linux desktop with `xvfb-run`): the maintainer-only step remains
  open because this host lacks a display server. Each lift slice
  reduces the surface area future Bottleneck 1–5 work targets, but
  the AC8 timing pipeline (`tool/run_e2e_timing.sh`) still requires
  an interactive Linux desktop capture.

## Label transition

`backlog:implementation` **not** moved to `backlog:verification` —
several private E2E helpers remain inline (e.g. the fleet turn-loop
itself, the final-naval-check block), and AC6–AC10 still need a
maintainer Linux-desktop timing capture.

Refs #2336

Made with [Cursor](https://cursor.com)