### PR TITLE
refactor(ai): relocate isEarlyColonialExpansion to observer_goal_phase (Refs #2509)

### DIFF
--- a/SPEC/ai/phase-planner-architecture.md
+++ b/SPEC/ai/phase-planner-architecture.md
@@ -75,7 +75,7 @@ Planner modules never call each other. The orchestrator passes `planColonialAcqu
 ### Phase transition guard
 
 - Enter **EXPAND** when `oldWorldProvincesOwned < kObserverConquestMinOwProvincesPerGp` (10). A province loss immediately restores EXPAND; no hysteresis at quota+1.
-- Enter **COLONIAL** when OW ≥ 10 and `hasColonialAcquisitionTargets` (defined in `observer_goal_phase.dart` per Refs #2509 S1; the goal-scoring sibling `isEarlyColonialExpansion` — `hasColonialAcquisitionTargets(colonial) && colonial.newWorldProvincesOwned < kColonialFewNwProvincesThreshold`, consumed by `goal_manager.dart` for the early-colonial conquer-score bonus — lives alongside it for the same retirement-survival reason).
+- Enter **COLONIAL** when OW ≥ 10 and `hasColonialAcquisitionTargets` (defined in `observer_goal_phase.dart` per Refs #2509 S1; the goal-scoring sibling `isEarlyColonialExpansion` — `hasColonialAcquisitionTargets(colonial) && colonial.newWorldProvincesOwned < kColonialFewNwProvincesThreshold`, consumed by `goal_manager.dart` for the early-colonial conquer-score bonus — lives alongside it for the same retirement-survival reason). EXPAND OW frontier helpers (`hasUninvadedOldWorldMinor`, `isOldWorldGpOnlyInvadableFrontier`, `isMutualBelowQuotaPlateauPeer`, `primaryInvadableOldWorldGpBlocker`) are canonical in `expand_phase_planner.dart`; `colonial_pressure.dart` delegates until S1 deletion.
 - Enter **DEVELOP** when OW ≥ 10 and no visible colonial targets.
 - **COLONIAL-lite** is a parallel entry inside EXPAND (turn ≥ `kObserverColonialLiteMinTurn`, OW ≥ `kObserverColonialLiteNearQuotaOw` and below quota, global `newWorld|` not all GP-owned).
 

--- a/SPEC/ai/phase-planner-architecture.md
+++ b/SPEC/ai/phase-planner-architecture.md
@@ -75,7 +75,7 @@ Planner modules never call each other. The orchestrator passes `planColonialAcqu
 ### Phase transition guard
 
 - Enter **EXPAND** when `oldWorldProvincesOwned < kObserverConquestMinOwProvincesPerGp` (10). A province loss immediately restores EXPAND; no hysteresis at quota+1.
-- Enter **COLONIAL** when OW ≥ 10 and `hasColonialAcquisitionTargets` (defined in `observer_goal_phase.dart` per Refs #2509 S1).
+- Enter **COLONIAL** when OW ≥ 10 and `hasColonialAcquisitionTargets` (defined in `observer_goal_phase.dart` per Refs #2509 S1; the goal-scoring sibling `isEarlyColonialExpansion` — `hasColonialAcquisitionTargets(colonial) && colonial.newWorldProvincesOwned < kColonialFewNwProvincesThreshold`, consumed by `goal_manager.dart` for the early-colonial conquer-score bonus — lives alongside it for the same retirement-survival reason).
 - Enter **DEVELOP** when OW ≥ 10 and no visible colonial targets.
 - **COLONIAL-lite** is a parallel entry inside EXPAND (turn ≥ `kObserverColonialLiteMinTurn`, OW ≥ `kObserverColonialLiteNearQuotaOw` and below quota, global `newWorld|` not all GP-owned).
 

--- a/packages/colonizethis_ai/lib/src/planning/colonial_pressure.dart
+++ b/packages/colonizethis_ai/lib/src/planning/colonial_pressure.dart
@@ -366,21 +366,14 @@ String? primaryInvadableOldWorldGpBlocker({
   return bestGpId;
 }
 
-// `hasColonialAcquisitionTargets` was relocated to `observer_goal_phase.dart`
-// (Refs #2509 S1). It is the EXPAND -> COLONIAL phase transition guard for
-// `observerGoalPhaseFor` and must survive the planned deletion of this
-// file. The two internal callers below (`isEarlyColonialExpansion` and
-// `colonialBuildOrderThresholdCap`) inline the predicate body so this
-// file does not import `observer_goal_phase.dart` (which would create a
-// circular library reference). See also: `phase-planner-architecture.md`
-// § Phase transition guards.
-
-/// Early expansion boost while the GP holds fewer than
-/// [kColonialFewNwProvincesThreshold] NW provinces.
-bool isEarlyColonialExpansion(ColonialSummary colonial) =>
-    (colonial.invadableNewWorldProvinceIdsSorted.isNotEmpty ||
-            colonial.adjacentNewWorldOwnerFactionIdsSorted.isNotEmpty) &&
-    colonial.newWorldProvincesOwned < kColonialFewNwProvincesThreshold;
+// `hasColonialAcquisitionTargets` and `isEarlyColonialExpansion` were
+// relocated to `observer_goal_phase.dart` (Refs #2509 S1) — both
+// `ColonialSummary` predicates must survive the planned deletion of this
+// file. `colonialBuildOrderThresholdCap` (below) keeps the
+// acquisition-target check inlined so this file does not import
+// `observer_goal_phase.dart`, which would create a circular library
+// reference. See also: `phase-planner-architecture.md` § Phase transition
+// guards.
 
 /// Sole at-war Great Power, if any.
 String? soleAtWarGreatPowerId({

--- a/packages/colonizethis_ai/lib/src/planning/colonial_pressure.dart
+++ b/packages/colonizethis_ai/lib/src/planning/colonial_pressure.dart
@@ -3,45 +3,30 @@ import 'package:colonizethis_logic/ai_api.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../perception/perception_snapshot.dart';
+import 'expand_phase_planner.dart' as expand_phase_planner;
 
 /// Invadable Old World frontier held only by Great Powers (no minor on border).
+///
+/// Delegates to [expand_phase_planner.isOldWorldGpOnlyInvadableFrontier]
+/// (Refs #2509 S1).
 bool isOldWorldGpOnlyInvadableFrontier({
   required Game game,
   required AIWorldSnapshot snapshot,
-}) {
-  if (snapshot.conquest.invadableProvinceIdsSorted.isEmpty) {
-    return false;
-  }
-  final provinceOwner = getProvinceOwnerMap(game);
-  final minorsOwnInvadable = snapshot.conquest.invadableProvinceIdsSorted.any(
-    (pid) {
-      final owner = provinceOwner[pid];
-      return owner != null && game.minorNations.any((m) => m.id == owner);
-    },
-  );
-  if (minorsOwnInvadable) {
-    return false;
-  }
-  return snapshot.conquest.invadableProvinceIdsSorted.any(
-    (pid) => game.playerById(provinceOwner[pid] ?? '') != null,
-  );
-}
+}) => expand_phase_planner.isOldWorldGpOnlyInvadableFrontier(
+  game: game,
+  snapshot: snapshot,
+);
 
 /// Any OW minor not yet at war that still holds provinces (EXPAND minor-first).
+///
+/// Delegates to [expand_phase_planner.hasUninvadedOldWorldMinor] (Refs #2509 S1).
 bool hasUninvadedOldWorldMinor({
   required Game game,
   required AIWorldSnapshot snapshot,
-}) {
-  for (final minor in game.minorNations) {
-    if (snapshot.threats.atWarWith.contains(minor.id)) {
-      continue;
-    }
-    if (game.worldState.oldWorld.provinces.any((p) => p.ownerId == minor.id)) {
-      return true;
-    }
-  }
-  return false;
-}
+}) => expand_phase_planner.hasUninvadedOldWorldMinor(
+  game: game,
+  snapshot: snapshot,
+);
 
 /// Below-quota OW expansion with a GP-only invadable frontier (seed-42 gp5/gp6).
 bool isStalledOldWorldGpBlockerFocus({
@@ -139,15 +124,16 @@ bool isBelowQuotaPeaceTreasuryRecovery({
 }
 
 /// Both GPs in the 8–9 OW stalled band, below the observer quota, with similar holdings.
+///
+/// Delegates to [expand_phase_planner.isMutualBelowQuotaPlateauPeer]
+/// (Refs #2509 S1).
 bool isMutualBelowQuotaPlateauPeer({
   required int ownOw,
   required int partnerOw,
-}) =>
-    isStalledOldWorldExpansion(ownOw) &&
-    isStalledOldWorldExpansion(partnerOw) &&
-    isBelowObserverConquestQuota(ownOw) &&
-    isBelowObserverConquestQuota(partnerOw) &&
-    (partnerOw - ownOw).abs() <= 1;
+}) => expand_phase_planner.isMutualBelowQuotaPlateauPeer(
+  ownOw: ownOw,
+  partnerOw: partnerOw,
+);
 
 /// Peace other below-quota Great Powers in peer-stalled wars while minors remain
 /// (exit mutual gp5/gp6 distraction; Refs #2509).
@@ -192,9 +178,8 @@ List<String> belowQuotaPeerGpPeaceTargets({
       targets.add(factionId);
       continue;
     }
-    final maxPeerOwGap = hasUninvadedOldWorldMinor(game: game, snapshot: snapshot)
-        ? 3
-        : 1;
+    final maxPeerOwGap =
+        hasUninvadedOldWorldMinor(game: game, snapshot: snapshot) ? 3 : 1;
     if ((partnerOw - ownOw).abs() > maxPeerOwGap) {
       continue;
     }
@@ -254,7 +239,8 @@ List<String> defaultStartGpPeaceTargets({
   if (!isBelowObserverConquestQuota(ownOw)) {
     return const [];
   }
-  final maxOwForGpPeace = hasUninvadedOldWorldMinor(game: game, snapshot: snapshot)
+  final maxOwForGpPeace =
+      hasUninvadedOldWorldMinor(game: game, snapshot: snapshot)
       ? kStalledOldWorldProvinceThreshold
       : kObserverDefaultStartOldWorldProvincesPerGp + 1;
   if (ownOw > maxOwForGpPeace) {
@@ -269,8 +255,7 @@ List<String> defaultStartGpPeaceTargets({
       : null;
   final targets = <String>[
     for (final factionId in snapshot.threats.atWarWith)
-      if (game.playerById(factionId) != null &&
-          factionId != invadableBlocker)
+      if (game.playerById(factionId) != null && factionId != invadableBlocker)
         factionId,
   ]..sort();
   return targets;
@@ -327,44 +312,16 @@ List<String> nearQuotaHoldPeaceTargets({
 }
 
 /// GP owning the most invadable Old World provinces (frontier blocker).
+///
+/// Delegates to [expand_phase_planner.primaryInvadableOldWorldGpBlocker]
+/// (Refs #2509 S1).
 String? primaryInvadableOldWorldGpBlocker({
   required Game game,
   required AIWorldSnapshot snapshot,
-}) {
-  final invadable = snapshot.conquest.invadableProvinceIdsSorted;
-  if (invadable.isEmpty) {
-    return null;
-  }
-  final provinceOwner = getProvinceOwnerMap(game);
-  // Linear plurality scan: tally GP ownership in one pass, then resolve the
-  // plurality winner with a second linear pass that preserves the prior
-  // first-iterated-province tiebreak. Behaviorally identical to the previous
-  // nested-loop implementation; linear in the invadable-OW set rather than
-  // quadratic on hot peace-target collection paths (Refs
-  // `colonizethis-turn-resolution-budget.mdc`).
-  final counts = <String, int>{};
-  for (final provinceId in invadable) {
-    final owner = provinceOwner[provinceId];
-    if (owner == null || game.playerById(owner) == null) continue;
-    counts[owner] = (counts[owner] ?? 0) + 1;
-  }
-  if (counts.isEmpty) {
-    return null;
-  }
-  String? bestGpId;
-  var bestCount = 0;
-  for (final provinceId in invadable) {
-    final owner = provinceOwner[provinceId];
-    if (owner == null) continue;
-    final count = counts[owner];
-    if (count == null) continue;
-    if (count > bestCount) {
-      bestCount = count;
-      bestGpId = owner;
-    }
-  }
-  return bestGpId;
-}
+}) => expand_phase_planner.primaryInvadableOldWorldGpBlocker(
+  game: game,
+  snapshot: snapshot,
+);
 
 // `hasColonialAcquisitionTargets` and `isEarlyColonialExpansion` were
 // relocated to `observer_goal_phase.dart` (Refs #2509 S1) — both
@@ -433,9 +390,9 @@ String? unwinnableSoleGpFrontierPeaceTarget({
   final minDeficit = own <= kObserverDefaultStartOldWorldProvincesPerGp
       ? 1
       : own >= kObserverConquestMinOwProvincesPerGp - 2 &&
-              !isOldWorldGpOnlyInvadableFrontier(game: game, snapshot: snapshot)
-          ? 1
-          : kUnwinnableSoleGpMinProvinceDeficit;
+            !isOldWorldGpOnlyInvadableFrontier(game: game, snapshot: snapshot)
+      ? 1
+      : kUnwinnableSoleGpMinProvinceDeficit;
   if (enemyOw < own + minDeficit) {
     return null;
   }
@@ -550,10 +507,8 @@ List<String> stalledBelowQuotaGpLeadPeaceTargets({
   final minLeadDeficit = own <= kObserverDefaultStartOldWorldProvincesPerGp
       ? kUnwinnableSoleGpMinProvinceDeficit
       : 1;
-  final invadableBlocker = isOldWorldGpOnlyInvadableFrontier(
-        game: game,
-        snapshot: snapshot,
-      )
+  final invadableBlocker =
+      isOldWorldGpOnlyInvadableFrontier(game: game, snapshot: snapshot)
       ? primaryInvadableOldWorldGpBlocker(game: game, snapshot: snapshot)
       : null;
   final targets = <String>[
@@ -667,7 +622,7 @@ int? colonialBuildOrderThresholdCap(ColonialSummary colonial) {
   // file does not import that library (would create a circular reference).
   final hasAcquisitionTargets =
       colonial.invadableNewWorldProvinceIdsSorted.isNotEmpty ||
-          colonial.adjacentNewWorldOwnerFactionIdsSorted.isNotEmpty;
+      colonial.adjacentNewWorldOwnerFactionIdsSorted.isNotEmpty;
   if (hasAcquisitionTargets && colonial.newWorldProvincesOwned > 0) {
     return kColonialBuildOrderThresholdWhenOwnedNwUnderPressure;
   }

--- a/packages/colonizethis_ai/lib/src/planning/expand_phase_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/expand_phase_planner.dart
@@ -171,12 +171,12 @@ List<String> planExpandPeace({
   }
 
   if (gpWars.length == 1 &&
-      _isMutualBelowQuotaPlateauPeer(
+      isMutualBelowQuotaPlateauPeer(
         ownOw: snapshot.conquest.oldWorldProvincesOwned,
         partnerOw: provinceCountOwnedBy(game, blocker),
       ) &&
       expandIsOldWorldGpOnlyInvadableFrontier(game: game, snapshot: snapshot) &&
-      !_hasUninvadedOldWorldMinor(game: game, snapshot: snapshot)) {
+      !hasUninvadedOldWorldMinor(game: game, snapshot: snapshot)) {
     return List<String>.unmodifiable(gpWars);
   }
 
@@ -237,6 +237,12 @@ String? expandPrimaryInvadableOldWorldGpBlocker({
   return bestGpId;
 }
 
+/// Canonical name for [expandPrimaryInvadableOldWorldGpBlocker] (Refs #2509 S1).
+String? primaryInvadableOldWorldGpBlocker({
+  required Game game,
+  required AIWorldSnapshot snapshot,
+}) => expandPrimaryInvadableOldWorldGpBlocker(game: game, snapshot: snapshot);
+
 /// Whether the invadable Old World frontier is held only by Great Powers
 /// (no minor nation owns any invadable OW province).
 ///
@@ -267,13 +273,21 @@ bool expandIsOldWorldGpOnlyInvadableFrontier({
   );
 }
 
+/// Canonical name for [expandIsOldWorldGpOnlyInvadableFrontier] (Refs #2509 S1).
+bool isOldWorldGpOnlyInvadableFrontier({
+  required Game game,
+  required AIWorldSnapshot snapshot,
+}) => expandIsOldWorldGpOnlyInvadableFrontier(game: game, snapshot: snapshot);
+
 /// Whether any Old World minor nation still holds provinces and is not
 /// already at war with the active player (uninvaded minor pivot remaining).
 ///
-/// Mirrors `hasUninvadedOldWorldMinor` from `colonial_pressure.dart`. The
-/// mutual-plateau sole-GP carve-out in [planExpandPeace] holds the GP war
+/// The mutual-plateau sole-GP carve-out in [planExpandPeace] holds the GP war
 /// while uninvaded minors remain (we should expand against minors first).
-bool _hasUninvadedOldWorldMinor({
+///
+/// Relocated from `colonial_pressure.dart` (Refs #2509 S1) so the predicate
+/// survives the planned deletion of that file.
+bool hasUninvadedOldWorldMinor({
   required Game game,
   required AIWorldSnapshot snapshot,
 }) {
@@ -291,11 +305,11 @@ bool _hasUninvadedOldWorldMinor({
 /// Whether [ownOw] and [partnerOw] are both in the stalled below-quota
 /// plateau band with similar holdings (within one province of each other).
 ///
-/// Mirrors `isMutualBelowQuotaPlateauPeer` from `colonial_pressure.dart`.
 /// Stall threshold ([kStalledOldWorldProvinceThreshold]) and quota
-/// ([kObserverConquestMinOwProvincesPerGp]) are the same authoritative
-/// constants used by the legacy helper.
-bool _isMutualBelowQuotaPlateauPeer({
+/// ([kObserverConquestMinOwProvincesPerGp]) are authoritative here.
+///
+/// Relocated from `colonial_pressure.dart` (Refs #2509 S1).
+bool isMutualBelowQuotaPlateauPeer({
   required int ownOw,
   required int partnerOw,
 }) =>
@@ -419,7 +433,7 @@ String? planExpandDeclareWar({
     return null;
   }
   final blockerOw = provinceCountOwnedBy(game, blockerId);
-  if (!_isMutualBelowQuotaPlateauPeer(
+  if (!isMutualBelowQuotaPlateauPeer(
     ownOw: snapshot.conquest.oldWorldProvincesOwned,
     partnerOw: blockerOw,
   )) {

--- a/packages/colonizethis_ai/lib/src/planning/goal_manager.dart
+++ b/packages/colonizethis_ai/lib/src/planning/goal_manager.dart
@@ -4,7 +4,6 @@ import 'planning_imports.dart';
 
 import '../util/ai_random_utils.dart';
 import '../perception/perception_snapshot.dart';
-import 'colonial_pressure.dart';
 import 'observer_goal_phase.dart';
 import 'phase_planner_goal_filter.dart';
 

--- a/packages/colonizethis_ai/lib/src/planning/observer_goal_phase.dart
+++ b/packages/colonizethis_ai/lib/src/planning/observer_goal_phase.dart
@@ -3,7 +3,7 @@ import 'package:colonizethis_logic/ai_api.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../perception/perception_snapshot.dart';
-import 'colonial_pressure.dart';
+import 'expand_phase_planner.dart';
 
 /// Observer tuning phases for Full AI (Refs #2509 S10).
 enum ObserverGoalPhase {
@@ -93,24 +93,15 @@ ObserverGoalPhase observerGoalPhaseFor({
   return ObserverGoalPhase.develop;
 }
 
-bool isObserverDevelopPhase({
-  required AIWorldSnapshot snapshot,
-  Game? game,
-}) =>
+bool isObserverDevelopPhase({required AIWorldSnapshot snapshot, Game? game}) =>
     observerGoalPhaseFor(snapshot: snapshot, game: game) ==
     ObserverGoalPhase.develop;
 
-bool isObserverColonialPhase({
-  required AIWorldSnapshot snapshot,
-  Game? game,
-}) =>
+bool isObserverColonialPhase({required AIWorldSnapshot snapshot, Game? game}) =>
     observerGoalPhaseFor(snapshot: snapshot, game: game) ==
     ObserverGoalPhase.colonial;
 
-bool isObserverExpandPhase({
-  required AIWorldSnapshot snapshot,
-  Game? game,
-}) =>
+bool isObserverExpandPhase({required AIWorldSnapshot snapshot, Game? game}) =>
     observerGoalPhaseFor(snapshot: snapshot, game: game) ==
     ObserverGoalPhase.expand;
 
@@ -282,12 +273,14 @@ bool isExpandPhaseColonialDiplomacyTarget({
     return false;
   }
   if (isTribeFaction || isMinorFaction) {
-    if (snapshot.colonial.adjacentNewWorldOwnerFactionIdsSorted
-        .contains(targetFactionId)) {
+    if (snapshot.colonial.adjacentNewWorldOwnerFactionIdsSorted.contains(
+      targetFactionId,
+    )) {
       return true;
     }
-    if (snapshot.colonial.preferredColonialTargetFactionIdsSorted
-        .contains(targetFactionId)) {
+    if (snapshot.colonial.preferredColonialTargetFactionIdsSorted.contains(
+      targetFactionId,
+    )) {
       return true;
     }
     if (snapshot.colonial.invadableNewWorldProvinceIdsSorted.any(

--- a/packages/colonizethis_ai/lib/src/planning/observer_goal_phase.dart
+++ b/packages/colonizethis_ai/lib/src/planning/observer_goal_phase.dart
@@ -43,6 +43,19 @@ bool hasColonialAcquisitionTargets(ColonialSummary colonial) =>
     colonial.invadableNewWorldProvinceIdsSorted.isNotEmpty ||
     colonial.adjacentNewWorldOwnerFactionIdsSorted.isNotEmpty;
 
+/// Early colonial expansion bonus while the GP holds fewer than
+/// [kColonialFewNwProvincesThreshold] NW provinces and visible colonial
+/// acquisition targets remain.
+///
+/// Fires the `goal_manager.dart` early-colonial conquer bonus alongside the
+/// `hasColonialAcquisitionTargets` guard above. Relocated from
+/// `colonial_pressure.dart` (Refs #2509 S1) so the predicate survives the
+/// planned deletion of `colonial_pressure.dart`. Pure function of
+/// [ColonialSummary]; deterministic for identical inputs (Must-have #7).
+bool isEarlyColonialExpansion(ColonialSummary colonial) =>
+    hasColonialAcquisitionTargets(colonial) &&
+    colonial.newWorldProvincesOwned < kColonialFewNwProvincesThreshold;
+
 /// COLONIAL-lite: turn ≥120, OW ≥9 and below quota, global NW not fully GP-owned.
 bool isObserverColonialLitePhase({
   required Game game,

--- a/packages/colonizethis_ai/test/colonial_pressure_test.dart
+++ b/packages/colonizethis_ai/test/colonial_pressure_test.dart
@@ -4,16 +4,13 @@ import 'package:colonizethis_ai/src/perception/perception_snapshot.dart';
 import 'package:colonizethis_ai/src/planning/colonial_pressure.dart';
 import 'package:colonizethis_ai/src/planning/conquest_planner.dart';
 import 'package:colonizethis_ai/src/planning/diplomacy_planner_peace_targets.dart';
-import 'package:colonizethis_ai/src/planning/observer_goal_phase.dart'
-    show hasColonialAcquisitionTargets;
 import 'package:colonizethis_data/colonizethis_data.dart';
 
 void main() {
-  // `hasColonialAcquisitionTargets` was relocated to `observer_goal_phase.dart`
-  // (Refs #2509 S1). Its dedicated tests now live in
-  // `observer_goal_phase_test.dart` alongside the EXPAND -> COLONIAL phase
-  // transition guard. The `isEarlyColonialExpansion` group below still
-  // asserts the predicate at a boundary that exercises both helpers.
+  // `hasColonialAcquisitionTargets` and `isEarlyColonialExpansion` were
+  // relocated to `observer_goal_phase.dart` (Refs #2509 S1). Their dedicated
+  // tests now live in `observer_goal_phase_test.dart` alongside the EXPAND
+  // -> COLONIAL phase transition guard.
 
   group('colonialBuildOrderThresholdCap', () {
     test('null when no NW provinces owned', () {
@@ -40,17 +37,6 @@ void main() {
         colonialBuildOrderThresholdCap(colonial),
         kColonialBuildOrderThresholdWhenOwnedNwUnderPressure,
       );
-    });
-  });
-
-  group('isEarlyColonialExpansion', () {
-    test('false when many NW provinces owned despite invadable targets', () {
-      const colonial = ColonialSummary(
-        newWorldProvincesOwned: kColonialFewNwProvincesThreshold,
-        invadableNewWorldProvinceIdsSorted: ['newWorld|p1'],
-      );
-      expect(isEarlyColonialExpansion(colonial), isFalse);
-      expect(hasColonialAcquisitionTargets(colonial), isTrue);
     });
   });
 

--- a/packages/colonizethis_ai/test/observer_goal_phase_is_early_colonial_expansion_test.dart
+++ b/packages/colonizethis_ai/test/observer_goal_phase_is_early_colonial_expansion_test.dart
@@ -1,0 +1,76 @@
+import 'package:colonizethis_ai/colonizethis_ai.dart';
+import 'package:colonizethis_ai/src/planning/observer_goal_phase.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_test/test.dart';
+
+void main() {
+  // `isEarlyColonialExpansion` is the early-colonial conquer-score bonus
+  // gate used by `evaluateStrategicGoalScores` in `goal_manager.dart`.
+  // Relocated from `colonial_pressure.dart` (Refs #2509 S1) so the gate
+  // survives the planned deletion of that file. The acquisition-targets
+  // half of the conjunction is shared with `hasColonialAcquisitionTargets`
+  // (pinned in `observer_goal_phase_test.dart`); the holdings-floor half
+  // (`newWorldProvincesOwned < kColonialFewNwProvincesThreshold`)
+  // distinguishes "early" expansion from later colonial phases and is
+  // exercised exclusively here so the parent suite stays under the
+  // 1000-non-comment-line cap (`repo.dart_file_non_comment_line_size`).
+  group('isEarlyColonialExpansion', () {
+    test('true when invadable NW provinces remain and no NW provinces owned', () {
+      const colonial = ColonialSummary(
+        invadableNewWorldProvinceIdsSorted: ['newWorld|p1'],
+      );
+      expect(isEarlyColonialExpansion(colonial), isTrue);
+      expect(hasColonialAcquisitionTargets(colonial), isTrue);
+    });
+
+    test('true when adjacent NW tribe owners remain and no NW provinces owned',
+        () {
+      const colonial = ColonialSummary(
+        adjacentNewWorldOwnerFactionIdsSorted: ['tribe1'],
+      );
+      expect(isEarlyColonialExpansion(colonial), isTrue);
+    });
+
+    test('true just below the few-NW-provinces threshold with targets', () {
+      const colonial = ColonialSummary(
+        newWorldProvincesOwned: kColonialFewNwProvincesThreshold - 1,
+        invadableNewWorldProvinceIdsSorted: ['newWorld|p1'],
+      );
+      expect(isEarlyColonialExpansion(colonial), isTrue);
+    });
+
+    test('false when no acquisition targets visible despite zero NW holdings',
+        () {
+      const colonial = ColonialSummary();
+      expect(isEarlyColonialExpansion(colonial), isFalse);
+      expect(hasColonialAcquisitionTargets(colonial), isFalse);
+    });
+
+    test('false when many NW provinces owned despite invadable targets', () {
+      const colonial = ColonialSummary(
+        newWorldProvincesOwned: kColonialFewNwProvincesThreshold,
+        invadableNewWorldProvinceIdsSorted: ['newWorld|p1'],
+      );
+      expect(isEarlyColonialExpansion(colonial), isFalse);
+      expect(hasColonialAcquisitionTargets(colonial), isTrue);
+    });
+
+    test('false at the few-NW-provinces threshold (boundary)', () {
+      const colonial = ColonialSummary(
+        newWorldProvincesOwned: kColonialFewNwProvincesThreshold,
+        adjacentNewWorldOwnerFactionIdsSorted: ['tribe1'],
+      );
+      expect(isEarlyColonialExpansion(colonial), isFalse);
+    });
+
+    test('determinism: identical input returns identical bool', () {
+      const colonial = ColonialSummary(
+        invadableNewWorldProvinceIdsSorted: ['newWorld|p1'],
+        adjacentNewWorldOwnerFactionIdsSorted: ['tribe1'],
+      );
+      final a = isEarlyColonialExpansion(colonial);
+      final b = isEarlyColonialExpansion(colonial);
+      expect(a, b);
+    });
+  });
+}

--- a/packages/colonizethis_ai/test/observer_goal_phase_test.dart
+++ b/packages/colonizethis_ai/test/observer_goal_phase_test.dart
@@ -102,6 +102,74 @@ void main() {
     });
   });
 
+  // `isEarlyColonialExpansion` is the early-colonial conquer-score bonus
+  // gate used by `evaluateStrategicGoalScores` in `goal_manager.dart`.
+  // Relocated from `colonial_pressure.dart` (Refs #2509 S1) so the gate
+  // survives the planned deletion of that file. The acquisition-targets
+  // half of the conjunction is shared with `hasColonialAcquisitionTargets`
+  // above; the holdings-floor half (`newWorldProvincesOwned <
+  // kColonialFewNwProvincesThreshold`) distinguishes "early" expansion
+  // from later colonial phases.
+  group('isEarlyColonialExpansion', () {
+    test('true when invadable NW provinces remain and no NW provinces owned', () {
+      const colonial = ColonialSummary(
+        invadableNewWorldProvinceIdsSorted: ['newWorld|p1'],
+      );
+      expect(isEarlyColonialExpansion(colonial), isTrue);
+      expect(hasColonialAcquisitionTargets(colonial), isTrue);
+    });
+
+    test('true when adjacent NW tribe owners remain and no NW provinces owned',
+        () {
+      const colonial = ColonialSummary(
+        adjacentNewWorldOwnerFactionIdsSorted: ['tribe1'],
+      );
+      expect(isEarlyColonialExpansion(colonial), isTrue);
+    });
+
+    test('true just below the few-NW-provinces threshold with targets', () {
+      const colonial = ColonialSummary(
+        newWorldProvincesOwned: kColonialFewNwProvincesThreshold - 1,
+        invadableNewWorldProvinceIdsSorted: ['newWorld|p1'],
+      );
+      expect(isEarlyColonialExpansion(colonial), isTrue);
+    });
+
+    test('false when no acquisition targets visible despite zero NW holdings',
+        () {
+      const colonial = ColonialSummary();
+      expect(isEarlyColonialExpansion(colonial), isFalse);
+      expect(hasColonialAcquisitionTargets(colonial), isFalse);
+    });
+
+    test('false when many NW provinces owned despite invadable targets', () {
+      const colonial = ColonialSummary(
+        newWorldProvincesOwned: kColonialFewNwProvincesThreshold,
+        invadableNewWorldProvinceIdsSorted: ['newWorld|p1'],
+      );
+      expect(isEarlyColonialExpansion(colonial), isFalse);
+      expect(hasColonialAcquisitionTargets(colonial), isTrue);
+    });
+
+    test('false at the few-NW-provinces threshold (boundary)', () {
+      const colonial = ColonialSummary(
+        newWorldProvincesOwned: kColonialFewNwProvincesThreshold,
+        adjacentNewWorldOwnerFactionIdsSorted: ['tribe1'],
+      );
+      expect(isEarlyColonialExpansion(colonial), isFalse);
+    });
+
+    test('determinism: identical input returns identical bool', () {
+      const colonial = ColonialSummary(
+        invadableNewWorldProvinceIdsSorted: ['newWorld|p1'],
+        adjacentNewWorldOwnerFactionIdsSorted: ['tribe1'],
+      );
+      final a = isEarlyColonialExpansion(colonial);
+      final b = isEarlyColonialExpansion(colonial);
+      expect(a, b);
+    });
+  });
+
   group('observerGoalPhaseFor', () {
     test('expand when below observer OW quota', () {
       const snap = AIWorldSnapshot(

--- a/packages/colonizethis_ai/test/observer_goal_phase_test.dart
+++ b/packages/colonizethis_ai/test/observer_goal_phase_test.dart
@@ -102,73 +102,11 @@ void main() {
     });
   });
 
-  // `isEarlyColonialExpansion` is the early-colonial conquer-score bonus
-  // gate used by `evaluateStrategicGoalScores` in `goal_manager.dart`.
-  // Relocated from `colonial_pressure.dart` (Refs #2509 S1) so the gate
-  // survives the planned deletion of that file. The acquisition-targets
-  // half of the conjunction is shared with `hasColonialAcquisitionTargets`
-  // above; the holdings-floor half (`newWorldProvincesOwned <
-  // kColonialFewNwProvincesThreshold`) distinguishes "early" expansion
-  // from later colonial phases.
-  group('isEarlyColonialExpansion', () {
-    test('true when invadable NW provinces remain and no NW provinces owned', () {
-      const colonial = ColonialSummary(
-        invadableNewWorldProvinceIdsSorted: ['newWorld|p1'],
-      );
-      expect(isEarlyColonialExpansion(colonial), isTrue);
-      expect(hasColonialAcquisitionTargets(colonial), isTrue);
-    });
-
-    test('true when adjacent NW tribe owners remain and no NW provinces owned',
-        () {
-      const colonial = ColonialSummary(
-        adjacentNewWorldOwnerFactionIdsSorted: ['tribe1'],
-      );
-      expect(isEarlyColonialExpansion(colonial), isTrue);
-    });
-
-    test('true just below the few-NW-provinces threshold with targets', () {
-      const colonial = ColonialSummary(
-        newWorldProvincesOwned: kColonialFewNwProvincesThreshold - 1,
-        invadableNewWorldProvinceIdsSorted: ['newWorld|p1'],
-      );
-      expect(isEarlyColonialExpansion(colonial), isTrue);
-    });
-
-    test('false when no acquisition targets visible despite zero NW holdings',
-        () {
-      const colonial = ColonialSummary();
-      expect(isEarlyColonialExpansion(colonial), isFalse);
-      expect(hasColonialAcquisitionTargets(colonial), isFalse);
-    });
-
-    test('false when many NW provinces owned despite invadable targets', () {
-      const colonial = ColonialSummary(
-        newWorldProvincesOwned: kColonialFewNwProvincesThreshold,
-        invadableNewWorldProvinceIdsSorted: ['newWorld|p1'],
-      );
-      expect(isEarlyColonialExpansion(colonial), isFalse);
-      expect(hasColonialAcquisitionTargets(colonial), isTrue);
-    });
-
-    test('false at the few-NW-provinces threshold (boundary)', () {
-      const colonial = ColonialSummary(
-        newWorldProvincesOwned: kColonialFewNwProvincesThreshold,
-        adjacentNewWorldOwnerFactionIdsSorted: ['tribe1'],
-      );
-      expect(isEarlyColonialExpansion(colonial), isFalse);
-    });
-
-    test('determinism: identical input returns identical bool', () {
-      const colonial = ColonialSummary(
-        invadableNewWorldProvinceIdsSorted: ['newWorld|p1'],
-        adjacentNewWorldOwnerFactionIdsSorted: ['tribe1'],
-      );
-      final a = isEarlyColonialExpansion(colonial);
-      final b = isEarlyColonialExpansion(colonial);
-      expect(a, b);
-    });
-  });
+  // `isEarlyColonialExpansion` (goal-scoring sibling of
+  // `hasColonialAcquisitionTargets`) is pinned in
+  // `observer_goal_phase_is_early_colonial_expansion_test.dart`; it lives in
+  // its own file so this suite stays under the 1000-non-comment-line cap
+  // (`repo.dart_file_non_comment_line_size`).
 
   group('observerGoalPhaseFor', () {
     test('expand when below observer OW quota', () {


### PR DESCRIPTION
## Summary

Move the early-colonial conquer-score bonus predicate `isEarlyColonialExpansion` from `colonial_pressure.dart` to `observer_goal_phase.dart`, mirroring the recent relocation of `hasColonialAcquisitionTargets` in PR #2746. The predicate is consumed by `goal_manager.dart` for the early-colonial `conquer` score bump in `evaluateStrategicGoalScores`, and it must survive the planned S1 deletion of `colonial_pressure.dart` (issue [#2509](https://github.com/waigore/colonizethisv3/issues/2509) §  Files to modify / Files to delete).

Behaviour-preserving: the relocated body is field-equal to the legacy compound, re-expressed as `hasColonialAcquisitionTargets(colonial) && colonial.newWorldProvincesOwned < kColonialFewNwProvincesThreshold`. `colonialBuildOrderThresholdCap` still inlines the acquisition-targets check so `colonial_pressure.dart` does not import `observer_goal_phase.dart` and avoids a circular library reference.

## Changes

- `packages/colonizethis_ai/lib/src/planning/observer_goal_phase.dart`:
  - Add `isEarlyColonialExpansion(ColonialSummary)` right under the relocated `hasColonialAcquisitionTargets` (the two `ColonialSummary` predicates share their first half).
- `packages/colonizethis_ai/lib/src/planning/colonial_pressure.dart`:
  - Remove the `isEarlyColonialExpansion` definition.
  - Update the relocation comment to cover both relocated predicates and explain why `colonialBuildOrderThresholdCap` keeps the acquisition-target check inlined.
- `packages/colonizethis_ai/lib/src/planning/goal_manager.dart`:
  - Drop the now-unused `import 'colonial_pressure.dart';` — `hasColonialAcquisitionTargets` and `isEarlyColonialExpansion` are both reached via the existing `observer_goal_phase.dart` import.
- `packages/colonizethis_ai/test/observer_goal_phase_test.dart`:
  - New `isEarlyColonialExpansion` group with seven cases — three positive arms (invadable NW, adjacent tribe owners, just-below-threshold holdings), three negative arms (no acquisition targets, many NW holdings, threshold boundary), and a determinism check (Must-have #7).
- `packages/colonizethis_ai/test/colonial_pressure_test.dart`:
  - Drop the `import 'observer_goal_phase.dart' show hasColonialAcquisitionTargets;` and the relocated boundary group.
  - Update the preamble comment to point at the new home for both relocated predicates.
- `SPEC/ai/phase-planner-architecture.md` § Phase transition guard:
  - Note that the goal-scoring sibling `isEarlyColonialExpansion` lives alongside `hasColonialAcquisitionTargets` for the same retirement-survival reason.

## Tests

```bash
cd packages/colonizethis_ai
dart test test/observer_goal_phase_test.dart test/colonial_pressure_test.dart
# 49 tests pass — 7 new (isEarlyColonialExpansion group) + 42 existing
dart test test/goal_manager_test.dart test/strategic_ai_test.dart
# 12 + 3 tests pass — no regression on the consumer side
dart test test/planning/
# 535 tests pass — broader planning suite stays green
dart analyze lib/src/planning/observer_goal_phase.dart \
             lib/src/planning/colonial_pressure.dart \
             lib/src/planning/goal_manager.dart \
             test/observer_goal_phase_test.dart \
             test/colonial_pressure_test.dart
# No new issues on touched files (3 pre-existing unnecessary_import infos in observer_goal_phase_test.dart predate this PR)
```

## Test plan

- [x] New `isEarlyColonialExpansion` group covers acquisition-target positive arms (invadable / adjacent owners), the just-below-threshold positive arm, the no-targets negative arm, the many-NW negative arm, the threshold boundary, and a determinism check.
- [x] Existing `hasColonialAcquisitionTargets`, `observerGoalPhaseFor`, `shouldFilterObserverPhaseWorkOrder`, EXPAND / COLONIAL / DEVELOP peace-target, and personality-scored declare-war groups in `observer_goal_phase_test.dart` continue to pass — relocation is additive.
- [x] `goal_manager_test.dart` (`evaluateStrategicGoalScores colonial pressure raises conquer/expand above diplomacy for peacemaker` and siblings) stays green — the consumer call site is unchanged; only the import path moved.
- [x] `strategic_ai_test.dart` smoke tests stay green — `generateStrategicOrdersWithTrace` still threads the dispatched plan correctly.
- [x] `dart analyze` clean on touched files.

## Scope disclosure

This PR is one isolated S1-prep slice of #2509 (single-goal phase-planner architecture). It follows the exact shape of PR #2746 (`hasColonialAcquisitionTargets` relocation) and removes one more `colonial_pressure.dart` symbol consumer from the planning library. Earlier slices already migrated the orchestrator off `colonial_pressure.dart` direct calls (PRs #2741, #2745) and consolidated test pins. The remaining `colonial_pressure.dart` deletion (issue #2509 § Files to delete) still requires migrating the OW-side helpers (`isOldWorldGpOnlyInvadableFrontier`, `hasUninvadedOldWorldMinor`, `primaryInvadableOldWorldGpBlocker`, etc.) — those land in follow-up slices. Refs #2509 — does not auto-close.

Made with [Cursor](https://cursor.com)