### PR TITLE
docs: add combat UI specs and Widgetbook entries (Refs #2748)

### DIFF
--- a/SPEC/program/app-ui-wiring.md
+++ b/SPEC/program/app-ui-wiring.md
@@ -78,8 +78,10 @@ For `train_civilians` and `train_military`, shared order/count orchestration mus
 
 | ID | Widget | Status |
 |----|--------|--------|
-| `quick_battle_result` | `QuickBattleResultDialog` | `quickBattleResultDialogId` |
-| `combat_mode_choice` | `CombatModeChoiceDialog` (`CombatModeChosenEvent` on choice) | `combatModeChoiceDialogId` |
+| `quick_battle_result` | [`QuickBattleResultDialog`](../ui/quick-battle-result-dialog.md) | `quickBattleResultDialogId` |
+| `combat_mode_choice` | [`CombatModeChoiceDialog`](../ui/combat-mode-choice-dialog.md) (`CombatModeChosenEvent` on choice) | `combatModeChoiceDialogId` |
+
+Combat-flow non-dialog screens (constructed directly by the orchestrator, not via `OpenDialogEvent`) are documented in [`quick-battle-screen.md`](../ui/quick-battle-screen.md), with sub-views [`quick-battle-deployment-view.md`](../ui/quick-battle-deployment-view.md) and [`quick-battle-action-selector.md`](../ui/quick-battle-action-selector.md).
 
 **Local by design (no `OpenDialogEvent`):** map display options (`GameMapArea`), tech detail (`TechTreeWidget`), civilian work-target sheet (`CivilianUnitsPanel`), next-turn confirmation (`GameMapArea`), in-game Android back exit confirmation (`GameScreen`), research tech picker (`TechnologyPanel`), **`CtDropdown`** internal picker, **new-game setup progress and error dialogs** after leader confirmation (see **SPEC/ui/game-initializing.md**).
 

--- a/SPEC/ui/combat-mode-choice-dialog.md
+++ b/SPEC/ui/combat-mode-choice-dialog.md
@@ -1,0 +1,143 @@
+# Combat Mode Choice Dialog
+
+**SPEC/ui** — Modal dialog that lets the player pick between Auto-Resolve and Quick Battle for an upcoming combat. Game model: [quick-battle.md](../game/quick-battle.md), [siege-mechanics.md](../game/siege-mechanics.md). Resolver: [quick-battle-resolution.md](../program/quick-battle-resolution.md). Dialog wiring: [app-ui-wiring.md](../program/app-ui-wiring.md). Follow-up screen: [quick-battle-screen.md](quick-battle-screen.md).
+
+---
+
+## Widget contract
+
+`CombatModeChoiceDialog` is a presentational `StatelessWidget` (`app/lib/features/game/combat/combat_mode_choice_dialog.dart`) wrapped in a `CtDialogShell`.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `bus` | `AppEventBus` | yes | Bus used to emit `CombatModeChosenEvent(CombatMode)` once the player picks a mode. |
+| `provinceName` | `String` | yes | Display name of the contested province; rendered in the dialog title. May be empty (`''`) if upstream did not resolve a name; in that case the title shows the localized template with no name interpolated. |
+| `isCapitalSiege` | `bool` | yes | When `true`, the dialog forces Quick Battle as the only option (auto-resolve is hidden); when `false`, both options are offered. |
+
+The widget owns no internal state. It pops itself via `Navigator.of(context).pop()` once the user picks a mode.
+
+---
+
+## Trigger conditions
+
+- The dialog is opened via `OpenDialogEvent(combatModeChoiceDialogId, params)` where `combatModeChoiceDialogId == 'combat_mode_choice'` (declared in `app/lib/core/services/app_event_handler_scope.dart`). The builder for this id is registered in `app/lib/core/services/app_event_handler_scope_dialog_builders.dart` and constructs the dialog with `provinceName` and `isCapitalSiege` from the event `params`.
+- Required params:
+  - `provinceName: String` — display name of the contested province.
+  - `isCapitalSiege: bool` — `true` for capital sieges per [siege-mechanics.md](../game/siege-mechanics.md).
+- The dialog must not be opened by direct `showDialog` calls from feature panels; cross-cutting opening is bus-driven per [app-ui-wiring.md](../program/app-ui-wiring.md).
+
+---
+
+## Layout / wireframe
+
+### Regular province (`isCapitalSiege == false`)
+
+```text
++------------------------------------------------+
+| CtDialogShell                                  |
+| +--------------------------------------------+ |
+| | Combat at <provinceName>     (titleMedium) | |
+| |                                            | |
+| | Choose how to resolve this combat.         | |
+| |                                            | |
+| |               [ Auto-Resolve ] [ Quick Battle ] | |
+| +--------------------------------------------+ |
++------------------------------------------------+
+```
+
+### Capital siege (`isCapitalSiege == true`)
+
+```text
++------------------------------------------------+
+| CtDialogShell                                  |
+| +--------------------------------------------+ |
+| | Combat at <provinceName>     (titleMedium) | |
+| |                                            | |
+| | Capital sieges must be resolved with       | |
+| | Quick Battle.                              | |
+| |                                            | |
+| |                              [ Quick Battle ] | |
+| +--------------------------------------------+ |
++------------------------------------------------+
+```
+
+- Outer container: `CtDialogShell`.
+- Inner column: `Column(mainAxisSize: min, crossAxisAlignment: start)`.
+- Title: `Text` styled `Theme.of(context).textTheme.titleMedium`, rendered via `appL10n(context).quickBattle_combatAt(provinceName)`.
+- 8 dp gap, then explanatory body text:
+  - `appL10n(context).quickBattle_capitalSiegeQuickBattleOnly` when `isCapitalSiege == true`.
+  - `appL10n(context).quickBattle_chooseCombatMode` otherwise.
+- 16 dp gap, then a `Row(mainAxisAlignment: end)` with action buttons:
+  - Regular: `[ Auto-Resolve ]` (`appL10n(context).quickBattle_autoResolve`) followed by 8 dp spacer and `[ Quick Battle ]` (`appL10n(context).quickBattle_quickBattle`).
+  - Capital siege: only `[ Quick Battle ]`.
+- Buttons are `CtNinePatchButton`s; Material buttons are not permitted.
+
+---
+
+## States and variants
+
+| State | Trigger | Render |
+|-------|---------|--------|
+| Default (regular) | `isCapitalSiege == false` | Body text from `quickBattle_chooseCombatMode`; both action buttons visible. |
+| Capital siege | `isCapitalSiege == true` | Body text from `quickBattle_capitalSiegeQuickBattleOnly`; only Quick Battle button visible. Auto-Resolve button is **omitted from the tree**, not merely disabled. |
+| Empty province name | `provinceName == ''` | Title still renders the localized `quickBattle_combatAt` template; the empty string is interpolated as-is. |
+
+The dialog is modal; it does not auto-dismiss without a player choice.
+
+---
+
+## Navigation
+
+- **Entry:** `OpenDialogEvent(combatModeChoiceDialogId, params)` from the combat phase orchestrator.
+- **Exit on Auto-Resolve tap (regular only):** Emit `CombatModeChosenEvent(CombatMode.autoResolve)` on the supplied `bus`, then call `Navigator.of(context).pop()`.
+- **Exit on Quick Battle tap:** Emit `CombatModeChosenEvent(CombatMode.quickBattle)` on the supplied `bus`, then call `Navigator.of(context).pop()`.
+- The dialog does not push or pop other routes. Downstream wiring (e.g., opening [quick-battle-screen.md](quick-battle-screen.md)) is owned by the listener of `CombatModeChosenEvent`, not the dialog.
+
+---
+
+## Components
+
+- `CtDialogShell` (`app/lib/widgets/ct_dialog_shell.dart`).
+- `CtNinePatchButton` (`app/lib/widgets/ct_nine_patch_button.dart`).
+- Localized strings via `appL10n(context).quickBattle_*`.
+- `AppEventBus` (`packages/colonizethis_models`) for emitting `CombatModeChosenEvent`.
+- No Material buttons.
+
+---
+
+## Acceptance Criteria (Given–When–Then)
+
+- Given the dialog is opened via `OpenDialogEvent(combatModeChoiceDialogId, {'provinceName': 'Lisbon', 'isCapitalSiege': false})`,
+  When the UI layer renders the dialog,
+  Then the dialog displays the title `Combat at Lisbon` (localized template), the body text from `quickBattle_chooseCombatMode`, and exactly two `CtNinePatchButton`s labeled with `quickBattle_autoResolve` and `quickBattle_quickBattle`.
+
+- Given the dialog is opened with `isCapitalSiege: true`,
+  When the UI layer renders the dialog,
+  Then the body text comes from `quickBattle_capitalSiegeQuickBattleOnly`, only one `CtNinePatchButton` labeled with `quickBattle_quickBattle` is present, and no Auto-Resolve button is in the widget tree.
+
+- Given the dialog is mounted with `isCapitalSiege: false` and a bus listener subscribed to `CombatModeChosenEvent`,
+  When the user taps the Auto-Resolve button,
+  Then the dialog emits exactly one `CombatModeChosenEvent(CombatMode.autoResolve)` on the supplied bus and pops itself off the navigator stack.
+
+- Given the dialog is mounted with `isCapitalSiege: false` and a bus listener subscribed to `CombatModeChosenEvent`,
+  When the user taps the Quick Battle button,
+  Then the dialog emits exactly one `CombatModeChosenEvent(CombatMode.quickBattle)` on the supplied bus and pops itself off the navigator stack.
+
+- Given the dialog is mounted with `isCapitalSiege: true` and a bus listener subscribed to `CombatModeChosenEvent`,
+  When the user taps the Quick Battle button,
+  Then the dialog emits exactly one `CombatModeChosenEvent(CombatMode.quickBattle)` and pops itself.
+
+- Given the dialog is mounted,
+  When the UI layer renders the widget tree,
+  Then there is exactly one `CtDialogShell` and zero Material `ElevatedButton`, `TextButton`, or `OutlinedButton` widgets in the dialog subtree.
+
+---
+
+## Widgetbook
+
+Catalog directory: `Combat Mode Choice Dialog` (registered in `app/lib/widgetbook/catalog.dart`). Required use cases:
+
+1. **Regular province** — `provinceName: 'Lisbon'`, `isCapitalSiege: false`; both buttons visible.
+2. **Capital siege** — `provinceName: 'Madrid'`, `isCapitalSiege: true`; Quick Battle only.
+
+Each use case wires a fresh `AppEventBus.create()` so the catalog story does not leak `CombatModeChosenEvent` listeners between runs.

--- a/SPEC/ui/quick-battle-action-selector.md
+++ b/SPEC/ui/quick-battle-action-selector.md
@@ -1,0 +1,120 @@
+# Quick Battle Action Selector
+
+**SPEC/ui** — CP-based action picker rendered inside [Quick Battle Screen](quick-battle-screen.md) when the player drives Quick Battle interactively. Game model: [quick-battle.md](../game/quick-battle.md) § Turn structure and actions. Resolver: [quick-battle-resolution.md](../program/quick-battle-resolution.md).
+
+---
+
+## Widget contract
+
+`QuickBattleActionSelector` is a presentational `StatelessWidget` (`app/lib/features/game/combat/quick_battle_action_selector.dart`).
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `cpRemaining` | `int` | yes | Command Points (CP) currently available to the side. Integer in range `0..3`. |
+| `onActionSelected` | `ValueChanged<QuickBattleAction>` | yes | Invoked exactly once when the player taps an enabled action button. |
+
+The widget owns no internal state; CP is pushed in by the parent (`QuickBattleScreen` for current phase, AI/observer overrides in future).
+
+---
+
+## Trigger conditions
+
+The widget is mounted by `QuickBattleScreen` only when `interactive == true`. In headless / non-interactive mode (`interactive == false`), the parent renders a `CtNinePatchButton` labeled `Resolve (Auto)` instead and never instantiates this widget.
+
+---
+
+## Layout / wireframe
+
+```text
++----------------------------------------------------+
+| Command Points: <cpRemaining>     (titleSmall)     |
+| +------------------------------------------------+ |
+| | Wrap (spacing 8, runSpacing 8)                 | |
+| | [ Volley Fire (1 CP) ] [ Defend (1 CP) ]       | |
+| | [ Maneuver (1 CP) ] [ Fall Back (2 CP) ]       | |
+| | [ Assault (2 CP) ]                             | |
+| +------------------------------------------------+ |
++----------------------------------------------------+
+```
+
+- Outer layout: `Column(crossAxisAlignment: start, mainAxisSize: min)`.
+- CP label: `Text` styled with `Theme.of(context).textTheme.titleSmall`, formatted via `appL10n(context).quickBattle_commandPoints(cpRemaining)`.
+- 8 dp vertical gap, then a `Wrap(spacing: 8, runSpacing: 8)` of action buttons.
+- Buttons are `CtNinePatchButton`s with localized labels (`appL10n(context).quickBattle_actionWithCost(label, cost)`); Material `ElevatedButton`/`TextButton` are not permitted.
+
+### Action catalog (current phase)
+
+| Action | CP cost | Label key |
+|--------|---------|-----------|
+| `QuickBattleAction.volleyFire` | `1` | `quickBattle_action_volleyFire` |
+| `QuickBattleAction.defendEntrench` | `1` | `quickBattle_action_defend` |
+| `QuickBattleAction.maneuver` | `1` | `quickBattle_action_maneuver` |
+| `QuickBattleAction.fallBackRefuseFlank` | `2` | `quickBattle_action_fallBack` |
+| `QuickBattleAction.assaultCharge` | `2` | `quickBattle_action_assault` |
+
+The action set, ordering, and CP costs above match [quick-battle.md](../game/quick-battle.md) § Turn structure and actions and must stay in sync with `QuickBattleAction` enum values.
+
+---
+
+## States and variants
+
+| State | Trigger | Render |
+|-------|---------|--------|
+| Full CP | `cpRemaining == 3` | All five buttons enabled. |
+| Reduced CP (`1 ≤ cpRemaining < 2`) | One CP left after a 2-CP action. | 1-CP buttons (Volley Fire, Defend, Maneuver) enabled; 2-CP buttons disabled. |
+| Reduced CP (`cpRemaining == 2`) | Two CP left. | All five buttons enabled. |
+| Spent (`cpRemaining == 0`) | Side has spent all CP this round. | All buttons disabled (`CtNinePatchButton.onPressed == null`). |
+| Negative `cpRemaining` | Defensive: parent passes a negative value. | All buttons disabled. |
+
+A button is **enabled** iff `cpRemaining >= cost(action)`; otherwise the button renders disabled (`onPressed: null`). The widget does not deduct CP itself; the parent updates `cpRemaining` after each tap.
+
+---
+
+## Navigation
+
+- **Entry:** Mounted by `QuickBattleScreen` when `interactive == true`.
+- **Exit:** When the user taps an enabled action button, the widget invokes `onActionSelected(action)` once. The parent decides what happens next (e.g., apply the action, recompute CP, advance round).
+- **Cross-panel events:** None. The widget does not call `AppEventBus.emit`, `Navigator.push`, or `showDialog`.
+
+---
+
+## Components
+
+- `CtNinePatchButton` (shared pixel-art button; `app/lib/widgets/ct_nine_patch_button.dart`).
+- `Wrap` for responsive button layout.
+- `Text` styled with `titleSmall`.
+- No Material buttons (`ElevatedButton`, `TextButton`, etc.) per UXD 02 / pixel-art component rule.
+
+---
+
+## Acceptance Criteria (Given–When–Then)
+
+- Given a `QuickBattleActionSelector` with `cpRemaining = 3` is mounted,
+  When the UI layer renders the widget,
+  Then the UI layer displays five `CtNinePatchButton`s in this order — Volley Fire (1 CP), Defend (1 CP), Maneuver (1 CP), Fall Back (2 CP), Assault (2 CP) — and every button has a non-null `onPressed`.
+
+- Given a `QuickBattleActionSelector` with `cpRemaining = 1`,
+  When the UI layer renders the widget,
+  Then the buttons for `volleyFire`, `defendEntrench`, and `maneuver` are enabled (non-null `onPressed`), and the buttons for `fallBackRefuseFlank` and `assaultCharge` are disabled (`onPressed == null`).
+
+- Given a `QuickBattleActionSelector` with `cpRemaining = 0`,
+  When the UI layer renders the widget,
+  Then all five action buttons are disabled (`onPressed == null`) and the CP label reads `Command Points: 0` (or its localized equivalent).
+
+- Given a `QuickBattleActionSelector` with `cpRemaining = 3` and an `onActionSelected` callback,
+  When the user taps the Volley Fire button,
+  Then the UI layer invokes `onActionSelected(QuickBattleAction.volleyFire)` exactly once and does not invoke any other callback or emit any `AppEvent`.
+
+- Given a `QuickBattleActionSelector` with `cpRemaining = -1` (defensive value supplied by parent),
+  When the UI layer renders the widget,
+  Then all five action buttons are disabled (`onPressed == null`) and the widget does not throw.
+
+- Given a `QuickBattleActionSelector` is mounted,
+  When the UI layer renders the widget,
+  Then the widget contains no `ElevatedButton`, `TextButton`, or `OutlinedButton` (Material) widgets.
+
+---
+
+## Widgetbook
+
+Catalog directory: `Quick Battle Action Selector` (registered in `app/lib/widgetbook/catalog.dart`). At least one default use case with `cpRemaining = 3` (all actions enabled). Additional use cases are encouraged for `cpRemaining = 1` (mixed enabled/disabled) and `cpRemaining = 0` (all disabled).

--- a/SPEC/ui/quick-battle-deployment-view.md
+++ b/SPEC/ui/quick-battle-deployment-view.md
@@ -1,0 +1,122 @@
+# Quick Battle Deployment View
+
+**SPEC/ui** — Read-only view that visualizes attacker and defender lane / line composition for a Quick Battle. Used as a sub-view inside [Quick Battle Screen](quick-battle-screen.md). Game model: [quick-battle.md](../game/quick-battle.md). Resolver: [quick-battle-resolution.md](../program/quick-battle-resolution.md).
+
+---
+
+## Widget contract
+
+`QuickBattleDeploymentView` is a presentational `StatelessWidget` (`app/lib/features/game/combat/quick_battle_deployment_view.dart`).
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `attackerDeployment` | `QuickBattleDeployment` | yes | Side composition; one entry per `QuickBattleGroup` (lane, line, unit ids, cohesion). |
+| `defenderDeployment` | `QuickBattleDeployment` | yes | Same shape as attacker. |
+| `attackerName` | `String` | no (default `'Attacker'`) | Header label for the attacker block. |
+| `defenderName` | `String` | no (default `'Defender'`) | Header label for the defender block. |
+
+The widget does not own state, callbacks, or business logic. It only renders the supplied composition.
+
+---
+
+## Trigger conditions
+
+The widget is mounted by `QuickBattleScreen` whenever its result view is not active (rounds 1..N). It is **not** registered as a dialog id and is never opened directly via `OpenDialogEvent`.
+
+---
+
+## Layout / wireframe
+
+```text
++------------------------------------------------+
+| Attacker (titleMedium)                         |
+| +--------------------------------------------+ |
+| | CtPanel (12 dp padding)                    | |
+| |                                            | |
+| | [Center Front: 3 units (Cohesion 3)]       | |
+| | [Center Front: 2 units]                    | |
+| +--------------------------------------------+ |
+|                                                |
+| Defender (titleMedium)                         |
+| +--------------------------------------------+ |
+| | CtPanel (12 dp padding)                    | |
+| |                                            | |
+| | [Center Front: 4 units (Cohesion 3)]       | |
+| +--------------------------------------------+ |
++------------------------------------------------+
+```
+
+- Outer layout: `Column` with `crossAxisAlignment: stretch` and `mainAxisSize: min`.
+- 16 dp vertical spacing between attacker and defender blocks.
+- Each side: title `Text` (theme `titleMedium`) followed by a `CtPanel` containing a `Wrap(spacing: 12, runSpacing: 8)` of group rows.
+- Each group row formats as `<Lane> <Line>: <unitCount> units[ (Cohesion <c>)]`. The cohesion suffix is suppressed when `cohesion <= 0`.
+
+### Lane and line labels
+
+- Lane: `LEFT → 'Left'`, `CENTER → 'Center'`, `RIGHT → 'Right'`, `RESERVE → 'Reserve'`.
+- Line: `FRONT → 'Front'`, `SUPPORT → 'Support'`.
+
+The widget renders all groups returned by the resolver input. The current Quick Battle phase only populates `CENTER + FRONT` groups (see [quick-battle.md](../game/quick-battle.md) § Battlefield layout); any future expansion to `LEFT/RIGHT/RESERVE` and `SUPPORT` is rendered automatically without code changes here.
+
+---
+
+## States and variants
+
+| State | Trigger | Render |
+|-------|---------|--------|
+| Default | Both deployments contain at least one group. | Two stacked side blocks with all groups listed. |
+| Empty side | A side's `groups` list is empty. | Side title shown; `CtPanel` body renders an empty `Wrap` (no group rows). |
+| Cohesion 0 | A group's `cohesion` is `0`. | Row text omits the `(Cohesion <c>)` suffix. |
+| Custom names | `attackerName` / `defenderName` provided. | Headers display the supplied strings instead of `'Attacker'` / `'Defender'`. |
+
+Both sides always render in the order **attacker → defender** to match resolver semantics.
+
+---
+
+## Navigation
+
+- **Entry:** Always rendered as a child inside `QuickBattleScreen` when the round phase is active.
+- **Exit:** None. The widget is removed from the tree when `QuickBattleScreen` switches to its result view (`onComplete`) or is dismissed.
+- **Cross-panel events:** None. The widget does not subscribe to or emit `AppEventBus` events; cross-screen behavior belongs to `QuickBattleScreen`.
+
+---
+
+## Components
+
+- `CtPanel` (shared pixel-art panel; `app/lib/widgets/ct_panel.dart`).
+- `Text` from `Theme.of(context).textTheme.titleMedium` and `bodySmall`.
+- No `CtNinePatchButton` here; this view is purely informational.
+
+---
+
+## Acceptance Criteria (Given–When–Then)
+
+- Given a `QuickBattleDeploymentView` with an attacker deployment containing one `QuickBattleGroup(lane: center, line: front, unitIds: [3 ids], cohesion: 3)` and `attackerName: 'Castile'`,
+  When the UI layer renders the widget,
+  Then the UI layer displays the header text `Castile` followed by a `CtPanel` containing a row whose text equals `Center Front: 3 units (Cohesion 3)`.
+
+- Given a `QuickBattleDeploymentView` with a defender group whose `cohesion` is `0`,
+  When the UI layer renders the widget,
+  Then the row for that group displays `<Lane> <Line>: <n> units` with no `(Cohesion ...)` suffix.
+
+- Given a `QuickBattleDeploymentView` constructed without `attackerName` or `defenderName`,
+  When the UI layer renders the widget,
+  Then the attacker header displays the literal string `Attacker` and the defender header displays the literal string `Defender`.
+
+- Given a `QuickBattleDeploymentView` whose attacker `groups` list is empty,
+  When the UI layer renders the widget,
+  Then the attacker header is shown, a `CtPanel` is rendered, and no group rows appear inside that panel.
+
+- Given a `QuickBattleDeploymentView` with attacker groups for lanes `center` and `right` and lines `front` and `support`,
+  When the UI layer renders the widget,
+  Then each group row uses the canonical labels `Left/Center/Right/Reserve` for lane and `Front/Support` for line, and groups appear in the order returned by `attackerDeployment.groups` (no client-side sort).
+
+- Given a `QuickBattleDeploymentView` is mounted with non-null deployments,
+  When the user views the screen,
+  Then the widget does not emit any `AppEvent`, does not call `Navigator.push`, and does not call `showDialog`.
+
+---
+
+## Widgetbook
+
+Catalog directory: `Quick Battle Deployment View` (registered alongside other combat catalog folders in `app/lib/widgetbook/catalog.dart`). At least one default use case with both attacker and defender groups configured at `CENTER + FRONT`. Mobile viewport may be added if the layout differs meaningfully on narrow widths.

--- a/SPEC/ui/quick-battle-result-dialog.md
+++ b/SPEC/ui/quick-battle-result-dialog.md
@@ -1,0 +1,130 @@
+# Quick Battle Result Dialog
+
+**SPEC/ui** — Modal dialog that presents the outcome of a Quick Battle. Game model: [quick-battle.md](../game/quick-battle.md). Resolver: [quick-battle-resolution.md](../program/quick-battle-resolution.md). Dialog wiring: [app-ui-wiring.md](../program/app-ui-wiring.md). Sibling: [combat-mode-choice-dialog.md](combat-mode-choice-dialog.md).
+
+---
+
+## Widget contract
+
+`QuickBattleResultDialog` is a presentational `StatelessWidget` (`app/lib/features/game/combat/quick_battle_result_dialog.dart`) wrapped in a `CtDialogShell`.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `result` | `QuickBattleResult` | yes | Output of `resolveQuickBattle` (winner, casualties, `provinceFlips`, etc.). |
+| `attackerName` | `String` | no (default `'Attacker'`) | Display name of the attacker; used in winner text and casualty rows. |
+| `defenderName` | `String` | no (default `'Defender'`) | Display name of the defender. |
+
+The widget owns no internal state. It pops itself via `Navigator.of(context).pop()` when the user taps OK.
+
+---
+
+## Trigger conditions
+
+- The dialog is opened via `OpenDialogEvent(quickBattleResultDialogId, params)` where `quickBattleResultDialogId == 'quick_battle_result'` (declared in `app/lib/core/services/app_event_handler_scope.dart`). The builder for this id is registered in `app/lib/core/services/app_event_handler_scope_dialog_builders.dart` and constructs the dialog from the event `params`.
+- Required params:
+  - `result: QuickBattleResult` — when missing, the builder renders `SizedBox.shrink()` (no dialog content).
+  - `attackerName: String?` — defaults to `'Attacker'` when absent.
+  - `defenderName: String?` — defaults to `'Defender'` when absent.
+- The dialog is typically opened by the combat phase orchestrator after [quick-battle-screen.md](quick-battle-screen.md) calls its `onComplete`, or after a headless / observer Quick Battle completes.
+
+---
+
+## Layout / wireframe
+
+```text
++------------------------------------------------+
+| CtDialogShell                                  |
+| +--------------------------------------------+ |
+| | <Winner text>                (titleMedium) | |
+| |                                            | |
+| | (Optional) Province captured!  (bold)      | |
+| |                                            | |
+| | <Attacker> casualties: <attackerCount>     | |
+| | <Defender> casualties: <defenderCount>     | |
+| |                                            | |
+| |                                    [ OK ]  | |
+| +--------------------------------------------+ |
++------------------------------------------------+
+```
+
+- Outer container: `CtDialogShell`.
+- Inner column: `Column(mainAxisSize: min, crossAxisAlignment: start)`.
+- Winner text uses `Theme.of(context).textTheme.titleMedium` and is built from `appL10n(context).quickBattle_battleResult(<winnerString>)`, where `<winnerString>` is one of:
+  - `quickBattle_attackerWins(attackerName)` — when `result.winner == QuickBattleWinner.attacker`.
+  - `quickBattle_defenderHolds(defenderName)` — when `result.winner == QuickBattleWinner.defender`.
+  - `quickBattle_mutualExhaustion` — when `result.winner == QuickBattleWinner.mutualExhaustion`.
+- 8 dp gap, then conditionally render `quickBattle_provinceCaptured` (`fontWeight: bold`) only when `result.provinceFlips == true`.
+- 8 dp gap, then two casualty rows:
+  - `appL10n(context).quickBattle_casualties(attackerName, result.attackerCasualties.length)`.
+  - `appL10n(context).quickBattle_casualties(defenderName, result.defenderCasualties.length)`.
+- 16 dp gap, then `Align(alignment: centerRight)` containing a single `CtNinePatchButton` labeled `appL10n(context).quickBattle_ok`.
+
+---
+
+## States and variants
+
+| Outcome | Trigger | Render |
+|---------|---------|--------|
+| Attacker wins | `result.winner == QuickBattleWinner.attacker` | Winner text from `quickBattle_attackerWins(attackerName)`. Province-capture line shown only when `result.provinceFlips == true`. |
+| Defender holds | `result.winner == QuickBattleWinner.defender` | Winner text from `quickBattle_defenderHolds(defenderName)`. Province-capture line is suppressed (defender holds implies no flip). |
+| Mutual exhaustion | `result.winner == QuickBattleWinner.mutualExhaustion` | Winner text from `quickBattle_mutualExhaustion`. Province-capture line is suppressed. |
+| Province flip | `result.provinceFlips == true` | Bold `quickBattle_provinceCaptured` line rendered above casualty counts. |
+| No flip | `result.provinceFlips == false` | Province-capture line is omitted from the tree. |
+| Empty casualties | Either side's `casualties.length == 0` | Casualty row still shown with count `0`. |
+
+The dialog is modal; it does not auto-dismiss.
+
+---
+
+## Navigation
+
+- **Entry:** `OpenDialogEvent(quickBattleResultDialogId, params)` from the combat phase orchestrator.
+- **Exit on OK tap:** `Navigator.of(context).pop()`. The dialog does not emit any `AppEvent`; downstream consumers track battle outcome through the resolver result that was already applied to `WorldState`, not through the OK tap.
+- **Hardware back / dismiss:** Standard modal route dismissal pops the dialog without applying any side effects (the resolver result was applied upstream).
+
+---
+
+## Components
+
+- `CtDialogShell` (`app/lib/widgets/ct_dialog_shell.dart`).
+- `CtNinePatchButton` (`app/lib/widgets/ct_nine_patch_button.dart`).
+- Localized strings via `appL10n(context).quickBattle_*`.
+- No Material buttons.
+
+---
+
+## Acceptance Criteria (Given–When–Then)
+
+- Given the dialog is opened with `result.winner == QuickBattleWinner.attacker`, `result.provinceFlips == true`, `attackerName: 'Castile'`, `defenderName: 'England'`,
+  When the UI layer renders the dialog,
+  Then the title text is `quickBattle_battleResult(quickBattle_attackerWins('Castile'))`, a bold `quickBattle_provinceCaptured` line is rendered, and two casualty rows are rendered using `quickBattle_casualties('Castile', ...)` and `quickBattle_casualties('England', ...)`.
+
+- Given the dialog is opened with `result.winner == QuickBattleWinner.defender` and `result.provinceFlips == false`,
+  When the UI layer renders the dialog,
+  Then the title text is `quickBattle_battleResult(quickBattle_defenderHolds(<defenderName>))` and no `quickBattle_provinceCaptured` line is in the widget tree.
+
+- Given the dialog is opened with `result.winner == QuickBattleWinner.mutualExhaustion`,
+  When the UI layer renders the dialog,
+  Then the title text equals `quickBattle_battleResult(quickBattle_mutualExhaustion)`, no `quickBattle_provinceCaptured` line is rendered, and the casualty rows are still present.
+
+- Given the dialog is mounted on a navigator,
+  When the user taps the OK `CtNinePatchButton`,
+  Then `Navigator.of(context).pop()` is called exactly once and the dialog emits no `AppEvent`.
+
+- Given the dialog builder receives event params with `result == null`,
+  When the dialog id `quick_battle_result` is dispatched through `OpenDialogEvent`,
+  Then the builder returns `SizedBox.shrink()` (per `app_event_handler_scope_dialog_builders.dart`) and no Quick Battle dialog appears on screen.
+
+- Given the dialog is opened with `attackerName` and `defenderName` omitted,
+  When the UI layer renders the dialog,
+  Then the casualty rows interpolate the literal strings `Attacker` and `Defender` (via the `String` defaults on the widget contract).
+
+- Given the dialog is mounted,
+  When the UI layer renders the widget tree,
+  Then there is exactly one `CtDialogShell`, zero Material `ElevatedButton`, `TextButton`, or `OutlinedButton`, and exactly one `CtNinePatchButton` labeled with `quickBattle_ok`.
+
+---
+
+## Widgetbook
+
+Catalog directory: `Quick Battle Result Dialog` (registered in `app/lib/widgetbook/catalog.dart`). At least one default use case constructs a `QuickBattleResultDialog` with a sample `QuickBattleResult` (attacker wins, `provinceFlips: true`, two attacker casualty ids, one defender casualty id). Additional use cases for defender hold and mutual exhaustion are encouraged.

--- a/SPEC/ui/quick-battle-screen.md
+++ b/SPEC/ui/quick-battle-screen.md
@@ -1,0 +1,150 @@
+# Quick Battle Screen
+
+**SPEC/ui** — Tactical mini-game screen that runs a single Quick Battle from deployment to result. Game model: [quick-battle.md](../game/quick-battle.md). Resolver pipeline: [quick-battle-resolution.md](../program/quick-battle-resolution.md). Combat mode entry: [combat-mode-choice-dialog.md](combat-mode-choice-dialog.md). Final result presentation: [quick-battle-result-dialog.md](quick-battle-result-dialog.md). Sub-views: [quick-battle-deployment-view.md](quick-battle-deployment-view.md), [quick-battle-action-selector.md](quick-battle-action-selector.md). Dialog wiring: [app-ui-wiring.md](../program/app-ui-wiring.md).
+
+---
+
+## Widget contract
+
+`QuickBattleScreen` is a `StatefulWidget` (`app/lib/features/game/combat/quick_battle_screen.dart`) presented inside a `CtDialogShell` (max width 400 dp, max height 500 dp).
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `input` | `QuickBattleInput` | yes | Battle context (factions, deployments, province, max rounds, seed) built upstream by the combat pipeline (see [quick-battle-resolution.md](../program/quick-battle-resolution.md)). |
+| `onComplete` | `ValueChanged<QuickBattleResult>` | yes | Invoked exactly once when the user dismisses the result view via Continue. |
+| `interactive` | `bool` | no (default `false`) | When `true`, the player picks an action via [quick-battle-action-selector.md](quick-battle-action-selector.md) before resolving. When `false`, the screen runs the resolver with default actions (Volley Fire) automatically on mount. |
+
+The widget is presentational with respect to game state — it does not read providers; resolution runs in-process through `colonizethis_logic.resolveQuickBattle`.
+
+---
+
+## Trigger conditions
+
+- The screen is opened by the combat phase resolver when the player has chosen Quick Battle for a province (see [combat-mode-choice-dialog.md](combat-mode-choice-dialog.md)) or when a capital siege forces Quick Battle.
+- The screen is **not** registered as an `OpenDialogEvent` id in `app/lib/core/services/app_event_handler_scope.dart`. The orchestrating combat flow constructs `QuickBattleScreen` directly (or via a future typed event) and supplies `onComplete` to feed the result back into the combat pipeline.
+- While `turnResolutionBlockingProvider == true`, normal bus-driven dialogs are gated per [app-ui-wiring.md](../program/app-ui-wiring.md) § Turn resolution in progress; Quick Battle invocation must coordinate with that gate (typically the combat phase pauses turn-resolution UI dismissal until the screen completes).
+
+---
+
+## Layout / wireframe
+
+### Round phase (interactive or headless, before result)
+
+```text
++------------------------------------------------+
+| CtDialogShell (max 400 x 500 dp)               |
+| +--------------------------------------------+ |
+| | Round X of Y           (titleMedium)       | |
+| |                                            | |
+| | QuickBattleDeploymentView                  | |
+| |   (attacker block, then defender block)    | |
+| |                                            | |
+| | -- if interactive == true --               | |
+| | QuickBattleActionSelector(cpRemaining: 3)  | |
+| |                                            | |
+| | -- if interactive == false --              | |
+| | [ Resolve (Auto) ]   (CtNinePatchButton)   | |
+| +--------------------------------------------+ |
++------------------------------------------------+
+```
+
+- Outer container: `CtDialogShell(maxWidth: 400, maxHeight: 500)`.
+- Inner column: `Column(mainAxisSize: min, crossAxisAlignment: stretch)`.
+- Title text: `appL10n(context).quickBattle_round(_round, widget.input.maxRounds)`.
+- 12 dp gap before the deployment view; 12 dp gap before the action selector or auto-resolve button.
+
+### Result phase (after resolver returns)
+
+```text
++------------------------------------------------+
+| CtDialogShell                                  |
+| +--------------------------------------------+ |
+| | <Winner text>                (titleMedium) | |
+| | (Optional) Province captured!  (bold)      | |
+| |                                            | |
+| | <Attacker> casualties: <n>                 | |
+| | <Defender> casualties: <n>                 | |
+| |                                            | |
+| |                              [ Continue ]  | |
+| +--------------------------------------------+ |
++------------------------------------------------+
+```
+
+- Winner text comes from `QuickBattleResult.winner` mapped to `quickBattle_attackerWins`, `quickBattle_defenderHolds`, or `quickBattle_mutualExhaustion`.
+- `provinceCaptured` line appears only when `result.provinceFlips == true`.
+- Continue button (`CtNinePatchButton`) invokes `onComplete(result)` exactly once.
+
+---
+
+## States and variants
+
+| Mode | Trigger | Behavior |
+|------|---------|----------|
+| Headless / AI | `interactive == false` | `initState` calls `_runWithDefaults`, which invokes `resolveQuickBattle(input)` with default round actions and transitions directly to the result phase. The Resolve (Auto) button remains visible during the same frame as a manual fallback. |
+| Interactive | `interactive == true` | Round phase renders `QuickBattleActionSelector` with `cpRemaining: 3`. Tapping an action invokes `_onActionSelected`, which calls `resolveQuickBattle` with three rounds of explicit actions (the chosen action followed by two default Volley Fire rounds) and transitions to the result phase. |
+| Result | `_result != null` (after either path) | Round-phase widgets are unmounted; result view renders winner, optional province-capture line, casualties, and Continue. |
+
+The current Quick Battle phase only deploys `CENTER + FRONT` units (see [quick-battle.md](../game/quick-battle.md) § Battlefield layout). The screen still renders any `LEFT/RIGHT/RESERVE` or `SUPPORT` groups returned by future resolver inputs without code changes.
+
+---
+
+## Navigation
+
+- **Entry points:**
+  - Combat phase orchestrator after the player chooses `CombatMode.quickBattle` via [combat-mode-choice-dialog.md](combat-mode-choice-dialog.md), or when `isCapitalSiege == true` (forced Quick Battle, see [siege-mechanics.md](../game/siege-mechanics.md)).
+  - Future AI / observer paths may construct the screen with `interactive: false` to run the resolver inside a dialog tree without user input.
+- **Exit:** Always via `onComplete(QuickBattleResult)` once the user taps Continue. The orchestrator typically follows up by emitting `OpenDialogEvent(quickBattleResultDialogId)` so the result is presented through the canonical dialog registry (`QuickBattleResultDialog`), or by applying the result directly when no further confirmation is needed.
+- **Hardware back / dismiss:** The screen does not handle Android back; the orchestrator keeps the screen alive until `onComplete` fires.
+
+---
+
+## Components
+
+- `CtDialogShell` (`app/lib/widgets/ct_dialog_shell.dart`).
+- `CtNinePatchButton` (Resolve (Auto) and Continue).
+- [`QuickBattleDeploymentView`](quick-battle-deployment-view.md) — sub-view rendered every round.
+- [`QuickBattleActionSelector`](quick-battle-action-selector.md) — sub-view rendered only when `interactive == true`.
+- Localized strings via `appL10n(context).quickBattle_*`.
+- No Material buttons.
+
+---
+
+## Acceptance Criteria (Given–When–Then)
+
+- Given a `QuickBattleScreen` is mounted with valid `input`, `onComplete` callback, and `interactive: false`,
+  When the framework runs the first frame,
+  Then the screen calls `resolveQuickBattle(input)` once and transitions to the result view; the result view renders the winner text, the casualty counts for both sides, and a Continue `CtNinePatchButton`.
+
+- Given a `QuickBattleScreen` is mounted with `interactive: false`,
+  When the user taps the Continue button on the result view,
+  Then the screen invokes `onComplete(result)` exactly once with the resolver's `QuickBattleResult` and does not invoke `onComplete` a second time on subsequent taps.
+
+- Given a `QuickBattleScreen` is mounted with `interactive: true`,
+  When the framework runs the first frame,
+  Then the screen does not call `resolveQuickBattle`, displays `QuickBattleDeploymentView` and `QuickBattleActionSelector(cpRemaining: 3)`, and does not display the Resolve (Auto) button.
+
+- Given a `QuickBattleScreen` is mounted with `interactive: true` and `cpRemaining = 3`,
+  When the user taps the Volley Fire action button,
+  Then the screen calls `resolveQuickBattle(input, roundActions: [VolleyFire, VolleyFire, VolleyFire])` and transitions to the result view.
+
+- Given a `QuickBattleScreen` is mounted with an `input.maxRounds == 3`,
+  When the round phase is rendered,
+  Then the title text equals the localized `quickBattle_round(1, 3)` string.
+
+- Given a `QuickBattleResult` returned by the resolver has `provinceFlips == true`,
+  When the result view renders,
+  Then the result view displays the localized `quickBattle_provinceCaptured` line in bold above the casualty counts.
+
+- Given a `QuickBattleResult` returned by the resolver has `provinceFlips == false`,
+  When the result view renders,
+  Then the result view does not display the `quickBattle_provinceCaptured` line.
+
+- Given a `QuickBattleScreen` is mounted,
+  When the framework runs `build`,
+  Then the widget tree contains exactly one `CtDialogShell` with `maxWidth: 400` and `maxHeight: 500` and no Material `ElevatedButton`, `TextButton`, or `OutlinedButton`.
+
+---
+
+## Widgetbook
+
+Catalog directory: `Quick Battle Screen` (registered in `app/lib/widgetbook/catalog.dart`). At least one default use case constructs a non-interactive `QuickBattleScreen` with a sample `QuickBattleInput` (two factions, three or more units per side at `CENTER + FRONT`) and a no-op `onComplete`. Additional use cases are encouraged for the interactive variant.

--- a/app/lib/widgetbook/catalog.dart
+++ b/app/lib/widgetbook/catalog.dart
@@ -12,6 +12,11 @@ import 'package:widgetbook/widgetbook.dart';
 
 import '../config/themes.dart';
 import '../providers/games_provider.dart';
+import '../features/game/combat/combat_mode_choice_dialog.dart';
+import '../features/game/combat/quick_battle_action_selector.dart';
+import '../features/game/combat/quick_battle_deployment_view.dart';
+import '../features/game/combat/quick_battle_result_dialog.dart';
+import '../features/game/combat/quick_battle_screen.dart';
 import '../features/game/widgets/civilian_units_panel.dart';
 import '../features/game/widgets/diplomacy_panel.dart';
 import '../features/game/widgets/military_units_panel.dart';
@@ -107,6 +112,7 @@ class CtWidgetbookApp extends StatelessWidget {
         ...techTreeDirectories,
         ...interventionDialogueDirectories,
         ...turnNewsDialogDirectories,
+        ...combatUiDirectories,
       ],
       lightTheme: AppThemes.colonial,
       darkTheme: AppThemes.colonial,

--- a/app/lib/widgetbook/catalog_part3.dart
+++ b/app/lib/widgetbook/catalog_part3.dart
@@ -370,3 +370,216 @@ class _MapWithOverlayStoryState extends State<_MapWithOverlayStory> {
     );
   }
 }
+
+QuickBattleInput _sampleQuickBattleInput() {
+  return const QuickBattleInput(
+    attackerFactionId: 'castile',
+    defenderFactionId: 'england',
+    provinceId: 'oldWorld|p_lisbon',
+    regionId: 'oldWorld',
+    attackerDeployment: QuickBattleDeployment(
+      groups: [
+        QuickBattleGroup(
+          lane: QuickBattleLane.center,
+          line: QuickBattleLine.front,
+          unitIds: ['a1', 'a2', 'a3', 'a4'],
+          cohesion: 3,
+        ),
+      ],
+    ),
+    defenderDeployment: QuickBattleDeployment(
+      groups: [
+        QuickBattleGroup(
+          lane: QuickBattleLane.center,
+          line: QuickBattleLine.front,
+          unitIds: ['d1', 'd2', 'd3'],
+          cohesion: 3,
+        ),
+      ],
+    ),
+    maxRounds: 3,
+    seed: 1,
+  );
+}
+
+MaterialApp _combatStoryFrame(Widget child) {
+  return MaterialApp(
+    theme: AppThemes.colonial,
+    localizationsDelegates: AppLocalizationsBinding.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: Scaffold(body: Center(child: child)),
+  );
+}
+
+/// Combat UI stories.
+/// SPEC/ui/quick-battle-screen.md, quick-battle-deployment-view.md,
+/// quick-battle-action-selector.md, combat-mode-choice-dialog.md,
+/// quick-battle-result-dialog.md.
+List<WidgetbookNode> get combatUiDirectories => [
+  WidgetbookFolder(
+    name: 'Quick Battle',
+    children: [
+      WidgetbookUseCase(
+        name: 'Quick Battle Screen — non-interactive',
+        builder: (context) => _combatStoryFrame(
+          ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 400, maxHeight: 500),
+            child: QuickBattleScreen(
+              input: _sampleQuickBattleInput(),
+              onComplete: (_) {},
+            ),
+          ),
+        ),
+      ),
+      WidgetbookUseCase(
+        name: 'Quick Battle Screen — interactive',
+        builder: (context) => _combatStoryFrame(
+          ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 400, maxHeight: 500),
+            child: QuickBattleScreen(
+              input: _sampleQuickBattleInput(),
+              onComplete: (_) {},
+              interactive: true,
+            ),
+          ),
+        ),
+      ),
+      WidgetbookUseCase(
+        name: 'Deployment view',
+        builder: (context) => _combatStoryFrame(
+          ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 400),
+            child: const Padding(
+              padding: EdgeInsets.all(16),
+              child: QuickBattleDeploymentView(
+                attackerDeployment: QuickBattleDeployment(
+                  groups: [
+                    QuickBattleGroup(
+                      lane: QuickBattleLane.center,
+                      line: QuickBattleLine.front,
+                      unitIds: ['a1', 'a2', 'a3', 'a4'],
+                      cohesion: 3,
+                    ),
+                  ],
+                ),
+                defenderDeployment: QuickBattleDeployment(
+                  groups: [
+                    QuickBattleGroup(
+                      lane: QuickBattleLane.center,
+                      line: QuickBattleLine.front,
+                      unitIds: ['d1', 'd2', 'd3'],
+                      cohesion: 2,
+                    ),
+                  ],
+                ),
+                attackerName: 'Castile',
+                defenderName: 'England',
+              ),
+            ),
+          ),
+        ),
+      ),
+      WidgetbookUseCase(
+        name: 'Action selector — full CP',
+        builder: (context) => _combatStoryFrame(
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: QuickBattleActionSelector(
+              cpRemaining: 3,
+              onActionSelected: (_) {},
+            ),
+          ),
+        ),
+      ),
+      WidgetbookUseCase(
+        name: 'Action selector — 1 CP (assault disabled)',
+        builder: (context) => _combatStoryFrame(
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: QuickBattleActionSelector(
+              cpRemaining: 1,
+              onActionSelected: (_) {},
+            ),
+          ),
+        ),
+      ),
+      WidgetbookUseCase(
+        name: 'Action selector — spent (0 CP)',
+        builder: (context) => _combatStoryFrame(
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: QuickBattleActionSelector(
+              cpRemaining: 0,
+              onActionSelected: (_) {},
+            ),
+          ),
+        ),
+      ),
+      WidgetbookUseCase(
+        name: 'Combat mode choice — regular province',
+        builder: (context) => _combatStoryFrame(
+          CombatModeChoiceDialog(
+            bus: AppEventBus.create(),
+            provinceName: 'Lisbon',
+            isCapitalSiege: false,
+          ),
+        ),
+      ),
+      WidgetbookUseCase(
+        name: 'Combat mode choice — capital siege',
+        builder: (context) => _combatStoryFrame(
+          CombatModeChoiceDialog(
+            bus: AppEventBus.create(),
+            provinceName: 'Madrid',
+            isCapitalSiege: true,
+          ),
+        ),
+      ),
+      WidgetbookUseCase(
+        name: 'Quick Battle result — attacker wins, province flips',
+        builder: (context) => _combatStoryFrame(
+          const QuickBattleResultDialog(
+            result: QuickBattleResult(
+              winner: QuickBattleWinner.attacker,
+              attackerCasualties: ['a3'],
+              defenderCasualties: ['d1', 'd2'],
+              provinceFlips: true,
+            ),
+            attackerName: 'Castile',
+            defenderName: 'England',
+          ),
+        ),
+      ),
+      WidgetbookUseCase(
+        name: 'Quick Battle result — defender holds',
+        builder: (context) => _combatStoryFrame(
+          const QuickBattleResultDialog(
+            result: QuickBattleResult(
+              winner: QuickBattleWinner.defender,
+              attackerCasualties: ['a1', 'a2', 'a3'],
+              defenderCasualties: ['d1'],
+              provinceFlips: false,
+            ),
+            attackerName: 'Castile',
+            defenderName: 'England',
+          ),
+        ),
+      ),
+      WidgetbookUseCase(
+        name: 'Quick Battle result — mutual exhaustion',
+        builder: (context) => _combatStoryFrame(
+          const QuickBattleResultDialog(
+            result: QuickBattleResult(
+              winner: QuickBattleWinner.mutualExhaustion,
+              attackerCasualties: ['a1'],
+              defenderCasualties: ['d1'],
+              provinceFlips: false,
+            ),
+            attackerName: 'Castile',
+            defenderName: 'England',
+          ),
+        ),
+      ),
+    ],
+  ),
+];

--- a/app/test/combat_ui_specs_test.dart
+++ b/app/test/combat_ui_specs_test.dart
@@ -1,0 +1,398 @@
+// Pins SPEC/ui combat dialog and sub-view contracts:
+// - SPEC/ui/quick-battle-deployment-view.md
+// - SPEC/ui/quick-battle-action-selector.md
+// - SPEC/ui/combat-mode-choice-dialog.md
+// - SPEC/ui/quick-battle-result-dialog.md
+
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:colonizethis_app/features/game/combat/combat_mode_choice_dialog.dart';
+import 'package:colonizethis_app/features/game/combat/quick_battle_action_selector.dart';
+import 'package:colonizethis_app/features/game/combat/quick_battle_deployment_view.dart';
+import 'package:colonizethis_app/features/game/combat/quick_battle_result_dialog.dart';
+import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
+
+Widget _frame(Widget child) {
+  return MaterialApp(
+    home: Scaffold(body: child),
+  );
+}
+
+void main() {
+  suppressLogsForTests();
+
+  group('QuickBattleDeploymentView (SPEC/ui/quick-battle-deployment-view.md)', () {
+    testWidgets('renders attacker and defender headers with custom names',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(_frame(
+        const QuickBattleDeploymentView(
+          attackerDeployment: QuickBattleDeployment(
+            groups: [
+              QuickBattleGroup(
+                lane: QuickBattleLane.center,
+                line: QuickBattleLine.front,
+                unitIds: ['a1', 'a2', 'a3'],
+                cohesion: 3,
+              ),
+            ],
+          ),
+          defenderDeployment: QuickBattleDeployment(
+            groups: [
+              QuickBattleGroup(
+                lane: QuickBattleLane.center,
+                line: QuickBattleLine.front,
+                unitIds: ['d1', 'd2'],
+                cohesion: 3,
+              ),
+            ],
+          ),
+          attackerName: 'Castile',
+          defenderName: 'England',
+        ),
+      ));
+
+      expect(find.text('Castile'), findsOneWidget);
+      expect(find.text('England'), findsOneWidget);
+      expect(find.text('Center Front: 3 units (Cohesion 3)'), findsOneWidget);
+      expect(find.text('Center Front: 2 units (Cohesion 3)'), findsOneWidget);
+    });
+
+    testWidgets('omits cohesion suffix when cohesion is 0',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(_frame(
+        const QuickBattleDeploymentView(
+          attackerDeployment: QuickBattleDeployment(
+            groups: [
+              QuickBattleGroup(
+                lane: QuickBattleLane.center,
+                line: QuickBattleLine.front,
+                unitIds: ['a1'],
+                cohesion: 0,
+              ),
+            ],
+          ),
+          defenderDeployment: QuickBattleDeployment(
+            groups: [
+              QuickBattleGroup(
+                lane: QuickBattleLane.center,
+                line: QuickBattleLine.front,
+                unitIds: ['d1'],
+                cohesion: 1,
+              ),
+            ],
+          ),
+        ),
+      ));
+
+      expect(find.text('Center Front: 1 units'), findsOneWidget);
+      expect(find.text('Center Front: 1 units (Cohesion 1)'), findsOneWidget);
+    });
+
+    testWidgets('uses default Attacker / Defender headers when names are omitted',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(_frame(
+        const QuickBattleDeploymentView(
+          attackerDeployment: QuickBattleDeployment(),
+          defenderDeployment: QuickBattleDeployment(),
+        ),
+      ));
+
+      expect(find.text('Attacker'), findsOneWidget);
+      expect(find.text('Defender'), findsOneWidget);
+    });
+  });
+
+  group('QuickBattleActionSelector (SPEC/ui/quick-battle-action-selector.md)', () {
+    testWidgets('with cpRemaining=3 every action button is enabled',
+        (WidgetTester tester) async {
+      QuickBattleAction? picked;
+      await tester.pumpWidget(_frame(
+        QuickBattleActionSelector(
+          cpRemaining: 3,
+          onActionSelected: (a) => picked = a,
+        ),
+      ));
+
+      // No Material buttons in the selector — pixel-art only.
+      expect(find.byType(ElevatedButton), findsNothing);
+      expect(find.byType(TextButton), findsNothing);
+      expect(find.byType(OutlinedButton), findsNothing);
+
+      await tester.tap(find.textContaining('Volley Fire'));
+      await tester.pump();
+      expect(picked, QuickBattleAction.volleyFire);
+    });
+
+    testWidgets('with cpRemaining=1 the 2-CP buttons are disabled',
+        (WidgetTester tester) async {
+      var taps = 0;
+      await tester.pumpWidget(_frame(
+        QuickBattleActionSelector(
+          cpRemaining: 1,
+          onActionSelected: (_) => taps++,
+        ),
+      ));
+
+      // 1-CP action remains tappable.
+      await tester.tap(find.textContaining('Volley Fire'));
+      await tester.pump();
+      expect(taps, 1);
+
+      // 2-CP actions must not invoke the callback (button disabled, hit-test no-op).
+      await tester.tap(find.textContaining('Assault'), warnIfMissed: false);
+      await tester.pump();
+      expect(taps, 1);
+
+      await tester.tap(find.textContaining('Fall Back'), warnIfMissed: false);
+      await tester.pump();
+      expect(taps, 1);
+    });
+
+    testWidgets('with cpRemaining=0 every action button is disabled',
+        (WidgetTester tester) async {
+      var taps = 0;
+      await tester.pumpWidget(_frame(
+        QuickBattleActionSelector(
+          cpRemaining: 0,
+          onActionSelected: (_) => taps++,
+        ),
+      ));
+
+      for (final label in const [
+        'Volley Fire',
+        'Defend',
+        'Maneuver',
+        'Fall Back',
+        'Assault',
+      ]) {
+        await tester.tap(find.textContaining(label), warnIfMissed: false);
+      }
+      await tester.pump();
+      expect(taps, 0);
+    });
+  });
+
+  group('CombatModeChoiceDialog (SPEC/ui/combat-mode-choice-dialog.md)', () {
+    testWidgets(
+        'regular province emits autoResolve on Auto-Resolve and pops the route',
+        (WidgetTester tester) async {
+      final bus = AppEventBus.create();
+      final received = <CombatMode>[];
+      final sub = bus.on<CombatModeChosenEvent>().listen((e) {
+        received.add(e.mode);
+      });
+      addTearDown(() async {
+        await sub.cancel();
+      });
+
+      await tester.pumpWidget(_frame(
+        Builder(builder: (ctx) {
+          return TextButton(
+            child: const Text('open'),
+            onPressed: () {
+              showDialog<void>(
+                context: ctx,
+                builder: (_) => CombatModeChoiceDialog(
+                  bus: bus,
+                  provinceName: 'Lisbon',
+                  isCapitalSiege: false,
+                ),
+              );
+            },
+          );
+        }),
+      ));
+
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('Lisbon'), findsOneWidget);
+      expect(find.textContaining('Auto-Resolve'), findsOneWidget);
+      expect(find.textContaining('Quick Battle'), findsOneWidget);
+
+      await tester.tap(find.textContaining('Auto-Resolve'));
+      await tester.pumpAndSettle();
+
+      expect(received, [CombatMode.autoResolve]);
+      // Dialog popped — the underlying open button is visible again.
+      expect(find.text('open'), findsOneWidget);
+    });
+
+    testWidgets('regular province emits quickBattle on Quick Battle',
+        (WidgetTester tester) async {
+      final bus = AppEventBus.create();
+      final received = <CombatMode>[];
+      final sub = bus.on<CombatModeChosenEvent>().listen((e) {
+        received.add(e.mode);
+      });
+      addTearDown(() async {
+        await sub.cancel();
+      });
+
+      await tester.pumpWidget(_frame(
+        Builder(builder: (ctx) {
+          return TextButton(
+            child: const Text('open'),
+            onPressed: () {
+              showDialog<void>(
+                context: ctx,
+                builder: (_) => CombatModeChoiceDialog(
+                  bus: bus,
+                  provinceName: 'Lisbon',
+                  isCapitalSiege: false,
+                ),
+              );
+            },
+          );
+        }),
+      ));
+
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.textContaining('Quick Battle'));
+      await tester.pumpAndSettle();
+
+      expect(received, [CombatMode.quickBattle]);
+    });
+
+    testWidgets('capital siege variant only renders Quick Battle button',
+        (WidgetTester tester) async {
+      final bus = AppEventBus.create();
+      final received = <CombatMode>[];
+      final sub = bus.on<CombatModeChosenEvent>().listen((e) {
+        received.add(e.mode);
+      });
+      addTearDown(() async {
+        await sub.cancel();
+      });
+
+      await tester.pumpWidget(_frame(
+        Builder(builder: (ctx) {
+          return TextButton(
+            child: const Text('open'),
+            onPressed: () {
+              showDialog<void>(
+                context: ctx,
+                builder: (_) => CombatModeChoiceDialog(
+                  bus: bus,
+                  provinceName: 'Madrid',
+                  isCapitalSiege: true,
+                ),
+              );
+            },
+          );
+        }),
+      ));
+
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('Auto-Resolve'), findsNothing);
+      // Exactly one pixel-art button is rendered (the Quick Battle button);
+      // the body text may also include the phrase "Quick Battle" so we count
+      // CtNinePatchButton instances rather than text occurrences.
+      expect(find.byType(CtNinePatchButton), findsOneWidget);
+
+      await tester.tap(find.byType(CtNinePatchButton));
+      await tester.pumpAndSettle();
+
+      expect(received, [CombatMode.quickBattle]);
+    });
+  });
+
+  group('QuickBattleResultDialog (SPEC/ui/quick-battle-result-dialog.md)', () {
+    testWidgets('attacker wins + provinceFlips renders captured banner',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(_frame(
+        const QuickBattleResultDialog(
+          result: QuickBattleResult(
+            winner: QuickBattleWinner.attacker,
+            attackerCasualties: ['a3'],
+            defenderCasualties: ['d1', 'd2'],
+            provinceFlips: true,
+          ),
+          attackerName: 'Castile',
+          defenderName: 'England',
+        ),
+      ));
+
+      expect(find.textContaining('Castile'), findsWidgets);
+      expect(find.textContaining('England'), findsWidgets);
+      expect(find.textContaining('captured'), findsOneWidget);
+      expect(find.text('OK'), findsOneWidget);
+    });
+
+    testWidgets('defender holds suppresses captured banner',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(_frame(
+        const QuickBattleResultDialog(
+          result: QuickBattleResult(
+            winner: QuickBattleWinner.defender,
+            attackerCasualties: ['a1', 'a2'],
+            defenderCasualties: ['d1'],
+            provinceFlips: false,
+          ),
+          attackerName: 'Castile',
+          defenderName: 'England',
+        ),
+      ));
+
+      expect(find.textContaining('captured'), findsNothing);
+    });
+
+    testWidgets('mutual exhaustion suppresses captured banner',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(_frame(
+        const QuickBattleResultDialog(
+          result: QuickBattleResult(
+            winner: QuickBattleWinner.mutualExhaustion,
+            attackerCasualties: ['a1'],
+            defenderCasualties: ['d1'],
+            provinceFlips: false,
+          ),
+        ),
+      ));
+
+      expect(find.textContaining('captured'), findsNothing);
+      expect(find.text('OK'), findsOneWidget);
+    });
+
+    testWidgets('OK button pops the dialog route',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(_frame(
+        Builder(builder: (ctx) {
+          return TextButton(
+            child: const Text('open'),
+            onPressed: () {
+              showDialog<void>(
+                context: ctx,
+                builder: (_) => const QuickBattleResultDialog(
+                  result: QuickBattleResult(
+                    winner: QuickBattleWinner.attacker,
+                    attackerCasualties: [],
+                    defenderCasualties: [],
+                    provinceFlips: true,
+                  ),
+                ),
+              );
+            },
+          );
+        }),
+      ));
+
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+      expect(find.text('OK'), findsOneWidget);
+
+      await tester.tap(find.text('OK'));
+      await tester.pumpAndSettle();
+      expect(find.text('OK'), findsNothing);
+      // Underlying open button is visible again — dialog popped.
+      expect(find.text('open'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Brings five combat UI widgets in `app/lib/features/game/combat/` from zero UI documentation coverage to a fully documented state by adding dedicated `SPEC/ui` specs and Widgetbook catalog entries. Refs #2748 — does not auto-close.

## Done in this push

### New `SPEC/ui` files (one per widget)

Each new spec follows the structure of `SPEC/ui/main-menu.md` (widget contract, trigger conditions, layout/wireframe, states & variants, navigation, components, Given–When–Then acceptance criteria, Widgetbook reference) and cross-references `SPEC/game/quick-battle.md`, `SPEC/program/quick-battle-resolution.md`, and `SPEC/program/app-ui-wiring.md`:

- `SPEC/ui/quick-battle-screen.md` — non-interactive vs interactive modes, round phase vs result phase, `onComplete` contract, headless auto-resolve path.
- `SPEC/ui/quick-battle-deployment-view.md` — attacker/defender stack inside `CtPanel`, lane/line label table, cohesion suffix rule, default `'Attacker'`/`'Defender'` headers.
- `SPEC/ui/quick-battle-action-selector.md` — five-action catalog with CP costs, enable/disable rules per `cpRemaining`, no-Material-buttons constraint.
- `SPEC/ui/combat-mode-choice-dialog.md` — regular vs capital-siege variants, `combat_mode_choice` dialog id, `CombatModeChosenEvent` emission contract, `provinceName` empty-string handling.
- `SPEC/ui/quick-battle-result-dialog.md` — `quick_battle_result` dialog id, three winner states, `provinceFlips` conditional banner, OK button pop semantics.

### `SPEC/program/app-ui-wiring.md` updates

- The dialog registry rows for `combat_mode_choice` and `quick_battle_result` now hyperlink to the new UI specs.
- Added a one-line pointer below the table to `quick-battle-screen.md`, `quick-battle-deployment-view.md`, and `quick-battle-action-selector.md` for the non-dialog combat flow (orchestrator-constructed screens).

### Widgetbook entries (`app/lib/widgetbook/catalog_part3.dart`)

New `Quick Battle` folder added alongside the existing combat catalog folders, with 11 use cases:

- **Quick Battle Screen** — non-interactive (default) and interactive variants.
- **Deployment view** — attacker + defender at `CENTER + FRONT` with custom names.
- **Action selector** — `cpRemaining = 3` (full), `1` (assault disabled), `0` (all disabled).
- **Combat mode choice** — regular province (both buttons) and capital siege (Quick Battle only).
- **Quick Battle result** — attacker wins + provinceFlips, defender holds, mutual exhaustion.

`catalog.dart` now imports the five combat widget files, the new directories list is wired into `CtWidgetbookApp`, and a small `_combatStoryFrame` helper threads localization delegates so dialogs that use `appL10n(context)` and `Navigator.of(context).pop()` work inside Widgetbook stories.

### Tests

- New `app/test/combat_ui_specs_test.dart` (13 widget tests) pins the AC contracts of the four widgets that did not previously have direct test coverage:
  - **Deployment view** — custom names render, cohesion-0 omits suffix, default headers.
  - **Action selector** — full / partial (1 CP) / spent (0 CP) tap behaviour, no Material buttons.
  - **Combat mode choice** — regular variant emits `autoResolve` and `quickBattle` correctly; capital-siege variant only renders one `CtNinePatchButton` and emits `quickBattle`.
  - **Result dialog** — attacker-wins-with-flip shows captured banner, defender hold and mutual exhaustion suppress it, OK button pops the route.
- Existing `app/test/quick_battle_screen_test.dart` continues to cover `QuickBattleScreen` non-interactive and interactive paths.

## Verification

- `cd app && flutter analyze lib/widgetbook/ test/combat_ui_specs_test.dart test/quick_battle_screen_test.dart` — no issues.
- `cd app && flutter test test/combat_ui_specs_test.dart` — **13/13 pass**.
- `cd app && flutter test test/quick_battle_screen_test.dart` — **2/2 pass**.
- `CT_REPO_LINT_INCLUDE_APP=true GITHUB_BASE_REF=dev CT_REPO_LINT_BASE_SHA=$(git merge-base HEAD origin/dev) dart run tool/ct_repo_lint.dart` — **all 47 rules pass**.

## ACs covered

- AC1–AC5: five new `SPEC/ui` files, each containing widget contract, layout, triggers, states, navigation, and GWT ACs.
- AC6–AC10: five new Widgetbook entries (with multiple use cases for the dialog and action-selector variants), all rendering inside the `Quick Battle` folder of the catalog.
- AC11 (Widgetbook builds without error): `flutter analyze lib/widgetbook/` clean; new use cases analyse cleanly.
- AC12: each new spec references `SPEC/game/quick-battle.md`, `SPEC/program/quick-battle-resolution.md`, and `SPEC/program/app-ui-wiring.md`; the wiring SPEC's dialog-registry rows now link back to the two dialog specs.

## Scope disclosure

This PR fully implements the documentation-only scope of Refs #2748 (no production behavior changes). Pixel-art asset generation per UXD 04–07 is not in scope here — the widgets already use the existing pixel-art component catalog (`CtDialogShell`, `CtNinePatchButton`, `CtPanel`).

Made with [Cursor](https://cursor.com)