### PR TITLE
docs: add victory overlay UI spec and Widgetbook entries (Refs #2749)

### DIFF
--- a/SPEC/game/victory.md
+++ b/SPEC/game/victory.md
@@ -43,7 +43,9 @@ When the campaign reaches the **calendar cap** (`Game.calendarCampaignHalted == 
 
 ## Victory Screen (UI)
 
-- When `Game.victory != null`, the app shows a **victory screen** (overlay or dedicated view).
+Authoritative layout, triggers, states, navigation, and acceptance criteria: **[victory-overlay.md](../ui/victory-overlay.md)**.
+
+- When `Game.victory != null`, the app shows the **victory overlay** (`VictoryOverlay` / `VictoryPanel` on `GameScreen`).
 - **Content:** Winner’s display name, victory type label (e.g. “Military victory”), turn number. Option to **return to main menu** or **view final state** (continue viewing the map without further turns).
 - No further orders or turn advancement once victory is set.
 

--- a/SPEC/ui/victory-overlay.md
+++ b/SPEC/ui/victory-overlay.md
@@ -1,0 +1,124 @@
+# Victory Overlay
+
+**SPEC/ui** — Full-screen overlay shown when a military victory is recorded. Game model: [victory.md](../game/victory.md). Navigation target for “Return to Main Menu”: [main-menu.md](main-menu.md). Host screen: `GameScreen` (`app/lib/features/game/flame/game_screen.dart`).
+
+---
+
+## Widget contract
+
+| Widget | Type | Parameters | Description |
+|--------|------|------------|-------------|
+| `VictoryOverlay` | `StatefulWidget` | `game` (`Game`), `victory` (`VictoryState`), `bus` (`AppEventBus`) | Full-screen semi-transparent scrim with centered `VictoryPanel`. Owns `_dismissed` so “View final state” hides the overlay without a route change. |
+| `VictoryPanel` | `StatelessWidget` | `game`, `victory`, `bus`, `onViewFinalState` (`VoidCallback?`, optional) | Presentational panel inside `CtPanel`; resolves winner display name and victory-type label. |
+
+Implementation: `app/lib/features/game/flame/victory_overlay.dart`.
+
+---
+
+## Layout / wireframe
+
+```text
++----------------------------------------------------------+
+|  (full screen, Colors.black54 scrim)                     |
+|                                                          |
+|              +--------------------------------+          |
+|              | CtPanel (padding 24)           |          |
+|              |  <Victory type label>          |          |
+|              |    headlineSmall               |          |
+|              |                                |          |
+|              |  <Winner> wins on turn <N>.    |          |
+|              |    bodyLarge, centered         |          |
+|              |                                |          |
+|              |  [ Return to Main Menu ]       |          |
+|              |  [ View Final State ]          |          |
+|              |    Row, mainAxisSize: min      |          |
+|              +--------------------------------+          |
+|                                                          |
++----------------------------------------------------------+
+```
+
+- Outer: `Positioned.fill` → `Container(color: Colors.black54)` → `Center` → outer `Padding(24)` → `VictoryPanel`.
+- Title: `appL10n(context).victory_military` when `victory.type == VictoryType.military` (only variant implemented).
+- Body: `appL10n(context).victory_winnerOnTurn(winner.displayName, victory.turnNumber)`.
+- Buttons: two `CtNinePatchButton`s in a `Row` with 12 dp spacing — “Return to Main Menu” (left), “View Final State” (right).
+- No Material buttons.
+
+Winner resolution: `game.playerById(victory.winnerPlayerId) ?? game.players.first`.
+
+---
+
+## Trigger conditions
+
+- `GameScreen` renders `VictoryOverlay` when `game != null && game.victory != null` (see `game_screen.dart` build `Stack` children).
+- The overlay is the topmost interactive layer above the Flame canvas / map area, next-turn control, and pause affordances.
+- Turn advancement and full turn resolution are blocked while `Game.victory != null` via `GameMapAreaStateLogic.allowsFullTurnResolution` (returns `false` when victory is set). See [victory.md](../game/victory.md) § Victory Check and § Victory Screen (UI).
+
+---
+
+## States and variants
+
+| State | Condition | UI |
+|-------|-----------|-----|
+| Overlay visible (default) | `VictoryOverlay` mounted, `_dismissed == false` | Scrim + `VictoryPanel` shown. |
+| Overlay dismissed | User tapped “View Final State”; `_dismissed == true` | `VictoryOverlay` returns `SizedBox.shrink()`; map/canvas remains visible; `Game.victory` stays set; further turns remain blocked. |
+| Military victory | `victory.type == VictoryType.military` | Title uses `victory_military` l10n string. |
+| Future types | `VictoryType.economic`, `VictoryType.scientific` | Not implemented ([victory.md](../game/victory.md) § Out of scope). Spec reserves extension: add l10n labels and `switch` arms when product adds types. |
+
+Calendar campaign halt (`Game.calendarCampaignHalted == true` with `Game.victory == null`) does **not** use this overlay; see [victory.md](../game/victory.md) § Calendar campaign end.
+
+---
+
+## Navigation
+
+| Action | Behavior |
+|--------|----------|
+| Return to Main Menu | `bus.emit(const NavigateToShellEvent())` → shell navigates to main menu per [main-menu.md](main-menu.md) § Return from game. |
+| View Final State | Invokes `onViewFinalState` → `VictoryOverlay` sets `_dismissed = true`. No `AppEvent`; no route pop. |
+| Other exits | No settings, load-game, or in-game panel entry points from this overlay. |
+
+---
+
+## Components
+
+- `CtPanel` (`app/lib/widgets/ct_panel.dart`).
+- `CtNinePatchButton` (`app/lib/widgets/ct_nine_patch_button.dart`).
+- Localized strings: `victory_military`, `victory_winnerOnTurn`, `victory_returnToMainMenu`, `victory_viewFinalState` via `appL10n(context)`.
+
+---
+
+## Acceptance Criteria (Given–When–Then)
+
+- Given `Game.victory` is a `VictoryState` with `type: VictoryType.military`, `turnNumber: 12`, and a resolvable `winnerPlayerId`,
+  When `GameScreen` builds with that game,
+  Then the UI layer renders `VictoryOverlay` above the game stack and shows the military victory label and a winner sentence containing turn `12`.
+
+- Given `VictoryOverlay` is visible,
+  When the user taps “View final state”,
+  Then the overlay is removed from the widget tree (`Military victory` text is no longer found) and `Game.victory` remains non-null.
+
+- Given `VictoryOverlay` is visible and an `AppEventBus` is wired,
+  When the user taps “Return to main menu”,
+  Then the UI layer emits exactly one `NavigateToShellEvent` on that bus.
+
+- Given `Game.victory != null`,
+  When the system evaluates `GameMapAreaStateLogic.allowsFullTurnResolution(game)`,
+  Then the result is `false` (next-turn and full resolution paths stay disabled).
+
+- Given `victory.winnerPlayerId` does not match any player in `game.players`,
+  When `VictoryPanel` builds,
+  Then the winner sentence uses `game.players.first.displayName` as the winner name (fallback).
+
+- Given `VictoryPanel` is mounted in a test or Widgetbook harness,
+  When the widget tree is built,
+  Then there are zero Material `ElevatedButton`, `TextButton`, or `OutlinedButton` widgets and exactly two `CtNinePatchButton` instances.
+
+---
+
+## Widgetbook
+
+Catalog folder: **Victory** (registered in `app/lib/widgetbook/catalog.dart` via `victoryUiDirectories`). Use cases:
+
+1. **Victory panel — military (default):** `VictoryPanel` with `getDebugInitGameResult().game`, sample `VictoryState` (`VictoryType.military`, turn `45`, first player as winner), and a throwaway `AppEventBus`.
+2. **Victory overlay — full scrim (optional):** `VictoryOverlay` inside a fixed-size `Stack` to show the dimmed full-screen presentation.
+
+Automated widget tests: `app/test/victory_overlay_test.dart`.

--- a/app/lib/widgetbook/catalog.dart
+++ b/app/lib/widgetbook/catalog.dart
@@ -23,6 +23,7 @@ import '../features/game/widgets/province_overlay_demo_data.dart';
 import '../features/game/widgets/tech_tree_widget.dart';
 import '../features/game/screens/technology_screen.dart';
 import '../features/game/dialogue/intervention_dialogue_overlay.dart';
+import '../features/game/flame/victory_overlay.dart';
 import '../features/game/flame/region_map_component.dart'
     show CtMapVisibilityMode;
 import '../features/game/widgets/train_civilians_dialog.dart';
@@ -107,6 +108,7 @@ class CtWidgetbookApp extends StatelessWidget {
         ...techTreeDirectories,
         ...interventionDialogueDirectories,
         ...turnNewsDialogDirectories,
+        ...victoryUiDirectories,
       ],
       lightTheme: AppThemes.colonial,
       darkTheme: AppThemes.colonial,

--- a/app/lib/widgetbook/catalog_part3.dart
+++ b/app/lib/widgetbook/catalog_part3.dart
@@ -370,3 +370,68 @@ class _MapWithOverlayStoryState extends State<_MapWithOverlayStory> {
     );
   }
 }
+
+VictoryState _sampleVictoryState(Game game) {
+  return VictoryState(
+    winnerPlayerId: game.players.first.id,
+    type: VictoryType.military,
+    turnNumber: 45,
+  );
+}
+
+MaterialApp _victoryStoryFrame(Widget child) {
+  return MaterialApp(
+    theme: AppThemes.colonial,
+    localizationsDelegates: AppLocalizationsBinding.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: Scaffold(body: Center(child: child)),
+  );
+}
+
+/// Victory overlay stories. SPEC/ui/victory-overlay.md.
+List<WidgetbookNode> get victoryUiDirectories => [
+  WidgetbookFolder(
+    name: 'Victory',
+    children: [
+      WidgetbookUseCase(
+        name: 'Victory panel — military',
+        builder: (context) {
+          final game = getDebugInitGameResult().game;
+          final victory = _sampleVictoryState(game);
+          return _victoryStoryFrame(
+            VictoryPanel(
+              game: game,
+              victory: victory,
+              bus: AppEventBus.create(),
+            ),
+          );
+        },
+      ),
+      WidgetbookUseCase(
+        name: 'Victory overlay — full scrim',
+        builder: (context) {
+          final game = getDebugInitGameResult().game;
+          final victory = _sampleVictoryState(game);
+          return _victoryStoryFrame(
+            SizedBox(
+              width: 400,
+              height: 560,
+              child: Stack(
+                children: [
+                  ColoredBox(
+                    color: Theme.of(context).colorScheme.surfaceContainerHighest,
+                  ),
+                  VictoryOverlay(
+                    game: game,
+                    victory: victory,
+                    bus: AppEventBus.create(),
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    ],
+  ),
+];

--- a/app/test/victory_overlay_test.dart
+++ b/app/test/victory_overlay_test.dart
@@ -1,4 +1,5 @@
 import 'package:colonizethis_app/features/game/flame/victory_overlay.dart';
+import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
 import 'package:colonizethis_app/widgets/debug_init_game.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:colonizethis_models/colonizethis_models.dart' as ct_models;
@@ -106,6 +107,33 @@ void main() {
     await tester.pump();
 
     expect(emitted, isA<ct_models.NavigateToShellEvent>());
+  });
+
+  testWidgets('VictoryPanel uses first player when winner id is unknown',
+      (WidgetTester tester) async {
+    final victory = ct_models.VictoryState(
+      winnerPlayerId: 'nonexistent-player',
+      type: ct_models.VictoryType.military,
+      turnNumber: 45,
+    );
+    final fallbackName = game.players.first.displayName;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: VictoryPanel(
+            game: game,
+            victory: victory,
+            bus: victoryTestBus,
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining(fallbackName), findsOneWidget);
+    expect(find.textContaining('turn 45'), findsOneWidget);
+    expect(find.byType(CtNinePatchButton), findsNWidgets(2));
   });
 }
 


### PR DESCRIPTION
## Summary

Adds authoritative UI documentation and Widgetbook coverage for `VictoryOverlay` / `VictoryPanel`, bringing the victory flow to the same spec/catalog standard as other documented overlays. Refs #2749 — does not auto-close.

## Done in this push

- **`SPEC/ui/victory-overlay.md`** — widget contract, layout wireframe, trigger conditions (`GameScreen` when `Game.victory != null`), states (visible vs dismissed, military-only), navigation (`NavigateToShellEvent`, view-final-state dismissal), components, and Given–When–Then ACs.
- **`SPEC/game/victory.md`** — § Victory Screen (UI) now points to the new UI spec as authoritative.
- **Widgetbook** — `Victory` folder with two use cases: military `VictoryPanel` (default) and full-scrim `VictoryOverlay` inside a bounded `Stack`.
- **Tests** — extended `app/test/victory_overlay_test.dart` with winner-id fallback and `CtNinePatchButton` count coverage (4/4 pass).

## Verification

- `cd app && flutter analyze lib/widgetbook/ test/victory_overlay_test.dart` — clean
- `cd app && flutter test test/victory_overlay_test.dart` — **4/4 pass**

## ACs covered

- AC1: `SPEC/ui/victory-overlay.md` with contract, layout, triggers, states, navigation, GWT ACs
- AC2: Widgetbook entry with default military `VictoryPanel` use case
- AC3: Widgetbook analyzes cleanly (no hardcoded UI strings in catalog)
- AC4: UI spec references `SPEC/game/victory.md` for trigger/model
- AC5: `SPEC/game/victory.md` updated with pointer to UI spec

## Scope disclosure

Documentation and catalog only — no production behavior changes. Existing `victory_overlay_test.dart` already covered overlay dismiss and shell navigation; this PR adds the spec, Widgetbook stories, and one additional panel fallback test.


Made with [Cursor](https://cursor.com)