### PR TITLE
fix(ui): narrow GameTopBar at 320 dp — close GameScreen overflow pin (Refs #2870 S10)

### DIFF
--- a/app/lib/features/game/widgets/game_top_bar.dart
+++ b/app/lib/features/game/widgets/game_top_bar.dart
@@ -203,6 +203,35 @@ class GameTopBar extends StatelessWidget {
     );
   }
 
+  List<Widget> _buildNarrowRowChildren({required bool isMinViewport}) {
+    return <Widget>[
+      _GameTopBarHamburger(onPressed: onToggleSideMenu, tooltip: menuTooltip),
+      const SizedBox(width: leadingGap),
+      Expanded(
+        child: Align(
+          alignment: Alignment.centerRight,
+          child: _buildNextTurnButton(compactHorizontalPadding: isMinViewport),
+        ),
+      ),
+    ];
+  }
+
+  List<Widget> _buildWideRowChildren(BuildContext context) {
+    return <Widget>[
+      _GameTopBarHamburger(onPressed: onToggleSideMenu, tooltip: menuTooltip),
+      const SizedBox(width: leadingGap),
+      if (observeBannerLabel != null) ...<Widget>[
+        _buildObserveBanner(context),
+        const SizedBox(width: leadingGap),
+      ],
+      Expanded(child: Center(child: _buildTurnDisplay(context))),
+      const SizedBox(width: trailingGap),
+      _GameTopBarPauseButton(onPressed: onPausePressed, tooltip: pauseTooltip),
+      const SizedBox(width: trailingGap),
+      _buildNextTurnButton(compactHorizontalPadding: false),
+    ];
+  }
+
   @override
   Widget build(BuildContext context) {
     final double viewportWidth = MediaQuery.sizeOf(context).width;
@@ -227,40 +256,8 @@ class GameTopBar extends StatelessWidget {
           child: Row(
             crossAxisAlignment: CrossAxisAlignment.center,
             children: isNarrow
-                ? <Widget>[
-                    _GameTopBarHamburger(
-                      onPressed: onToggleSideMenu,
-                      tooltip: menuTooltip,
-                    ),
-                    const SizedBox(width: leadingGap),
-                    Expanded(
-                      child: Align(
-                        alignment: Alignment.centerRight,
-                        child: _buildNextTurnButton(
-                          compactHorizontalPadding: isMinViewport,
-                        ),
-                      ),
-                    ),
-                  ]
-                : <Widget>[
-                    _GameTopBarHamburger(
-                      onPressed: onToggleSideMenu,
-                      tooltip: menuTooltip,
-                    ),
-                    const SizedBox(width: leadingGap),
-                    if (observeBannerLabel != null) ...<Widget>[
-                      _buildObserveBanner(context),
-                      const SizedBox(width: leadingGap),
-                    ],
-                    Expanded(child: Center(child: _buildTurnDisplay(context))),
-                    const SizedBox(width: trailingGap),
-                    _GameTopBarPauseButton(
-                      onPressed: onPausePressed,
-                      tooltip: pauseTooltip,
-                    ),
-                    const SizedBox(width: trailingGap),
-                    _buildNextTurnButton(compactHorizontalPadding: false),
-                  ],
+                ? _buildNarrowRowChildren(isMinViewport: isMinViewport)
+                : _buildWideRowChildren(context),
           ),
         ),
       ),

--- a/app/lib/features/game/widgets/game_top_bar.dart
+++ b/app/lib/features/game/widgets/game_top_bar.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../../config/constants.dart';
 import '../../../config/editorial_monocle_palette.dart';
 import '../../../widgets/ct_gradients.dart';
 import '../../../widgets/ct_nine_patch_button.dart';
@@ -11,9 +12,12 @@ import '../flame/game_screen_shared.dart'
 /// bordered pause affordance, and the wood-panel `Next turn` button.
 ///
 /// SPEC: `SPEC/ui/in-game-shell-narrow.md` § Top bar, `SPEC/ui/empire-overview.md`
-/// (in-game shell), and the canonical [CtTopBar] chrome contract in
+/// (in-game shell), `SPEC/ui/mobile-adaptation.md` § 4 In-game shell
+/// (`< kNarrowBreakpoint`: hamburger + turn-counter / Next-turn button only),
+/// and the canonical [CtTopBar] chrome contract in
 /// `SPEC/ui/pixel-art-ui-catalog.md` § Editorial-monocle palette
-/// (gradient + 1 px `--accent-dim` bottom border). Issue #2861 S1.
+/// (gradient + 1 px `--accent-dim` bottom border). Issue #2861 S1; narrow
+/// top-bar chrome #2870 S10.
 ///
 /// Renders a fixed-height [SizedBox] wrapped in a [DecoratedBox] that
 /// paints [CtGradients.topBarGradient] and a 1 px
@@ -174,7 +178,7 @@ class GameTopBar extends StatelessWidget {
     );
   }
 
-  Widget _buildNextTurnButton() {
+  Widget _buildNextTurnButton({required bool compactHorizontalPadding}) {
     return ConstrainedBox(
       constraints: const BoxConstraints(
         minHeight: nextTurnMinHeight,
@@ -186,14 +190,25 @@ class GameTopBar extends StatelessWidget {
         onPressed: nextTurnEnabled ? () => onNextTurn() : null,
         disabledOpacityOverride: kNextTurnDisabledOpacity,
         minHeight: nextTurnMinHeight,
-        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
-        child: Text(nextTurnText, maxLines: 1),
+        padding: EdgeInsets.symmetric(
+          horizontal: compactHorizontalPadding ? 8 : 12,
+          vertical: 4,
+        ),
+        child: Text(
+          nextTurnText,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+        ),
       ),
     );
   }
 
   @override
   Widget build(BuildContext context) {
+    final double viewportWidth = MediaQuery.sizeOf(context).width;
+    final bool isNarrow = viewportWidth < kNarrowBreakpoint;
+    final bool isMinViewport = viewportWidth <= kMinViewportWidth;
+
     return SizedBox(
       key: surfaceKey,
       height: height,
@@ -211,25 +226,41 @@ class GameTopBar extends StatelessWidget {
           padding: const EdgeInsets.symmetric(horizontal: horizontalPadding),
           child: Row(
             crossAxisAlignment: CrossAxisAlignment.center,
-            children: <Widget>[
-              _GameTopBarHamburger(
-                onPressed: onToggleSideMenu,
-                tooltip: menuTooltip,
-              ),
-              const SizedBox(width: leadingGap),
-              if (observeBannerLabel != null) ...<Widget>[
-                _buildObserveBanner(context),
-                const SizedBox(width: leadingGap),
-              ],
-              Expanded(child: Center(child: _buildTurnDisplay(context))),
-              const SizedBox(width: trailingGap),
-              _GameTopBarPauseButton(
-                onPressed: onPausePressed,
-                tooltip: pauseTooltip,
-              ),
-              const SizedBox(width: trailingGap),
-              _buildNextTurnButton(),
-            ],
+            children: isNarrow
+                ? <Widget>[
+                    _GameTopBarHamburger(
+                      onPressed: onToggleSideMenu,
+                      tooltip: menuTooltip,
+                    ),
+                    const SizedBox(width: leadingGap),
+                    Expanded(
+                      child: Align(
+                        alignment: Alignment.centerRight,
+                        child: _buildNextTurnButton(
+                          compactHorizontalPadding: isMinViewport,
+                        ),
+                      ),
+                    ),
+                  ]
+                : <Widget>[
+                    _GameTopBarHamburger(
+                      onPressed: onToggleSideMenu,
+                      tooltip: menuTooltip,
+                    ),
+                    const SizedBox(width: leadingGap),
+                    if (observeBannerLabel != null) ...<Widget>[
+                      _buildObserveBanner(context),
+                      const SizedBox(width: leadingGap),
+                    ],
+                    Expanded(child: Center(child: _buildTurnDisplay(context))),
+                    const SizedBox(width: trailingGap),
+                    _GameTopBarPauseButton(
+                      onPressed: onPausePressed,
+                      tooltip: pauseTooltip,
+                    ),
+                    const SizedBox(width: trailingGap),
+                    _buildNextTurnButton(compactHorizontalPadding: false),
+                  ],
           ),
         ),
       ),

--- a/app/test/game_screen_320dp_min_viewport_test.dart
+++ b/app/test/game_screen_320dp_min_viewport_test.dart
@@ -32,17 +32,6 @@
 //    widths `GameMapPlayersBar` reappears so the contrast also pins the
 //    Req 6 narrow-only suppression.
 //
-// Known SPEC § 7 gap (documented inline in the 320 dp test below, with
-// `TODO(#2870 S10)` follow-up): an internal `Row` in the in-game shell
-// (likely the GameTopBar — hamburger + observe banner + centered turn
-// display + pause + Next-turn button) currently overflows horizontally
-// at kMinViewportWidth. The 320 dp pin therefore deliberately drains
-// the exception via `tester.takeException()` so the chrome-presence
-// assertions still execute, and asserts the exception IS present so
-// the follow-up fix surfaces here as a clear delta (flip the
-// assertion back to `isNull`) instead of as a silent regression
-// somewhere else.
-//
 // SPEC: `SPEC/ui/mobile-adaptation.md` § 7 (Minimum-viewport pin).
 // SPEC: `SPEC/ui/empire-overview.md` (left-rail empire buttons + top bar).
 // SPEC: `SPEC/ui/in-game-shell-narrow.md` § Top bar.
@@ -178,47 +167,20 @@ void main() {
     () {
       testWidgets(
         'AC (positive) GameScreen @ 320×640: narrow top bar + '
-        'left-rail chrome renders end-to-end, players bar is hidden '
-        '(Req 6); overflow gap documented for follow-up',
+        'left-rail chrome renders end-to-end without overflow, '
+        'players bar is hidden (Req 6)',
         (WidgetTester tester) async {
           await pumpGameScreenAtSize(tester, size: _kMinViewport);
 
-          // SPEC § 7 (no horizontal overflow at 320 dp) is NOT YET MET
-          // for the live `GameScreen` composite: an internal `Row`
-          // (likely the GameTopBar — hamburger + observe banner +
-          // centered turn display + pause + Next-turn button) overflows
-          // by ~116 px on the right at kMinViewportWidth. This pin
-          // therefore deliberately drains the exception via
-          // `tester.takeException()` so the chrome-presence assertions
-          // below still execute, and documents the gap inline so the
-          // follow-up fix (responsive Next-turn button label / pause
-          // suppression / ellipsized turn display) shows up as a clear
-          // delta against this pin instead of as a silent regression
-          // somewhere else.
-          //
-          // The chrome-presence assertions below (hamburger, turn
-          // counter, left-rail empire buttons, players-bar hidden) are
-          // the in-progress portion of Refs #2870 S10 + Req 6 that the
-          // existing 320 dp pin coverage gap was missing. Pinning them
-          // here is what makes the players-bar `findsNothing` contract
-          // a regression guard rather than a silently-true expectation.
-          //
-          // TODO(#2870 S10): Once the GameScreen-side overflow at
-          // 320 dp is closed, flip this assertion back to
-          // `expect(tester.takeException(), isNull, ...)` and remove
-          // the drain below. The wide negative control (1024 × 768)
-          // already asserts no exception so the regression contract on
-          // the host overflow detection itself stays intact.
-          final Object? overflowAt320 = tester.takeException();
           expect(
-            overflowAt320,
-            isNotNull,
+            tester.takeException(),
+            isNull,
             reason:
-                'Pre-condition pin: at kMinViewportWidth (320 dp) the '
-                'in-game shell currently overflows horizontally. When '
-                'this expectation flips (overflow is fixed), update '
-                'the assertion above to the SPEC § 7 contract '
-                '(takeException() is null) and delete the drain.',
+                'SPEC/ui/mobile-adaptation.md § 7: at kMinViewportWidth '
+                '(320 dp) the live GameScreen composite must pump without '
+                'a RenderFlex overflow exception. The narrow GameTopBar '
+                'layout (hamburger + trailing Next-turn button only) '
+                'closes the prior ~116 px top-bar overflow gap.',
           );
 
           expect(

--- a/app/test/game_top_bar_test.dart
+++ b/app/test/game_top_bar_test.dart
@@ -1,3 +1,4 @@
+import 'package:colonizethis_app/config/constants.dart';
 import 'package:colonizethis_app/config/editorial_monocle_palette.dart';
 import 'package:colonizethis_app/features/game/flame/game_screen_shared.dart'
     show kGameMapNextTurnButtonKey, kNextTurnDisabledOpacity;
@@ -45,16 +46,19 @@ void main() {
     String menuTooltip = 'Menu',
     String pauseTooltip = 'Pause menu',
     String? observeBannerLabel,
+    double hostWidth = 600,
   }) {
     return MaterialApp(
       home: Scaffold(
-        body: SizedBox(
-          width: 600,
-          height: 200,
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.start,
-            children: <Widget>[
-              GameTopBar(
+        body: MediaQuery(
+          data: MediaQueryData(size: Size(hostWidth, 200)),
+          child: SizedBox(
+            width: hostWidth,
+            height: 200,
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.start,
+              children: <Widget>[
+                GameTopBar(
                 onToggleSideMenu: onToggleSideMenu,
                 onPausePressed: onPausePressed,
                 onNextTurn: onNextTurn,
@@ -69,6 +73,7 @@ void main() {
           ),
         ),
       ),
+    ),
     );
   }
 
@@ -397,6 +402,61 @@ void main() {
       await tester.tap(pauseFinder);
       await tester.pump();
       expect(pauseTaps, 1);
+    },
+  );
+
+  testWidgets(
+    'narrow layout (< kNarrowBreakpoint) shows hamburger + Next turn only',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        hostFor(
+          onToggleSideMenu: () {},
+          onPausePressed: () {},
+          onNextTurn: () async {},
+          nextTurnEnabled: true,
+          turnDisplayText: 'Turn 42 / Year 1650',
+          nextTurnText: 'Next turn (42 / 1650)',
+          observeBannerLabel: 'Observing: gp1',
+          hostWidth: kMinViewportWidth,
+        ),
+      );
+      await tester.pump();
+
+      expect(
+        tester.takeException(),
+        isNull,
+        reason:
+            'SPEC/ui/mobile-adaptation.md § 4 + § 7: narrow top bar must '
+            'not overflow at kMinViewportWidth.',
+      );
+
+      expect(find.byKey(GameTopBar.hamburgerKey), findsOneWidget);
+      expect(find.byKey(kGameMapNextTurnButtonKey), findsOneWidget);
+      expect(find.textContaining('Next turn'), findsOneWidget);
+      expect(find.byKey(GameTopBar.turnDisplayKey), findsNothing);
+      expect(find.byKey(GameTopBar.pauseButtonKey), findsNothing);
+      expect(find.byKey(GameTopBar.observeBannerKey), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'wide layout (≥ kNarrowBreakpoint) still shows center turn + pause',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        hostFor(
+          onToggleSideMenu: () {},
+          onPausePressed: () {},
+          onNextTurn: () async {},
+          nextTurnEnabled: true,
+          turnDisplayText: 'Turn 42 / Year 1650',
+          nextTurnText: 'Next turn (42 / 1650)',
+          hostWidth: kNarrowBreakpoint,
+        ),
+      );
+      await tester.pump();
+
+      expect(find.byKey(GameTopBar.turnDisplayKey), findsOneWidget);
+      expect(find.byKey(GameTopBar.pauseButtonKey), findsOneWidget);
     },
   );
 }


### PR DESCRIPTION
## Summary

- At viewport widths `< kNarrowBreakpoint` (600 dp), `GameTopBar` now renders only the hamburger and the trailing **Next turn** control per `SPEC/ui/mobile-adaptation.md` § 4 In-game shell (center turn label, pause button, and observe banner suppressed on narrow).
- At `kMinViewportWidth` (320 dp), the Next-turn button uses slightly tighter horizontal padding and ellipsized label text so the live `GameScreen` composite satisfies `SPEC/ui/mobile-adaptation.md` § 7 without `RenderFlex` overflow.
- Flips the `game_screen_320dp_min_viewport_test.dart` positive pin from the documented pre-condition (`takeException()` non-null) to the full § 7 contract (`takeException()` is null).

## Done in this push

- Narrow `GameTopBar` layout branch + unit/widget tests (`game_top_bar_test.dart`).
- `GameScreen` 320×640 pin now asserts no horizontal overflow.

## Deferred (issue #2870)

- Remaining subtasks S1–S9 (province panel bottom slot, production/diplomacy narrow behavior, main-menu ≤430 dp, game-setup stacking, dialog scaling sweep, Widgetbook mobile stories for all listed screens).
- Pause affordance on narrow viewports is not re-homed to the side menu in this slice (wide layout unchanged).

## Acceptance criteria (this PR)

| AC | Status |
|----|--------|
| 320 dp: no horizontal overflow on GameScreen (mobile-adaptation § 7) | Covered by updated pin |
| 320 dp: players bar hidden (Req 6) | Already pinned; unchanged |
| `< 600 dp`: top bar hamburger + turn counter only | Covered by `GameTopBar` narrow branch + tests |

## Tests

```bash
cd app && flutter test test/game_top_bar_test.dart test/game_screen_320dp_min_viewport_test.dart
```

Refs #2870

Made with [Cursor](https://cursor.com)