### PR TITLE
feat(ui): require non-null decision before submit for overture / call-to-arms (#2867)

### DIFF
--- a/SPEC/ui/call-to-arms-dialogue-overlay.md
+++ b/SPEC/ui/call-to-arms-dialogue-overlay.md
@@ -19,7 +19,7 @@
 
 Internal state ownership:
 
-- Maintains `_join: List<bool>` (default `true`) — one entry per pending call — toggled by the row-level Join and Refuse buttons.
+- Maintains `_join: List<bool?>` (default `null` for every entry — i.e. undecided) — one entry per pending call — toggled by the row-level Join and Refuse buttons. Join tap sets the entry to `true`; Refuse tap sets it to `false`. Per issue #2867 R25 the Submit button stays disabled until **every** entry is non-null.
 - Does **not** own a `CtDialogueView`, `DialogueRunner`, or any Yarn asset. There is no intro phase; the overlay renders the decision list as soon as it is mounted.
 
 ---
@@ -28,7 +28,7 @@ Internal state ownership:
 
 - **Entry:** Rendered by `GameScreen` when `pendingDiplomacyProvider` exposes `PendingCallToArms(pending)` (see [`pending-diplomacy-state.md`](pending-diplomacy-state.md) and [`game-screen.md`](game-screen.md)). The notifier is replaced wholesale on each turn-resolution result, so a single overlay instance handles all calls for one resume cycle.
 - **Asset load:** None. The overlay has no Yarn integration, no Jenny `DialogueRunner`, and does not call `rootBundle.loadString`. No failure path needs an error affordance.
-- **Dismissal:** Exclusively driven by the player tapping **Submit**. The overlay does not provide a per-call dismiss or close button; the player must resolve every row before submitting (rows always carry a current `_join[i]` value, so Submit is always enabled).
+- **Dismissal:** Exclusively driven by the player tapping **Submit**. The overlay does not provide a per-call dismiss or close button; the player must resolve every row before submitting — Submit is **disabled** while any `_join[i]` is still `null` (issue #2867 R25) and becomes enabled only after the player has tapped Join or Refuse for every pending call.
 
 ---
 
@@ -68,8 +68,8 @@ Scrim is `Material(color: EditorialMonoclePalette.dialogScrim)` (canonical `--di
 
 | State | Trigger | Render |
 |-------|---------|--------|
-| Decision list | Overlay is mounted with `pending.length >= 1` | One Join/Refuse row per `pending[i]`; Join sets `_join[i] = true`, Refuse sets `_join[i] = false`. Submit calls `onDecisions(...)` with one `CallToArmsDecision` per pending using the current `_join` value. |
-| Empty decision list | Overlay is mounted with `pending.length == 0` | The shell still renders the title / intro labels and a Submit button; Submit invokes `onDecisions` with an empty list so the host can clear the pending provider. |
+| Decision list | Overlay is mounted with `pending.length >= 1` | One Join/Refuse row per `pending[i]`; every entry starts undecided (`_join[i] == null`). Join tap sets `_join[i] = true`, Refuse tap sets `_join[i] = false`. Submit is **disabled** while any entry is still `null` (issue #2867 R25); when every entry is non-null, Submit becomes enabled and a tap calls `onDecisions(...)` with one `CallToArmsDecision` per pending using the resolved `_join!` value. |
+| Empty decision list | Overlay is mounted with `pending.length == 0` | The shell still renders the title / intro labels and a Submit button; Submit is enabled (there is no row to gate on) and tapping it invokes `onDecisions` with an empty list so the host can clear the pending provider. |
 
 There are no loading, transient, or error variants; absence of a Yarn dependency is what differentiates this overlay from [`overture-dialogue-overlay.md`](overture-dialogue-overlay.md) and [`game-start-intro-overlay.md`](game-start-intro-overlay.md).
 
@@ -105,13 +105,21 @@ There are no loading, transient, or error variants; absence of a Yarn dependency
   When the widget tree settles,
   Then the overlay renders one row inside a `CtDialogShell` whose prompt is the localized `game_callToArms_prompt('Portugal', 'Spain')`, with Join, Refuse, and Submit `CtNinePatchButton`s visible.
 
-- Given the overlay is mounted with `n` pending calls and the default `_join` list of all `true`,
-  When the user taps **Submit** without changing any toggle,
-  Then `onDecisions` is invoked exactly once with a `List<CallToArmsDecision>` of length `n`, each entry has `accepted == true`, and the `allyGpId` / `defenderGpId` / `aggressorGpId` fields exactly match the corresponding `pending[i]`.
+- Given the overlay is mounted with `n >= 1` pending calls and every `_join[i]` defaults to `null`,
+  When the widget tree settles before any Join / Refuse tap,
+  Then the Submit `CtNinePatchButton` reports `enabled == false` so the player cannot submit decisions that have not been made (issue #2867 R25).
+
+- Given the overlay is mounted with two pending calls and every `_join[i]` is still `null`,
+  When the user taps Join on the first row but leaves the second row undecided,
+  Then the Submit `CtNinePatchButton` remains `enabled == false` and `onDecisions` has not been invoked (issue #2867 R25 negative case).
 
 - Given the overlay is mounted with two pending calls,
-  When the user taps **Refuse** on the first row and **Join** (already selected) on the second row, then taps **Submit**,
-  Then `onDecisions` is invoked exactly once with `decisions[0].accepted == false` and `decisions[1].accepted == true`, and the list order matches `pending` exactly.
+  When the user taps Refuse on the first row and Join on the second row,
+  Then the Submit `CtNinePatchButton` becomes `enabled == true`, tapping Submit invokes `onDecisions` exactly once with `decisions[0].accepted == false` and `decisions[1].accepted == true`, and the list order matches `pending` exactly.
+
+- Given the overlay is mounted with `n` pending calls and every row has been resolved via Join / Refuse tap,
+  When the user taps Submit once,
+  Then `onDecisions` is invoked exactly once with a `List<CallToArmsDecision>` of length `n`, and each entry's `allyGpId` / `defenderGpId` / `aggressorGpId` exactly match the corresponding `pending[i]`.
 
 - Given the overlay is constructed with an empty `pending` list,
   When the widget tree settles,

--- a/SPEC/ui/overture-dialogue-overlay.md
+++ b/SPEC/ui/overture-dialogue-overlay.md
@@ -25,7 +25,7 @@ Internal state ownership (phase 1 — intro):
 - Owns at most one `CtDialogueView` and one `jenny.DialogueRunner` during the Yarn intro phase.
 - Reads the Yarn source from `kDialogueOvertureAsset` (`assets/dialogue/overture.yarn`) via `rootBundle`; the asset bundle is not configurable in production but the intro itself can be bypassed with `skipIntroForTest`.
 - Hard-codes the intro node id `DialoguePoint/overture_target_response`; throws a `StateError` (caught and surfaced as `_loadError`) when the node is missing from the parsed asset.
-- Maintains `_accepted: List<bool>` (default `true`) — one entry per pending overture — toggled by the row-level Accept and Reject buttons in phase 2.
+- Maintains `_accepted: List<bool?>` (default `null` for every entry — i.e. undecided) — one entry per pending overture — toggled by the row-level Accept and Reject buttons in phase 2. Accept tap sets the entry to `true`; Reject tap sets it to `false`. Per issue #2867 R23 the Submit button stays disabled until **every** entry is non-null.
 
 ---
 
@@ -103,7 +103,7 @@ Error mode renders the same `Stack` but the `CtDialogShell` body is the localize
 | Presenting line (phase 1) | `!_introDone && _view!.currentLine != null` | Line text + right-aligned Continue button; tap calls `_view!.advanceLine()`. |
 | Presenting choice (phase 1) | `!_introDone && _view!.currentLine == null && _view!.currentChoice != null` | Vertical stack of one `CtNinePatchButton` per `choice.options[i]`; tap calls `_view!.selectOption(i)`. |
 | Transient (phase 1) | `!_introDone && _view!.currentLine == null && _view!.currentChoice == null` | `CtLoadingIndicator` inside the shell. |
-| Offer list (phase 2) | `_introDone && _loadError == null` | Title + intro + one Accept/Reject row per `pendingOvertures[i]`; Accept sets `_accepted[i] = true`, Reject sets `_accepted[i] = false`. Submit calls `onDecisions(...)` with one `OvertureDecision` per offer using the current `_accepted` value. |
+| Offer list (phase 2) | `_introDone && _loadError == null` | Title + intro + one Accept/Reject row per `pendingOvertures[i]`; every entry starts undecided (`_accepted[i] == null`). Accept tap sets `_accepted[i] = true`, Reject tap sets `_accepted[i] = false`. Submit is **disabled** while any entry is still `null` (issue #2867 R23); when every entry is non-null, Submit becomes enabled and a tap calls `onDecisions(...)` with one `OvertureDecision` per offer using the resolved `_accepted!` value. |
 | Error | `_loadError != null` | Localized error text (`game_overture_loadError`) + single Continue button; tapping Continue invokes `_submit()` immediately (so the host advances even when the Yarn asset is broken). |
 
 Exactly one variant is rendered at a time. Phase 2 is the only state in which Accept / Reject toggles are interactive; phase 1 has no offer rows.
@@ -123,8 +123,8 @@ Exactly one variant is rendered at a time. Phase 2 is the only state in which Ac
 | Control / gesture | When enabled | Emits / calls | Side effects |
 |-------------------|--------------|---------------|--------------|
 | Yarn Continue / options | Phase 1 intro | Jenny runner advances | — |
-| Accept / Reject toggles | Phase 2 | Updates `_accepted` list | — |
-| Submit | Phase 2 | `onDecisions(List<OvertureDecision>)` once | Host calls `resumeOvertureDecisions` and clears pending state. |
+| Accept / Reject toggles | Phase 2 | Updates `_accepted[i]` to `true` (Accept) or `false` (Reject) | Re-evaluates Submit enable state. |
+| Submit | Phase 2; **disabled** until every `_accepted[i]` is non-null (#2867 R23) | `onDecisions(List<OvertureDecision>)` once | Host calls `resumeOvertureDecisions` and clears pending state. |
 
 No direct `AppEventBus` or `Navigator` usage in the overlay.
 
@@ -168,13 +168,21 @@ No direct `AppEventBus` or `Navigator` usage in the overlay.
   When the widget tree is inspected,
   Then the phase-2 body contains exactly one `CtBrassDivider` rendered between the localized `game_overture_title` title `Text` and the localized `game_overture_intro` intro `Text`, the title `Text.style.color` equals `EditorialMonoclePalette.accent`, the title `Text.style.letterSpacing` equals `style.fontSize! * 0.05` (canonical `0.05em` per #2867 R2), and the intro `Text.style.color` equals `EditorialMonoclePalette.muted` with `fontStyle == FontStyle.italic`.
 
-- Given the overlay is in phase 2 with `n` pending overtures and the default `_accepted` list of all `true`,
-  When the user taps **Submit** without changing any toggle,
-  Then `onDecisions` is invoked exactly once with a `List<OvertureDecision>` of length `n`, each entry has `accepted == true`, and the `offererGpId` / `targetFactionId` / `stage` fields exactly match the corresponding `pendingOvertures[i]`.
+- Given the overlay is in phase 2 with `n >= 1` pending overtures and every `_accepted[i]` defaults to `null`,
+  When the widget tree settles before any Accept / Reject tap,
+  Then the Submit `CtNinePatchButton` reports `enabled == false` so the player cannot submit decisions that have not been made (issue #2867 R23).
+
+- Given the overlay is in phase 2 with two pending overtures and every `_accepted[i]` is still `null`,
+  When the user taps Accept on the first row but leaves the second row undecided,
+  Then the Submit `CtNinePatchButton` remains `enabled == false` and `onDecisions` has not been invoked (issue #2867 R23 negative case).
 
 - Given the overlay is in phase 2 with two pending overtures,
-  When the user taps **Reject** on the second row and then **Submit**,
-  Then `onDecisions` is invoked exactly once with `decisions[0].accepted == true` and `decisions[1].accepted == false`, and no further widget rebuild changes the order of the decisions.
+  When the user taps Accept on the first row and Reject on the second row,
+  Then the Submit `CtNinePatchButton` becomes `enabled == true`, tapping Submit invokes `onDecisions` exactly once with `decisions[0].accepted == true` and `decisions[1].accepted == false`, and the order matches `pendingOvertures` exactly.
+
+- Given the overlay is in phase 2 with `n` pending overtures and every row has been resolved via Accept / Reject tap,
+  When the user taps Submit once,
+  Then `onDecisions` is invoked exactly once with a `List<OvertureDecision>` of length `n`, and each entry's `offererGpId` / `targetFactionId` / `stage` exactly match the corresponding `pendingOvertures[i]`.
 
 - Given the overlay's Yarn asset load fails (`_loadError != null` with any exception),
   When the widget rebuilds after `setState`,
@@ -182,7 +190,7 @@ No direct `AppEventBus` or `Navigator` usage in the overlay.
 
 - Given the overlay is in the error variant,
   When the user taps the error-state Continue button,
-  Then `onDecisions` is invoked exactly once with one `OvertureDecision` per `pendingOvertures` entry (`accepted == true` by default) so the host can still resume turn resolution.
+  Then `onDecisions` is invoked exactly once with one `OvertureDecision` per `pendingOvertures` entry; each entry uses `accepted == true` as the deterministic degraded fallback so the host can still resume turn resolution even though the Yarn intro asset failed to load. The R23 "non-null decision" gating applies only to the interactive phase-2 list; the error-state Continue button has no such gate because the player has no per-offer choice in this variant.
 
 - Given the overlay is mounted with a custom `CtLogger`,
   When `_loadAndRunIntro` throws,

--- a/app/lib/features/game/dialogue/call_to_arms_dialogue_overlay.dart
+++ b/app/lib/features/game/dialogue/call_to_arms_dialogue_overlay.dart
@@ -32,12 +32,26 @@ class CallToArmsDialogueOverlay extends StatefulWidget {
 }
 
 class _CallToArmsDialogueOverlayState extends State<CallToArmsDialogueOverlay> {
-  late List<bool> _join;
+  /// Per-call decisions; `null` means the player has not yet tapped Join or
+  /// Refuse on that row. The Submit button stays disabled until every entry
+  /// is non-null (issue #2867 R25 / AC5).
+  late List<bool?> _join;
 
   @override
   void initState() {
     super.initState();
-    _join = List.filled(widget.pending.length, true);
+    _join = List<bool?>.filled(widget.pending.length, null);
+  }
+
+  /// True when every pending call row has a non-null decision; gates the
+  /// Submit `CtNinePatchButton` per #2867 R25
+  /// (`SPEC/ui/call-to-arms-dialogue-overlay.md` § Acceptance Criteria —
+  /// non-null decision required).
+  bool get _allDecided {
+    for (final bool? value in _join) {
+      if (value == null) return false;
+    }
+    return true;
   }
 
   String _gpName(String gpId) {
@@ -54,7 +68,7 @@ class _CallToArmsDialogueOverlayState extends State<CallToArmsDialogueOverlay> {
           allyGpId: c.allyGpId,
           defenderGpId: c.defenderGpId,
           aggressorGpId: c.aggressorGpId,
-          accepted: _join[i],
+          accepted: _join[i] ?? true,
         ),
       );
     }
@@ -147,7 +161,9 @@ class _CallToArmsDialogueOverlayState extends State<CallToArmsDialogueOverlay> {
                     Align(
                       alignment: Alignment.centerRight,
                       child: CtNinePatchButton(
-                        onPressed: _submit,
+                        key: const ValueKey<String>('callToArmsSubmitButton'),
+                        enabled: _allDecided,
+                        onPressed: _allDecided ? _submit : null,
                         child: Text(l10n.game_callToArms_submit),
                       ),
                     ),

--- a/app/lib/features/game/dialogue/overture_dialogue_overlay.dart
+++ b/app/lib/features/game/dialogue/overture_dialogue_overlay.dart
@@ -51,17 +51,31 @@ class _OvertureDialogueOverlayState extends State<OvertureDialogueOverlay> {
   bool _introDone = false;
   CtDialogueView? _view;
   Object? _loadError;
-  late List<bool> _accepted;
+
+  /// Per-offer decisions; `null` means the player has not yet tapped Accept
+  /// or Reject on that row. The Submit button stays disabled until every
+  /// entry is non-null (issue #2867 R23 / AC4).
+  late List<bool?> _accepted;
 
   @override
   void initState() {
     super.initState();
-    _accepted = List.filled(widget.pendingOvertures.length, true);
+    _accepted = List<bool?>.filled(widget.pendingOvertures.length, null);
     if (widget.skipIntroForTest) {
       _introDone = true;
     } else {
       _loadAndRunIntro();
     }
+  }
+
+  /// True when every pending overture row has a non-null decision; gates the
+  /// phase-2 Submit `CtNinePatchButton` per #2867 R23 (`SPEC/ui/overture-dialogue-overlay.md`
+  /// § Acceptance Criteria — non-null decision required).
+  bool get _allDecided {
+    for (final bool? value in _accepted) {
+      if (value == null) return false;
+    }
+    return true;
   }
 
   Future<void> _loadAndRunIntro() async {
@@ -131,7 +145,28 @@ class _OvertureDialogueOverlayState extends State<OvertureDialogueOverlay> {
           offererGpId: offer.offererGpId,
           targetFactionId: offer.targetFactionId,
           stage: offer.stage,
-          accepted: _accepted[i],
+          accepted: _accepted[i] ?? true,
+        ),
+      );
+    }
+    widget.onDecisions(decisions);
+  }
+
+  /// Degraded error-state submit: the Yarn intro failed to load, so the
+  /// per-offer Accept/Reject UI is never shown. Emit a deterministic
+  /// `accepted == true` decision per offer so the host can still resume
+  /// turn resolution (`SPEC/ui/overture-dialogue-overlay.md` § AC error
+  /// variant). This bypasses the R23 non-null gate by design — the player
+  /// has no interactive choice in this variant.
+  void _submitErrorFallback() {
+    final decisions = <OvertureDecision>[];
+    for (final OvertureOffer offer in widget.pendingOvertures) {
+      decisions.add(
+        OvertureDecision(
+          offererGpId: offer.offererGpId,
+          targetFactionId: offer.targetFactionId,
+          stage: offer.stage,
+          accepted: true,
         ),
       );
     }
@@ -157,7 +192,7 @@ class _OvertureDialogueOverlayState extends State<OvertureDialogueOverlay> {
                       Text(l10n.game_overture_loadError('$_loadError')),
                       const SizedBox(height: 16),
                       CtNinePatchButton(
-                        onPressed: () => _submit(),
+                        onPressed: _submitErrorFallback,
                         child: Text(l10n.game_intervention_continue),
                       ),
                     ],
@@ -282,7 +317,9 @@ class _OvertureDialogueOverlayState extends State<OvertureDialogueOverlay> {
                     Align(
                       alignment: Alignment.centerRight,
                       child: CtNinePatchButton(
-                        onPressed: _submit,
+                        key: const ValueKey<String>('overtureSubmitButton'),
+                        enabled: _allDecided,
+                        onPressed: _allDecided ? _submit : null,
                         child: Text(l10n.game_callToArms_submit),
                       ),
                     ),

--- a/app/test/call_to_arms_dialogue_overlay_dark_chrome_test.dart
+++ b/app/test/call_to_arms_dialogue_overlay_dark_chrome_test.dart
@@ -1,6 +1,7 @@
 import 'package:colonizethis_app/config/editorial_monocle_palette.dart';
 import 'package:colonizethis_app/config/themes.dart';
 import 'package:colonizethis_app/features/game/dialogue/call_to_arms_dialogue_overlay.dart';
+import 'package:colonizethis_app/features/game/widgets/chrome/ct_nine_patch_button.dart';
 import 'package:colonizethis_app/widgets/ct_brass_divider.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
@@ -142,5 +143,39 @@ void main() {
         reason: 'No Material in the overlay should still use Colors.black54.',
       );
     });
+
+    testWidgets(
+      'Submit stays disabled until every pending call has a non-null '
+      'decision (#2867 R25 / AC5)',
+      (WidgetTester tester) async {
+        await pumpOverlay(tester);
+
+        final Finder submitFinder = find.byKey(
+          const ValueKey<String>('callToArmsSubmitButton'),
+        );
+        expect(submitFinder, findsOneWidget);
+
+        CtNinePatchButton submitButton() =>
+            tester.widget<CtNinePatchButton>(submitFinder);
+
+        expect(
+          submitButton().enabled,
+          isFalse,
+          reason:
+              'Submit must start disabled when the row defaults to '
+              'undecided (#2867 R25).',
+        );
+
+        await tester.tap(find.text('Join'));
+        await tester.pump();
+        expect(
+          submitButton().enabled,
+          isTrue,
+          reason:
+              'Submit must enable as soon as every row has a non-null '
+              'decision (#2867 R25 positive case).',
+        );
+      },
+    );
   });
 }

--- a/app/test/dialogue_overlays_specs_test.dart
+++ b/app/test/dialogue_overlays_specs_test.dart
@@ -473,7 +473,8 @@ void main() {
     );
 
     testWidgets(
-      'default Submit emits one OvertureDecision per offer with accepted=true',
+      'tapping Accept on every row emits one OvertureDecision per offer with accepted=true '
+      '(#2867 R23 / AC4 — Submit enables after all decided)',
       (WidgetTester tester) async {
         List<OvertureDecision>? captured;
         await tester.pumpWidget(
@@ -493,6 +494,11 @@ void main() {
             onDecisions: (d) => captured = d,
           ),
         );
+        await _pumpUntilSettled(tester);
+
+        await tester.tap(find.text('Accept').at(0));
+        await _pumpUntilSettled(tester);
+        await tester.tap(find.text('Accept').at(1));
         await _pumpUntilSettled(tester);
 
         await tester.tap(find.text('Submit'));
@@ -510,7 +516,8 @@ void main() {
     );
 
     testWidgets(
-      'tapping Reject on the second row flips that decision before Submit',
+      'tapping Accept on the first row and Reject on the second row before Submit '
+      '(#2867 R23 / AC4 — mixed decision)',
       (WidgetTester tester) async {
         List<OvertureDecision>? captured;
         await tester.pumpWidget(
@@ -532,6 +539,8 @@ void main() {
         );
         await _pumpUntilSettled(tester);
 
+        await tester.tap(find.text('Accept').at(0));
+        await _pumpUntilSettled(tester);
         await tester.tap(find.text('Reject').at(1));
         await _pumpUntilSettled(tester);
 
@@ -543,6 +552,50 @@ void main() {
         expect(captured![0].accepted, isTrue);
         expect(captured![1].accepted, isFalse);
         expect(captured![1].offererGpId, 'gp_portugal');
+      },
+    );
+
+    testWidgets(
+      'Submit stays disabled and does not invoke onDecisions while any '
+      'overture row is still undecided (#2867 R23 / AC4 negative case)',
+      (WidgetTester tester) async {
+        List<OvertureDecision>? captured;
+        await tester.pumpWidget(
+          wrap(
+            offers: const [
+              OvertureOffer(
+                offererGpId: 'gp_spain',
+                targetFactionId: 'gp_player',
+                stage: OvertureStage.tradeConsulate,
+              ),
+              OvertureOffer(
+                offererGpId: 'gp_portugal',
+                targetFactionId: 'gp_player',
+                stage: OvertureStage.embassy,
+              ),
+            ],
+            onDecisions: (d) => captured = d,
+          ),
+        );
+        await _pumpUntilSettled(tester);
+
+        // `warnIfMissed: false` because the disabled button intentionally
+        // ignores hit-tests (per CtNinePatchButton § Disabled).
+        await tester.tap(find.text('Submit'), warnIfMissed: false);
+        await _pumpUntilSettled(tester);
+        expect(captured, isNull);
+
+        await tester.tap(find.text('Accept').at(0));
+        await _pumpUntilSettled(tester);
+        await tester.tap(find.text('Submit'), warnIfMissed: false);
+        await _pumpUntilSettled(tester);
+        expect(
+          captured,
+          isNull,
+          reason:
+              'Submit must remain disabled while the second row is still '
+              'undecided (#2867 R23).',
+        );
       },
     );
 
@@ -646,8 +699,8 @@ void main() {
       );
 
       testWidgets(
-        'default Submit emits one CallToArmsDecision per pending '
-        'with accepted=true',
+        'tapping Join on every row emits one CallToArmsDecision per pending '
+        'with accepted=true (#2867 R25 / AC5 — Submit enables after all decided)',
         (WidgetTester tester) async {
           List<CallToArmsDecision>? captured;
           await tester.pumpWidget(
@@ -667,6 +720,11 @@ void main() {
               onDecisions: (d) => captured = d,
             ),
           );
+          await _pumpUntilSettled(tester);
+
+          await tester.tap(find.text('Join').at(0));
+          await _pumpUntilSettled(tester);
+          await tester.tap(find.text('Join').at(1));
           await _pumpUntilSettled(tester);
 
           await tester.tap(find.text('Submit'));
@@ -682,7 +740,8 @@ void main() {
       );
 
       testWidgets(
-        'tapping Refuse on the first row flips that decision before Submit',
+        'tapping Refuse on the first row and Join on the second row before Submit '
+        '(#2867 R25 / AC5 — mixed decision)',
         (WidgetTester tester) async {
           List<CallToArmsDecision>? captured;
           await tester.pumpWidget(
@@ -704,7 +763,9 @@ void main() {
           );
           await _pumpUntilSettled(tester);
 
-          await tester.tap(find.text('Refuse').first);
+          await tester.tap(find.text('Refuse').at(0));
+          await _pumpUntilSettled(tester);
+          await tester.tap(find.text('Join').at(1));
           await _pumpUntilSettled(tester);
 
           await tester.tap(find.text('Submit'));
@@ -713,6 +774,50 @@ void main() {
           expect(captured, isNotNull);
           expect(captured![0].accepted, isFalse);
           expect(captured![1].accepted, isTrue);
+        },
+      );
+
+      testWidgets(
+        'Submit stays disabled and does not invoke onDecisions while any '
+        'call-to-arms row is still undecided (#2867 R25 / AC5 negative case)',
+        (WidgetTester tester) async {
+          List<CallToArmsDecision>? captured;
+          await tester.pumpWidget(
+            wrap(
+              pending: const [
+                CallToArmsPending(
+                  allyGpId: 'gp_player',
+                  defenderGpId: 'gp_portugal',
+                  aggressorGpId: 'gp_spain',
+                ),
+                CallToArmsPending(
+                  allyGpId: 'gp_player',
+                  defenderGpId: 'gp_spain',
+                  aggressorGpId: 'gp_portugal',
+                ),
+              ],
+              onDecisions: (d) => captured = d,
+            ),
+          );
+          await _pumpUntilSettled(tester);
+
+          // `warnIfMissed: false` because the disabled button intentionally
+          // ignores hit-tests (per CtNinePatchButton § Disabled).
+          await tester.tap(find.text('Submit'), warnIfMissed: false);
+          await _pumpUntilSettled(tester);
+          expect(captured, isNull);
+
+          await tester.tap(find.text('Refuse').at(0));
+          await _pumpUntilSettled(tester);
+          await tester.tap(find.text('Submit'), warnIfMissed: false);
+          await _pumpUntilSettled(tester);
+          expect(
+            captured,
+            isNull,
+            reason:
+                'Submit must remain disabled while the second row is still '
+                'undecided (#2867 R25).',
+          );
         },
       );
 

--- a/app/test/overture_dialogue_overlay_test.dart
+++ b/app/test/overture_dialogue_overlay_test.dart
@@ -7,6 +7,7 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'package:colonizethis_app/config/editorial_monocle_palette.dart';
 import 'package:colonizethis_app/features/game/dialogue/overture_dialogue_overlay.dart';
+import 'package:colonizethis_app/features/game/widgets/chrome/ct_nine_patch_button.dart';
 import 'package:colonizethis_app/widgets/ct_brass_divider.dart';
 import 'package:colonizethis_app/widgets/ct_dialog_shell.dart';
 
@@ -53,7 +54,7 @@ void main() {
 
   group('OvertureDialogueOverlay', () {
     testWidgets(
-      'skipIntroForTest: Accept/Reject toggles and Submit yields decisions',
+      'skipIntroForTest: Accept first + Reject second + Submit yields decisions in order (#2867 R23 / AC4)',
       (WidgetTester tester) async {
         final offers = <OvertureOffer>[
           const OvertureOffer(
@@ -84,6 +85,15 @@ void main() {
         // Separator between offerer and stage is its own --muted Text.
         expect(find.text(': '), findsNWidgets(2));
 
+        // Every row starts undecided per #2867 R23 / AC4, so Submit is
+        // disabled and tapping it must be a no-op. `warnIfMissed: false`
+        // because the disabled button intentionally ignores hit-tests.
+        await tester.tap(find.text('Submit'), warnIfMissed: false);
+        await tester.pump();
+        expect(submitted, isNull);
+
+        await tester.tap(find.text('Accept').first);
+        await tester.pump();
         await tester.tap(find.text('Reject').last);
         await tester.pump();
 
@@ -96,6 +106,111 @@ void main() {
         expect(submitted![1].accepted, isFalse);
         expect(submitted![0].stage, OvertureStage.tradeConsulate);
         expect(submitted![1].stage, OvertureStage.embassy);
+      },
+    );
+
+    testWidgets(
+      'phase 2 Submit is disabled until every row has a non-null decision '
+      '(#2867 R23 / AC4 — positive enable transition)',
+      (WidgetTester tester) async {
+        final offers = <OvertureOffer>[
+          const OvertureOffer(
+            offererGpId: 'gp2',
+            targetFactionId: 'gp1',
+            stage: OvertureStage.tradeConsulate,
+          ),
+          const OvertureOffer(
+            offererGpId: 'gp2',
+            targetFactionId: 'gp1',
+            stage: OvertureStage.embassy,
+          ),
+        ];
+
+        await pumpOverlay(tester, offers: offers, onDecisions: null);
+
+        final Finder submitFinder = find.byKey(
+          const ValueKey<String>('overtureSubmitButton'),
+        );
+        expect(submitFinder, findsOneWidget);
+
+        CtNinePatchButton submitButton() =>
+            tester.widget<CtNinePatchButton>(submitFinder);
+
+        expect(
+          submitButton().enabled,
+          isFalse,
+          reason:
+              'Submit must start disabled when every overture row defaults '
+              'to undecided (#2867 R23).',
+        );
+
+        await tester.tap(find.text('Accept').first);
+        await tester.pump();
+        expect(
+          submitButton().enabled,
+          isFalse,
+          reason:
+              'Submit must remain disabled when only the first row has been '
+              'decided (#2867 R23 negative case).',
+        );
+
+        await tester.tap(find.text('Reject').last);
+        await tester.pump();
+        expect(
+          submitButton().enabled,
+          isTrue,
+          reason:
+              'Submit must enable once every overture row has a non-null '
+              'decision (#2867 R23 positive case).',
+        );
+      },
+    );
+
+    testWidgets(
+      'phase 2 Submit disabled while only the second row is decided '
+      '(#2867 R23 / AC4 — negative case)',
+      (WidgetTester tester) async {
+        final offers = <OvertureOffer>[
+          const OvertureOffer(
+            offererGpId: 'gp2',
+            targetFactionId: 'gp1',
+            stage: OvertureStage.tradeConsulate,
+          ),
+          const OvertureOffer(
+            offererGpId: 'gp2',
+            targetFactionId: 'gp1',
+            stage: OvertureStage.embassy,
+          ),
+        ];
+        List<OvertureDecision>? submitted;
+
+        await pumpOverlay(
+          tester,
+          offers: offers,
+          onDecisions: (d) => submitted = List.of(d),
+        );
+
+        await tester.tap(find.text('Reject').last);
+        await tester.pump();
+
+        final Finder submitFinder = find.byKey(
+          const ValueKey<String>('overtureSubmitButton'),
+        );
+        final CtNinePatchButton submitButton = tester
+            .widget<CtNinePatchButton>(submitFinder);
+        expect(submitButton.enabled, isFalse);
+
+        // `warnIfMissed: false` because the disabled button intentionally
+        // ignores hit-tests (per CtNinePatchButton § Disabled).
+        await tester.tap(find.text('Submit'), warnIfMissed: false);
+        await tester.pump();
+        expect(
+          submitted,
+          isNull,
+          reason:
+              'Tapping the disabled Submit must not invoke onDecisions '
+              'while any row is still undecided (#2867 R23).',
+        );
       },
     );
 


### PR DESCRIPTION
## Summary

Refs #2867 — Implements ACs 4 and 5 of the DLG*/OVL*/SHEL4* restyle in one focused slice. The overture (OVL30001) and call-to-arms (OVL40001) overlays now:

- Track each per-row decision as `bool?` (default `null` — undecided).
- Disable the Submit `CtNinePatchButton` until every row has a non-null decision (issue R23 / R25).
- Set the entry to `true` or `false` only on explicit Accept / Reject / Join / Refuse taps.
- Preserve the existing error-state Continue fallback on the overture overlay so the host can still resume turn resolution when the Yarn asset fails to load (deterministic `accepted == true` per offer in the error variant only).

## Done in this push (Refs #2867 ACs 4 + 5)

- **SPEC/ui/overture-dialogue-overlay.md** — `_accepted: List<bool?>` default null; R23 Submit-disable contract + new positive / negative ACs.
- **SPEC/ui/call-to-arms-dialogue-overlay.md** — `_join: List<bool?>` default null; R25 Submit-disable contract + matching ACs.
- **OvertureDialogueOverlay** (`app/lib/features/game/dialogue/overture_dialogue_overlay.dart`)
  - `_accepted: List<bool?>` initialised to all-null.
  - `_allDecided` getter gates the Submit `CtNinePatchButton` (`enabled` + nullable `onPressed`).
  - Stable key `overtureSubmitButton` so widget tests can inspect enabled state without string-matching.
  - Error-state `_submitErrorFallback` emits `accepted: true` per offer (spec-authorised degraded path).
- **CallToArmsDialogueOverlay** (`app/lib/features/game/dialogue/call_to_arms_dialogue_overlay.dart`)
  - `_join: List<bool?>` initialised to all-null.
  - Mirror `_allDecided` gate + `callToArmsSubmitButton` key.
- Tests
  - `overture_dialogue_overlay_test.dart` — explicit Accept/Reject taps; positive enable-transition; negative null-submit guard.
  - `dialogue_overlays_specs_test.dart` — rewrote default-Submit tests as Accept-all / Join-all flows; new negative partial-decision tests for both surfaces.
  - `call_to_arms_dialogue_overlay_dark_chrome_test.dart` — focused R25 enable-after-decision test.

## Deferred (still on #2867; no parallel PRs)

- **R22 / R24** — swap the Accept / Reject and Join / Refuse `CtNinePatchButton`s for `CtToggleSwitch` with `--success` / `--danger` glow tones. This requires either extending the #2859 S9 `CtToggleSwitch` (currently `--accent`-only) with a `tone` parameter, or composing two mutually exclusive toggles per row. Tracked for a follow-up slice on the same issue.
- **S13** — Widgetbook story refresh once the toggle swap lands; current stories still render and exercise the new disabled-Submit gate.
- The other 11 surfaces enumerated in #2867 (move army/fleet, transfer, turn news, next-turn confirmation, leader selection, intervention, game-start intro, pause menu, game initializing) — already implemented on `dev` prior to this PR; verified via spot-reads of the corresponding widgets and tests.

Refs #2867 — does **not** auto-close the issue; remaining R22 / R24 / S13 scope keeps it open.

## Test plan

- [x] `flutter test test/overture_dialogue_overlay_test.dart test/call_to_arms_dialogue_overlay_dark_chrome_test.dart test/dialogue_overlays_specs_test.dart test/dialogue_acceptance_test.dart` → **All 40 tests passed**
- [x] `flutter test test/overture_dialogue_intro_test.dart test/game_screen_overture_pending_test.dart` → **All 2 tests passed**
- [x] `flutter analyze` on touched lib/test files → **No issues found**

Made with [Cursor](https://cursor.com)