### PR TITLE
feat(ui): intervention overlay dark editorial-monocle chrome (Refs #2867)

### DIFF
--- a/SPEC/ui/screens/pending-intervention-overlay.md
+++ b/SPEC/ui/screens/pending-intervention-overlay.md
@@ -21,7 +21,8 @@ Present **all** `InterventionPrompt` rows for the current pending batch before t
 
 ## Layout (modal)
 
-- **Frame:** `CtDialogShell` centered over the game; `Material` scrim `Colors.black54`.
+- **Frame:** `CtDialogShell` centered over the game; `Material` scrim resolves to `EditorialMonoclePalette.dialogScrim` (the canonical `--dialog-scrim` token from `SPEC/ui/pixel-art-ui-catalog.md` § Dialog scrim). No hard-coded scrim color (no `Colors.black54`).
+- **Per-prompt header (situation + choices panel only):** A `Pending Intervention` title (display-style text, color `--accent`, letter-spacing `0.05em`, weight `w600`) sits above a `CtBrassDivider` (`SPEC/ui/pixel-art-ui-catalog.md` § CtBrassDivider). The yarn line panels and the degraded error panel do not show the title or divider — those phases continue to render only the yarn content and the controls. Matches the editorial-monocle dialog pattern in `SPEC/ui/components/` and the issue-#2867 R26b dialog chrome contract.
 - **Phases:** (1) Yarn intro node — line(s) + Continue; (2) Per prompt: Yarn situation node (variables: aggressor, defender, intervening names) + Continue; (3) Three `CtNinePatchButton` actions: **Intervene**, **Do naught**, **Diplomatic protest** → map to `InterventionChoice`; (4) Yarn reaction node for that choice + Continue; repeat until all prompts decided; (5) implicit submit — parent receives full `InterventionDecision` list.
 
 ---
@@ -52,3 +53,6 @@ Variables are set on `YarnProject.variables` before `startDialogue`.
 - Given the player has selected a choice for prompt k, when the reaction Yarn node finishes, then the UI layer either advances to prompt k+1 or, if k+1 == N, invokes the callback with N `InterventionDecision` values whose triples match the prompts and whose `InterventionChoice` values match the selections.
 - Given Yarn fails to load, when the overlay is shown, then the UI layer shows an error affordance and still allows submitting decisions (degraded path) so the player is not soft-locked.
 - Given turn resolution returns a different pending type after intervention resume, when the parent applies the result, then `pendingDiplomacyProvider` reflects only the new pending type (never two kinds at once).
+- Given the overlay renders the situation + choices panel for any prompt k, when the panel is inspected, then it contains a single `Pending Intervention` title `Text` (whose `style.color` is `EditorialMonoclePalette.accent`) immediately followed by exactly one `CtBrassDivider`; the title and divider precede the resolution-progress line and the situation summary.
+- Given the overlay mounts any phase (Yarn line panel, situation + choices panel, or degraded error panel), when the underlying `Material` scrim color is inspected, then it equals `EditorialMonoclePalette.dialogScrim` and no `Colors.black54` (or other hard-coded RGB) scrim is used by the overlay widget.
+- Given the overlay is in a Yarn line phase (intro, situation Yarn node, or reaction Yarn node), when the panel is inspected, then neither the `Pending Intervention` title nor the `CtBrassDivider` is rendered (the title + divider are exclusive to the situation + choices panel).

--- a/app/lib/features/game/dialogue/intervention_dialogue_overlay.dart
+++ b/app/lib/features/game/dialogue/intervention_dialogue_overlay.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_app/config/app_assets.dart';
+import 'package:colonizethis_app/config/editorial_monocle_palette.dart';
 import 'package:colonizethis_app/config/ui_screen_ids.dart';
 import 'package:flutter/material.dart';
 import 'package:colonizethis_app/package_logger.dart';
@@ -10,6 +11,7 @@ import 'package:flutter/services.dart';
 import 'package:jenny/jenny.dart';
 
 import '../../../../l10n/l10n.dart';
+import '../../../../widgets/ct_brass_divider.dart';
 import '../../../../widgets/ct_dialog_shell.dart';
 import '../../../../widgets/ct_loading_indicator.dart';
 import '../../../../widgets/ct_nine_patch_button.dart';
@@ -233,7 +235,7 @@ class _InterventionDialogueOverlayState
         children: [
           widget.child,
           Material(
-            color: Colors.black54,
+            color: EditorialMonoclePalette.dialogScrim,
             child: Center(
               child: CtDialogShell(
                 maxWidth: 520,
@@ -275,7 +277,7 @@ class _InterventionDialogueOverlayState
         children: [
           widget.child,
           Material(
-            color: Colors.black54,
+            color: EditorialMonoclePalette.dialogScrim,
             child: Center(
               child: CtDialogShell(
                 child: const Padding(
@@ -329,6 +331,14 @@ class _InterventionDialogueOverlayState
       );
     } else if (_awaitingChoice) {
       final prompt = widget.prompts[_promptIndex];
+      final ThemeData theme = Theme.of(context);
+      final TextStyle baseTitle =
+          theme.textTheme.titleMedium ?? const TextStyle(fontSize: 16);
+      final TextStyle titleStyle = baseTitle.copyWith(
+        color: EditorialMonoclePalette.accent,
+        fontWeight: FontWeight.w600,
+        letterSpacing: 0.05 * (baseTitle.fontSize ?? 16),
+      );
       dialoguePanel = CtDialogShell(
         maxWidth: 520,
         child: Padding(
@@ -338,11 +348,18 @@ class _InterventionDialogueOverlayState
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
               Text(
+                l10n.game_intervention_title,
+                style: titleStyle,
+              ),
+              const SizedBox(height: 12),
+              const CtBrassDivider(),
+              const SizedBox(height: 12),
+              Text(
                 l10n.game_intervention_resolutionProgress(
                   _promptIndex + 1,
                   widget.prompts.length,
                 ),
-                style: Theme.of(context).textTheme.titleSmall,
+                style: theme.textTheme.titleSmall,
               ),
               const SizedBox(height: 12),
               Text(
@@ -354,7 +371,7 @@ class _InterventionDialogueOverlayState
                   ),
                   _factionDisplayName(widget.game, prompt.interveningGpId),
                 ),
-                style: Theme.of(context).textTheme.bodyMedium,
+                style: theme.textTheme.bodyMedium,
               ),
               const SizedBox(height: 16),
               CtNinePatchButton(
@@ -385,7 +402,7 @@ class _InterventionDialogueOverlayState
       children: [
         widget.child,
         Material(
-          color: Colors.black54,
+          color: EditorialMonoclePalette.dialogScrim,
           child: Center(child: dialoguePanel),
         ),
       ],

--- a/app/lib/l10n/app_localizations_contract.dart
+++ b/app/lib/l10n/app_localizations_contract.dart
@@ -268,6 +268,9 @@ abstract class AppLocalizations {
   /// Submit all call-to-arms choices.
   String get game_callToArms_submit;
 
+  /// Dialog title shown above the per-prompt situation panel in the intervention overlay (OVL50001).
+  String get game_intervention_title;
+
   /// Error banner when intervention Yarn fails to load.
   String game_intervention_loadError(String error);
 

--- a/app/lib/l10n/app_localizations_en_part1.dart
+++ b/app/lib/l10n/app_localizations_en_part1.dart
@@ -277,6 +277,9 @@ mixin _AppLocalizationsEnStrings1 on AppLocalizations {
   String get game_callToArms_submit => 'Submit';
 
   @override
+  String get game_intervention_title => 'Pending Intervention';
+
+  @override
   String game_intervention_loadError(String error) {
     return 'Could not load intervention dialogue: $error';
   }

--- a/app/lib/l10n/arb/app_en.arb
+++ b/app/lib/l10n/arb/app_en.arb
@@ -382,6 +382,10 @@
   "@game_callToArms_submit": {
     "description": "Submit all call-to-arms choices."
   },
+  "game_intervention_title": "Pending Intervention",
+  "@game_intervention_title": {
+    "description": "Dialog title shown above the per-prompt situation panel in the intervention overlay (OVL50001)."
+  },
   "game_intervention_loadError": "Could not load intervention dialogue: {error}",
   "@game_intervention_loadError": {
     "description": "Error banner when intervention Yarn fails to load.",

--- a/app/test/intervention_dialogue_overlay_test.dart
+++ b/app/test/intervention_dialogue_overlay_test.dart
@@ -1,5 +1,7 @@
+import 'package:colonizethis_app/config/editorial_monocle_palette.dart';
 import 'package:colonizethis_app/config/themes.dart';
 import 'package:colonizethis_app/features/game/dialogue/intervention_dialogue_overlay.dart';
+import 'package:colonizethis_app/widgets/ct_brass_divider.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
@@ -13,43 +15,109 @@ class _FailingAssetBundle extends Fake implements AssetBundle {
   }
 }
 
+/// Minimal Jenny-valid yarn project covering every node id referenced by
+/// `InterventionDialogueOverlay`. Each node is a single line so a single
+/// advance moves Jenny past the node; this keeps the deterministic widget
+/// tests independent of the production `assets/dialogue/intervention.yarn`
+/// payload (which adds presentation-only `-> Continue` choices).
+class _MinimalInterventionAssetBundle extends Fake implements AssetBundle {
+  @override
+  Future<String> loadString(String key, {bool cache = true}) {
+    return Future.value(
+      'title: DialoguePoint/intervention_intro\n'
+      '---\n'
+      'intro line\n'
+      '===\n'
+      '\n'
+      'title: DialoguePoint/intervention_situation\n'
+      '---\n'
+      'situation line\n'
+      '===\n'
+      '\n'
+      'title: DialoguePoint/intervention_reaction_intervene\n'
+      '---\n'
+      'react intervene\n'
+      '===\n'
+      '\n'
+      'title: DialoguePoint/intervention_reaction_do_nothing\n'
+      '---\n'
+      'react do nothing\n'
+      '===\n'
+      '\n'
+      'title: DialoguePoint/intervention_reaction_protest\n'
+      '---\n'
+      'react protest\n'
+      '===\n',
+    );
+  }
+}
+
+Game _buildSinglePromptGame(String id) {
+  return Game(
+    id: id,
+    worldState: const WorldState(
+      turnState: TurnState(phase: TurnPhase.orders, turnNumber: 1),
+      oldWorld: RegionData(),
+      newWorld: RegionData(),
+    ),
+    players: const [
+      Player(id: 'gp1', displayName: 'Human', isHuman: true, treasury: 0),
+      Player(id: 'gp2', displayName: 'Aggressor', isHuman: false, treasury: 0),
+    ],
+    minorNations: const [
+      MinorNation(id: 'minor1', displayName: 'Minor 1'),
+    ],
+  );
+}
+
+const _kSinglePrompt = [
+  InterventionPrompt(
+    aggressorGpId: 'gp2',
+    defenderMinorOrTribeId: 'minor1',
+    interveningGpId: 'gp1',
+  ),
+];
+
+/// Returns the scrim color used by the `Material` widget that the overlay
+/// stacks over `widget.child`. The overlay scrim is the unique `Material`
+/// inside `InterventionDialogueOverlay`'s subtree whose color resolves to a
+/// non-transparent, non-zero opacity value (the `Dialog` shell internally
+/// uses a transparent Material).
+Color _overlayScrimColor(WidgetTester tester) {
+  final scrimMaterials = tester
+      .widgetList<Material>(
+        find.descendant(
+          of: find.byType(InterventionDialogueOverlay),
+          matching: find.byType(Material),
+        ),
+      )
+      .where((m) {
+        final c = m.color;
+        return c != null && c.a > 0;
+      })
+      .toList();
+  expect(
+    scrimMaterials,
+    isNotEmpty,
+    reason: 'Overlay should mount a Material scrim above widget.child',
+  );
+  return scrimMaterials.first.color!;
+}
+
 void main() {
   suppressLogsForTests();
 
   testWidgets(
     'InterventionDialogueOverlay degraded path submits do-nothing decisions when Yarn fails',
     (WidgetTester tester) async {
-      final game = Game(
-        id: 'iv_degraded',
-        worldState: const WorldState(
-          turnState: TurnState(phase: TurnPhase.orders, turnNumber: 1),
-          oldWorld: RegionData(),
-          newWorld: RegionData(),
-        ),
-        players: const [
-          Player(id: 'gp1', displayName: 'Human', isHuman: true, treasury: 0),
-          Player(id: 'gp2', displayName: 'Aggressor', isHuman: false, treasury: 0),
-        ],
-        minorNations: const [
-          MinorNation(id: 'minor1', displayName: 'Minor 1'),
-        ],
-      );
-
-      const prompts = [
-        InterventionPrompt(
-          aggressorGpId: 'gp2',
-          defenderMinorOrTribeId: 'minor1',
-          interveningGpId: 'gp1',
-        ),
-      ];
-
+      final game = _buildSinglePromptGame('iv_degraded');
       List<InterventionDecision>? captured;
       await tester.pumpWidget(
         MaterialApp(
           theme: AppThemes.colonial,
           home: InterventionDialogueOverlay(
             game: game,
-            prompts: prompts,
+            prompts: _kSinglePrompt,
             skipIntroForTest: true,
             assetBundle: _FailingAssetBundle(),
             onDecisions: (d) => captured = d,
@@ -60,7 +128,10 @@ void main() {
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 100));
 
-      expect(find.textContaining('Could not load intervention dialogue'), findsOneWidget);
+      expect(
+        find.textContaining('Could not load intervention dialogue'),
+        findsOneWidget,
+      );
       await tester.tap(find.text('Continue'));
       await tester.pump();
 
@@ -70,6 +141,147 @@ void main() {
       expect(captured!.single.aggressorGpId, 'gp2');
       expect(captured!.single.defenderMinorOrTribeId, 'minor1');
       expect(captured!.single.interveningGpId, 'gp1');
+    },
+  );
+
+  testWidgets(
+    'InterventionDialogueOverlay degraded panel scrim resolves to dialogScrim token',
+    (WidgetTester tester) async {
+      final game = _buildSinglePromptGame('iv_degraded_scrim');
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: AppThemes.editorialMonocle,
+          home: InterventionDialogueOverlay(
+            game: game,
+            prompts: _kSinglePrompt,
+            skipIntroForTest: true,
+            assetBundle: _FailingAssetBundle(),
+            onDecisions: (_) {},
+            child: const SizedBox.expand(),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(_overlayScrimColor(tester), EditorialMonoclePalette.dialogScrim);
+    },
+  );
+
+  testWidgets(
+    'InterventionDialogueOverlay situation panel renders Pending Intervention title + CtBrassDivider',
+    (WidgetTester tester) async {
+      final game = _buildSinglePromptGame('iv_situation_title');
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: AppThemes.editorialMonocle,
+          home: InterventionDialogueOverlay(
+            game: game,
+            prompts: _kSinglePrompt,
+            skipIntroForTest: true,
+            assetBundle: _MinimalInterventionAssetBundle(),
+            onDecisions: (_) {},
+            child: const SizedBox.expand(),
+          ),
+        ),
+      );
+      // Yarn load is async; pump until the situation line appears.
+      for (int i = 0; i < 20; i++) {
+        await tester.pump(const Duration(milliseconds: 50));
+        if (find.text('situation line').evaluate().isNotEmpty) break;
+      }
+      expect(
+        find.text('situation line'),
+        findsOneWidget,
+        reason: 'Situation Yarn line should render before the player advances',
+      );
+      // Advance past the situation line to land in the awaiting-choice panel.
+      await tester.tap(find.text('Continue'));
+      for (int i = 0; i < 20; i++) {
+        await tester.pump(const Duration(milliseconds: 50));
+        if (find.text('Pending Intervention').evaluate().isNotEmpty) break;
+      }
+
+      expect(
+        find.text('Pending Intervention'),
+        findsOneWidget,
+        reason:
+            'Situation + choices panel must show the editorial-monocle title',
+      );
+      expect(
+        find.byType(CtBrassDivider),
+        findsOneWidget,
+        reason:
+            'Situation + choices panel must show one CtBrassDivider beneath the title',
+      );
+
+      final titleStyle = tester
+          .widget<Text>(find.text('Pending Intervention'))
+          .style;
+      expect(titleStyle, isNotNull);
+      expect(titleStyle!.color, EditorialMonoclePalette.accent);
+      expect(titleStyle.fontWeight, FontWeight.w600);
+    },
+  );
+
+  testWidgets(
+    'InterventionDialogueOverlay situation panel scrim resolves to dialogScrim token',
+    (WidgetTester tester) async {
+      final game = _buildSinglePromptGame('iv_situation_scrim');
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: AppThemes.editorialMonocle,
+          home: InterventionDialogueOverlay(
+            game: game,
+            prompts: _kSinglePrompt,
+            skipIntroForTest: true,
+            assetBundle: _MinimalInterventionAssetBundle(),
+            onDecisions: (_) {},
+            child: const SizedBox.expand(),
+          ),
+        ),
+      );
+      for (int i = 0; i < 20; i++) {
+        await tester.pump(const Duration(milliseconds: 50));
+        if (find.text('situation line').evaluate().isNotEmpty) break;
+      }
+      await tester.tap(find.text('Continue'));
+      for (int i = 0; i < 20; i++) {
+        await tester.pump(const Duration(milliseconds: 50));
+        if (find.text('Pending Intervention').evaluate().isNotEmpty) break;
+      }
+
+      expect(_overlayScrimColor(tester), EditorialMonoclePalette.dialogScrim);
+    },
+  );
+
+  testWidgets(
+    'InterventionDialogueOverlay Yarn-line panel does NOT render the title or CtBrassDivider',
+    (WidgetTester tester) async {
+      final game = _buildSinglePromptGame('iv_yarn_line_no_title');
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: AppThemes.editorialMonocle,
+          home: InterventionDialogueOverlay(
+            game: game,
+            prompts: _kSinglePrompt,
+            skipIntroForTest: true,
+            assetBundle: _MinimalInterventionAssetBundle(),
+            onDecisions: (_) {},
+            child: const SizedBox.expand(),
+          ),
+        ),
+      );
+      // Pump until the situation Yarn line panel is on screen.
+      for (int i = 0; i < 20; i++) {
+        await tester.pump(const Duration(milliseconds: 50));
+        if (find.text('situation line').evaluate().isNotEmpty) break;
+      }
+
+      expect(find.text('situation line'), findsOneWidget);
+      // Title + divider must only render in the awaiting-choice panel.
+      expect(find.text('Pending Intervention'), findsNothing);
+      expect(find.byType(CtBrassDivider), findsNothing);
     },
   );
 }


### PR DESCRIPTION
## Summary

Brings `InterventionDialogueOverlay` (OVL50001) into line with the issue-#2867 R26b dialog-chrome contract:

- Replace hard-coded `Colors.black54` scrim with `EditorialMonoclePalette.dialogScrim` on all three phases (degraded error, Yarn-loading, situation + choices).
- Add a `Pending Intervention` title (color `--accent`, weight `w600`, letter-spacing `0.05em`) followed by a `CtBrassDivider` above the per-prompt situation + choices panel, matching the editorial-monocle dialog pattern already shipped by Call to Arms (PR #2954).
- Update `SPEC/ui/screens/pending-intervention-overlay.md` so the dialog-scrim token, the new title/divider header, and the variant-rendering rule (title/divider only on the situation + choices panel) are the source of truth; add Given–When–Then ACs that map directly to the new tests.
- Add a `game_intervention_title` l10n key (ARB + contract + en localization) reading **Pending Intervention**.

## Scope

| Subtask | Status | Notes |
|---------|--------|-------|
| #2867 S9 (Intervention overlay chrome — R26a/R26b) | **In this PR** | Phase chrome (scrim + title + divider) + SPEC + tests. |
| Differentiated `Intervene` / `Diplomatic protest` / `Do naught` button styling (primary / secondary / muted) per R26b | **Deferred** | The current `CtNinePatchButton` catalog has only a `dangerVariant` flag (no primary/secondary/muted variants); the sibling Call to Arms overlay (PR #2954, merged) ships uniform `CtNinePatchButton` styling for its Join / Refuse buttons and is the established pattern. Differentiated variants need a Ct-* catalog change and belong in a follow-up slice. |
| Pause menu (#2867 S11) | **Out of scope** | The current `SPEC/ui/pause-menu-panel.md` explicitly forbids the 5-button layout requested by R28; that contradiction must be resolved by a SPEC change first. |
| Other #2867 subtasks (S3 Transfer, S6 Leader Selection, S13 Widgetbook) | **Out of scope** | Tracked by their own slices / already partially covered by merged PRs. |

## SPEC updated

- `SPEC/ui/screens/pending-intervention-overlay.md`
  - Layout: documents `EditorialMonoclePalette.dialogScrim` scrim and the per-prompt header (title + `CtBrassDivider`).
  - ACs: 3 new Given–When–Then ACs (title + divider on the situation panel; dialog-scrim on every phase; no title/divider on Yarn-line phases).

## Implementation

`app/lib/features/game/dialogue/intervention_dialogue_overlay.dart`:
- 3× `Material(color: Colors.black54)` → `Material(color: EditorialMonoclePalette.dialogScrim)`.
- Situation + choices panel: prepends `Text('Pending Intervention', accent / w600 / 0.05em)` + `CtBrassDivider` above the existing resolution-progress + situation summary + 3 choice buttons.

`app/lib/l10n/arb/app_en.arb`, `app_localizations_contract.dart`, `app_localizations_en_part1.dart`:
- Add `game_intervention_title` → **Pending Intervention**.

## Tests

`app/test/intervention_dialogue_overlay_test.dart` (5 tests, all green locally):
- (existing, retained) degraded path submits do-nothing decisions when Yarn fails.
- (new) degraded panel scrim resolves to `EditorialMonoclePalette.dialogScrim`.
- (new) situation panel renders `Pending Intervention` title + exactly one `CtBrassDivider`; title style has accent color + w600.
- (new) situation panel scrim resolves to `EditorialMonoclePalette.dialogScrim`.
- (new, negative) Yarn-line phase does NOT render the title or `CtBrassDivider`.

Commands run locally:

- `flutter test test/intervention_dialogue_overlay_test.dart` → **5 passed**.
- `flutter test test/game_screen_intervention_flow_test.dart test/ui_screen_id_bindings_test.dart` → **32 passed** (no regressions on the existing intervention flow / screen-id bindings).
- `dart analyze lib/features/game/dialogue/intervention_dialogue_overlay.dart test/intervention_dialogue_overlay_test.dart` → **No issues found**.

## Notes

- Tests use a `_MinimalInterventionAssetBundle` stub yarn project that includes only the node ids consumed by the overlay, so the situation + choices state can be exercised deterministically without depending on the production `assets/dialogue/intervention.yarn` payload.
- No production behavior changes other than the visual chrome / scrim token / new title. Yarn flow, `InterventionDecision` contract, and bus wiring are unchanged.

Refs #2867

Made with [Cursor](https://cursor.com)