### PR TITLE
feat(logic): non-GP extraction pipeline for minors and tribes (Refs #2991)

### DIFF
--- a/SPEC/game/extraction-and-improvements.md
+++ b/SPEC/game/extraction-and-improvements.md
@@ -104,6 +104,38 @@ Each **Great Power** player with a non-null **`capitalTile`** receives a fixed q
   When the System runs `computeExtraction` for that game state  
   Then that player's **land** extraction totals include **B** additional units of commodity id `grain`, even when that player's connected tile set is empty.
 
+### Non-Great-Power extraction (Minor Nations and Tribes)
+
+Minor Nations and Tribes are **not** `Game.players` (they do not hold a `Player` stockpile and never submit orders per [factions.md](factions.md)). Their extraction is computed by a parallel function on the same per-tile formula, with three differences from Great Power extraction:
+
+1. **Tech cap:** Minors and Tribes do **not** research tech. Their per-tile production uses **`defaultExtractionCap = 1`** for every resource — no per-resource cap unlock, no scalar override. The improvement level on a non-GP tile is therefore clamped to **`min(improvementLevel, 1)`** before the transport-cap step in § Extraction formula and town development cap. Starting developed tiles seeded per [factions.md](factions.md) § Starting developed resources (Minor Nations and Tribes) are at improvement level **1** by design, so this clamp does not reduce baseline yield.
+
+2. **Prospecting:** Minors and Tribes do **not** have Explorers and never prospect. **Mineral resources** (iron, copper, tin, coal, silver, gold, gems, diamonds) on non-GP tiles are **always excluded** from non-GP extraction (the § Mineral Prospecting Gate's "(b) prospected" arm can never be satisfied). Non-mineral resources (grain, meat, wool, horses, timber, sugarCane, tobacco, cotton, furs, spices) follow the same formula as GPs.
+
+3. **No overseas, no capital-tile grain bonus:** Minors are Old-World-only and Tribes are New-World-only per [factions.md](factions.md); every tile a non-GP faction owns is in the **same region** as that faction's capital. Non-GP extraction therefore produces **land-only** totals — no overseas bucket, no naval-interception interaction, no cargo allocation. The `capitalTileGrainBonusPerTurn` (Great-Power-only by definition above) is **not** added to non-GP totals.
+
+Connectivity resolution for non-GP factions is specified separately under [capital-and-connectivity.md](capital-and-connectivity.md); the non-GP extraction function takes a per-faction `ConnectivityResult` as input so the connectivity resolver and the extraction pipeline remain decoupled.
+
+Non-GP extraction totals are returned per-faction-id (minor or tribe id) and are consumed by the World Market phase as system-authored offers — they are **not** added to any `Player.stockpile` and do **not** flow through Riches-to-treasury, Consumption, or Production. The full auto-offer flow is specified in [world-market.md](world-market.md) § Minor and tribe auto-sell.
+
+**Acceptance criteria**
+
+- Given a Minor Nation `m` with a `capitalProvinceId` in region `OW`, a connected non-mineral resource tile with improvement level `L ≥ 1`, transport cap `T ≥ 1`, and the province's `townDevelopmentLevel` is `D`  
+  When the System runs non-GP extraction for `m`  
+  Then `m`'s extraction totals for that resource's commodity include exactly `min(min(L, 1), T, D')` units, where `D' = D` if the tile is in `m`'s capital province (or a non-capital province with port town connected to capital per § Extraction formula and town development cap) and `D' = ∞` otherwise
+
+- Given a Tribe `t` with a `capitalProvinceId` in region `NW` and a connected **mineral** resource tile (iron, copper, tin, coal, silver, gold, gems, or diamonds) of any improvement level  
+  When the System runs non-GP extraction for `t`  
+  Then `t`'s extraction totals do **not** include any units for that mineral commodity (minerals are excluded for non-GP factions because Minors and Tribes never prospect)
+
+- Given a Minor Nation `m` with `capitalTile` set and `Game.capitalTileGrainBonusPerTurn` equal to a non-negative integer `B`  
+  When the System runs non-GP extraction for `m`  
+  Then `m`'s extraction totals do **not** include the `B` grain bonus (the bonus is Great-Power-only); `m`'s grain total is determined solely by connected grain tile yields
+
+- Given the System runs non-GP extraction for any Minor Nation or Tribe  
+  When the function returns its result  
+  Then every per-faction totals map produced contains only **land** quantities (no overseas bucket), and the function does **not** invoke sea-transport allocation, naval interception, or `Player`-stockpile mutation
+
 ### Improvement Build Eligibility (Builder)
 
 A Builder may build an improvement on a tile only if: (a) the tile has a **resource** (per terrain/ruleset; no improvement on empty tiles), (b) the tile's improvement level is below the **max improvement level** (4), and (c) the **next** improvement level (current + 1) does not exceed the player's **tech-allowed extraction cap** (see [tech-and-extraction-cap.md](tech-and-extraction-cap.md)). The order engine rejects build_improvement work orders when the tile has no resource or when the player lacks sufficient tech to build the next level.

--- a/SPEC/game/factions.md
+++ b/SPEC/game/factions.md
@@ -56,7 +56,7 @@ A **faction** is an entity that owns provinces (in any region) and has a defined
 | Defend            | Yes         | Yes          | Yes    |
 | Provinces count to victory | OW yes | Yes (for controller) | No |
 
-Extraction and ownership apply per faction; only Great Powers have stockpiles and receive extraction in the economy phase. Minors and Tribes' production may feed trade/market per economy spec.
+Extraction and ownership apply per faction. Great Powers extract into their `Player.stockpile` via `computeExtraction` in the Extraction phase. Minor Nations and Tribes do not have a `Player.stockpile`; their extraction is computed by a parallel non-GP function whose per-faction totals feed the World Market phase as system-authored offers (see [extraction-and-improvements.md](extraction-and-improvements.md) § Non-Great-Power extraction (Minor Nations and Tribes) and [world-market.md](world-market.md) § Minor and tribe auto-sell).
 
 ---
 

--- a/packages/colonizethis_logic/lib/colonizethis_logic.dart
+++ b/packages/colonizethis_logic/lib/colonizethis_logic.dart
@@ -60,6 +60,7 @@ export 'src/economy/economy_extraction.dart';
 export 'src/economy/economy_production.dart';
 export 'src/economy/economy_preview_stockpile_phase.dart';
 export 'src/economy/economy_riches_to_treasury.dart';
+export 'src/economy/non_gp_extraction.dart';
 export 'src/economy/resource_extractor.dart';
 export 'src/economy/sea_transport.dart';
 export 'src/economy/worker_action_cost.dart';

--- a/packages/colonizethis_logic/lib/src/economy/non_gp_extraction.dart
+++ b/packages/colonizethis_logic/lib/src/economy/non_gp_extraction.dart
@@ -1,0 +1,251 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import '../constants.dart';
+import '../logging.dart';
+import '../world/connectivity_resolver.dart';
+import '../world/province_lookup.dart';
+import '../world/tile_key_coordinates.dart';
+
+/// Per-faction extraction for non-Great-Power factions (Minor Nations and
+/// Tribes). Mirrors the per-tile formula in
+/// [computeExtraction](resource_extractor.dart) with three documented
+/// differences from the Great Power flow, normative in
+/// `SPEC/game/extraction-and-improvements.md` § Non-Great-Power extraction:
+///
+///   1. Tech cap is fixed at [defaultExtractionCap] for every resource (Minors
+///      and Tribes do not research tech).
+///   2. Mineral resources (`iron`, `copper`, `tin`, `coal`, `silver`, `gold`,
+///      `gems`, `diamonds`) are unconditionally excluded — Minors and Tribes
+///      do not have Explorers and never prospect, so the Mineral Prospecting
+///      Gate's prospected arm can never be satisfied.
+///   3. Output is **land-only** — Minors are Old-World-only and Tribes are
+///      New-World-only per `SPEC/game/factions.md`, so every owned tile is in
+///      the same region as the faction's capital. No overseas bucket, no
+///      sea-transport allocation, no naval-interception interaction. The
+///      Great-Power-only capital-tile grain bonus is not added.
+///
+/// Output map is keyed by the minor/tribe `id`. Values are the per-commodity
+/// extracted quantities for that turn. Per `SPEC/game/factions.md`, Minors and
+/// Tribes have no `Player.stockpile`; the World Market phase consumes this map
+/// as the source of system-authored auto-offers — see
+/// `SPEC/game/world-market.md` § Minor and tribe auto-sell.
+///
+/// [connectivityByFactionId] is supplied by the caller (the non-GP
+/// connectivity resolver, issue #2991 subtask C3, is intentionally separate so
+/// extraction and connectivity remain decoupled). Tests may synthesize this
+/// map with hand-built [ConnectivityResult] fixtures.
+Map<String, Map<CommodityId, int>> computeNonGreatPowerExtraction({
+  required Game game,
+  required Map<String, TileMapResult> tileMapByRegion,
+  required Map<String, ConnectivityResult> connectivityByFactionId,
+}) {
+  if (game.minorNations.isEmpty && game.tribes.isEmpty) {
+    return const <String, Map<CommodityId, int>>{};
+  }
+  if (tileMapByRegion.isEmpty) {
+    return const <String, Map<CommodityId, int>>{};
+  }
+  logicLog.d(
+    'non_gp_extraction compute start minors=${game.minorNations.length} '
+    'tribes=${game.tribes.length}',
+  );
+
+  final provincesByFullId = <String, Province>{
+    for (final p in allProvinces(game.worldState)) p.id: p,
+  };
+  final portTileKeys = game.worldState.portsByProvinceSeaboard.values.toSet();
+
+  final out = <String, Map<CommodityId, int>>{};
+
+  void runForFaction({
+    required String factionId,
+    required String? capitalProvinceId,
+    required String? capitalRegionId,
+  }) {
+    if (capitalProvinceId == null || capitalRegionId == null) {
+      return;
+    }
+    final cr = connectivityByFactionId[factionId];
+    if (cr == null) {
+      return;
+    }
+    final connected = cr.connected;
+    if (connected.isEmpty) {
+      return;
+    }
+    final pathTransportCap = cr.pathTransportCap;
+    final roadRuleTiles = cr.connectedByRoadRule;
+
+    final totals = <CommodityId, int>{};
+    for (final tileKey in connected) {
+      final contribution = _computeNonGpTileContribution(
+        game: game,
+        tileMapByRegion: tileMapByRegion,
+        factionCapitalProvinceId: capitalProvinceId,
+        factionCapitalRegionId: capitalRegionId,
+        tileKey: tileKey,
+        connectedTileKeys: connected,
+        pathTransportCap: pathTransportCap,
+        connectedByRoadRule: roadRuleTiles,
+        portTileKeys: portTileKeys,
+        provincesByFullId: provincesByFullId,
+      );
+      if (contribution == null) continue;
+      totals[contribution.commodityId] =
+          (totals[contribution.commodityId] ?? 0) + contribution.units;
+    }
+    if (totals.isNotEmpty) {
+      out[factionId] = totals;
+    }
+  }
+
+  for (final minor in game.minorNations) {
+    runForFaction(
+      factionId: minor.id,
+      capitalProvinceId: minor.capitalProvinceId,
+      capitalRegionId: minor.capitalTile?.regionId,
+    );
+  }
+  for (final tribe in game.tribes) {
+    runForFaction(
+      factionId: tribe.id,
+      capitalProvinceId: tribe.capitalProvinceId,
+      capitalRegionId: tribe.capitalTile?.regionId,
+    );
+  }
+
+  final totalUnits = out.values.fold<int>(
+    0,
+    (s, m) => s + m.values.fold(0, (a, b) => a + b),
+  );
+  logicLog.d(
+    'non_gp_extraction compute end factions=${out.length} totalUnits=$totalUnits',
+  );
+  return out;
+}
+
+/// Single-commodity contribution from one connected tile owned by a non-GP
+/// faction. Returns null when the tile contributes no units (not connected,
+/// invalid tile key, no resource, mineral resource excluded for non-GPs,
+/// missing province row, or computed effective units `<= 0`).
+///
+/// Mirrors the per-tile branches of
+/// [computeTileExtractionContributionForPlayer](resource_extractor.dart) with
+/// the three documented non-GP simplifications (default tech cap, no
+/// prospecting, no capital-tile grain bonus). The town-development-cap branch
+/// (capital province; non-capital with connected port town) is preserved
+/// byte-for-byte so that minors and tribes whose capital province has a
+/// non-default town-development level are extracted with the same
+/// town-development semantics as Great Powers.
+_NonGpTileContribution? _computeNonGpTileContribution({
+  required Game game,
+  required Map<String, TileMapResult> tileMapByRegion,
+  required String factionCapitalProvinceId,
+  required String factionCapitalRegionId,
+  required String tileKey,
+  required Set<String> connectedTileKeys,
+  required Map<String, int> pathTransportCap,
+  required Set<String> connectedByRoadRule,
+  required Set<String> portTileKeys,
+  required Map<String, Province> provincesByFullId,
+}) {
+  if (!connectedTileKeys.contains(tileKey)) {
+    return null;
+  }
+  final coords = parseTileKeyCoordinates(tileKey);
+  if (coords == null) return null;
+  if (coords.x < 0 || coords.y < 0) return null;
+
+  final map = tileMapByRegion[coords.regionId];
+  if (map == null) return null;
+
+  final resource = map.resourceAt(coords.x, coords.y);
+  if (resource == null) return null;
+
+  // Resource enum name is the canonical commodity id; matches the existing
+  // GP-side `_resourceToCommodityId` switch (see resource_extractor.dart) and
+  // `kMineralResourceIds` membership check in constants.dart.
+  final CommodityId commodityId = resource.name;
+
+  if (kMineralResourceIds.contains(commodityId)) {
+    // Non-GP factions never prospect — exclude minerals unconditionally per
+    // SPEC/game/extraction-and-improvements.md § Non-Great-Power extraction.
+    return null;
+  }
+
+  final provinceId = '${coords.regionId}|${coords.provinceLocalId}';
+  final province = provincesByFullId[provinceId];
+  if (province == null) {
+    final msg =
+        'non_gp_extraction province missing tileKey=$tileKey '
+        'provinceId=$provinceId (region-scoped lookup failed; '
+        'SPEC/game/world-model-identity.md)';
+    logicLog.e(msg, error: StateError(msg), stackTrace: StackTrace.current);
+    return null;
+  }
+
+  final townDevelopmentCap = province.townDevelopmentLevel;
+  final townTileKey = province.townTileKey;
+  final townTileIsPort =
+      townTileKey != null && portTileKeys.contains(townTileKey);
+
+  final improvementLevel = game.worldState.tileState
+      .improvementLevel(tileKey)
+      .clamp(0, 4);
+  final roadLevel = game.worldState.tileState.roadLevel(tileKey);
+  final isPort = portTileKeys.contains(tileKey);
+  final tileTransportLevel = isPort ? 4 : (roadLevel > 0 ? roadLevel : 0);
+  final pathCap = pathTransportCap[tileKey] ?? tileTransportLevel;
+
+  // Non-GP tech cap is the package-wide default (1) for every resource: Minors
+  // and Tribes do not research tech.
+  const techCap = defaultExtractionCap;
+  final production = (improvementLevel < techCap ? improvementLevel : techCap)
+      .clamp(0, 4);
+  var effective = (production < pathCap ? production : pathCap).clamp(0, 4);
+
+  final isCapitalProvince = provinceId == factionCapitalProvinceId;
+  final usesRoadRule = connectedByRoadRule.contains(tileKey);
+  if (isCapitalProvince) {
+    effective =
+        (effective < townDevelopmentCap ? effective : townDevelopmentCap).clamp(
+          0,
+          4,
+        );
+  } else if (!usesRoadRule && townTileIsPort) {
+    // Town rule only (non-capital) with connected port town applies town cap;
+    // mirrors the GP branch in resource_extractor.dart.
+    effective =
+        (effective < townDevelopmentCap ? effective : townDevelopmentCap).clamp(
+          0,
+          4,
+        );
+  }
+  if (effective <= 0) {
+    return null;
+  }
+  // The faction-capital-region check is preserved for parity with the GP
+  // helper; in current SPEC every owned non-GP tile is same-region, so this
+  // branch is informational only — non-GP output is always land-only.
+  final isLandRelativeToCapital = coords.regionId == factionCapitalRegionId;
+  if (!isLandRelativeToCapital) {
+    // Non-GP factions cannot own tiles outside their capital region under
+    // current SPEC; emit a debug log and skip so this stays observable if a
+    // future ruleset changes that invariant.
+    logicLog.d(
+      'non_gp_extraction skip overseas tile factionCapitalRegionId='
+      '$factionCapitalRegionId tileRegionId=${coords.regionId} '
+      'tileKey=$tileKey',
+    );
+    return null;
+  }
+  return _NonGpTileContribution(commodityId: commodityId, units: effective);
+}
+
+class _NonGpTileContribution {
+  const _NonGpTileContribution({required this.commodityId, required this.units});
+
+  final CommodityId commodityId;
+  final int units;
+}

--- a/packages/colonizethis_logic/test/non_gp_extraction_part1_test.dart
+++ b/packages/colonizethis_logic/test/non_gp_extraction_part1_test.dart
@@ -1,0 +1,238 @@
+// Part 1: SPEC-AC tests for `computeNonGreatPowerExtraction` — Issue #2991 C2.
+//
+// Anchors the three SPEC contracts in
+// `SPEC/game/extraction-and-improvements.md` § Non-Great-Power extraction:
+//
+//   1. Tech cap is `defaultExtractionCap = 1` for every resource — non-GP
+//      improvement level is clamped to 1 before transport/town caps apply.
+//   2. Mineral resources are unconditionally excluded (minors/tribes never
+//      prospect; the prospecting gate's "(b) prospected" arm can never fire).
+//   3. Capital-tile grain bonus is Great-Power-only (not applied to non-GP
+//      totals).
+//
+// Negative/boundary and aggregation cases live in
+// `non_gp_extraction_part2_test.dart`. Helpers are in
+// `non_gp_extraction_test_support.dart` so each part stays inside the
+// `repo.logic_test_file_size` 400-line budget.
+
+import 'package:colonizethis_test/test.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import 'non_gp_extraction_test_support.dart';
+
+void main() {
+  group('computeNonGreatPowerExtraction (SPEC ACs)', () {
+    test('minor with non-mineral connected tile produces 1 unit at imp=1', () {
+      const provinceId = 'oldWorld|m1';
+      final tileMap = tileMapAllInProvinceForNonGpExtractionTest(
+        provinceId: provinceId,
+        width: 2,
+        height: 2,
+        resources: [
+          [null, Resource.grain],
+          [null, null],
+        ],
+      );
+      final tileState = TileMapState()
+          .setImprovement('oldWorld|m1|1|0', 1)
+          .setRoadLevel('oldWorld|m1|1|0', 1);
+      final game = gameForNonGpExtractionTest(
+        provinces: [
+          capitalProvinceForNonGpExtractionTest(provinceId: provinceId),
+        ],
+        tileState: tileState,
+        minorNations: [testMinor()],
+      );
+
+      final result = computeNonGreatPowerExtraction(
+        game: game,
+        tileMapByRegion: {'oldWorld': tileMap},
+        connectivityByFactionId: {
+          'm1': ConnectivityResult(connected: {'oldWorld|m1|1|0'}),
+        },
+      );
+
+      expect(result, contains('m1'));
+      expect(result['m1'], equals(<CommodityId, int>{'grain': 1}));
+    });
+
+    test(
+      'tech cap clamps higher-improvement non-mineral tile to 1 unit '
+      '(SPEC AC: defaultExtractionCap = 1, applied before transport/town)',
+      () {
+        const provinceId = 'oldWorld|m1';
+        final tileMap = tileMapAllInProvinceForNonGpExtractionTest(
+          provinceId: provinceId,
+          width: 2,
+          height: 2,
+          resources: [
+            [null, Resource.grain],
+            [null, null],
+          ],
+        );
+        // GP-side this would yield 4 (improvement=4, transport=4, town
+        // development=4). Non-GP tech cap of 1 clamps production to 1, so the
+        // effective yield is 1 regardless of how high the tile is improved.
+        final tileState = TileMapState()
+            .setImprovement('oldWorld|m1|1|0', 4)
+            .setRoadLevel('oldWorld|m1|1|0', 4);
+        final game = gameForNonGpExtractionTest(
+          provinces: [
+            capitalProvinceForNonGpExtractionTest(
+              provinceId: provinceId,
+              townDev: 4,
+            ),
+          ],
+          tileState: tileState,
+          minorNations: [testMinor()],
+        );
+
+        final result = computeNonGreatPowerExtraction(
+          game: game,
+          tileMapByRegion: {'oldWorld': tileMap},
+          connectivityByFactionId: {
+            'm1': ConnectivityResult(connected: {'oldWorld|m1|1|0'}),
+          },
+        );
+
+        expect(result['m1'], equals(<CommodityId, int>{'grain': 1}));
+      },
+    );
+
+    test(
+      'mineral resources on non-GP tiles are unconditionally excluded '
+      '(SPEC AC: tribes/minors never prospect)',
+      () {
+        const provinceId = 'newWorld|t1';
+        final tileMap = tileMapAllInProvinceForNonGpExtractionTest(
+          provinceId: provinceId,
+          width: 2,
+          height: 2,
+          resources: [
+            [null, Resource.iron],
+            [null, Resource.grain],
+          ],
+        );
+        // Even at the maximum legal improvement/transport the iron tile is
+        // dropped: minors and tribes have no Explorers and so cannot satisfy
+        // the prospecting gate. The adjacent grain tile is unaffected.
+        final tileState = TileMapState()
+            .setImprovement('newWorld|t1|1|0', 4)
+            .setRoadLevel('newWorld|t1|1|0', 4)
+            .setImprovement('newWorld|t1|1|1', 1)
+            .setRoadLevel('newWorld|t1|1|1', 1);
+        final game = gameForNonGpExtractionTest(
+          provinces: const [],
+          newWorldProvinces: [
+            Province(
+              id: provinceId,
+              regionId: 'newWorld',
+              ownerId: 't1',
+              townDevelopmentLevel: 1,
+            ),
+          ],
+          tileState: tileState,
+          tribes: [testTribe()],
+        );
+
+        final result = computeNonGreatPowerExtraction(
+          game: game,
+          tileMapByRegion: {'newWorld': tileMap},
+          connectivityByFactionId: {
+            't1': ConnectivityResult(
+              connected: {'newWorld|t1|1|0', 'newWorld|t1|1|1'},
+            ),
+          },
+        );
+
+        expect(result['t1'], equals(<CommodityId, int>{'grain': 1}));
+        expect(result['t1'], isNot(contains('iron')));
+      },
+    );
+
+    test(
+      'capital-tile grain bonus is NOT applied to non-GP totals '
+      '(SPEC AC: Great-Power-only rule)',
+      () {
+        // No connected tiles for the minor, just a capital tile + a
+        // capital-tile grain bonus of 5 in the Game config. GP-equivalent
+        // factions would receive +5 grain from the bonus per
+        // SPEC/game/extraction-and-improvements.md § Capital tile grain bonus
+        // (Great Powers). Non-GP factions must not.
+        const provinceId = 'oldWorld|m1';
+        final game = gameForNonGpExtractionTest(
+          provinces: [
+            capitalProvinceForNonGpExtractionTest(provinceId: provinceId),
+          ],
+          capitalTileGrainBonusPerTurn: 5,
+          minorNations: [testMinor()],
+        );
+
+        final result = computeNonGreatPowerExtraction(
+          game: game,
+          tileMapByRegion: {
+            'oldWorld': tileMapAllInProvinceForNonGpExtractionTest(
+              provinceId: provinceId,
+              width: 1,
+              height: 1,
+              resources: const [
+                [null],
+              ],
+            ),
+          },
+          connectivityByFactionId: {
+            'm1': ConnectivityResult(connected: const <String>{}),
+          },
+        );
+
+        // No connected tiles + no bonus → minor produces nothing this turn and
+        // is not even present in the per-faction output map.
+        expect(result, isNot(contains('m1')));
+      },
+    );
+
+    test(
+      'non-GP output is land-only (SPEC AC: no overseas bucket, no GP-side '
+      'side-effects on Player.stockpile)',
+      () {
+        const provinceId = 'oldWorld|m1';
+        final tileMap = tileMapAllInProvinceForNonGpExtractionTest(
+          provinceId: provinceId,
+          width: 1,
+          height: 1,
+          resources: const [
+            [Resource.timber],
+          ],
+        );
+        final tileState = TileMapState()
+            .setImprovement('oldWorld|m1|0|0', 1)
+            .setRoadLevel('oldWorld|m1|0|0', 1);
+        final game = gameForNonGpExtractionTest(
+          provinces: [
+            capitalProvinceForNonGpExtractionTest(provinceId: provinceId),
+          ],
+          tileState: tileState,
+          minorNations: [testMinor()],
+        );
+
+        final result = computeNonGreatPowerExtraction(
+          game: game,
+          tileMapByRegion: {'oldWorld': tileMap},
+          connectivityByFactionId: {
+            'm1': ConnectivityResult(connected: {'oldWorld|m1|0|0'}),
+          },
+        );
+
+        // The returned map's keys are faction ids and values are flat
+        // commodity → quantity maps. There is no overseas bucket exposed by
+        // the contract, and no `Player.stockpile` mutation is observable —
+        // the game value is reused unchanged by callers (verified by the
+        // contract; no `Game` is returned).
+        expect(result['m1'], equals(<CommodityId, int>{'timber': 1}));
+        expect(result['m1']?.keys, hasLength(1));
+      },
+    );
+  });
+}

--- a/packages/colonizethis_logic/test/non_gp_extraction_part2_test.dart
+++ b/packages/colonizethis_logic/test/non_gp_extraction_part2_test.dart
@@ -1,0 +1,305 @@
+// Part 2: negative / boundary / multi-faction tests for
+// `computeNonGreatPowerExtraction` — Issue #2991 C2.
+//
+// SPEC-AC happy paths are pinned in `non_gp_extraction_part1_test.dart`. This
+// suite pins the contract's behaviour for:
+//
+//   * empty inputs (factions, tile maps, connectivity);
+//   * factions without capital metadata (silently skipped, no throw);
+//   * tiles whose effective yield is zero after the transport / town-dev
+//     branches (suppressed from output, not emitted as `commodity: 0`);
+//   * multi-faction runs (minor + tribe, distinct keys in output);
+//   * aggregation across multiple connected tiles of the same commodity.
+
+import 'package:colonizethis_test/test.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import 'non_gp_extraction_test_support.dart';
+
+void main() {
+  group('computeNonGreatPowerExtraction (boundary + multi-faction)', () {
+    test(
+      'empty minors and tribes lists yield an empty result and skip lookups',
+      () {
+        final game = gameForNonGpExtractionTest(provinces: const []);
+        final result = computeNonGreatPowerExtraction(
+          game: game,
+          tileMapByRegion: const <String, TileMapResult>{},
+          connectivityByFactionId: const <String, ConnectivityResult>{},
+        );
+        expect(result, isEmpty);
+      },
+    );
+
+    test(
+      'empty tileMapByRegion short-circuits even when minors/tribes present',
+      () {
+        final game = gameForNonGpExtractionTest(
+          provinces: [
+            capitalProvinceForNonGpExtractionTest(provinceId: 'oldWorld|m1'),
+          ],
+          minorNations: [testMinor()],
+        );
+        final result = computeNonGreatPowerExtraction(
+          game: game,
+          tileMapByRegion: const <String, TileMapResult>{},
+          connectivityByFactionId: {
+            'm1': ConnectivityResult(connected: {'oldWorld|m1|1|0'}),
+          },
+        );
+        expect(result, isEmpty);
+      },
+    );
+
+    test(
+      'minor without capitalProvinceId or capitalTile is skipped silently '
+      '(no throw, no entry in output)',
+      () {
+        final game = gameForNonGpExtractionTest(
+          provinces: const [],
+          minorNations: const [
+            // No capitalProvinceId.
+            MinorNation(id: 'm1'),
+            // Only provinceId, no capitalTile (so no regionId either).
+            MinorNation(id: 'm2', capitalProvinceId: 'oldWorld|m2'),
+          ],
+        );
+        final result = computeNonGreatPowerExtraction(
+          game: game,
+          tileMapByRegion: {
+            'oldWorld': tileMapAllInProvinceForNonGpExtractionTest(
+              provinceId: 'oldWorld|m2',
+              width: 1,
+              height: 1,
+              resources: const [
+                [Resource.grain],
+              ],
+            ),
+          },
+          connectivityByFactionId: {
+            'm1': ConnectivityResult(connected: {'oldWorld|m1|0|0'}),
+            'm2': ConnectivityResult(connected: {'oldWorld|m2|0|0'}),
+          },
+        );
+        expect(result, isEmpty);
+      },
+    );
+
+    test(
+      'minor with capital but no connectivity entry in the input is skipped',
+      () {
+        const provinceId = 'oldWorld|m1';
+        final tileMap = tileMapAllInProvinceForNonGpExtractionTest(
+          provinceId: provinceId,
+          width: 1,
+          height: 1,
+          resources: const [
+            [Resource.grain],
+          ],
+        );
+        final tileState = TileMapState()
+            .setImprovement('oldWorld|m1|0|0', 1)
+            .setRoadLevel('oldWorld|m1|0|0', 1);
+        final game = gameForNonGpExtractionTest(
+          provinces: [
+            capitalProvinceForNonGpExtractionTest(provinceId: provinceId),
+          ],
+          tileState: tileState,
+          minorNations: [testMinor()],
+        );
+
+        final result = computeNonGreatPowerExtraction(
+          game: game,
+          tileMapByRegion: {'oldWorld': tileMap},
+          connectivityByFactionId: const <String, ConnectivityResult>{},
+        );
+
+        expect(result, isEmpty);
+      },
+    );
+
+    test(
+      'tile with road level 0 (no transport path) yields 0 even when listed '
+      'as connected and improved',
+      () {
+        // Path transport cap defaults to the tile's own transport level when
+        // not supplied; with road level 0, pathCap is 0, and effective yield
+        // is min(prod=1, pathCap=0) = 0.
+        const provinceId = 'oldWorld|m1';
+        final tileMap = tileMapAllInProvinceForNonGpExtractionTest(
+          provinceId: provinceId,
+          width: 2,
+          height: 2,
+          resources: [
+            [null, Resource.timber],
+            [null, null],
+          ],
+        );
+        final tileState = TileMapState().setImprovement('oldWorld|m1|1|0', 1);
+        final game = gameForNonGpExtractionTest(
+          provinces: [
+            capitalProvinceForNonGpExtractionTest(provinceId: provinceId),
+          ],
+          tileState: tileState,
+          minorNations: [testMinor()],
+        );
+
+        final result = computeNonGreatPowerExtraction(
+          game: game,
+          tileMapByRegion: {'oldWorld': tileMap},
+          connectivityByFactionId: {
+            'm1': ConnectivityResult(connected: {'oldWorld|m1|1|0'}),
+          },
+        );
+
+        expect(result, isEmpty);
+      },
+    );
+
+    test(
+      'minor and tribe in the same Game both produce per-faction totals '
+      'keyed by their ids',
+      () {
+        const minorProv = 'oldWorld|m1';
+        const tribeProv = 'newWorld|t1';
+        final owMap = tileMapAllInProvinceForNonGpExtractionTest(
+          provinceId: minorProv,
+          width: 1,
+          height: 1,
+          resources: const [
+            [Resource.timber],
+          ],
+        );
+        final nwMap = tileMapAllInProvinceForNonGpExtractionTest(
+          provinceId: tribeProv,
+          width: 1,
+          height: 1,
+          resources: const [
+            [Resource.furs],
+          ],
+        );
+        final tileState = TileMapState()
+            .setImprovement('oldWorld|m1|0|0', 1)
+            .setRoadLevel('oldWorld|m1|0|0', 1)
+            .setImprovement('newWorld|t1|0|0', 1)
+            .setRoadLevel('newWorld|t1|0|0', 1);
+        final game = gameForNonGpExtractionTest(
+          provinces: [
+            capitalProvinceForNonGpExtractionTest(provinceId: minorProv),
+          ],
+          newWorldProvinces: [
+            Province(
+              id: tribeProv,
+              regionId: 'newWorld',
+              ownerId: 't1',
+              townDevelopmentLevel: 1,
+            ),
+          ],
+          tileState: tileState,
+          minorNations: [testMinor()],
+          tribes: [testTribe()],
+        );
+
+        final result = computeNonGreatPowerExtraction(
+          game: game,
+          tileMapByRegion: {'oldWorld': owMap, 'newWorld': nwMap},
+          connectivityByFactionId: {
+            'm1': ConnectivityResult(connected: {'oldWorld|m1|0|0'}),
+            't1': ConnectivityResult(connected: {'newWorld|t1|0|0'}),
+          },
+        );
+
+        expect(result.keys, unorderedEquals(<String>['m1', 't1']));
+        expect(result['m1'], equals(<CommodityId, int>{'timber': 1}));
+        expect(result['t1'], equals(<CommodityId, int>{'furs': 1}));
+      },
+    );
+
+    test(
+      'aggregates multiple connected non-mineral tiles of the same commodity '
+      'into a single per-faction total',
+      () {
+        const provinceId = 'oldWorld|m1';
+        final tileMap = tileMapAllInProvinceForNonGpExtractionTest(
+          provinceId: provinceId,
+          width: 3,
+          height: 1,
+          resources: const [
+            [Resource.grain, Resource.grain, Resource.timber],
+          ],
+        );
+        final tileState = TileMapState()
+            .setImprovement('oldWorld|m1|0|0', 1)
+            .setRoadLevel('oldWorld|m1|0|0', 1)
+            .setImprovement('oldWorld|m1|1|0', 1)
+            .setRoadLevel('oldWorld|m1|1|0', 1)
+            .setImprovement('oldWorld|m1|2|0', 1)
+            .setRoadLevel('oldWorld|m1|2|0', 1);
+        final game = gameForNonGpExtractionTest(
+          provinces: [
+            capitalProvinceForNonGpExtractionTest(provinceId: provinceId),
+          ],
+          tileState: tileState,
+          minorNations: [testMinor()],
+        );
+        final result = computeNonGreatPowerExtraction(
+          game: game,
+          tileMapByRegion: {'oldWorld': tileMap},
+          connectivityByFactionId: {
+            'm1': ConnectivityResult(
+              connected: {
+                'oldWorld|m1|0|0',
+                'oldWorld|m1|1|0',
+                'oldWorld|m1|2|0',
+              },
+            ),
+          },
+        );
+        expect(
+          result['m1'],
+          equals(<CommodityId, int>{'grain': 2, 'timber': 1}),
+        );
+      },
+    );
+
+    test(
+      'tile in a province whose town development level is 0 yields 0 '
+      'in the capital province (town dev cap is a hard floor)',
+      () {
+        const provinceId = 'oldWorld|m1';
+        final tileMap = tileMapAllInProvinceForNonGpExtractionTest(
+          provinceId: provinceId,
+          width: 2,
+          height: 1,
+          resources: const [
+            [null, Resource.timber],
+          ],
+        );
+        final tileState = TileMapState()
+            .setImprovement('oldWorld|m1|1|0', 1)
+            .setRoadLevel('oldWorld|m1|1|0', 1);
+        final game = gameForNonGpExtractionTest(
+          provinces: [
+            // Town dev = 0 caps capital-province effective yield to 0.
+            capitalProvinceForNonGpExtractionTest(
+              provinceId: provinceId,
+              townDev: 0,
+            ),
+          ],
+          tileState: tileState,
+          minorNations: [testMinor()],
+        );
+        final result = computeNonGreatPowerExtraction(
+          game: game,
+          tileMapByRegion: {'oldWorld': tileMap},
+          connectivityByFactionId: {
+            'm1': ConnectivityResult(connected: {'oldWorld|m1|1|0'}),
+          },
+        );
+        expect(result, isEmpty);
+      },
+    );
+  });
+}

--- a/packages/colonizethis_logic/test/non_gp_extraction_test_support.dart
+++ b/packages/colonizethis_logic/test/non_gp_extraction_test_support.dart
@@ -1,0 +1,111 @@
+// Shared fixture helpers for `non_gp_extraction_part*_test.dart`.
+//
+// Kept here (rather than inlined per file) so the suite stays inside the
+// 400-line `repo.logic_test_file_size` lint budget while still using the same
+// minimal-Game fixtures across the part-1 (positive / SPEC-AC) and part-2
+// (negative / boundary / aggregation) suites. Refs #2991 C2.
+
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+/// A capital-province row with sane defaults for non-GP extraction tests:
+/// town dev = 1 (matches starting developed tile level), region inferred from
+/// the prefixed [provinceId].
+Province capitalProvinceForNonGpExtractionTest({
+  required String provinceId,
+  int townDev = 1,
+}) {
+  final regionId = provinceId.split('|').first;
+  final factionId = provinceId.split('|').last;
+  return Province(
+    id: provinceId,
+    regionId: regionId,
+    ownerId: factionId,
+    townDevelopmentLevel: townDev,
+  );
+}
+
+/// Square tile map of size [width] × [height] where every cell belongs to the
+/// same prefixed [provinceId] and resources are read from [resources].
+TileMapResult tileMapAllInProvinceForNonGpExtractionTest({
+  required String provinceId,
+  required int width,
+  required int height,
+  required List<List<Resource?>> resources,
+}) {
+  final localId = provinceId.split('|').last;
+  final grid = List<List<String>>.generate(
+    height,
+    (_) => List<String>.filled(width, localId),
+  );
+  return TileMapResult(
+    width: width,
+    height: height,
+    grid: grid,
+    resourceGrid: resources,
+  );
+}
+
+/// Builds a minimal [Game] hosting the supplied non-GP factions. Used by the
+/// test suite to keep each scenario's setup local and readable.
+Game gameForNonGpExtractionTest({
+  required List<Province> provinces,
+  TileMapState? tileState,
+  List<MinorNation> minorNations = const [],
+  List<Tribe> tribes = const [],
+  int capitalTileGrainBonusPerTurn = 0,
+  List<Province> newWorldProvinces = const [],
+}) {
+  return Game(
+    id: 'g_test',
+    capitalTileGrainBonusPerTurn: capitalTileGrainBonusPerTurn,
+    worldState: WorldState(
+      turnState: TurnState(turnNumber: 1, phase: TurnPhase.orders),
+      oldWorld: RegionData(provinces: provinces),
+      newWorld: RegionData(provinces: newWorldProvinces),
+      tileState: tileState ?? TileMapState(),
+    ),
+    players: const [],
+    minorNations: minorNations,
+    tribes: tribes,
+  );
+}
+
+/// A standard one-tile minor nation in `oldWorld|m1` with capital at (0,0),
+/// used by part-1 and part-2 suites to keep boilerplate down.
+MinorNation testMinor({
+  String id = 'm1',
+  String provinceId = 'oldWorld|m1',
+  int capitalX = 0,
+  int capitalY = 0,
+}) {
+  return MinorNation(
+    id: id,
+    capitalProvinceId: provinceId,
+    capitalTile: CapitalTile(
+      regionId: provinceId.split('|').first,
+      provinceId: provinceId,
+      x: capitalX,
+      y: capitalY,
+    ),
+  );
+}
+
+/// A standard one-tile tribe in `newWorld|t1` with capital at (0,0).
+Tribe testTribe({
+  String id = 't1',
+  String provinceId = 'newWorld|t1',
+  int capitalX = 0,
+  int capitalY = 0,
+}) {
+  return Tribe(
+    id: id,
+    capitalProvinceId: provinceId,
+    capitalTile: CapitalTile(
+      regionId: provinceId.split('|').first,
+      provinceId: provinceId,
+      x: capitalX,
+      y: capitalY,
+    ),
+  );
+}

--- a/tool/logic_all_provinces_sanctions.yaml
+++ b/tool/logic_all_provinces_sanctions.yaml
@@ -86,3 +86,9 @@ sanctions:
     rationale: Extraction builds a once-per-call province id index for O(1) tile-to-province lookups across both regions.
     spec: SPEC/program/logic-dual-region-province-access.md
     issue: https://github.com/waigore/colonizethisv3/issues/2394
+
+  - path: packages/colonizethis_logic/lib/src/economy/non_gp_extraction.dart
+    line: 55
+    rationale: Non-GP extraction builds a once-per-call province id index for O(1) tile-to-province lookups across both regions, mirroring resource_extractor.dart for minor nations and tribes.
+    spec: SPEC/program/logic-dual-region-province-access.md
+    issue: https://github.com/waigore/colonizethisv3/issues/2991


### PR DESCRIPTION
## Summary

Implements subtask **C2** of #2991: extend the extraction pipeline to compute per-tile yields for Minor Nations and Tribes.

- Adds `computeNonGreatPowerExtraction()` in `packages/colonizethis_logic/lib/src/economy/non_gp_extraction.dart`
- Documents three non-GP extraction differences in `SPEC/game/extraction-and-improvements.md` (fixed tech cap, mineral exclusion, land-only output)
- Updates `SPEC/game/factions.md` to reference non-GP extraction feeding the World Market phase
- 13 unit tests covering positive/negative ACs with synthetic minor/tribe fixtures

## Scope (C2 only)

This PR delivers the **extraction computation** for non-GP factions. It does **not** include:
- C1: initial developed resources in game setup
- C3: non-GP connectivity resolution (caller supplies `connectivityByFactionId`)
- C4–C7: auto-offer generation, purchased-tile routing, integration tests

## Key design decisions

1. **Separate function** rather than extending `computeExtraction()` — avoids breaking GP callers and reflects the three documented simplifications.
2. **Connectivity decoupled** — extraction accepts a pre-built `connectivityByFactionId` map so C3 can land independently.
3. **Mineral exclusion unconditional** — non-GPs never prospect, so minerals are always skipped.

## Tests

- `non_gp_extraction_part1_test.dart` — core AC tests (minor/tribe yields, tech cap, mineral exclusion)
- `non_gp_extraction_part2_test.dart` — boundary cases (no capital, no connectivity, multi-faction aggregation)
- Full `colonizethis_logic` suite passes (1863 tests)

Refs #2991

Made with [Cursor](https://cursor.com)