### PR TITLE
docs: link ctdev-app.md to shell-screen.md and game-screen.md (Refs #2750)

### DIFF
--- a/SPEC/program/ctdev-app.md
+++ b/SPEC/program/ctdev-app.md
@@ -40,3 +40,16 @@
 ## Relationship to init_game CLI
 
 `tool/init_game` remains a headless CLI (savegames, optional PNG/markdown). ctdev is the canonical visualization surface: developers run init-game flows inside ctdev or load CLI-generated saves.
+
+---
+
+## Related — Main player app screens
+
+ctdev is a developer tool and does **not** host the main player app's shell or in-game surface. Reviewers landing here from the main player app should follow these dedicated specs instead:
+
+| Main player app screen | Dedicated SPEC |
+|------------------------|----------------|
+| `ShellScreen` (`Routes.shell`, `app/lib/features/shell/shell_screen.dart`) | [`../ui/shell-screen.md`](../ui/shell-screen.md) |
+| `GameScreen` (`Routes.game`, `app/lib/features/game/flame/game_screen.dart`) | [`../ui/game-screen.md`](../ui/game-screen.md) |
+
+Cross-cutting routing/bus rules for both player-app screens live in [`app-ui-wiring.md`](app-ui-wiring.md) § Routes. The ctdev tool's own screens (Init Game Config, Init Game Map Debug, Running Game) remain documented in the **Main Screens / Tabs** table above and are unrelated to `ShellScreen` / `GameScreen`.

--- a/app/test/ctdev_app_links_player_app_screens_test.dart
+++ b/app/test/ctdev_app_links_player_app_screens_test.dart
@@ -1,0 +1,149 @@
+/// Pins the SPEC cross-reference AC from issue #2750:
+///
+/// > "`SPEC/program/ctdev-app.md` 'Main Screens / Tabs' table (or equivalent
+/// >  shell/game rows) links to `SPEC/ui/shell-screen.md` and
+/// >  `SPEC/ui/game-screen.md`. No further expansion of `ctdev-app.md` screen
+/// >  descriptions is required by this issue."
+///
+/// `ctdev-app.md` is the program-side spec for the ctdev developer tool and
+/// does not own player-app screen rows. The AC is satisfied by a dedicated
+/// "Related — Main player app screens" section in `ctdev-app.md` that
+/// cross-references the two new player-app screen specs landed by the parent
+/// slice (PR #2756). This pin reads `SPEC/program/ctdev-app.md` from disk and
+/// fails if either relative link is removed, so the cross-reference cannot
+/// silently regress.
+///
+/// Refs GitHub #2750.
+library;
+
+import 'dart:io';
+
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter_test/flutter_test.dart';
+
+const String _ctdevAppSpecRelativePath = 'SPEC/program/ctdev-app.md';
+
+const String _shellScreenSpecLink = '../ui/shell-screen.md';
+const String _gameScreenSpecLink = '../ui/game-screen.md';
+
+String _readCtdevAppSpec() {
+  final repoRoot = Directory.current.path;
+  // `flutter test` from `app/` and `dart test` from repo root both need to
+  // locate the spec; tolerate either CWD without bespoke runner config.
+  final candidates = <File>[
+    File('$repoRoot/$_ctdevAppSpecRelativePath'),
+    File('$repoRoot/../$_ctdevAppSpecRelativePath'),
+  ];
+  for (final file in candidates) {
+    if (file.existsSync()) {
+      return file.readAsStringSync();
+    }
+  }
+  fail(
+    'Could not locate `$_ctdevAppSpecRelativePath` at any of: '
+    '${candidates.map((f) => f.path).join(', ')}. '
+    'Issue #2750 SPEC-cross-reference pin must read the on-disk spec to '
+    'guard the player-app screen links.',
+  );
+}
+
+void main() {
+  suppressLogsForTests();
+
+  group(
+    'SPEC/program/ctdev-app.md cross-references the main player app screens '
+    '(Refs #2750)',
+    () {
+      late final String specBody = _readCtdevAppSpec();
+
+      test('links to SPEC/ui/shell-screen.md via the documented relative path',
+          () {
+        expect(
+          specBody.contains(_shellScreenSpecLink),
+          isTrue,
+          reason:
+              'Issue #2750 AC requires `SPEC/program/ctdev-app.md` to point '
+              'readers at the dedicated `SPEC/ui/shell-screen.md` for the '
+              'player app shell screen. The relative link '
+              '`$_shellScreenSpecLink` (from `SPEC/program/`) is the form '
+              'documented in the new "Related — Main player app screens" '
+              'section and matches the cross-reference style used elsewhere '
+              'in `SPEC/program/`. Removing it strands a reader who lands on '
+              'the ctdev tool spec and would otherwise miss the player-app '
+              'screen contract.',
+        );
+      });
+
+      test('links to SPEC/ui/game-screen.md via the documented relative path',
+          () {
+        expect(
+          specBody.contains(_gameScreenSpecLink),
+          isTrue,
+          reason:
+              'Issue #2750 AC requires `SPEC/program/ctdev-app.md` to point '
+              'readers at the dedicated `SPEC/ui/game-screen.md` for the '
+              'player app in-game screen. The relative link '
+              '`$_gameScreenSpecLink` (from `SPEC/program/`) is the form '
+              'documented in the new "Related — Main player app screens" '
+              'section and matches the cross-reference style used elsewhere '
+              'in `SPEC/program/`. Removing it strands a reader who lands on '
+              'the ctdev tool spec and would otherwise miss the player-app '
+              'in-game screen contract.',
+        );
+      });
+
+      test(
+        'lists both player-app screen pointers under a dedicated section '
+        '(not in the ctdev "Main Screens / Tabs" table)',
+        () {
+          // Negative pin: the ctdev "Main Screens / Tabs" table documents the
+          // *ctdev* dev tool screens (Init Game Config, Init Game Map Debug,
+          // Running Game). Player-app screens must not be smuggled into that
+          // table, because they are not ctdev features. The AC's "equivalent
+          // shell/game rows" wording is satisfied by a separate, clearly
+          // labelled cross-reference section, mirrored by this assertion.
+          final mainScreensHeaderIdx = specBody.indexOf('## Main Screens / Tabs');
+          final relatedPlayerAppHeaderIdx =
+              specBody.indexOf('## Related — Main player app screens');
+
+          expect(
+            mainScreensHeaderIdx,
+            greaterThanOrEqualTo(0),
+            reason:
+                'ctdev-app.md must keep its "Main Screens / Tabs" section so '
+                'this negative pin can measure the boundary between ctdev '
+                'screens and player-app cross-references.',
+          );
+          expect(
+            relatedPlayerAppHeaderIdx,
+            greaterThan(mainScreensHeaderIdx),
+            reason:
+                'The new "Related — Main player app screens" section must '
+                'appear after the ctdev-screens table so player-app pointers '
+                'live in their own section instead of polluting the ctdev '
+                'screens table (Refs #2750 scope decision).',
+          );
+
+          final shellLinkIdx = specBody.indexOf(_shellScreenSpecLink);
+          final gameLinkIdx = specBody.indexOf(_gameScreenSpecLink);
+          expect(
+            shellLinkIdx,
+            greaterThan(relatedPlayerAppHeaderIdx),
+            reason:
+                'The shell-screen.md pointer must live in the "Related — '
+                'Main player app screens" section to avoid implying ctdev '
+                'hosts ShellScreen.',
+          );
+          expect(
+            gameLinkIdx,
+            greaterThan(relatedPlayerAppHeaderIdx),
+            reason:
+                'The game-screen.md pointer must live in the "Related — '
+                'Main player app screens" section to avoid implying ctdev '
+                'hosts GameScreen.',
+          );
+        },
+      );
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Follow-up slice on issue #2750 (Document ShellScreen and GameScreen with SPECs and Widgetbook entries). PR #2756 landed the SPEC files, Widgetbook stories, and widget pins, but did not satisfy the remaining cross-reference AC against `SPEC/program/ctdev-app.md`. This PR closes that gap with a small documentation change plus a spec-pin test. Refs #2750 — does not auto-close.

## Done in this push

- **`SPEC/program/ctdev-app.md`** — adds a new **"Related — Main player app screens"** section linking to `../ui/shell-screen.md` and `../ui/game-screen.md`, plus a pointer to `app-ui-wiring.md` for the routing/bus rules shared by both player-app screens. Explicitly notes that ctdev's own screens (Init Game Config, Init Game Map Debug, Running Game) remain the authoritative content of the existing **Main Screens / Tabs** table, so the player-app cross-references do not pollute the ctdev-screens row table.
- **`app/test/ctdev_app_links_player_app_screens_test.dart`** — 3 spec-pin tests that read `SPEC/program/ctdev-app.md` from disk and assert:
  - **Positive 1:** the relative link `../ui/shell-screen.md` appears in the spec body.
  - **Positive 2:** the relative link `../ui/game-screen.md` appears in the spec body.
  - **Negative:** both links live **after** the new section header (i.e. inside the dedicated "Related — Main player app screens" section), not somewhere inside the ctdev-screens table. Guards against regressions that would re-conflate ctdev tool screens with player-app screens.

The test uses the same path-candidate fallback pattern as `app/test/new_game_fleet_reaches_new_world_e2e_test_no_private_constants_test.dart` so it runs cleanly from either `app/` (under `flutter test`) or the repo root.

## ACs covered

Issue #2750 AC (verbatim):

> "`SPEC/program/ctdev-app.md` 'Main Screens / Tabs' table (or equivalent shell/game rows) links to `SPEC/ui/shell-screen.md` and `SPEC/ui/game-screen.md`. No further expansion of `ctdev-app.md` screen descriptions is required by this issue."

- Wording resolution: ctdev-app.md does not own player-app rows (the file is the spec for the **ctdev dev tool**, not the main app), so the literal "equivalent shell/game rows" wording is interpreted as "an equivalent cross-reference target". The dedicated "Related — Main player app screens" section satisfies the AC's intent — readers landing on `ctdev-app.md` can now follow direct relative links to the new player-app screen specs landed by #2756 — without misleadingly listing player-app screens as ctdev screens.
- AC pinning: the three new tests fail if either relative link is removed or moved out of the dedicated section, so this AC cannot silently regress.

## Verification

- `cd app && flutter analyze test/ctdev_app_links_player_app_screens_test.dart` → **No issues found**
- `cd app && flutter test test/ctdev_app_links_player_app_screens_test.dart` → **3/3 pass**
- `cd app && flutter test test/shell_game_screen_specs_test.dart test/ctdev_app_links_player_app_screens_test.dart` → **11/11 pass** (no regression on the parent slice's widget pins from #2756)
- `CT_REPO_LINT_INCLUDE_APP=true dart run tool/ct_repo_lint.dart` → **all 47 rule(s) passed**

## Scope disclosure

Documentation cross-reference and a single SPEC-pin test only. No production code, no Widgetbook stories, no behavior changes. The `ctdev-app.md` "Main Screens / Tabs" table content is untouched (per the issue's "expanding ctdev-app.md screen entries is out of scope" decision). Closing the issue is intentionally deferred until verification.


Made with [Cursor](https://cursor.com)