### PR TITLE
feat(ui): trade screen Market tab read-only commodity table (Refs #2993 E5a)

### DIFF
--- a/SPEC/ui/trade-screen.md
+++ b/SPEC/ui/trade-screen.md
@@ -4,7 +4,7 @@
 **SPEC/ui** — Full-screen World Market trade surface. Implementation: `app/lib/features/game/screens/trade_screen.dart`.
 **Widgetbook:** `Trade Screen` → `app/lib/widgetbook/catalog.dart`. Game rules: [world-market.md](../game/world-market.md); resolution algorithm: [world-market-resolution.md](../program/world-market-resolution.md); core data model deferred to issue [#2989](https://github.com/waigore/colonizethisv3/issues/2989); UI scope tracked in issue [#2993](https://github.com/waigore/colonizethisv3/issues/2993). Parent design: [issue #2988](https://github.com/waigore/colonizethisv3/issues/2988).
 
-> **Status:** Draft. This document records the contract for the scaffold slices: E1+E2+E3 ship the route, screen ID, left-rail button, and dark editorial-monocle chrome; E4 (this slice) lands the durable two-tab body structure (Market + Deal Book) with placeholder panels inside each tab. The Market tab's live commodity rows + cargo indicator and the Deal Book tab's live ledger arrive in follow-up slices once #2989 introduces `WorldMarketState` / `TradeOrder` (#2993 E5 + E6).
+> **Status:** Draft. This document records the contract for the scaffold slices: E1+E2+E3 ship the route, screen ID, left-rail button, and dark editorial-monocle chrome; E4 lands the durable two-tab body structure (Market + Deal Book). The Market tab now renders the **read-only commodity table** (`#2993` E5a) sourced from `Game.worldMarketState` — one row per tradeable commodity with last market price + previous-turn aggregate `Bids / Offers` volumes. The interactive Market controls (bid/offer toggle, quantity stepper, priority dropdown, cargo-remaining indicator) ship in follow-up `#2993` E5 slices, and the Deal Book live ledger ships in `#2993` E6 once a per-player ledger surface lands on top of #2989 / #2990's `MarketActivity` + world-market turn phase.
 
 ---
 
@@ -22,7 +22,9 @@ The screen exposes static keys consumed by widget tests:
 - `TradeScreen.screenId` — `UiScreenIds.tradeScreen` (`GAME60001`).
 - `TradeScreen.topBarKey` — `ValueKey<String>('tradeScreenTopBar')`.
 - `TradeScreen.tabsBodyKey` — `ValueKey<String>('tradeScreenTabsBody')` (root of the two-tab Market + Deal Book body; replaces the prior `placeholderBodyKey` from the E1+E2+E3 scaffold and remains stable when E5/E6 swap each tab's body for the live content).
-- `TradeScreen.marketTabBodyKey` — `ValueKey<String>('tradeScreenMarketTabBody')` (Market tab body root; visible by default).
+- `TradeScreen.marketTabBodyKey` — `ValueKey<String>('tradeScreenMarketTabBody')` (Market tab body root; visible by default; spans the placeholder, the read-only commodity table from `#2993` E5a, and the future interactive controls).
+- `TradeScreen.marketCommodityListKey` — `ValueKey<String>('tradeScreenMarketCommodityList')` (scrollable container inside the Market tab body hosting the per-commodity rows; introduced by `#2993` E5a).
+- `TradeScreen.marketCommodityRowKey(CommodityId)` — `ValueKey<String>('tradeScreenMarketRow:<commodityId>')` (per-row key so widget tests can pin a specific commodity without text matching; introduced by `#2993` E5a).
 - `TradeScreen.dealBookTabBodyKey` — `ValueKey<String>('tradeScreenDealBookTabBody')` (Deal Book tab body root; visible after the user taps the `Deal Book` label).
 
 ---
@@ -47,7 +49,7 @@ The screen is **not** opened from a Flame canvas overlay, the side menu, or any 
 - **Icon + title:** 18 × 18 logical-px pixel-art trade icon `assets/icons/32/ui_icon_trade.png` rendered between the back affordance and the title. Title literal `Trade`, dark-theme `titleMedium` slot (Cinzel display family per `AppThemes.editorialMonocle`).
 - **Height + chrome:** Fixed 36 px high (`CtTopBar.height`), filled with `CtGradients.topBarGradient`, 1 px `--accent-dim` bottom border. No hardcoded colours; all chrome resolves through `EditorialMonoclePalette`.
 
-### Body (current scaffold — `_TradeScreenTabsBody`)
+### Body (current — `_TradeScreenTabsBody`)
 
 ```
 Padding (16 dp)
@@ -55,28 +57,40 @@ Padding (16 dp)
     └── CtTabStrip                     // SPEC § Pixel-art component catalog → CtTabStrip
         ├── tabLabels: ['Market', 'Deal Book']
         └── tabViews (IndexedStack)
-            ├── _MarketTabPlaceholder  // keyed `tradeScreenMarketTabBody`
-            │   └── CtPanel
-            │       ├── Text 'Market' (titleMedium, --accent)
-            │       └── Text muted scaffold copy (bodyMedium, --muted)
+            ├── _MarketTabContent      // keyed `tradeScreenMarketTabBody`
+            │   └── SingleChildScrollView (keyed `tradeScreenMarketCommodityList`)
+            │       └── Column (one row per tradeable commodity, 22 rows)
+            │           └── Padding (keyed `tradeScreenMarketRow:<id>`)
+            │               └── _MarketCommodityRow
+            │                   ├── Row
+            │                   │   ├── Text <displayName> (titleSmall, --accent)
+            │                   │   └── Text <price | "—"> (titleSmall, --accentBright)
+            │                   └── Text 'Bids N / Offers M' (bodySmall, --muted)
             └── _DealBookTabPlaceholder // keyed `tradeScreenDealBookTabBody`
                 └── CtPanel
                     ├── Text 'Deal Book' (titleMedium, --accent)
                     └── Text muted scaffold copy (bodyMedium, --muted)
 ```
 
-The two-tab body is the durable structure E5 (Market) and E6 (Deal Book) replace the placeholder panels in. The `CtTabStrip` widget owns the dark-chrome label band (selected = `--accentBright` text on `--accentDim` 25 % alpha background; unselected = `--muted` text on `--surface` 50 % alpha background; 1 px `--accent` / `--accentDim` border per `pixel-art-ui-catalog.md` § `CtTabStrip`) and the `IndexedStack` that mounts both placeholder bodies so widget tests can reach either tab via `find.byKey` regardless of which is currently visible. Default selection is the **Market** tab (index 0).
+The two-tab body is the durable structure each follow-up Market slice (E5b interactive controls, E5c cargo indicator) and Deal Book slice (E6) keep building inside. The `CtTabStrip` widget owns the dark-chrome label band (selected = `--accentBright` text on `--accentDim` 25 % alpha background; unselected = `--muted` text on `--surface` 50 % alpha background; 1 px `--accent` / `--accentDim` border per `pixel-art-ui-catalog.md` § `CtTabStrip`) and the `IndexedStack` that mounts both tab bodies so widget tests can reach either tab via `find.byKey` regardless of which is currently visible. Default selection is the **Market** tab (index 0).
 
-Each placeholder body uses canonical palette tokens only and carries copy naming the parent and depending issues (`#2989`, `#2990`, `#2993` E5 / E6) so reviewers can see which follow-up unlocks each tab's live content.
+The Market tab body is the read-only commodity table (`#2993` E5a). It iterates `CommodityCatalog.all` filtered to the tradeable subset — every commodity whose `CommodityCategory` is **not** `riches` and whose id is **not** `spices` (22 rows total per [`world-market.md`](../game/world-market.md) §Tradeable commodities). Rows are sorted alphabetically by display name (case-insensitive) so the order is deterministic for widget tests and Widgetbook stories. Each row reads:
 
-### Body (planned — `#2993` E5 + E6)
+- the **commodity display name** in `--accent` (`titleSmall`),
+- the **last market price** from `Game.worldMarketState.prices[commodityId]` in `--accentBright` (`titleSmall`), formatted to one decimal place; the canonical em-dash glyph `—` renders when the commodity is absent from `prices` (typically only in tests / Widgetbook stories that instantiate `WorldMarketState.empty`),
+- the **previous-turn aggregate volume** line `Bids X / Offers Y` from `Game.worldMarketState.lastTurnActivity[commodityId]` in `--muted` (`bodySmall`); commodities absent from `lastTurnActivity` default to `Bids 0 / Offers 0` so the column reads consistently.
 
-The interactive layout per parent design (`#2988` § UI Design) replaces the placeholder bodies inside the same tab strip once #2989 data types are available:
+The Deal Book placeholder body uses canonical palette tokens only and carries copy naming the parent and depending issues (`#2989`, `#2990`, `#2993` E6) so reviewers can see which follow-up unlocks its live ledger.
 
-- **Market tab (E5):** scrollable list of all 22 tradeable commodities (28 total minus 5 riches minus spices) — each row a commodity name + icon, last market price, bid/offer toggle, quantity stepper, priority dropdown, and inline previous-turn aggregate volumes (`Bids N / Offers M`). Persistent header strip shows `Cargo remaining: X` and clamps any bid stepper that would exceed the cross-commodity cap.
+### Body (planned — follow-up `#2993` E5 + E6)
+
+The Market read-only table above is the foundation. Follow-up slices extend each commodity row in place inside the same tab strip:
+
+- **Market tab — interactive controls (`#2993` E5b):** bid/offer toggle (segmented control), quantity stepper, priority dropdown bound to `#2989 kMaxTradePriority`. The toggle, stepper, and dropdown extend each row in place; the row keying and ordering contract above is preserved so tests pinning row keys continue to resolve.
+- **Market tab — cargo indicator (`#2993` E5c):** persistent header strip above the commodity list shows `Cargo remaining: X` and clamps any bid stepper that would exceed the cross-commodity cap.
 - **Deal Book tab (E6):** two-panel ledger of the previous turn's filled / partial / unfilled bids and offers, with treasury totals.
 
-When E5 / E6 land, replace each placeholder block in this document with the live wireframe (commodity row, ledger row, cross-commodity cargo behaviour, priority-dropdown source `#2989 kMaxTradePriority`) without changing the surrounding tab strip / `CtPanel` / padding chrome — the tab structure stays the same.
+When E5b / E5c / E6 land, replace the relevant subsections of this document (row content, header strip, ledger layout) without changing the surrounding tab strip / `CtPanel` / padding chrome — the tab structure stays the same.
 
 ---
 
@@ -109,11 +123,11 @@ The interactive contract is documented in `#2988` § UI Design (Market tab toggl
 
 | ID | Variant | Trigger | Render difference |
 |----|---------|---------|-------------------|
-| `GAME60001` | Default — Market tab (a) | Human player active; Market tab selected (initial state) | Dark chrome + `_TradeScreenTabsBody` with the Market tab (`tradeScreenMarketTabBody`) foregrounded inside `CtTabStrip.IndexedStack`. |
-| `GAME60001` | Default — Deal Book tab (b) | Human player active; user has tapped the `Deal Book` tab label | Dark chrome + `_TradeScreenTabsBody` with the Deal Book tab (`tradeScreenDealBookTabBody`) foregrounded inside `CtTabStrip.IndexedStack`. |
-| `GAME60001` | Observe mode (c) | `shellPanelsNotDefined(ref) == true` | Body switches to `ObserveModeNotDefinedPanel(title: 'Trade')`; the tab strip (and both placeholder bodies) are not mounted under this branch. |
+| `GAME60001` | Default — Market tab (a) | Human player active; Market tab selected (initial state) | Dark chrome + `_TradeScreenTabsBody` with the Market tab (`tradeScreenMarketTabBody`) foregrounded; the body is the read-only commodity table keyed `tradeScreenMarketCommodityList` with one `tradeScreenMarketRow:<id>` per tradeable commodity (`#2993` E5a). |
+| `GAME60001` | Default — Deal Book tab (b) | Human player active; user has tapped the `Deal Book` tab label | Dark chrome + `_TradeScreenTabsBody` with the Deal Book tab (`tradeScreenDealBookTabBody`) foregrounded; the body remains the placeholder `CtPanel` until `#2993` E6 lands the live ledger. |
+| `GAME60001` | Observe mode (c) | `shellPanelsNotDefined(ref) == true` | Body switches to `ObserveModeNotDefinedPanel(title: 'Trade')`; the tab strip (and both tab bodies) are not mounted under this branch. |
 
-When E5/E6 land, the variant table stays as is — only each tab body's render description changes from "placeholder" to the live commodity list / Deal Book ledger.
+When the follow-up E5b/E5c/E6 slices land, the variant table stays as is — only each tab body's render description changes from "placeholder" / "read-only commodity table" to the live interactive Market controls / Deal Book ledger.
 
 ---
 
@@ -133,14 +147,14 @@ When E5/E6 land, the variant table stays as is — only each tab body's render d
 
 Folder name **Trade Screen** in `app/lib/widgetbook/catalog.dart` (registered via `tradeScreenDirectories`).
 
-Use cases for the scaffold slices (E1+E2+E3+E4):
+Use cases for the current slice (E1+E2+E3+E4+E5a):
 
 | Use case | Proves |
 |----------|--------|
-| `Scaffold (Market tab)` | Default mount of `TradeScreen` with the dark `CtTopBar` and `_TradeScreenTabsBody` showing the Market tab placeholder selected (the initial state visited by every gameplay session). |
+| `Scaffold (Market tab)` | Default mount of `TradeScreen` with the dark `CtTopBar` and `_TradeScreenTabsBody` showing the Market tab read-only commodity table selected (the initial state visited by every gameplay session). |
 | `Scaffold (mobile)` | Same default story inside `mobileViewport` (360 × 640 dp) to satisfy the per-spec mobile use case (`SPEC/ui/mobile-adaptation.md`). |
 
-E5+ slices append `Market tab — live commodity list`, `Market tab — cargo warning`, `Deal Book tab — mixed fills`, etc. as the bodies land. The tab structure remains the same; only each tab body's content advances.
+Follow-up E5b/E5c/E6 slices append `Market tab — interactive controls`, `Market tab — cargo warning`, `Deal Book tab — mixed fills`, etc. as the bodies land. The tab structure remains the same; only each tab body's content advances.
 
 ---
 
@@ -167,6 +181,14 @@ E5+ slices append `Market tab — live commodity list`, `Market tab — cargo wa
 - **Given** the viewport width is exactly `kMinViewportWidth` (320 dp) and the height is at least 640 dp, **when** `TradeScreen` is rendered against the `getDebugInitGameResult()` fixture under the default `shellPlayerContextProvider` (`showPlayerChrome: true`), **then** `WidgetTester.takeException()` returns `null`, the dark `CtTopBar` keyed `TradeScreen.topBarKey` renders with literal title `Trade` and back label `Map`, and the tabs body keyed `TradeScreen.tabsBodyKey` renders the Market / Deal Book tab strip within the 320 dp column without horizontal overflow (per [mobile-adaptation.md](mobile-adaptation.md) § 7).
 - **Given** the viewport width is exactly `kMinViewportWidth` (320 dp) and the height is at least 640 dp, **when** `TradeScreen` is rendered against the same fixture under a `shellPlayerContextProvider` override whose `showPlayerChrome` is `false` (global observe), **then** `WidgetTester.takeException()` returns `null`, the dark `CtTopBar` still paints, the `ObserveModeNotDefinedPanel` sentinel with literal title `Trade` renders, and the tabs body keyed `TradeScreen.tabsBodyKey` is absent (the observe override only swaps the body; the chrome keeps its 320 dp overflow contract per [mobile-adaptation.md](mobile-adaptation.md) § 7).
 
-### Full screen (`#2993` E5–E8 — implement when bodies land)
+### Market tab — read-only commodity table (`#2993` E5a)
 
-Migrate the parent-issue ACs from `#2988` § Acceptance criteria — UI into Given–When–Then rows under this section as each follow-up slice ships (bid/offer toggle, mutual exclusion, Deal Book ledger, cargo warning, observe-mode disabling).
+- **Given** the `TradeScreen` is mounted with a human player, observe mode is **not** active, and `Game.worldMarketState` is otherwise unconstrained, **then** the Market tab body keyed `tradeScreenMarketTabBody` contains exactly one `tradeScreenMarketCommodityList` widget that hosts exactly 22 rows keyed `tradeScreenMarketRow:<commodityId>` — one row for every `Commodity` in `CommodityCatalog.all` whose `category` is not `CommodityCategory.riches` and whose `id` is not `'spices'`.
+- **Given** the same conditions, **then** the row order inside `tradeScreenMarketCommodityList` is the deterministic alphabetical order of the tradeable commodities by display name (case-insensitive; falling back to commodity id when the display name is null) — every row's `Offset.dy` is strictly greater than the previous row's `Offset.dy`.
+- **Given** the same conditions and `Game.worldMarketState.prices` contains an entry `{'timber': 30.0}` (and no entry for `'iron'`), **when** the Market tab body renders, **then** the `tradeScreenMarketRow:timber` row contains the text `30.0` (one decimal place) and the `tradeScreenMarketRow:iron` row contains the canonical em-dash glyph `—` as the price text.
+- **Given** the same conditions and `Game.worldMarketState.lastTurnActivity` contains `{'timber': MarketActivity(totalBidQuantity: 12, totalOfferQuantity: 8)}` (and no entry for `'fabric'`), **when** the Market tab body renders, **then** the `tradeScreenMarketRow:timber` row contains the text `Bids 12 / Offers 8` and the `tradeScreenMarketRow:fabric` row contains the text `Bids 0 / Offers 0` (zero-default for commodities absent from the activity map).
+- **Given** the `TradeScreen` is mounted with a human player and observe mode is **not** active, **then** the `tradeScreenMarketCommodityList` widget is present **only** under the `tradeScreenMarketTabBody` subtree (not under the off-stage `tradeScreenDealBookTabBody` subtree, even when reached via `find.byKey(..., skipOffstage: false)`).
+
+### Full screen (follow-up `#2993` E5b / E5c / E6 — implement when bodies land)
+
+Migrate the remaining parent-issue ACs from `#2988` § Acceptance criteria — UI into Given–When–Then rows under this section as each follow-up slice ships (bid/offer toggle, mutual exclusion, Deal Book ledger, cargo warning, observe-mode disabling).

--- a/app/lib/features/game/screens/trade_screen.dart
+++ b/app/lib/features/game/screens/trade_screen.dart
@@ -1,18 +1,24 @@
 // Full-screen World Market Trade screen. SPEC/ui/trade-screen.md.
 //
-// **Scope of this slice (Refs #2993 E4 — tab scaffold):** route + screen ID
-// + dark editorial-monocle chrome + observe-mode guard + two-tab body
-// (Market + Deal Book) with placeholder copy inside each tab.
+// **Scope of the current slice (Refs #2993 E5a — Market tab read-only
+// commodity table):** route + screen ID + dark editorial-monocle chrome +
+// observe-mode guard + two-tab body (Market + Deal Book). The Market tab
+// now renders a read-only commodity table sourced from `Game.worldMarketState`
+// (last market price + previous-turn aggregate `Bids / Offers` volumes per
+// commodity, sorted alphabetically by display name). The Deal Book tab
+// remains a placeholder until `MarketActivity` per-player ledger work
+// lands (Refs #2989, #2990, #2993 E6).
 //
-// The interactive Market tab (commodity rows, bid/offer toggle, quantity
-// stepper, priority dropdown, cargo-remaining indicator) and Deal Book
-// ledger tab content remain deferred to follow-up slices that depend on
-// the `WorldMarketState` / `TradeOrder` types from #2989. The tab strip
-// and per-tab placeholder bodies are the durable UI structure those
-// follow-up slices replace, so the scaffold contract this file ships
-// matches what `SPEC/ui/trade-screen.md` § Layout / wireframe records as
-// the canonical body for the screen until then.
+// The interactive Market controls (bid/offer toggle, quantity stepper,
+// priority dropdown, cargo-remaining indicator) remain deferred to
+// follow-up slices that depend on `currentOrdersProvider` plumbing
+// (Refs #2993 E5b — Cargo) and the Deal Book live ledger (Refs #2993 E6).
+// The two-tab structure is the durable wireframe those follow-up slices
+// continue to build on, so the contract this file ships matches what
+// `SPEC/ui/trade-screen.md` § Layout / wireframe records as the canonical
+// body for the screen.
 
+import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -33,11 +39,10 @@ import '../widgets/observe_mode_not_defined_panel.dart';
 /// Dark editorial-monocle chrome per `SPEC/ui/trade-screen.md` § Top bar: a
 /// `CtTopBar` carrying the `Map` back affordance, the 18 × 18 pixel-art
 /// trade icon, and the literal title `Trade`. The body is a two-tab
-/// `CtTabStrip` (Market + Deal Book) with placeholder copy inside each
-/// tab; once #2989's `WorldMarketState` / `TradeOrder` data types land
-/// the placeholders are replaced with the live Market commodity list and
-/// Deal Book ledger described in `SPEC/ui/trade-screen.md` § Layout /
-/// wireframe.
+/// `CtTabStrip` (Market + Deal Book). The Market tab renders a
+/// read-only commodity table sourced from `game.worldMarketState`
+/// (Refs #2993 E5a); the Deal Book tab keeps the placeholder copy until
+/// the per-player ledger work for Refs #2993 E6 lands.
 class TradeScreen extends ConsumerWidget {
   const TradeScreen({super.key, required this.game, required this.player});
 
@@ -73,12 +78,27 @@ class TradeScreen extends ConsumerWidget {
   /// E5+E6.
   static const Key tabsBodyKey = ValueKey<String>('tradeScreenTabsBody');
 
-  /// Stable widget key for the Market tab placeholder body. Pin point for
-  /// widget tests asserting the Market tab body is present in the tab
-  /// strip's `IndexedStack` (visible when the Market tab is selected,
-  /// which is the default).
+  /// Stable widget key for the Market tab body. Pin point for widget
+  /// tests asserting the Market tab body is present in the tab strip's
+  /// `IndexedStack` (visible when the Market tab is selected, which is
+  /// the default). The same key spans the placeholder, the read-only
+  /// commodity table introduced by Refs #2993 E5a, and the live
+  /// interactive controls planned for follow-up E5 slices.
   static const Key marketTabBodyKey =
       ValueKey<String>('tradeScreenMarketTabBody');
+
+  /// Stable widget key for the scrollable commodity list inside the
+  /// Market tab body (Refs #2993 E5a). Lets widget tests reach the
+  /// `ListView` that hosts the per-commodity rows without coupling to
+  /// the row identities themselves.
+  static const Key marketCommodityListKey =
+      ValueKey<String>('tradeScreenMarketCommodityList');
+
+  /// Per-row key for a Market tab commodity row. Deterministic so widget
+  /// tests can pin a specific commodity (e.g. `timber`) without relying
+  /// on text matching.
+  static Key marketCommodityRowKey(CommodityId commodityId) =>
+      ValueKey<String>('tradeScreenMarketRow:$commodityId');
 
   /// Stable widget key for the Deal Book tab placeholder body. Pin point
   /// for widget tests asserting the Deal Book tab body is present in the
@@ -121,7 +141,10 @@ class TradeScreen extends ConsumerWidget {
           // ignore: avoid_hardcoded_strings_in_widgets
           return const ObserveModeNotDefinedPanel(title: 'Trade');
         }
-        return const _TradeScreenTabsBody(key: tabsBodyKey);
+        return _TradeScreenTabsBody(
+          key: tabsBodyKey,
+          game: displayGame,
+        );
       },
     );
   }
@@ -131,15 +154,18 @@ class TradeScreen extends ConsumerWidget {
 ///
 /// Hosts a [CtTabStrip] inside a [CtPanel] so the dark editorial-monocle
 /// surface mirrors the chrome already established for sibling
-/// full-screen feature surfaces (production, diplomacy). Each tab body is
-/// a placeholder [CtPanel] that names the parent issue and the follow-up
-/// slice unlocking the live content; the placeholders match the contract
-/// recorded in `SPEC/ui/trade-screen.md` § Layout / wireframe and are
-/// the durable structure the live Market commodity list (#2993 E5) and
-/// Deal Book ledger (#2993 E6) replace once #2989's `WorldMarketState`
-/// data types land.
+/// full-screen feature surfaces (production, diplomacy). The Market tab
+/// renders a read-only commodity table sourced from
+/// [Game.worldMarketState] (Refs #2993 E5a); the Deal Book tab keeps the
+/// placeholder copy until the per-player ledger work for Refs #2993 E6
+/// lands. The two-tab structure stays as the durable wireframe so the
+/// follow-up interactive Market controls (toggle, stepper, priority
+/// dropdown, cargo indicator) can swap each tab body in place without
+/// remounting the strip.
 class _TradeScreenTabsBody extends StatelessWidget {
-  const _TradeScreenTabsBody({super.key});
+  const _TradeScreenTabsBody({super.key, required this.game});
+
+  final Game game;
 
   @override
   Widget build(BuildContext context) {
@@ -152,9 +178,14 @@ class _TradeScreenTabsBody extends StatelessWidget {
             TradeScreen.marketTabLabel,
             TradeScreen.dealBookTabLabel,
           ],
-          tabViews: const <Widget>[
-            _MarketTabPlaceholder(key: TradeScreen.marketTabBodyKey),
-            _DealBookTabPlaceholder(key: TradeScreen.dealBookTabBodyKey),
+          tabViews: <Widget>[
+            _MarketTabContent(
+              key: TradeScreen.marketTabBodyKey,
+              game: game,
+            ),
+            const _DealBookTabPlaceholder(
+              key: TradeScreen.dealBookTabBodyKey,
+            ),
           ],
         ),
       ),
@@ -162,30 +193,176 @@ class _TradeScreenTabsBody extends StatelessWidget {
   }
 }
 
-/// Placeholder body for the Market tab (`#2993` E5 unlocks the live
-/// commodity list once #2989 ships `WorldMarketState` / `TradeOrder`).
-class _MarketTabPlaceholder extends StatelessWidget {
-  const _MarketTabPlaceholder({super.key});
+/// Read-only commodity table for the Market tab (Refs #2993 E5a).
+///
+/// Renders one row per tradeable commodity (the full
+/// [CommodityCatalog.all] list with [CommodityCategory.riches] and
+/// `spices` filtered out per SPEC/game/world-market.md §Tradeable
+/// commodities — 22 rows total). Each row pins:
+///
+/// * `commodity name` (`titleSmall`, `--accent`),
+/// * `last market price` from [WorldMarketState.prices] (`titleSmall`,
+///   `--accentBright`) — formatted to one decimal place; a long em dash
+///   renders when the commodity is absent from the state map (an
+///   empty / un-seeded market — typically only seen in tests),
+/// * the previous-turn aggregate volume line `Bids X / Offers Y` from
+///   [WorldMarketState.lastTurnActivity] (`bodySmall`, `--muted`).
+///
+/// Rows are sorted by display name (case-insensitive) so the order is
+/// deterministic for widget tests and Widgetbook stories. The list is
+/// scrollable (the future bid/offer controls in Refs #2993 E5b extend
+/// each row in place; the cargo indicator header from Refs #2993 E5c
+/// lands above the list when its plumbing arrives — Refs #2988 §UI
+/// Design).
+class _MarketTabContent extends StatelessWidget {
+  const _MarketTabContent({super.key, required this.game});
 
-  // ignore: avoid_hardcoded_strings_in_widgets
-  static const String _titleText = 'Market';
+  final Game game;
 
+  /// Rendered when a commodity has no entry in [WorldMarketState.prices]
+  /// (typically only happens in unit tests / Widgetbook stories that
+  /// instantiate `WorldMarketState.empty`).
   // ignore: avoid_hardcoded_strings_in_widgets
-  static const String _bodyText =
-      'Bid and offer controls, the per-commodity price + previous-turn '
-      'volume rows, the priority dropdown, and the cross-commodity '
-      'cargo-remaining indicator land alongside the World Market core '
-      'data types (Refs #2989, #2993 E5).';
+  static const String priceUnknownGlyph = '—';
+
+  /// Inline label prefix for the previous-turn bid volume column.
+  // ignore: avoid_hardcoded_strings_in_widgets
+  static const String bidsLabel = 'Bids';
+
+  /// Inline label prefix for the previous-turn offer volume column.
+  // ignore: avoid_hardcoded_strings_in_widgets
+  static const String offersLabel = 'Offers';
 
   @override
   Widget build(BuildContext context) {
-    return _TabPlaceholderPanel(title: _titleText, body: _bodyText);
+    final ThemeData theme = Theme.of(context);
+    final TextStyle nameStyle =
+        (theme.textTheme.titleSmall ?? const TextStyle(fontSize: 14))
+            .copyWith(color: EditorialMonoclePalette.accent);
+    final TextStyle priceStyle =
+        (theme.textTheme.titleSmall ?? const TextStyle(fontSize: 14))
+            .copyWith(color: EditorialMonoclePalette.accentBright);
+    final TextStyle volumeStyle =
+        (theme.textTheme.bodySmall ?? const TextStyle(fontSize: 12))
+            .copyWith(color: EditorialMonoclePalette.muted);
+
+    final List<Commodity> rows = _tradeableCommoditiesSortedByDisplayName();
+    final WorldMarketState market = game.worldMarketState;
+
+    // SingleChildScrollView + Column (instead of ListView.builder) so
+    // every commodity row is built up-front. Widget tests pin all 22
+    // tradeable rows by key without scrolling; the row count is bounded
+    // by the catalog size (22) so the eager build cost is negligible
+    // and the deterministic ordering survives Widgetbook stories that
+    // render the screen inside a non-scrollable container.
+    return SingleChildScrollView(
+      key: TradeScreen.marketCommodityListKey,
+      padding: EdgeInsets.zero,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          for (int index = 0; index < rows.length; index++)
+            Padding(
+              key: TradeScreen.marketCommodityRowKey(rows[index].id),
+              padding: EdgeInsets.only(top: index == 0 ? 0 : 12),
+              child: _MarketCommodityRow(
+                commodityDisplayName:
+                    rows[index].displayName ?? rows[index].id,
+                priceText: _formatPrice(market.prices[rows[index].id]),
+                volumeText: _volumeText(
+                  market.lastTurnActivity[rows[index].id] ??
+                      MarketActivity.empty,
+                ),
+                nameStyle: nameStyle,
+                priceStyle: priceStyle,
+                volumeStyle: volumeStyle,
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  static String _volumeText(MarketActivity activity) {
+    return '$bidsLabel ${activity.totalBidQuantity} / '
+        '$offersLabel ${activity.totalOfferQuantity}';
+  }
+
+  /// Returns the tradeable commodities (catalog minus riches + spices)
+  /// sorted alphabetically by display name (case-insensitive). Spices
+  /// are excluded explicitly per Refs #2988 §UI Design — the Market tab
+  /// shows 22 tradeable rows (full catalog minus riches and spices).
+  static List<Commodity> _tradeableCommoditiesSortedByDisplayName() {
+    final List<Commodity> filtered = <Commodity>[
+      for (final Commodity c in CommodityCatalog.all)
+        if (c.category != CommodityCategory.riches && c.id != 'spices') c,
+    ];
+    filtered.sort((Commodity a, Commodity b) {
+      final String an = (a.displayName ?? a.id).toLowerCase();
+      final String bn = (b.displayName ?? b.id).toLowerCase();
+      return an.compareTo(bn);
+    });
+    return filtered;
+  }
+
+  static String _formatPrice(double? price) {
+    if (price == null) return priceUnknownGlyph;
+    return price.toStringAsFixed(1);
+  }
+}
+
+/// One row of the Market tab read-only commodity table. Lays the
+/// content on a two-line column so the row remains overflow-safe at
+/// the 320 dp minimum viewport (SPEC/ui/mobile-adaptation.md §7).
+class _MarketCommodityRow extends StatelessWidget {
+  const _MarketCommodityRow({
+    required this.commodityDisplayName,
+    required this.priceText,
+    required this.volumeText,
+    required this.nameStyle,
+    required this.priceStyle,
+    required this.volumeStyle,
+  });
+
+  final String commodityDisplayName;
+  final String priceText;
+  final String volumeText;
+  final TextStyle nameStyle;
+  final TextStyle priceStyle;
+  final TextStyle volumeStyle;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: <Widget>[
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.baseline,
+          textBaseline: TextBaseline.alphabetic,
+          children: <Widget>[
+            Expanded(
+              child: Text(
+                commodityDisplayName,
+                style: nameStyle,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+            const SizedBox(width: 8),
+            Text(priceText, style: priceStyle),
+          ],
+        ),
+        const SizedBox(height: 2),
+        Text(volumeText, style: volumeStyle),
+      ],
+    );
   }
 }
 
 /// Placeholder body for the Deal Book tab (`#2993` E6 unlocks the live
-/// previous-turn ledger once #2989 / #2990 ship `MarketActivity` and
-/// the world-market turn phase).
+/// previous-turn ledger once a per-player ledger surface ships on top
+/// of #2989 / #2990's `MarketActivity` + world-market turn phase).
 class _DealBookTabPlaceholder extends StatelessWidget {
   const _DealBookTabPlaceholder({super.key});
 
@@ -197,22 +374,6 @@ class _DealBookTabPlaceholder extends StatelessWidget {
       'Previous-turn filled, partial, and unfilled bids and offers — '
       'with treasury totals — render here once the world-market turn '
       'phase ships (Refs #2989, #2990, #2993 E6).';
-
-  @override
-  Widget build(BuildContext context) {
-    return _TabPlaceholderPanel(title: _titleText, body: _bodyText);
-  }
-}
-
-/// Shared placeholder body for both tabs: a single dark-token
-/// [CtPanel] carrying the tab title and a muted explanatory body. Keeps
-/// each tab's placeholder visually identical so reviewers can confirm
-/// tab-switch behaviour without the chrome biasing the read.
-class _TabPlaceholderPanel extends StatelessWidget {
-  const _TabPlaceholderPanel({required this.title, required this.body});
-
-  final String title;
-  final String body;
 
   @override
   Widget build(BuildContext context) {
@@ -231,9 +392,9 @@ class _TabPlaceholderPanel extends StatelessWidget {
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,
           children: <Widget>[
-            Text(title, style: titleStyle),
+            Text(_titleText, style: titleStyle),
             const SizedBox(height: 8),
-            Text(body, style: bodyStyle),
+            Text(_bodyText, style: bodyStyle),
           ],
         ),
       ),

--- a/app/lib/widgetbook/catalog_part6.dart
+++ b/app/lib/widgetbook/catalog_part6.dart
@@ -286,6 +286,24 @@ List<WidgetbookNode> get diplomacyDetailScreenDirectories => [
 
 Game _tradeScreenStoryGame() {
   const humanId = 'gp_human';
+  // Seed the world market state so the Refs #2993 E5a read-only
+  // commodity table renders representative prices + previous-turn
+  // aggregate volumes for a handful of commodities — the remaining
+  // rows render the em-dash price glyph + `Bids 0 / Offers 0` zero
+  // default so reviewers can see both code paths at a glance.
+  const Map<CommodityId, double> prices = <CommodityId, double>{
+    'timber': 30.0,
+    'iron': 80.0,
+    'grain': 50.0,
+    'fabric': 120.0,
+    'castIron': 175.0,
+  };
+  const Map<CommodityId, MarketActivity> activity =
+      <CommodityId, MarketActivity>{
+    'timber': MarketActivity(totalBidQuantity: 12, totalOfferQuantity: 8),
+    'iron': MarketActivity(totalBidQuantity: 5, totalOfferQuantity: 14),
+    'grain': MarketActivity(totalBidQuantity: 18, totalOfferQuantity: 18),
+  };
   return Game(
     id: 'wb_trade_screen',
     worldState: WorldState(
@@ -301,6 +319,10 @@ Game _tradeScreenStoryGame() {
     diplomacyRelations: const [],
     diplomaticHistoryEvents: const [],
     dossierEvidenceEntries: const [],
+    worldMarketState: const WorldMarketState(
+      prices: prices,
+      lastTurnActivity: activity,
+    ),
   );
 }
 
@@ -330,9 +352,16 @@ Widget _tradeScreenDefaultStory() {
   );
 }
 
-/// Trade screen stories. SPEC/ui/trade-screen.md (Refs #2993 E1+E2+E3+E4
-/// scaffold slice — two-tab body with placeholder panels until #2989 /
-/// #2990 data types land for the live Market and Deal Book content).
+/// Trade screen stories. SPEC/ui/trade-screen.md.
+///
+/// Refs #2993 E1+E2+E3+E4 ship the route, screen ID, left-rail button,
+/// dark editorial-monocle chrome, and the durable two-tab body. Refs
+/// #2993 E5a (this slice) adds the Market tab's read-only commodity
+/// table sourced from `Game.worldMarketState` — the story Game seeds a
+/// representative subset of `prices` + `lastTurnActivity` so reviewers
+/// can see both the populated and zero-default rendering paths in one
+/// scroll. The Deal Book tab body remains the placeholder until Refs
+/// #2993 E6.
 List<WidgetbookNode> get tradeScreenDirectories => [
   WidgetbookFolder(
     name: 'Trade Screen',

--- a/app/test/trade_screen_market_tab_commodity_table_test.dart
+++ b/app/test/trade_screen_market_tab_commodity_table_test.dart
@@ -1,0 +1,354 @@
+// Widget tests for the Market tab read-only commodity table
+// (Refs #2993 E5a). SPEC/ui/trade-screen.md § Body — Market tab.
+//
+// Exercises the durable contract for the Market tab body:
+//
+//  * one row per tradeable commodity (full CommodityCatalog minus
+//    riches and `spices` — 22 rows total per SPEC/game/world-market.md
+//    §Tradeable commodities),
+//  * deterministic alphabetical sort by display name so widget tests
+//    and Widgetbook stories pin the same ordering,
+//  * last market price sourced from `Game.worldMarketState.prices`
+//    (rendered as the em-dash glyph `—` when the commodity is absent
+//    from the map — typically only seen in tests / Widgetbook stories
+//    that instantiate `WorldMarketState.empty`),
+//  * previous-turn aggregate volume line `Bids X / Offers Y` sourced
+//    from `Game.worldMarketState.lastTurnActivity`.
+//
+// The interactive Market controls (bid/offer toggle, quantity stepper,
+// priority dropdown, cargo indicator) ship in follow-up slices and are
+// out of scope for this pin file.
+
+import 'package:colonizethis_app/config/themes.dart';
+import 'package:colonizethis_app/features/game/screens/trade_screen.dart';
+import 'package:colonizethis_app/providers/games_provider.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Builds a synthetic Game with one human player and a populated
+/// [WorldMarketState] so the Market tab table renders deterministic
+/// rows the assertions below pin. Mirrors the lightweight Widgetbook
+/// Game factory in `catalog_part6.dart` so the same data shape proves
+/// the contract in both surfaces.
+Game _buildGame({
+  Map<CommodityId, double>? prices,
+  Map<CommodityId, MarketActivity>? activity,
+}) {
+  return Game(
+    id: 'test_trade_screen_market_tab',
+    worldState: WorldState(
+      turnState: TurnState(phase: TurnPhase.orders, turnNumber: 1),
+      oldWorld: const RegionData(),
+      newWorld: const RegionData(),
+    ),
+    turnTimeMapping: TurnTimeMapping.gdd01,
+    players: [
+      // ignore: avoid_hardcoded_strings_in_widgets
+      Player(id: 'gp_h', displayName: 'England', isHuman: true, treasury: 500),
+    ],
+    diplomacyRelations: const [],
+    diplomaticHistoryEvents: const [],
+    dossierEvidenceEntries: const [],
+    worldMarketState: WorldMarketState(
+      prices: prices ?? const <CommodityId, double>{},
+      lastTurnActivity:
+          activity ?? const <CommodityId, MarketActivity>{},
+    ),
+  );
+}
+
+/// Pumps the [TradeScreen] in isolation (no Hive, no AppEventBus
+/// listeners) so the assertions can pin the Market tab body without
+/// the full in-game shell. Mirrors the lightweight harness used by
+/// `trade_screen_320dp_min_viewport_test.dart`.
+Future<void> _pumpTradeScreen(
+  WidgetTester tester, {
+  required Game game,
+}) async {
+  final Player player = game.players.first;
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
+      ],
+      child: MaterialApp(
+        theme: AppThemes.editorialMonocle,
+        home: TradeScreen(game: game, player: player),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+void main() {
+  suppressLogsForTests();
+
+  group(
+    'TradeScreen Market tab read-only commodity table (Refs #2993 E5a)',
+    () {
+      testWidgets(
+        'renders 22 tradeable rows (CommodityCatalog minus riches + spices) '
+        'inside marketCommodityListKey',
+        (tester) async {
+          await _pumpTradeScreen(tester, game: _buildGame());
+
+          final list = find.byKey(TradeScreen.marketCommodityListKey);
+          expect(list, findsOneWidget);
+
+          final List<Commodity> tradeable = <Commodity>[
+            for (final Commodity c in CommodityCatalog.all)
+              if (c.category != CommodityCategory.riches && c.id != 'spices') c,
+          ];
+          expect(
+            tradeable.length,
+            22,
+            reason:
+                'SPEC/game/world-market.md §Tradeable commodities — the '
+                'tradeable set is the full CommodityCatalog minus riches '
+                'and spices (22 rows). If this count changes, '
+                'SPEC/game/world-market.md and SPEC/ui/trade-screen.md '
+                'must both be updated together with the row pin below.',
+          );
+
+          // Each tradeable commodity must be present as a row keyed by
+          // its commodity id, scoped under the marketCommodityListKey.
+          for (final Commodity c in tradeable) {
+            final rowFinder = find.descendant(
+              of: list,
+              matching: find.byKey(TradeScreen.marketCommodityRowKey(c.id)),
+            );
+            expect(
+              rowFinder,
+              findsOneWidget,
+              reason:
+                  'tradeable commodity `${c.id}` must render a row keyed '
+                  'tradeScreenMarketRow:${c.id} inside the Market tab list.',
+            );
+          }
+        },
+      );
+
+      testWidgets(
+        'excludes riches commodities and the `spices` advanced commodity '
+        '(negative AC: no row key for gold / silver / gems / diamonds / spices)',
+        (tester) async {
+          await _pumpTradeScreen(tester, game: _buildGame());
+
+          final list = find.byKey(TradeScreen.marketCommodityListKey);
+          expect(list, findsOneWidget);
+
+          for (final CommodityId excluded in <CommodityId>[
+            CommodityCatalog.gold.id,
+            CommodityCatalog.silver.id,
+            CommodityCatalog.gems.id,
+            CommodityCatalog.diamonds.id,
+            CommodityCatalog.spices.id,
+          ]) {
+            expect(
+              find.byKey(TradeScreen.marketCommodityRowKey(excluded)),
+              findsNothing,
+              reason:
+                  'SPEC/game/world-market.md §Tradeable commodities — '
+                  '`$excluded` is not tradeable and must not render a row.',
+            );
+          }
+        },
+      );
+
+      testWidgets(
+        'rows are sorted alphabetically by display name (case-insensitive) '
+        '— deterministic order pin',
+        (tester) async {
+          await _pumpTradeScreen(tester, game: _buildGame());
+
+          final List<Commodity> tradeable = <Commodity>[
+            for (final Commodity c in CommodityCatalog.all)
+              if (c.category != CommodityCategory.riches && c.id != 'spices') c,
+          ];
+          final List<Commodity> expectedOrder = List<Commodity>.of(tradeable)
+            ..sort((Commodity a, Commodity b) {
+              final String an = (a.displayName ?? a.id).toLowerCase();
+              final String bn = (b.displayName ?? b.id).toLowerCase();
+              return an.compareTo(bn);
+            });
+
+          final List<Offset> positions = <Offset>[
+            for (final Commodity c in expectedOrder)
+              tester.getTopLeft(
+                find.byKey(TradeScreen.marketCommodityRowKey(c.id)),
+              ),
+          ];
+
+          for (int i = 1; i < positions.length; i++) {
+            expect(
+              positions[i].dy,
+              greaterThan(positions[i - 1].dy),
+              reason:
+                  'Row `${expectedOrder[i].id}` must appear below row '
+                  '`${expectedOrder[i - 1].id}` (alphabetical by display '
+                  'name, case-insensitive).',
+            );
+          }
+
+          // Concrete spot-check: `Cast iron` precedes `Cigars` precedes
+          // `Coal` (deterministic alphabetical pin so a regression in
+          // the comparator surfaces with a readable failure).
+          final castIron = tester.getTopLeft(
+            find.byKey(
+              TradeScreen.marketCommodityRowKey(CommodityCatalog.castIron.id),
+            ),
+          );
+          final cigars = tester.getTopLeft(
+            find.byKey(
+              TradeScreen.marketCommodityRowKey(CommodityCatalog.cigars.id),
+            ),
+          );
+          final coal = tester.getTopLeft(
+            find.byKey(
+              TradeScreen.marketCommodityRowKey(CommodityCatalog.coal.id),
+            ),
+          );
+          expect(castIron.dy, lessThan(cigars.dy));
+          expect(cigars.dy, lessThan(coal.dy));
+        },
+      );
+
+      testWidgets(
+        'renders the live `WorldMarketState.prices` price for a seeded '
+        'commodity (timber=30.0 → `30.0`) and the em-dash glyph for an '
+        'unseeded commodity (iron, absent from the prices map)',
+        (tester) async {
+          await _pumpTradeScreen(
+            tester,
+            game: _buildGame(
+              prices: const <CommodityId, double>{'timber': 30.0},
+            ),
+          );
+
+          // Seeded commodity row shows the formatted price text.
+          final timberRow = find.byKey(
+            TradeScreen.marketCommodityRowKey(CommodityCatalog.timber.id),
+          );
+          expect(timberRow, findsOneWidget);
+          expect(
+            find.descendant(of: timberRow, matching: find.text('30.0')),
+            findsOneWidget,
+            reason:
+                'SPEC/ui/trade-screen.md § Body — Market tab: the price '
+                'cell reads `Game.worldMarketState.prices[commodityId]` '
+                'formatted to one decimal place.',
+          );
+
+          // Unseeded commodity row shows the canonical em-dash glyph.
+          final ironRow = find.byKey(
+            TradeScreen.marketCommodityRowKey(CommodityCatalog.iron.id),
+          );
+          expect(ironRow, findsOneWidget);
+          expect(
+            find.descendant(
+              of: ironRow,
+              matching: find.text(
+                // ignore: avoid_hardcoded_strings_in_widgets
+                '—',
+              ),
+            ),
+            findsOneWidget,
+            reason:
+                'SPEC/ui/trade-screen.md § Body — Market tab: rows for '
+                'commodities absent from `WorldMarketState.prices` show '
+                'the em-dash glyph as the price-unknown sentinel.',
+          );
+        },
+      );
+
+      testWidgets(
+        'renders the previous-turn aggregate volume line `Bids X / Offers Y` '
+        'from WorldMarketState.lastTurnActivity (with zero-default for '
+        'commodities absent from the activity map)',
+        (tester) async {
+          await _pumpTradeScreen(
+            tester,
+            game: _buildGame(
+              activity: const <CommodityId, MarketActivity>{
+                'timber': MarketActivity(
+                  totalBidQuantity: 12,
+                  totalOfferQuantity: 8,
+                ),
+              },
+            ),
+          );
+
+          final timberRow = find.byKey(
+            TradeScreen.marketCommodityRowKey(CommodityCatalog.timber.id),
+          );
+          expect(timberRow, findsOneWidget);
+          expect(
+            find.descendant(
+              of: timberRow,
+              // ignore: avoid_hardcoded_strings_in_widgets
+              matching: find.text('Bids 12 / Offers 8'),
+            ),
+            findsOneWidget,
+            reason:
+                'SPEC/ui/trade-screen.md § Body — Market tab: per-row '
+                'inline aggregate volumes sourced from '
+                '`WorldMarketState.lastTurnActivity[commodityId]`.',
+          );
+
+          // Commodity not present in the activity map falls back to 0/0.
+          final fabricRow = find.byKey(
+            TradeScreen.marketCommodityRowKey(CommodityCatalog.fabric.id),
+          );
+          expect(fabricRow, findsOneWidget);
+          expect(
+            find.descendant(
+              of: fabricRow,
+              // ignore: avoid_hardcoded_strings_in_widgets
+              matching: find.text('Bids 0 / Offers 0'),
+            ),
+            findsOneWidget,
+            reason:
+                'SPEC/ui/trade-screen.md § Body — Market tab: rows for '
+                'commodities absent from `WorldMarketState.lastTurnActivity` '
+                'default to a zero-volume line so the column reads '
+                'consistently for every row.',
+          );
+        },
+      );
+
+      testWidgets(
+        'commodity rows render only inside the Market tab body — the off-stage '
+        'Deal Book tab placeholder body does not host any commodity row keys',
+        (tester) async {
+          await _pumpTradeScreen(tester, game: _buildGame());
+
+          // Sanity: Market tab body hosts the list and rows.
+          expect(
+            find.descendant(
+              of: find.byKey(TradeScreen.marketTabBodyKey),
+              matching: find.byKey(TradeScreen.marketCommodityListKey),
+            ),
+            findsOneWidget,
+          );
+
+          // The off-stage Deal Book body must not host any commodity row
+          // — both off-stage and on-stage scopes.
+          expect(
+            find.descendant(
+              of: find.byKey(
+                TradeScreen.dealBookTabBodyKey,
+                skipOffstage: false,
+              ),
+              matching: find.byKey(TradeScreen.marketCommodityListKey),
+            ),
+            findsNothing,
+          );
+        },
+      );
+    },
+  );
+}

--- a/app/test/trade_screen_scaffold_test.dart
+++ b/app/test/trade_screen_scaffold_test.dart
@@ -381,23 +381,14 @@ void main() {
     );
 
     testWidgets(
-      'each tab body renders its dark editorial-monocle title — Market '
-      '(visible by default) and Deal Book (after tap)',
+      'Deal Book tab body still renders its dark editorial-monocle '
+      'placeholder title — Deal Book (after tap)',
       (tester) async {
         await tester.pumpWidget(buildTradeRouteHost());
         await pumpSettleCapped(tester);
 
         await tester.tap(find.text('open trade'));
         await pumpSettleCapped(tester);
-
-        // Market tab body is on stage by default — title renders to the
-        // visible foreground.
-        final marketTitle = find.descendant(
-          of: find.byKey(TradeScreen.marketTabBodyKey),
-          // ignore: avoid_hardcoded_strings_in_widgets
-          matching: find.text('Market'),
-        );
-        expect(marketTitle, findsOneWidget);
 
         // Tap the Deal Book tab label to swap the on-stage child.
         final dealBookLabel = find.descendant(
@@ -408,8 +399,10 @@ void main() {
         await tester.tap(dealBookLabel);
         await pumpSettleCapped(tester);
 
-        // After tap, the Deal Book tab body is on stage and its title
-        // renders.
+        // After tap, the Deal Book tab body is on stage and its
+        // placeholder title renders inside the tab body keyed
+        // tradeScreenDealBookTabBody (Refs #2993 E6 follow-up replaces
+        // this placeholder with the live ledger).
         final dealBookTitle = find.descendant(
           of: find.byKey(TradeScreen.dealBookTabBodyKey),
           // ignore: avoid_hardcoded_strings_in_widgets


### PR DESCRIPTION
## Summary

Replaces the Trade Screen Market tab placeholder body with a read-only commodity table sourced from `Game.worldMarketState` — the next implementation slice of #2993 World Market trade screen and UI (parent meta #2988, `priority:high`).

Each row in the Market tab now renders:

- the commodity display name (`titleSmall`, `--accent`),
- the **last market price** from `WorldMarketState.prices` (`titleSmall`, `--accentBright`), formatted to one decimal place; em-dash glyph renders when the commodity is absent from the map (only surfaced by tests / Widgetbook stories that instantiate `WorldMarketState.empty`),
- the **previous-turn aggregate volume** line `Bids X / Offers Y` from `WorldMarketState.lastTurnActivity` (`bodySmall`, `--muted`); rows absent from the activity map default to `Bids 0 / Offers 0` so the column reads consistently.

Rows iterate `CommodityCatalog.all` filtered to the tradeable subset (every commodity whose `CommodityCategory` is **not** `riches` and whose id is **not** `spices` — 22 rows per `SPEC/game/world-market.md` § Tradeable commodities), sorted alphabetically by display name for deterministic ordering across tests, Widgetbook stories, and Widgetbook screenshots.

## What's in this slice

- `app/lib/features/game/screens/trade_screen.dart` — replaces `_MarketTabPlaceholder` with `_MarketTabContent` (read-only commodity table inside a `SingleChildScrollView` so all 22 rows are built up front and the 320 dp viewport stays overflow-safe). Adds stable widget keys `marketCommodityListKey` and `marketCommodityRowKey(commodityId)` so widget tests and follow-up slices pin rows without text matching.
- `SPEC/ui/trade-screen.md` — documents the new wireframe (per-row content, alphabetical ordering, em-dash / zero-default semantics, stable keys), refreshes the variants table, and adds five Given–When–Then ACs covering count + filter, alphabetical ordering, price sourcing + em-dash fallback, aggregate-volume sourcing + zero-default, and scoping to the Market tab body only.
- `app/test/trade_screen_market_tab_commodity_table_test.dart` (new) — six widget tests covering the ACs end-to-end (22-row count, riches + spices exclusion, alphabetical row order with concrete spot-check, seeded vs. unseeded price text, populated vs. zero-default aggregate volume, off-stage Deal Book body scoping).
- `app/test/trade_screen_scaffold_test.dart` — updates the pre-existing "Market title in tab body" assertion (the title text moved out of the body when the placeholder was replaced) and keeps the Deal Book half of the original test as-is so the placeholder Deal Book contract is still pinned.
- `app/lib/widgetbook/catalog_part6.dart` — seeds a representative subset of `prices` + `lastTurnActivity` in the trade-screen story Game so reviewers see both the populated and zero-default rendering paths in one scroll.

## What's deferred (future #2993 slices)

The interactive Market controls (bid/offer toggle, quantity stepper, priority dropdown bound to `kMaxTradePriority`) and the persistent `Cargo remaining: X` header strip remain deferred to follow-up Refs #2993 E5b / E5c slices, and the Deal Book live ledger remains deferred to Refs #2993 E6 (it depends on a per-player ledger surface on top of #2989 / #2990's `MarketActivity` + world-market turn phase). The two-tab `_TradeScreenTabsBody` structure, the `CtTabStrip` chrome, and the existing scaffold widget keys are unchanged so those follow-ups swap each tab body in place.

## Coverage vs. #2988 / #2993 acceptance criteria

This slice closes the read-only display rows in #2993's AC list and is the foundation for the E5b interactive AC rows (the same row keys + ordering contract carry forward). It does not touch #2988's matching, FTP, first right of refusal, AI, or Deal Book ACs — those remain owned by their sub-issues (#2989, #2990, #2991, #2992, #2993 E6, #2994).

## Test plan

- [x] `flutter test test/trade_screen_market_tab_commodity_table_test.dart` — 6/6 pass (count + filter, alphabetical order, price sourcing + em-dash fallback, aggregate-volume sourcing + zero-default, off-stage scoping)
- [x] `flutter test test/trade_screen_scaffold_test.dart` — 12/12 pass (scaffold chrome, tab structure, observe mode, Deal Book placeholder title, left rail navigation)
- [x] `flutter test test/trade_screen_320dp_min_viewport_test.dart` — 4/4 pass (320 dp + 1024 dp overflow contract for both default and global-observe paths)
- [x] `flutter test test/widgetbook_entry_test.dart` — Widgetbook catalog still builds
- [x] `dart test test/check_screen_registry_active_paths_test.dart` — registry contract still passes
- [x] `flutter analyze lib/features/game/screens/trade_screen.dart test/trade_screen_market_tab_commodity_table_test.dart test/trade_screen_scaffold_test.dart lib/widgetbook/catalog_part6.dart` — no issues

Made with [Cursor](https://cursor.com)