### PR TITLE
refactor(app): debug console scrim uses dialogScrim token (Refs #2914 S1)

### DIFF
--- a/app/lib/features/game/flame/debug_console_overlay_panel.dart
+++ b/app/lib/features/game/flame/debug_console_overlay_panel.dart
@@ -1,3 +1,4 @@
+import 'package:colonizethis_app/config/editorial_monocle_palette.dart';
 import 'package:colonizethis_app/l10n/l10n.dart';
 import 'package:colonizethis_debug_console/colonizethis_debug_console.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
@@ -74,7 +75,7 @@ class _DebugConsoleOverlayPanelState extends State<DebugConsoleOverlayPanel> {
               Expanded(
                 child: Container(
                   padding: const EdgeInsets.all(6),
-                  color: Colors.black54,
+                  color: EditorialMonoclePalette.dialogScrim,
                   child: _buildLogList(),
                 ),
               ),
@@ -136,7 +137,7 @@ class _DebugConsoleOverlayPanelState extends State<DebugConsoleOverlayPanel> {
           hintText: l10n.debugConsole_hintSpawnCivilian,
           hintStyle: TextStyle(color: Colors.white.withValues(alpha: 0.6)),
           filled: true,
-          fillColor: Colors.black54,
+          fillColor: EditorialMonoclePalette.dialogScrim,
           border: OutlineInputBorder(borderRadius: BorderRadius.circular(4)),
         ),
       ),

--- a/app/test/issue_2914_s1_debug_console_dialog_scrim_test.dart
+++ b/app/test/issue_2914_s1_debug_console_dialog_scrim_test.dart
@@ -19,7 +19,7 @@ library;
 import 'dart:convert' show LineSplitter;
 import 'dart:io' show Directory, File, FileSystemEntity;
 
-import 'package:flutter_test/flutter_test.dart';
+import 'package:colonizethis_test/test.dart';
 
 void main() {
   group('Refs #2914 S1: debug console scrim uses EditorialMonoclePalette', () {

--- a/app/test/issue_2914_s1_debug_console_dialog_scrim_test.dart
+++ b/app/test/issue_2914_s1_debug_console_dialog_scrim_test.dart
@@ -1,0 +1,106 @@
+/// Pins #2914 S1 — `app/lib/features/` must not paint the legacy
+/// `Colors.black54` scrim. The canonical dark-theme scrim is
+/// `EditorialMonoclePalette.dialogScrim`, per `SPEC/ui/pixel-art-ui-catalog.md`
+/// § Dialog scrim ("Widgets MUST resolve the scrim through that token ...
+/// rather than hard-coding `Colors.black54` / hex literals.").
+///
+/// Two complementary pins:
+///
+/// 1. Positive: `debug_console_overlay_panel.dart` references
+///    `EditorialMonoclePalette.dialogScrim` and never references the legacy
+///    `Colors.black54` literal.
+/// 2. Negative / regression sweep: no Dart source under `app/lib/features/`
+///    contains `Colors.black54` outside of line comments (which may still
+///    document the ban itself).
+///
+/// Refs #2914 S1.
+library;
+
+import 'dart:convert' show LineSplitter;
+import 'dart:io' show Directory, File, FileSystemEntity;
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Refs #2914 S1: debug console scrim uses EditorialMonoclePalette', () {
+    test(
+        'debug_console_overlay_panel.dart references '
+        'EditorialMonoclePalette.dialogScrim and not Colors.black54', () {
+      const String relativePath =
+          'lib/features/game/flame/debug_console_overlay_panel.dart';
+      final File file = File(relativePath);
+      expect(
+        file.existsSync(),
+        isTrue,
+        reason: 'fixture file must exist at $relativePath',
+      );
+      final String source = file.readAsStringSync();
+
+      expect(
+        source.contains('EditorialMonoclePalette.dialogScrim'),
+        isTrue,
+        reason:
+            'Refs #2914 S1: the debug-console overlay panel scrim and input '
+            'fill must resolve through EditorialMonoclePalette.dialogScrim, '
+            'the canonical dark-theme scrim token defined in '
+            'SPEC/ui/pixel-art-ui-catalog.md § Dialog scrim.',
+      );
+
+      // Strip line comments and string-literal occurrences so the pin only
+      // fires on actual code references to the banned Material literal.
+      final Iterable<String> nonCommentLines = source
+          .split('\n')
+          .map((String line) => line.trimLeft())
+          .where((String line) => !line.startsWith('//'));
+      expect(
+        nonCommentLines.any((String line) => line.contains('Colors.black54')),
+        isFalse,
+        reason:
+            'Refs #2914 S1 / SPEC/ui/pixel-art-ui-catalog.md § Dialog scrim: '
+            'the legacy Material Colors.black54 literal must not be reintroduced '
+            'in debug_console_overlay_panel.dart; use '
+            'EditorialMonoclePalette.dialogScrim instead.',
+      );
+    });
+  });
+
+  group('Refs #2914 S1: no Colors.black54 in app/lib/features/ (regression)',
+      () {
+    test(
+        'no Dart source under app/lib/features/ references Colors.black54 '
+        'outside of line comments', () {
+      final Directory featuresDir = Directory('lib/features');
+      expect(
+        featuresDir.existsSync(),
+        isTrue,
+        reason: 'fixture root must exist at lib/features',
+      );
+
+      final List<String> violations = <String>[];
+      for (final FileSystemEntity entity
+          in featuresDir.listSync(recursive: true, followLinks: false)) {
+        if (entity is! File) continue;
+        if (!entity.path.endsWith('.dart')) continue;
+
+        final List<String> lines = const LineSplitter().convert(
+          entity.readAsStringSync(),
+        );
+        for (int i = 0; i < lines.length; i++) {
+          if (lines[i].trimLeft().startsWith('//')) continue;
+          if (!lines[i].contains('Colors.black54')) continue;
+          violations.add('${entity.path}:${i + 1}: ${lines[i].trim()}');
+        }
+      }
+
+      expect(
+        violations,
+        isEmpty,
+        reason:
+            'Refs #2914 S1 / SPEC/ui/pixel-art-ui-catalog.md § Dialog scrim: '
+            'app/lib/features/ must not paint Material Colors.black54 as the '
+            'dialog scrim; resolve from EditorialMonoclePalette.dialogScrim. '
+            'Violations:\n  ${violations.join('\n  ')}',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

First slice of #2914 — **S1: Zero `Colors.black54` in `app/lib/features/`**. Replaces the two `Colors.black54` literals in `app/lib/features/game/flame/debug_console_overlay_panel.dart` (the Material wash around the log list and the input fill) with `EditorialMonoclePalette.dialogScrim`, the dark-theme scrim token authorised by [`SPEC/ui/pixel-art-ui-catalog.md`](../tree/dev/SPEC/ui/pixel-art-ui-catalog.md) § Dialog scrim:

> The Dart implementation exposes this token as `EditorialMonoclePalette.dialogScrim` (`app/lib/config/editorial_monocle_palette.dart`). Widgets MUST resolve the scrim through that token (or, for `showDialog` calls, by passing `EditorialMonoclePalette.dialogScrim` as `barrierColor`) rather than hard-coding `Colors.black54` / hex literals.

The four dialogue overlays (`call_to_arms_`, `overture_`, `intervention_`, `game_start_intro_`) and `game_side_menu.dart` already migrated to `dialogScrim` in earlier PRs (#2867 line). `debug_console_overlay_panel.dart` was the last remaining holdout in `app/lib/features/**`.

`Refs #2914` — does not auto-close; the umbrella issue closes when every sub-task (S2–S9 + G1/G2) is delivered.

## Scope

### Done in this push (#2914 S1)

| Layer | Change |
|-------|--------|
| **Source** | `app/lib/features/game/flame/debug_console_overlay_panel.dart` — add `editorial_monocle_palette.dart` import; swap `color: Colors.black54` (Container wash, line 77 before) and `fillColor: Colors.black54` (InputDecoration, line 139 before) for `EditorialMonoclePalette.dialogScrim`. |
| **Tests** | New `app/test/issue_2914_s1_debug_console_dialog_scrim_test.dart` — 2 pins mapped to S1 AC. |

### Tests added (positive + negative regression sweep)

1. **Positive — debug console source pin.** `debug_console_overlay_panel.dart` references `EditorialMonoclePalette.dialogScrim` and contains no `Colors.black54` literal in non-comment code.
2. **Negative — repo-wide regression sweep.** Walks every `*.dart` file under `app/lib/features/` and asserts none contain `Colors.black54` outside line comments (line comments may still _document_ the ban; only code regressions fail). This pin directly maps S1's AC ("Zero `Colors.black54` in `app/lib/features/`") and prevents the literal from creeping back into any other feature file.

### ACs covered now (#2914)

- [x] **S1** — Zero `Colors.black54` in `app/lib/features/` (debug console panel migrated + repo-wide regression pin landed).
- [ ] S2 / S3 / S4 / S5 / S6 / S7 / S8 / S9, Phase 0a / 0b, G1 / G2 — out of scope for this slice; tracked under #2914.

### Out of scope (deferred to follow-ups under the same umbrella issue)

- **S3 (broader `Colors.*` cleanup):** `Colors.white` / `Colors.black` text labels inside the same debug-console panel are kept as-is for this PR — they are foreground text on a Material chrome that has not yet been re-skinned to a Ct-* component. They belong with S3 and will be tackled when the debug console moves onto the Ct-* catalog (separate slice). Pinning `Colors.black54` does not regress this future work.
- **G1 (`check_app_editorial_monocle_colors` CI gate):** this PR's negative-sweep widget test pins the S1-scoped `Colors.black54` ban only; the broader grep gate covering `Colors.green` / `Colors.red` / `Colors.grey.shade*` etc. lands with G1 itself.
- **`debug_console_overlay_panel.dart` Material wrapper / `IconButton` migration:** part of S8 (Material ban remediation), tracked separately.

## SPEC alignment

No SPEC update required — `SPEC/ui/pixel-art-ui-catalog.md` § Dialog scrim already names `EditorialMonoclePalette.dialogScrim` as the canonical token and literally bans `Colors.black54`. This PR brings the last unmigrated feature file into conformance and adds a static regression pin so the literal cannot return.

## Verification

- `flutter test app/test/issue_2914_s1_debug_console_dialog_scrim_test.dart --reporter=compact` → **2/2 pass** (positive debug-console pin + repo-wide regression sweep).
- `flutter test app/test/debug_console_overlay_panel_test.dart --reporter=compact` → **12/12 pass** (existing widget behavior unchanged).
- `dart analyze app/lib/features/game/flame/debug_console_overlay_panel.dart app/test/issue_2914_s1_debug_console_dialog_scrim_test.dart` → only a pre-existing unused-import info on `package:flutter/services.dart` (`KeyEventResult`, unrelated to this slice).
- `dart run custom_lint` (on touched files) → **No issues found**.

## Test plan

- [x] New S1 regression test (positive + negative) passes locally.
- [x] Existing `DebugConsoleOverlayPanel` widget tests pass without modification.
- [x] Static analysis / `custom_lint` clean on touched files.
- [ ] CI on this PR.

Made with [Cursor](https://cursor.com)