### PR TITLE
test(e2e): lift checkExploreEnabledFromCivilianPanel into shared library + pin (Refs #2336)

### DIFF
--- a/app/integration_test/e2e_helpers.dart
+++ b/app/integration_test/e2e_helpers.dart
@@ -20,6 +20,7 @@ export 'e2e_test_shared.dart'
         e2eAdaptivePollRampAfterIdle,
         e2eAwaitNwCoastalOrVisibleLandForBundledExplore,
         e2eBundledExploreRejectionDiagnostics,
+        e2eCheckExploreEnabledFromCivilianPanel,
         e2eExploreAssignEnabledFromCivilianSnapshot,
         e2eFleetReachDoneFromCtSnapshotOnly,
         e2eHarnessDetectsNonHomeFleetInNewWorld,
@@ -33,7 +34,9 @@ export 'e2e_test_shared.dart'
         e2ePickMoveDestinationAndConfirm,
         e2eTryNavalMoveSegment,
         e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot,
+        kE2eCheckExploreEnabledFromCivilianPanelPhase,
         kE2eDefaultBundledExploreReadinessMaxTurns,
+        kE2eDefaultBundledExploreSweepWait,
         kE2eDefaultNavalMoveSegmentUiWait,
         e2ePumpUntil,
         e2ePumpUntilConditionOrIdle,
@@ -238,6 +241,25 @@ Future<bool> anyExplorerHasEnabledExploreAssignFleet(
   tester,
   maxUiResponseWait: maxUiResponseWait,
   maxPanelSweepSteps: maxPanelSweepSteps,
+);
+
+/// Stable public name for [e2eCheckExploreEnabledFromCivilianPanel] so the
+/// post-bundle Explore scenario consumes the AC1 barrel only (Refs GitHub
+/// #2336 AC1 / AC2 / AC5 / Bottleneck 5). Forwards to the implementation in
+/// `e2e_test_shared_panels.dart`.
+Future<bool> checkExploreEnabledFromCivilianPanel(
+  WidgetTester tester, {
+  E2ePerfLog? perf,
+  Duration maxUiResponseWait = kE2eDefaultBundledExploreSweepWait,
+  String waitUntilFoundPhase = 'wait_until_found_civilian_panel',
+  String afterSheetPanelsClearPhase =
+      'pump_until_panels_cleared_after_close_sheet_fleet_civilian_open',
+}) => e2eCheckExploreEnabledFromCivilianPanel(
+  tester,
+  perf: perf,
+  maxUiResponseWait: maxUiResponseWait,
+  waitUntilFoundPhase: waitUntilFoundPhase,
+  afterSheetPanelsClearPhase: afterSheetPanelsClearPhase,
 );
 
 /// Stable public name for [e2eAwaitNwCoastalOrVisibleLandForBundledExplore]

--- a/app/integration_test/e2e_test_shared_panels.dart
+++ b/app/integration_test/e2e_test_shared_panels.dart
@@ -1262,3 +1262,90 @@ Future<void> e2eAwaitNwCoastalOrVisibleLandForBundledExplore(
     }
   }
 }
+
+/// Canonical phase label recorded by [e2eCheckExploreEnabledFromCivilianPanel]
+/// for each invocation. Matches the pre-lift private closure literal in
+/// `new_game_fleet_reaches_new_world_e2e_test.dart`, which the post-bundle
+/// Explore scenario emitted once initially and once per `maxBoundedTurnRetries`
+/// iteration; any future timing harness that aggregates per-phase totals must
+/// continue to see this label so the readiness retry slice stays attributable
+/// (Refs GitHub #2336 AC1 / AC2 / AC8 / `SPEC/program/e2e-integration-tests.md`
+/// § Baseline / post-refactor timing).
+const String kE2eCheckExploreEnabledFromCivilianPanelPhase =
+    'bundled_explore_retry_loop';
+
+/// Opens the civilian panel, waits for [kCtE2ECivilianPanelRootKey] to mount,
+/// evaluates [e2eAnyExplorerHasEnabledExploreAssignFleet], closes the bottom
+/// sheet, and records the elapsed wall-clock under
+/// [kE2eCheckExploreEnabledFromCivilianPanelPhase] with meta
+/// `'result=enabled'` or `'result=not_enabled'`.
+///
+/// Lifted from the formerly private `checkExploreEnabledFromCivilianPanel`
+/// closure in `new_game_fleet_reaches_new_world_e2e_test.dart` (Refs GitHub
+/// #2336 AC1 / AC2 / AC5 / Bottleneck 5). The post-bundle Explore scenario
+/// invoked this helper once initially and then inside a bounded retry window
+/// (`maxBoundedTurnRetries = 8`) — centralising it preserves the phase-label
+/// and perf-timing surface the AC8 timing pipeline keys off, while removing
+/// the last file-scope private orchestration helper in the fleet bundled
+/// Explore path. The widget-test pin in
+/// `app/test/e2e_check_explore_enabled_from_civilian_panel_test.dart` guards
+/// against silent regressions because the integration suite cannot validate
+/// this directly today (`app_e2e_linux` is a no-op per
+/// `SPEC/program/e2e-integration-tests.md` § CI).
+///
+/// Contract:
+///
+/// - Delegates panel opening to [e2eOpenCivilianPanel] with
+///   [bottomSheetCloseTimeout] / [afterSheetPanelsClearPhase] forwarded so the
+///   AC1 phase labels remain stable for log-driven attribution.
+/// - Waits for [kCtE2ECivilianPanelRootKey] with [maxUiResponseWait] under
+///   the [waitUntilFoundPhase] label so the live opener's race window is the
+///   same as the pre-lift closure.
+/// - Returns the verdict from
+///   [e2eAnyExplorerHasEnabledExploreAssignFleet] verbatim (snapshot
+///   short-circuit included) — the helper itself never widens or narrows
+///   that decision.
+/// - Always calls [e2eCloseBottomSheet] before returning, even on `true`,
+///   so the caller can immediately enter the next retry / next-turn step
+///   without the sheet blocking subsequent rail/marker taps.
+/// - Emits exactly one [E2ePerfLog.timing] entry per call (when [perf] is
+///   non-null) under [kE2eCheckExploreEnabledFromCivilianPanelPhase] with the
+///   `'result=...'` meta.
+Future<bool> e2eCheckExploreEnabledFromCivilianPanel(
+  WidgetTester tester, {
+  E2ePerfLog? perf,
+  Duration maxUiResponseWait = kE2eDefaultBundledExploreSweepWait,
+  String waitUntilFoundPhase = 'wait_until_found_civilian_panel',
+  String afterSheetPanelsClearPhase =
+      'pump_until_panels_cleared_after_close_sheet_fleet_civilian_open',
+}) async {
+  final phaseSw = Stopwatch()..start();
+  await e2eOpenCivilianPanel(
+    tester,
+    perf: perf,
+    afterSheetPanelsClearPhase: afterSheetPanelsClearPhase,
+    bottomSheetCloseTimeout: maxUiResponseWait,
+  );
+  await e2eWaitUntilFound(
+    tester,
+    find.byKey(kCtE2ECivilianPanelRootKey),
+    timeout: maxUiResponseWait,
+    perf: perf,
+    phaseName: waitUntilFoundPhase,
+  );
+  final enabled = await e2eAnyExplorerHasEnabledExploreAssignFleet(
+    tester,
+    maxUiResponseWait: maxUiResponseWait,
+  );
+  await e2eCloseBottomSheet(
+    tester,
+    perf: perf,
+    overallTimeout: maxUiResponseWait,
+  );
+  perf?.timing(
+    kE2eCheckExploreEnabledFromCivilianPanelPhase,
+    phaseSw.elapsed,
+    meta: 'result=${enabled ? "enabled" : "not_enabled"}',
+  );
+  return enabled;
+}

--- a/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers_part2.dart
+++ b/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers_part2.dart
@@ -111,3 +111,21 @@ part of 'new_game_fleet_reaches_new_world_e2e_test.dart';
 /// barrel alias `advanceOneHumanTurn` (`e2e_helpers.dart`); the widget-test
 /// pin in `app/test/e2e_advance_one_human_turn_test.dart` carries the
 /// behavioural contract.
+
+/// The `checkExploreEnabledFromCivilianPanel` closure (formerly declared
+/// inside the post-bundle Explore `testWidgets` body in
+/// `new_game_fleet_reaches_new_world_e2e_test.dart`) was lifted into
+/// [e2eCheckExploreEnabledFromCivilianPanel]
+/// (`e2e_test_shared_panels.dart`) so the open-civilian / wait /
+/// any-explorer-enabled / close-sheet / perf-timing sequence is shared
+/// and unit-pinned (Refs GitHub #2336 AC1 / AC2 / AC5 / Bottleneck 5).
+/// The fleet scenario calls the lifted form through the AC1 barrel alias
+/// `checkExploreEnabledFromCivilianPanel` (`e2e_helpers.dart`). The
+/// widget-test pin in
+/// `app/test/e2e_check_explore_enabled_from_civilian_panel_test.dart`
+/// guards against silent regressions because the integration suite
+/// cannot validate this directly today (`app_e2e_linux` is a no-op per
+/// `SPEC/program/e2e-integration-tests.md` § CI). A regression here
+/// would burn `maxBoundedTurnRetries (8) × ~5 s` retry wall-clock on
+/// the bundled-Explore path — Bottleneck 5 in
+/// `SPEC/program/e2e-integration-tests.md` § Determinism.

--- a/app/integration_test/new_game_fleet_reaches_new_world_e2e_test.dart
+++ b/app/integration_test/new_game_fleet_reaches_new_world_e2e_test.dart
@@ -340,39 +340,11 @@ void main() {
       );
 
       await e2eTapNewWorldRegionTabIfPresent(tester);
-      Future<bool> checkExploreEnabledFromCivilianPanel() async {
-        final phaseSw = Stopwatch()..start();
-        await openCivilianPanel(
-          tester,
-          afterSheetPanelsClearPhase:
-              'pump_until_panels_cleared_after_close_sheet_fleet_civilian_open',
-          bottomSheetCloseTimeout: _kMaxUiResponseWait,
-        );
-        await waitUntilFound(
-          tester,
-          find.byKey(kCtE2ECivilianPanelRootKey),
-          timeout: _kMaxUiResponseWait,
-          perf: perf,
-          phaseName: 'wait_until_found_civilian_panel',
-        );
-        final enabled = await anyExplorerHasEnabledExploreAssignFleet(
-          tester,
-          maxUiResponseWait: _kMaxUiResponseWait,
-        );
-        await closeBottomSheet(
-          tester,
-          perf: perf,
-          overallTimeout: _kMaxUiResponseWait,
-        );
-        perf.timing(
-          'bundled_explore_retry_loop',
-          phaseSw.elapsed,
-          meta: 'result=${enabled ? "enabled" : "not_enabled"}',
-        );
-        return enabled;
-      }
-
-      var exploreEnabled = await checkExploreEnabledFromCivilianPanel();
+      var exploreEnabled = await checkExploreEnabledFromCivilianPanel(
+        tester,
+        perf: perf,
+        maxUiResponseWait: _kMaxUiResponseWait,
+      );
       // Linux CI can require more than three post-reveal turns before the
       // Assign list surfaces an enabled Explore row for at least one explorer.
       // Keep strict failure semantics, but widen the bounded retry window.
@@ -388,7 +360,11 @@ void main() {
         await advanceOneHumanTurn(tester, l10n: l10n, perf: perf);
         await dismissTransientUi(tester, perf: perf);
         await e2eTapNewWorldRegionTabIfPresent(tester);
-        exploreEnabled = await checkExploreEnabledFromCivilianPanel();
+        exploreEnabled = await checkExploreEnabledFromCivilianPanel(
+          tester,
+          perf: perf,
+          maxUiResponseWait: _kMaxUiResponseWait,
+        );
       }
       if (!exploreEnabled) {
         if (!e2ePlayerHasAnyNewWorldFoggedOrBetterFromCtSnapshot(

--- a/app/test/e2e_check_explore_enabled_from_civilian_panel_test.dart
+++ b/app/test/e2e_check_explore_enabled_from_civilian_panel_test.dart
@@ -1,0 +1,320 @@
+/// Pins the widget-tree contract of
+/// [e2eCheckExploreEnabledFromCivilianPanel]
+/// (`app/integration_test/e2e_test_shared_panels.dart`).
+///
+/// The post-bundle Explore scenario in
+/// `new_game_fleet_reaches_new_world_e2e_test.dart` calls this helper via
+/// the AC1 barrel alias `checkExploreEnabledFromCivilianPanel` once
+/// initially and again on each retry of the bounded
+/// `maxBoundedTurnRetries = 8` window. A silent rename or fail-open here
+/// would either:
+///
+///   - Skip the open-civilian / wait / Explore-readiness / close-sheet
+///     orchestration and let the strict Explore-enabled assertion run
+///     against stale UI — masking a real production regression; or
+///   - Stall on the slow `maxPanelSweepSteps (16) × per-step Assign sweep`
+///     path the snapshot short-circuit already avoids — Bottleneck 5 in
+///     `SPEC/program/e2e-integration-tests.md` § Determinism, burning
+///     wall-clock the lift was meant to centralise.
+///
+/// The integration suite cannot validate this directly today (the
+/// `app_e2e_linux` lane is a no-op per
+/// `SPEC/program/e2e-integration-tests.md` § CI), so the widget-test
+/// layer carries the behavioural pin.
+///
+/// Refs GitHub #2336 AC1 / AC2 / AC5 / Bottleneck 5.
+library;
+
+import 'package:colonizethis_app/config/ct_e2e.dart';
+import 'package:colonizethis_app/config/ct_e2e_last_panel_snapshot.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart'
+    show kWorkTargetBuildRoad, kWorkTargetExplore;
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../integration_test/e2e_helpers.dart';
+
+const String _human = 'gp1';
+
+const TurnState _orderingTurn = TurnState(
+  phase: TurnPhase.orders,
+  turnNumber: 1,
+);
+
+const Orders _emptyOrders = Orders();
+
+Game _game() => const Game(
+  id: 'g1',
+  worldState: WorldState(
+    turnState: _orderingTurn,
+    oldWorld: RegionData(),
+    newWorld: RegionData(),
+  ),
+  players: [Player(id: _human, displayName: 'You', isHuman: true)],
+);
+
+CtE2eCivilianPanelSnapshot _snapshot({
+  Map<String, List<String>> availableWorkTargets = const {},
+}) => CtE2eCivilianPanelSnapshot(
+  game: _game(),
+  humanPlayerId: _human,
+  currentOrders: _emptyOrders,
+  availableWorkTargets: availableWorkTargets,
+);
+
+/// Mounts an already-visible civilian panel root under
+/// [kCtE2ECivilianPanelRootKey]. The lifted helper's first step
+/// ([e2eOpenCivilianPanel]) short-circuits when this key resolves to a
+/// hit-testable element, so the widget test never needs to drive the empire
+/// rail / marker tap path (those production-only triggers are out of scope
+/// for the pin).
+Widget _wrapPanelAlreadyOpen() => MaterialApp(
+  home: Scaffold(
+    body: KeyedSubtree(
+      key: kCtE2ECivilianPanelRootKey,
+      child: ListView(
+        children: const [ListTile(title: Text('panel content placeholder'))],
+      ),
+    ),
+  ),
+);
+
+/// Captures every `debugPrint` line emitted while [body] runs and restores
+/// the original printer afterwards (defensive in `finally` so a thrown
+/// expectation does not leak the override into later tests). Mirrors the
+/// pattern used by `e2e_perf_log_markers_test.dart`.
+Future<List<String>> _captureDebugPrints(Future<void> Function() body) async {
+  final captured = <String>[];
+  final original = debugPrint;
+  debugPrint = (String? message, {int? wrapWidth}) {
+    captured.add(message ?? '');
+  };
+  try {
+    await body();
+  } finally {
+    debugPrint = original;
+  }
+  return captured;
+}
+
+void main() {
+  suppressLogsForTests();
+
+  setUp(() {
+    ctE2eCivilianPanelSnapshot = null;
+  });
+
+  tearDown(() {
+    ctE2eCivilianPanelSnapshot = null;
+  });
+
+  group('e2eCheckExploreEnabledFromCivilianPanel — phase label const', () {
+    test(
+      'kE2eCheckExploreEnabledFromCivilianPanelPhase matches the legacy '
+      '`bundled_explore_retry_loop` literal',
+      () {
+        expect(
+          kE2eCheckExploreEnabledFromCivilianPanelPhase,
+          'bundled_explore_retry_loop',
+          reason:
+              'The lifted-from constant must match the legacy private '
+              'closure literal `bundled_explore_retry_loop` so any AC8 '
+              'timing aggregator (or future `tool/run_e2e_timing.sh` '
+              'consumer) that groups per-phase totals continues to see '
+              'the same key. A silent rename would surface as missing '
+              'phase data in the readiness retry slice, not as a test '
+              'failure here in the slow CI lane.',
+        );
+      },
+    );
+  });
+
+  group(
+    'e2eCheckExploreEnabledFromCivilianPanel — snapshot-driven verdict',
+    () {
+      testWidgets(
+        'snapshot hints Explore enabled → returns true, emits '
+        '`result=enabled` timing',
+        (tester) async {
+          ctE2eCivilianPanelSnapshot = _snapshot(
+            availableWorkTargets: const {
+              'explorer-1': [kWorkTargetExplore],
+            },
+          );
+          await tester.pumpWidget(_wrapPanelAlreadyOpen());
+          final perf = E2ePerfLog('pin_check_explore_enabled');
+          late bool result;
+          final lines = await _captureDebugPrints(() async {
+            result = await e2eCheckExploreEnabledFromCivilianPanel(
+              tester,
+              perf: perf,
+            );
+          });
+          expect(
+            result,
+            isTrue,
+            reason:
+                'The snapshot short-circuit `true` verdict from '
+                '[e2eAnyExplorerHasEnabledExploreAssignFleet] must propagate '
+                'verbatim — a regression that re-walked the (empty) panel '
+                'would either flip the verdict or burn the Bottleneck 5 '
+                'sweep budget on every retry.',
+          );
+          expect(
+            lines.where(
+              (l) => l.contains(
+                'phase=bundled_explore_retry_loop',
+              ),
+            ),
+            hasLength(1),
+            reason:
+                'Exactly one `bundled_explore_retry_loop` timing marker '
+                'must be emitted per call so the AC8 retry-loop slice '
+                'stays attributable. Zero entries would surface as '
+                'missing data in the timing pipeline; two or more would '
+                'double-count the slice.',
+          );
+          expect(
+            lines.singleWhere(
+              (l) => l.contains('phase=bundled_explore_retry_loop'),
+            ),
+            contains('meta=result=enabled'),
+            reason:
+                'The `result=enabled` meta is how the AC8 timing pipeline '
+                'distinguishes a true verdict from a false one without '
+                're-running the helper. A regression that dropped the meta '
+                'or used a different literal (e.g. `true` instead of '
+                '`enabled`) would silently collapse the two branches in '
+                'aggregates.',
+          );
+        },
+      );
+
+      testWidgets(
+        'snapshot hints no Explore enabled → returns false, emits '
+        '`result=not_enabled` timing',
+        (tester) async {
+          ctE2eCivilianPanelSnapshot = _snapshot(
+            availableWorkTargets: const {
+              'unit-1': [kWorkTargetBuildRoad],
+            },
+          );
+          await tester.pumpWidget(_wrapPanelAlreadyOpen());
+          final perf = E2ePerfLog('pin_check_explore_disabled');
+          late bool result;
+          final lines = await _captureDebugPrints(() async {
+            result = await e2eCheckExploreEnabledFromCivilianPanel(
+              tester,
+              perf: perf,
+            );
+          });
+          expect(
+            result,
+            isFalse,
+            reason:
+                'The snapshot short-circuit `false` verdict is '
+                'contractually distinct from `null` and must propagate '
+                'verbatim. A regression that conflated `false` with '
+                '`null` would attempt the (empty) panel sweep and then '
+                'time out, masking the real "Explore not assignable" '
+                'state with a flaky timeout.',
+          );
+          expect(
+            lines.singleWhere(
+              (l) => l.contains('phase=bundled_explore_retry_loop'),
+            ),
+            contains('meta=result=not_enabled'),
+            reason:
+                'The `result=not_enabled` meta is the only signal a '
+                'downstream timing aggregator has for the false branch. '
+                'A regression that emitted `result=false` or no meta '
+                'would lose the per-branch breakdown the AC8 pipeline '
+                'depends on.',
+          );
+        },
+      );
+    },
+  );
+
+  group('e2eCheckExploreEnabledFromCivilianPanel — perf forwarding', () {
+    testWidgets(
+      'perf: null is a no-op (no `bundled_explore_retry_loop` marker emitted)',
+      (tester) async {
+        ctE2eCivilianPanelSnapshot = _snapshot(
+          availableWorkTargets: const {
+            'explorer-1': [kWorkTargetExplore],
+          },
+        );
+        await tester.pumpWidget(_wrapPanelAlreadyOpen());
+        final lines = await _captureDebugPrints(() async {
+          await e2eCheckExploreEnabledFromCivilianPanel(tester);
+        });
+        expect(
+          lines.where(
+            (l) => l.contains('phase=bundled_explore_retry_loop'),
+          ),
+          isEmpty,
+          reason:
+              'When the caller passes `perf: null`, the helper must not '
+              'fabricate a perf log or call `timing` against a fallback '
+              'sink. A regression that auto-instantiated `E2ePerfLog` '
+              'here would emit unattributed markers in any production '
+              'tester that opted out of perf logging.',
+        );
+      },
+    );
+  });
+
+  group('e2eCheckExploreEnabledFromCivilianPanel — AC1 barrel forwarding', () {
+    testWidgets(
+      'checkExploreEnabledFromCivilianPanel (barrel alias) returns the same '
+      'verdict as the lifted form',
+      (tester) async {
+        ctE2eCivilianPanelSnapshot = _snapshot(
+          availableWorkTargets: const {
+            'explorer-1': [kWorkTargetExplore],
+          },
+        );
+        await tester.pumpWidget(_wrapPanelAlreadyOpen());
+        final result = await checkExploreEnabledFromCivilianPanel(tester);
+        expect(
+          result,
+          isTrue,
+          reason:
+              'The AC1 barrel wrapper must forward arguments in the '
+              'documented order and produce identical verdicts — a '
+              'regression that swapped `perf` with `maxUiResponseWait`, '
+              'dropped the snapshot path, or accidentally captured a '
+              'fresh default would surface here, not in the slow CI '
+              'lane.',
+        );
+      },
+    );
+
+    test(
+      'checkExploreEnabledFromCivilianPanel is re-exported as a tear-off '
+      '(compile-time signature pin)',
+      () {
+        final Future<bool> Function(
+          WidgetTester, {
+          E2ePerfLog? perf,
+          Duration maxUiResponseWait,
+          String waitUntilFoundPhase,
+          String afterSheetPanelsClearPhase,
+        })
+        ref = checkExploreEnabledFromCivilianPanel;
+        expect(
+          ref,
+          isNotNull,
+          reason:
+              'The AC1 barrel must continue to export the helper with '
+              'the documented signature. A silent removal from the '
+              '`show` clause or an arg-name change on the wrapper would '
+              'fail this tear-off assignment at compile time.',
+        );
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Lifts the formerly file-scope `checkExploreEnabledFromCivilianPanel` closure
from the post-bundle Explore `testWidgets` body in
`new_game_fleet_reaches_new_world_e2e_test.dart` into the public
`e2eCheckExploreEnabledFromCivilianPanel` in `e2e_test_shared_panels.dart`,
and re-exposes it through the AC1 barrel `e2e_helpers.dart` as
`checkExploreEnabledFromCivilianPanel`. Mirrors the slice cadence of #2720 /
#2722 / #2723 / #2724 / #2725 / #2726 and removes the last private
orchestration closure tied to the fleet bundled-Explore retry loop.

The new `kE2eCheckExploreEnabledFromCivilianPanelPhase = 'bundled_explore_retry_loop'`
keeps the perf-timing phase label byte-identical so any AC8 timing harness
that aggregates retry-loop slices continues to see the same key. Call sites
in the fleet scenario (initial check + bounded retry loop up to
`maxBoundedTurnRetries = 8`) switch to the AC1 alias.

## Scope

**Done in this push:** AC1 (single canonical implementation) + AC2 (all E2E
files reference the shared library only) for the `checkExploreEnabledFromCivilianPanel`
slice. Includes the AC1 barrel re-export, the call-site rewrite in
`new_game_fleet_reaches_new_world_e2e_test.dart`, and the `part2` doc trail
documenting the lift.

**Remaining for #2336:** AC6–AC10 still require a maintainer Linux desktop
3x `integration_test` run + `tool/run_e2e_timing.sh` baseline/after table
for AC8/AC9 (this host lacks `xvfb-run` / display, so the timing pipeline
cannot run here). PRs adding new shared-helper pins and AC4/AC5 polling
improvements continue to accrue.

## Tests

New file `app/test/e2e_check_explore_enabled_from_civilian_panel_test.dart`
(6 tests, no production code changes). Coverage:

- phase-label constant matches the legacy `bundled_explore_retry_loop` literal
- snapshot hint = enabled -> returns true and emits `result=enabled` timing
- snapshot hint = not enabled -> returns false and emits `result=not_enabled`
  timing
- `perf: null` is a no-op (no `bundled_explore_retry_loop` marker emitted)
- AC1 barrel alias forwarding (`checkExploreEnabledFromCivilianPanel`)
  produces the same verdict as the lifted form
- compile-time signature pin via tear-off assignment on the barrel alias

The widget-test layer carries the behavioural contract because the
integration suite cannot validate this directly today (`app_e2e_linux` is a
no-op per `SPEC/program/e2e-integration-tests.md` § CI).

## Local verification

- `flutter analyze integration_test/` — no issues
- `flutter test test/e2e_check_explore_enabled_from_civilian_panel_test.dart`
  — 6/6 pass
- `flutter test` on the 5 sibling pin files + barrel test
  (`e2e_any_explorer_has_enabled_explore_assign_fleet_test.dart`,
  `e2e_explore_assign_enabled_from_civilian_snapshot_test.dart`,
  `e2e_await_nw_coastal_or_visible_land_for_bundled_explore_test.dart`,
  `e2e_test_shared_smoke_test.dart`, `e2e_helpers_barrel_test.dart`,
  and the new file) — 91/91 pass

Refs #2336

Made with [Cursor](https://cursor.com)