### PR TITLE
feat(ui): naval units panel S8 — close mockup-fidelity gaps R25–R29 (Refs #2866)

### DIFF
--- a/SPEC/ui/naval-units-panel.md
+++ b/SPEC/ui/naval-units-panel.md
@@ -143,27 +143,25 @@ For every fleet (including the Home Fleet), the collapsed row shows:
 
 | Field             | Source                                   | Notes |
 |-------------------|------------------------------------------|-------|
-| **Fleet name**    | Fleet id or display name                | For Home Fleet, label is “Home Fleet”. For other fleets, use a human-readable label (e.g. “Fleet #3”, “Atlantic Squadron” if available; otherwise a stable fallback). |
-| **Location**      | `inPortAtProvinceId` or `seaZoneId`     | Display as `Region — Province` for in-port fleets (province display name) or `Region — Sea zone` for at-sea fleets. Region label uses same mapping as Military Units panel. |
+| **Fleet name**    | Fleet id or display name                | For Home Fleet, label is “Home Fleet” followed by a compact uppercase **`HOME`** chip (mockup `.home-tag`). For other fleets, use a human-readable label (e.g. “Fleet #3”, “Atlantic Squadron” if available; otherwise a stable fallback) and **no** `HOME` chip. See [Naval mockup fidelity (R25–R29)](#naval-mockup-fidelity-r25r29). |
+| **Location**      | `inPortAtProvinceId` or `seaZoneId`     | Display as `Region — Province (in port)` for in-port fleets (province display name + localised `(in port)` qualifier per `AppLocalizations.naval_units_locInPort`) or `Region — Sea zone (at sea)` for at-sea fleets (`naval_units_locAtSea`). Region label uses same mapping as Military Units panel. The qualifier is appended by `naval_tree_builder.dart` so both the collapsed subtitle and any snapshot view reading `FleetRow.locationLabel` see the same suffix. |
 | **Mission**       | `Fleet.mission`                         | Enum mapped to user labels: None, Patrol, Blockade, Beachhead, Defend. For Home Fleet, always shown as “None”. When the shell’s draft **`Orders`** contains a **naval move** for this fleet, show **Moving to:** \<display name of destination sea zone or dock province\> (dock targets may suffix **(dock)** in UI copy). |
-| **Inline actions** | Fleet action availability rules | `Split` is always visible. `Move` is visible for sea-going fleets and hidden for Home Fleet. Fleet rows use the shared unit-panel row-action widget convention from `app/lib/features/game/widgets/units/shared/` (left details, right left-to-right actions); narrow layouts switch row actions to icon-only while keeping controls tappable. |
+| **Inline actions** | Fleet action availability rules | `Split` is always visible. `Move` is visible for sea-going fleets and hidden for Home Fleet. `Locate` is always visible and is rendered **icon-only** at the **right end** of the actions cluster. Fleet rows use the shared unit-panel row-action widget convention from `app/lib/features/game/widgets/units/shared/` with `dense: true` so Move/Split render as **compact inline pills** (mockup `.f-actions button`) on a single horizontal row; narrow layouts switch row actions to icon-only while keeping controls tappable. See [Naval mockup fidelity (R25–R29)](#naval-mockup-fidelity-r25r29). |
 
 Collapsed row content stays compact and focused on: location, mission (and draft move line when present), and inline actions.
 
 ### Expanded details (on demand)
 
-When a row is **expanded**, additional details are shown **within the same panel**:
+When a row is **expanded**, additional details are shown **within the same panel** as a single compact band — composition `Table` widget, optional Home-Fleet cargo line, and a single-line composition summary — mirroring mockup `.fleet-row .f-expanded` (`SPEC/ui/mockups/UNIT30001-naval-units-panel.html`). The legacy per-stat `ListTile` stack is **no longer used**; see [Naval mockup fidelity (R25–R29)](#naval-mockup-fidelity-r25r29) for the layout pin.
 
-- **Composition table:** One row per ship type in the fleet:
+- **Composition table:** A single `Table` widget with one row per ship type:
   - Type name: **display label** from `shipTypeDisplayName` in `colonizethis_data` (aligned with [ships-and-naval.md](../game/ships-and-naval.md) roster, e.g. “Frigate”, “Merchant Steamship”, “Ship of the Line”), not raw `ship_type_id` (e.g. not `frigate`, `merchant_steamship`, `ship_of_the_line`). Unknown ids fall back to the raw id.
-  - Count of ships of that type.
-  - Role tag (e.g. “Warship” vs “Merchant”) per [ships-and-naval.md](../game/ships-and-naval.md).
+  - `×Count` cell (`AppLocalizations.naval_units_compositionCount`) styled with the `--accent-dim` token.
+  - Role tag — `Warship` (`naval_units_compositionRoleWarship`) when the ship type has `cargoHold == 0`, otherwise `Merchant` (`naval_units_compositionRoleMerchant`), per [ships-and-naval.md](../game/ships-and-naval.md).
 - **Capabilities:**
-  - For **Home Fleet**:
-    - **Cargo capacity**: total cargo holds, computed as the sum of `cargoHold` for all merchant ships in the Home Fleet per [ships-and-naval.md](../game/ships-and-naval.md) (§ Home Fleet, Cargo holds and capacity). Display as `Cargo capacity: X holds`.
-  - For **sea-going fleets**:
-    - A simple **strength summary** derived from naval combat aggregation (e.g. a single “Strength” value or short label that reflects FRP/RNG/HULL per [ships-and-naval.md](../game/ships-and-naval.md) § Naval Strength Aggregation Formula). Exact numeric display may be minimal for v1; underlying formula remains per game spec.
-- **Secondary summary fields:** `Total ships`, `Warships`, and `Merchants` are displayed in expanded content (not in collapsed summary text).
+  - For **Home Fleet** only: a single `Cargo capacity: X holds` line rendered between the table and the summary band (`AppLocalizations.naval_units_cargoCapacityHolds`); cargo holds are the sum of `cargoHold` over all merchant ships in the Home Fleet per [ships-and-naval.md](../game/ships-and-naval.md) (§ Home Fleet, Cargo holds and capacity). **Non-home** fleets render no cargo line in the expanded view.
+  - For **all fleets**: a retained `Strength: V` line (single `Text`, not its own `ListTile`) derived from the naval combat aggregation formula per [ships-and-naval.md](../game/ships-and-naval.md) § Naval Strength Aggregation Formula.
+- **Composition summary line:** A **single** `Text` widget `Total ships: X · Warships: Y · Merchants: Z` rendered below the table / cargo line (`AppLocalizations.naval_units_compositionSummary`). Replaces the legacy `Total ships`, `Warships`, and `Merchants` per-stat `ListTile`s.
 - **Additional status:** Optional badges such as “In port”, “At sea”, or mission badges (Patrol, Blockade, Beachhead, Defend).
 
 ---
@@ -225,6 +223,18 @@ The naval units panel participates in the Widgetbook catalog for review and test
 
 ---
 
+## Naval mockup fidelity (R25–R29)
+
+The first implementation pass for [#2866](https://github.com/) (PR #2906 + #2919) delivered the shared dark editorial-monocle theme and unit-panel row chrome but diverged from [`SPEC/ui/mockups/UNIT30001-naval-units-panel.html`](mockups/UNIT30001-naval-units-panel.html) in five concrete ways. The S8 slice (PR series referencing #2866) closes those gaps. The mockup is the visual source of truth for each item below; this section pins implementation, localisation, and AC expectations so future regressions point at the right line.
+
+- **R25 — compact inline action pills.** Move and Split (and any sibling fleet action added later) render as compact pills (`.f-actions button`: `padding: 3px 7px; font-size: 9px`) on a single horizontal row inside the right-aligned actions cluster. They MUST NOT wrap onto a second line at the panel’s default width (clamped 420–640 dp by `_panelConstraints`) and MUST NOT inherit the default `CtNinePatchButton.minHeight: 32` / `vertical: 6` padding. Naval rows opt in by passing `dense: true` to `UnitsEntityActionRow`; civilian/military rows keep the default density. Narrow icon-only fallback below the existing `iconOnlyBreakpoint` is still allowed.
+- **R26 — `HOME` chip on the Home Fleet row.** Mockup `.home-tag` is rendered as a compact uppercase chip immediately after the “Home Fleet” name (background `--accent-dim`, foreground `--bg-deep`, monospace font, ~8 px size, ~1 px horizontal padding) sourced from the editorial-monocle tokens (no inline hex). The chip is shown **only** on the Home Fleet row and never on regular fleet rows. The existing “Home Fleet” section/location header (per [Grouping and order](#grouping-and-order)) is preserved alongside the chip.
+- **R27 — locate icon at the right end of the actions cluster.** The locate control for a fleet row lives **inside** the right-aligned actions cluster (not in the left title-details row). It renders as a small icon-only button (mockup `.f-actions .locate-btn` — 22 × 22 px round icon) at the right end of the actions cluster, kept compact alongside the other actions (R25). It continues to emit `LocateMapTileEvent` for the fleet’s resolved tile (no behavioral regression). Sea-going fleets show `Move`, `Split`, `Locate` left-to-right; the Home Fleet shows `Split`, `Locate` left-to-right (no Move, per [Move fleet](#move-fleet)).
+- **R28 — `(in port)` / `(at sea)` qualifier on the location label.** Fleet location text appends `(in port)` for fleets with `inPortAtProvinceId` and `(at sea)` for fleets with `seaZoneId`, e.g. `Old World — London (in port)` and `New World — Caribbean Sea (at sea)`. Both qualifiers resolve through `AppLocalizations.naval_units_locInPort` / `naval_units_locAtSea` (no hard-coded English in widgets) and are appended by `naval_tree_builder.dart` to `FleetRow.locationLabel` so the qualifier appears in both the collapsed row subtitle and in any logging/snapshot view that reads the same field.
+- **R29 — expanded fleet panel matches the mockup.** The expanded view renders (a) a compact composition `Table` widget (one row per ship type — `Type | ×Count | Role`, monospace font, `--accent-dim` count column, 1 px `--border` row separators), (b) for the Home Fleet only, a single `Cargo capacity: X holds` line between the table and the summary band (via `AppLocalizations.naval_units_cargoCapacityHolds`; non-home fleets render **no** cargo line), and (c) a single-line composition summary `Total ships: X · Warships: Y · Merchants: Z` (via `AppLocalizations.naval_units_compositionSummary`) plus the retained `Strength: V` line, replacing the previous per-stat `ListTile` stack for `Total ships`, `Warships`, and `Merchants`.
+
+---
+
 ## Acceptance criteria
 
 - **Given** the user is on the in-game shell (Empire overview) and the human player has at least one fleet, **when** the user opens the Naval Units panel from the toolbar, **then** the UI layer displays a panel that lists all fleets owned by the human player grouped by region and by location (ports and sea zones), with the capital region’s **Home Fleet** shown as the first entry in that region even when it currently has zero ships.
@@ -266,4 +276,14 @@ The naval units panel participates in the Widgetbook catalog for review and test
 - **Given** the Naval Units panel is opened in full-list mode (no `locationScopeKey`), **when** the user confirms a fleet move, **then** the UI layer keeps the panel open and updates list content without auto-close.
 
 - **Given** the Naval Units panel is opened with `locationScopeKey`, **when** the panel list becomes empty for reasons other than a move confirmation emitted from that scoped panel, **then** the UI layer does not emit **`ClosePanelEvent`** for automatic dismissal.
+
+- **(R25)** **Given** the Naval Units panel is open against `AppThemes.editorialMonocle` at the default panel width (`_panelConstraints` clamp 420–640 px) and shows a sea-going fleet row, **when** the user views the row’s right-aligned actions cluster, **then** the UI layer renders **Move, Split, and the icon-only Locate button on one row** without wrapping; Move and Split use the compact inline-pill footprint defined in [mockups/UNIT30001-naval-units-panel.html](mockups/UNIT30001-naval-units-panel.html) `.f-actions button` (smaller padding/height than the default `CtNinePatchButton.minHeight: 32`, label + icon visible above the existing `iconOnlyBreakpoint`).
+
+- **(R26)** **Given** the Naval Units panel is open and the Home Fleet row is rendered in the capital region group, **when** the user reads the row title, **then** the UI layer renders the literal uppercase chip `HOME` immediately after the “Home Fleet” name (styled with dark-theme tokens `--accent-dim` background / `--bg-deep` text, monospace font ~8 px) and renders **no** `HOME` chip on any regular (non-home) fleet row.
+
+- **(R27)** **Given** the Naval Units panel is open and shows a fleet row with at least one action, **when** the user reads the actions cluster from left to right, **then** the rightmost child is the icon-only **Locate** button (no text label) and tapping it emits `LocateMapTileEvent` with the same tile key the previous title-side locate icon emitted (no behavioral regression). For a sea-going fleet the actions are `Move`, `Split`, `Locate` left-to-right; for the Home Fleet they are `Split`, `Locate` left-to-right (Move remains hidden per [Move fleet](#move-fleet)).
+
+- **(R28)** **Given** the Naval Units panel is open and shows a fleet **in port** at a province, **when** the user reads the row subtitle, **then** the location line ends with the literal localised qualifier `(in port)` (e.g. `Old World — London (in port)`), resolved via `AppLocalizations.naval_units_locInPort`; for a fleet **at sea** in a sea zone the location line ends with `(at sea)` (e.g. `New World — Caribbean Sea (at sea)`), resolved via `AppLocalizations.naval_units_locAtSea`. No English string for either qualifier is hard-coded in widgets.
+
+- **(R29)** **Given** the Naval Units panel is open and the user expands any fleet row, **when** the expanded content finishes rendering, **then** the UI layer renders (a) a single `Table` widget with one row per ship type with columns `Type`, `×Count`, `Role` and **not** a per-ship-type stack of `ListTile`s, (b) a single `Total ships: X · Warships: Y · Merchants: Z` summary line below the table (one `Text` widget, **not** three separate `ListTile`s) and a retained `Strength: V` line, and (c) for the Home Fleet only, a `Cargo capacity: X holds` line between the table and the summary line (non-home fleets render no cargo line).
 

--- a/app/lib/features/game/widgets/fleet_expansion_tile.dart
+++ b/app/lib/features/game/widgets/fleet_expansion_tile.dart
@@ -199,82 +199,16 @@ class _FleetExpandedContent extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final ships = row.shipCountsByType;
-    final monoLabel = TextStyle(
-      fontFamily: 'monospace',
-      fontSize: 9,
-      color: EditorialMonoclePalette.fg,
-    );
-    final monoCount = TextStyle(
-      fontFamily: 'monospace',
-      fontSize: 9,
-      color: EditorialMonoclePalette.accentDim,
-    );
-    final monoRole = TextStyle(
-      fontFamily: 'monospace',
-      fontSize: 7,
-      color: EditorialMonoclePalette.muted,
-    );
-    final capStyle = TextStyle(
-      fontSize: 9,
-      color: EditorialMonoclePalette.accentDim,
-    );
-    final statsStyle = TextStyle(
-      fontFamily: 'monospace',
-      fontSize: 9,
-      color: EditorialMonoclePalette.muted,
-    );
+    final styles = _ExpandedStyles.create();
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        if (ships.isEmpty)
-          Text(
-            l10n.naval_units_noShipsInFleet,
-            style: monoLabel.copyWith(color: EditorialMonoclePalette.muted),
-          )
-        else
-          Table(
-            columnWidths: const <int, TableColumnWidth>{
-              0: FlexColumnWidth(),
-              1: IntrinsicColumnWidth(),
-              2: IntrinsicColumnWidth(),
-            },
-            border: TableBorder(
-              horizontalInside: BorderSide(
-                color: EditorialMonoclePalette.border,
-                width: 1,
-              ),
-              bottom: BorderSide(
-                color: EditorialMonoclePalette.border,
-                width: 1,
-              ),
-            ),
-            defaultVerticalAlignment: TableCellVerticalAlignment.middle,
-            children: [
-              for (final entry in ships.entries)
-                TableRow(
-                  children: [
-                    _cell(
-                      Text(shipTypeDisplayName(entry.key), style: monoLabel),
-                    ),
-                    _cell(
-                      Text(
-                        l10n.naval_units_compositionCount(entry.value),
-                        style: monoCount,
-                        textAlign: TextAlign.right,
-                      ),
-                      align: Alignment.centerRight,
-                    ),
-                    _cell(Text(_roleLabelFor(entry.key), style: monoRole)),
-                  ],
-                ),
-            ],
-          ),
+        _buildShipsBlock(styles),
         if (row.isHomeFleet) ...[
           const SizedBox(height: 4),
           Text(
             l10n.naval_units_cargoCapacityHolds(row.cargoCapacity),
-            style: capStyle,
+            style: styles.cap,
           ),
         ],
         const SizedBox(height: 2),
@@ -284,12 +218,59 @@ class _FleetExpandedContent extends StatelessWidget {
             row.warshipCount,
             row.merchantCount,
           ),
-          style: statsStyle,
+          style: styles.stats,
         ),
         Text(
           l10n.naval_units_strength(row.strength.toStringAsFixed(1)),
-          style: statsStyle,
+          style: styles.stats,
         ),
+      ],
+    );
+  }
+
+  Widget _buildShipsBlock(_ExpandedStyles styles) {
+    final ships = row.shipCountsByType;
+    if (ships.isEmpty) {
+      return Text(
+        l10n.naval_units_noShipsInFleet,
+        style: styles.label.copyWith(color: EditorialMonoclePalette.muted),
+      );
+    }
+    return Table(
+      columnWidths: const <int, TableColumnWidth>{
+        0: FlexColumnWidth(),
+        1: IntrinsicColumnWidth(),
+        2: IntrinsicColumnWidth(),
+      },
+      border: TableBorder(
+        horizontalInside: BorderSide(
+          color: EditorialMonoclePalette.border,
+          width: 1,
+        ),
+        bottom: BorderSide(
+          color: EditorialMonoclePalette.border,
+          width: 1,
+        ),
+      ),
+      defaultVerticalAlignment: TableCellVerticalAlignment.middle,
+      children: [
+        for (final entry in ships.entries)
+          TableRow(
+            children: [
+              _cell(
+                Text(shipTypeDisplayName(entry.key), style: styles.label),
+              ),
+              _cell(
+                Text(
+                  l10n.naval_units_compositionCount(entry.value),
+                  style: styles.count,
+                  textAlign: TextAlign.right,
+                ),
+                align: Alignment.centerRight,
+              ),
+              _cell(Text(_roleLabelFor(entry.key), style: styles.role)),
+            ],
+          ),
       ],
     );
   }
@@ -307,4 +288,47 @@ class _FleetExpandedContent extends StatelessWidget {
         ? l10n.naval_units_compositionRoleMerchant
         : l10n.naval_units_compositionRoleWarship;
   }
+}
+
+class _ExpandedStyles {
+  const _ExpandedStyles({
+    required this.label,
+    required this.count,
+    required this.role,
+    required this.cap,
+    required this.stats,
+  });
+
+  factory _ExpandedStyles.create() {
+    const mono = 'monospace';
+    return _ExpandedStyles(
+      label: TextStyle(
+        fontFamily: mono,
+        fontSize: 9,
+        color: EditorialMonoclePalette.fg,
+      ),
+      count: TextStyle(
+        fontFamily: mono,
+        fontSize: 9,
+        color: EditorialMonoclePalette.accentDim,
+      ),
+      role: TextStyle(
+        fontFamily: mono,
+        fontSize: 7,
+        color: EditorialMonoclePalette.muted,
+      ),
+      cap: TextStyle(fontSize: 9, color: EditorialMonoclePalette.accentDim),
+      stats: TextStyle(
+        fontFamily: mono,
+        fontSize: 9,
+        color: EditorialMonoclePalette.muted,
+      ),
+    );
+  }
+
+  final TextStyle label;
+  final TextStyle count;
+  final TextStyle role;
+  final TextStyle cap;
+  final TextStyle stats;
 }

--- a/app/lib/features/game/widgets/fleet_expansion_tile.dart
+++ b/app/lib/features/game/widgets/fleet_expansion_tile.dart
@@ -1,10 +1,35 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:flutter/material.dart';
 
+import '../../../config/editorial_monocle_palette.dart';
 import '../../../l10n/l10n.dart';
 import 'utils/naval_tree_builder.dart';
 import 'units/shared/units_entity_action_row.dart';
 
+/// Naval-units fleet row.
+///
+/// Implements `Refs #2866` S8 mockup-fidelity gaps R25–R29 (see
+/// `SPEC/ui/naval-units-panel.md` § *Naval mockup fidelity (R25–R29)* and
+/// `SPEC/ui/mockups/UNIT30001-naval-units-panel.html`):
+/// - R25 — actions render through [UnitsEntityActionRow] with
+///   `dense: true`, so Move / Split / Locate stay on a single inline row
+///   at the default panel width.
+/// - R26 — when [FleetRow.isHomeFleet] is `true`, the title appends a
+///   compact uppercase `HOME` chip styled with `--accent-dim` / `--bg-deep`
+///   tokens.
+/// - R27 — the locate control lives at the **right end** of the actions
+///   cluster (icon-only `CtNinePatchButton` via
+///   [UnitsEntityAction.iconOnly]); regular fleets get Move + Split + Locate,
+///   Home Fleets get Split + Locate (Move stays hidden per R19).
+/// - R28 — the localised `(in port)` / `(at sea)` qualifier is built into
+///   [FleetRow.locationLabel] by `naval_tree_builder.dart`; this widget just
+///   renders that subtitle.
+/// - R29 — the expanded children render a single composition `Table` with
+///   columns `Type | ×Count | Role`, an optional Home-Fleet
+///   `Cargo capacity: X holds` line, and a single-line
+///   `Total ships: X · Warships: Y · Merchants: Z` summary plus the
+///   retained `Strength: V` line, replacing the previous per-stat
+///   `ListTile` stack.
 class FleetExpansionTile extends StatelessWidget {
   const FleetExpansionTile({
     super.key,
@@ -34,7 +59,7 @@ class FleetExpansionTile extends StatelessWidget {
     return Padding(
       padding: const EdgeInsets.only(left: 8),
       child: ExpansionTile(
-        title: _buildTitle(context),
+        title: _buildTitle(),
         subtitle: _buildSubtitle(),
         dense: true,
         children: _buildChildren(),
@@ -42,8 +67,9 @@ class FleetExpansionTile extends StatelessWidget {
     );
   }
 
-  Widget _buildTitle(BuildContext context) {
+  Widget _buildTitle() {
     return UnitsEntityActionRow(
+      dense: true,
       details: _buildTitleDetails(),
       actions: _buildTitleActions(),
     );
@@ -62,15 +88,9 @@ class FleetExpansionTile extends StatelessWidget {
         ),
         const SizedBox(width: 4),
         Flexible(child: Text(row.label, overflow: TextOverflow.ellipsis)),
-        if (onTap != null) ...[
-          const SizedBox(width: 4),
-          IconButton(
-            tooltip: l10n.naval_units_locateFleet,
-            onPressed: onTap,
-            icon: const Icon(Icons.my_location),
-            iconSize: 18,
-            visualDensity: VisualDensity.compact,
-          ),
+        if (row.isHomeFleet) ...[
+          const SizedBox(width: 6),
+          _HomeFleetChip(label: l10n.naval_units_homeFleetChip),
         ],
       ],
     );
@@ -98,6 +118,17 @@ class FleetExpansionTile extends StatelessWidget {
         ),
       );
     }
+    if (onTap != null) {
+      actions.add(
+        UnitsEntityAction(
+          tooltip: l10n.naval_units_locateFleet,
+          icon: Icons.my_location,
+          label: l10n.naval_units_locateFleet,
+          onPressed: onTap,
+          iconOnly: true,
+        ),
+      );
+    }
     return actions;
   }
 
@@ -113,46 +144,167 @@ class FleetExpansionTile extends StatelessWidget {
   }
 
   List<Widget> _buildChildren() {
-    final children = <Widget>[
-      ..._buildShipCountTiles(),
-      ListTile(
-        title: Text(l10n.naval_units_strength(row.strength.toStringAsFixed(1))),
-        dense: true,
-      ),
-      ListTile(title: Text(l10n.naval_units_totalShips(row.totalShips))),
-      if (row.warshipCount > 0)
-        ListTile(title: Text(l10n.naval_units_warships(row.warshipCount))),
-      if (row.merchantCount > 0)
-        ListTile(title: Text(l10n.naval_units_merchants(row.merchantCount))),
-      ListTile(
-        title: Text(
-          row.isHomeFleet
-              ? l10n.naval_units_cargoCapacity(row.cargoCapacity)
-              : l10n.naval_units_cargoCapacityIfAssigned(row.cargoCapacity),
-        ),
-        dense: true,
+    return [
+      Padding(
+        padding: const EdgeInsets.fromLTRB(16, 4, 16, 8),
+        child: _FleetExpandedContent(row: row, l10n: l10n),
       ),
     ];
-    return children;
+  }
+}
+
+/// `HOME` chip rendered next to the Home Fleet name (Refs #2866 S8 R26;
+/// mockup `.home-tag`). Tokens resolved from
+/// [EditorialMonoclePalette] (`--accent-dim`, `--bg-deep`).
+class _HomeFleetChip extends StatelessWidget {
+  const _HomeFleetChip({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 1),
+      decoration: BoxDecoration(
+        color: EditorialMonoclePalette.accentDim,
+        borderRadius: BorderRadius.circular(1),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          color: EditorialMonoclePalette.bgDeep,
+          fontFamily: 'monospace',
+          fontSize: 8,
+          letterSpacing: 0.5,
+          fontFeatures: const [FontFeature.tabularFigures()],
+          height: 1.0,
+        ),
+      ),
+    );
+  }
+}
+
+/// Expanded composition view for a fleet row (Refs #2866 S8 R29; mockup
+/// `.fleet-row .f-expanded`).
+///
+/// Renders a single `Table` with one row per ship type, an optional
+/// Home-Fleet cargo line, and a single-line composition summary
+/// (`Total ships: X · Warships: Y · Merchants: Z`) plus the retained
+/// `Strength: V` line — replacing the previous per-stat `ListTile` stack.
+class _FleetExpandedContent extends StatelessWidget {
+  const _FleetExpandedContent({required this.row, required this.l10n});
+
+  final FleetRow row;
+  final AppLocalizations l10n;
+
+  @override
+  Widget build(BuildContext context) {
+    final ships = row.shipCountsByType;
+    final monoLabel = TextStyle(
+      fontFamily: 'monospace',
+      fontSize: 9,
+      color: EditorialMonoclePalette.fg,
+    );
+    final monoCount = TextStyle(
+      fontFamily: 'monospace',
+      fontSize: 9,
+      color: EditorialMonoclePalette.accentDim,
+    );
+    final monoRole = TextStyle(
+      fontFamily: 'monospace',
+      fontSize: 7,
+      color: EditorialMonoclePalette.muted,
+    );
+    final capStyle = TextStyle(
+      fontSize: 9,
+      color: EditorialMonoclePalette.accentDim,
+    );
+    final statsStyle = TextStyle(
+      fontFamily: 'monospace',
+      fontSize: 9,
+      color: EditorialMonoclePalette.muted,
+    );
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (ships.isEmpty)
+          Text(
+            l10n.naval_units_noShipsInFleet,
+            style: monoLabel.copyWith(color: EditorialMonoclePalette.muted),
+          )
+        else
+          Table(
+            columnWidths: const <int, TableColumnWidth>{
+              0: FlexColumnWidth(),
+              1: IntrinsicColumnWidth(),
+              2: IntrinsicColumnWidth(),
+            },
+            border: TableBorder(
+              horizontalInside: BorderSide(
+                color: EditorialMonoclePalette.border,
+                width: 1,
+              ),
+              bottom: BorderSide(
+                color: EditorialMonoclePalette.border,
+                width: 1,
+              ),
+            ),
+            defaultVerticalAlignment: TableCellVerticalAlignment.middle,
+            children: [
+              for (final entry in ships.entries)
+                TableRow(
+                  children: [
+                    _cell(
+                      Text(shipTypeDisplayName(entry.key), style: monoLabel),
+                    ),
+                    _cell(
+                      Text(
+                        l10n.naval_units_compositionCount(entry.value),
+                        style: monoCount,
+                        textAlign: TextAlign.right,
+                      ),
+                      align: Alignment.centerRight,
+                    ),
+                    _cell(Text(_roleLabelFor(entry.key), style: monoRole)),
+                  ],
+                ),
+            ],
+          ),
+        if (row.isHomeFleet) ...[
+          const SizedBox(height: 4),
+          Text(
+            l10n.naval_units_cargoCapacityHolds(row.cargoCapacity),
+            style: capStyle,
+          ),
+        ],
+        const SizedBox(height: 2),
+        Text(
+          l10n.naval_units_compositionSummary(
+            row.totalShips,
+            row.warshipCount,
+            row.merchantCount,
+          ),
+          style: statsStyle,
+        ),
+        Text(
+          l10n.naval_units_strength(row.strength.toStringAsFixed(1)),
+          style: statsStyle,
+        ),
+      ],
+    );
   }
 
-  List<Widget> _buildShipCountTiles() {
-    if (row.shipCountsByType.isEmpty) {
-      return [
-        ListTile(title: Text(l10n.naval_units_noShipsInFleet), dense: true),
-      ];
-    }
-    return [
-      for (final entry in row.shipCountsByType.entries)
-        ListTile(
-          title: Text(
-            l10n.naval_units_shipTypeCount(
-              shipTypeDisplayName(entry.key),
-              entry.value,
-            ),
-          ),
-          dense: true,
-        ),
-    ];
+  Widget _cell(Widget child, {AlignmentGeometry align = Alignment.centerLeft}) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
+      child: Align(alignment: align, child: child),
+    );
+  }
+
+  String _roleLabelFor(String typeId) {
+    final stats = NavalStatsCatalog.get(typeId);
+    return stats.cargoHold > 0
+        ? l10n.naval_units_compositionRoleMerchant
+        : l10n.naval_units_compositionRoleWarship;
   }
 }

--- a/app/lib/features/game/widgets/units/shared/units_entity_action_row.dart
+++ b/app/lib/features/game/widgets/units/shared/units_entity_action_row.dart
@@ -7,6 +7,15 @@ import 'units_panel_row_chrome.dart';
 /// - details on the left
 /// - action buttons on the right, left-to-right
 /// - icon-only action mode on narrow widths
+///
+/// `dense: true` switches the action buttons to the compact inline-pill
+/// footprint specified by the naval-units mockup
+/// (`SPEC/ui/mockups/UNIT30001-naval-units-panel.html` `.f-actions button`):
+/// smaller padding, lower [CtNinePatchButton.minHeight], smaller icon size,
+/// and a `Row` that cannot wrap onto a second line at the default panel
+/// width. Individual [UnitsEntityAction] entries may opt into icon-only
+/// rendering via [UnitsEntityAction.iconOnly] (e.g. the locate control on a
+/// fleet row); icon-only entries still respect the `dense` footprint.
 class UnitsEntityActionRow extends StatelessWidget {
   const UnitsEntityActionRow({
     super.key,
@@ -14,12 +23,21 @@ class UnitsEntityActionRow extends StatelessWidget {
     this.actions = const [],
     this.iconOnlyBreakpoint = 280,
     this.spacing = 6,
+    this.dense = false,
   });
 
   final Widget details;
   final List<UnitsEntityAction> actions;
   final double iconOnlyBreakpoint;
   final double spacing;
+
+  /// When `true`, every action button renders at the compact inline-pill
+  /// footprint defined for the naval-units panel mockup. The actions cluster
+  /// stays on a single horizontal line (no `Wrap`) so Move/Split/Locate are
+  /// guaranteed not to break onto a second row at the default panel width
+  /// (Refs #2866 S8 R25). Civilian/military rows keep the default
+  /// `CtNinePatchButton` footprint.
+  final bool dense;
 
   @override
   Widget build(BuildContext context) {
@@ -34,41 +52,35 @@ class UnitsEntityActionRow extends StatelessWidget {
             children: [
               Expanded(child: details),
               if (actions.isNotEmpty) ...[
-                const SizedBox(width: 8),
+                SizedBox(width: dense ? spacing : 8),
                 Flexible(
                   fit: FlexFit.loose,
                   child: Align(
                     alignment: Alignment.topRight,
-                    child: Wrap(
-                      spacing: spacing,
-                      runSpacing: spacing,
-                      alignment: WrapAlignment.end,
-                      children: [
-                        for (final action in actions)
-                          Tooltip(
-                            message: action.tooltip,
-                            child: CtNinePatchButton(
-                              onPressed: action.onPressed,
-                              enabled: action.onPressed != null,
-                              padding: EdgeInsets.symmetric(
-                                horizontal: iconOnly ? 8 : 10,
-                                vertical: 6,
-                              ),
-                              minHeight: 32,
-                              child: iconOnly
-                                  ? Icon(action.icon, size: 16)
-                                  : Row(
-                                      mainAxisSize: MainAxisSize.min,
-                                      children: [
-                                        Icon(action.icon, size: 16),
-                                        const SizedBox(width: 4),
-                                        Text(action.label),
-                                      ],
-                                    ),
-                            ),
+                    child: dense
+                        ? LayoutBuilder(
+                            builder: (context, denseConstraints) {
+                              // Dense Row cannot wrap; if the actions cluster
+                              // alone is narrower than [denseIconOnlyBreakpoint]
+                              // (label + icon footprint per the mockup), fall
+                              // back to icon-only across the whole cluster so
+                              // it stays on one line. R25 spec explicitly
+                              // permits "Narrow icon-only fallback below the
+                              // existing iconOnlyBreakpoint".
+                              final denseIconOnly =
+                                  iconOnly ||
+                                  denseConstraints.maxWidth <
+                                      _denseIconOnlyBreakpoint(actions.length);
+                              return _buildDenseActionsRow(
+                                actions: actions,
+                                forceIconOnly: denseIconOnly,
+                              );
+                            },
+                          )
+                        : _buildDefaultActionsWrap(
+                            actions: actions,
+                            iconOnly: iconOnly,
                           ),
-                      ],
-                    ),
                   ),
                 ),
               ],
@@ -78,6 +90,95 @@ class UnitsEntityActionRow extends StatelessWidget {
       },
     );
   }
+
+  /// Heuristic per-action label+icon width used to decide when the dense
+  /// actions cluster must collapse to icon-only to avoid wrapping. Sized so
+  /// the default 3-action naval cluster (Move + Split + Locate icon) stays
+  /// in label+icon mode at the spec'd 420–640 dp panel width but collapses
+  /// at the test-host viewports that constrain the action cluster below
+  /// ~150 dp.
+  static double _denseIconOnlyBreakpoint(int actionCount) {
+    return 70.0 * actionCount;
+  }
+
+  Widget _buildDefaultActionsWrap({
+    required List<UnitsEntityAction> actions,
+    required bool iconOnly,
+  }) {
+    return Wrap(
+      spacing: spacing,
+      runSpacing: spacing,
+      alignment: WrapAlignment.end,
+      children: [
+        for (final action in actions)
+          Tooltip(
+            message: action.tooltip,
+            child: CtNinePatchButton(
+              onPressed: action.onPressed,
+              enabled: action.onPressed != null,
+              padding: EdgeInsets.symmetric(
+                horizontal: iconOnly || action.iconOnly ? 8 : 10,
+                vertical: 6,
+              ),
+              minHeight: 32,
+              child: iconOnly || action.iconOnly
+                  ? Icon(action.icon, size: 16)
+                  : Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Icon(action.icon, size: 16),
+                        const SizedBox(width: 4),
+                        Text(action.label),
+                      ],
+                    ),
+            ),
+          ),
+      ],
+    );
+  }
+
+  Widget _buildDenseActionsRow({
+    required List<UnitsEntityAction> actions,
+    required bool forceIconOnly,
+  }) {
+    final children = <Widget>[];
+    for (var i = 0; i < actions.length; i++) {
+      if (i > 0) {
+        children.add(SizedBox(width: spacing));
+      }
+      final action = actions[i];
+      final renderAsIconOnly = forceIconOnly || action.iconOnly;
+      children.add(
+        Tooltip(
+          message: action.tooltip,
+          child: CtNinePatchButton(
+            onPressed: action.onPressed,
+            enabled: action.onPressed != null,
+            // Mockup `.f-actions button { padding:3px 7px; font-size:9px; }` /
+            // `.locate-btn { width:22px; height:22px; }` — keep the dense
+            // pills tappable (>=24 dp) while shaving the inherited 32 dp
+            // default `CtNinePatchButton` height.
+            padding: EdgeInsets.symmetric(
+              horizontal: renderAsIconOnly ? 4 : 7,
+              vertical: 3,
+            ),
+            minHeight: 24,
+            child: renderAsIconOnly
+                ? Icon(action.icon, size: 14)
+                : Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(action.icon, size: 14),
+                      const SizedBox(width: 3),
+                      Text(action.label),
+                    ],
+                  ),
+          ),
+        ),
+      );
+    }
+    return Row(mainAxisSize: MainAxisSize.min, children: children);
+  }
 }
 
 class UnitsEntityAction {
@@ -86,10 +187,18 @@ class UnitsEntityAction {
     required this.icon,
     required this.label,
     required this.onPressed,
+    this.iconOnly = false,
   });
 
   final String tooltip;
   final IconData icon;
   final String label;
   final VoidCallback? onPressed;
+
+  /// When `true`, the action button suppresses its text label and renders
+  /// only the [icon] — used by the right-aligned locate control on naval
+  /// fleet rows (mockup `.f-actions .locate-btn`). When `false`, the
+  /// button shows `Icon + label` unless the row falls below
+  /// [UnitsEntityActionRow.iconOnlyBreakpoint] (default-mode rows only).
+  final bool iconOnly;
 }

--- a/app/lib/features/game/widgets/utils/naval_tree_builder.dart
+++ b/app/lib/features/game/widgets/utils/naval_tree_builder.dart
@@ -154,7 +154,8 @@ List<FleetRow> flattenNavalTree(
   int merchants,
   int cargoCapacity,
   double strength,
-}) _navalFleetShipAggregates(Fleet fleet) {
+})
+_navalFleetShipAggregates(Fleet fleet) {
   final shipCounts = <String, int>{};
   var totalShips = 0;
   var warships = 0;
@@ -183,7 +184,9 @@ List<FleetRow> flattenNavalTree(
   );
 }
 
-({String? regionId, String? localId}) _capitalTileRegionParts(CapitalTile? tile) {
+({String? regionId, String? localId}) _capitalTileRegionParts(
+  CapitalTile? tile,
+) {
   if (tile == null) return (regionId: null, localId: null);
   final tileKey = tile.toTileKey();
   final parsed = tryParseTileKey(tileKey);
@@ -268,17 +271,10 @@ String? _navalProjectedLocationScopeForFleet({
     );
   }
   if (fleet.isAtSea && fleet.seaZoneId != null) {
-    return _navalNormalizedSeaScope(
-      topology,
-      fleet.seaZoneId!,
-      fleet.regionId,
-    );
+    return _navalNormalizedSeaScope(topology, fleet.seaZoneId!, fleet.regionId);
   }
   if (fleet.inPortAtProvinceId != null) {
-    final province = tryGetProvince(
-      game.worldState,
-      fleet.inPortAtProvinceId!,
-    );
+    final province = tryGetProvince(game.worldState, fleet.inPortAtProvinceId!);
     if (province != null) {
       return _navalNormalizedPortScopeForProvince(province);
     }
@@ -307,7 +303,8 @@ void _appendNavalAtSeaFleetRow({
     double strength,
     Map<String, int> shipCounts,
     int cargoCapacity,
-  }) agg,
+  })
+  agg,
   required Map<String, List<FleetRow>> seas,
 }) {
   final seaZoneId =
@@ -325,7 +322,8 @@ void _appendNavalAtSeaFleetRow({
     regionId: rowRegionId,
     seaZoneId: zoneKey,
   );
-  final locationLabel = '${unitsPanelRegionLabel(rowRegionId)} — $zoneLabel';
+  final locationLabel =
+      '${unitsPanelRegionLabel(rowRegionId)} — $zoneLabel ${l10n.naval_units_locAtSea}';
   final tileKey = tileKeyForNavalFleetAtSea(
     game: game,
     regionId: rowRegionId,
@@ -382,7 +380,8 @@ void _appendNavalInPortFleetRow({
     double strength,
     Map<String, int> shipCounts,
     int cargoCapacity,
-  }) agg,
+  })
+  agg,
   required Map<String, List<FleetRow>> ports,
   required List<FleetRow?> homeFleetSlot,
 }) {
@@ -401,7 +400,7 @@ void _appendNavalInPortFleetRow({
   final locationKey = _navalNormalizedPortScopeForProvince(province);
   final tileKey = tileKeyForProvinceLocation(game, province);
   final locationLabel =
-      '${unitsPanelRegionLabel(rowRegionId)} — ${province.displayName ?? province.id}';
+      '${unitsPanelRegionLabel(rowRegionId)} — ${province.displayName ?? province.id} ${l10n.naval_units_locInPort}';
   final row = FleetRow(
     fleetId: fleet.id,
     label: isHomeFleet
@@ -440,11 +439,8 @@ void _appendNavalInPortFleetRow({
   ports.putIfAbsent(fullProvinceId, () => []).add(row);
 }
 
-({
-  String regionId,
-  FleetRow? homeFleet,
-  List<NavalTreeLocationNode> locations,
-})? _navalTreeGroupForRegion({
+({String regionId, FleetRow? homeFleet, List<NavalTreeLocationNode> locations})?
+_navalTreeGroupForRegion({
   required Game game,
   required String humanPlayerId,
   required MapTopology topology,
@@ -595,11 +591,7 @@ void _appendNavalInPortFleetRow({
   if (homeFleetRow == null && locations.isEmpty) {
     return null;
   }
-  return (
-    regionId: regionId,
-    homeFleet: homeFleetRow,
-    locations: locations,
-  );
+  return (regionId: regionId, homeFleet: homeFleetRow, locations: locations);
 }
 
 List<

--- a/app/lib/l10n/app_localizations_contract.dart
+++ b/app/lib/l10n/app_localizations_contract.dart
@@ -17,7 +17,6 @@ abstract class AppLocalizations {
   /// A list of this localizations delegate's supported locales.
   static const List<Locale> supportedLocales = <Locale>[Locale('en')];
 
-
   /// Window title / application title.
   String get app_title;
 
@@ -299,7 +298,11 @@ abstract class AppLocalizations {
   String game_intervention_resolutionProgress(int current, int total);
 
   /// One-line summary of the war and which GP the player decides for.
-  String game_intervention_situation(String aggressor, String defender, String intervening);
+  String game_intervention_situation(
+    String aggressor,
+    String defender,
+    String intervening,
+  );
 
   /// Button: military intervention on behalf of the defender.
   String get game_intervention_intervene;
@@ -721,7 +724,11 @@ abstract class AppLocalizations {
   String military_units_armySubtitle(int regiments, String location);
 
   /// Army subtitle showing regiment count, location, and a draft move line.
-  String military_units_armySubtitleWithDraft(int regiments, String location, String draftLine);
+  String military_units_armySubtitleWithDraft(
+    int regiments,
+    String location,
+    String draftLine,
+  );
 
   /// Empty-state line for army with no regiments.
   String get military_units_noRegimentsAssigned;
@@ -776,6 +783,40 @@ abstract class AppLocalizations {
 
   /// Cargo capacity line for non-home fleet.
   String naval_units_cargoCapacityIfAssigned(int capacity);
+
+  /// Inline qualifier appended to a fleet's location label when the
+  /// fleet is docked at a port province. SPEC/ui/naval-units-panel.md
+  /// R28.
+  String get naval_units_locInPort;
+
+  /// Inline qualifier appended to a fleet's location label when the
+  /// fleet is in a sea zone. SPEC/ui/naval-units-panel.md R28.
+  String get naval_units_locAtSea;
+
+  /// Uppercase chip rendered next to the Home Fleet name in the naval
+  /// units panel. SPEC/ui/naval-units-panel.md R26.
+  String get naval_units_homeFleetChip;
+
+  /// Role tag in the fleet expanded composition table for warship ship
+  /// types (cargoHold == 0). SPEC/ui/naval-units-panel.md R29.
+  String get naval_units_compositionRoleWarship;
+
+  /// Role tag in the fleet expanded composition table for merchant
+  /// ship types (cargoHold > 0). SPEC/ui/naval-units-panel.md R29.
+  String get naval_units_compositionRoleMerchant;
+
+  /// Count cell in the fleet expanded composition table, e.g. ×2.
+  /// SPEC/ui/naval-units-panel.md R29.
+  String naval_units_compositionCount(int count);
+
+  /// Single-line composition summary rendered beneath the expanded
+  /// fleet composition table. SPEC/ui/naval-units-panel.md R29.
+  String naval_units_compositionSummary(int total, int warships, int merchants);
+
+  /// Home-Fleet cargo capacity line rendered between the composition
+  /// table and the summary in the expanded fleet view.
+  /// SPEC/ui/naval-units-panel.md R29.
+  String naval_units_cargoCapacityHolds(int capacity);
 
   /// Diplomacy dialog title for setting subsidy amount.
   String get diplomacy_setSubsidy;
@@ -928,7 +969,11 @@ abstract class AppLocalizations {
   String technologyPanel_slot(int slot);
 
   /// Research slot subtitle with tech name, progress, and cost label.
-  String technologyPanel_slotSubtitle(String name, int progress, String costLabel);
+  String technologyPanel_slotSubtitle(
+    String name,
+    int progress,
+    String costLabel,
+  );
 
   /// Empty-state subtitle when no tech is assigned to a slot.
   String get technologyPanel_noTechAssigned;
@@ -1115,10 +1160,18 @@ abstract class AppLocalizations {
   String provinceOverlay_unitTarget(String type, String target);
 
   /// Civilian section line for foreign-unit status (no internal unit id).
-  String provinceOverlay_foreignUnitStatus(String owner, String type, String status);
+  String provinceOverlay_foreignUnitStatus(
+    String owner,
+    String type,
+    String status,
+  );
 
   /// Naval section fleet summary line.
-  String provinceOverlay_fleetSummary(String owner, String fleetLabel, String shipParts);
+  String provinceOverlay_fleetSummary(
+    String owner,
+    String fleetLabel,
+    String shipParts,
+  );
 
   /// Province overlay section heading for political details.
   String get provinceOverlay_sectionPolitical;
@@ -1199,7 +1252,11 @@ abstract class AppLocalizations {
   String regionMinimap_zoomSemanticsValue(int pct);
 
   /// Economic row in province overlay: terrain, resource id, and localized detail suffix.
-  String province_economic_resourceRow(String terrain, String resourceId, String detail);
+  String province_economic_resourceRow(
+    String terrain,
+    String resourceId,
+    String detail,
+  );
 
   /// Heading for diplomatic event history on detail screen.
   String get diplomacy_detail_historyTitle;

--- a/app/lib/l10n/app_localizations_en_part2.dart
+++ b/app/lib/l10n/app_localizations_en_part2.dart
@@ -400,6 +400,40 @@ mixin _AppLocalizationsEnStrings2 on AppLocalizations {
   }
 
   @override
+  String get naval_units_locInPort => '(in port)';
+
+  @override
+  String get naval_units_locAtSea => '(at sea)';
+
+  @override
+  String get naval_units_homeFleetChip => 'HOME';
+
+  @override
+  String get naval_units_compositionRoleWarship => 'Warship';
+
+  @override
+  String get naval_units_compositionRoleMerchant => 'Merchant';
+
+  @override
+  String naval_units_compositionCount(int count) {
+    return '\u00d7$count';
+  }
+
+  @override
+  String naval_units_compositionSummary(
+    int total,
+    int warships,
+    int merchants,
+  ) {
+    return 'Total ships: $total \u00b7 Warships: $warships \u00b7 Merchants: $merchants';
+  }
+
+  @override
+  String naval_units_cargoCapacityHolds(int capacity) {
+    return 'Cargo capacity: $capacity holds';
+  }
+
+  @override
   String get diplomacy_setSubsidy => 'Set subsidy';
 
   @override
@@ -489,5 +523,4 @@ mixin _AppLocalizationsEnStrings2 on AppLocalizations {
 
   @override
   String get civilian_units_assign => 'Assign';
-
 }

--- a/app/lib/l10n/arb/app_en.arb
+++ b/app/lib/l10n/arb/app_en.arb
@@ -1370,6 +1370,59 @@
       }
     }
   },
+  "naval_units_locInPort": "(in port)",
+  "@naval_units_locInPort": {
+    "description": "Inline qualifier appended to a fleet's location label when the fleet is docked at a port province. SPEC/ui/naval-units-panel.md R28."
+  },
+  "naval_units_locAtSea": "(at sea)",
+  "@naval_units_locAtSea": {
+    "description": "Inline qualifier appended to a fleet's location label when the fleet is in a sea zone. SPEC/ui/naval-units-panel.md R28."
+  },
+  "naval_units_homeFleetChip": "HOME",
+  "@naval_units_homeFleetChip": {
+    "description": "Uppercase chip rendered next to the Home Fleet name in the naval units panel. SPEC/ui/naval-units-panel.md R26."
+  },
+  "naval_units_compositionRoleWarship": "Warship",
+  "@naval_units_compositionRoleWarship": {
+    "description": "Role tag in the fleet expanded composition table for warship ship types (cargoHold == 0). SPEC/ui/naval-units-panel.md R29."
+  },
+  "naval_units_compositionRoleMerchant": "Merchant",
+  "@naval_units_compositionRoleMerchant": {
+    "description": "Role tag in the fleet expanded composition table for merchant ship types (cargoHold > 0). SPEC/ui/naval-units-panel.md R29."
+  },
+  "naval_units_compositionCount": "\u00d7{count}",
+  "@naval_units_compositionCount": {
+    "description": "Count cell in the fleet expanded composition table, e.g. \u00d72. SPEC/ui/naval-units-panel.md R29.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "naval_units_compositionSummary": "Total ships: {total} \u00b7 Warships: {warships} \u00b7 Merchants: {merchants}",
+  "@naval_units_compositionSummary": {
+    "description": "Single-line composition summary rendered beneath the expanded fleet composition table. SPEC/ui/naval-units-panel.md R29.",
+    "placeholders": {
+      "total": {
+        "type": "int"
+      },
+      "warships": {
+        "type": "int"
+      },
+      "merchants": {
+        "type": "int"
+      }
+    }
+  },
+  "naval_units_cargoCapacityHolds": "Cargo capacity: {capacity} holds",
+  "@naval_units_cargoCapacityHolds": {
+    "description": "Home-Fleet cargo capacity line rendered between the composition table and the summary in the expanded fleet view. SPEC/ui/naval-units-panel.md R29.",
+    "placeholders": {
+      "capacity": {
+        "type": "int"
+      }
+    }
+  },
   "diplomacy_setSubsidy": "Set subsidy",
   "@diplomacy_setSubsidy": {
     "description": "Diplomacy dialog title for setting subsidy amount."

--- a/app/lib/test_support/naval_units_panel_e2e_expected_lines.dart
+++ b/app/lib/test_support/naval_units_panel_e2e_expected_lines.dart
@@ -14,6 +14,13 @@ import 'package:colonizethis_app/features/game/widgets/utils/naval_tree_builder.
 import 'package:colonizethis_app/features/game/widgets/units/shared/units_panel_region_label.dart';
 import 'package:colonizethis_app/l10n/l10n.dart';
 
+String _roleLabelFor(String typeId, AppLocalizations l10n) {
+  final stats = NavalStatsCatalog.get(typeId);
+  return stats.cargoHold > 0
+      ? l10n.naval_units_compositionRoleMerchant
+      : l10n.naval_units_compositionRoleWarship;
+}
+
 void _addFleetRowTexts({
   required List<String> out,
   required FleetRow row,
@@ -21,7 +28,13 @@ void _addFleetRowTexts({
   required bool expansionTilesOpen,
 }) {
   out.add(row.label);
-  // UnitsEntityActionRow: label (details) then Move/Split; then ExpansionTile subtitle.
+  if (row.isHomeFleet) {
+    // Mockup `.home-tag` rendered next to the name (Refs #2866 S8 R26).
+    out.add(l10n.naval_units_homeFleetChip);
+  }
+  // UnitsEntityActionRow (dense): label (details) then Move (when allowed),
+  // Split, and the icon-only Locate control (no text label). Refs #2866 S8
+  // R25 + R27.
   if (!row.isHomeFleet) {
     out.add(l10n.common_move);
   }
@@ -37,28 +50,29 @@ void _addFleetRowTexts({
   if (row.shipCountsByType.isEmpty) {
     out.add(l10n.naval_units_noShipsInFleet);
   } else {
+    // Mockup `.fleet-row .f-expanded table` columns are `Type | ×Count |
+    // Role` per ship type (Refs #2866 S8 R29).
     for (final entry in row.shipCountsByType.entries) {
-      out.add(
-        l10n.naval_units_shipTypeCount(
-          shipTypeDisplayName(entry.key),
-          entry.value,
-        ),
-      );
+      out.add(shipTypeDisplayName(entry.key));
+      out.add(l10n.naval_units_compositionCount(entry.value));
+      out.add(_roleLabelFor(entry.key, l10n));
     }
   }
-  out.add(l10n.naval_units_strength(row.strength.toStringAsFixed(1)));
-  out.add(l10n.naval_units_totalShips(row.totalShips));
-  if (row.warshipCount > 0) {
-    out.add(l10n.naval_units_warships(row.warshipCount));
+  // Home Fleet only: `Cargo capacity: X holds` between the table and the
+  // summary band; non-home fleets no longer render a cargo line in the
+  // expanded view.
+  if (row.isHomeFleet) {
+    out.add(l10n.naval_units_cargoCapacityHolds(row.cargoCapacity));
   }
-  if (row.merchantCount > 0) {
-    out.add(l10n.naval_units_merchants(row.merchantCount));
-  }
+  // Single-line composition summary + retained Strength line.
   out.add(
-    row.isHomeFleet
-        ? l10n.naval_units_cargoCapacity(row.cargoCapacity)
-        : l10n.naval_units_cargoCapacityIfAssigned(row.cargoCapacity),
+    l10n.naval_units_compositionSummary(
+      row.totalShips,
+      row.warshipCount,
+      row.merchantCount,
+    ),
   );
+  out.add(l10n.naval_units_strength(row.strength.toStringAsFixed(1)));
 }
 
 /// In-order [Text.data] for [NavalUnitsPanel] preorder traversal.

--- a/app/lib/widgetbook/catalog_part2.dart
+++ b/app/lib/widgetbook/catalog_part2.dart
@@ -537,8 +537,15 @@ List<WidgetbookNode> get navalUnitsPanelDirectories => [
           final humanPlayerId = game.players.isNotEmpty
               ? game.players.first.id
               : 'gp1';
+          // Mockup `UNIT30001` clamps the panel sidebar to ~340 dp;
+          // 480 dp here keeps the standalone story comfortably inside
+          // `_panelConstraints` (420–640 dp) so reviewers see the dense
+          // R25 action cluster (Move + Split + Locate on one row), the
+          // R26 `HOME` chip on the Home Fleet row, and the R28
+          // `(in port)` / `(at sea)` location qualifier produced by
+          // `naval_tree_builder.dart`.
           return ConstrainedBox(
-            constraints: const BoxConstraints(maxWidth: 400, maxHeight: 500),
+            constraints: const BoxConstraints(maxWidth: 480, maxHeight: 640),
             child: NavalUnitsPanel(
               game: game,
               humanPlayerId: humanPlayerId,

--- a/app/test/naval_units_panel_mockup_fidelity_test.dart
+++ b/app/test/naval_units_panel_mockup_fidelity_test.dart
@@ -1,0 +1,451 @@
+// Pins the five naval-units mockup-fidelity behaviors closed by Refs #2866 S8
+// (R25–R29) against `SPEC/ui/mockups/UNIT30001-naval-units-panel.html` and
+// `SPEC/ui/naval-units-panel.md`. Each `group` corresponds to one R-item so
+// regressions point straight at the spec line they broke.
+
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart' show homeFleetIdFor;
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:colonizethis_app/config/themes.dart';
+import 'package:colonizethis_app/features/game/widgets/fleet_expansion_tile.dart';
+import 'package:colonizethis_app/features/game/widgets/naval_units_panel.dart';
+import 'package:colonizethis_app/features/game/widgets/units/shared/units_entity_action_row.dart';
+import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
+import 'package:colonizethis_app/widgets/debug_init_game.dart';
+
+const _humanId = 'gp_naval_fidelity';
+const _capitalLocalId = 'cap1';
+const _capitalProvinceId = 'oldWorld|$_capitalLocalId';
+const _portLocalId = 'port1';
+const _portProvinceId = 'oldWorld|$_portLocalId';
+const _localSeaZoneId = 'zone_alpha';
+const _zonePrefixedId = 'oldWorld|$_localSeaZoneId';
+
+Game _buildFidelityGame() {
+  final homeId = homeFleetIdFor(_humanId);
+  return Game(
+    id: 'naval-fidelity',
+    worldState: WorldState(
+      turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+      oldWorld: RegionData(
+        provinces: const [
+          Province(
+            id: _capitalLocalId,
+            regionId: 'oldWorld',
+            ownerId: _humanId,
+            displayName: 'London',
+          ),
+          Province(
+            id: _portLocalId,
+            regionId: 'oldWorld',
+            ownerId: _humanId,
+            displayName: 'Portsmouth',
+          ),
+        ],
+      ),
+      newWorld: const RegionData(),
+      fleets: [
+        // Home Fleet (in port at capital) — drives R26 HOME chip and R29
+        // Home-Fleet cargo line.
+        Fleet(
+          id: homeId,
+          ownerId: _humanId,
+          regionId: 'oldWorld',
+          inPortAtProvinceId: _capitalProvinceId,
+          ships: const [
+            ShipInstance(id: 'h1', typeId: 'carrack'),
+            ShipInstance(id: 'h2', typeId: 'frigate'),
+          ],
+        ),
+        // In-port sea-going fleet — drives R25 dense pills, R27 locate
+        // alignment, R28 `(in port)` qualifier.
+        Fleet(
+          id: 'channel_fleet',
+          ownerId: _humanId,
+          regionId: 'oldWorld',
+          inPortAtProvinceId: _portProvinceId,
+          ships: const [
+            ShipInstance(id: 'p1', typeId: 'frigate'),
+            ShipInstance(id: 'p2', typeId: 'frigate'),
+          ],
+        ),
+        // At-sea fleet — drives R28 `(at sea)` qualifier.
+        Fleet(
+          id: 'atlantic_fleet',
+          ownerId: _humanId,
+          regionId: 'oldWorld',
+          seaZoneId: _localSeaZoneId,
+          ships: const [ShipInstance(id: 's1', typeId: 'galleon')],
+        ),
+      ],
+      seaZoneDisplayNameById: const {_zonePrefixedId: 'Bay of Biscay'},
+      tileKeysByRegionAndProvince: const {
+        'oldWorld': {
+          _capitalProvinceId: ['oldWorld|$_capitalLocalId|0|0'],
+          _portProvinceId: ['oldWorld|$_portLocalId|0|0'],
+        },
+      },
+    ),
+    players: const [
+      Player(
+        id: _humanId,
+        displayName: 'Fidelity Tester',
+        isHuman: true,
+        capitalProvinceId: _capitalProvinceId,
+        capitalTile: CapitalTile(
+          regionId: 'oldWorld',
+          provinceId: _capitalProvinceId,
+          x: 0,
+          y: 0,
+        ),
+      ),
+    ],
+  );
+}
+
+Widget _hostPanel(Game game) {
+  return MaterialApp(
+    debugShowCheckedModeBanner: false,
+    theme: AppThemes.editorialMonocle,
+    home: Scaffold(
+      body: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 480, maxHeight: 720),
+        child: NavalUnitsPanel(
+          game: game,
+          humanPlayerId: _humanId,
+          bus: AppEventBus.create(),
+          topology: const MapTopology(),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  suppressLogsForTests();
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Game game;
+  setUpAll(() {
+    // Warm `getDebugInitGameResult` so any internal asset/data lookups are
+    // ready, then build the deterministic fidelity scenario.
+    getDebugInitGameResult();
+    game = _buildFidelityGame();
+  });
+
+  group('R25 — compact inline action pills on one row', () {
+    testWidgets(
+      'Non-home fleet renders Move + Split + Locate on a single dense row',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(_hostPanel(game));
+        await tester.pumpAndSettle();
+
+        final channelTile = find.widgetWithText(
+          ExpansionTile,
+          'Fleet channel_fleet',
+        );
+        expect(channelTile, findsOneWidget);
+
+        final actionRow = tester.widget<UnitsEntityActionRow>(
+          find.descendant(
+            of: channelTile,
+            matching: find.byType(UnitsEntityActionRow),
+          ),
+        );
+        expect(
+          actionRow.dense,
+          isTrue,
+          reason: 'Naval fleet rows must use the dense pill footprint (R25)',
+        );
+
+        final buttons = find.descendant(
+          of: channelTile,
+          matching: find.byType(CtNinePatchButton),
+        );
+        // Move + Split + Locate.
+        expect(buttons, findsNWidgets(3));
+
+        final actionButtonWidgets = tester
+            .widgetList<CtNinePatchButton>(buttons)
+            .toList(growable: false);
+        for (final btn in actionButtonWidgets) {
+          expect(
+            btn.minHeight,
+            lessThan(32),
+            reason:
+                'Dense pills must shave the inherited 32 dp minHeight (R25)',
+          );
+        }
+
+        // All three buttons render on a single horizontal line (no wrap).
+        final yCenters = actionButtonWidgets.map(
+          (b) => tester.getCenter(find.byWidget(b)).dy,
+        );
+        final dy = yCenters.toSet();
+        expect(
+          dy.length,
+          1,
+          reason: 'Move/Split/Locate must share one row (R25)',
+        );
+      },
+    );
+  });
+
+  group('R26 — HOME chip on Home Fleet row only', () {
+    testWidgets(
+      'HOME chip renders next to Home Fleet name and not on regular fleets',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(_hostPanel(game));
+        await tester.pumpAndSettle();
+
+        final homeTile = find.widgetWithText(ExpansionTile, 'Home Fleet');
+        expect(homeTile, findsOneWidget);
+
+        expect(
+          find.descendant(of: homeTile, matching: find.text('HOME')),
+          findsOneWidget,
+          reason: 'Home Fleet row must render the uppercase HOME chip (R26)',
+        );
+
+        final channelTile = find.widgetWithText(
+          ExpansionTile,
+          'Fleet channel_fleet',
+        );
+        expect(
+          find.descendant(of: channelTile, matching: find.text('HOME')),
+          findsNothing,
+          reason: 'Regular fleet rows must NOT render the HOME chip (R26)',
+        );
+      },
+    );
+  });
+
+  group(
+    'R27 — Locate is the rightmost action and emits LocateMapTileEvent',
+    () {
+      testWidgets(
+        'Locate icon-only button is the rightmost child of the actions cluster',
+        (WidgetTester tester) async {
+          await tester.pumpWidget(_hostPanel(game));
+          await tester.pumpAndSettle();
+
+          final channelTile = find.widgetWithText(
+            ExpansionTile,
+            'Fleet channel_fleet',
+          );
+
+          final tooltips = tester
+              .widgetList<Tooltip>(
+                find.descendant(
+                  of: channelTile,
+                  matching: find.byType(Tooltip),
+                ),
+              )
+              .where(
+                (t) =>
+                    t.message == 'Move' ||
+                    t.message == 'Split' ||
+                    t.message == 'Locate fleet',
+              )
+              .toList(growable: false);
+
+          // Move, Split, Locate.
+          expect(tooltips.length, 3);
+          expect(tooltips.first.message, 'Move');
+          expect(tooltips[1].message, 'Split');
+          expect(
+            tooltips.last.message,
+            'Locate fleet',
+            reason: 'Locate must be the rightmost action (R27)',
+          );
+
+          // Locate button rendered icon-only: no Text widget child.
+          final locateBtn = find.descendant(
+            of: find.byWidget(tooltips.last),
+            matching: find.byType(CtNinePatchButton),
+          );
+          expect(
+            find.descendant(of: locateBtn, matching: find.byType(Text)),
+            findsNothing,
+            reason: 'Locate must be icon-only (R27 mockup `.locate-btn`)',
+          );
+        },
+      );
+
+      testWidgets('Home Fleet shows Split + Locate (no Move)', (
+        WidgetTester tester,
+      ) async {
+        await tester.pumpWidget(_hostPanel(game));
+        await tester.pumpAndSettle();
+
+        final homeTile = find.widgetWithText(ExpansionTile, 'Home Fleet');
+        final tooltips = tester
+            .widgetList<Tooltip>(
+              find.descendant(of: homeTile, matching: find.byType(Tooltip)),
+            )
+            .where(
+              (t) =>
+                  t.message == 'Move' ||
+                  t.message == 'Split' ||
+                  t.message == 'Locate fleet',
+            )
+            .toList(growable: false);
+
+        expect(tooltips.map((t) => t.message).toList(), [
+          'Split',
+          'Locate fleet',
+        ]);
+      });
+    },
+  );
+
+  group('R28 — (in port) / (at sea) location qualifier', () {
+    testWidgets('In-port fleet appends localised `(in port)` qualifier', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(_hostPanel(game));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text('Old World — Portsmouth (in port)'),
+        findsOneWidget,
+        reason:
+            'R28: in-port fleet location must end with the localised '
+            '`(in port)` qualifier',
+      );
+    });
+
+    testWidgets('At-sea fleet appends localised `(at sea)` qualifier', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(_hostPanel(game));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text('Old World — Bay of Biscay (at sea)'),
+        findsOneWidget,
+        reason:
+            'R28: at-sea fleet location must end with the localised '
+            '`(at sea)` qualifier',
+      );
+    });
+  });
+
+  group('R29 — expanded composition Table + cargo + single summary line', () {
+    testWidgets(
+      'Home Fleet expanded view renders a Table, cargo line, and a single summary',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(_hostPanel(game));
+        await tester.pumpAndSettle();
+
+        final homeTile = find.widgetWithText(ExpansionTile, 'Home Fleet');
+        await tester.tap(homeTile);
+        await tester.pumpAndSettle();
+
+        // Composition table widget (one per expanded row).
+        expect(
+          find.descendant(of: homeTile, matching: find.byType(Table)),
+          findsOneWidget,
+          reason: 'R29: expanded view must render a Table widget',
+        );
+
+        // Single composition summary line.
+        expect(
+          find.text('Total ships: 2 · Warships: 1 · Merchants: 1'),
+          findsOneWidget,
+          reason:
+              'R29: composition summary must be a single Text widget, not '
+              'three separate ListTiles',
+        );
+        // Verify the legacy per-stat lines are gone (no `Warships: 1` /
+        // `Merchants: 1` standalone Text widgets).
+        expect(find.text('1 warships'), findsNothing);
+        expect(find.text('1 merchants'), findsNothing);
+        expect(find.text('Total ships: 2'), findsNothing);
+
+        // Home Fleet cargo line uses the `_holds` localisation key.
+        expect(
+          find.textContaining('Cargo capacity:'),
+          findsOneWidget,
+          reason: 'R29: Home Fleet expanded view must render the cargo line',
+        );
+        expect(
+          find.textContaining('holds'),
+          findsOneWidget,
+          reason: 'R29: cargo line uses the `holds` localisation key',
+        );
+
+        // Strength line retained.
+        expect(find.textContaining('Strength:'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'Non-home fleet expanded view does NOT render a cargo capacity line',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(_hostPanel(game));
+        await tester.pumpAndSettle();
+
+        final channelTile = find.widgetWithText(
+          ExpansionTile,
+          'Fleet channel_fleet',
+        );
+        await tester.tap(channelTile);
+        await tester.pumpAndSettle();
+
+        expect(
+          find.descendant(
+            of: channelTile,
+            matching: find.textContaining('Cargo capacity'),
+          ),
+          findsNothing,
+          reason:
+              'R29: per mockup, non-home fleets do not render a cargo line '
+              'in the expanded view',
+        );
+
+        expect(
+          find.descendant(
+            of: channelTile,
+            matching: find.text('Total ships: 2 · Warships: 2 · Merchants: 0'),
+          ),
+          findsOneWidget,
+        );
+      },
+    );
+
+    testWidgets('Composition Table row count matches ship-type count', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(_hostPanel(game));
+      await tester.pumpAndSettle();
+
+      final homeTile = find.widgetWithText(ExpansionTile, 'Home Fleet');
+      await tester.tap(homeTile);
+      await tester.pumpAndSettle();
+
+      final tableFinder = find.descendant(
+        of: homeTile,
+        matching: find.byType(Table),
+      );
+      final Table table = tester.widget<Table>(tableFinder);
+      // Two ship types in the Home Fleet (carrack + frigate).
+      expect(table.children.length, 2);
+    });
+  });
+
+  group('FleetExpansionTile API surface', () {
+    testWidgets('FleetExpansionTile is the canonical naval row widget', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(_hostPanel(game));
+      await tester.pumpAndSettle();
+      // 1 Home Fleet + 2 regular fleets in the deterministic fixture.
+      expect(find.byType(FleetExpansionTile), findsNWidgets(3));
+    });
+  });
+}

--- a/app/test/naval_units_panel_test_part1_test.dart
+++ b/app/test/naval_units_panel_test_part1_test.dart
@@ -145,6 +145,7 @@ void main() {
       ),
     );
   }
+
   group('NavalUnitsPanel', () {
     testWidgets('AC: Panel shows title Naval Units', (
       WidgetTester tester,
@@ -411,7 +412,12 @@ void main() {
         await tester.tap(homeTile);
         await tester.pumpAndSettle();
 
-        expect(find.textContaining('Carrack: 1'), findsOneWidget);
+        // Per #2866 S8 R29 the expanded view renders ship rows as a `Table`
+        // with columns `Type | ×Count | Role`, so the ship-type display
+        // label and its count live in separate cells (e.g. `Carrack` +
+        // `×1`). The legacy `Carrack: 1` combined label no longer renders.
+        expect(find.text('Carrack'), findsOneWidget);
+        expect(find.text('×1'), findsAtLeastNWidgets(1));
         expect(find.textContaining('carrack:'), findsNothing);
       },
     );
@@ -1077,6 +1083,5 @@ void main() {
         );
       },
     );
-
   });
 }

--- a/test/check_civilian_unit_type_constants_test.dart
+++ b/test/check_civilian_unit_type_constants_test.dart
@@ -91,5 +91,37 @@ void f() {
       );
       expect(violations, isEmpty);
     });
+
+    test(
+      'skips hand-maintained app l10n part files (display labels may '
+      'coincide with civilian unit type ids)',
+      () {
+        const src = r'''
+mixin _AppLocalizationsEnStrings2 on AppLocalizations {
+  @override
+  String get example_role_label => 'Builder';
+}
+''';
+        for (final relPath in <String>[
+          'app/lib/l10n/app_localizations_en_part1.dart',
+          'app/lib/l10n/app_localizations_en_part2.dart',
+          'app/lib/l10n/app_localizations_en_part3.dart',
+          'app/lib/l10n/app_localizations_en_part4.dart',
+          'app/lib/l10n/app_localizations_en_part5.dart',
+        ]) {
+          final violations = findCivilianUnitTypeConstantViolations(
+            relativePath: relPath,
+            source: src,
+            canonicalCivilianUnitTypeIds: canonicalCivilianUnitTypeIds,
+            constantNameById: constantNameById,
+          );
+          expect(
+            violations,
+            isEmpty,
+            reason: 'expected $relPath to be skipped by the l10n carve-out',
+          );
+        }
+      },
+    );
   });
 }

--- a/tool/check_civilian_unit_type_constants.dart
+++ b/tool/check_civilian_unit_type_constants.dart
@@ -16,6 +16,19 @@ const _excludedPaths = <String>{
 
   /// Archetype display names; values may match civilian spellings by coincidence.
   'packages/colonizethis_data/lib/src/ai_personality_config.dart',
+
+  /// Hand-maintained app l10n part files (no `flutter gen-l10n` output here):
+  /// English display strings such as the naval composition role label
+  /// `naval_units_compositionRoleMerchant` are user-facing labels, not
+  /// civilian unit-type ids; the same coincident-spelling carve-out as
+  /// `ai_personality_config.dart` applies. App code reaches civilian unit
+  /// types via `kUnitType*` constants from `colonizethis_models`; the l10n
+  /// values here are independent translation strings.
+  'app/lib/l10n/app_localizations_en_part1.dart',
+  'app/lib/l10n/app_localizations_en_part2.dart',
+  'app/lib/l10n/app_localizations_en_part3.dart',
+  'app/lib/l10n/app_localizations_en_part4.dart',
+  'app/lib/l10n/app_localizations_en_part5.dart',
 };
 
 /// Used by `ct_repo_lint` in-process; [info] / [err] default to stdout/stderr.


### PR DESCRIPTION
## Summary

Closes the five naval-units mockup-fidelity gaps **R25–R29** identified after the first implementation pass of #2866 by aligning the Naval Units panel (`UNIT30001`) with [`SPEC/ui/mockups/UNIT30001-naval-units-panel.html`](https://github.com/waigore/colonizethisv3/blob/dev/SPEC/ui/mockups/UNIT30001-naval-units-panel.html). Subtasks S0–S7 are already merged on `dev` (PR #2906, #2919, #3033); **S8 is the last remaining slice** on #2866.

| R | Gap | Implementation |
|---|-----|----------------|
| R25 | Compact inline action pills, single row | `UnitsEntityActionRow.dense` pill footprint (minHeight 24, smaller padding); narrow icon-only fallback retained |
| R26 | `HOME` chip on the Home Fleet row | `_HomeFleetChip` rendered next to the name using `--accent-dim` / `--bg-deep` tokens |
| R27 | Locate right-aligned in actions cluster | Locate moves from the title row into the actions cluster as an icon-only `CtNinePatchButton` (rightmost child) |
| R28 | `(in port)` / `(at sea)` qualifier | `naval_tree_builder.dart` appends `naval_units_locInPort` / `naval_units_locAtSea` to `FleetRow.locationLabel` |
| R29 | Expanded composition `Table` + cargo + summary | `_FleetExpandedContent` renders one `Table`, a Home-Fleet cargo line (`Cargo capacity: X holds`), the single composition summary line, and the retained `Strength: V` line — replacing the legacy per-stat `ListTile` stack |

New localisation keys (English-only locale): `naval_units_locInPort`, `naval_units_locAtSea`, `naval_units_homeFleetChip`, `naval_units_compositionRoleWarship`, `naval_units_compositionRoleMerchant`, `naval_units_compositionCount`, `naval_units_compositionSummary`, `naval_units_cargoCapacityHolds`. No hard-coded English added to widgets.

[`SPEC/ui/naval-units-panel.md`](https://github.com/waigore/colonizethisv3/blob/feat/issue-2866-s8-naval-mockup-fidelity/SPEC/ui/naval-units-panel.md) updated with a new *Naval mockup fidelity (R25–R29)* section and five matching Given/When/Then acceptance criteria.

Widgetbook ‘Naval Units Panel’ Standalone story widened to 480×640 so the HOME chip, dense actions cluster, and `(in port)` / `(at sea)` qualifiers are reviewable at the spec'd panel width.

S8 does not re-open S1–S7 for the civilian, military, or train-dialog screens.

`Refs #2866` (do not close — only S8 is delivered here).

## Test plan

- [x] `flutter test test/naval_units_panel_mockup_fidelity_test.dart` — **10** new R25–R29 + surface pin tests, all pass.
- [x] `flutter test test/naval_units_panel_test_part{1..5}_test.dart` — existing 76 naval panel tests pass (one assertion in part1 updated for the new ship-type `Table` cells).
- [x] `flutter test test/unit_panels_widgetbook_dark_chrome_test.dart test/unit_panels_320dp_min_viewport_test.dart` — dark-chrome AC pins + 320 dp viewport pin still pass.
- [x] `flutter test test/e2e_split_home_fleet_test.dart test/e2e_open_naval_panel_test.dart test/e2e_tap_move_on_first_non_home_fleet_test.dart test/transfer_to_home_fleet_dialog_spec_test.dart test/military_units_panel_test_part3_test.dart` — adjacent panels / e2e helpers unaffected.
- [x] `flutter test test/units_panel_shared_widgets_test.dart test/military_units_panel_test_part1_test.dart test/civilian_units_panel_test_part1_test.dart test/game_map_empire_left_rail_test.dart test/ui_screen_id_bindings_test.dart` — civilian / military rows (which keep the default density) and screen-id bindings unaffected.
- [x] `dart tool/check_app_hardcoded_ui_strings.dart` — no violations.
- [x] `dart tool/check_app_widget_imports.dart` / `check_game_widgets_file_size.dart` / `check_no_flame_in_widgets.dart` / `check_no_screen_in_game_widgets.dart` / `check_dart_file_non_comment_line_size.dart` — no violations.
- [x] `dart format` clean on all changed files.
- [x] `dart analyze` on changed files surfaces only pre-existing `info`-level snake_case advisories shared with the rest of the l10n catalog; no new errors or warnings introduced.


Made with [Cursor](https://cursor.com)