### PR TITLE
refactor(ai): canonicalize cheapestRegimentBuildTreasuryCost and isBelowQuotaPeaceZeroRegimentsRebuild in expand_phase_planner (Refs #2509)

### DIFF
--- a/packages/colonizethis_ai/lib/src/planning/colonial_phase_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/colonial_phase_planner.dart
@@ -204,6 +204,7 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../perception/perception_snapshot.dart';
 import 'army_conquest_prep.dart' show regimentCountForPlayer;
+import 'expand_phase_planner.dart' as expand_phase_planner;
 import 'observer_goal_phase.dart' show primaryColonialGpBlocker;
 
 /// Returns the deterministic list of at-war Great Powers the active player
@@ -786,21 +787,15 @@ List<String> _acquisitionIterationOrder(ColonialSummary colonial) {
 /// Minimum [RegimentEconomyCatalog] build treasury cost (deterministic
 /// catalog scan).
 ///
-/// Mirrors `_cheapestRegimentBuildTreasuryCost` in
-/// `expand_phase_planner.dart` (Refs #2509 § EXPAND phase planner) so
-/// the COLONIAL declare-war arm stays self-contained against the S1
-/// deletion of `colonial_pressure.dart`. Linear in the catalog size,
-/// matching the budget-rule note in
-/// `colonizethis-turn-resolution-budget.mdc`.
-int _cheapestRegimentBuildTreasuryCost() {
-  var min = 999999999;
-  for (final econ in RegimentEconomyCatalog.byId.values) {
-    if (econ.buildTreasuryCost < min) {
-      min = econ.buildTreasuryCost;
-    }
-  }
-  return min;
-}
+/// Delegates to the canonical
+/// [expand_phase_planner.cheapestRegimentBuildTreasuryCost] (Refs #2509
+/// S1) so the COLONIAL declare-war arm shares the same affordability
+/// gate as `planExpandDeclareWar` / `planExpandEconomy`. The COLONIAL
+/// planner intentionally keeps the call site private so it remains
+/// self-contained against the planned S1 deletion of
+/// `colonial_pressure.dart`.
+int _cheapestRegimentBuildTreasuryCost() =>
+    expand_phase_planner.cheapestRegimentBuildTreasuryCost();
 
 /// True when [playerId] owns at least one [kUnitTypeMerchant] unit
 /// with [UnitStatus.idle] in either region. Region of the Merchant is

--- a/packages/colonizethis_ai/lib/src/planning/colonial_pressure.dart
+++ b/packages/colonizethis_ai/lib/src/planning/colonial_pressure.dart
@@ -71,15 +71,12 @@ bool isBelowQuotaPeaceInsufficientRegiments({
 }
 
 /// Minimum [RegimentEconomyCatalog] build treasury cost (deterministic catalog scan).
-int cheapestRegimentBuildTreasuryCost() {
-  var min = 999999999;
-  for (final econ in RegimentEconomyCatalog.byId.values) {
-    if (econ.buildTreasuryCost < min) {
-      min = econ.buildTreasuryCost;
-    }
-  }
-  return min;
-}
+///
+/// Delegates to [expand_phase_planner.cheapestRegimentBuildTreasuryCost]
+/// (Refs #2509 S1) so the canonical implementation lives alongside the
+/// EXPAND-trap callers that govern the treasury affordability gate.
+int cheapestRegimentBuildTreasuryCost() =>
+    expand_phase_planner.cheapestRegimentBuildTreasuryCost();
 
 /// Below-quota EXPAND GP at peace with insufficient regiments and effective
 /// treasury (cash plus same-turn pending riches) below cheapest regiment build.

--- a/packages/colonizethis_ai/lib/src/planning/colonial_pressure.dart
+++ b/packages/colonizethis_ai/lib/src/planning/colonial_pressure.dart
@@ -83,14 +83,20 @@ int cheapestRegimentBuildTreasuryCost() =>
 ///
 /// Triggers overseas cargo preference so auto-transport can deliver riches to
 /// stockpile before the next build pass (Refs #2509).
+///
+/// Delegates to [expand_phase_planner.isBelowQuotaPeaceZeroRegimentsRebuild]
+/// (Refs #2509 S1) so the canonical implementation lives alongside the
+/// EXPAND-trap callers that share the zero-regiments / invadable-frontier
+/// gate.
 bool isBelowQuotaPeaceZeroRegimentsRebuild({
   required int oldWorldProvincesOwned,
   required int regimentCount,
   required bool hasInvadableProvinces,
-}) =>
-    isBelowObserverConquestQuota(oldWorldProvincesOwned) &&
-    regimentCount == 0 &&
-    hasInvadableProvinces;
+}) => expand_phase_planner.isBelowQuotaPeaceZeroRegimentsRebuild(
+  oldWorldProvincesOwned: oldWorldProvincesOwned,
+  regimentCount: regimentCount,
+  hasInvadableProvinces: hasInvadableProvinces,
+);
 
 bool isBelowQuotaPeaceTreasuryRecovery({
   required int oldWorldProvincesOwned,

--- a/packages/colonizethis_ai/lib/src/planning/expand_phase_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/expand_phase_planner.dart
@@ -657,6 +657,42 @@ int cheapestRegimentBuildTreasuryCost() {
   return min;
 }
 
+/// Below-quota EXPAND GP with zero standing regiments and a non-empty
+/// invadable Old World frontier.
+///
+/// Canonical home (Refs #2509 S1) for the legacy
+/// `isBelowQuotaPeaceZeroRegimentsRebuild` predicate previously hosted in
+/// `colonial_pressure.dart` (Arm A of the legacy below-quota treasury-recovery
+/// composite). The function captures the EXPAND-trap "zero regiments with
+/// frontier to expand into" arm shared by:
+///
+///   - [planExpandEconomy] Arm A (`regimentCount == 0 && hasInvadable` →
+///     `forceCheapestRegimentBuild: true`), which signals the orchestrator
+///     to force a regiment build attempt regardless of treasury (cargo
+///     boost in Arm C handles the funding side).
+///   - The legacy `isBelowQuotaPeaceTreasuryRecovery` composite still
+///     surfacing through `colonial_pressure.dart` (composed with the
+///     `isBelowQuotaPeaceInsufficientRegiments` arm) so the cargo-delivery
+///     trigger and the planner directive cannot drift apart while the
+///     S5 orchestrator wire-up is in flight.
+///
+/// `colonial_pressure.dart` retains a thin delegating stub for legacy
+/// import sites (the `colonial_pressure_below_quota_peace_*` tests and
+/// `phase_planner_economy_filter.dart`) so the planned S1 deletion of
+/// that file leaves no orphan callers.
+///
+/// Pure and deterministic — identical inputs always yield identical
+/// results (Refs #2509 Must-have #7). Constant-time (no catalog or
+/// game-state scan).
+bool isBelowQuotaPeaceZeroRegimentsRebuild({
+  required int oldWorldProvincesOwned,
+  required int regimentCount,
+  required bool hasInvadableProvinces,
+}) =>
+    isBelowObserverConquestQuota(oldWorldProvincesOwned) &&
+    regimentCount == 0 &&
+    hasInvadableProvinces;
+
 /// EXPAND-phase conquest destination filter returned by [planExpandMilitary].
 ///
 /// Two ascending-sorted lists describe the priority subset of OW

--- a/packages/colonizethis_ai/lib/src/planning/expand_phase_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/expand_phase_planner.dart
@@ -350,7 +350,7 @@ bool isMutualBelowQuotaPlateauPeer({
 /// Returns:
 ///   - `null` when [ConquestSummary.invadableProvinceIdsSorted] is empty
 ///     (no OW frontier to expand into) or when treasury is below
-///     `_cheapestRegimentBuildTreasuryCost()` (the player cannot afford a
+///     [cheapestRegimentBuildTreasuryCost] (the player cannot afford a
 ///     regiment to follow up the declaration; the spec
 ///     "skip if treasury < cheapestRegimentBuildTreasuryCost" arm).
 ///   - The lowest-id minor faction owning an invadable OW province and
@@ -378,7 +378,7 @@ String? planExpandDeclareWar({
   if (invadable.isEmpty) return null;
   final player = game.playerById(snapshot.playerId);
   if (player == null) return null;
-  if (player.treasury < _cheapestRegimentBuildTreasuryCost()) {
+  if (player.treasury < cheapestRegimentBuildTreasuryCost()) {
     return null;
   }
 
@@ -488,7 +488,7 @@ class ExpandEconomyPlan {
   ///     `0 < regimentCount < kBelowQuotaPeaceMinRegimentsBeforeDeclareWar`
   ///     with non-empty invadable OW frontier and effective treasury
   ///     (cash + [pendingRichesTreasuryDelta]) at or above
-  ///     `_cheapestRegimentBuildTreasuryCost()`.
+  ///     [cheapestRegimentBuildTreasuryCost].
   final bool forceCheapestRegimentBuild;
 
   /// True when the orchestrator should add
@@ -498,7 +498,7 @@ class ExpandEconomyPlan {
   ///
   /// Set when below quota AND effective treasury (cash +
   /// [pendingRichesTreasuryDelta]) is strictly below
-  /// `_cheapestRegimentBuildTreasuryCost()` (issue #2509 § EXPAND phase
+  /// [cheapestRegimentBuildTreasuryCost] (issue #2509 § EXPAND phase
   /// planner § planExpandEconomy "treasury < cheapest" arm). The
   /// boost composes with [forceCheapestRegimentBuild] so a GP that is
   /// told to force a build AND cannot currently afford one still gets
@@ -605,7 +605,7 @@ ExpandEconomyPlan planExpandEconomy({
   final regimentCount = regimentCountForPlayer(game, snapshot.playerId);
   final effectiveTreasury =
       player.treasury + pendingRichesTreasuryDelta(stockpile: player.stockpile);
-  final cheapest = _cheapestRegimentBuildTreasuryCost();
+  final cheapest = cheapestRegimentBuildTreasuryCost();
 
   // Arm A: regimentCount == 0 AND hasInvadable -> force rebuild
   // (no treasury gate per spec; the build pipeline still applies its
@@ -637,12 +637,17 @@ ExpandEconomyPlan planExpandEconomy({
 /// Minimum [RegimentEconomyCatalog] build treasury cost (deterministic
 /// catalog scan).
 ///
-/// Mirrors `cheapestRegimentBuildTreasuryCost` from `colonial_pressure.dart`
-/// so the new planner stays self-contained against the S1 deletion of
-/// that file (Refs #2509 § EXPAND phase planner). Linear in the catalog
-/// size, matching the budget-rule note in
+/// Canonical home (Refs #2509 S1) for the EXPAND-trap treasury affordability
+/// gate used by [planExpandDeclareWar] (treasury floor before declaring),
+/// [planExpandEconomy] (arms B/C threshold for force-build and treasury
+/// recovery cargo), and the [planColonialAcquisition] declare-war arm in
+/// `colonial_phase_planner.dart`. `colonial_pressure.dart` retains a
+/// thin delegating stub for legacy import sites so the planned S1
+/// deletion of that file leaves no orphan callers.
+///
+/// Linear in the catalog size, matching the budget-rule note in
 /// `colonizethis-turn-resolution-budget.mdc`.
-int _cheapestRegimentBuildTreasuryCost() {
+int cheapestRegimentBuildTreasuryCost() {
   var min = 999999999;
   for (final econ in RegimentEconomyCatalog.byId.values) {
     if (econ.buildTreasuryCost < min) {

--- a/packages/colonizethis_ai/test/planning/expand_phase_planner_below_quota_peace_zero_regiments_rebuild_test.dart
+++ b/packages/colonizethis_ai/test/planning/expand_phase_planner_below_quota_peace_zero_regiments_rebuild_test.dart
@@ -1,0 +1,188 @@
+// Pins the canonical `isBelowQuotaPeaceZeroRegimentsRebuild` helper in
+// `expand_phase_planner.dart` (Refs #2509 S1).
+//
+// This helper is Arm A of the EXPAND-trap below-quota rebuild gate:
+// a below-quota GP with zero standing regiments and a non-empty invadable
+// OW frontier is told to force a regiment build regardless of treasury
+// (Arm C handles the cargo-recovery side). It is shared by:
+//
+//   - `planExpandEconomy` Arm A in `expand_phase_planner.dart`
+//     (`regimentCount == 0 && hasInvadable` → `forceCheapestRegimentBuild`).
+//   - `isBelowQuotaPeaceTreasuryRecovery` in `colonial_pressure.dart` —
+//     a composite that short-circuits to `true` when this predicate fires.
+//
+// The S1 plan in #2509 deletes `colonial_pressure.dart` outright, so the
+// public helper now lives in `expand_phase_planner.dart`. This test pins
+// the canonical entrypoint directly so the delegation stub in
+// `colonial_pressure.dart` can be removed in a future slice without
+// regressing the legacy `isBelowQuotaPeaceTreasuryRecovery` composite or
+// the planner's Arm A path.
+//
+// Behavioral invariants pinned here (all deterministic, constant-time):
+//
+//   1. Returns `true` exactly when all three legacy conditions hold
+//      together: below the observer conquest quota, zero standing
+//      regiments, and a non-empty invadable OW frontier. Each condition
+//      is necessary — flipping any single input to its "off" value must
+//      drop the result to `false`. This protects against a regression
+//      that swapped `&&` for `||` or dropped one input from the
+//      composite.
+//   2. The quota gate is sourced from
+//      `isBelowObserverConquestQuota` (i.e. strictly
+//      `< kObserverConquestMinOwProvincesPerGp`), not a hard-coded
+//      literal. Pinning at the boundary (quota-1, quota, quota+1) keeps
+//      the helper aligned with the shared EXPAND quota constant if it is
+//      ever retuned in `ai_victory_config.dart`.
+//   3. The result is deterministic across repeated calls — required by
+//      issue #2509 Must-have #7 "Determinism: same save + seeds → same
+//      orders; phase planners are pure functions with deterministic
+//      inputs." Two consecutive calls with identical inputs must yield
+//      the same value (no hidden global mutation, no rng).
+//   4. The delegating stub in `colonial_pressure.dart` returns the same
+//      value as the canonical helper for every relevant input
+//      combination — required so the legacy
+//      `isBelowQuotaPeaceTreasuryRecovery` callers and the EXPAND
+//      planner agree on the zero-regiments rebuild boundary. A drift
+//      here would silently let one code path trigger the cargo-recovery
+//      composite while the other planner Arm A diverges.
+
+import 'package:colonizethis_ai/src/planning/colonial_pressure.dart'
+    as colonial_pressure;
+import 'package:colonizethis_ai/src/planning/expand_phase_planner.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_test/test.dart';
+
+void main() {
+  group('isBelowQuotaPeaceZeroRegimentsRebuild', () {
+    test('returns true when all three conditions hold together', () {
+      expect(
+        isBelowQuotaPeaceZeroRegimentsRebuild(
+          oldWorldProvincesOwned: kObserverConquestMinOwProvincesPerGp - 1,
+          regimentCount: 0,
+          hasInvadableProvinces: true,
+        ),
+        isTrue,
+        reason:
+            'Below-quota GP with zero regiments and an invadable OW frontier '
+            'is the EXPAND-trap rebuild trigger; the helper must report true '
+            'so `planExpandEconomy` Arm A can force a build attempt.',
+      );
+    });
+
+    test('drops to false when OW holdings reach the observer quota', () {
+      expect(
+        isBelowQuotaPeaceZeroRegimentsRebuild(
+          oldWorldProvincesOwned: kObserverConquestMinOwProvincesPerGp,
+          regimentCount: 0,
+          hasInvadableProvinces: true,
+        ),
+        isFalse,
+        reason:
+            'At quota the GP is no longer in EXPAND territory for this gate; '
+            'the helper must short-circuit so the EXPAND-only force-build '
+            'directive does not leak into COLONIAL / DEVELOP play.',
+      );
+      expect(
+        isBelowQuotaPeaceZeroRegimentsRebuild(
+          oldWorldProvincesOwned: kObserverConquestMinOwProvincesPerGp + 1,
+          regimentCount: 0,
+          hasInvadableProvinces: true,
+        ),
+        isFalse,
+        reason:
+            'Above quota the GP must not trigger the EXPAND-trap rebuild '
+            'arm — sanity check that the boundary is strict (`<`, not '
+            '`<=`) and matches `isBelowObserverConquestQuota`.',
+      );
+    });
+
+    test('drops to false when standing regiments are present', () {
+      expect(
+        isBelowQuotaPeaceZeroRegimentsRebuild(
+          oldWorldProvincesOwned: kObserverConquestMinOwProvincesPerGp - 1,
+          regimentCount: 1,
+          hasInvadableProvinces: true,
+        ),
+        isFalse,
+        reason:
+            'The Arm A trigger requires `regimentCount == 0`; any standing '
+            'regiments push the GP into the Arm B / insufficient-regiments '
+            'branch instead, so the helper must not fire here.',
+      );
+    });
+
+    test('drops to false when no invadable OW frontier is available', () {
+      expect(
+        isBelowQuotaPeaceZeroRegimentsRebuild(
+          oldWorldProvincesOwned: kObserverConquestMinOwProvincesPerGp - 1,
+          regimentCount: 0,
+          hasInvadableProvinces: false,
+        ),
+        isFalse,
+        reason:
+            'Without an invadable OW frontier the rebuild directive has '
+            'nothing to act on; the helper must report false so the '
+            'planner does not waste a build cycle in a sealed map state.',
+      );
+    });
+
+    test('is deterministic across repeated calls (Must-have #7)', () {
+      // Pure helper with explicit inputs; calling twice with identical
+      // inputs must yield the same value. A regression that introduced
+      // rng or mutable cache state would surface here as a divergence
+      // between the two calls.
+      final first = isBelowQuotaPeaceZeroRegimentsRebuild(
+        oldWorldProvincesOwned: kObserverConquestMinOwProvincesPerGp - 1,
+        regimentCount: 0,
+        hasInvadableProvinces: true,
+      );
+      final second = isBelowQuotaPeaceZeroRegimentsRebuild(
+        oldWorldProvincesOwned: kObserverConquestMinOwProvincesPerGp - 1,
+        regimentCount: 0,
+        hasInvadableProvinces: true,
+      );
+      expect(
+        first,
+        second,
+        reason:
+            'Pure helper must return identical results on repeated calls — '
+            'required by issue #2509 Must-have #7 (phase planners are pure '
+            'functions with deterministic inputs).',
+      );
+    });
+
+    test('colonial_pressure delegation stub returns the canonical value', () {
+      // Pins the S1 delegation contract: the legacy public symbol
+      // exported from `colonial_pressure.dart` must mirror the canonical
+      // helper for every relevant truth-table input so removing the stub
+      // in a future slice cannot silently shift the EXPAND-trap rebuild
+      // boundary for legacy callers.
+      const ow = kObserverConquestMinOwProvincesPerGp - 1;
+      for (final regimentCount in const [0, 1]) {
+        for (final hasInvadableProvinces in const [true, false]) {
+          expect(
+            colonial_pressure.isBelowQuotaPeaceZeroRegimentsRebuild(
+              oldWorldProvincesOwned: ow,
+              regimentCount: regimentCount,
+              hasInvadableProvinces: hasInvadableProvinces,
+            ),
+            isBelowQuotaPeaceZeroRegimentsRebuild(
+              oldWorldProvincesOwned: ow,
+              regimentCount: regimentCount,
+              hasInvadableProvinces: hasInvadableProvinces,
+            ),
+            reason:
+                '`colonial_pressure.isBelowQuotaPeaceZeroRegimentsRebuild` '
+                'is a thin delegating stub for legacy callers; it must '
+                'mirror the canonical helper exactly so the EXPAND '
+                'planner Arm A and the legacy '
+                '`isBelowQuotaPeaceTreasuryRecovery` composite agree on '
+                'the zero-regiments rebuild trigger '
+                '(regimentCount=$regimentCount, '
+                'hasInvadableProvinces=$hasInvadableProvinces).',
+          );
+        }
+      }
+    });
+  });
+}

--- a/packages/colonizethis_ai/test/planning/expand_phase_planner_cheapest_regiment_cost_test.dart
+++ b/packages/colonizethis_ai/test/planning/expand_phase_planner_cheapest_regiment_cost_test.dart
@@ -1,0 +1,125 @@
+// Pins the canonical `cheapestRegimentBuildTreasuryCost` helper in
+// `expand_phase_planner.dart` (Refs #2509 S1).
+//
+// This helper governs the EXPAND-trap treasury affordability gate that is
+// shared by `planExpandDeclareWar` (priority-arm skip when treasury is
+// below the cheapest regiment cost), `planExpandEconomy`
+// (`ExpandEconomyPlan.boostTreasuryRecoveryCargo` when below-quota cash +
+// pending riches cannot fund a build), and the COLONIAL declare-war arm
+// in `colonial_phase_planner.dart`. The same value also backs the
+// `isBelowQuotaPeaceTreasuryRecovery` cargo trigger in
+// `colonial_pressure.dart` (now a thin delegating stub).
+//
+// The S1 plan in #2509 deletes `colonial_pressure.dart` outright, so the
+// public helper now lives in `expand_phase_planner.dart`. This test pins
+// the canonical entrypoint directly so the delegation stubs in
+// `colonial_pressure.dart` and the private wrapper in
+// `colonial_phase_planner.dart` can be removed in a future slice without
+// regressing the cross-phase callers.
+//
+// Behavioral invariants pinned here (all deterministic against the
+// embedded [RegimentEconomyCatalog]):
+//
+//   1. Returns the strict minimum of every catalog entry's
+//      `buildTreasuryCost`, not the first entry, not the sum, not a
+//      cached constant from `ai_victory_config.dart`. The catalog scan
+//      is exhaustive so adding a cheaper regiment shifts the result;
+//      adding an expensive regiment does not.
+//   2. The result is strictly positive (regiment builds always require
+//      treasury) so the `treasury < cheapest` branches in EXPAND /
+//      COLONIAL stay reachable when treasury == 0.
+//   3. The result is deterministic across repeated calls — required by
+//      issue #2509 Must-have #7 "Determinism: same save + seeds → same
+//      orders; phase planners are pure functions with deterministic
+//      inputs." Two consecutive calls inside the same isolate must
+//      yield the same value (no hidden global mutation, no rng).
+//   4. The delegating stub in `colonial_pressure.dart` returns the same
+//      value as the canonical helper — required so the legacy
+//      `isBelowQuotaPeaceTreasuryRecovery` callers and the EXPAND /
+//      COLONIAL phase planners agree on the affordability boundary.
+//      A drift here would silently let one code path declare war while
+//      the other still gates on cargo recovery for the same GP.
+
+import 'package:colonizethis_ai/src/planning/colonial_pressure.dart'
+    as colonial_pressure;
+import 'package:colonizethis_ai/src/planning/expand_phase_planner.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_test/test.dart';
+
+void main() {
+  group('cheapestRegimentBuildTreasuryCost', () {
+    test('matches the strict minimum across the regiment economy catalog', () {
+      // Recompute the expected minimum without sharing the helper's loop
+      // shape so a regression that swapped the comparison (`>` instead
+      // of `<`) or returned the first entry would not also pass this
+      // test. The catalog snapshot is deterministic at process start.
+      final entries = RegimentEconomyCatalog.byId.values.toList();
+      expect(
+        entries,
+        isNotEmpty,
+        reason:
+            'RegimentEconomyCatalog must ship at least one regiment so the '
+            'EXPAND affordability gate has a meaningful floor.',
+      );
+      final expected = entries
+          .map((econ) => econ.buildTreasuryCost)
+          .reduce((a, b) => a < b ? a : b);
+      expect(
+        cheapestRegimentBuildTreasuryCost(),
+        expected,
+        reason:
+            'Helper must return the strict catalog minimum so the EXPAND-trap '
+            '`treasury < cheapest` gate stays consistent with `planExpand*` '
+            'callers and the COLONIAL declare-war arm.',
+      );
+    });
+
+    test('returns a strictly positive treasury cost', () {
+      // A non-positive result would make the `treasury < cheapest` gate
+      // in `planExpandDeclareWar` unreachable at treasury == 0 (negative
+      // costs invert the comparison; zero leaves a GP at zero treasury
+      // free to declare war). Either regression would break the EXPAND
+      // suppression / recovery contract documented in issue #2509.
+      expect(
+        cheapestRegimentBuildTreasuryCost(),
+        greaterThan(0),
+        reason:
+            'Regiment builds always cost treasury; a zero / negative floor '
+            'would silently bypass the EXPAND-trap affordability gate.',
+      );
+    });
+
+    test('is deterministic across repeated calls (Must-have #7)', () {
+      // The helper is pure with no inputs; calling twice in the same
+      // isolate must yield the same value. A regression that introduced
+      // rng (e.g. randomized catalog iteration) or mutable cache state
+      // would surface here as a divergence between the two calls.
+      final first = cheapestRegimentBuildTreasuryCost();
+      final second = cheapestRegimentBuildTreasuryCost();
+      expect(
+        first,
+        second,
+        reason:
+            'Pure helper must return identical results on repeated calls — '
+            'required by issue #2509 Must-have #7 (phase planners are pure '
+            'functions with deterministic inputs).',
+      );
+    });
+
+    test('colonial_pressure delegation stub returns the canonical value', () {
+      // Pins the S1 delegation contract: removing the legacy public
+      // `cheapestRegimentBuildTreasuryCost` symbol from
+      // `colonial_pressure.dart` must keep returning the same value as
+      // the canonical helper for as long as the stub survives.
+      expect(
+        colonial_pressure.cheapestRegimentBuildTreasuryCost(),
+        cheapestRegimentBuildTreasuryCost(),
+        reason:
+            '`colonial_pressure.cheapestRegimentBuildTreasuryCost` is a thin '
+            'delegating stub for legacy callers; it must mirror the '
+            'canonical helper exactly so the EXPAND and COLONIAL phase '
+            'planners agree on the affordability boundary.',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

S1 migration prep slices for issue #2509: promote two EXPAND-trap helpers
to public canonical entries in `expand_phase_planner.dart` and convert
the `colonial_pressure.dart` copies to thin delegating stubs. Both
moves are byte-identical refactors — zero behavior change, zero risk to
live AI play, and they each remove one more entry from the S1 deletion
list for `colonial_pressure.dart`.

### Slice A — `cheapestRegimentBuildTreasuryCost`

- Canonical home: `expand_phase_planner.dart` (matches PR #2761's
  S1-migration pattern).
- `colonial_pressure.dart`'s public `cheapestRegimentBuildTreasuryCost()`
  becomes a thin delegating stub so legacy import sites (notably
  `economy_planner.dart` and the existing
  `colonial_pressure_below_quota_peace_*` tests) keep working untouched.
- `colonial_phase_planner.dart`'s private
  `_cheapestRegimentBuildTreasuryCost()` also delegates to the canonical
  helper so the COLONIAL declare-war arm shares the exact same
  affordability gate as `planExpandDeclareWar` / `planExpandEconomy` —
  no behavior change, no duplicated catalog scan.

### Slice B — `isBelowQuotaPeaceZeroRegimentsRebuild`

- Canonical home: `expand_phase_planner.dart` (Arm A of the EXPAND-trap
  below-quota rebuild gate; same predicate that `planExpandEconomy`
  Arm A already computes inline).
- `colonial_pressure.dart`'s public `isBelowQuotaPeaceZeroRegimentsRebuild()`
  becomes a thin delegating stub so legacy callers (notably
  `isBelowQuotaPeaceTreasuryRecovery` and the existing
  `colonial_pressure_below_quota_peace_*` tests) keep working untouched.
- The canonical body keeps the same
  `isBelowObserverConquestQuota && regimentCount == 0 && hasInvadableProvinces`
  truth table — zero behavior change.

## Scope (this PR vs #2509)

**Done in this PR (S1 migration prep):**
- Canonical `cheapestRegimentBuildTreasuryCost` home in `expand_phase_planner.dart`.
- Canonical `isBelowQuotaPeaceZeroRegimentsRebuild` home in `expand_phase_planner.dart`.
- Delegation stubs in `colonial_pressure.dart` and (for cheapest cost)
  `colonial_phase_planner.dart`.
- Two focused tests under `packages/colonizethis_ai/test/planning/`
  pinning canonical semantics + delegation parity for both helpers.

**Deferred (tracked on #2509):**
- S1: full deletion of `colonial_pressure.dart` and
  `diplomacy_planner_peace_targets.dart` once all call sites migrate.
- S5: orchestrator fully on phase planners.
- S7–S8: observer integration gates + un-skip
  `seed42_observer_conquest_regression_test`.

## Tests

- New: `packages/colonizethis_ai/test/planning/expand_phase_planner_cheapest_regiment_cost_test.dart`
  (4 cases: catalog-minimum semantics, strict positivity, determinism
  across repeated calls, `colonial_pressure` delegation parity).
- New: `packages/colonizethis_ai/test/planning/expand_phase_planner_below_quota_peace_zero_regiments_rebuild_test.dart`
  (6 cases: positive truth-table fire, three single-input negatives —
  at-quota / above-quota / regiment-present / no-frontier — determinism,
  and `colonial_pressure` delegation parity across all relevant
  truth-table inputs).
- Re-verified: `expand_phase_planner_declare_war_test.dart`,
  `expand_phase_planner_economy_test.dart`,
  `colonial_pressure_below_quota_peace_treasury_recovery_branches_test.dart`,
  `colonial_pressure_below_quota_peace_insufficient_regiments_test.dart`,
  `phase_planner_economy_filter_below_quota_peace_test.dart`,
  `economy_planner_phase_plan_injection_test.dart`.
- Full package run: 1197 tests passing (`dart test --concurrency=4`).
- `dart analyze` on the changed files and the new tests: clean.

## Behavior

Zero behavior change in both slices:

- Slice A: the canonical body in
  `expand_phase_planner.cheapestRegimentBuildTreasuryCost()` is the
  same `RegimentEconomyCatalog.byId.values` minimum-scan that
  previously lived in three places. All three sites now share the
  single canonical implementation.
- Slice B: the canonical body in
  `expand_phase_planner.isBelowQuotaPeaceZeroRegimentsRebuild()` is
  the same `isBelowObserverConquestQuota && regimentCount == 0 && hasInvadableProvinces`
  truth table that previously lived in `colonial_pressure.dart`.

Refs #2509 — does not auto-close.

Made with [Cursor](https://cursor.com)
