### PR TITLE
docs: fix catalog_part4 location in 4 dialogue overlay SPECs (Refs #2753)

### DIFF
--- a/SPEC/ui/call-to-arms-dialogue-overlay.md
+++ b/SPEC/ui/call-to-arms-dialogue-overlay.md
@@ -116,7 +116,7 @@ There are no loading, transient, or error variants; absence of a Yarn dependency
 
 ## Widgetbook
 
-Catalog directory: `Call to Arms Dialogue Overlay` (registered in `app/lib/widgetbook/catalog.dart` via `callToArmsDialogueOverlayDirectories` in `catalog_part3.dart`). Required use cases:
+Catalog directory: `Call to Arms Dialogue Overlay` (registered in `app/lib/widgetbook/catalog.dart` via `callToArmsDialogueOverlayDirectories` in `catalog_part4.dart`). Required use cases:
 
 1. **Default — two pending calls** — wraps a localized `widgetbook_gameShell` child in `CallToArmsDialogueOverlay` with a small in-memory `Game` and two `CallToArmsPending` entries from different aggressor / defender combinations. The story exercises Join/Refuse toggles and the Submit button across two rows.
 

--- a/SPEC/ui/ct-dialogue-view.md
+++ b/SPEC/ui/ct-dialogue-view.md
@@ -101,7 +101,7 @@ Logging follows the [logging core principle](../program/logging/logging.md): no 
 
 ## Widgetbook
 
-Catalog directory: `Dialogue Engine` (registered in `app/lib/widgetbook/catalog.dart` via `ctDialogueViewDirectories` in `catalog_part3.dart`). Required use cases:
+Catalog directory: `Dialogue Engine` (registered in `app/lib/widgetbook/catalog.dart` via `ctDialogueViewDirectories` in `catalog_part4.dart`). Required use cases:
 
 1. **Lines and choice trace** — runs a small inline Yarn snippet (two lines + one choice) under a `CtDialogueView`, renders the live `currentLine` / `currentChoice` next to manual **Advance** and **Select option** buttons. The story acts as the canonical visual probe for the state machine described above and lets reviewers exercise both `advanceLine` and `selectOption` without loading any real Yarn assets from disk.
 

--- a/SPEC/ui/game-start-intro-overlay.md
+++ b/SPEC/ui/game-start-intro-overlay.md
@@ -139,7 +139,7 @@ Error mode renders the same `Stack` but the `CtDialogShell` body is the localize
 
 ## Widgetbook
 
-Catalog directory: `Game Start Intro Overlay` (registered in `app/lib/widgetbook/catalog.dart` via `gameStartIntroOverlayDirectories` in `catalog_part3.dart`). Required use cases:
+Catalog directory: `Game Start Intro Overlay` (registered in `app/lib/widgetbook/catalog.dart` via `gameStartIntroOverlayDirectories` in `catalog_part4.dart`). Required use cases:
 
 1. **Default — single-line intro** — wraps an inline placeholder child in `GameStartIntroOverlay` using a stub `AssetBundle` that returns a minimal Yarn document (one line, one Continue option) for `kDialogueGameIntroAsset`. The story exercises the loading → presenting-line → dismissed transitions without depending on the production asset path.
 

--- a/SPEC/ui/overture-dialogue-overlay.md
+++ b/SPEC/ui/overture-dialogue-overlay.md
@@ -150,7 +150,7 @@ Exactly one variant is rendered at a time. Phase 2 is the only state in which Ac
 
 ## Widgetbook
 
-Catalog directory: `Overture Dialogue Overlay` (registered in `app/lib/widgetbook/catalog.dart` via `overtureDialogueOverlayDirectories` in `catalog_part3.dart`). Required use cases:
+Catalog directory: `Overture Dialogue Overlay` (registered in `app/lib/widgetbook/catalog.dart` via `overtureDialogueOverlayDirectories` in `catalog_part4.dart`). Required use cases:
 
 1. **Default — two pending overtures** — wraps a localized `widgetbook_gameShell` child in `OvertureDialogueOverlay` with `skipIntroForTest: true` so the story renders phase 2 immediately without depending on the production Yarn asset. The story exercises Accept/Reject toggles and the Submit button across two offers from different offerers.
 


### PR DESCRIPTION
## Summary

The four UI SPEC files landed by PR #2759 for issue #2753 each cite the
Widgetbook getter as living in `catalog_part3.dart`, but the actual
`catalog_part4.dart` file (also new in #2759) is the real owner of all
four getters. `catalog_part3.dart` exists for unrelated panel stories
and does not declare any of these getters.

This PR fixes the SPEC accuracy gap so SPEC-driven readers (and any
SPEC↔code conformance scanners) can locate the catalog entries described
in each widget's documentation. Pure documentation; no behavioral or
code changes.

## Files changed

- `SPEC/ui/ct-dialogue-view.md` — `catalog_part3.dart` → `catalog_part4.dart`
- `SPEC/ui/game-start-intro-overlay.md` — same
- `SPEC/ui/overture-dialogue-overlay.md` — same
- `SPEC/ui/call-to-arms-dialogue-overlay.md` — same

## Verification

```bash
grep -rn "catalog_part[0-9]" SPEC/ui/
# All four dialogue overlay SPECs now reference catalog_part4.dart.

grep -n "ctDialogueViewDirectories\|gameStartIntroOverlayDirectories\|overtureDialogueOverlayDirectories\|callToArmsDialogueOverlayDirectories" \
  app/lib/widgetbook/catalog_part4.dart
# All four getters confirmed defined in catalog_part4.dart.
```

No Dart code, tests, or generated outputs are touched, so no analyzer
or test runs are needed for this change. Catalog wiring in
`app/lib/widgetbook/catalog.dart` already includes the four getters via
`...ctDialogueViewDirectories`, `...gameStartIntroOverlayDirectories`,
`...overtureDialogueOverlayDirectories`, and
`...callToArmsDialogueOverlayDirectories`.

## ACs covered (issue #2753)

This closes the last residual gap on AC4 (every new SPEC reference is
accurate against the codebase): all four SPECs now point at the file
where their Widgetbook getter actually lives, restoring SPEC ↔ code
correspondence for the dialogue overlay surfaces.

## Scope disclosure

Done in this push:
- Replace four `catalog_part3.dart` mentions with `catalog_part4.dart`
  in the four dialogue overlay UI SPECs.

Deferred / out of scope:
- No code or test changes; the existing catalog wiring and
  `app/test/dialogue_overlays_specs_test.dart` already reference the
  correct getters.

Refs #2753


Made with [Cursor](https://cursor.com)