### PR TITLE
refactor(ai): relocate hasColonialAcquisitionTargets to observer_goal_phase (Refs #2509)

### DIFF
--- a/SPEC/ai/phase-planner-architecture.md
+++ b/SPEC/ai/phase-planner-architecture.md
@@ -6,7 +6,7 @@
 
 Each Great Power computes a deterministic `ObserverGoalPhase` from its `PlayerView` → `AIWorldSnapshot` once per turn. The phase dispatches to a self-contained **planner module** that makes one primary decision per domain — no cross-phase score aggregation or predicate fan-out.
 
-Phase definitions, suppressions, and COLONIAL-lite stay normative in [ai-architecture.md](ai-architecture.md). This file specifies module contracts, orchestrator dispatch, data flow, and acceptance criteria for the phase-planner replacement of the legacy scoring-ratchet helpers.
+Phase definitions, suppressions, and COLONIAL-lite stay normative in [ai-architecture.md](ai-architecture.md). This file specifies module contracts, orchestrator dispatch, data flow, and acceptance criteria.
 
 ## Rules
 
@@ -75,7 +75,7 @@ Planner modules never call each other. The orchestrator passes `planColonialAcqu
 ### Phase transition guard
 
 - Enter **EXPAND** when `oldWorldProvincesOwned < kObserverConquestMinOwProvincesPerGp` (10). A province loss immediately restores EXPAND; no hysteresis at quota+1.
-- Enter **COLONIAL** when OW ≥ 10 and `hasColonialAcquisitionTargets`.
+- Enter **COLONIAL** when OW ≥ 10 and `hasColonialAcquisitionTargets` (defined in `observer_goal_phase.dart` per Refs #2509 S1).
 - Enter **DEVELOP** when OW ≥ 10 and no visible colonial targets.
 - **COLONIAL-lite** is a parallel entry inside EXPAND (turn ≥ `kObserverColonialLiteMinTurn`, OW ≥ `kObserverColonialLiteNearQuotaOw` and below quota, global `newWorld|` not all GP-owned).
 

--- a/packages/colonizethis_ai/lib/src/planning/colonial_pressure.dart
+++ b/packages/colonizethis_ai/lib/src/planning/colonial_pressure.dart
@@ -366,15 +366,20 @@ String? primaryInvadableOldWorldGpBlocker({
   return bestGpId;
 }
 
-/// Sea-reachable unowned NW provinces or tribe/minor owners still to clear.
-bool hasColonialAcquisitionTargets(ColonialSummary colonial) =>
-    colonial.invadableNewWorldProvinceIdsSorted.isNotEmpty ||
-    colonial.adjacentNewWorldOwnerFactionIdsSorted.isNotEmpty;
+// `hasColonialAcquisitionTargets` was relocated to `observer_goal_phase.dart`
+// (Refs #2509 S1). It is the EXPAND -> COLONIAL phase transition guard for
+// `observerGoalPhaseFor` and must survive the planned deletion of this
+// file. The two internal callers below (`isEarlyColonialExpansion` and
+// `colonialBuildOrderThresholdCap`) inline the predicate body so this
+// file does not import `observer_goal_phase.dart` (which would create a
+// circular library reference). See also: `phase-planner-architecture.md`
+// § Phase transition guards.
 
 /// Early expansion boost while the GP holds fewer than
 /// [kColonialFewNwProvincesThreshold] NW provinces.
 bool isEarlyColonialExpansion(ColonialSummary colonial) =>
-    hasColonialAcquisitionTargets(colonial) &&
+    (colonial.invadableNewWorldProvinceIdsSorted.isNotEmpty ||
+            colonial.adjacentNewWorldOwnerFactionIdsSorted.isNotEmpty) &&
     colonial.newWorldProvincesOwned < kColonialFewNwProvincesThreshold;
 
 /// Sole at-war Great Power, if any.
@@ -664,8 +669,13 @@ String? consolidateGainsSoleGpPeaceTarget({
 
 /// When non-null, build-order pass uses `min(buildThreshold, value)`.
 int? colonialBuildOrderThresholdCap(ColonialSummary colonial) {
-  if (hasColonialAcquisitionTargets(colonial) &&
-      colonial.newWorldProvincesOwned > 0) {
+  // `hasColonialAcquisitionTargets` body is inlined here (Refs #2509 S1)
+  // because the canonical home is now `observer_goal_phase.dart` and this
+  // file does not import that library (would create a circular reference).
+  final hasAcquisitionTargets =
+      colonial.invadableNewWorldProvinceIdsSorted.isNotEmpty ||
+          colonial.adjacentNewWorldOwnerFactionIdsSorted.isNotEmpty;
+  if (hasAcquisitionTargets && colonial.newWorldProvincesOwned > 0) {
     return kColonialBuildOrderThresholdWhenOwnedNwUnderPressure;
   }
   if (colonial.newWorldProvincesOwned > 0) {

--- a/packages/colonizethis_ai/lib/src/planning/diplomacy_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/diplomacy_planner.dart
@@ -1,6 +1,7 @@
 import '../perception/perception_snapshot.dart';
 import 'planning_imports.dart';
 import 'colonial_pressure.dart';
+import 'observer_goal_phase.dart';
 export 'colonial_pressure.dart'
     show
         consolidateGainsSoleGpPeaceTarget,

--- a/packages/colonizethis_ai/lib/src/planning/naval_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/naval_planner.dart
@@ -2,7 +2,6 @@ import 'dart:math' as math;
 
 import 'colonial_naval_scoring.dart';
 import 'planning_imports.dart';
-import 'colonial_pressure.dart';
 import 'observer_goal_phase.dart';
 import '../perception/perception_snapshot.dart';
 import 'phase_planner_dispatch.dart';

--- a/packages/colonizethis_ai/lib/src/planning/observer_goal_phase.dart
+++ b/packages/colonizethis_ai/lib/src/planning/observer_goal_phase.dart
@@ -34,6 +34,15 @@ bool globalNewWorldHasNonGpOwnership(Game game) {
   return false;
 }
 
+/// Sea-reachable unowned NW provinces or tribe/minor owners still to clear.
+///
+/// EXPAND -> COLONIAL phase transition guard for `observerGoalPhaseFor`.
+/// Relocated from `colonial_pressure.dart` (Refs #2509 S1) so the guard
+/// survives the planned deletion of `colonial_pressure.dart`.
+bool hasColonialAcquisitionTargets(ColonialSummary colonial) =>
+    colonial.invadableNewWorldProvinceIdsSorted.isNotEmpty ||
+    colonial.adjacentNewWorldOwnerFactionIdsSorted.isNotEmpty;
+
 /// COLONIAL-lite: turn ≥120, OW ≥9 and below quota, global NW not fully GP-owned.
 bool isObserverColonialLitePhase({
   required Game game,

--- a/packages/colonizethis_ai/test/colonial_pressure_test.dart
+++ b/packages/colonizethis_ai/test/colonial_pressure_test.dart
@@ -4,29 +4,16 @@ import 'package:colonizethis_ai/src/perception/perception_snapshot.dart';
 import 'package:colonizethis_ai/src/planning/colonial_pressure.dart';
 import 'package:colonizethis_ai/src/planning/conquest_planner.dart';
 import 'package:colonizethis_ai/src/planning/diplomacy_planner_peace_targets.dart';
+import 'package:colonizethis_ai/src/planning/observer_goal_phase.dart'
+    show hasColonialAcquisitionTargets;
 import 'package:colonizethis_data/colonizethis_data.dart';
 
 void main() {
-  group('hasColonialAcquisitionTargets', () {
-    test('true when invadable NW provinces remain', () {
-      const colonial = ColonialSummary(
-        invadableNewWorldProvinceIdsSorted: ['newWorld|p1'],
-      );
-      expect(hasColonialAcquisitionTargets(colonial), isTrue);
-    });
-
-    test('true when adjacent NW tribe owners remain', () {
-      const colonial = ColonialSummary(
-        adjacentNewWorldOwnerFactionIdsSorted: ['tribe1'],
-      );
-      expect(hasColonialAcquisitionTargets(colonial), isTrue);
-    });
-
-    test('false when NW holdings exist but no acquisition targets', () {
-      const colonial = ColonialSummary(newWorldProvincesOwned: 12);
-      expect(hasColonialAcquisitionTargets(colonial), isFalse);
-    });
-  });
+  // `hasColonialAcquisitionTargets` was relocated to `observer_goal_phase.dart`
+  // (Refs #2509 S1). Its dedicated tests now live in
+  // `observer_goal_phase_test.dart` alongside the EXPAND -> COLONIAL phase
+  // transition guard. The `isEarlyColonialExpansion` group below still
+  // asserts the predicate at a boundary that exercises both helpers.
 
   group('colonialBuildOrderThresholdCap', () {
     test('null when no NW provinces owned', () {

--- a/packages/colonizethis_ai/test/observer_goal_phase_test.dart
+++ b/packages/colonizethis_ai/test/observer_goal_phase_test.dart
@@ -9,6 +9,99 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart';
 
 void main() {
+  // `hasColonialAcquisitionTargets` is the EXPAND -> COLONIAL phase
+  // transition guard for `observerGoalPhaseFor`. Relocated from
+  // `colonial_pressure.dart` (Refs #2509 S1) so the guard survives the
+  // planned deletion of that file.
+  group('hasColonialAcquisitionTargets', () {
+    test('true when invadable NW provinces remain', () {
+      const colonial = ColonialSummary(
+        invadableNewWorldProvinceIdsSorted: ['newWorld|p1'],
+      );
+      expect(hasColonialAcquisitionTargets(colonial), isTrue);
+    });
+
+    test('true when adjacent NW tribe owners remain', () {
+      const colonial = ColonialSummary(
+        adjacentNewWorldOwnerFactionIdsSorted: ['tribe1'],
+      );
+      expect(hasColonialAcquisitionTargets(colonial), isTrue);
+    });
+
+    test(
+      'true when both invadable provinces and adjacent owners are present',
+      () {
+        const colonial = ColonialSummary(
+          invadableNewWorldProvinceIdsSorted: ['newWorld|p1'],
+          adjacentNewWorldOwnerFactionIdsSorted: ['tribe1'],
+        );
+        expect(hasColonialAcquisitionTargets(colonial), isTrue);
+      },
+    );
+
+    test('false when NW holdings exist but no acquisition targets', () {
+      const colonial = ColonialSummary(newWorldProvincesOwned: 12);
+      expect(hasColonialAcquisitionTargets(colonial), isFalse);
+    });
+
+    test('false when colonial summary is fully empty', () {
+      const colonial = ColonialSummary();
+      expect(hasColonialAcquisitionTargets(colonial), isFalse);
+    });
+
+    test('drives observerGoalPhaseFor EXPAND -> COLONIAL transition guard', () {
+      const baseSnapshot = AIWorldSnapshot(
+        playerId: 'gp1',
+        threats: ThreatSummary(),
+        opportunities: OpportunitySummary(),
+        conquest: ConquestSummary(oldWorldProvincesOwned: 10),
+        colonial: ColonialSummary(
+          invadableNewWorldProvinceIdsSorted: ['newWorld|p1'],
+        ),
+        economy: EconomySummary(),
+        relations: {},
+      );
+      expect(
+        hasColonialAcquisitionTargets(baseSnapshot.colonial),
+        isTrue,
+        reason: 'guard fires the COLONIAL branch in observerGoalPhaseFor',
+      );
+      expect(
+        observerGoalPhaseFor(snapshot: baseSnapshot),
+        ObserverGoalPhase.colonial,
+      );
+
+      const developSnapshot = AIWorldSnapshot(
+        playerId: 'gp1',
+        threats: ThreatSummary(),
+        opportunities: OpportunitySummary(),
+        conquest: ConquestSummary(oldWorldProvincesOwned: 10),
+        colonial: ColonialSummary(newWorldProvincesOwned: 5),
+        economy: EconomySummary(),
+        relations: {},
+      );
+      expect(
+        hasColonialAcquisitionTargets(developSnapshot.colonial),
+        isFalse,
+        reason: 'absence of guard routes observerGoalPhaseFor to DEVELOP',
+      );
+      expect(
+        observerGoalPhaseFor(snapshot: developSnapshot),
+        ObserverGoalPhase.develop,
+      );
+    });
+
+    test('determinism: identical input returns identical bool', () {
+      const colonial = ColonialSummary(
+        invadableNewWorldProvinceIdsSorted: ['newWorld|p1'],
+        adjacentNewWorldOwnerFactionIdsSorted: ['tribe1'],
+      );
+      final a = hasColonialAcquisitionTargets(colonial);
+      final b = hasColonialAcquisitionTargets(colonial);
+      expect(a, b);
+    });
+  });
+
   group('observerGoalPhaseFor', () {
     test('expand when below observer OW quota', () {
       const snap = AIWorldSnapshot(


### PR DESCRIPTION
## Summary

S1-prep slice for **Refs #2509**: move the EXPAND -> COLONIAL phase transition guard `hasColonialAcquisitionTargets(ColonialSummary)` out of the legacy `colonial_pressure.dart` and into its canonical home next to `observerGoalPhaseFor` in `observer_goal_phase.dart`, so the predicate survives the planned S1 deletion of `colonial_pressure.dart`.

Behaviour-preserving refactor. No phase decision, no production order, and no resolver output changes.

## Changes

- `packages/colonizethis_ai/lib/src/planning/observer_goal_phase.dart` — define `hasColonialAcquisitionTargets` here; docstring pins it as the EXPAND -> COLONIAL guard and points back to the SPEC.
- `packages/colonizethis_ai/lib/src/planning/colonial_pressure.dart` — drop the definition; inline the predicate body inside the two internal callers (`isEarlyColonialExpansion`, `colonialBuildOrderThresholdCap`) to avoid a circular library reference back into `observer_goal_phase.dart` while the legacy module is still alive.
- `packages/colonizethis_ai/lib/src/planning/diplomacy_planner.dart` — add explicit import of `observer_goal_phase.dart` for the relocated symbol (was implicit via `colonial_pressure.dart`).
- `packages/colonizethis_ai/lib/src/planning/naval_planner.dart` — drop the now-unused `colonial_pressure.dart` import (the file only needed `observer_goal_phase.dart` helpers, which were already imported).
- `packages/colonizethis_ai/test/observer_goal_phase_test.dart` — host the dedicated `hasColonialAcquisitionTargets` test group; grow assertions to pin the predicate as the COLONIAL guard inside `observerGoalPhaseFor` (true case routes to `ObserverGoalPhase.colonial`, false case routes to DEVELOP) plus a determinism check.
- `packages/colonizethis_ai/test/colonial_pressure_test.dart` — remove the relocated group; import the symbol from its new home for the existing `isEarlyColonialExpansion` boundary case; comment notes the relocation.
- `SPEC/ai/phase-planner-architecture.md` — record the new canonical home of the predicate next to the COLONIAL transition bullet.

## Test plan

- [x] `dart analyze` for touched libs and tests — no new findings (only 3 pre-existing `unnecessary_import` infos in `observer_goal_phase_test.dart`, unrelated to this slice).
- [x] `dart test` for `packages/colonizethis_ai` (full package suite) — green.
- [x] `dart run tool/ct_repo_lint.dart` — all 47 rules pass.
- [x] SPEC word-count budget respected (`SPEC/ai/phase-planner-architecture.md` <= 1000 words).

Refs #2509

Made with [Cursor](https://cursor.com)