### PR TITLE
feat(logic): release unused extraction cargo to world market (Refs #2990 B2)

### DIFF
--- a/packages/colonizethis_logic/lib/src/turn/phases/extraction_phase.dart
+++ b/packages/colonizethis_logic/lib/src/turn/phases/extraction_phase.dart
@@ -91,16 +91,11 @@ Game runExtractionPhase(
       // used at departure, so this is the correct value to subtract from
       // the home-fleet cargo when computing trade cargo capacity in phase
       // 13 (see SPEC/game/world-market.md § Cargo).
-      if (overseasShippedTonnageOut != null && overseasDelivered.isNotEmpty) {
-        var shipped = 0;
-        for (final v in overseasDelivered.values) {
-          shipped += v;
-        }
-        if (shipped > 0) {
-          overseasShippedTonnageOut[player.id] =
-              (overseasShippedTonnageOut[player.id] ?? 0) + shipped;
-        }
-      }
+      _recordOverseasShippedTonnage(
+        overseasShippedTonnageOut,
+        player.id,
+        overseasDelivered,
+      );
       if (overseasDelivered.isNotEmpty) {
         extractionSeed =
             (extractionSeed * kTurnResolutionLcgMultiplier +
@@ -120,6 +115,24 @@ Game runExtractionPhase(
     updatedPlayers.add(player.copyWith(stockpile: stockpile));
   }
   return currentState.withPlayers(updatedPlayers);
+}
+
+void _recordOverseasShippedTonnage(
+  Map<String, int>? out,
+  String playerId,
+  Map<CommodityId, int> overseasDelivered,
+) {
+  if (out == null || overseasDelivered.isEmpty) {
+    return;
+  }
+  var shipped = 0;
+  for (final v in overseasDelivered.values) {
+    shipped += v;
+  }
+  if (shipped <= 0) {
+    return;
+  }
+  out[playerId] = (out[playerId] ?? 0) + shipped;
 }
 
 TurnPhaseStepOutcome extractionTurnPhaseHandler(

--- a/packages/colonizethis_logic/lib/src/turn/phases/extraction_phase.dart
+++ b/packages/colonizethis_logic/lib/src/turn/phases/extraction_phase.dart
@@ -12,12 +12,25 @@ import '../turn_resolver_config.dart';
 import '../turn_seed_constants.dart';
 
 /// Extraction phase: connectivity, land/overseas extraction, interception.
+///
+/// When [overseasShippedTonnageOut] is supplied, the function additionally
+/// records the post-cargo-cap, pre-interception overseas tonnage actually
+/// shipped per Great Power into the supplied map (keyed by player id). Those
+/// holds are committed at departure regardless of any later trade
+/// interception losses, so they consume ship capacity for the rest of the
+/// turn. Callers that need the cargo-released-to-trade signal documented in
+/// `SPEC/game/world-market.md` § Cargo (the *Cargo released by under-used
+/// extraction* AC) pass a mutable map; legacy callers omit the parameter and
+/// retain the existing behaviour (no tonnage accounting). The scripted
+/// `extractedByPlayerId` fast path bypasses auto-transport entirely, so no
+/// tonnage entries are recorded for that path.
 Game runExtractionPhase(
   Game state,
   MapTopology topology,
   Map<String, TileMapResult>? tileMapByRegion,
-  Map<String, Map<CommodityId, int>> extractedByPlayerId,
-) {
+  Map<String, Map<CommodityId, int>> extractedByPlayerId, {
+  Map<String, int>? overseasShippedTonnageOut,
+}) {
   if (extractedByPlayerId.isNotEmpty) {
     return applyExtractionForPlayers(state, extractedByPlayerId);
   }
@@ -73,6 +86,21 @@ Game runExtractionPhase(
         overseasTotals: tot.overseas,
         allocatedToStockpile: overseasDelivered,
       );
+      // Record the cargo-holds actually committed to overseas trade this
+      // turn before interception adjusts the delivered map. The holds are
+      // used at departure, so this is the correct value to subtract from
+      // the home-fleet cargo when computing trade cargo capacity in phase
+      // 13 (see SPEC/game/world-market.md § Cargo).
+      if (overseasShippedTonnageOut != null && overseasDelivered.isNotEmpty) {
+        var shipped = 0;
+        for (final v in overseasDelivered.values) {
+          shipped += v;
+        }
+        if (shipped > 0) {
+          overseasShippedTonnageOut[player.id] =
+              (overseasShippedTonnageOut[player.id] ?? 0) + shipped;
+        }
+      }
       if (overseasDelivered.isNotEmpty) {
         extractionSeed =
             (extractionSeed * kTurnResolutionLcgMultiplier +
@@ -98,13 +126,24 @@ TurnPhaseStepOutcome extractionTurnPhaseHandler(
   TurnPipelineState acc,
   TurnResolverConfig config,
   int turn,
-) => TurnPhaseStepContinue(
-  acc.copyWith(
-    game: runExtractionPhase(
-      acc.game,
-      config.topology,
-      config.tileMapByRegion,
-      config.extractedByPlayerId,
+) {
+  // Capture per-player overseas tonnage actually shipped so the world
+  // market phase (#2990, B2 follow-up) can subtract it from the
+  // home-fleet cargo when computing trade cargo capacity. See
+  // SPEC/game/world-market.md § Cargo — AC "Cargo released by under-used
+  // extraction".
+  final shippedTonnageByPlayerId = <String, int>{};
+  final nextGame = runExtractionPhase(
+    acc.game,
+    config.topology,
+    config.tileMapByRegion,
+    config.extractedByPlayerId,
+    overseasShippedTonnageOut: shippedTonnageByPlayerId,
+  );
+  return TurnPhaseStepContinue(
+    acc.copyWith(
+      game: nextGame,
+      overseasExtractionShippedTonnageByPlayerId: shippedTonnageByPlayerId,
     ),
-  ),
-);
+  );
+}

--- a/packages/colonizethis_logic/lib/src/turn/phases/world_market_phase.dart
+++ b/packages/colonizethis_logic/lib/src/turn/phases/world_market_phase.dart
@@ -38,13 +38,17 @@ import '../turn_resolver_config.dart';
 ///    stockpile/cargo per `SPEC/game/world-market.md` § Order persistence
 ///    will land in a follow-up commit alongside the validator's
 ///    re-entry hook).
-/// 3. Computes per-GP `tradeCargoCapacity` via [cargoHoldsForHomeFleet].
-///    The full `max(0, totalHomeFleetCargoHolds - overseasExtractionActualTonnage)`
-///    formula in `SPEC/game/world-market.md` § Cargo lands once the extraction
-///    phase publishes per-player actual tonnage onto [TurnPipelineState];
-///    until then this slice treats extraction tonnage as zero (the common case
-///    in Issue-B integration tests) and the SPEC AC for cargo released by
-///    extraction is intentionally deferred to that follow-up.
+/// 3. Computes per-GP `tradeCargoCapacity` as
+///    `max(0, cargoHoldsForHomeFleet − overseasExtractionShippedTonnage)`,
+///    where the overseas tonnage signal is the per-player value the
+///    extraction phase published onto
+///    [TurnPipelineState.overseasExtractionShippedTonnageByPlayerId]
+///    (post-cargo-cap, pre-interception). Implements the SPEC AC *Cargo
+///    released by under-used extraction* in
+///    `SPEC/game/world-market.md` § Cargo: any extraction holds reserved
+///    but not consumed are released to trade. Missing entries are treated
+///    as zero tonnage so the legacy direct-handler test path (no upstream
+///    extraction phase) keeps using the full home-fleet capacity.
 /// 4. Runs [DealMatcher.matchDeals] with FTP keys from
 ///    [ftpPairKeysFromGame].
 /// 5. Applies transfers: buyer treasury debit + seller treasury credit (GP
@@ -132,12 +136,18 @@ TurnPhaseStepOutcome worldMarketTurnPhaseHandler(
 
   final fleetsByIdStartOfPhase = fleetsByIdForWorld(game.worldState);
   final tradeCapacityByFactionId = <String, int>{};
+  final extractionTonnageByPlayerId =
+      acc.overseasExtractionShippedTonnageByPlayerId;
   for (final player in game.players) {
-    tradeCapacityByFactionId[player.id] = cargoHoldsForHomeFleet(
+    final homeFleetHolds = cargoHoldsForHomeFleet(
       game,
       player.id,
       fleetsById: fleetsByIdStartOfPhase,
     );
+    final shippedByExtraction =
+        extractionTonnageByPlayerId[player.id] ?? 0;
+    final tradeCapacity = homeFleetHolds - shippedByExtraction;
+    tradeCapacityByFactionId[player.id] = tradeCapacity > 0 ? tradeCapacity : 0;
   }
 
   final ftpPairKeys = ftpPairKeysFromGame(game);

--- a/packages/colonizethis_logic/lib/src/turn/turn_pipeline_state.dart
+++ b/packages/colonizethis_logic/lib/src/turn/turn_pipeline_state.dart
@@ -11,6 +11,7 @@ class TurnPipelineState {
     Map<String, double>? landFeedingCoverageByPlayerId,
     Map<String, double>? navalFeedingCoverageByPlayerId,
     Map<String, WorkerIdleCounts>? idleLabourByPlayerId,
+    Map<String, int>? overseasExtractionShippedTonnageByPlayerId,
   }) : landFeedingCoverageByPlayerId = Map<String, double>.from(
          landFeedingCoverageByPlayerId ?? const {},
        ),
@@ -19,6 +20,9 @@ class TurnPipelineState {
        ),
        idleLabourByPlayerId = Map<String, WorkerIdleCounts>.from(
          idleLabourByPlayerId ?? const {},
+       ),
+       overseasExtractionShippedTonnageByPlayerId = Map<String, int>.from(
+         overseasExtractionShippedTonnageByPlayerId ?? const {},
        );
 
   final Game game;
@@ -26,11 +30,31 @@ class TurnPipelineState {
   final Map<String, double> navalFeedingCoverageByPlayerId;
   final Map<String, WorkerIdleCounts> idleLabourByPlayerId;
 
+  /// Per-Great-Power total cargo-hold tonnage actually shipped by the
+  /// extraction phase's overseas auto-transport step this turn.
+  ///
+  /// The sum is the **post-cargo-cap, pre-interception** allocation
+  /// returned by `allocateOverseasToStockpile`: those holds are committed
+  /// at departure regardless of any subsequent trade-interception losses,
+  /// so they consume ship capacity for the rest of the turn. Per
+  /// `SPEC/game/world-market.md` § Cargo and the *Cargo released by
+  /// under-used extraction* AC, phase 13 (World Market) computes per-GP
+  /// trade cargo capacity as
+  /// `max(0, cargoHoldsForHomeFleet − overseasExtractionShippedTonnage)`,
+  /// so any reserved-but-unused extraction capacity is released to trade.
+  ///
+  /// Missing entries (or scripted-extraction runs that bypass the
+  /// auto-transport loop) are treated as zero tonnage by the world-market
+  /// phase, preserving the legacy contract for callers that have not
+  /// wired this signal.
+  final Map<String, int> overseasExtractionShippedTonnageByPlayerId;
+
   TurnPipelineState copyWith({
     Game? game,
     Map<String, double>? landFeedingCoverageByPlayerId,
     Map<String, double>? navalFeedingCoverageByPlayerId,
     Map<String, WorkerIdleCounts>? idleLabourByPlayerId,
+    Map<String, int>? overseasExtractionShippedTonnageByPlayerId,
   }) {
     return TurnPipelineState(
       game: game ?? this.game,
@@ -39,6 +63,9 @@ class TurnPipelineState {
       navalFeedingCoverageByPlayerId:
           navalFeedingCoverageByPlayerId ?? this.navalFeedingCoverageByPlayerId,
       idleLabourByPlayerId: idleLabourByPlayerId ?? this.idleLabourByPlayerId,
+      overseasExtractionShippedTonnageByPlayerId:
+          overseasExtractionShippedTonnageByPlayerId ??
+              this.overseasExtractionShippedTonnageByPlayerId,
     );
   }
 

--- a/packages/colonizethis_logic/test/turn/extraction_phase_overseas_shipped_tonnage_test.dart
+++ b/packages/colonizethis_logic/test/turn/extraction_phase_overseas_shipped_tonnage_test.dart
@@ -1,0 +1,224 @@
+import 'package:colonizethis_logic/src/turn/phases/extraction_phase.dart';
+import 'package:colonizethis_logic/src/turn/turn_pipeline_state.dart';
+import 'package:colonizethis_logic/src/turn/turn_resolver_config.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_test/test.dart';
+
+import '../extraction_auto_transport_test_fixtures.dart';
+
+/// Producer side of the cargo-released-by-extraction signal (Refs #2990
+/// B2). Asserts that:
+///
+/// * `runExtractionPhase(..., overseasShippedTonnageOut: out)` records the
+///   per-player post-cargo-cap, pre-interception allocation into `out`
+///   when the auto-transport path runs.
+/// * `extractionTurnPhaseHandler` plumbs the recorded tonnage onto
+///   [TurnPipelineState.overseasExtractionShippedTonnageByPlayerId].
+/// * The scripted-extraction fast path (non-empty
+///   `config.extractedByPlayerId`) does *not* populate tonnage (no
+///   auto-transport is run, so no holds are committed).
+///
+/// The consumer side (world-market phase subtracting tonnage from cargo
+/// capacity) is covered in `world_market_phase_extraction_cargo_test.dart`.
+void main() {
+  group(
+    'runExtractionPhase — overseasShippedTonnageOut (Refs #2990 B2)',
+    () {
+      test(
+        'auto-transport path records per-player tonnage matching the sum '
+        'of allocated overseas commodities',
+        () {
+          final (:game, :tileMapByRegion) = extractionAutoTransportFixture(
+            nwResourceGrid: const [
+              [Resource.sugarCane, Resource.sugarCane],
+              [Resource.sugarCane, Resource.sugarCane],
+            ],
+            nwImprovementLevel: 1,
+          );
+          final topology = crossRegionSeaTopologyForExtractionTests();
+          final priorStockpile = game.players
+              .firstWhere((p) => p.id == 'pl1')
+              .stockpile;
+
+          final shipped = <String, int>{};
+          final next = runExtractionPhase(
+            game,
+            topology,
+            tileMapByRegion,
+            <String, Map<CommodityId, int>>{},
+            overseasShippedTonnageOut: shipped,
+          );
+
+          final nextPlayer = next.players.firstWhere((p) => p.id == 'pl1');
+          // Use the sugarCane stockpile delta as a reliable lower bound:
+          // anything in the post-extraction stockpile beyond the prior
+          // amount and beyond the land-extracted amount came from overseas
+          // auto-transport and therefore must have been shipped.
+          final sugarBefore = priorStockpile.quantityOf(
+            CommodityCatalog.sugarCane.id,
+          );
+          final sugarAfter = nextPlayer.stockpile.quantityOf(
+            CommodityCatalog.sugarCane.id,
+          );
+          final sugarOverseas = sugarAfter - sugarBefore;
+          expect(
+            sugarOverseas,
+            greaterThan(0),
+            reason:
+                'fixture configures NW sugarCane overseas extraction; the '
+                'test depends on at least one unit arriving',
+          );
+
+          expect(
+            shipped['pl1'],
+            isNotNull,
+            reason: 'pl1 has an overseas allocation → tonnage must be '
+                'recorded under the player id',
+          );
+          // No interception in this fixture (no enemies, no patrols), so
+          // the recorded tonnage equals the delivered amount on the
+          // stockpile.
+          expect(shipped['pl1'], sugarOverseas);
+        },
+      );
+
+      test(
+        'scripted extractedByPlayerId fast path does NOT record tonnage '
+        '(auto-transport is bypassed)',
+        () {
+          final game = Game(
+            id: 'g1',
+            players: const [
+              Player(
+                id: 'pl1',
+                displayName: 'Spain',
+                isHuman: true,
+              ),
+            ],
+            worldState: const WorldState(
+              turnState: TurnState(phase: TurnPhase.extraction, turnNumber: 0),
+              oldWorld: RegionData(),
+              newWorld: RegionData(),
+            ),
+          );
+          final shipped = <String, int>{};
+          runExtractionPhase(
+            game,
+            const MapTopology(nodes: [], edges: []),
+            const <String, TileMapResult>{},
+            <String, Map<CommodityId, int>>{
+              'pl1': {CommodityCatalog.grain.id: 10},
+            },
+            overseasShippedTonnageOut: shipped,
+          );
+          expect(
+            shipped,
+            isEmpty,
+            reason:
+                'scripted extraction path skips overseas auto-transport, '
+                'so no cargo holds are committed and no tonnage entries '
+                'are recorded',
+          );
+        },
+      );
+
+      test(
+        'overseasShippedTonnageOut omitted → backwards-compatible (no '
+        'exception, no observable behaviour change)',
+        () {
+          final (:game, :tileMapByRegion) = extractionAutoTransportFixture(
+            nwResourceGrid: const [
+              [Resource.sugarCane, Resource.sugarCane],
+              [Resource.sugarCane, Resource.sugarCane],
+            ],
+            nwImprovementLevel: 1,
+          );
+          final topology = crossRegionSeaTopologyForExtractionTests();
+          // Should run cleanly without any tonnage parameter (legacy
+          // callers — economy preview pipeline, debug tests).
+          final next = runExtractionPhase(
+            game,
+            topology,
+            tileMapByRegion,
+            <String, Map<CommodityId, int>>{},
+          );
+          expect(next, isNotNull);
+        },
+      );
+    },
+  );
+
+  group(
+    'extractionTurnPhaseHandler — TurnPipelineState plumbing (Refs #2990 B2)',
+    () {
+      test(
+        'handler publishes the recorded tonnage onto '
+        'TurnPipelineState.overseasExtractionShippedTonnageByPlayerId',
+        () {
+          final (:game, :tileMapByRegion) = extractionAutoTransportFixture(
+            nwResourceGrid: const [
+              [Resource.sugarCane, Resource.sugarCane],
+              [Resource.sugarCane, Resource.sugarCane],
+            ],
+            nwImprovementLevel: 1,
+          );
+          final topology = crossRegionSeaTopologyForExtractionTests();
+          final acc = TurnPipelineState(game: game);
+          final config = TurnResolverConfig(
+            topology: topology,
+            orders: const Orders(),
+            tileMapByRegion: tileMapByRegion,
+          );
+
+          final next =
+              (extractionTurnPhaseHandler(acc, config, 0)
+                      as TurnPhaseStepContinue)
+                  .pipeline;
+
+          expect(
+            next.overseasExtractionShippedTonnageByPlayerId['pl1'],
+            isNotNull,
+          );
+          expect(
+            next.overseasExtractionShippedTonnageByPlayerId['pl1']!,
+            greaterThan(0),
+          );
+        },
+      );
+
+      test(
+        'handler leaves tonnage map empty when no auto-transport runs '
+        '(scripted extraction fast path)',
+        () {
+          final game = Game(
+            id: 'g1',
+            players: const [
+              Player(id: 'pl1', displayName: 'Spain', isHuman: true),
+            ],
+            worldState: const WorldState(
+              turnState: TurnState(phase: TurnPhase.extraction, turnNumber: 0),
+              oldWorld: RegionData(),
+              newWorld: RegionData(),
+            ),
+          );
+          final acc = TurnPipelineState(game: game);
+          final config = TurnResolverConfig(
+            topology: const MapTopology(nodes: [], edges: []),
+            orders: const Orders(),
+            extractedByPlayerId: <String, Map<CommodityId, int>>{
+              'pl1': {CommodityCatalog.grain.id: 10},
+            },
+          );
+
+          final next =
+              (extractionTurnPhaseHandler(acc, config, 0)
+                      as TurnPhaseStepContinue)
+                  .pipeline;
+
+          expect(next.overseasExtractionShippedTonnageByPlayerId, isEmpty);
+        },
+      );
+    },
+  );
+}

--- a/packages/colonizethis_logic/test/turn/world_market_phase_extraction_cargo_test.dart
+++ b/packages/colonizethis_logic/test/turn/world_market_phase_extraction_cargo_test.dart
@@ -1,0 +1,331 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/src/economy/sea_transport.dart';
+import 'package:colonizethis_logic/src/turn/phases/world_market_phase.dart';
+import 'package:colonizethis_logic/src/turn/turn_pipeline_state.dart';
+import 'package:colonizethis_logic/src/turn/turn_resolver_config.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+/// Cargo-released-by-extraction integration for the world market phase
+/// (Refs #2990 B2 / SPEC/game/world-market.md § Cargo — AC *Cargo released
+/// by under-used extraction*).
+///
+/// The world-market phase now subtracts the per-player overseas tonnage
+/// shipped by the extraction phase (read from
+/// [TurnPipelineState.overseasExtractionShippedTonnageByPlayerId]) from
+/// the home-fleet cargo holds when sizing each Great Power's trade cargo
+/// capacity. These tests assert the consumer side of that contract end to
+/// end through [worldMarketTurnPhaseHandler] — the extraction handler's
+/// populate side is exercised by
+/// `extraction_phase_overseas_shipped_tonnage_test.dart`.
+void main() {
+  group(
+    'worldMarketTurnPhaseHandler — extraction tonnage subtraction '
+    '(Refs #2990 B2)',
+    () {
+      test(
+        'tradeCapacity = homeFleetCargo − overseasShippedTonnage; '
+        'bid partial-fills against the reduced cap',
+        () {
+          // No home fleet → cargoHoldsForHomeFleet returns the default stub
+          // of 24 holds. Extraction shipped 12 of those holds this turn, so
+          // remaining trade cargo = 24 − 12 = 12. The buyer bids 24 timber
+          // at the matching offer, and the matcher must partial-fill at 12
+          // (the released cargo) with the remaining 12 carrying forward.
+          const buyerId = 'gpBuyer';
+          const sellerId = 'gpSeller';
+          final game = _gameWithTwoGps(
+            sellerStockpile: const Stockpile().applyDelta('timber', 30),
+            sellerTreasury: 0,
+            buyerTreasury: 100000,
+            marketPrices: const {'timber': 30.0},
+          );
+          // Sanity: the default stub for a player without a home fleet is
+          // 24 — anchor the assertion on the public constant so the test
+          // documents the arithmetic without re-coupling to internals.
+          expect(defaultCargoHoldsStub, 24);
+
+          final acc = TurnPipelineState(
+            game: game,
+            overseasExtractionShippedTonnageByPlayerId: const <String, int>{
+              buyerId: 12,
+            },
+          );
+          final config = TurnResolverConfig(
+            topology: const MapTopology(nodes: [], edges: []),
+            orders: Orders(
+              tradeOrdersByPlayerId: {
+                sellerId: [
+                  TradeOrder(
+                    commodityId: 'timber',
+                    type: TradeOrderType.offer,
+                    quantity: 24,
+                    priority: 1,
+                  ),
+                ],
+                buyerId: [
+                  TradeOrder(
+                    commodityId: 'timber',
+                    type: TradeOrderType.bid,
+                    quantity: 24,
+                    priority: 1,
+                  ),
+                ],
+              },
+            ),
+          );
+
+          final next = (worldMarketTurnPhaseHandler(acc, config, 3)
+                  as TurnPhaseStepContinue)
+              .pipeline
+              .game;
+
+          final buyer = next.players.firstWhere((p) => p.id == buyerId);
+          expect(
+            buyer.stockpile.quantityOf('timber'),
+            12,
+            reason:
+                'bid capped by trade cargo capacity (24 stub − 12 extraction '
+                'tonnage = 12 holds available for trade shipping)',
+          );
+          final carryBids =
+              next.worldMarketState.carryForwardBidsByFactionId[buyerId];
+          expect(carryBids, isNotNull);
+          expect(carryBids!.single.commodityId, 'timber');
+          expect(
+            carryBids.single.quantity,
+            12,
+            reason:
+                'residual 12 units of the 24-unit bid carry forward at the '
+                'original priority',
+          );
+        },
+      );
+
+      test(
+        'overseas shipped tonnage ≥ home-fleet capacity clamps trade cargo '
+        'to 0 — no fills, full bid carry-forward',
+        () {
+          // Extraction shipped 24 holds (saturating the default stub) so
+          // trade cargo capacity clamps at 0 for the buyer this turn. No
+          // bid quantity should match.
+          const buyerId = 'gpBuyer';
+          const sellerId = 'gpSeller';
+          final game = _gameWithTwoGps(
+            sellerStockpile: const Stockpile().applyDelta('timber', 10),
+            sellerTreasury: 0,
+            buyerTreasury: 100000,
+            marketPrices: const {'timber': 30.0},
+          );
+          final acc = TurnPipelineState(
+            game: game,
+            overseasExtractionShippedTonnageByPlayerId: const <String, int>{
+              buyerId: 24,
+            },
+          );
+          final config = TurnResolverConfig(
+            topology: const MapTopology(nodes: [], edges: []),
+            orders: Orders(
+              tradeOrdersByPlayerId: {
+                sellerId: [
+                  TradeOrder(
+                    commodityId: 'timber',
+                    type: TradeOrderType.offer,
+                    quantity: 5,
+                    priority: 1,
+                  ),
+                ],
+                buyerId: [
+                  TradeOrder(
+                    commodityId: 'timber',
+                    type: TradeOrderType.bid,
+                    quantity: 5,
+                    priority: 1,
+                  ),
+                ],
+              },
+            ),
+          );
+
+          final next = (worldMarketTurnPhaseHandler(acc, config, 3)
+                  as TurnPhaseStepContinue)
+              .pipeline
+              .game;
+
+          final buyer = next.players.firstWhere((p) => p.id == buyerId);
+          expect(
+            buyer.stockpile.quantityOf('timber'),
+            0,
+            reason: 'tradeCapacity clamped to 0 leaves zero room for fills',
+          );
+          expect(
+            buyer.treasury,
+            100000,
+            reason: 'no debit when no deal fills',
+          );
+          final carryBids =
+              next.worldMarketState.carryForwardBidsByFactionId[buyerId];
+          expect(carryBids, isNotNull);
+          expect(carryBids!.single.quantity, 5);
+        },
+      );
+
+      test(
+        'overseas shipped tonnage exceeding home-fleet capacity does not '
+        'underflow tradeCapacity (released-cargo clamp at 0)',
+        () {
+          // Tonnage > home-fleet capacity should still clamp at 0, never
+          // negative. This guards against accidental signed arithmetic.
+          const buyerId = 'gpBuyer';
+          const sellerId = 'gpSeller';
+          final game = _gameWithTwoGps(
+            sellerStockpile: const Stockpile().applyDelta('timber', 5),
+            sellerTreasury: 0,
+            buyerTreasury: 1000,
+            marketPrices: const {'timber': 30.0},
+          );
+          final acc = TurnPipelineState(
+            game: game,
+            overseasExtractionShippedTonnageByPlayerId: const <String, int>{
+              buyerId: 999,
+            },
+          );
+          final config = TurnResolverConfig(
+            topology: const MapTopology(nodes: [], edges: []),
+            orders: Orders(
+              tradeOrdersByPlayerId: {
+                sellerId: [
+                  TradeOrder(
+                    commodityId: 'timber',
+                    type: TradeOrderType.offer,
+                    quantity: 5,
+                    priority: 1,
+                  ),
+                ],
+                buyerId: [
+                  TradeOrder(
+                    commodityId: 'timber',
+                    type: TradeOrderType.bid,
+                    quantity: 5,
+                    priority: 1,
+                  ),
+                ],
+              },
+            ),
+          );
+
+          final next = (worldMarketTurnPhaseHandler(acc, config, 3)
+                  as TurnPhaseStepContinue)
+              .pipeline
+              .game;
+
+          final buyer = next.players.firstWhere((p) => p.id == buyerId);
+          expect(buyer.stockpile.quantityOf('timber'), 0);
+          // The deal matcher must not have observed a negative capacity.
+          // Carry-forward should preserve the full bid quantity.
+          final carryBids =
+              next.worldMarketState.carryForwardBidsByFactionId[buyerId];
+          expect(carryBids, isNotNull);
+          expect(carryBids!.single.quantity, 5);
+        },
+      );
+
+      test(
+        'missing tonnage entry defaults to 0 — buyer keeps full home-fleet '
+        'capacity (legacy contract preserved)',
+        () {
+          // Empty extraction tonnage map → behaviour identical to the
+          // pre-#2990 B2 handler: trade cargo capacity equals the full
+          // home-fleet stub, so a 5-unit bid against a 5-unit offer fills
+          // completely.
+          const buyerId = 'gpBuyer';
+          const sellerId = 'gpSeller';
+          final game = _gameWithTwoGps(
+            sellerStockpile: const Stockpile().applyDelta('timber', 5),
+            sellerTreasury: 0,
+            buyerTreasury: 1000,
+            marketPrices: const {'timber': 30.0},
+          );
+          final acc = TurnPipelineState(game: game);
+          final config = TurnResolverConfig(
+            topology: const MapTopology(nodes: [], edges: []),
+            orders: Orders(
+              tradeOrdersByPlayerId: {
+                sellerId: [
+                  TradeOrder(
+                    commodityId: 'timber',
+                    type: TradeOrderType.offer,
+                    quantity: 5,
+                    priority: 1,
+                  ),
+                ],
+                buyerId: [
+                  TradeOrder(
+                    commodityId: 'timber',
+                    type: TradeOrderType.bid,
+                    quantity: 5,
+                    priority: 1,
+                  ),
+                ],
+              },
+            ),
+          );
+
+          final next = (worldMarketTurnPhaseHandler(acc, config, 3)
+                  as TurnPhaseStepContinue)
+              .pipeline
+              .game;
+
+          final buyer = next.players.firstWhere((p) => p.id == buyerId);
+          expect(
+            buyer.stockpile.quantityOf('timber'),
+            5,
+            reason:
+                'no extraction tonnage on the pipeline state → full home-fleet '
+                'cargo available for trade (matches the pre-B2 contract)',
+          );
+          expect(
+            next.worldMarketState.carryForwardBidsByFactionId,
+            isEmpty,
+          );
+        },
+      );
+    },
+  );
+}
+
+Game _gameWithTwoGps({
+  required Stockpile sellerStockpile,
+  required int sellerTreasury,
+  required int buyerTreasury,
+  required Map<CommodityId, double> marketPrices,
+}) {
+  return Game(
+    id: 'g1',
+    players: [
+      Player(
+        id: 'gpSeller',
+        displayName: 'Seller',
+        isHuman: false,
+        stockpile: sellerStockpile,
+        treasury: sellerTreasury,
+      ),
+      Player(
+        id: 'gpBuyer',
+        displayName: 'Buyer',
+        isHuman: false,
+        stockpile: Stockpile.empty,
+        treasury: buyerTreasury,
+      ),
+    ],
+    worldState: const WorldState(
+      turnState: TurnState(
+        phase: TurnPhase.worldMarket,
+        turnNumber: 3,
+      ),
+      oldWorld: RegionData(),
+      newWorld: RegionData(),
+    ),
+    worldMarketState: WorldMarketState.empty.copyWith(prices: marketPrices),
+  );
+}


### PR DESCRIPTION
## Summary

Implements the deferred B2 piece of #2990: phase 13 (World Market) now sizes each Great Power's trade cargo capacity as `max(0, cargoHoldsForHomeFleet − overseasExtractionShippedTonnage)`, so any overseas-extraction holds reserved but **not actually shipped** are released to trade shipping. This closes the SPEC AC *Cargo released by under-used extraction* in [`SPEC/game/world-market.md`](../SPEC/game/world-market.md) § Cargo and resolves the explicit deferred-handoff note at [`SPEC/program/world-market-resolution.md`](../SPEC/program/world-market-resolution.md) line 367.

## What changed

**Producer side — extraction phase**

- `runExtractionPhase` gains an optional `Map<String, int>? overseasShippedTonnageOut` parameter. When supplied, the function records each player's **post-cargo-cap, pre-interception** shipped tonnage (sum of `allocateOverseasToStockpile` output). Cargo holds are committed at departure, so trade interception losses do not release them back to trade.
- `extractionTurnPhaseHandler` plumbs the captured map onto a new `TurnPipelineState.overseasExtractionShippedTonnageByPlayerId` field via `copyWith`.
- Legacy callers (`economy_preview_pipeline.dart`, `debug_flip_province_turn_downstream_test.dart`) omit the parameter and keep prior behaviour. The scripted `extractedByPlayerId` fast path bypasses auto-transport entirely and records nothing.

**Consumer side — world market phase**

- `worldMarketTurnPhaseHandler` reads the per-player tonnage from `TurnPipelineState` and computes `tradeCapacity = max(0, cargoHoldsForHomeFleet − shipped)` per Great Power before passing to the deal matcher.
- Missing entries (no upstream extraction phase, e.g. existing direct-handler tests) default to zero tonnage, preserving the original B3 contract.

**Pipeline state**

- New optional field `Map<String, int> overseasExtractionShippedTonnageByPlayerId` on `TurnPipelineState`, threaded through `copyWith`.

## SPEC coverage

| AC | Source | Status |
|---|---|---|
| Cargo released by under-used extraction (reserve 20 / ship 12 → tradeCap = holds − 12) | `SPEC/game/world-market.md` § Cargo (line 76) | Now implemented |
| Phase handler folds in extraction-tonnage subtraction | `SPEC/program/world-market-resolution.md` (line 367) | Now active (handler reads new pipeline-state field) |

## Tests

- New `test/turn/world_market_phase_extraction_cargo_test.dart` — 4 cases on the consumer side: cap with tonnage, clamp-to-zero, no-underflow, and missing-tonnage legacy contract.
- New `test/turn/extraction_phase_overseas_shipped_tonnage_test.dart` — 5 cases on the producer side: auto-transport recording (asserts the exact stockpile delta), scripted-extraction skip, omitted-out-param compatibility, handler plumbing through `TurnPipelineState`, and scripted-handler skip.
- Existing extraction auto-transport tests, world-market B3/B5 integration tests, and the full logic test suite (2053 tests) pass unchanged.

## Verification

- `dart test test/turn/world_market_phase_extraction_cargo_test.dart` → 4/4 pass
- `dart test test/turn/extraction_phase_overseas_shipped_tonnage_test.dart` → 5/5 pass
- `dart test test/turn/` → 53/53 pass
- `dart test` (full `colonizethis_logic` suite) → 2053/2053 pass
- `dart analyze` on touched files → No issues found

## Scope notes

- **Done in this push:** B2 deferred slice — extraction tonnage signal + phase consumer + SPEC-AC tests. No behaviour change for the no-tonnage / no-extraction paths.
- **Not in scope:** Minor/tribe auto-sell (#2991), first-right-of-refusal additions beyond what's already merged (#2992), and AI treasury planner integration (#2994). Order-suggestion `tradeCargoCapacity` continues to use the gross `cargoHoldsForHomeFleet` per its API surface (validator-clean default) — the phase handler is the only place where the subtraction needs to apply per the SPEC.

Refs #2990

Made with [Cursor](https://cursor.com)