### PR TITLE
refactor(e2e): retire private fleet-reach constants for shared public ones (Refs #2336)

### DIFF
--- a/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers.dart
+++ b/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers.dart
@@ -1,22 +1,26 @@
 part of 'new_game_fleet_reaches_new_world_e2e_test.dart';
 
-/// Locked full-init may succeed only after [GameService] bumps `mapSeed` on a
-/// topology/assigner retry (`effectiveSeed + 100003`, …), producing longer
-/// coast→warp→New World paths than nominal seed-42 alone. Keep this above the
-/// worst observed CI need (Refs #1849 / PR 1849).
-const int _kMaxNextTurnTapsForNwFleetReach = 35;
-
-/// Hard cap for any single “wait until UI shows X” poll (`waitUntilFound`,
-/// next-turn label settle, panel-open loops). Fail immediately when exceeded.
-const Duration _kMaxUiResponseWait = Duration(seconds: 5);
-
-/// Entire fleet e2e must finish within this wall clock (success or guarded fail).
+/// Legacy file-scope constants (`_kMaxNextTurnTapsForNwFleetReach`,
+/// `_kMaxUiResponseWait`, `_kFleetE2eMaxWallClock`) were retired from this
+/// `part` file because each was a value-identical private alias for a
+/// shared public constant on the AC1 barrel (Refs GitHub #2336 AC1 / AC2).
+/// Call sites in `new_game_fleet_reaches_new_world_e2e_test.dart` now consume
+/// the public names directly:
 ///
-/// Aliases the shared [kE2eMaxWallClock] (`e2e_test_shared.dart`) so all three
-/// E2E scenarios use the same 5-minute cap from
-/// `SPEC/program/e2e-integration-tests.md` § Determinism PR runtime rule
-/// (Refs GitHub #2336).
-const Duration _kFleetE2eMaxWallClock = kE2eMaxWallClock;
+/// | Retired private (legacy literal)                | Public replacement                  | Source                                  |
+/// |-------------------------------------------------|-------------------------------------|-----------------------------------------|
+/// | `_kMaxNextTurnTapsForNwFleetReach` (`35`)       | [kE2eDefaultFleetReachLoopMaxTurns] | `e2e_test_shared_fleet_reach_loop.dart` |
+/// | `_kMaxUiResponseWait` (`Duration(seconds: 5)`)  | [kE2eDefaultNavalMoveSegmentUiWait] | `e2e_test_shared_panels.dart`           |
+/// | `_kFleetE2eMaxWallClock` (`kE2eMaxWallClock`)   | [kE2eMaxWallClock]                  | `e2e_test_shared.dart`                  |
+///
+/// The byte-identical legacy-literal contract is unit-pinned in
+/// `app/test/e2e_fleet_reach_turn_loop_test.dart` (35-turn cap),
+/// `app/test/e2e_try_naval_move_segment_test.dart` (5 s UI response cap),
+/// `app/test/e2e_make_wall_clock_guard_test.dart` (5-minute wall-clock cap),
+/// and the AC2 source-of-truth pin in
+/// `app/test/new_game_fleet_reaches_new_world_e2e_test_no_private_constants_test.dart`
+/// guards against silent re-introduction of any file-scope `_k*` constant in
+/// the integration test library.
 
 /// Region-tab tap helpers `_tapNewWorldRegionTabIfPresent` and
 /// `_tapOldWorldRegionTab` were lifted into [e2eTapNewWorldRegionTabIfPresent]
@@ -31,7 +35,7 @@ const Duration _kFleetE2eMaxWallClock = kE2eMaxWallClock;
 /// [e2eTapMoveOnFirstNonHomeFleet] (`e2e_test_shared_panels.dart`) so the
 /// non-home Move-tap contract is shared and unit-pinned (Refs GitHub #2336
 /// AC1 / AC2). The fleet-reach loop calls this helper through
-/// [tryNavalMoveSegment] up to `_kMaxNextTurnTapsForNwFleetReach (35)`
+/// [tryNavalMoveSegment] up to [kE2eDefaultFleetReachLoopMaxTurns] (35)
 /// times per scenario; the widget-test pin in
 /// `app/test/e2e_tap_move_on_first_non_home_fleet_test.dart` carries the
 /// behavioural contract because the integration suite cannot validate it
@@ -57,8 +61,8 @@ const Duration _kFleetE2eMaxWallClock = kE2eMaxWallClock;
 /// this directly today (`app_e2e_linux` is a no-op per
 /// `SPEC/program/e2e-integration-tests.md` § CI). A regression here would
 /// stall the fleet-reach loop at the per-call
-/// [kE2eDefaultMoveFleetDialogBudget] cap × `_kMaxNextTurnTapsForNwFleetReach
-/// (35)` turns — Bottleneck 4 in
+/// [kE2eDefaultMoveFleetDialogBudget] cap ×
+/// [kE2eDefaultFleetReachLoopMaxTurns] (35) turns — Bottleneck 4 in
 /// `SPEC/program/e2e-integration-tests.md` § Determinism.
 
 /// `_tryNavalMoveSegment` was lifted into [e2eTryNavalMoveSegment]

--- a/app/integration_test/new_game_fleet_reaches_new_world_e2e_test.dart
+++ b/app/integration_test/new_game_fleet_reaches_new_world_e2e_test.dart
@@ -14,15 +14,15 @@ void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   testWidgets('new game → non-home fleet at sea in New World '
-      '(≤$_kMaxNextTurnTapsForNwFleetReach Next turn taps)', (
+      '(≤$kE2eDefaultFleetReachLoopMaxTurns Next turn taps)', (
     WidgetTester tester,
   ) async {
     final preamble = await enterFleetReachScenarioReady(
       tester,
       testName: 'new_game_fleet_reaches_new_world',
       bootstrapForIntegrationTest: bootstrapForIntegrationTest,
-      maxUiResponseWait: _kMaxUiResponseWait,
-      wallClockCap: _kFleetE2eMaxWallClock,
+      maxUiResponseWait: kE2eDefaultNavalMoveSegmentUiWait,
+      wallClockCap: kE2eMaxWallClock,
     );
     final perf = preamble.perf;
     final testSw = preamble.testSw;
@@ -34,8 +34,8 @@ void main() {
       l10n,
       perf: perf,
       ensureUnderWallClock: ensureUnderWallClock,
-      maxUiResponseWait: _kMaxUiResponseWait,
-      maxTurns: _kMaxNextTurnTapsForNwFleetReach,
+      maxUiResponseWait: kE2eDefaultNavalMoveSegmentUiWait,
+      maxTurns: kE2eDefaultFleetReachLoopMaxTurns,
     );
     final earlyReturnMeta = fleetReachLoopExitTestTotalMetaLabel(
       loopResult.exit,
@@ -57,9 +57,9 @@ void main() {
     await ensureNonHomeFleetInNwAfterLoop(
       tester,
       perf: perf,
-      maxUiResponseWait: _kMaxUiResponseWait,
+      maxUiResponseWait: kE2eDefaultNavalMoveSegmentUiWait,
       failureMessageBuilder: (lastException) =>
-          'After $_kMaxNextTurnTapsForNwFleetReach Next turn resolutions, no non-home human fleet in region '
+          'After $kE2eDefaultFleetReachLoopMaxTurns Next turn resolutions, no non-home human fleet in region '
           'newWorld (ctE2eNavalPanelSnapshot / naval panel UI). '
           'Last exception: $lastException',
     );
@@ -74,8 +74,8 @@ void main() {
         tester,
         testName: 'new_game_fleet_explore_enabled_post_bundle',
         bootstrapForIntegrationTest: bootstrapForIntegrationTest,
-        maxUiResponseWait: _kMaxUiResponseWait,
-        wallClockCap: _kFleetE2eMaxWallClock,
+        maxUiResponseWait: kE2eDefaultNavalMoveSegmentUiWait,
+        wallClockCap: kE2eMaxWallClock,
       );
       final perf = preamble.perf;
       final testSw = preamble.testSw;
@@ -87,8 +87,8 @@ void main() {
         l10n,
         perf: perf,
         ensureUnderWallClock: ensureUnderWallClock,
-        maxUiResponseWait: _kMaxUiResponseWait,
-        maxTurns: _kMaxNextTurnTapsForNwFleetReach,
+        maxUiResponseWait: kE2eDefaultNavalMoveSegmentUiWait,
+        maxTurns: kE2eDefaultFleetReachLoopMaxTurns,
       );
       CtE2eNavalPanelSnapshot? lastKnownNavalSnapshot =
           loopResult.lastKnownNavalSnapshot;
@@ -96,7 +96,7 @@ void main() {
       final finalCheck = await ensureNonHomeFleetInNwAfterLoop(
         tester,
         perf: perf,
-        maxUiResponseWait: _kMaxUiResponseWait,
+        maxUiResponseWait: kE2eDefaultNavalMoveSegmentUiWait,
         failureMessageBuilder: (lastException) =>
             'Explorer explore e2e requires a non-home human fleet in New World first. '
             'Last exception: $lastException',
@@ -110,7 +110,7 @@ void main() {
         tester,
         l10n,
         ensureUnderWallClock: ensureUnderWallClock,
-        maxUiResponseWait: _kMaxUiResponseWait,
+        maxUiResponseWait: kE2eDefaultNavalMoveSegmentUiWait,
       );
 
       await e2eTapNewWorldRegionTabIfPresent(tester);
@@ -125,7 +125,7 @@ void main() {
         tester,
         l10n,
         perf: perf,
-        maxUiResponseWait: _kMaxUiResponseWait,
+        maxUiResponseWait: kE2eDefaultNavalMoveSegmentUiWait,
       );
       if (!exploreEnabled) {
         await handleBundledExploreFailure(

--- a/app/test/new_game_fleet_reaches_new_world_e2e_test_no_private_constants_test.dart
+++ b/app/test/new_game_fleet_reaches_new_world_e2e_test_no_private_constants_test.dart
@@ -1,0 +1,219 @@
+/// Pins the AC2 "no surviving file-scope private constants" contract for
+/// the fleet-reach E2E scenario library
+/// (`app/integration_test/new_game_fleet_reaches_new_world_e2e_test.dart` and
+/// its two `part` files).
+///
+/// Before this slice, the library carried three private file-scope
+/// constants in `new_game_fleet_reaches_new_world_e2e_helpers.dart` that
+/// duplicated public constants already exported through the AC1 barrel
+/// (`app/integration_test/e2e_helpers.dart`):
+///
+/// | Retired private (legacy literal)                | Public replacement                  | Source                                  |
+/// |-------------------------------------------------|-------------------------------------|-----------------------------------------|
+/// | `_kMaxNextTurnTapsForNwFleetReach` (`35`)       | `kE2eDefaultFleetReachLoopMaxTurns` | `e2e_test_shared_fleet_reach_loop.dart` |
+/// | `_kMaxUiResponseWait` (`Duration(seconds: 5)`)  | `kE2eDefaultNavalMoveSegmentUiWait` | `e2e_test_shared_panels.dart`           |
+/// | `_kFleetE2eMaxWallClock` (`kE2eMaxWallClock`)   | `kE2eMaxWallClock`                  | `e2e_test_shared.dart`                  |
+///
+/// AC2 requires that the four E2E test files contain no duplicated private
+/// helper or constant whose semantics are already supplied by the shared
+/// library. Per-constant value pins already exist
+/// (`e2e_fleet_reach_turn_loop_test.dart`, `e2e_try_naval_move_segment_test.dart`,
+/// `e2e_make_wall_clock_guard_test.dart`), but they each cover one constant
+/// in isolation. This file is the single AC2 source-of-truth pin that:
+///
+/// 1. Re-asserts the byte-identical legacy literals on the public
+///    replacements so a coordinated rename of one of the three constants
+///    cannot silently drift any single leg of the migration off the
+///    pre-lift value.
+/// 2. Reads the integration test library source on disk and asserts that
+///    none of the three retired private symbols (or any other `^const
+///    _k...` file-scope private constant) reappears in the library — the
+///    structural guard that the migration was completed in source, not
+///    merely papered over by a value-equal proxy.
+///
+/// A regression that re-introduced `_kMaxNextTurnTapsForNwFleetReach =
+/// 35` (for example) would compile and pass every existing per-constant
+/// pin, but would also re-create the AC2-violating duplication the
+/// `e2e_test_shared_fleet_reach_loop.dart` lift was meant to retire. This
+/// pin makes that regression fail in `flutter test test/` before it can
+/// land on `dev`.
+///
+/// The integration suite itself cannot enforce this today (the
+/// `app_e2e_linux` lane is a no-op per
+/// `SPEC/program/e2e-integration-tests.md` § CI), so this widget-test
+/// layer carries the AC2 source-of-truth pin.
+///
+/// Refs GitHub #2336 AC1 / AC2 / Bottleneck 6.
+library;
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import '../integration_test/e2e_helpers.dart';
+
+const String _integrationTestRelativePath =
+    'integration_test/new_game_fleet_reaches_new_world_e2e_test.dart';
+const String _helpersPart1RelativePath =
+    'integration_test/new_game_fleet_reaches_new_world_e2e_helpers.dart';
+const String _helpersPart2RelativePath =
+    'integration_test/new_game_fleet_reaches_new_world_e2e_helpers_part2.dart';
+
+const List<String> _retiredPrivateConstantNames = <String>[
+  '_kMaxNextTurnTapsForNwFleetReach',
+  '_kMaxUiResponseWait',
+  '_kFleetE2eMaxWallClock',
+];
+
+/// Anchored regex that matches any file-scope `const _kXxx = ...;` line in
+/// Dart source — i.e. the AC2-violating shape this pin retired. The
+/// `multiLine: true` flag lets `^` match the start of any line in the
+/// file, not only the start of the whole string.
+final RegExp _fileScopePrivateConstantPattern = RegExp(
+  r'^const\s+(?:final\s+)?[A-Za-z_<>?,\s\.]+?\s+_k[A-Za-z0-9_]+\s*=',
+  multiLine: true,
+);
+
+String _readIntegrationTestSource(String relativePath) {
+  final repoRoot = Directory.current.path;
+  // app/test/ is the typical working directory under `flutter test`; the
+  // fallback `..` path traversal keeps the test runnable from either the
+  // repo root or the `app/` directory without requiring a custom Flutter
+  // test runner invocation.
+  final candidates = <File>[
+    File('$repoRoot/$relativePath'),
+    File('$repoRoot/app/$relativePath'),
+    File('$repoRoot/../$relativePath'),
+  ];
+  for (final file in candidates) {
+    if (file.existsSync()) {
+      return file.readAsStringSync();
+    }
+  }
+  fail(
+    'Could not locate integration test source at any of: '
+    '${candidates.map((f) => f.path).join(', ')}. '
+    'AC2 source-of-truth pin must read the integration_test library to '
+    'guard against re-introduction of file-scope private constants.',
+  );
+}
+
+void main() {
+  group('AC2 — legacy private fleet-reach constants now public', () {
+    test(
+      'kE2eDefaultFleetReachLoopMaxTurns preserves the legacy '
+      '_kMaxNextTurnTapsForNwFleetReach (35) value',
+      () {
+        expect(
+          kE2eDefaultFleetReachLoopMaxTurns,
+          35,
+          reason:
+              'Migration target [kE2eDefaultFleetReachLoopMaxTurns] must keep '
+              'the byte-identical literal of the retired private '
+              '`_kMaxNextTurnTapsForNwFleetReach` (35) so the fleet-reach '
+              'scenarios exercise the same Bottleneck 4 ceiling they used '
+              'pre-lift (Refs GitHub #2336 AC1 / AC2).',
+        );
+      },
+    );
+
+    test(
+      'kE2eDefaultNavalMoveSegmentUiWait preserves the legacy '
+      '_kMaxUiResponseWait (Duration(seconds: 5)) value',
+      () {
+        expect(
+          kE2eDefaultNavalMoveSegmentUiWait,
+          const Duration(seconds: 5),
+          reason:
+              'Migration target [kE2eDefaultNavalMoveSegmentUiWait] must keep '
+              'the byte-identical literal of the retired private '
+              '`_kMaxUiResponseWait` (5 s) so every fleet-reach UI-response '
+              'wait (move dialog, naval panel open, post-loop snapshot '
+              'reach) fails fast at the same Bottleneck 4 boundary it used '
+              'pre-lift (Refs GitHub #2336 AC1 / AC2).',
+        );
+      },
+    );
+
+    test(
+      'kE2eMaxWallClock preserves the legacy _kFleetE2eMaxWallClock '
+      '(Duration(minutes: 5)) alias',
+      () {
+        expect(
+          kE2eMaxWallClock,
+          const Duration(minutes: 5),
+          reason:
+              'Migration target [kE2eMaxWallClock] must keep the byte-'
+              'identical 5-minute wall-clock cap the retired private '
+              '`_kFleetE2eMaxWallClock` aliased so the PR runtime rule in '
+              '`SPEC/program/e2e-integration-tests.md` § Determinism remains '
+              'enforced across all three E2E scenarios (Refs GitHub #2336 '
+              'AC10).',
+        );
+      },
+    );
+  });
+
+  group('AC2 — fleet-reach E2E library carries no file-scope private '
+      'constants', () {
+    test(
+      'integration test library source contains no `_k*` private constants '
+      '(none of the three retired names, and no other file-scope `^const '
+      '_k...` declarations)',
+      () {
+        final sources = <String, String>{
+          _integrationTestRelativePath:
+              _readIntegrationTestSource(_integrationTestRelativePath),
+          _helpersPart1RelativePath:
+              _readIntegrationTestSource(_helpersPart1RelativePath),
+          _helpersPart2RelativePath:
+              _readIntegrationTestSource(_helpersPart2RelativePath),
+        };
+
+        for (final entry in sources.entries) {
+          final source = entry.value;
+          // Strip Dart line and block comments so doc-comment provenance
+          // references (e.g. "lifted from `_kMaxNextTurnTapsForNwFleetReach`")
+          // do not falsely trigger the structural guard. Only live code
+          // declarations should match.
+          final code = source
+              .replaceAll(RegExp(r'/\*[\s\S]*?\*/'), '')
+              .replaceAll(RegExp(r'//[^\n]*'), '');
+
+          for (final retired in _retiredPrivateConstantNames) {
+            final declPattern = RegExp(
+              '^[^\\n]*\\b$retired\\s*=',
+              multiLine: true,
+            );
+            expect(
+              declPattern.hasMatch(code),
+              isFalse,
+              reason:
+                  '${entry.key} must not re-introduce the retired private '
+                  'constant `$retired` (AC2 § no surviving file-scope '
+                  'duplicates of shared-library values). Use the public '
+                  'replacement from the AC1 barrel '
+                  '(`e2e_helpers.dart`) instead.',
+            );
+          }
+
+          final structuralMatches = _fileScopePrivateConstantPattern
+              .allMatches(code)
+              .map((m) => m.group(0))
+              .toList(growable: false);
+          expect(
+            structuralMatches,
+            isEmpty,
+            reason:
+                '${entry.key} must not declare any file-scope `_k*` private '
+                'constant (AC2 source-of-truth pin). If a new shared value '
+                'is needed, expose it as a public `kE2eDefault*` constant on '
+                'the shared library (`e2e_test_shared*.dart`) and consume '
+                'it through the AC1 barrel (`e2e_helpers.dart`). Matches: '
+                '$structuralMatches.',
+          );
+        }
+      },
+    );
+  });
+}

--- a/app/test/new_game_fleet_reaches_new_world_e2e_test_no_private_constants_test.dart
+++ b/app/test/new_game_fleet_reaches_new_world_e2e_test_no_private_constants_test.dart
@@ -46,6 +46,7 @@
 /// Refs GitHub #2336 AC1 / AC2 / Bottleneck 6.
 library;
 
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'dart:io';
 
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;

--- a/app/test/new_game_fleet_reaches_new_world_e2e_test_no_private_constants_test.dart
+++ b/app/test/new_game_fleet_reaches_new_world_e2e_test_no_private_constants_test.dart
@@ -48,6 +48,7 @@ library;
 
 import 'dart:io';
 
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter_test/flutter_test.dart';
 
 import '../integration_test/e2e_helpers.dart';
@@ -99,6 +100,7 @@ String _readIntegrationTestSource(String relativePath) {
 }
 
 void main() {
+  suppressLogsForTests();
   group('AC2 — legacy private fleet-reach constants now public', () {
     test(
       'kE2eDefaultFleetReachLoopMaxTurns preserves the legacy '


### PR DESCRIPTION
## Summary

Replace three file-scope private constants in the fleet-reach E2E library with the public values they already aliased on the AC1 barrel:

| Retired private (legacy literal)              | Public replacement                  | Source                                  |
|-----------------------------------------------|-------------------------------------|-----------------------------------------|
| `_kMaxNextTurnTapsForNwFleetReach` (`35`)     | `kE2eDefaultFleetReachLoopMaxTurns` | `e2e_test_shared_fleet_reach_loop.dart` |
| `_kMaxUiResponseWait` (`Duration(seconds: 5)`)| `kE2eDefaultNavalMoveSegmentUiWait` | `e2e_test_shared_panels.dart`           |
| `_kFleetE2eMaxWallClock` (`kE2eMaxWallClock`) | `kE2eMaxWallClock`                  | `e2e_test_shared.dart`                  |

Behaviour-preserving: each public replacement equals its retired private literal byte-for-byte. The 35-turn fleet-reach budget, the 5-second per-UI-response cap (Bottleneck 4 / H1–H3), and the 5-minute wall-clock cap (PR runtime rule § `SPEC/program/e2e-integration-tests.md`) are all unchanged.

## Why

AC2 of issue #2336 calls for *\"duplicated private helpers … should not remain — only imports of the shared library are used\"*. The three retired constants were the last surviving file-scope `_k*` private duplicates of public values already exported through `e2e_helpers.dart`, so this slice closes the AC2 gap that the prior 20+ \"lift X into shared library\" slices (#2645, #2640, #2722, #2724, #2725, #2726, #2727, #2731, etc.) left behind for the fleet-reach scenario.

## Changes

- `app/integration_test/new_game_fleet_reaches_new_world_e2e_test.dart`:
  - Title interpolation uses `kE2eDefaultFleetReachLoopMaxTurns` instead of `_kMaxNextTurnTapsForNwFleetReach`.
  - Every `_kMaxUiResponseWait` call-site argument switched to `kE2eDefaultNavalMoveSegmentUiWait` (preamble construction, fleet-reach turn loop, final-naval-check, post-bundle scenario, bundled-explore readiness wait, await-explore-enabled retry).
  - Every `_kFleetE2eMaxWallClock` call-site switched to `kE2eMaxWallClock`.
  - Failure-message interpolation uses `kE2eDefaultFleetReachLoopMaxTurns`.
- `app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers.dart`:
  - Three private constants deleted.
  - Per-constant breadcrumb block at the top replaced with a single retirement table pointing each legacy private name at its public replacement and its source module.
  - Two lower-down doc comments that name `_kMaxNextTurnTapsForNwFleetReach` updated to reference `kE2eDefaultFleetReachLoopMaxTurns` so the docstrings no longer point at a retired symbol.
- `app/test/new_game_fleet_reaches_new_world_e2e_test_no_private_constants_test.dart` (**new, 4 tests, no production code changes**):
  - Per-constant byte-identical legacy-literal pins (consolidating the existing per-helper pins in `e2e_fleet_reach_turn_loop_test.dart`, `e2e_try_naval_move_segment_test.dart`, `e2e_make_wall_clock_guard_test.dart` so a coordinated rename of any one constant cannot silently drift off the pre-lift value).
  - **Structural AC2 source-of-truth pin:** reads the integration-test library source on disk and asserts that none of the three retired private symbols, and no other file-scope `^const _k...` declaration, reappears in the library — the structural guard that the migration was completed in source, not merely papered over by a value-equal proxy. Comments are stripped before scanning so the historical breadcrumb references that still name the retired symbols in `///` provenance docs do not falsely trigger the regression guard.

The integration suite itself cannot enforce this today (the `app_e2e_linux` lane is a no-op per `SPEC/program/e2e-integration-tests.md` § CI), so this widget-test layer carries the AC2 pin.

## Tests

\`\`\`bash
cd app
flutter analyze integration_test/ test/new_game_fleet_reaches_new_world_e2e_test_no_private_constants_test.dart
# No issues found.

flutter test test/new_game_fleet_reaches_new_world_e2e_test_no_private_constants_test.dart
# 4/4 pass — 3 byte-identical legacy-literal pins + 1 structural pin.

flutter test test/e2e_fleet_reach_turn_loop_test.dart \
             test/e2e_try_naval_move_segment_test.dart \
             test/e2e_make_wall_clock_guard_test.dart \
             test/e2e_helpers_barrel_test.dart \
             test/e2e_enter_fleet_reach_scenario_ready_test.dart
# 67/67 pass — no regression on adjacent fleet-reach / wall-clock / barrel pins.
\`\`\`

## Test plan

- [x] **AC2 — no surviving file-scope private constants:** new pin reads the three integration-test library files (`new_game_fleet_reaches_new_world_e2e_test.dart` + two `part` files) and asserts no `^const _k...` declarations and no occurrence of the retired symbol names in live code (comments stripped before scanning).
- [x] **Legacy 35-turn cap preserved:** `kE2eDefaultFleetReachLoopMaxTurns == 35` re-pinned in the consolidated test; existing pin in `e2e_fleet_reach_turn_loop_test.dart` still passes.
- [x] **Legacy 5-second UI-response cap preserved:** `kE2eDefaultNavalMoveSegmentUiWait == Duration(seconds: 5)` re-pinned; existing pin in `e2e_try_naval_move_segment_test.dart` still passes.
- [x] **Legacy 5-minute wall-clock cap preserved:** `kE2eMaxWallClock == Duration(minutes: 5)` re-pinned; existing pin in `e2e_make_wall_clock_guard_test.dart` still passes.
- [x] **AC1 barrel re-exports unchanged:** `e2e_helpers_barrel_test.dart` AC1 pin suite still passes (67 tests across the adjacent pins).
- [x] **`flutter analyze`:** clean on the touched files and on the new test pin.

## Scope disclosure

This PR is one isolated AC2 slice of #2336 (no surviving file-scope private constants in the fleet-reach E2E library). It does not touch:

- AC8 / AC9 baseline-vs-after wall-clock measurement (still requires a maintainer Linux desktop `tool/run_e2e_timing.sh` capture; this host lacks `xvfb-run` / display).
- AC4 high-impact pump-site replacements (already addressed by the H1–H4 / H5–H10 lift cadence merged through PR #2731 / #2742).
- AC10 stability (3-consecutive runs) — same E2E capture dependency as AC8 / AC9.
- The two `part` files themselves — the breadcrumb provenance trail other PRs reference (and the AC2 documentation table for the retired constants) lives there as documentation only.

Refs #2336 — does not auto-close.

Made with [Cursor](https://cursor.com)