### PR TITLE
feat(ui): trade screen Market tab cargo indicator + cap + warning (Refs #2993 E5c)

### DIFF
--- a/SPEC/ui/trade-screen.md
+++ b/SPEC/ui/trade-screen.md
@@ -4,7 +4,7 @@
 **SPEC/ui** — Full-screen World Market trade surface. Implementation: `app/lib/features/game/screens/trade_screen.dart`.
 **Widgetbook:** `Trade Screen` → `app/lib/widgetbook/catalog.dart`. Game rules: [world-market.md](../game/world-market.md); resolution algorithm: [world-market-resolution.md](../program/world-market-resolution.md); core data model deferred to issue [#2989](https://github.com/waigore/colonizethisv3/issues/2989); UI scope tracked in issue [#2993](https://github.com/waigore/colonizethisv3/issues/2993). Parent design: [issue #2988](https://github.com/waigore/colonizethisv3/issues/2988).
 
-> **Status:** Draft. This document records the contract for the scaffold slices: E1+E2+E3 ship the route, screen ID, left-rail button, and dark editorial-monocle chrome; E4 lands the durable two-tab body structure (Market + Deal Book). The Market tab now renders the **commodity table with interactive bid/offer/none direction selector + quantity stepper** (`#2993` E5a + E5b) sourced from `Game.worldMarketState` and `currentOrdersProvider`. Each row shows last market price + previous-turn aggregate `Bids / Offers` volumes alongside the interactive controls; the controls write `Orders.tradeOrdersByPlayerId[player.id]` via the pure helpers `applyTradeOrderForPlayer` / `removeTradeOrderForPlayer` in `colonizethis_logic`. The remaining Market controls (priority dropdown, cargo-remaining indicator) ship in follow-up `#2993` E5c slices, and the Deal Book live ledger ships in `#2993` E6 once a per-player ledger surface lands on top of #2989 / #2990's `MarketActivity` + world-market turn phase.
+> **Status:** Draft. This document records the contract for the scaffold slices: E1+E2+E3 ship the route, screen ID, left-rail button, and dark editorial-monocle chrome; E4 lands the durable two-tab body structure (Market + Deal Book). The Market tab now renders the **commodity table with interactive bid/offer/none direction selector + quantity stepper + cross-commodity cargo indicator and warning** (`#2993` E5a + E5b + E5c) sourced from `Game.worldMarketState`, `Game.worldState.fleets` (via `cargoHoldsForHomeFleet`), and `currentOrdersProvider`. Each row shows last market price + previous-turn aggregate `Bids / Offers` volumes alongside the interactive controls; the controls write `Orders.tradeOrdersByPlayerId[player.id]` via the pure helpers `applyTradeOrderForPlayer` / `removeTradeOrderForPlayer` in `colonizethis_logic`, and the cross-commodity bid total is clamped to the player's trade cargo capacity. The remaining Market control (priority dropdown) ships when the data API in #2989 exposes `kMaxTradePriority`, and the Deal Book live ledger ships in `#2993` E6 once a per-player ledger surface lands on top of #2989 / #2990's `MarketActivity` + world-market turn phase.
 
 ---
 
@@ -31,6 +31,8 @@ The screen exposes static keys consumed by widget tests:
 - `TradeScreen.marketRowDecrementKey(CommodityId)` — `ValueKey<String>('tradeScreenMarketRow:<id>:decrement')` (per-row stepper `−` button; decrements `TradeOrder.quantity` by 1, clamped at `marketRowQuantityMin = 1` — Refs `#2993` E5b).
 - `TradeScreen.marketRowIncrementKey(CommodityId)` — `ValueKey<String>('tradeScreenMarketRow:<id>:increment')` (per-row stepper `+` button; increments `TradeOrder.quantity` by 1 — Refs `#2993` E5b).
 - `TradeScreen.marketRowQuantityTextKey(CommodityId)` — `ValueKey<String>('tradeScreenMarketRow:<id>:quantity')` (per-row quantity readout; renders the staged `TradeOrder.quantity` or `marketRowQuantityIdleGlyph` (`—`) when no direction is staged — Refs `#2993` E5b).
+- `TradeScreen.marketCargoIndicatorKey` — `ValueKey<String>('tradeScreenMarketCargoIndicator')` (persistent header strip above the commodity list; renders the `Cargo remaining: X` text where `X = max(0, tradeCargoCapacity − totalStagedBidQuantity)` for the human player — Refs `#2993` E5c).
+- `TradeScreen.marketCargoWarningKey` — `ValueKey<String>('tradeScreenMarketCargoWarning')` (per-screen warning row rendered immediately below the cargo indicator when `remainingCargo == 0` AND `totalStagedBidQuantity > 0`; absent otherwise — Refs `#2993` E5c).
 - `TradeScreen.dealBookTabBodyKey` — `ValueKey<String>('tradeScreenDealBookTabBody')` (Deal Book tab body root; visible after the user taps the `Deal Book` label).
 
 ---
@@ -65,21 +67,27 @@ Padding (16 dp)
         └── tabViews (IndexedStack)
             ├── _MarketTabContent      // keyed `tradeScreenMarketTabBody`
             │   └── (Opacity + IgnorePointer when `canMutateViaUi == false`)
-            │       └── SingleChildScrollView (keyed `tradeScreenMarketCommodityList`)
-            │           └── Column (one row per tradeable commodity, 22 rows)
-            │               └── Padding (keyed `tradeScreenMarketRow:<id>`)
-            │                   └── _MarketCommodityRow
-            │                       ├── Row
-            │                       │   ├── Text <displayName> (titleSmall, --accent)
-            │                       │   └── Text <price | "—"> (titleSmall, --accentBright)
-            │                       ├── Text 'Bids N / Offers M' (bodySmall, --muted)
-            │                       └── Wrap (per-row interactive controls — Refs #2993 E5b)
-            │                           ├── CtChoiceChip 'None'  (`...:none`)
-            │                           ├── CtChoiceChip 'Bid'   (`...:bid`)
-            │                           ├── CtChoiceChip 'Offer' (`...:offer`)
-            │                           ├── _StepperButton '−'   (`...:decrement`)
-            │                           ├── Text <quantity | '—'> (`...:quantity`)
-            │                           └── _StepperButton '+'   (`...:increment`)
+            │       └── Column
+            │           ├── Text 'Cargo remaining: X' (`tradeScreenMarketCargoIndicator`,
+            │           │     bodySmall, --accent — Refs #2993 E5c)
+            │           ├── Text 'Cargo limit reached …' (`tradeScreenMarketCargoWarning`,
+            │           │     bodySmall, --danger — only when remainingCargo == 0
+            │           │     AND totalStagedBidQuantity > 0)
+            │           └── SingleChildScrollView (keyed `tradeScreenMarketCommodityList`)
+            │               └── Column (one row per tradeable commodity, 22 rows)
+            │                   └── Padding (keyed `tradeScreenMarketRow:<id>`)
+            │                       └── _MarketCommodityRow
+            │                           ├── Row
+            │                           │   ├── Text <displayName> (titleSmall, --accent)
+            │                           │   └── Text <price | "—"> (titleSmall, --accentBright)
+            │                           ├── Text 'Bids N / Offers M' (bodySmall, --muted)
+            │                           └── Wrap (per-row interactive controls — Refs #2993 E5b)
+            │                               ├── CtChoiceChip 'None'  (`...:none`)
+            │                               ├── CtChoiceChip 'Bid'   (`...:bid`)
+            │                               ├── CtChoiceChip 'Offer' (`...:offer`)
+            │                               ├── _StepperButton '−'   (`...:decrement`)
+            │                               ├── Text <quantity | '—'> (`...:quantity`)
+            │                               └── _StepperButton '+'   (`...:increment`)
             └── _DealBookTabPlaceholder // keyed `tradeScreenDealBookTabBody`
                 └── CtPanel
                     ├── Text 'Deal Book' (titleMedium, --accent)
@@ -96,15 +104,29 @@ The Market tab body is the read-only commodity table (`#2993` E5a). It iterates 
 
 The Deal Book placeholder body uses canonical palette tokens only and carries copy naming the parent and depending issues (`#2989`, `#2990`, `#2993` E6) so reviewers can see which follow-up unlocks its live ledger.
 
-### Body (planned — follow-up `#2993` E5c + E6)
+### Cargo indicator + per-stepper cap + warning (`#2993` E5c)
 
-The Market interactive table above is the foundation. Follow-up slices extend each commodity row in place inside the same tab strip:
+Above the commodity list the Market tab body renders a persistent header column with two text rows:
+
+- `tradeScreenMarketCargoIndicator` — `Cargo remaining: X` where `X = max(0, tradeCargoCapacity − totalStagedBidQuantity)`. `tradeCargoCapacity` is `cargoHoldsForHomeFleet(game, player.id)` (the home-fleet cargo holds, falling back to `defaultCargoHoldsStub = 24` when the player has no home fleet yet). `totalStagedBidQuantity` is the sum of `TradeOrder.quantity` across all staged `TradeOrderType.bid` orders for `player.id` in `currentOrdersProvider`. The text is live: as bids are incremented / decremented / toggled to offers / removed via the `None` chip, the indicator updates immediately. Offers do not consume cargo (per `#2988` § Cargo Constraint Model) and are excluded from the sum.
+- `tradeScreenMarketCargoWarning` — only mounted when `remainingCargo == 0` AND `totalStagedBidQuantity > 0`. Renders the literal `Cargo limit reached — increase your fleet capacity or reduce bids.` in `EditorialMonoclePalette.danger` (`bodySmall`). When `remainingCargo > 0` or `totalStagedBidQuantity == 0`, this widget is **absent** from the tree (`find.byKey(marketCargoWarningKey)` resolves to zero widgets).
+
+The per-row bid stepper and direction chips honour the cross-commodity cap:
+
+- **Increment a staged bid:** allowed only when `remainingCargo > 0`. When `remainingCargo == 0`, the increment tap is a silent no-op (`currentOrdersProvider` is not mutated) so the cross-commodity bid total never exceeds `tradeCargoCapacity`. Decrement and offer-side increment / decrement are unaffected by the cap (offers do not consume cargo and decrementing a bid only frees cargo).
+- **Toggle a row to `Bid` from `None` / `Offer`:** allowed only when at least 1 unit fits — i.e. the row's `maxAllowedBidQuantity = remainingCargo + priorBidContribution > 0`, where `priorBidContribution` is the row's prior `TradeOrder.quantity` when its prior direction was already `Bid` (and 0 otherwise). The new staged `TradeOrder.quantity` is `min(desiredQuantity, maxAllowedBidQuantity)` where `desiredQuantity` is the prior `TradeOrder.quantity` (preserved across direction changes) when it exists, otherwise `marketRowQuantityDefault` (1). When `maxAllowedBidQuantity <= 0` the toggle is a silent no-op and the row remains in its prior direction.
+- **Toggle a row to `Offer` / `None`:** never blocked by cargo (offers and `None` free or don't consume cargo).
+
+`tradeCargoCapacity == 0` is a valid state: the indicator renders `Cargo remaining: 0`, no bids can be staged via direction toggle or increment, and the warning row is absent until at least one bid is staged (which itself is impossible at capacity 0, so the warning row never mounts at capacity 0 — the indicator alone communicates the no-cargo state).
+
+### Body (planned — follow-up `#2993` E5b cont. + E6)
+
+The Market interactive table above plus the E5c cargo indicator are the foundation. Follow-up slices extend each commodity row in place inside the same tab strip:
 
 - **Market tab — priority dropdown (`#2993` E5b cont.):** integer dropdown bounded by the `kMaxTradePriority` (or equivalent) value exposed by the data API in `#2989`. The current slice defaults staged trade orders to priority 1 and flags the integration for the follow-up bound.
-- **Market tab — cargo indicator (`#2993` E5c):** persistent header strip above the commodity list shows `Cargo remaining: X` and clamps any bid stepper that would exceed the cross-commodity cap.
 - **Deal Book tab (E6):** two-panel ledger of the previous turn's filled / partial / unfilled bids and offers, with treasury totals.
 
-When E5c / E6 land, replace the relevant subsections of this document (header strip, ledger layout) without changing the surrounding tab strip / `CtPanel` / padding chrome — the tab structure stays the same.
+When E6 lands, replace the relevant subsections of this document (ledger layout) without changing the surrounding tab strip / `CtPanel` / padding chrome — the tab structure stays the same.
 
 ---
 
@@ -129,12 +151,15 @@ When E5c / E6 land, replace the relevant subsections of this document (header st
 | Per-row `Offer` chip (`marketRowOfferChipKey`) | `canMutateViaUi == true` | `applyTradeOrderForPlayer(...TradeOrder(commodityId, type: offer, quantity: prior?.quantity ?? marketRowQuantityDefault, priority: prior?.priority ?? marketRowDefaultPriority))` written to `currentOrdersProvider`. | Stages an offer for the commodity. Mutual exclusion: replaces any prior bid. |
 | Per-row stepper `+` (`marketRowIncrementKey`) | `canMutateViaUi == true` AND a direction is staged | `applyTradeOrderForPlayer(...prior.copyWith(quantity: prior.quantity + 1))`. | Increments the staged `TradeOrder.quantity` by 1. No-op when no direction is staged. |
 | Per-row stepper `−` (`marketRowDecrementKey`) | `canMutateViaUi == true` AND staged direction has `quantity > marketRowQuantityMin` | `applyTradeOrderForPlayer(...prior.copyWith(quantity: prior.quantity − 1))`. | Decrements the staged `TradeOrder.quantity` by 1. Clamped at `marketRowQuantityMin` (1); going below 1 is reached via the `None` chip. |
+| Per-row stepper `+` on a `Bid` row when `remainingCargo == 0` | `canMutateViaUi == true` AND staged `TradeOrderType.bid` AND `remainingCargo == 0` | No-op — `currentOrdersProvider` is **not** mutated. | Cross-commodity bid total stays at `tradeCargoCapacity`; the `tradeScreenMarketCargoWarning` row remains mounted (it was already mounted at saturation). |
+| Per-row `Bid` chip when toggle would exceed cargo (`maxAllowedBidQuantity > 0` AND `desiredQuantity > maxAllowedBidQuantity`) | `canMutateViaUi == true` | `applyTradeOrderForPlayer(... TradeOrder(type: bid, quantity: maxAllowedBidQuantity, …))`. | Staged bid is clamped to the remaining cargo (`desiredQuantity` falls back from the prior `quantity` to the remaining cargo when it is smaller). |
+| Per-row `Bid` chip when no bid fits (`maxAllowedBidQuantity <= 0`) | `canMutateViaUi == true` | No-op — `currentOrdersProvider` is **not** mutated. | Row stays in its prior direction; cross-commodity bid total stays at `tradeCargoCapacity`; the `tradeScreenMarketCargoWarning` row remains mounted. |
 
 Observe-mode (`canMutateViaUi == false`, distinct from the global-observe / panels-not-defined sentinel covered by variant `c`): the Market tab body is wrapped in `IgnorePointer` and dimmed by an `Opacity` of `0.7`; the chips and stepper buttons remain mounted (so the static read-only data renders) but taps are blocked and `currentOrdersProvider` is not mutated. This matches the production-screen read-only pattern (`canEdit ? panel : IgnorePointer(child: panel)`).
 
-### Future user actions (`#2993` E5c + E6)
+### Future user actions (`#2993` E5b cont. + E6)
 
-The interactive contract for the priority dropdown, cargo-remaining indicator, cargo warning, and Deal Book read-only ledger is documented in `#2988` § UI Design. Mirror those rows into this **Behavior** table when E5c / E6 land — the tab-switch and direction-chip rows above stay untouched because the tab + row structure does not change.
+The interactive contract for the priority dropdown (bound to `kMaxTradePriority` once #2989 exposes it) and the Deal Book read-only ledger is documented in `#2988` § UI Design. Mirror those rows into this **Behavior** table when the follow-up slices land — the tab-switch, direction-chip, and cargo-indicator rows above stay untouched because the tab + row + header structure does not change.
 
 ---
 
@@ -146,7 +171,9 @@ The interactive contract for the priority dropdown, cargo-remaining indicator, c
 | `GAME60001` | Default — Deal Book tab (b) | Human player active; user has tapped the `Deal Book` tab label | Dark chrome + `_TradeScreenTabsBody` with the Deal Book tab (`tradeScreenDealBookTabBody`) foregrounded; the body remains the placeholder `CtPanel` until `#2993` E6 lands the live ledger. |
 | `GAME60001` | Observe mode (c) | `shellPanelsNotDefined(ref) == true` | Body switches to `ObserveModeNotDefinedPanel(title: 'Trade')`; the tab strip (and both tab bodies) are not mounted under this branch. |
 
-When the follow-up E5b/E5c/E6 slices land, the variant table stays as is — only each tab body's render description changes from "placeholder" / "read-only commodity table" to the live interactive Market controls / Deal Book ledger.
+When the follow-up E6 slice lands, the variant table stays as is — only the Deal Book tab body's render description changes from "placeholder" to the live ledger.
+
+The Market tab body's cargo indicator + warning state described in [§ Cargo indicator + per-stepper cap + warning (`#2993` E5c)](#cargo-indicator--per-stepper-cap--warning-2993-e5c) is an internal substate of variant `a` (Default — Market tab): the indicator row is always mounted under `tradeScreenMarketTabBody`; the warning row mounts and dismounts as the staged-bid total saturates / desaturates the player's `tradeCargoCapacity`.
 
 ---
 
@@ -166,14 +193,16 @@ When the follow-up E5b/E5c/E6 slices land, the variant table stays as is — onl
 
 Folder name **Trade Screen** in `app/lib/widgetbook/catalog.dart` (registered via `tradeScreenDirectories`).
 
-Use cases for the current slice (E1+E2+E3+E4+E5a):
+Use cases for the current slice (E1+E2+E3+E4+E5a+E5b+E5c):
 
 | Use case | Proves |
 |----------|--------|
-| `Scaffold (Market tab)` | Default mount of `TradeScreen` with the dark `CtTopBar` and `_TradeScreenTabsBody` showing the Market tab read-only commodity table selected (the initial state visited by every gameplay session). |
+| `Scaffold (Market tab)` | Default mount of `TradeScreen` with the dark `CtTopBar` and `_TradeScreenTabsBody` showing the Market tab read-only commodity table selected (the initial state visited by every gameplay session). The cargo indicator renders `Cargo remaining: 24` (home-fleet stub capacity, no staged bids). |
 | `Scaffold (mobile)` | Same default story inside `mobileViewport` (360 × 640 dp) to satisfy the per-spec mobile use case (`SPEC/ui/mobile-adaptation.md`). |
+| `Market tab — staged bid + offer (Refs #2993 E5b)` | Story Game with `currentOrdersProvider` pre-seeded so reviewers see an active `Bid` (timber, qty 4) and `Offer` (fabric, qty 7) without needing to drive the chips themselves. Cargo indicator reads `Cargo remaining: 20` (`24 − 4`). |
+| `Market tab — cargo saturated (Refs #2993 E5c)` | Story Game with `currentOrdersProvider` pre-seeded to stage bids whose total quantity equals `tradeCargoCapacity` so the cargo indicator reads `Cargo remaining: 0` and the warning row `tradeScreenMarketCargoWarning` is mounted. Reviewers can confirm the dark-theme `--danger` palette and the cargo-limit copy without touching the chips. |
 
-Follow-up E5b/E5c/E6 slices append `Market tab — interactive controls`, `Market tab — cargo warning`, `Deal Book tab — mixed fills`, etc. as the bodies land. The tab structure remains the same; only each tab body's content advances.
+Follow-up E5b cont./E6 slices append `Market tab — priority dropdown`, `Deal Book tab — mixed fills`, etc. as the bodies land. The tab structure remains the same; only each tab body's content advances.
 
 ---
 
@@ -221,6 +250,19 @@ Follow-up E5b/E5c/E6 slices append `Market tab — interactive controls`, `Marke
 - **Given** the row for commodity X has a staged `TradeOrder(type: bid)` and the user toggles a different commodity Y to `Offer`, **then** both rows have a staged TradeOrder simultaneously — `tradeOrdersByPlayerId[player.id].length == 2` — confirming mutual exclusion is per-commodity, not per-player.
 - **Given** the `TradeScreen` is mounted with `shellPlayerContextProvider.canMutateViaUi == false` (observing another GP — distinct from the `showPlayerChrome == false` global-observe sentinel covered by variant `c`), **when** the user attempts to tap any of the row's direction chips, increment, or decrement buttons, **then** `currentOrdersProvider` is **not** mutated (the Market tab body is wrapped in `IgnorePointer` so taps do not propagate); the chips and stepper remain mounted in the widget tree so the read-only data still renders.
 
-### Full screen (follow-up `#2993` E5c / E6 — implement when bodies land)
+### Market tab — cross-commodity cargo indicator + cap + warning (`#2993` E5c)
 
-Migrate the remaining parent-issue ACs from `#2988` § Acceptance criteria — UI into Given–When–Then rows under this section as each follow-up slice ships (priority dropdown bound to `kMaxTradePriority`, Deal Book ledger, cargo-remaining indicator, cargo warning).
+- **Given** the `TradeScreen` is mounted with a human player, observe mode is **not** active, the player has no home fleet (`cargoHoldsForHomeFleet` falls back to `defaultCargoHoldsStub = 24`), and `currentOrdersProvider.tradeOrdersByPlayerId[player.id]` is empty (or contains only offers), **then** the Market tab body contains exactly one widget keyed `TradeScreen.marketCargoIndicatorKey` whose visible `Text` is `Cargo remaining: 24` and **no** widget keyed `TradeScreen.marketCargoWarningKey` is mounted (`find.byKey(marketCargoWarningKey)` resolves to zero widgets).
+- **Given** the same conditions and the player has staged `TradeOrder`s totalling 7 across two commodities (e.g. `Bid` timber qty 4 + `Bid` iron qty 3), **then** the cargo indicator visible `Text` is `Cargo remaining: 17` (`24 − 7`) and the cargo warning row is still absent.
+- **Given** the player has `tradeCargoCapacity = 10` (e.g. via a home-fleet override) and has staged `Bid`s totalling 10 across commodities (`Bid` timber qty 6 + `Bid` iron qty 4), **then** the cargo indicator reads `Cargo remaining: 0` AND the cargo warning row keyed `TradeScreen.marketCargoWarningKey` is mounted with the literal text `Cargo limit reached — increase your fleet capacity or reduce bids.`.
+- **Given** the player has `tradeCargoCapacity = 10`, has staged `Bid` timber qty 6 (cargo remaining 4), and is staging on commodity X via `marketRowIncrementKey`, **when** the user repeatedly taps the `+` button on commodity X, **then** the staged quantity for commodity X increments by 1 per tap up to qty 4 (cargo remaining 0); the next `+` tap on commodity X is a silent no-op (`currentOrdersProvider` is **not** mutated), the staged TradeOrder.quantity stays at 4, the cargo indicator reads `Cargo remaining: 0`, and `tradeScreenMarketCargoWarning` is mounted.
+- **Given** the player has `tradeCargoCapacity = 10`, has staged `Bid` timber qty 6 and `Bid` iron qty 4 (cargo remaining 0), **when** the user taps the `Bid` chip on commodity grain (`marketRowBidChipKey('grain')`), **then** the toggle is a silent no-op (`currentOrdersProvider` is **not** mutated, no `TradeOrder` for grain is staged), cargo indicator stays at `Cargo remaining: 0`, and the warning row stays mounted. The cross-commodity bid total stays at 10 and never exceeds `tradeCargoCapacity`.
+- **Given** the player has `tradeCargoCapacity = 10` and a staged `Offer` for fabric qty 8 (offers don't consume cargo so cargo remaining is 10), **when** the user taps the `Bid` chip on commodity fabric (toggling fabric's direction from `Offer` to `Bid`), **then** the staged `TradeOrder` for fabric is replaced by `TradeOrder(type: bid, quantity: 8)` (the prior quantity is preserved because it fits inside cargo capacity) and the cargo indicator updates to `Cargo remaining: 2`.
+- **Given** the player has `tradeCargoCapacity = 10`, has staged `Bid` timber qty 9 (cargo remaining 1), and has a staged `Offer` for fabric qty 5, **when** the user taps the `Bid` chip on commodity fabric, **then** the staged `TradeOrder` for fabric is replaced by `TradeOrder(type: bid, quantity: 1)` (the prior 5 is clamped to the remaining cargo of 1, not the prior offer's 5) and the cargo indicator updates to `Cargo remaining: 0` and the warning row is mounted.
+- **Given** the player has `tradeCargoCapacity = 10`, has staged `Bid` timber qty 10 (cargo remaining 0), **when** the user taps the `−` button on timber (`marketRowDecrementKey('timber')`), **then** the staged `TradeOrder.quantity` for timber decrements to 9, the cargo indicator updates to `Cargo remaining: 1`, and the warning row keyed `TradeScreen.marketCargoWarningKey` is removed from the widget tree.
+- **Given** the player has `tradeCargoCapacity = 10`, has staged `Bid` timber qty 10, **when** the user taps the `None` chip on timber (`marketRowNoneChipKey('timber')`), **then** the staged `TradeOrder` for timber is removed, the cargo indicator updates to `Cargo remaining: 10`, and the warning row is removed (because `totalStagedBidQuantity == 0`).
+- **Given** the `TradeScreen` is mounted with `shellPlayerContextProvider.canMutateViaUi == false`, **then** the cargo indicator and (when applicable) warning row remain mounted with the same text values as in the editable case (they read directly from `Game` + `currentOrdersProvider` regardless of the observe-mode `IgnorePointer`).
+
+### Full screen (follow-up `#2993` E5b cont. / E6 — implement when bodies land)
+
+Migrate the remaining parent-issue ACs from `#2988` § Acceptance criteria — UI into Given–When–Then rows under this section as each follow-up slice ships (priority dropdown bound to `kMaxTradePriority`, Deal Book ledger).

--- a/app/lib/features/game/screens/trade_screen.dart
+++ b/app/lib/features/game/screens/trade_screen.dart
@@ -1,34 +1,46 @@
 // Full-screen World Market Trade screen. SPEC/ui/trade-screen.md.
 //
-// **Scope (Refs #2993 E5a + E5b):**
+// **Scope (Refs #2993 E5a + E5b + E5c):**
 // - E5a (already shipped) — route + screen ID + dark editorial-monocle
 //   chrome + observe-mode guard + two-tab body (Market + Deal Book) +
 //   read-only commodity table (last market price + previous-turn
 //   aggregate `Bids / Offers` volumes per commodity, sorted alphabetically
 //   by display name).
-// - E5b (this slice) — interactive bid/offer/none direction selector and
-//   quantity stepper per row, wired to `currentOrdersProvider` so each
-//   change updates `Orders.tradeOrdersByPlayerId[player.id]` via the
+// - E5b (already shipped) — interactive bid/offer/none direction selector
+//   and quantity stepper per row, wired to `currentOrdersProvider` so
+//   each change updates `Orders.tradeOrdersByPlayerId[player.id]` via the
 //   pure helpers `applyTradeOrderForPlayer` / `removeTradeOrderForPlayer`
 //   in `colonizethis_logic`. Mutual exclusion is structural: at most
 //   one staged `TradeOrder` per (player, commodityId) pair, so toggling
 //   from `Bid` to `Offer` (or vice versa) replaces the prior direction
-//   in place. Observe mode (the GP-observation `canMutateViaUi == false`
-//   case, distinct from the "global observe / panels not defined"
-//   sentinel) wraps the controls in `IgnorePointer` and visually dims
-//   them so the table reads as read-only.
+//   in place.
+// - E5c (this slice) — cross-commodity cargo-remaining indicator + cap +
+//   warning. A persistent header strip above the commodity list renders
+//   `Cargo remaining: X` where `X = max(0, tradeCargoCapacity − totalBid)`.
+//   `tradeCargoCapacity` is `cargoHoldsForHomeFleet(game, player.id)`
+//   (falling back to `defaultCargoHoldsStub = 24` when the player has no
+//   home fleet). `totalBid` is the sum of staged `TradeOrderType.bid`
+//   quantities for the player; offers don't consume cargo (per #2988
+//   §Cargo Constraint Model). When the cap is reached
+//   (`remainingCargo == 0 AND totalBid > 0`), a warning row is mounted
+//   below the indicator. Bid increments and `Bid` toggles are clamped
+//   so the cross-commodity bid total never exceeds `tradeCargoCapacity`.
+//
+// Observe mode (the GP-observation `canMutateViaUi == false` case,
+// distinct from the "global observe / panels not defined" sentinel)
+// wraps the controls in `IgnorePointer` and visually dims them so the
+// table reads as read-only; the cargo indicator + warning stay live
+// (they read directly from `Game` + `currentOrdersProvider`).
 //
 // Deferred to follow-up slices:
 // - Priority dropdown (default priority 1 today; integration with the
 //   `kMaxTradePriority` API surface is tracked under #2989).
-// - Cross-commodity cargo-remaining indicator + per-stepper cap +
-//   warning (Refs #2993 E5c).
 // - Deal Book live ledger (Refs #2993 E6) once the per-player ledger
 //   surface ships on top of #2989 / #2990's `MarketActivity` + world-market
 //   turn phase.
 //
-// The two-tab structure is the durable wireframe E5c / E6 continue to
-// build on, so the contract this file ships matches what
+// The two-tab structure is the durable wireframe E6 continues to build
+// on, so the contract this file ships matches what
 // `SPEC/ui/trade-screen.md` § Layout / wireframe records as the canonical
 // body for the screen.
 
@@ -180,6 +192,35 @@ class TradeScreen extends ConsumerWidget {
   /// em-dash so the visual language is consistent across the row.
   // ignore: avoid_hardcoded_strings_in_widgets
   static const String marketRowQuantityIdleGlyph = '—';
+
+  /// Stable widget key for the cross-commodity cargo indicator header
+  /// rendered above the Market tab commodity list (Refs #2993 E5c).
+  /// The widget at this key renders `Cargo remaining: X` where
+  /// `X = max(0, tradeCargoCapacity − totalStagedBidQuantity)`.
+  static const Key marketCargoIndicatorKey =
+      ValueKey<String>('tradeScreenMarketCargoIndicator');
+
+  /// Stable widget key for the cargo-limit warning row rendered below
+  /// the cargo indicator (Refs #2993 E5c). Only mounted when
+  /// `remainingCargo == 0` AND `totalStagedBidQuantity > 0`; absent
+  /// otherwise so widget tests can `expect(find.byKey(...), findsNothing)`
+  /// in the steady non-saturated state.
+  static const Key marketCargoWarningKey =
+      ValueKey<String>('tradeScreenMarketCargoWarning');
+
+  /// Localized cargo indicator prefix. SPEC/ui/trade-screen.md §
+  /// Cargo indicator pins the literal `"Cargo remaining:"` so widget
+  /// tests can drive the indicator via `find.text` without coupling to
+  /// the localization catalog before the trade screen is l10n-ised.
+  // ignore: avoid_hardcoded_strings_in_widgets
+  static const String cargoIndicatorPrefix = 'Cargo remaining:';
+
+  /// Cargo-limit warning copy rendered below the cargo indicator when
+  /// the staged cross-commodity bid total saturates the player's
+  /// `tradeCargoCapacity` (Refs #2993 E5c).
+  // ignore: avoid_hardcoded_strings_in_widgets
+  static const String cargoLimitWarningText =
+      'Cargo limit reached — increase your fleet capacity or reduce bids.';
 
   /// Stable widget key for the Deal Book tab placeholder body. Pin point
   /// for widget tests asserting the Deal Book tab body is present in the
@@ -376,10 +417,23 @@ class _MarketTabContent extends ConsumerWidget {
     final TextStyle quantityStyle =
         (theme.textTheme.titleSmall ?? const TextStyle(fontSize: 14))
             .copyWith(color: EditorialMonoclePalette.accentBright);
+    final TextStyle cargoIndicatorStyle =
+        (theme.textTheme.bodySmall ?? const TextStyle(fontSize: 12))
+            .copyWith(color: EditorialMonoclePalette.accent);
+    final TextStyle cargoWarningStyle =
+        (theme.textTheme.bodySmall ?? const TextStyle(fontSize: 12))
+            .copyWith(color: EditorialMonoclePalette.danger);
 
     final List<Commodity> rows = _tradeableCommoditiesSortedByDisplayName();
     final WorldMarketState market = game.worldMarketState;
     final Orders orders = ref.watch(currentOrdersProvider);
+
+    final int tradeCargoCapacity = cargoHoldsForHomeFleet(game, playerId);
+    final int totalStagedBid = _totalStagedBidQuantity(orders, playerId);
+    final int remainingCargo = tradeCargoCapacity - totalStagedBid;
+    final int clampedRemaining = remainingCargo < 0 ? 0 : remainingCargo;
+    final bool warningVisible =
+        clampedRemaining == 0 && totalStagedBid > 0;
 
     // SingleChildScrollView + Column (instead of ListView.builder) so
     // every commodity row is built up-front. Widget tests pin all 22
@@ -428,17 +482,60 @@ class _MarketTabContent extends ConsumerWidget {
       ),
     );
 
-    // Observe-mode (canMutateViaUi == false): wrap in IgnorePointer +
-    // Opacity so the table reads as read-only without remounting the
-    // row tree (callbacks still fire-safe when not used; the tap is
-    // simply blocked by IgnorePointer).
+    final Widget header = Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: <Widget>[
+        Text(
+          '${TradeScreen.cargoIndicatorPrefix} $clampedRemaining',
+          key: TradeScreen.marketCargoIndicatorKey,
+          style: cargoIndicatorStyle,
+        ),
+        if (warningVisible) ...<Widget>[
+          const SizedBox(height: 4),
+          Text(
+            TradeScreen.cargoLimitWarningText,
+            key: TradeScreen.marketCargoWarningKey,
+            style: cargoWarningStyle,
+          ),
+        ],
+        const SizedBox(height: 8),
+      ],
+    );
+
+    final Widget body = Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      mainAxisSize: MainAxisSize.min,
+      children: <Widget>[
+        header,
+        // Flexible so the scrollable list still wins remaining height
+        // when the body is mounted inside a constrained column (the
+        // ancestor CtPanel + IndexedStack); when unconstrained it falls
+        // back to the natural intrinsic height.
+        Flexible(child: list),
+      ],
+    );
+
+    // Observe-mode (canMutateViaUi == false): wrap the **interactive**
+    // list in IgnorePointer + Opacity so the chips and stepper read as
+    // read-only, but leave the cargo indicator + warning header live
+    // (they're read-only telemetry that should still surface state).
     if (!canEdit) {
-      return Opacity(
-        opacity: _observeModeOpacity,
-        child: IgnorePointer(child: list),
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          header,
+          Flexible(
+            child: Opacity(
+              opacity: _observeModeOpacity,
+              child: IgnorePointer(child: list),
+            ),
+          ),
+        ],
       );
     }
-    return list;
+    return body;
   }
 
   /// Visual dim factor applied to the Market tab body when the screen
@@ -468,10 +565,35 @@ class _MarketTabContent extends ConsumerWidget {
       playerId,
       commodityId,
     );
-    final int quantity =
+    final int desiredQuantity =
         prior?.quantity ?? TradeScreen.marketRowQuantityDefault;
     final int priority =
         prior?.priority ?? TradeScreen.marketRowDefaultPriority;
+
+    int quantity = desiredQuantity;
+    if (next == TradeOrderType.bid) {
+      // Refs #2993 E5c: clamp the staged bid quantity so the
+      // cross-commodity bid total never exceeds the player's
+      // tradeCargoCapacity. The row's own prior bid contribution (if
+      // any) is added back because it is already included in the
+      // running total and will be replaced by `applyTradeOrderForPlayer`.
+      final int tradeCargoCapacity =
+          cargoHoldsForHomeFleet(game, playerId);
+      final int totalStagedBid = _totalStagedBidQuantity(orders, playerId);
+      final int priorBidContribution =
+          prior?.type == TradeOrderType.bid ? prior!.quantity : 0;
+      final int maxAllowedBidQuantity =
+          (tradeCargoCapacity - totalStagedBid) + priorBidContribution;
+      if (maxAllowedBidQuantity <= 0) {
+        // Cargo budget exhausted — refuse the toggle so the row stays
+        // in its prior direction (or remains `None`). The warning row
+        // is already mounted (or will mount as soon as a bid lands).
+        return;
+      }
+      if (desiredQuantity > maxAllowedBidQuantity) {
+        quantity = maxAllowedBidQuantity;
+      }
+    }
     final TradeOrder nextOrder = TradeOrder(
       commodityId: commodityId,
       type: next,
@@ -503,6 +625,16 @@ class _MarketTabContent extends ConsumerWidget {
     final int rawNext = prior.quantity + delta;
     if (rawNext < TradeScreen.marketRowQuantityMin) return;
     if (rawNext == prior.quantity) return;
+    if (prior.type == TradeOrderType.bid && delta > 0) {
+      // Refs #2993 E5c: increment is blocked when the cross-commodity
+      // bid budget is exhausted. The row's own current quantity is
+      // already part of `totalStagedBid` — we only need any unused
+      // headroom to grow it by `delta`.
+      final int tradeCargoCapacity =
+          cargoHoldsForHomeFleet(game, playerId);
+      final int totalStagedBid = _totalStagedBidQuantity(orders, playerId);
+      if (totalStagedBid + delta > tradeCargoCapacity) return;
+    }
     final TradeOrder nextOrder = prior.copyWith(quantity: rawNext);
     final Orders updated = applyTradeOrderForPlayer(
       orders: orders,
@@ -510,6 +642,20 @@ class _MarketTabContent extends ConsumerWidget {
       order: nextOrder,
     );
     notifier.replaceAll(updated);
+  }
+
+  /// Returns the sum of `TradeOrder.quantity` across all staged
+  /// `TradeOrderType.bid` orders for [playerId] in [orders]. Offers do
+  /// not consume cargo (per `#2988` § Cargo Constraint Model) and are
+  /// excluded from the sum.
+  static int _totalStagedBidQuantity(Orders orders, String playerId) {
+    final List<TradeOrder>? list = orders.tradeOrdersByPlayerId[playerId];
+    if (list == null || list.isEmpty) return 0;
+    int total = 0;
+    for (final TradeOrder o in list) {
+      if (o.type == TradeOrderType.bid) total += o.quantity;
+    }
+    return total;
   }
 
   static String _volumeText(MarketActivity activity) {

--- a/app/lib/features/game/screens/trade_screen.dart
+++ b/app/lib/features/game/screens/trade_screen.dart
@@ -487,6 +487,7 @@ class _MarketTabContent extends ConsumerWidget {
       mainAxisSize: MainAxisSize.min,
       children: <Widget>[
         Text(
+          // ignore: avoid_hardcoded_strings_in_widgets
           '${TradeScreen.cargoIndicatorPrefix} $clampedRemaining',
           key: TradeScreen.marketCargoIndicatorKey,
           style: cargoIndicatorStyle,

--- a/app/lib/widgetbook/catalog_part6.dart
+++ b/app/lib/widgetbook/catalog_part6.dart
@@ -385,19 +385,69 @@ Orders _tradeScreenStoryStagedOrders() {
   );
 }
 
+/// Pre-staged Orders snapshot used by the "Market tab — cargo
+/// saturated (Refs #2993 E5c)" use case so reviewers see the
+/// `Cargo remaining: 0` indicator alongside the dark-theme `--danger`
+/// warning row without having to drive the stepper themselves. The
+/// story Game has no home fleet so `cargoHoldsForHomeFleet` falls back
+/// to `defaultCargoHoldsStub = 24`; saturating bids therefore total
+/// 24 across four commodities to leave room for offers on the rest.
+Orders _tradeScreenStoryCargoSaturatedOrders() {
+  return Orders(
+    tradeOrdersByPlayerId: <String, List<TradeOrder>>{
+      'gp_human': <TradeOrder>[
+        TradeOrder(
+          commodityId: 'timber',
+          type: TradeOrderType.bid,
+          quantity: 8,
+          priority: 1,
+        ),
+        TradeOrder(
+          commodityId: 'iron',
+          type: TradeOrderType.bid,
+          quantity: 6,
+          priority: 1,
+        ),
+        TradeOrder(
+          commodityId: 'grain',
+          type: TradeOrderType.bid,
+          quantity: 6,
+          priority: 1,
+        ),
+        TradeOrder(
+          commodityId: 'castIron',
+          type: TradeOrderType.bid,
+          quantity: 4,
+          priority: 1,
+        ),
+        TradeOrder(
+          commodityId: 'fabric',
+          type: TradeOrderType.offer,
+          quantity: 7,
+          priority: 1,
+        ),
+      ],
+    },
+  );
+}
+
 /// Trade screen stories. SPEC/ui/trade-screen.md.
 ///
 /// Refs #2993 E1+E2+E3+E4 ship the route, screen ID, left-rail button,
 /// dark editorial-monocle chrome, and the durable two-tab body. Refs
 /// #2993 E5a adds the Market tab's read-only commodity table sourced
-/// from `Game.worldMarketState`. Refs #2993 E5b (this slice) wires the
-/// per-row interactive bid/offer/none direction selector and quantity
-/// stepper to `currentOrdersProvider`. The story Game seeds a
-/// representative subset of `prices` + `lastTurnActivity` so reviewers
-/// can see both the populated and zero-default rendering paths in one
-/// scroll; the staged-orders use case additionally seeds a `Bid` on
-/// timber and an `Offer` on fabric so the per-row selected chip + non-1
-/// quantity readout render. The Deal Book tab body remains the
+/// from `Game.worldMarketState`. Refs #2993 E5b wires the per-row
+/// interactive bid/offer/none direction selector and quantity stepper
+/// to `currentOrdersProvider`. Refs #2993 E5c (this slice) adds the
+/// persistent cross-commodity cargo indicator + cap + saturation
+/// warning. The story Game seeds a representative subset of `prices`
+/// + `lastTurnActivity` so reviewers can see both the populated and
+/// zero-default rendering paths in one scroll; the staged-orders use
+/// case additionally seeds a `Bid` on timber and an `Offer` on fabric
+/// so the per-row selected chip + non-1 quantity readout render. The
+/// cargo-saturated use case seeds bids totalling `defaultCargoHoldsStub`
+/// (24) so the indicator reads `Cargo remaining: 0` and the dark-theme
+/// `--danger` warning row mounts. The Deal Book tab body remains the
 /// placeholder until Refs #2993 E6.
 List<WidgetbookNode> get tradeScreenDirectories => [
   WidgetbookFolder(
@@ -416,6 +466,12 @@ List<WidgetbookNode> get tradeScreenDirectories => [
         name: 'Market tab — staged bid + offer (Refs #2993 E5b)',
         builder: (context) => _tradeScreenDefaultStory(
           initialOrders: _tradeScreenStoryStagedOrders(),
+        ),
+      ),
+      WidgetbookUseCase(
+        name: 'Market tab — cargo saturated (Refs #2993 E5c)',
+        builder: (context) => _tradeScreenDefaultStory(
+          initialOrders: _tradeScreenStoryCargoSaturatedOrders(),
         ),
       ),
     ],

--- a/app/test/trade_screen_market_tab_e5c_cargo_cap_test.dart
+++ b/app/test/trade_screen_market_tab_e5c_cargo_cap_test.dart
@@ -1,0 +1,612 @@
+// Widget tests for the Market tab cross-commodity cargo-remaining
+// indicator + per-stepper cap + warning row (Refs #2993 E5c).
+// SPEC/ui/trade-screen.md § Cargo indicator + per-stepper cap +
+// warning.
+//
+// Exercises the durable contract for the E5c cargo telemetry and cap:
+//
+//  * The cargo indicator (`marketCargoIndicatorKey`) is always
+//    mounted in the Market tab body and renders `Cargo remaining: X`
+//    where `X = max(0, tradeCargoCapacity − totalStagedBidQuantity)`.
+//  * `tradeCargoCapacity` comes from `cargoHoldsForHomeFleet` and
+//    falls back to `defaultCargoHoldsStub = 24` when the player has
+//    no home fleet.
+//  * Offers do not consume cargo (per #2988 § Cargo Constraint Model).
+//  * The warning row (`marketCargoWarningKey`) is only mounted when
+//    `remainingCargo == 0` AND `totalStagedBidQuantity > 0`; absent
+//    otherwise.
+//  * Bid increments are blocked when the cross-commodity bid total
+//    would exceed `tradeCargoCapacity`; the staged TradeOrder.quantity
+//    stays at its prior value and the indicator + warning state stays
+//    consistent.
+//  * Toggling a row to `Bid` is clamped: the staged quantity =
+//    min(desiredQuantity, maxAllowedBidQuantity); the cross-commodity
+//    bid total never exceeds `tradeCargoCapacity`.
+//  * Toggling a row to `Bid` is a silent no-op when
+//    `maxAllowedBidQuantity <= 0` (cargo budget already saturated by
+//    other commodities).
+//  * Decrement and `None` free cargo: the indicator updates and the
+//    warning row is removed when the cap is no longer saturated.
+//  * Observe-mode (`canMutateViaUi == false`): the cargo indicator and
+//    warning still mount with live text values; the chip / stepper
+//    taps are blocked by the existing `IgnorePointer` wrapper.
+
+import 'package:colonizethis_app/config/themes.dart';
+import 'package:colonizethis_app/features/game/flame/region_map_component.dart'
+    show CtMapVisibilityMode;
+import 'package:colonizethis_app/features/game/screens/trade_screen.dart';
+import 'package:colonizethis_app/features/game/shell_player_context.dart';
+import 'package:colonizethis_app/providers/games_provider.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart'
+    show homeFleetIdFor;
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const String _humanPlayerId = 'gp_h';
+const String _capProvinceId = 'oldWorld|cap1';
+
+/// Builds a game whose human player has either:
+///   * no home fleet (so `cargoHoldsForHomeFleet` falls back to the
+///     `defaultCargoHoldsStub = 24`), or
+///   * a synthetic home fleet whose ship-type ids sum to
+///     [tradeCargoCapacityOverride] cargo holds (used to pin the
+///     capacity at 10 for the saturation / clamp ACs).
+///
+/// Cargo-hold totals chosen so `tradeCargoCapacity == 10`:
+///   * `galleon` (cargoHold 6) + `fluyte` (cargoHold 4) = 10.
+Game _buildGame({int? tradeCargoCapacityOverride}) {
+  final List<Fleet> fleets = <Fleet>[];
+  if (tradeCargoCapacityOverride != null) {
+    // Validate the override mapping at call-site so a stale catalog
+    // change is caught by the test runner instead of producing a
+    // mis-sized fleet.
+    final int galleonHolds = NavalStatsCatalog.galleon.cargoHold;
+    final int fluyteHolds = NavalStatsCatalog.fluyte.cargoHold;
+    if (galleonHolds + fluyteHolds != 10) {
+      throw StateError(
+        'NavalStatsCatalog cargoHold drift: '
+        'galleon=$galleonHolds + fluyte=$fluyteHolds != 10. '
+        'Update the override mapping in this test.',
+      );
+    }
+    if (tradeCargoCapacityOverride != 10) {
+      throw StateError(
+        'Only tradeCargoCapacityOverride == 10 is currently '
+        'supported by this test harness.',
+      );
+    }
+    fleets.add(
+      Fleet(
+        id: homeFleetIdFor(_humanPlayerId),
+        ownerId: _humanPlayerId,
+        regionId: 'oldWorld',
+        inPortAtProvinceId: _capProvinceId,
+        ships: const [
+          ShipInstance(id: 'h1', typeId: 'galleon'),
+          ShipInstance(id: 'h2', typeId: 'fluyte'),
+        ],
+      ),
+    );
+  }
+  return Game(
+    id: 'test_trade_screen_e5c',
+    worldState: WorldState(
+      turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+      oldWorld: const RegionData(
+        provinces: [
+          Province(
+            id: 'cap1',
+            regionId: 'oldWorld',
+            // ignore: avoid_hardcoded_strings_in_widgets
+            displayName: 'Capital',
+          ),
+        ],
+      ),
+      newWorld: const RegionData(),
+      fleets: fleets,
+    ),
+    turnTimeMapping: TurnTimeMapping.gdd01,
+    players: const [
+      // ignore: avoid_hardcoded_strings_in_widgets
+      Player(id: _humanPlayerId, displayName: 'England', isHuman: true,
+          treasury: 500),
+    ],
+    diplomacyRelations: const [],
+    diplomaticHistoryEvents: const [],
+    dossierEvidenceEntries: const [],
+    worldMarketState: const WorldMarketState(),
+  );
+}
+
+Orders _orders(List<TradeOrder> tradeOrders) {
+  return Orders(
+    tradeOrdersByPlayerId: <String, List<TradeOrder>>{
+      _humanPlayerId: tradeOrders,
+    },
+  );
+}
+
+TradeOrder _bid(CommodityId commodityId, int quantity) {
+  return TradeOrder(
+    commodityId: commodityId,
+    type: TradeOrderType.bid,
+    quantity: quantity,
+    priority: 1,
+  );
+}
+
+TradeOrder _offer(CommodityId commodityId, int quantity) {
+  return TradeOrder(
+    commodityId: commodityId,
+    type: TradeOrderType.offer,
+    quantity: quantity,
+    priority: 1,
+  );
+}
+
+/// Mirrors the E5b harness — pumps [TradeScreen] in isolation under a
+/// [ProviderScope] that exposes [currentGameProvider],
+/// [currentOrdersProvider], and a (mockable) [shellPlayerContextProvider].
+/// Uses a tall (1024 × 4096) test viewport so every alphabetical row
+/// in the 22-commodity list lays out inside the scroll view at once.
+Future<ProviderContainer> _pumpTradeScreen(
+  WidgetTester tester, {
+  required Game game,
+  Orders initialOrders = const Orders(),
+  bool canMutateViaUi = true,
+}) async {
+  final Player player = game.players.first;
+  final ProviderContainer container = ProviderContainer(
+    overrides: [
+      currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
+      currentOrdersProvider.overrideWith(
+        () => CurrentOrdersNotifier(initialOrders),
+      ),
+      shellPlayerContextProvider.overrideWith(
+        (ref) => ShellPlayerContext(
+          effectiveHumanPlayerId: player.id,
+          viewingPlayerId: player.id,
+          mapVisibilityMode: CtMapVisibilityMode.full,
+          playerView: null,
+          omniscientDetail: false,
+          showPlayerChrome: true,
+          canMutateViaUi: canMutateViaUi,
+          // ignore: avoid_hardcoded_strings_in_widgets
+          debugCommandTargetPlayerId: player.id,
+          inObservePhase: !canMutateViaUi,
+          // ignore: avoid_hardcoded_strings_in_widgets
+          observeBannerLabel: canMutateViaUi ? null : 'Observing',
+          treasuryNotDefined: false,
+          cargoNotDefined: false,
+        ),
+      ),
+    ],
+  );
+  addTearDown(container.dispose);
+  await tester.binding.setSurfaceSize(const Size(1024, 4096));
+  addTearDown(() => tester.binding.setSurfaceSize(null));
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: container,
+      child: MaterialApp(
+        theme: AppThemes.editorialMonocle,
+        home: TradeScreen(game: game, player: player),
+      ),
+    ),
+  );
+  await tester.pump();
+  return container;
+}
+
+CommodityId get _timber => CommodityCatalog.timber.id;
+CommodityId get _iron => CommodityCatalog.iron.id;
+CommodityId get _fabric => CommodityCatalog.fabric.id;
+CommodityId get _grain => CommodityCatalog.grain.id;
+
+TradeOrder? _stagedOrder(
+  ProviderContainer container,
+  CommodityId commodityId,
+) {
+  final Orders orders = container.read(currentOrdersProvider);
+  final List<TradeOrder>? list =
+      orders.tradeOrdersByPlayerId[_humanPlayerId];
+  if (list == null) return null;
+  for (final TradeOrder o in list) {
+    if (o.commodityId == commodityId) return o;
+  }
+  return null;
+}
+
+int _totalStagedBid(ProviderContainer container) {
+  final Orders orders = container.read(currentOrdersProvider);
+  final List<TradeOrder>? list =
+      orders.tradeOrdersByPlayerId[_humanPlayerId];
+  if (list == null || list.isEmpty) return 0;
+  int total = 0;
+  for (final TradeOrder o in list) {
+    if (o.type == TradeOrderType.bid) total += o.quantity;
+  }
+  return total;
+}
+
+String _cargoIndicatorText(WidgetTester tester) {
+  final Text widget = tester.widget<Text>(
+    find.byKey(TradeScreen.marketCargoIndicatorKey),
+  );
+  return widget.data ?? '';
+}
+
+void main() {
+  suppressLogsForTests();
+
+  group(
+    'TradeScreen Market tab cargo indicator + cap + warning '
+    '(Refs #2993 E5c)',
+    () {
+      testWidgets(
+        'no home fleet and no staged orders → indicator reads '
+        '"Cargo remaining: 24" (defaultCargoHoldsStub) and the '
+        'warning row is absent',
+        (tester) async {
+          await _pumpTradeScreen(tester, game: _buildGame());
+
+          expect(
+            find.byKey(TradeScreen.marketCargoIndicatorKey),
+            findsOneWidget,
+          );
+          expect(_cargoIndicatorText(tester), 'Cargo remaining: 24');
+          expect(
+            find.byKey(TradeScreen.marketCargoWarningKey),
+            findsNothing,
+          );
+        },
+      );
+
+      testWidgets(
+        'staged offers do not consume cargo → indicator stays at the '
+        'full capacity and the warning row is absent',
+        (tester) async {
+          await _pumpTradeScreen(
+            tester,
+            game: _buildGame(),
+            initialOrders: _orders(<TradeOrder>[
+              _offer(_fabric, 7),
+              _offer(_timber, 3),
+            ]),
+          );
+
+          expect(_cargoIndicatorText(tester), 'Cargo remaining: 24');
+          expect(
+            find.byKey(TradeScreen.marketCargoWarningKey),
+            findsNothing,
+          );
+        },
+      );
+
+      testWidgets(
+        'staged bids totalling 7 (timber 4 + iron 3) under capacity 24 → '
+        'indicator reads "Cargo remaining: 17" and no warning is shown',
+        (tester) async {
+          await _pumpTradeScreen(
+            tester,
+            game: _buildGame(),
+            initialOrders: _orders(<TradeOrder>[
+              _bid(_timber, 4),
+              _bid(_iron, 3),
+            ]),
+          );
+
+          expect(_cargoIndicatorText(tester), 'Cargo remaining: 17');
+          expect(
+            find.byKey(TradeScreen.marketCargoWarningKey),
+            findsNothing,
+          );
+        },
+      );
+
+      testWidgets(
+        'capacity 10 with bids totalling 10 → indicator reads '
+        '"Cargo remaining: 0" AND the warning row is mounted with '
+        'the canonical copy',
+        (tester) async {
+          await _pumpTradeScreen(
+            tester,
+            game: _buildGame(tradeCargoCapacityOverride: 10),
+            initialOrders: _orders(<TradeOrder>[
+              _bid(_timber, 6),
+              _bid(_iron, 4),
+            ]),
+          );
+
+          expect(_cargoIndicatorText(tester), 'Cargo remaining: 0');
+          expect(
+            find.byKey(TradeScreen.marketCargoWarningKey),
+            findsOneWidget,
+          );
+          expect(
+            find.text(TradeScreen.cargoLimitWarningText),
+            findsOneWidget,
+          );
+        },
+      );
+
+      testWidgets(
+        'capacity 10 with bid timber 6 (cargo remaining 4): incrementing '
+        'timber `+` four times brings staged quantity to 10 then the '
+        'fifth `+` tap is a silent no-op (cross-commodity total clamped '
+        'at 10) and the warning row mounts at saturation',
+        (tester) async {
+          final ProviderContainer container = await _pumpTradeScreen(
+            tester,
+            game: _buildGame(tradeCargoCapacityOverride: 10),
+            initialOrders: _orders(<TradeOrder>[_bid(_timber, 6)]),
+          );
+
+          expect(_cargoIndicatorText(tester), 'Cargo remaining: 4');
+          expect(
+            find.byKey(TradeScreen.marketCargoWarningKey),
+            findsNothing,
+          );
+
+          for (int i = 0; i < 4; i++) {
+            await tester
+                .tap(find.byKey(TradeScreen.marketRowIncrementKey(_timber)));
+            await tester.pump();
+          }
+          expect(_stagedOrder(container, _timber)?.quantity, 10);
+          expect(_totalStagedBid(container), 10);
+          expect(_cargoIndicatorText(tester), 'Cargo remaining: 0');
+          expect(
+            find.byKey(TradeScreen.marketCargoWarningKey),
+            findsOneWidget,
+          );
+
+          // 5th increment is blocked by the cross-commodity cap.
+          await tester
+              .tap(find.byKey(TradeScreen.marketRowIncrementKey(_timber)));
+          await tester.pump();
+          expect(
+            _stagedOrder(container, _timber)?.quantity,
+            10,
+            reason: 'Refs #2993 E5c: bid increment blocked when '
+                'cross-commodity bid total saturates tradeCargoCapacity.',
+          );
+          expect(_totalStagedBid(container), 10);
+        },
+      );
+
+      testWidgets(
+        'capacity 10 with cargo saturated (timber 6 + iron 4): tapping '
+        '`Bid` on a fresh commodity (grain) is a silent no-op — no '
+        'TradeOrder for grain is staged and the cross-commodity bid '
+        'total stays at 10',
+        (tester) async {
+          final ProviderContainer container = await _pumpTradeScreen(
+            tester,
+            game: _buildGame(tradeCargoCapacityOverride: 10),
+            initialOrders: _orders(<TradeOrder>[
+              _bid(_timber, 6),
+              _bid(_iron, 4),
+            ]),
+          );
+
+          expect(_stagedOrder(container, _grain), isNull);
+
+          await tester
+              .tap(find.byKey(TradeScreen.marketRowBidChipKey(_grain)));
+          await tester.pump();
+
+          expect(
+            _stagedOrder(container, _grain),
+            isNull,
+            reason: 'Refs #2993 E5c: Bid toggle is a no-op when '
+                'maxAllowedBidQuantity <= 0.',
+          );
+          expect(_totalStagedBid(container), 10);
+          expect(_cargoIndicatorText(tester), 'Cargo remaining: 0');
+          expect(
+            find.byKey(TradeScreen.marketCargoWarningKey),
+            findsOneWidget,
+          );
+        },
+      );
+
+      testWidgets(
+        'capacity 10 with cargo saturated and a staged offer: tapping '
+        '`Bid` on the offer row is also blocked (the prior offer '
+        'survives because the toggle is rejected)',
+        (tester) async {
+          final ProviderContainer container = await _pumpTradeScreen(
+            tester,
+            game: _buildGame(tradeCargoCapacityOverride: 10),
+            initialOrders: _orders(<TradeOrder>[
+              _bid(_timber, 6),
+              _bid(_iron, 4),
+              _offer(_fabric, 5),
+            ]),
+          );
+
+          await tester
+              .tap(find.byKey(TradeScreen.marketRowBidChipKey(_fabric)));
+          await tester.pump();
+
+          final TradeOrder? fabric = _stagedOrder(container, _fabric);
+          expect(
+            fabric?.type,
+            TradeOrderType.offer,
+            reason: 'Refs #2993 E5c: bid toggle is rejected when '
+                'maxAllowedBidQuantity <= 0; the prior offer stays.',
+          );
+          expect(fabric?.quantity, 5);
+          expect(_totalStagedBid(container), 10);
+        },
+      );
+
+      testWidgets(
+        'capacity 10 with offer fabric 8 (cargo remaining 10): tapping '
+        '`Bid` on fabric preserves the prior quantity (8 ≤ 10) and '
+        'reduces cargo remaining to 2',
+        (tester) async {
+          final ProviderContainer container = await _pumpTradeScreen(
+            tester,
+            game: _buildGame(tradeCargoCapacityOverride: 10),
+            initialOrders: _orders(<TradeOrder>[_offer(_fabric, 8)]),
+          );
+
+          expect(_cargoIndicatorText(tester), 'Cargo remaining: 10');
+
+          await tester
+              .tap(find.byKey(TradeScreen.marketRowBidChipKey(_fabric)));
+          await tester.pump();
+
+          final TradeOrder? fabric = _stagedOrder(container, _fabric);
+          expect(fabric?.type, TradeOrderType.bid);
+          expect(fabric?.quantity, 8);
+          expect(_totalStagedBid(container), 8);
+          expect(_cargoIndicatorText(tester), 'Cargo remaining: 2');
+          expect(
+            find.byKey(TradeScreen.marketCargoWarningKey),
+            findsNothing,
+          );
+        },
+      );
+
+      testWidgets(
+        'capacity 10 with bid timber 9 (cargo remaining 1) AND offer '
+        'fabric 5: tapping `Bid` on fabric clamps the new staged '
+        'quantity to the remaining cargo (1, not the prior 5)',
+        (tester) async {
+          final ProviderContainer container = await _pumpTradeScreen(
+            tester,
+            game: _buildGame(tradeCargoCapacityOverride: 10),
+            initialOrders: _orders(<TradeOrder>[
+              _bid(_timber, 9),
+              _offer(_fabric, 5),
+            ]),
+          );
+
+          expect(_cargoIndicatorText(tester), 'Cargo remaining: 1');
+
+          await tester
+              .tap(find.byKey(TradeScreen.marketRowBidChipKey(_fabric)));
+          await tester.pump();
+
+          final TradeOrder? fabric = _stagedOrder(container, _fabric);
+          expect(fabric?.type, TradeOrderType.bid);
+          expect(
+            fabric?.quantity,
+            1,
+            reason: 'Refs #2993 E5c: bid toggle clamps quantity to '
+                'maxAllowedBidQuantity (remainingCargo + priorBidContribution).',
+          );
+          expect(_totalStagedBid(container), 10);
+          expect(_cargoIndicatorText(tester), 'Cargo remaining: 0');
+          expect(
+            find.byKey(TradeScreen.marketCargoWarningKey),
+            findsOneWidget,
+          );
+        },
+      );
+
+      testWidgets(
+        'capacity 10 saturated with bid timber 10: tapping `−` on '
+        'timber frees one unit of cargo, removes the warning row, and '
+        'updates the indicator to "Cargo remaining: 1"',
+        (tester) async {
+          final ProviderContainer container = await _pumpTradeScreen(
+            tester,
+            game: _buildGame(tradeCargoCapacityOverride: 10),
+            initialOrders: _orders(<TradeOrder>[_bid(_timber, 10)]),
+          );
+
+          expect(_cargoIndicatorText(tester), 'Cargo remaining: 0');
+          expect(
+            find.byKey(TradeScreen.marketCargoWarningKey),
+            findsOneWidget,
+          );
+
+          await tester
+              .tap(find.byKey(TradeScreen.marketRowDecrementKey(_timber)));
+          await tester.pump();
+
+          expect(_stagedOrder(container, _timber)?.quantity, 9);
+          expect(_cargoIndicatorText(tester), 'Cargo remaining: 1');
+          expect(
+            find.byKey(TradeScreen.marketCargoWarningKey),
+            findsNothing,
+          );
+        },
+      );
+
+      testWidgets(
+        'capacity 10 saturated with bid timber 10: tapping `None` on '
+        'timber removes the staged TradeOrder, frees the entire cargo '
+        'budget, and removes the warning row',
+        (tester) async {
+          final ProviderContainer container = await _pumpTradeScreen(
+            tester,
+            game: _buildGame(tradeCargoCapacityOverride: 10),
+            initialOrders: _orders(<TradeOrder>[_bid(_timber, 10)]),
+          );
+
+          await tester
+              .tap(find.byKey(TradeScreen.marketRowNoneChipKey(_timber)));
+          await tester.pump();
+
+          expect(_stagedOrder(container, _timber), isNull);
+          expect(_totalStagedBid(container), 0);
+          expect(_cargoIndicatorText(tester), 'Cargo remaining: 10');
+          expect(
+            find.byKey(TradeScreen.marketCargoWarningKey),
+            findsNothing,
+          );
+        },
+      );
+
+      testWidgets(
+        'observe mode (canMutateViaUi == false): the cargo indicator '
+        'and warning row stay mounted with live text values; the chip '
+        'taps are blocked by the existing IgnorePointer wrapper so '
+        'currentOrdersProvider is not mutated',
+        (tester) async {
+          final ProviderContainer container = await _pumpTradeScreen(
+            tester,
+            game: _buildGame(tradeCargoCapacityOverride: 10),
+            initialOrders: _orders(<TradeOrder>[
+              _bid(_timber, 6),
+              _bid(_iron, 4),
+            ]),
+            canMutateViaUi: false,
+          );
+
+          expect(_cargoIndicatorText(tester), 'Cargo remaining: 0');
+          expect(
+            find.byKey(TradeScreen.marketCargoWarningKey),
+            findsOneWidget,
+          );
+
+          // Attempting to tap the increment / None chip is swallowed by
+          // IgnorePointer (`warnIfMissed: false` silences the expected
+          // hit-test warning that surfaces when the wrapper absorbs
+          // the pointer event).
+          await tester.tap(
+            find.byKey(TradeScreen.marketRowNoneChipKey(_timber)),
+            warnIfMissed: false,
+          );
+          await tester.pump();
+
+          expect(
+            _stagedOrder(container, _timber)?.quantity,
+            6,
+            reason: 'Observe mode must not mutate currentOrdersProvider.',
+          );
+          expect(_cargoIndicatorText(tester), 'Cargo remaining: 0');
+        },
+      );
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Refs #2993 — implements subtask **E5c** of the Trade Screen UI work: the persistent cross-commodity cargo-remaining indicator, per-stepper bid cap, and saturation warning row. Satisfies parent **AC #5** (cargo cap + warning), with positive and negative tests mapped 1:1 to each Given–When–Then.

### What landed in this push

- **Cargo indicator** (`marketCargoIndicatorKey`) — persistent header strip above the Market tab commodity list. Renders `Cargo remaining: X` where `X = max(0, tradeCargoCapacity − totalStagedBidQuantity)`. `tradeCargoCapacity` reads from `cargoHoldsForHomeFleet(game, player.id)` (falls back to `defaultCargoHoldsStub = 24` when the player has no home fleet). Offers do not consume cargo (per #2988 § Cargo Constraint Model).
- **Warning row** (`marketCargoWarningKey`) — only mounts when `remainingCargo == 0 AND totalStagedBidQuantity > 0`. Renders `Cargo limit reached — increase your fleet capacity or reduce bids.` in `EditorialMonoclePalette.danger`. Absent in every other state so widget tests can `findsNothing` in the steady non-saturated case.
- **Per-stepper bid cap** — bid `+` is a silent no-op when the cross-commodity bid total would exceed capacity; the staged TradeOrder quantity stays at its prior value, the indicator stays at 0, and the warning stays mounted.
- **`Bid` toggle clamp** — staged quantity = `min(desiredQuantity, remainingCargo + priorBidContribution)`. When `maxAllowedBidQuantity ≤ 0` the toggle is rejected and the row keeps its prior direction.
- **Decrement / `None`** — free cargo immediately; the warning row unmounts as soon as cargo headroom returns.
- **Observe mode** — the indicator + warning stay mounted with live text; the existing `IgnorePointer` continues to block chip / stepper taps.

### SPEC

`SPEC/ui/trade-screen.md` updated with:

- new stable keys (`marketCargoIndicatorKey`, `marketCargoWarningKey`),
- layout / wireframe entries for the new indicator + warning rows,
- a § "Cargo indicator + per-stepper cap + warning" subsection describing the live computation and the cap semantics for both stepper and `Bid` toggle,
- new Behavior rows for the blocked / clamped paths,
- updated Variants note (E5c is an internal substate of variant `a`),
- new "Market tab — cargo saturated" Widgetbook use case,
- a full Given–When–Then AC table for E5c (10 ACs).

### Tests

`app/test/trade_screen_market_tab_e5c_cargo_cap_test.dart` (12 widget tests, all green):

- (1) default capacity 24, no orders → indicator `Cargo remaining: 24`, no warning.
- (2) offer-only state → indicator stays at 24, no warning.
- (3) bids totalling 7 under cap 24 → indicator `17`, no warning.
- (4) bids totalling 10 at cap 10 → indicator `0`, warning mounted with canonical copy.
- (5) cap 10, bid timber 6: four `+` taps reach `10`, fifth `+` blocked.
- (6) cap 10 saturated: tapping `Bid` on a fresh commodity is a no-op.
- (7) cap 10 saturated + staged offer: tapping `Bid` on the offer row is rejected.
- (8) cap 10 + offer fabric 8 → `Bid` on fabric preserves qty 8, cargo `2`.
- (9) cap 10 + bid timber 9 + offer fabric 5 → `Bid` on fabric clamps to 1.
- (10) cap 10 saturated → `−` frees cargo, removes the warning.
- (11) cap 10 saturated → `None` removes the order, removes the warning.
- (12) observe mode keeps indicator + warning live; chip taps are blocked.

### Widgetbook

`Trade Screen → Market tab — cargo saturated (Refs #2993 E5c)` use case pre-stages bids totalling 24 so reviewers see the indicator at `0` plus the dark-theme `--danger` warning row.

### Scope (deferred / remaining for #2993)

- Priority dropdown bound to `kMaxTradePriority` — still tracked under #2989 (data API exposes the bound). Out of scope for this slice.
- E6 — Deal Book live ledger. Out of scope.
- E7 / E8 — Widgetbook stories + tests for E6. Tracked once E6 lands.

Refs #2993

## Test plan

- [x] `flutter analyze` clean on touched files (`trade_screen.dart`, `catalog_part6.dart`, new test file).
- [x] `flutter test app/test/trade_screen_market_tab_e5c_cargo_cap_test.dart` — 12 / 12 green.
- [x] All sibling Trade Screen tests (scaffold, 320 dp pin, E5a, E5b) still pass alongside the new file (43 / 43 green together).
- [ ] CI: full `Quality` workflow on dev base — to be confirmed on this PR.


Made with [Cursor](https://cursor.com)