### PR TITLE
feat(widgetbook): Game Map Corner Controls narrow (360 dp) story (Refs #2870)

### DIFF
--- a/SPEC/ui/empire-overview.md
+++ b/SPEC/ui/empire-overview.md
@@ -231,6 +231,14 @@ On mobile: same tab row; map area fills available space; one region visible at a
 
 Folder: **Map Widget** — stories for map area with fixture topology and view data.
 
+Folder: **Game Map Corner Controls** — stories for [GameMapCornerControls](../../app/lib/features/game/flame/game_map_corner_controls.dart) registered from [`gameMapCornerControlsDirectories`](../../app/lib/widgetbook/catalog_part7.dart) and aggregated into `_ctWidgetbookDirectories` in [`catalog.dart`](../../app/lib/widgetbook/catalog.dart). Issue #2861 S4 + S12 story (4) corner controls row, plus the issue #2870 S9 narrow-layout variant.
+
+| Story | Purpose | Authority |
+|-------|---------|-----------|
+| Default — all three buttons enabled | Pins § Corner controls chrome: 32 × 32 dp surface, `CtGradients.railButtonGradient`, 22 × 22 dp glyph, hover/press accent-dim shift. | § Corner controls chrome |
+| Home-to-capital disabled (no human capital) | Exercises the disabled-state path when the underlying callback is `null`: tooltip + surface wrap in `IgnorePointer` + `Opacity(0.4)`. | § Corner controls chrome — Disabled state |
+| Narrow (360 dp) — 24 × 24 dp buttons, 2 dp gap | Pins § Narrow corner-control measurements: 24 × 24 dp surface, 2 dp gap, glyph unchanged at 22 × 22 dp. | § Narrow corner-control measurements; [mobile-adaptation.md](mobile-adaptation.md) § In-game shell |
+
 ---
 
 ## Acceptance criteria

--- a/app/lib/widgetbook/catalog_part7.dart
+++ b/app/lib/widgetbook/catalog_part7.dart
@@ -114,7 +114,10 @@ List<WidgetbookNode> get gameTabBarDirectories => [
 /// Game map corner controls stories. SPEC/ui/empire-overview.md
 /// § Corner controls chrome. Issue #2861 S4 + S12 story (4) corner
 /// controls row, including the disabled home-to-capital variant required
-/// by the AC at `homeToCapitalEnabled: false`.
+/// by the AC at `homeToCapitalEnabled: false`, and the narrow-layout
+/// variant added by issue #2870 S9 pinning the 24 × 24 dp + 2 dp gap
+/// measurements from `SPEC/ui/empire-overview.md` § Narrow corner-control
+/// measurements and `SPEC/ui/mobile-adaptation.md` § In-game shell.
 List<WidgetbookNode> get gameMapCornerControlsDirectories => [
   WidgetbookFolder(
     name: 'Game Map Corner Controls',
@@ -137,6 +140,18 @@ List<WidgetbookNode> get gameMapCornerControlsDirectories => [
             onCenterOnHomeCapital: () {},
             onOpenMapDisplayOptions: () {},
             homeToCapitalEnabled: false,
+          ),
+        ),
+      ),
+      WidgetbookUseCase(
+        name: 'Narrow (360 dp) — 24 × 24 dp buttons, 2 dp gap',
+        builder: (context) => _gameMapCornerControlsNarrowStoryFrame(
+          viewportWidth: 360,
+          child: GameMapCornerControls(
+            narrow: true,
+            onCycleBaseLayerDisplayMode: () {},
+            onCenterOnHomeCapital: () {},
+            onOpenMapDisplayOptions: () {},
           ),
         ),
       ),
@@ -428,6 +443,44 @@ MaterialApp _gameMapCornerControlsStoryFrame({required Widget child}) {
               child: child,
             ),
           ],
+        ),
+      ),
+    ),
+  );
+}
+
+/// Narrow-viewport corner controls frame: clamps the visible canvas to a
+/// representative narrow viewport width via `MediaQuery.size`, anchors
+/// the row bottom-left at the compressed 2 dp inset (matching the
+/// production stack on narrow), and forwards the editorial-monocle theme
+/// so the chrome reads identically to the wide story (issue #2870 S9;
+/// SPEC `SPEC/ui/empire-overview.md` § Narrow corner-control measurements;
+/// `SPEC/ui/mobile-adaptation.md` § In-game shell).
+MaterialApp _gameMapCornerControlsNarrowStoryFrame({
+  required double viewportWidth,
+  required Widget child,
+}) {
+  return MaterialApp(
+    debugShowCheckedModeBanner: false,
+    theme: AppThemes.editorialMonocle,
+    localizationsDelegates: AppLocalizationsBinding.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: MediaQuery(
+      data: MediaQueryData(size: Size(viewportWidth, 640)),
+      child: Scaffold(
+        backgroundColor: EditorialMonoclePalette.bgDeep,
+        body: SizedBox(
+          width: viewportWidth,
+          height: 640,
+          child: Stack(
+            children: [
+              Positioned(
+                left: 2,
+                bottom: 2,
+                child: child,
+              ),
+            ],
+          ),
         ),
       ),
     ),

--- a/app/test/widgetbook_in_game_shell_chrome_test.dart
+++ b/app/test/widgetbook_in_game_shell_chrome_test.dart
@@ -154,6 +154,7 @@ void main() {
           find.byType(GameMapCornerControls),
         );
         expect(defaultControls.homeToCapitalEnabled, isTrue);
+        expect(defaultControls.narrow, isFalse);
 
         await tester.pumpWidget(
           disabledStory.builder(tester.element(find.byType(View))),
@@ -163,6 +164,40 @@ void main() {
           find.byType(GameMapCornerControls),
         );
         expect(disabledControls.homeToCapitalEnabled, isFalse);
+        expect(disabledControls.narrow, isFalse);
+      },
+    );
+
+    testWidgets(
+      'Game Map Corner Controls folder exposes narrow variant '
+      '(Refs #2870 S9)',
+      (WidgetTester tester) async {
+        final narrowStory = _useCase(
+          gameMapCornerControlsDirectories,
+          folderName: 'Game Map Corner Controls',
+          useCaseName: 'Narrow (360 dp) — 24 × 24 dp buttons, 2 dp gap',
+        );
+        await tester.pumpWidget(
+          narrowStory.builder(tester.element(find.byType(View))),
+        );
+        await tester.pump();
+        final narrowControls = tester.widget<GameMapCornerControls>(
+          find.byType(GameMapCornerControls),
+        );
+        expect(
+          narrowControls.narrow,
+          isTrue,
+          reason:
+              'Narrow variant must construct GameMapCornerControls with '
+              'narrow: true so the 24 × 24 dp / 2 dp gap rule applies.',
+        );
+        expect(
+          narrowControls.homeToCapitalEnabled,
+          isTrue,
+          reason:
+              'Narrow story exercises the active state (all three buttons '
+              'enabled) at the narrow measurements.',
+        );
       },
     );
 


### PR DESCRIPTION
## Summary

Adds the issue #2870 S9 Widgetbook narrow-layout use case for
[`GameMapCornerControls`](../app/lib/features/game/flame/game_map_corner_controls.dart)
so reviewers can preview the 24 × 24 dp + 2 dp gap narrow-viewport
chrome without booting a game. Mirrors the per-widget narrow story
pattern already used by the player turn event feed card and (in flight
on PR #2983) the empire left rail and region minimap narrow variants.

The narrow measurement contract itself is already pinned in production
by `app/test/game_map_corner_controls_narrow_test.dart` (24 × 24 dp
surface, 2 dp gap, glyph unchanged at 22 × 22 dp; negative wide
regression guard). This slice extends **Widgetbook coverage** only —
no production widget code changes.

## Done in this push (Refs #2870)

- **Widgetbook** — `app/lib/widgetbook/catalog_part7.dart`:
  - New `Narrow (360 dp) — 24 × 24 dp buttons, 2 dp gap` use case in
    the `Game Map Corner Controls` folder, built with `narrow: true`.
  - New `_gameMapCornerControlsNarrowStoryFrame` helper that clamps
    the canvas via `MediaQuery.size`, paints the editorial-monocle
    scaffold, and anchors the row at the compressed 2 dp inset.
- **Tests** — `app/test/widgetbook_in_game_shell_chrome_test.dart`:
  - New `Game Map Corner Controls folder exposes narrow variant
    (Refs #2870 S9)` test pinning that the narrow use case constructs
    `GameMapCornerControls` with `narrow: true`.
  - Existing default + disabled test extended with `expect(.narrow,
    isFalse)` as a negative regression guard so wide stories cannot
    silently flip on the narrow flag.
- **SPEC** — `SPEC/ui/empire-overview.md`:
  - Added a story table under `## Widgetbook` documenting the
    `Game Map Corner Controls` folder (default / disabled / narrow)
    following the same shape PR #2983 introduces for empire left rail
    and region minimap.

## Acceptance criteria covered

- **Given** the Widgetbook **Game Map Corner Controls** folder loads,
  **when** the *Narrow (360 dp) — 24 × 24 dp buttons, 2 dp gap* use
  case builds, **then** the story mounts `GameMapCornerControls` with
  `narrow: true` (pinned by the new test).
- **Given** the existing default and disabled use cases build, **when**
  the underlying widget is inspected, **then** `narrow == false`
  (negative regression guard).
- **Given** the SPEC `## Widgetbook` section is read, **when** the
  Game Map Corner Controls table is inspected, **then** the
  default / disabled / narrow stories are listed with purpose + SPEC
  authority links.

Existing #2870 S3 acceptance criteria (24 × 24 dp / 2 dp gap / 22 × 22
glyph + wide regression guard) remain pinned by
`game_map_corner_controls_narrow_test.dart` — unchanged.

## Tests run

```
cd app && flutter test \\
    test/widgetbook_in_game_shell_chrome_test.dart \\
    test/game_map_corner_controls_narrow_test.dart   # 13/13 pass
cd app && flutter test test/widgetbook_entry_test.dart   # 1/1 pass
cd app && flutter analyze \\
    lib/widgetbook/catalog_part7.dart \\
    test/widgetbook_in_game_shell_chrome_test.dart   # No issues
```

## Scope (deferred)

This PR scopes itself to the **corner-controls narrow Widgetbook story**.
Other #2870 narrow Widgetbook stories already on dev or in flight:

- Empire left rail narrow story — PR #2983 (in flight on #2861 S12).
- Region minimap narrow story — PR #2983 (in flight on #2861 S12).
- Player turn event feed card narrow stories — already merged.

Other open #2870 subtasks (S2 province panel narrow behaviour,
remaining touch-target + 320 dp audits, side menu modal behaviour
verification) remain open as separate slices.

Refs #2870

Made with [Cursor](https://cursor.com)