### PR TITLE
feat(logic): emit per-commodity FilledDeal ledger on MarketActivity (Refs #2993 E6)

### DIFF
--- a/SPEC/program/world-market-resolution.md
+++ b/SPEC/program/world-market-resolution.md
@@ -76,6 +76,8 @@ class MarketActivity {
   final int totalOfferQuantity;
   final int filledQuantity;
   final double priceChangePercent;
+  final List<FilledDeal> deals;        // per-commodity Deal Book ledger
+  final List<MarketActivityNote> notes;
 }
 
 class WorldMarketState {
@@ -247,6 +249,10 @@ For each commodity that appears in any offer or bid (commodities iterated in alp
 
 `activityByCommodityId` records, per commodity with submitted volume, a `MarketActivity` with `totalBidQuantity` (sum of input bids), `totalOfferQuantity` (sum of input offers), `filledQuantity` (sum across emitted `FilledDeal`s), and `priceChangePercent = 0.0`. Price discovery is composed separately by the phase handler (Issue B / #2990) using `PriceDiscovery.computeNextPrice`, because only the phase handler knows which inputs are newly-submitted vs carry-forward.
 
+### Phase-handler activity rollup — `deals` ledger (Refs #2993 E6)
+
+`worldMarketTurnPhaseHandler` is the sole writer of `MarketActivity.deals`. After Step C/D it groups the resolved turn's `DealMatchResult.filledDeals` by `commodityId` and writes the per-commodity list (preserving emission order) onto the `MarketActivity` it builds for `WorldMarketState.lastTurnActivity`. The list is stored unmodifiable. Commodities that received submissions but produced zero fills carry an empty `deals` list; commodities with no submissions are absent from `lastTurnActivity` altogether. Carry-forward residuals are **not** in `deals` — they live on `carryForwardOffersByFactionId` / `carryForwardBidsByFactionId` and re-enter next turn's match. The Deal Book UI (`SPEC/ui/trade-screen.md` § Deal Book tab) filters `deals` per the active player's faction id (buyer or seller side) and never mutates the list in place.
+
 Edge cases:
 
 - Missing price for a commodity (`pricesByCommodityId` lookup returns `null`) is recorded on emitted `FilledDeal`s as `pricePerUnit = 0.0`. The phase handler is responsible for seeding `pricesByCommodityId` from `WorldMarketState.prices`; a missing entry signals a setup defect, not a runtime failure.
@@ -405,6 +411,9 @@ The pure helpers (`computeNextPrice`, `computeMarketActivity`, `DealMatcher.matc
 - **Deterministic matching.** Given two phase-13 runs with identical merged-order input, identical `WorldMarketState`, and identical seeds, when both runs execute Step C, then both emit byte-identical sequences of `FilledDeal` entries (same order, same quantities, same buyers/sellers) and produce byte-identical `MarketActivity` payloads.
 - **Carry-forward provenance preserved.** Given a current-turn bid by faction `f` of quantity 10 for commodity `c` at priority 2 that receives a partial fill of 4, when phase 13 produces carry-forwards in Step E, then `WorldMarketState.carryForwardBidsByFactionId[f]` contains one `TradeOrder` with `commodityId = c`, `quantity = 6`, `priority = 2` (the submitter is encoded by the map key, preserving attribution without requiring a per-order `submitterId` field).
 - **Phase placement preserved.** Given a turn whose phase sequence runs to completion, when the resolver emits phase markers, then `worldMarket` begins after the `buildWork end` marker and ends before the `endOfTurn start` marker, matching [turn-resolution-phases.md](turn-resolution-phases.md) § Acceptance criteria.
+- **Deals ledger emitted per commodity (Refs #2993 E6).** Given current-turn submissions that produce one or more `FilledDeal` entries for commodity `c`, when phase 13 builds `MarketActivity` for `c`, then `MarketActivity.deals` contains each `FilledDeal` exactly once in emission order, no `FilledDeal` for any other commodity, and the list is unmodifiable.
+- **Empty deals ledger for unfilled commodity.** Given a commodity `c` receives at least one submitted offer or bid but matching emits no `FilledDeal` for `c` (e.g. offer-only or insufficient cargo), when phase 13 builds `MarketActivity` for `c`, then `MarketActivity.deals.isEmpty` is true (not null, not absent) so the Deal Book UI can iterate it unconditionally.
+- **Deals JSON round-trip.** Given a `WorldMarketState` whose `lastTurnActivity[c].deals` has one or more `FilledDeal` entries, when the state is serialized to JSON and parsed back, then the restored `MarketActivity.deals` equals the original (`==` and `hashCode`) including each `FilledDeal`'s `isFirstRightOfRefusalMatch` and `isFtpMatch` flags.
 
 ### Data types (issue #2989)
 

--- a/SPEC/ui/trade-screen.md
+++ b/SPEC/ui/trade-screen.md
@@ -4,7 +4,7 @@
 **SPEC/ui** — Full-screen World Market trade surface. Implementation: `app/lib/features/game/screens/trade_screen.dart`.
 **Widgetbook:** `Trade Screen` → `app/lib/widgetbook/catalog.dart`. Game rules: [world-market.md](../game/world-market.md); resolution algorithm: [world-market-resolution.md](../program/world-market-resolution.md); core data model deferred to issue [#2989](https://github.com/waigore/colonizethisv3/issues/2989); UI scope tracked in issue [#2993](https://github.com/waigore/colonizethisv3/issues/2993). Parent design: [issue #2988](https://github.com/waigore/colonizethisv3/issues/2988).
 
-> **Status:** Draft. This document records the contract for the scaffold slices: E1+E2+E3 ship the route, screen ID, left-rail button, and dark editorial-monocle chrome; E4 lands the durable two-tab body structure (Market + Deal Book). The Market tab now renders the **commodity table with interactive bid/offer/none direction selector + quantity stepper + cross-commodity cargo indicator and warning** (`#2993` E5a + E5b + E5c) sourced from `Game.worldMarketState`, `Game.worldState.fleets` (via `cargoHoldsForHomeFleet`), and `currentOrdersProvider`. Each row shows last market price + previous-turn aggregate `Bids / Offers` volumes alongside the interactive controls; the controls write `Orders.tradeOrdersByPlayerId[player.id]` via the pure helpers `applyTradeOrderForPlayer` / `removeTradeOrderForPlayer` in `colonizethis_logic`, and the cross-commodity bid total is clamped to the player's trade cargo capacity. The remaining Market control (priority dropdown) ships when the data API in #2989 exposes `kMaxTradePriority`, and the Deal Book live ledger ships in `#2993` E6 once a per-player ledger surface lands on top of #2989 / #2990's `MarketActivity` + world-market turn phase.
+> **Status:** Draft. This document records the contract for the scaffold slices: E1+E2+E3 ship the route, screen ID, left-rail button, and dark editorial-monocle chrome; E4 lands the durable two-tab body structure (Market + Deal Book). The Market tab now renders the **commodity table with interactive bid/offer/none direction selector + quantity stepper + cross-commodity cargo indicator and warning** (`#2993` E5a + E5b + E5c) sourced from `Game.worldMarketState`, `Game.worldState.fleets` (via `cargoHoldsForHomeFleet`), and `currentOrdersProvider`. Each row shows last market price + previous-turn aggregate `Bids / Offers` volumes alongside the interactive controls; the controls write `Orders.tradeOrdersByPlayerId[player.id]` via the pure helpers `applyTradeOrderForPlayer` / `removeTradeOrderForPlayer` in `colonizethis_logic`, and the cross-commodity bid total is clamped to the player's trade cargo capacity. The **Deal Book tab now renders the live two-panel ledger** (`#2993` E6) sourced from `Game.worldMarketState.lastTurnActivity[*].deals` (per-commodity `FilledDeal` ledger emitted by the world-market phase handler — `SPEC/program/world-market-resolution.md` § Step F) and `WorldMarketState.carryForward{Bids,Offers}ByFactionId[playerId]`. The remaining Market control (priority dropdown) ships when the data API in #2989 exposes `kMaxTradePriority`.
 
 ---
 
@@ -33,7 +33,16 @@ The screen exposes static keys consumed by widget tests:
 - `TradeScreen.marketRowQuantityTextKey(CommodityId)` — `ValueKey<String>('tradeScreenMarketRow:<id>:quantity')` (per-row quantity readout; renders the staged `TradeOrder.quantity` or `marketRowQuantityIdleGlyph` (`—`) when no direction is staged — Refs `#2993` E5b).
 - `TradeScreen.marketCargoIndicatorKey` — `ValueKey<String>('tradeScreenMarketCargoIndicator')` (persistent header strip above the commodity list; renders the `Cargo remaining: X` text where `X = max(0, tradeCargoCapacity − totalStagedBidQuantity)` for the human player — Refs `#2993` E5c).
 - `TradeScreen.marketCargoWarningKey` — `ValueKey<String>('tradeScreenMarketCargoWarning')` (per-screen warning row rendered immediately below the cargo indicator when `remainingCargo == 0` AND `totalStagedBidQuantity > 0`; absent otherwise — Refs `#2993` E5c).
-- `TradeScreen.dealBookTabBodyKey` — `ValueKey<String>('tradeScreenDealBookTabBody')` (Deal Book tab body root; visible after the user taps the `Deal Book` label).
+- `TradeScreen.dealBookTabBodyKey` — `ValueKey<String>('tradeScreenDealBookTabBody')` (Deal Book tab body root; visible after the user taps the `Deal Book` label; key remained stable when `#2993` E6 swapped the placeholder for the live ledger).
+- `TradeScreen.dealBookContentKey` — `ValueKey<String>('tradeScreenDealBookContent')` (root of the live Deal Book two-panel ledger content sitting directly under `dealBookTabBodyKey` — Refs `#2993` E6).
+- `TradeScreen.dealBookBidsPanelKey` — `ValueKey<String>('tradeScreenDealBookBidsPanel')` (left/top container for the player's previous-turn buying activity panel; always mounted under the live ledger root — Refs `#2993` E6).
+- `TradeScreen.dealBookOffersPanelKey` — `ValueKey<String>('tradeScreenDealBookOffersPanel')` (right/bottom container for the player's previous-turn selling activity panel; always mounted under the live ledger root — Refs `#2993` E6).
+- `TradeScreen.dealBookBidsTotalsKey` — `ValueKey<String>('tradeScreenDealBookBidsTotals')` (per-panel totals row inside the bids panel; renders `Total spent: N` where `N = Σ (deal.quantity × deal.pricePerUnit).round()` across the player's filled bids only — carry-forwards excluded; always mounted — Refs `#2993` E6).
+- `TradeScreen.dealBookOffersTotalsKey` — `ValueKey<String>('tradeScreenDealBookOffersTotals')` (per-panel totals row inside the offers panel; renders `Total received: N` with the same aggregation rule applied to the player's filled sales; always mounted — Refs `#2993` E6).
+- `TradeScreen.dealBookBidsEmptyKey` — `ValueKey<String>('tradeScreenDealBookBidsEmpty')` (per-panel empty-state copy mounted only when the player has zero filled buys **and** zero carry-forward bids — Refs `#2993` E6).
+- `TradeScreen.dealBookOffersEmptyKey` — `ValueKey<String>('tradeScreenDealBookOffersEmpty')` (per-panel empty-state copy mounted only when the player has zero filled sales **and** zero carry-forward offers — Refs `#2993` E6).
+- `TradeScreen.dealBookFilledRowKey(side, index)` — `ValueKey<String>('tradeScreenDealBookFilledRow:<side>:<index>')` where `side` is `dealBookSideBids` (`'bids'`) or `dealBookSideOffers` (`'offers'`) and `index` is the zero-based position in the per-side filled-deals list (Refs `#2993` E6).
+- `TradeScreen.dealBookUnfilledRowKey(side, index)` — `ValueKey<String>('tradeScreenDealBookUnfilledRow:<side>:<index>')` per-row key for a carry-forward (unfilled) order on the per-side carry-forward list (Refs `#2993` E6).
 
 ---
 
@@ -88,10 +97,52 @@ Padding (16 dp)
             │                               ├── _StepperButton '−'   (`...:decrement`)
             │                               ├── Text <quantity | '—'> (`...:quantity`)
             │                               └── _StepperButton '+'   (`...:increment`)
-            └── _DealBookTabPlaceholder // keyed `tradeScreenDealBookTabBody`
-                └── CtPanel
-                    ├── Text 'Deal Book' (titleMedium, --accent)
-                    └── Text muted scaffold copy (bodyMedium, --muted)
+            └── _DealBookTabContent // keyed `tradeScreenDealBookTabBody`
+                └── Container (keyed `tradeScreenDealBookContent`)
+                    └── LayoutBuilder
+                        ├── (constraints.maxWidth >= dealBookTwoPanelMinWidth)
+                        │   Row
+                        │       ├── Expanded → _DealBookPanel (bids)
+                        │       ├── SizedBox(width: 12)
+                        │       └── Expanded → _DealBookPanel (offers)
+                        └── (otherwise)
+                            Column
+                                ├── _DealBookPanel (bids)
+                                ├── SizedBox(height: 12)
+                                └── _DealBookPanel (offers)
+
+_DealBookPanel (keyed `tradeScreenDealBookBidsPanel` / `tradeScreenDealBookOffersPanel`)
+└── CtPanel (padding 12 dp)
+    └── Column
+        ├── Text <panel title> (titleMedium, --accent)
+        │   panel titles: 'Your bids' | 'Your offers'
+        ├── (if filled.isEmpty AND unfilled.isEmpty)
+        │   Text <empty-state copy> (bodySmall, --muted,
+        │                            keyed dealBook{Side}EmptyKey)
+        ├── (otherwise)
+        │   ├── Text 'Filled' (labelMedium, --accentDim)
+        │   ├── (if filled.isEmpty)
+        │   │   Text 'No deals filled this turn.' (bodySmall, --muted)
+        │   ├── (otherwise) for each filled deal at index i:
+        │   │   _DealBookFilledRow (keyed
+        │   │     dealBookFilledRowKey(side, i))
+        │   │       └── Row
+        │   │           ├── Expanded Text '<commodityId> — qty Q × P = N'
+        │   │           │     (bodyMedium, --fg)
+        │   │           └── Text <FRR | FTP tags> (bodySmall, --muted)
+        │   ├── Text 'Unfilled (carry-forward)' (labelMedium, --accentDim)
+        │   ├── (if unfilled.isEmpty)
+        │   │   Text 'No orders carrying forward.' (bodySmall, --muted)
+        │   └── (otherwise) for each carry-forward order at index i:
+        │       _DealBookUnfilledRow (keyed
+        │         dealBookUnfilledRowKey(side, i))
+        │           └── Text '<commodityId> — qty Q (priority P)'
+        │                 (bodyMedium, --fg)
+        └── Text '<totals label>: <total>' (titleSmall, --accentBright,
+              keyed dealBook{Side}TotalsKey)
+            totals labels: 'Total spent' | 'Total received'
+            totals total = Σ (deal.quantity × deal.pricePerUnit).round()
+                           across filled rows only (carry-forwards excluded)
 ```
 
 The two-tab body is the durable structure each follow-up Market slice (E5b interactive controls, E5c cargo indicator) and Deal Book slice (E6) keep building inside. The `CtTabStrip` widget owns the dark-chrome label band (selected = `--accentBright` text on `--accentDim` 25 % alpha background; unselected = `--muted` text on `--surface` 50 % alpha background; 1 px `--accent` / `--accentDim` border per `pixel-art-ui-catalog.md` § `CtTabStrip`) and the `IndexedStack` that mounts both tab bodies so widget tests can reach either tab via `find.byKey` regardless of which is currently visible. Default selection is the **Market** tab (index 0).
@@ -102,7 +153,30 @@ The Market tab body is the read-only commodity table (`#2993` E5a). It iterates 
 - the **last market price** from `Game.worldMarketState.prices[commodityId]` in `--accentBright` (`titleSmall`), formatted to one decimal place; the canonical em-dash glyph `—` renders when the commodity is absent from `prices` (typically only in tests / Widgetbook stories that instantiate `WorldMarketState.empty`),
 - the **previous-turn aggregate volume** line `Bids X / Offers Y` from `Game.worldMarketState.lastTurnActivity[commodityId]` in `--muted` (`bodySmall`); commodities absent from `lastTurnActivity` default to `Bids 0 / Offers 0` so the column reads consistently.
 
-The Deal Book placeholder body uses canonical palette tokens only and carries copy naming the parent and depending issues (`#2989`, `#2990`, `#2993` E6) so reviewers can see which follow-up unlocks its live ledger.
+### Deal Book ledger content (`#2993` E6)
+
+The Deal Book tab body is now the live two-panel ledger described in the wireframe above. Each panel reads from `Game.worldMarketState`:
+
+- **Filled rows** are sourced from `lastTurnActivity[*].deals`, scoped per panel:
+  - Bids panel includes every `FilledDeal` whose `buyerFactionId == playerId`.
+  - Offers panel includes every `FilledDeal` whose `sellerFactionId == playerId`.
+  - Encounter order is the iteration order of `lastTurnActivity.entries` followed by the per-commodity `deals` list — deterministic for a given resolved-turn state because the world-market phase handler writes the per-commodity `deals` list in matcher emission order (FRR pre-pass → priority tiers → FTP → fallback per `SPEC/program/world-market-resolution.md` § Step F).
+- **Unfilled rows** are sourced from `carryForwardBidsByFactionId[playerId]` (bids panel) and `carryForwardOffersByFactionId[playerId]` (offers panel) in their stored list order.
+- **FRR / FTP tags** render on filled rows when `FilledDeal.isFirstRightOfRefusalMatch` / `isFtpMatch` is true, separated by a space (`FRR FTP` when both are true), in `--muted` `bodySmall` so the chrome reads as an audit annotation rather than a primary control.
+- **Totals row** sums `(deal.quantity × deal.pricePerUnit).round()` across the panel's filled rows only — carry-forwards have not cleared and so do not move treasury yet (per `SPEC/program/world-market-resolution.md` § Step C Treasury). The totals row is always mounted (`Total spent: 0` / `Total received: 0` when no filled deals exist) so widget tests can pin the affordance regardless of activity.
+- **Empty state** mounts the per-side empty-text only when both `filledRows.isEmpty` **and** `unfilledRows.isEmpty`; the totals row remains mounted underneath. When one side is populated and the other empty, each subsection renders its own "No deals filled this turn." / "No orders carrying forward." inline placeholder so the panel structure stays consistent.
+- **Cross-side coexistence:** When the world-market phase emits both `deals` and `MarketActivityNote` drop notes on the same commodity, the Deal Book reads only `deals` for filled rows; drop notes are owned by future observer/Deal Book surfaces (Refs `#2990` B3 follow-up) and are intentionally out of scope for this slice.
+
+The ledger is read-only: there are no interactive controls inside `_DealBookTabContent`, so the observe-mode `IgnorePointer` wrap that protects the Market tab is unnecessary here. The Deal Book content renders identically regardless of `shellPlayerContextProvider.canMutateViaUi`.
+
+### Responsive layout (`#2993` E6)
+
+`_DealBookTabContent` wraps the two panels in a `LayoutBuilder`:
+
+- When the inherited `BoxConstraints.maxWidth >= TradeScreen.dealBookTwoPanelMinWidth` (600 dp), the panels render in a `Row` with `Expanded(child: bidsPanel)`, a 12 dp `SizedBox`, and `Expanded(child: offersPanel)` — both panels share the same top anchor.
+- Below the threshold the panels stack vertically inside a `Column` (`mainAxisSize: MainAxisSize.min`, `crossAxisAlignment: CrossAxisAlignment.stretch`) with a 12 dp `SizedBox` between them. This keeps the Deal Book overflow-safe at the 320 dp minimum viewport per `SPEC/ui/mobile-adaptation.md` § 7.
+
+The 600 dp threshold matches the `kMinViewportWidth` (320 dp) + extra breathing room: between 320–599 dp the panels stack; at 600 dp+ they sit side-by-side.
 
 ### Cargo indicator + per-stepper cap + warning (`#2993` E5c)
 
@@ -119,14 +193,13 @@ The per-row bid stepper and direction chips honour the cross-commodity cap:
 
 `tradeCargoCapacity == 0` is a valid state: the indicator renders `Cargo remaining: 0`, no bids can be staged via direction toggle or increment, and the warning row is absent until at least one bid is staged (which itself is impossible at capacity 0, so the warning row never mounts at capacity 0 — the indicator alone communicates the no-cargo state).
 
-### Body (planned — follow-up `#2993` E5b cont. + E6)
+### Body (planned — follow-up `#2993` E5b cont.)
 
-The Market interactive table above plus the E5c cargo indicator are the foundation. Follow-up slices extend each commodity row in place inside the same tab strip:
+The Market interactive table above plus the E5c cargo indicator are the foundation. The remaining follow-up slice extends the per-row Market controls inside the same tab strip:
 
 - **Market tab — priority dropdown (`#2993` E5b cont.):** integer dropdown bounded by the `kMaxTradePriority` (or equivalent) value exposed by the data API in `#2989`. The current slice defaults staged trade orders to priority 1 and flags the integration for the follow-up bound.
-- **Deal Book tab (E6):** two-panel ledger of the previous turn's filled / partial / unfilled bids and offers, with treasury totals.
 
-When E6 lands, replace the relevant subsections of this document (ledger layout) without changing the surrounding tab strip / `CtPanel` / padding chrome — the tab structure stays the same.
+The Deal Book tab body's live two-panel ledger ships in this commit (Refs `#2993` E6) — see [§ Deal Book ledger content (`#2993` E6)](#deal-book-ledger-content-2993-e6) above for the layout, sources, and totals contract.
 
 ---
 
@@ -157,9 +230,9 @@ When E6 lands, replace the relevant subsections of this document (ledger layout)
 
 Observe-mode (`canMutateViaUi == false`, distinct from the global-observe / panels-not-defined sentinel covered by variant `c`): the Market tab body is wrapped in `IgnorePointer` and dimmed by an `Opacity` of `0.7`; the chips and stepper buttons remain mounted (so the static read-only data renders) but taps are blocked and `currentOrdersProvider` is not mutated. This matches the production-screen read-only pattern (`canEdit ? panel : IgnorePointer(child: panel)`).
 
-### Future user actions (`#2993` E5b cont. + E6)
+### Future user actions (`#2993` E5b cont.)
 
-The interactive contract for the priority dropdown (bound to `kMaxTradePriority` once #2989 exposes it) and the Deal Book read-only ledger is documented in `#2988` § UI Design. Mirror those rows into this **Behavior** table when the follow-up slices land — the tab-switch, direction-chip, and cargo-indicator rows above stay untouched because the tab + row + header structure does not change.
+The interactive contract for the priority dropdown (bound to `kMaxTradePriority` once #2989 exposes it) is documented in `#2988` § UI Design. Mirror those rows into this **Behavior** table when the follow-up slice lands — the tab-switch, direction-chip, and cargo-indicator rows above stay untouched because the tab + row + header structure does not change. The Deal Book ledger ships in this commit (Refs `#2993` E6) and is purely read-only: there are no interactive controls on `_DealBookTabContent`, so the User actions table above already covers every input on the screen.
 
 ---
 
@@ -168,12 +241,12 @@ The interactive contract for the priority dropdown (bound to `kMaxTradePriority`
 | ID | Variant | Trigger | Render difference |
 |----|---------|---------|-------------------|
 | `GAME60001` | Default — Market tab (a) | Human player active; Market tab selected (initial state) | Dark chrome + `_TradeScreenTabsBody` with the Market tab (`tradeScreenMarketTabBody`) foregrounded; the body is the read-only commodity table keyed `tradeScreenMarketCommodityList` with one `tradeScreenMarketRow:<id>` per tradeable commodity (`#2993` E5a). |
-| `GAME60001` | Default — Deal Book tab (b) | Human player active; user has tapped the `Deal Book` tab label | Dark chrome + `_TradeScreenTabsBody` with the Deal Book tab (`tradeScreenDealBookTabBody`) foregrounded; the body remains the placeholder `CtPanel` until `#2993` E6 lands the live ledger. |
+| `GAME60001` | Default — Deal Book tab (b) | Human player active; user has tapped the `Deal Book` tab label | Dark chrome + `_TradeScreenTabsBody` with the Deal Book tab (`tradeScreenDealBookTabBody`) foregrounded; the body is now the live `_DealBookTabContent` two-panel ledger (`tradeScreenDealBookContent`) with `tradeScreenDealBookBidsPanel` / `tradeScreenDealBookOffersPanel` containers and `tradeScreenDealBook{Bids,Offers}Totals` rows always mounted (Refs `#2993` E6). |
 | `GAME60001` | Observe mode (c) | `shellPanelsNotDefined(ref) == true` | Body switches to `ObserveModeNotDefinedPanel(title: 'Trade')`; the tab strip (and both tab bodies) are not mounted under this branch. |
 
-When the follow-up E6 slice lands, the variant table stays as is — only the Deal Book tab body's render description changes from "placeholder" to the live ledger.
-
 The Market tab body's cargo indicator + warning state described in [§ Cargo indicator + per-stepper cap + warning (`#2993` E5c)](#cargo-indicator--per-stepper-cap--warning-2993-e5c) is an internal substate of variant `a` (Default — Market tab): the indicator row is always mounted under `tradeScreenMarketTabBody`; the warning row mounts and dismounts as the staged-bid total saturates / desaturates the player's `tradeCargoCapacity`.
+
+The Deal Book ledger described in [§ Deal Book ledger content (`#2993` E6)](#deal-book-ledger-content-2993-e6) is an internal substate of variant `b` (Default — Deal Book tab): the bids and offers panel containers + per-side totals rows are always mounted under `tradeScreenDealBookContent`; the per-side empty-state, filled, and unfilled rows mount or dismount based on the player's `lastTurnActivity[*].deals` / `carryForward{Bids,Offers}ByFactionId[playerId]` content. Switching back and forth between the Market and Deal Book tabs preserves the IndexedStack state per the E4 contract.
 
 ---
 
@@ -186,6 +259,9 @@ The Market tab body's cargo indicator + warning state described in [§ Cargo ind
 - `CtPanel` (`SPEC/ui/pixel-art-ui-catalog.md` § `CtPanel`) — outer surface for the tabs body and inner surface for each tab placeholder.
 - `CtTabStrip` (`SPEC/ui/pixel-art-ui-catalog.md` § `CtTabStrip`) — dark editorial-monocle tab strip hosting the `Market` and `Deal Book` labels above the `IndexedStack` of tab bodies.
 - `ObserveModeNotDefinedPanel` (`app/lib/features/game/widgets/observe_mode_not_defined_panel.dart`) — shared observe-mode sentinel.
+- `_DealBookTabContent` (`app/lib/features/game/screens/trade_screen.dart`) — read-only two-panel ledger (Refs `#2993` E6) hosting both `_DealBookPanel` instances under a `LayoutBuilder` that picks `Row` vs `Column` based on `dealBookTwoPanelMinWidth`.
+- `_DealBookPanel` (`app/lib/features/game/screens/trade_screen.dart`) — single ledger panel; renders panel title, optional empty-state copy, the Filled / Unfilled sections, and the always-mounted totals row.
+- `_DealBookFilledRow` / `_DealBookUnfilledRow` (`app/lib/features/game/screens/trade_screen.dart`) — per-row widgets keyed by `dealBookFilledRowKey(side, index)` / `dealBookUnfilledRowKey(side, index)`.
 
 ---
 
@@ -202,7 +278,17 @@ Use cases for the current slice (E1+E2+E3+E4+E5a+E5b+E5c):
 | `Market tab — staged bid + offer (Refs #2993 E5b)` | Story Game with `currentOrdersProvider` pre-seeded so reviewers see an active `Bid` (timber, qty 4) and `Offer` (fabric, qty 7) without needing to drive the chips themselves. Cargo indicator reads `Cargo remaining: 20` (`24 − 4`). |
 | `Market tab — cargo saturated (Refs #2993 E5c)` | Story Game with `currentOrdersProvider` pre-seeded to stage bids whose total quantity equals `tradeCargoCapacity` so the cargo indicator reads `Cargo remaining: 0` and the warning row `tradeScreenMarketCargoWarning` is mounted. Reviewers can confirm the dark-theme `--danger` palette and the cargo-limit copy without touching the chips. |
 
-Follow-up E5b cont./E6 slices append `Market tab — priority dropdown`, `Deal Book tab — mixed fills`, etc. as the bodies land. The tab structure remains the same; only each tab body's content advances.
+Recommended Widgetbook use cases for the `#2993` E6 Deal Book slice (mount in `tradeScreenDirectories` as the live content matures):
+
+| Use case | Proves |
+|----------|--------|
+| `Deal Book tab — empty` | Default story Game with `lastTurnActivity == {}` and empty carry-forwards. Reviewers see both empty-state copies (`dealBookBidsEmpty` / `dealBookOffersEmpty`) and `Total spent: 0` / `Total received: 0` totals. |
+| `Deal Book tab — mixed fills + carry-forwards` | Story Game with one filled buy, one filled sale, FRR-tagged + FTP-tagged rows on each side, and at least one carry-forward bid and one carry-forward offer. Proves both Filled / Unfilled subsections render together. |
+| `Deal Book tab — mobile (stacked)` | Same data inside `mobileViewport` (360 × 640 dp) to prove the stacked layout (panels in a `Column`) below `dealBookTwoPanelMinWidth`. |
+
+These use cases share the same data sources as the trade screen runtime (`Game.worldMarketState`) so the Widgetbook contract evolves with the live render automatically.
+
+Follow-up E5b cont. slices append `Market tab — priority dropdown` as the priority API surface lands. The tab structure remains the same; only each tab body's content advances.
 
 ---
 
@@ -263,6 +349,26 @@ Follow-up E5b cont./E6 slices append `Market tab — priority dropdown`, `Deal B
 - **Given** the player has `tradeCargoCapacity = 10`, has staged `Bid` timber qty 10, **when** the user taps the `None` chip on timber (`marketRowNoneChipKey('timber')`), **then** the staged `TradeOrder` for timber is removed, the cargo indicator updates to `Cargo remaining: 10`, and the warning row is removed (because `totalStagedBidQuantity == 0`).
 - **Given** the `TradeScreen` is mounted with `shellPlayerContextProvider.canMutateViaUi == false`, **then** the cargo indicator and (when applicable) warning row remain mounted with the same text values as in the editable case (they read directly from `Game` + `currentOrdersProvider` regardless of the observe-mode `IgnorePointer`).
 
-### Full screen (follow-up `#2993` E5b cont. / E6 — implement when bodies land)
+### Deal Book tab — live two-panel ledger (`#2993` E6)
 
-Migrate the remaining parent-issue ACs from `#2988` § Acceptance criteria — UI into Given–When–Then rows under this section as each follow-up slice ships (priority dropdown bound to `kMaxTradePriority`, Deal Book ledger).
+- **Given** the `TradeScreen` is mounted with a human player, observe mode is **not** active, the player has zero `FilledDeal` entries on `lastTurnActivity[*].deals` (filtered by `buyerFactionId == playerId` and `sellerFactionId == playerId`), and the player has zero carry-forward bids and zero carry-forward offers, **when** the user taps the `Deal Book` tab label, **then** the Deal Book tab body keyed `tradeScreenDealBookTabBody` foregrounds, both `tradeScreenDealBookBidsEmpty` and `tradeScreenDealBookOffersEmpty` widgets are mounted, the `tradeScreenDealBookBidsTotals` widget renders the literal `Total spent: 0`, and the `tradeScreenDealBookOffersTotals` widget renders the literal `Total received: 0`.
+
+- **Given** the `TradeScreen` is mounted with a human player `gp_h`, observe mode is **not** active, and `lastTurnActivity['timber'].deals` contains exactly one `FilledDeal(sellerFactionId: 'gp_a', buyerFactionId: 'gp_h', commodityId: 'timber', quantity: 5, pricePerUnit: 30.0)`, **when** the user taps the `Deal Book` tab label, **then** the widget tree contains exactly one widget keyed `dealBookFilledRowKey(dealBookSideBids, 0)`, no widget keyed `dealBookFilledRowKey(dealBookSideBids, 1)`, the row text is `timber — qty 5 × 30.0 = 150`, no `tradeScreenDealBookBidsEmpty` widget is mounted, and the `tradeScreenDealBookBidsTotals` widget renders the literal `Total spent: 150`.
+
+- **Given** the same conditions and a second, **unrelated** deal `FilledDeal(sellerFactionId: 'gp_a', buyerFactionId: 'gp_b', commodityId: 'iron', quantity: 4, pricePerUnit: 50.0)` is present on `lastTurnActivity['iron'].deals`, **when** the user taps the `Deal Book` tab label, **then** no row keyed `dealBookFilledRowKey(dealBookSideBids, ?)` is mounted for the iron deal (the buyer filter excludes it), and the bids panel total spent remains `150`.
+
+- **Given** the `TradeScreen` is mounted with a human player `gp_h`, observe mode is **not** active, and `lastTurnActivity` contains two filled sales by `gp_h` — `timber qty 7 × 30.0` and `iron qty 3 × 60.0` — both with `sellerFactionId == 'gp_h'`, **when** the user taps the `Deal Book` tab label, **then** the widget tree contains exactly two widgets keyed `dealBookFilledRowKey(dealBookSideOffers, 0)` and `dealBookFilledRowKey(dealBookSideOffers, 1)`, and the `tradeScreenDealBookOffersTotals` widget renders the literal `Total received: 390` (`7×30 + 3×60`).
+
+- **Given** the `TradeScreen` is mounted with a human player `gp_h`, observe mode is **not** active, `lastTurnActivity` is empty, and `carryForwardBidsByFactionId['gp_h']` contains a single `TradeOrder(commodityId: 'timber', type: bid, quantity: 8, priority: 2)`, **when** the user taps the `Deal Book` tab label, **then** the widget tree contains exactly one widget keyed `dealBookUnfilledRowKey(dealBookSideBids, 0)`, the row text is `timber — qty 8 (priority 2)`, no `dealBookFilledRowKey(dealBookSideBids, ?)` widget is mounted, no `tradeScreenDealBookBidsEmpty` widget is mounted, and the `tradeScreenDealBookBidsTotals` widget continues to render the literal `Total spent: 0` (carry-forwards have not cleared and never contribute to treasury totals).
+
+- **Given** the `TradeScreen` is mounted with a human player `gp_h`, observe mode is **not** active, `lastTurnActivity` is empty, and `carryForwardOffersByFactionId` contains entries for `gp_h` (`fabric qty 6 priority 1`, `fabric qty 4 priority 3`) **and** for the foreign GP `gp_a` (`timber qty 99 priority 1`), **when** the user taps the `Deal Book` tab label, **then** the widget tree contains exactly two widgets keyed `dealBookUnfilledRowKey(dealBookSideOffers, 0)` and `dealBookUnfilledRowKey(dealBookSideOffers, 1)`, and no widget with text `timber — qty 99 (priority 1)` is mounted anywhere (player isolation: foreign carry-forwards never leak into the human player's Deal Book).
+
+- **Given** the `TradeScreen` is mounted with a human player `gp_h`, observe mode is **not** active, and `lastTurnActivity['timber'].deals` contains one FRR-tagged buy (`isFirstRightOfRefusalMatch: true`) and one FTP-tagged buy (`isFtpMatch: true`) both with `buyerFactionId == 'gp_h'`, **when** the user taps the `Deal Book` tab label, **then** the widget tree contains exactly two widgets keyed `dealBookFilledRowKey(dealBookSideBids, 0)` and `dealBookFilledRowKey(dealBookSideBids, 1)`, the literal text `FRR` appears exactly once on the page, the literal text `FTP` appears exactly once on the page, and `tradeScreenDealBookBidsTotals` renders the literal `Total spent: 180` (`3×30 + 3×30`).
+
+- **Given** the viewport width is at least `TradeScreen.dealBookTwoPanelMinWidth` (600 dp), **when** the Deal Book tab is foregrounded, **then** `tester.getTopLeft(find.byKey(dealBookOffersPanelKey)).dx` is strictly greater than `tester.getTopLeft(find.byKey(dealBookBidsPanelKey)).dx` and their `dy` values are equal (the panels render side-by-side with a shared top anchor inside the `Row`).
+
+- **Given** the viewport width is exactly `kMinViewportWidth` (320 dp) and the height is at least 640 dp, **when** the Deal Book tab is foregrounded, **then** `tester.takeException()` returns `null`, `tester.getTopLeft(find.byKey(dealBookOffersPanelKey)).dy` is strictly greater than `tester.getTopLeft(find.byKey(dealBookBidsPanelKey)).dy` (the panels stack vertically), and the Deal Book renders inside the 320 dp column without horizontal overflow.
+
+### Full screen (follow-up `#2993` E5b cont.)
+
+Migrate the remaining parent-issue ACs from `#2988` § Acceptance criteria — UI into Given–When–Then rows under this section as each follow-up slice ships (priority dropdown bound to `kMaxTradePriority`).

--- a/app/lib/features/game/screens/trade_screen.dart
+++ b/app/lib/features/game/screens/trade_screen.dart
@@ -1,6 +1,6 @@
 // Full-screen World Market Trade screen. SPEC/ui/trade-screen.md.
 //
-// **Scope (Refs #2993 E5a + E5b + E5c):**
+// **Scope (Refs #2993 E5a + E5b + E5c + E6):**
 // - E5a (already shipped) — route + screen ID + dark editorial-monocle
 //   chrome + observe-mode guard + two-tab body (Market + Deal Book) +
 //   read-only commodity table (last market price + previous-turn
@@ -14,33 +14,48 @@
 //   one staged `TradeOrder` per (player, commodityId) pair, so toggling
 //   from `Bid` to `Offer` (or vice versa) replaces the prior direction
 //   in place.
-// - E5c (this slice) — cross-commodity cargo-remaining indicator + cap +
-//   warning. A persistent header strip above the commodity list renders
-//   `Cargo remaining: X` where `X = max(0, tradeCargoCapacity − totalBid)`.
-//   `tradeCargoCapacity` is `cargoHoldsForHomeFleet(game, player.id)`
-//   (falling back to `defaultCargoHoldsStub = 24` when the player has no
-//   home fleet). `totalBid` is the sum of staged `TradeOrderType.bid`
-//   quantities for the player; offers don't consume cargo (per #2988
-//   §Cargo Constraint Model). When the cap is reached
-//   (`remainingCargo == 0 AND totalBid > 0`), a warning row is mounted
-//   below the indicator. Bid increments and `Bid` toggles are clamped
-//   so the cross-commodity bid total never exceeds `tradeCargoCapacity`.
+// - E5c (already shipped) — cross-commodity cargo-remaining indicator +
+//   cap + warning. A persistent header strip above the commodity list
+//   renders `Cargo remaining: X` where
+//   `X = max(0, tradeCargoCapacity − totalBid)`. `tradeCargoCapacity` is
+//   `cargoHoldsForHomeFleet(game, player.id)` (falling back to
+//   `defaultCargoHoldsStub = 24` when the player has no home fleet).
+//   `totalBid` is the sum of staged `TradeOrderType.bid` quantities for
+//   the player; offers don't consume cargo (per #2988 §Cargo Constraint
+//   Model). When the cap is reached (`remainingCargo == 0 AND
+//   totalBid > 0`), a warning row is mounted below the indicator. Bid
+//   increments and `Bid` toggles are clamped so the cross-commodity bid
+//   total never exceeds `tradeCargoCapacity`.
+// - E6 (this slice) — Deal Book live two-panel ledger. The Deal Book tab
+//   body now renders the player's own previous-turn `FilledDeal`s and
+//   carry-forward orders, sourced from
+//   `Game.worldMarketState.lastTurnActivity[*].deals` (filtered by
+//   `buyerFactionId` / `sellerFactionId`) and
+//   `WorldMarketState.carryForward{Bids,Offers}ByFactionId[playerId]`.
+//   Two panels — `Your bids` (left, treasury spent) and `Your offers`
+//   (right, treasury received) — each with a Filled section and an
+//   Unfilled (carry-forward) section, plus a totals row that sums
+//   `quantity × pricePerUnit` over the filled deals only (carry-forwards
+//   have not cleared so they do not contribute to treasury totals). On
+//   viewports narrower than `dealBookTwoPanelMinWidth` (600 dp) the two
+//   panels stack vertically; otherwise they sit side-by-side. The Deal
+//   Book is purely read-only — observe-mode does not need a separate
+//   `IgnorePointer` wrap because the ledger has no interactive controls.
 //
 // Observe mode (the GP-observation `canMutateViaUi == false` case,
 // distinct from the "global observe / panels not defined" sentinel)
-// wraps the controls in `IgnorePointer` and visually dims them so the
-// table reads as read-only; the cargo indicator + warning stay live
-// (they read directly from `Game` + `currentOrdersProvider`).
+// wraps the Market tab controls in `IgnorePointer` and visually dims
+// them so the table reads as read-only; the cargo indicator + warning
+// stay live (they read directly from `Game` + `currentOrdersProvider`).
+// The Deal Book ledger is rendered identically regardless of edit
+// permission — it always reflects the resolved-turn state.
 //
 // Deferred to follow-up slices:
 // - Priority dropdown (default priority 1 today; integration with the
 //   `kMaxTradePriority` API surface is tracked under #2989).
-// - Deal Book live ledger (Refs #2993 E6) once the per-player ledger
-//   surface ships on top of #2989 / #2990's `MarketActivity` + world-market
-//   turn phase.
 //
-// The two-tab structure is the durable wireframe E6 continues to build
-// on, so the contract this file ships matches what
+// The two-tab structure is the durable wireframe E6 builds inside, so
+// the contract this file ships matches what
 // `SPEC/ui/trade-screen.md` § Layout / wireframe records as the canonical
 // body for the screen.
 
@@ -222,12 +237,137 @@ class TradeScreen extends ConsumerWidget {
   static const String cargoLimitWarningText =
       'Cargo limit reached — increase your fleet capacity or reduce bids.';
 
-  /// Stable widget key for the Deal Book tab placeholder body. Pin point
-  /// for widget tests asserting the Deal Book tab body is present in the
-  /// tab strip's `IndexedStack` (visible when the Deal Book tab is
-  /// selected after the user taps the Deal Book label).
+  /// Stable widget key for the Deal Book tab body. Pin point for widget
+  /// tests asserting the Deal Book tab body is present in the tab
+  /// strip's `IndexedStack` (visible when the Deal Book tab is selected
+  /// after the user taps the Deal Book label). Refs #2993 E6 swapped
+  /// the placeholder for `_DealBookTabContent` — the key is intentionally
+  /// stable so existing tab-switch tests keep pinning the same body root.
   static const Key dealBookTabBodyKey =
       ValueKey<String>('tradeScreenDealBookTabBody');
+
+  /// Stable widget key for the root of the live Deal Book ledger content
+  /// (Refs #2993 E6). Sits directly under `dealBookTabBodyKey` and pins
+  /// the two-panel layout so widget tests can scope queries.
+  static const Key dealBookContentKey =
+      ValueKey<String>('tradeScreenDealBookContent');
+
+  /// Side identifier used to scope per-row Deal Book keys to the bids
+  /// panel (commodities the player **bought**).
+  static const String dealBookSideBids = 'bids';
+
+  /// Side identifier used to scope per-row Deal Book keys to the offers
+  /// panel (commodities the player **sold**).
+  static const String dealBookSideOffers = 'offers';
+
+  /// Stable widget key for the Deal Book bids panel container
+  /// (Refs #2993 E6).
+  static const Key dealBookBidsPanelKey =
+      ValueKey<String>('tradeScreenDealBookBidsPanel');
+
+  /// Stable widget key for the Deal Book offers panel container
+  /// (Refs #2993 E6).
+  static const Key dealBookOffersPanelKey =
+      ValueKey<String>('tradeScreenDealBookOffersPanel');
+
+  /// Stable widget key for the Deal Book bids panel treasury-totals row
+  /// (`Total spent: N`). Always mounted under the bids panel even when
+  /// `filledTotal == 0` so widget tests can pin the totals affordance.
+  static const Key dealBookBidsTotalsKey =
+      ValueKey<String>('tradeScreenDealBookBidsTotals');
+
+  /// Stable widget key for the Deal Book offers panel treasury-totals
+  /// row (`Total received: N`).
+  static const Key dealBookOffersTotalsKey =
+      ValueKey<String>('tradeScreenDealBookOffersTotals');
+
+  /// Stable widget key for the Deal Book bids panel empty-state copy.
+  /// Mounted only when the player has zero filled bids **and** zero
+  /// carry-forward bids for the resolved turn; absent otherwise.
+  static const Key dealBookBidsEmptyKey =
+      ValueKey<String>('tradeScreenDealBookBidsEmpty');
+
+  /// Stable widget key for the Deal Book offers panel empty-state copy.
+  /// Mounted only when the player has zero filled sales **and** zero
+  /// carry-forward offers for the resolved turn; absent otherwise.
+  static const Key dealBookOffersEmptyKey =
+      ValueKey<String>('tradeScreenDealBookOffersEmpty');
+
+  /// Per-row Deal Book key for a filled deal row, scoped by `side`
+  /// (`dealBookSideBids` or `dealBookSideOffers`) and the row's
+  /// zero-based index inside the per-side filled-deals list. Lets widget
+  /// tests pin a specific filled row without coupling to text matching.
+  static Key dealBookFilledRowKey(String side, int index) =>
+      ValueKey<String>('tradeScreenDealBookFilledRow:$side:$index');
+
+  /// Per-row Deal Book key for an unfilled (carry-forward) order row,
+  /// scoped by `side` and zero-based index.
+  static Key dealBookUnfilledRowKey(String side, int index) =>
+      ValueKey<String>('tradeScreenDealBookUnfilledRow:$side:$index');
+
+  /// Minimum viewport width (logical px) above which the Deal Book
+  /// renders its two panels side-by-side. Below this threshold the
+  /// panels stack vertically so the 320 dp minimum viewport stays
+  /// overflow-safe per `SPEC/ui/mobile-adaptation.md` § 7.
+  static const double dealBookTwoPanelMinWidth = 600;
+
+  /// Localized title for the Deal Book bids panel — the player's
+  /// previous-turn buying activity (filled buys + carry-forward bids).
+  // ignore: avoid_hardcoded_strings_in_widgets
+  static const String dealBookBidsPanelTitle = 'Your bids';
+
+  /// Localized title for the Deal Book offers panel — the player's
+  /// previous-turn selling activity (filled sales + carry-forward
+  /// offers).
+  // ignore: avoid_hardcoded_strings_in_widgets
+  static const String dealBookOffersPanelTitle = 'Your offers';
+
+  /// Localized section heading for filled rows inside a Deal Book panel.
+  // ignore: avoid_hardcoded_strings_in_widgets
+  static const String dealBookFilledHeading = 'Filled';
+
+  /// Localized section heading for carry-forward (unfilled) rows inside
+  /// a Deal Book panel.
+  // ignore: avoid_hardcoded_strings_in_widgets
+  static const String dealBookUnfilledHeading = 'Unfilled (carry-forward)';
+
+  /// Localized empty-state copy for the bids panel when the player has
+  /// neither filled bids nor carry-forward bids for the resolved turn.
+  // ignore: avoid_hardcoded_strings_in_widgets
+  static const String dealBookBidsEmptyText =
+      'No bids placed last turn.';
+
+  /// Localized empty-state copy for the offers panel when the player
+  /// has neither filled sales nor carry-forward offers for the resolved
+  /// turn.
+  // ignore: avoid_hardcoded_strings_in_widgets
+  static const String dealBookOffersEmptyText =
+      'No offers placed last turn.';
+
+  /// Localized totals label for the bids panel (treasury spent on
+  /// filled buys this turn — carry-forwards excluded because they have
+  /// not cleared).
+  // ignore: avoid_hardcoded_strings_in_widgets
+  static const String dealBookTotalSpentLabel = 'Total spent';
+
+  /// Localized totals label for the offers panel (treasury received
+  /// from filled sales this turn — carry-forwards excluded).
+  // ignore: avoid_hardcoded_strings_in_widgets
+  static const String dealBookTotalReceivedLabel = 'Total received';
+
+  /// Localized empty-state copy rendered inside a Deal Book panel's
+  /// **Filled** section when the player has no filled rows on that side
+  /// (but does have carry-forwards, so the panel itself is non-empty).
+  // ignore: avoid_hardcoded_strings_in_widgets
+  static const String dealBookFilledEmptyText = 'No deals filled this turn.';
+
+  /// Localized empty-state copy rendered inside a Deal Book panel's
+  /// **Unfilled** section when the player has no carry-forward orders
+  /// on that side (but does have filled rows, so the panel itself is
+  /// non-empty).
+  // ignore: avoid_hardcoded_strings_in_widgets
+  static const String dealBookUnfilledEmptyText =
+      'No orders carrying forward.';
 
   /// Tab label for the Market tab (default selection). SPEC §
   /// Layout / wireframe pins the literal `"Market"` so widget tests can
@@ -318,8 +458,10 @@ class _TradeScreenTabsBody extends StatelessWidget {
               playerId: playerId,
               canEdit: canEdit,
             ),
-            const _DealBookTabPlaceholder(
+            _DealBookTabContent(
               key: TradeScreen.dealBookTabBodyKey,
+              game: game,
+              playerId: playerId,
             ),
           ],
         ),
@@ -899,44 +1041,395 @@ class _StepperButton extends StatelessWidget {
   }
 }
 
-/// Placeholder body for the Deal Book tab (`#2993` E6 unlocks the live
-/// previous-turn ledger once a per-player ledger surface ships on top
-/// of #2989 / #2990's `MarketActivity` + world-market turn phase).
-class _DealBookTabPlaceholder extends StatelessWidget {
-  const _DealBookTabPlaceholder({super.key});
+/// Live Deal Book tab body (Refs #2993 E6). Renders the player's
+/// previous-turn buying and selling activity in a two-panel ledger
+/// sourced from `Game.worldMarketState.lastTurnActivity[*].deals`
+/// (filtered by `buyerFactionId` / `sellerFactionId`) and
+/// `carryForward{Bids,Offers}ByFactionId[playerId]`.
+///
+/// Layout collapses to a single stacked column below
+/// `TradeScreen.dealBookTwoPanelMinWidth` so the 320 dp minimum viewport
+/// stays overflow-safe (`SPEC/ui/mobile-adaptation.md` § 7). On wider
+/// viewports the bids panel sits left of the offers panel inside a
+/// `Row`.
+class _DealBookTabContent extends StatelessWidget {
+  const _DealBookTabContent({
+    super.key,
+    required this.game,
+    required this.playerId,
+  });
 
-  // ignore: avoid_hardcoded_strings_in_widgets
-  static const String _titleText = 'Deal Book';
-
-  // ignore: avoid_hardcoded_strings_in_widgets
-  static const String _bodyText =
-      'Previous-turn filled, partial, and unfilled bids and offers — '
-      'with treasury totals — render here once the world-market turn '
-      'phase ships (Refs #2989, #2990, #2993 E6).';
+  final Game game;
+  final String playerId;
 
   @override
   Widget build(BuildContext context) {
-    final ThemeData theme = Theme.of(context);
-    final TextStyle titleStyle =
-        (theme.textTheme.titleMedium ?? const TextStyle(fontSize: 16))
-            .copyWith(color: EditorialMonoclePalette.accent);
-    final TextStyle bodyStyle =
-        (theme.textTheme.bodyMedium ?? const TextStyle(fontSize: 14))
-            .copyWith(color: EditorialMonoclePalette.muted);
-    return Align(
+    final _DealBookViewData data = _DealBookViewData.build(
+      worldMarket: game.worldMarketState,
+      playerId: playerId,
+    );
+    return Container(
+      key: TradeScreen.dealBookContentKey,
       alignment: Alignment.topLeft,
-      child: CtPanel(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: <Widget>[
-            Text(_titleText, style: titleStyle),
-            const SizedBox(height: 8),
-            Text(_bodyText, style: bodyStyle),
-          ],
-        ),
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final bool wide =
+              constraints.maxWidth >= TradeScreen.dealBookTwoPanelMinWidth;
+          return _layoutPanels(
+            bidsPanel: _buildBidsPanel(data),
+            offersPanel: _buildOffersPanel(data),
+            wide: wide,
+          );
+        },
       ),
+    );
+  }
+
+  _DealBookPanel _buildBidsPanel(_DealBookViewData data) {
+    return _DealBookPanel(
+      key: TradeScreen.dealBookBidsPanelKey,
+      panelTitle: TradeScreen.dealBookBidsPanelTitle,
+      side: TradeScreen.dealBookSideBids,
+      filledRows: data.filledBids,
+      unfilledRows: data.unfilledBids,
+      totalsKey: TradeScreen.dealBookBidsTotalsKey,
+      emptyKey: TradeScreen.dealBookBidsEmptyKey,
+      totalsLabel: TradeScreen.dealBookTotalSpentLabel,
+      totalsAmount: data.totalSpent,
+      emptyText: TradeScreen.dealBookBidsEmptyText,
+    );
+  }
+
+  _DealBookPanel _buildOffersPanel(_DealBookViewData data) {
+    return _DealBookPanel(
+      key: TradeScreen.dealBookOffersPanelKey,
+      panelTitle: TradeScreen.dealBookOffersPanelTitle,
+      side: TradeScreen.dealBookSideOffers,
+      filledRows: data.filledOffers,
+      unfilledRows: data.unfilledOffers,
+      totalsKey: TradeScreen.dealBookOffersTotalsKey,
+      emptyKey: TradeScreen.dealBookOffersEmptyKey,
+      totalsLabel: TradeScreen.dealBookTotalReceivedLabel,
+      totalsAmount: data.totalReceived,
+      emptyText: TradeScreen.dealBookOffersEmptyText,
+    );
+  }
+
+  Widget _layoutPanels({
+    required Widget bidsPanel,
+    required Widget offersPanel,
+    required bool wide,
+  }) {
+    if (wide) {
+      return Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Expanded(child: bidsPanel),
+          const SizedBox(width: 12),
+          Expanded(child: offersPanel),
+        ],
+      );
+    }
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        bidsPanel,
+        const SizedBox(height: 12),
+        offersPanel,
+      ],
+    );
+  }
+}
+
+/// Pure value object built from `WorldMarketState` for the player's
+/// Deal Book view. Holds the four per-side row lists (filled / unfilled
+/// for bids and offers) and the two treasury totals. Pulled out so the
+/// rendering widget tree stays declarative and unit-testable.
+class _DealBookViewData {
+  const _DealBookViewData({
+    required this.filledBids,
+    required this.filledOffers,
+    required this.unfilledBids,
+    required this.unfilledOffers,
+    required this.totalSpent,
+    required this.totalReceived,
+  });
+
+  factory _DealBookViewData.build({
+    required WorldMarketState worldMarket,
+    required String playerId,
+  }) {
+    final List<FilledDeal> bids = <FilledDeal>[];
+    final List<FilledDeal> offers = <FilledDeal>[];
+    for (final MarketActivity activity in worldMarket.lastTurnActivity.values) {
+      for (final FilledDeal deal in activity.deals) {
+        if (deal.buyerFactionId == playerId) bids.add(deal);
+        if (deal.sellerFactionId == playerId) offers.add(deal);
+      }
+    }
+    int spent = 0;
+    for (final FilledDeal deal in bids) {
+      spent += (deal.quantity * deal.pricePerUnit).round();
+    }
+    int received = 0;
+    for (final FilledDeal deal in offers) {
+      received += (deal.quantity * deal.pricePerUnit).round();
+    }
+    return _DealBookViewData(
+      filledBids: List<FilledDeal>.unmodifiable(bids),
+      filledOffers: List<FilledDeal>.unmodifiable(offers),
+      unfilledBids:
+          worldMarket.carryForwardBidsByFactionId[playerId] ??
+              const <TradeOrder>[],
+      unfilledOffers:
+          worldMarket.carryForwardOffersByFactionId[playerId] ??
+              const <TradeOrder>[],
+      totalSpent: spent,
+      totalReceived: received,
+    );
+  }
+
+  final List<FilledDeal> filledBids;
+  final List<FilledDeal> filledOffers;
+  final List<TradeOrder> unfilledBids;
+  final List<TradeOrder> unfilledOffers;
+  final int totalSpent;
+  final int totalReceived;
+}
+
+/// Single ledger panel (one of `Your bids` / `Your offers`). Wraps the
+/// rows in a [CtPanel] so the dark editorial-monocle surface matches the
+/// sibling panels on this screen. Sections inside the panel:
+///
+/// * Title row (`titleMedium`, `--accent`).
+/// * Filled section heading + rows (or in-panel empty placeholder).
+/// * Unfilled section heading + rows (or in-panel empty placeholder).
+/// * Totals row pinned by [totalsKey].
+///
+/// When **both** `filledRows.isEmpty` and `unfilledRows.isEmpty`, the
+/// per-section headings collapse and a single empty-state line keyed
+/// [emptyKey] is rendered. The totals row remains mounted regardless so
+/// widget tests can pin the affordance.
+class _DealBookPanel extends StatelessWidget {
+  const _DealBookPanel({
+    super.key,
+    required this.panelTitle,
+    required this.side,
+    required this.filledRows,
+    required this.unfilledRows,
+    required this.totalsKey,
+    required this.emptyKey,
+    required this.totalsLabel,
+    required this.totalsAmount,
+    required this.emptyText,
+  });
+
+  final String panelTitle;
+  final String side;
+  final List<FilledDeal> filledRows;
+  final List<TradeOrder> unfilledRows;
+  final Key totalsKey;
+  final Key emptyKey;
+  final String totalsLabel;
+  final int totalsAmount;
+  final String emptyText;
+
+  @override
+  Widget build(BuildContext context) {
+    final _DealBookPanelStyles styles = _DealBookPanelStyles.of(context);
+    final bool panelEmpty = filledRows.isEmpty && unfilledRows.isEmpty;
+    return CtPanel(
+      padding: const EdgeInsets.all(12),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          Text(panelTitle, style: styles.title),
+          const SizedBox(height: 8),
+          if (panelEmpty)
+            Text(emptyText, key: emptyKey, style: styles.muted)
+          else
+            ..._buildSections(styles),
+          const SizedBox(height: 12),
+          Text(
+            // ignore: avoid_hardcoded_strings_in_widgets
+            '$totalsLabel: $totalsAmount',
+            key: totalsKey,
+            style: styles.totals,
+          ),
+        ],
+      ),
+    );
+  }
+
+  List<Widget> _buildSections(_DealBookPanelStyles styles) {
+    return <Widget>[
+      Text(TradeScreen.dealBookFilledHeading, style: styles.sectionHeading),
+      const SizedBox(height: 4),
+      ..._buildFilledRows(styles),
+      const SizedBox(height: 8),
+      Text(TradeScreen.dealBookUnfilledHeading, style: styles.sectionHeading),
+      const SizedBox(height: 4),
+      ..._buildUnfilledRows(styles),
+    ];
+  }
+
+  List<Widget> _buildFilledRows(_DealBookPanelStyles styles) {
+    if (filledRows.isEmpty) {
+      return <Widget>[
+        Text(TradeScreen.dealBookFilledEmptyText, style: styles.muted),
+      ];
+    }
+    return <Widget>[
+      for (int i = 0; i < filledRows.length; i++)
+        Padding(
+          padding: EdgeInsets.only(top: i == 0 ? 0 : 2),
+          child: _DealBookFilledRow(
+            rowKey: TradeScreen.dealBookFilledRowKey(side, i),
+            deal: filledRows[i],
+            rowStyle: styles.body,
+            tagStyle: styles.muted,
+          ),
+        ),
+    ];
+  }
+
+  List<Widget> _buildUnfilledRows(_DealBookPanelStyles styles) {
+    if (unfilledRows.isEmpty) {
+      return <Widget>[
+        Text(TradeScreen.dealBookUnfilledEmptyText, style: styles.muted),
+      ];
+    }
+    return <Widget>[
+      for (int i = 0; i < unfilledRows.length; i++)
+        Padding(
+          padding: EdgeInsets.only(top: i == 0 ? 0 : 2),
+          child: _DealBookUnfilledRow(
+            rowKey: TradeScreen.dealBookUnfilledRowKey(side, i),
+            order: unfilledRows[i],
+            rowStyle: styles.body,
+          ),
+        ),
+    ];
+  }
+}
+
+/// Resolved per-panel text styles, isolated as a value object so the
+/// [_DealBookPanel] build path stays under the 60-line cap.
+class _DealBookPanelStyles {
+  const _DealBookPanelStyles({
+    required this.title,
+    required this.sectionHeading,
+    required this.body,
+    required this.muted,
+    required this.totals,
+  });
+
+  factory _DealBookPanelStyles.of(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return _DealBookPanelStyles(
+      title: (theme.textTheme.titleMedium ?? const TextStyle(fontSize: 16))
+          .copyWith(color: EditorialMonoclePalette.accent),
+      sectionHeading:
+          (theme.textTheme.labelMedium ?? const TextStyle(fontSize: 12))
+              .copyWith(color: EditorialMonoclePalette.accentDim),
+      body: (theme.textTheme.bodyMedium ?? const TextStyle(fontSize: 14))
+          .copyWith(color: EditorialMonoclePalette.fg),
+      muted: (theme.textTheme.bodySmall ?? const TextStyle(fontSize: 12))
+          .copyWith(color: EditorialMonoclePalette.muted),
+      totals: (theme.textTheme.titleSmall ?? const TextStyle(fontSize: 14))
+          .copyWith(color: EditorialMonoclePalette.accentBright),
+    );
+  }
+
+  final TextStyle title;
+  final TextStyle sectionHeading;
+  final TextStyle body;
+  final TextStyle muted;
+  final TextStyle totals;
+}
+
+/// Single filled-deal row inside a Deal Book panel. Lays out
+/// `commodity — qty × price = notional` with optional FRR / FTP tags so
+/// the player can audit how the deal cleared per
+/// `SPEC/game/world-market.md` § Matching + § First Right of Refusal.
+class _DealBookFilledRow extends StatelessWidget {
+  const _DealBookFilledRow({
+    required this.rowKey,
+    required this.deal,
+    required this.rowStyle,
+    required this.tagStyle,
+  });
+
+  final Key rowKey;
+  final FilledDeal deal;
+  final TextStyle rowStyle;
+  final TextStyle tagStyle;
+
+  // ignore: avoid_hardcoded_strings_in_widgets
+  static const String _frrTag = 'FRR';
+  // ignore: avoid_hardcoded_strings_in_widgets
+  static const String _ftpTag = 'FTP';
+
+  @override
+  Widget build(BuildContext context) {
+    final int notional = (deal.quantity * deal.pricePerUnit).round();
+    final String priceText = deal.pricePerUnit.toStringAsFixed(1);
+    final List<String> tags = <String>[
+      if (deal.isFirstRightOfRefusalMatch) _frrTag,
+      if (deal.isFtpMatch) _ftpTag,
+    ];
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.baseline,
+      textBaseline: TextBaseline.alphabetic,
+      key: rowKey,
+      children: <Widget>[
+        Expanded(
+          child: Text(
+            // ignore: avoid_hardcoded_strings_in_widgets
+            '${deal.commodityId} — qty ${deal.quantity} × $priceText '
+            '= $notional',
+            style: rowStyle,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ),
+        if (tags.isNotEmpty) ...<Widget>[
+          const SizedBox(width: 6),
+          Text(
+            // ignore: avoid_hardcoded_strings_in_widgets
+            tags.join(' '),
+            style: tagStyle,
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+/// Single carry-forward order row inside a Deal Book panel. The order
+/// has not cleared yet so there is no per-unit price or notional —
+/// `commodity — qty N (priority P)` is the canonical readout.
+class _DealBookUnfilledRow extends StatelessWidget {
+  const _DealBookUnfilledRow({
+    required this.rowKey,
+    required this.order,
+    required this.rowStyle,
+  });
+
+  final Key rowKey;
+  final TradeOrder order;
+  final TextStyle rowStyle;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      // ignore: avoid_hardcoded_strings_in_widgets
+      '${order.commodityId} — qty ${order.quantity} '
+      '(priority ${order.priority})',
+      key: rowKey,
+      style: rowStyle,
+      overflow: TextOverflow.ellipsis,
     );
   }
 }

--- a/app/test/trade_screen_deal_book_tab_e6_test.dart
+++ b/app/test/trade_screen_deal_book_tab_e6_test.dart
@@ -1,0 +1,582 @@
+// Widget tests for the Deal Book tab live ledger (Refs #2993 E6).
+// SPEC/ui/trade-screen.md § Body — Deal Book tab.
+//
+// Exercises the durable contract for the Deal Book tab body:
+//
+//  * the live `_DealBookTabContent` mounts under
+//    `tradeScreenDealBookTabBody` with both bids and offers panels and
+//    treasury-totals rows always present (so widget tests can pin the
+//    totals affordance regardless of activity);
+//  * filled rows are sourced from
+//    `Game.worldMarketState.lastTurnActivity[*].deals`, scoped per
+//    panel by `buyerFactionId` (bids panel) and `sellerFactionId`
+//    (offers panel), with `quantity × pricePerUnit` summed into the
+//    totals row;
+//  * unfilled rows are sourced from
+//    `WorldMarketState.carryForward{Bids,Offers}ByFactionId[playerId]`
+//    so the previous turn's carry-forward orders are visible;
+//  * empty-state copy renders when the player has neither filled rows
+//    nor carry-forward orders on a side;
+//  * FRR / FTP tags render on filled rows that the matcher annotated
+//    so the player can audit why a deal cleared.
+
+import 'package:colonizethis_app/config/themes.dart';
+import 'package:colonizethis_app/features/game/screens/trade_screen.dart';
+import 'package:colonizethis_app/providers/games_provider.dart';
+import 'package:colonizethis_app/widgets/ct_tab_strip.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Synthetic [Game] with the human player `gp_h` and a foreign GP
+/// `gp_a` used to prove player isolation in the ledger filter. The
+/// `worldMarketState` is fully caller-controlled so each test pins the
+/// scenario it cares about (filled deals, carry-forwards, empties).
+Game _buildGame({
+  Map<CommodityId, MarketActivity> activity = const <CommodityId, MarketActivity>{},
+  Map<String, List<TradeOrder>> carryForwardBids =
+      const <String, List<TradeOrder>>{},
+  Map<String, List<TradeOrder>> carryForwardOffers =
+      const <String, List<TradeOrder>>{},
+}) {
+  return Game(
+    id: 'test_trade_screen_deal_book_e6',
+    worldState: WorldState(
+      turnState: TurnState(phase: TurnPhase.orders, turnNumber: 1),
+      oldWorld: const RegionData(),
+      newWorld: const RegionData(),
+    ),
+    turnTimeMapping: TurnTimeMapping.gdd01,
+    players: [
+      // ignore: avoid_hardcoded_strings_in_widgets
+      Player(id: 'gp_h', displayName: 'England', isHuman: true, treasury: 500),
+      // ignore: avoid_hardcoded_strings_in_widgets
+      Player(id: 'gp_a', displayName: 'Aragon', isHuman: false, treasury: 500),
+    ],
+    diplomacyRelations: const [],
+    diplomaticHistoryEvents: const [],
+    dossierEvidenceEntries: const [],
+    worldMarketState: WorldMarketState(
+      prices: const <CommodityId, double>{},
+      lastTurnActivity: activity,
+      carryForwardOffersByFactionId: carryForwardOffers,
+      carryForwardBidsByFactionId: carryForwardBids,
+    ),
+  );
+}
+
+Future<void> _pumpDealBookTab(
+  WidgetTester tester, {
+  required Game game,
+}) async {
+  final Player player = game.players.firstWhere((p) => p.isHuman);
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
+      ],
+      child: MaterialApp(
+        theme: AppThemes.editorialMonocle,
+        home: TradeScreen(game: game, player: player),
+      ),
+    ),
+  );
+  await tester.pump();
+  // Tab into the Deal Book tab so the live content is foregrounded.
+  final dealBookLabel = find.descendant(
+    of: find.byType(CtTabStrip),
+    matching: find.text(TradeScreen.dealBookTabLabel),
+  );
+  expect(dealBookLabel, findsOneWidget);
+  await tester.tap(dealBookLabel);
+  await tester.pump();
+}
+
+void main() {
+  suppressLogsForTests();
+
+  group('TradeScreen Deal Book tab — live ledger (Refs #2993 E6)', () {
+    testWidgets(
+      'empty state: panels show empty copy and totals read 0 when the '
+      'player has no filled deals and no carry-forwards',
+      (tester) async {
+        await _pumpDealBookTab(tester, game: _buildGame());
+
+        // Both empty-state keys are mounted because both filled and
+        // unfilled lists are empty per side.
+        expect(
+          find.byKey(TradeScreen.dealBookBidsEmptyKey),
+          findsOneWidget,
+        );
+        expect(
+          find.byKey(TradeScreen.dealBookOffersEmptyKey),
+          findsOneWidget,
+        );
+        // Empty-state copy renders the per-side literal.
+        expect(
+          find.text(TradeScreen.dealBookBidsEmptyText),
+          findsOneWidget,
+        );
+        expect(
+          find.text(TradeScreen.dealBookOffersEmptyText),
+          findsOneWidget,
+        );
+        // Totals rows are always mounted and render 0 in the empty case.
+        final bidsTotals = tester.widget<Text>(
+          find.byKey(TradeScreen.dealBookBidsTotalsKey),
+        );
+        expect(
+          bidsTotals.data,
+          '${TradeScreen.dealBookTotalSpentLabel}: 0',
+        );
+        final offersTotals = tester.widget<Text>(
+          find.byKey(TradeScreen.dealBookOffersTotalsKey),
+        );
+        expect(
+          offersTotals.data,
+          '${TradeScreen.dealBookTotalReceivedLabel}: 0',
+        );
+      },
+    );
+
+    testWidgets(
+      'filled bid (player == buyer) renders with notional and contributes '
+      'to the bids panel total spent; unrelated deal is excluded',
+      (tester) async {
+        final game = _buildGame(
+          activity: const <CommodityId, MarketActivity>{
+            'timber': MarketActivity(
+              totalBidQuantity: 5,
+              totalOfferQuantity: 5,
+              filledQuantity: 5,
+              deals: <FilledDeal>[
+                // Player gp_h buys 5 timber from gp_a at price 30.
+                FilledDeal(
+                  sellerFactionId: 'gp_a',
+                  buyerFactionId: 'gp_h',
+                  commodityId: 'timber',
+                  quantity: 5,
+                  pricePerUnit: 30.0,
+                ),
+              ],
+            ),
+            // Unrelated deal between two foreign factions; must NOT
+            // appear in the human player's ledger.
+            'iron': MarketActivity(
+              totalBidQuantity: 4,
+              totalOfferQuantity: 4,
+              filledQuantity: 4,
+              deals: <FilledDeal>[
+                FilledDeal(
+                  sellerFactionId: 'gp_a',
+                  buyerFactionId: 'gp_b',
+                  commodityId: 'iron',
+                  quantity: 4,
+                  pricePerUnit: 50.0,
+                ),
+              ],
+            ),
+          },
+        );
+        await _pumpDealBookTab(tester, game: game);
+
+        // The bids panel has exactly one filled row keyed at index 0
+        // (the timber buy), and the empty-state key is absent because
+        // the panel is no longer empty.
+        expect(
+          find.byKey(
+            TradeScreen.dealBookFilledRowKey(
+              TradeScreen.dealBookSideBids,
+              0,
+            ),
+          ),
+          findsOneWidget,
+        );
+        expect(
+          find.byKey(
+            TradeScreen.dealBookFilledRowKey(
+              TradeScreen.dealBookSideBids,
+              1,
+            ),
+          ),
+          findsNothing,
+        );
+        expect(
+          find.byKey(TradeScreen.dealBookBidsEmptyKey),
+          findsNothing,
+        );
+
+        // Row text encodes quantity × price = notional and uses the
+        // commodity id as the leading label per the SPEC E6 contract.
+        // ignore: avoid_hardcoded_strings_in_widgets
+        expect(find.text('timber — qty 5 × 30.0 = 150'), findsOneWidget);
+
+        // Treasury totals reflect the single filled buy notional only;
+        // the unrelated iron deal is excluded by the buyer filter.
+        final bidsTotals = tester.widget<Text>(
+          find.byKey(TradeScreen.dealBookBidsTotalsKey),
+        );
+        expect(
+          bidsTotals.data,
+          '${TradeScreen.dealBookTotalSpentLabel}: 150',
+        );
+
+        // The offers panel stays empty (the player did not sell
+        // anything this turn).
+        expect(
+          find.byKey(TradeScreen.dealBookOffersEmptyKey),
+          findsOneWidget,
+        );
+        final offersTotals = tester.widget<Text>(
+          find.byKey(TradeScreen.dealBookOffersTotalsKey),
+        );
+        expect(
+          offersTotals.data,
+          '${TradeScreen.dealBookTotalReceivedLabel}: 0',
+        );
+      },
+    );
+
+    testWidgets(
+      'filled offer (player == seller) renders in offers panel and sums '
+      'into the total received; multiple deals across commodities tally '
+      'a combined total',
+      (tester) async {
+        final game = _buildGame(
+          activity: const <CommodityId, MarketActivity>{
+            'timber': MarketActivity(
+              totalBidQuantity: 7,
+              totalOfferQuantity: 7,
+              filledQuantity: 7,
+              deals: <FilledDeal>[
+                FilledDeal(
+                  sellerFactionId: 'gp_h',
+                  buyerFactionId: 'gp_a',
+                  commodityId: 'timber',
+                  quantity: 7,
+                  pricePerUnit: 30.0,
+                ),
+              ],
+            ),
+            'iron': MarketActivity(
+              totalBidQuantity: 3,
+              totalOfferQuantity: 3,
+              filledQuantity: 3,
+              deals: <FilledDeal>[
+                FilledDeal(
+                  sellerFactionId: 'gp_h',
+                  buyerFactionId: 'gp_a',
+                  commodityId: 'iron',
+                  quantity: 3,
+                  pricePerUnit: 60.0,
+                ),
+              ],
+            ),
+          },
+        );
+        await _pumpDealBookTab(tester, game: game);
+
+        // Both filled rows render in the offers panel (indices 0 and 1
+        // in encounter order — ordered by lastTurnActivity map iteration).
+        expect(
+          find.byKey(
+            TradeScreen.dealBookFilledRowKey(
+              TradeScreen.dealBookSideOffers,
+              0,
+            ),
+          ),
+          findsOneWidget,
+        );
+        expect(
+          find.byKey(
+            TradeScreen.dealBookFilledRowKey(
+              TradeScreen.dealBookSideOffers,
+              1,
+            ),
+          ),
+          findsOneWidget,
+        );
+
+        // Total received = 7*30 + 3*60 = 210 + 180 = 390.
+        final offersTotals = tester.widget<Text>(
+          find.byKey(TradeScreen.dealBookOffersTotalsKey),
+        );
+        expect(
+          offersTotals.data,
+          '${TradeScreen.dealBookTotalReceivedLabel}: 390',
+        );
+
+        // The bids panel stays empty because the player did not buy.
+        expect(
+          find.byKey(TradeScreen.dealBookBidsEmptyKey),
+          findsOneWidget,
+        );
+      },
+    );
+
+    testWidgets(
+      'carry-forward bids render in the bids panel and do NOT contribute '
+      'to the total spent (they have not cleared)',
+      (tester) async {
+        final game = _buildGame(
+          carryForwardBids: <String, List<TradeOrder>>{
+            'gp_h': <TradeOrder>[
+              TradeOrder(
+                commodityId: 'timber',
+                type: TradeOrderType.bid,
+                quantity: 8,
+                priority: 2,
+              ),
+            ],
+          },
+        );
+        await _pumpDealBookTab(tester, game: game);
+
+        // Unfilled row keyed under the bids side.
+        expect(
+          find.byKey(
+            TradeScreen.dealBookUnfilledRowKey(
+              TradeScreen.dealBookSideBids,
+              0,
+            ),
+          ),
+          findsOneWidget,
+        );
+        // ignore: avoid_hardcoded_strings_in_widgets
+        expect(
+          find.text('timber — qty 8 (priority 2)'),
+          findsOneWidget,
+        );
+        // No filled row pinned for the bids side.
+        expect(
+          find.byKey(
+            TradeScreen.dealBookFilledRowKey(
+              TradeScreen.dealBookSideBids,
+              0,
+            ),
+          ),
+          findsNothing,
+        );
+        // Carry-forwards do not clear so total spent stays at 0.
+        final bidsTotals = tester.widget<Text>(
+          find.byKey(TradeScreen.dealBookBidsTotalsKey),
+        );
+        expect(
+          bidsTotals.data,
+          '${TradeScreen.dealBookTotalSpentLabel}: 0',
+        );
+        // Bids panel is no longer empty (carry-forward populates it).
+        expect(
+          find.byKey(TradeScreen.dealBookBidsEmptyKey),
+          findsNothing,
+        );
+        // Offers panel still empty.
+        expect(
+          find.byKey(TradeScreen.dealBookOffersEmptyKey),
+          findsOneWidget,
+        );
+      },
+    );
+
+    testWidgets(
+      'carry-forward offers render in the offers panel; per-side filter '
+      'isolation: another player\'s carry-forwards never appear',
+      (tester) async {
+        final game = _buildGame(
+          carryForwardOffers: <String, List<TradeOrder>>{
+            'gp_h': <TradeOrder>[
+              TradeOrder(
+                commodityId: 'fabric',
+                type: TradeOrderType.offer,
+                quantity: 6,
+                priority: 1,
+              ),
+              TradeOrder(
+                commodityId: 'fabric',
+                type: TradeOrderType.offer,
+                quantity: 4,
+                priority: 3,
+              ),
+            ],
+            // Foreign GP's carry-forward must never appear in the human
+            // player's Deal Book.
+            'gp_a': <TradeOrder>[
+              TradeOrder(
+                commodityId: 'timber',
+                type: TradeOrderType.offer,
+                quantity: 99,
+                priority: 1,
+              ),
+            ],
+          },
+        );
+        await _pumpDealBookTab(tester, game: game);
+
+        // Two carry-forward rows from gp_h scoped to the offers side.
+        expect(
+          find.byKey(
+            TradeScreen.dealBookUnfilledRowKey(
+              TradeScreen.dealBookSideOffers,
+              0,
+            ),
+          ),
+          findsOneWidget,
+        );
+        expect(
+          find.byKey(
+            TradeScreen.dealBookUnfilledRowKey(
+              TradeScreen.dealBookSideOffers,
+              1,
+            ),
+          ),
+          findsOneWidget,
+        );
+        // gp_a's carry-forward must NOT render anywhere on the page.
+        // ignore: avoid_hardcoded_strings_in_widgets
+        expect(find.text('timber — qty 99 (priority 1)'), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'FRR / FTP tags render on filled rows when the matcher annotated '
+      'the deal so players can audit how a fill cleared',
+      (tester) async {
+        final game = _buildGame(
+          activity: const <CommodityId, MarketActivity>{
+            'timber': MarketActivity(
+              totalBidQuantity: 6,
+              totalOfferQuantity: 6,
+              filledQuantity: 6,
+              deals: <FilledDeal>[
+                FilledDeal(
+                  sellerFactionId: 'M1',
+                  buyerFactionId: 'gp_h',
+                  commodityId: 'timber',
+                  quantity: 3,
+                  pricePerUnit: 30.0,
+                  isFirstRightOfRefusalMatch: true,
+                  sellerOriginTileKey: 'oldWorld|M1|0|0',
+                ),
+                FilledDeal(
+                  sellerFactionId: 'gp_a',
+                  buyerFactionId: 'gp_h',
+                  commodityId: 'timber',
+                  quantity: 3,
+                  pricePerUnit: 30.0,
+                  isFtpMatch: true,
+                ),
+              ],
+            ),
+          },
+        );
+        await _pumpDealBookTab(tester, game: game);
+
+        // Both deals appear as filled bid rows for the human player.
+        expect(
+          find.byKey(
+            TradeScreen.dealBookFilledRowKey(
+              TradeScreen.dealBookSideBids,
+              0,
+            ),
+          ),
+          findsOneWidget,
+        );
+        expect(
+          find.byKey(
+            TradeScreen.dealBookFilledRowKey(
+              TradeScreen.dealBookSideBids,
+              1,
+            ),
+          ),
+          findsOneWidget,
+        );
+        // FRR tag is rendered on the first row.
+        // ignore: avoid_hardcoded_strings_in_widgets
+        expect(find.text('FRR'), findsOneWidget);
+        // FTP tag is rendered on the second row.
+        // ignore: avoid_hardcoded_strings_in_widgets
+        expect(find.text('FTP'), findsOneWidget);
+        // Treasury spent on filled buys: 3*30 + 3*30 = 180.
+        final bidsTotals = tester.widget<Text>(
+          find.byKey(TradeScreen.dealBookBidsTotalsKey),
+        );
+        expect(
+          bidsTotals.data,
+          '${TradeScreen.dealBookTotalSpentLabel}: 180',
+        );
+      },
+    );
+
+    testWidgets(
+      'side-by-side layout: when the viewport is at least '
+      'dealBookTwoPanelMinWidth (600 dp) wide, the bids panel sits to '
+      'the left of the offers panel',
+      (tester) async {
+        // 700 dp wide × 800 dp tall — wider than the 600 dp threshold.
+        tester.view.physicalSize = const Size(700 * 3, 800 * 3);
+        tester.view.devicePixelRatio = 3.0;
+        addTearDown(() {
+          tester.view.resetPhysicalSize();
+          tester.view.resetDevicePixelRatio();
+        });
+
+        await _pumpDealBookTab(tester, game: _buildGame());
+
+        final Offset bidsTopLeft =
+            tester.getTopLeft(find.byKey(TradeScreen.dealBookBidsPanelKey));
+        final Offset offersTopLeft =
+            tester.getTopLeft(find.byKey(TradeScreen.dealBookOffersPanelKey));
+
+        expect(
+          offersTopLeft.dx,
+          greaterThan(bidsTopLeft.dx),
+          reason:
+              'SPEC/ui/trade-screen.md § Body — Deal Book tab pins the '
+              'bids panel to the left of the offers panel when the '
+              'viewport meets the dealBookTwoPanelMinWidth threshold.',
+        );
+        // Same baseline Y so the panels read as a single row.
+        expect(
+          offersTopLeft.dy,
+          equals(bidsTopLeft.dy),
+          reason:
+              'Two-panel mode aligns the bids and offers panels at the '
+              'same top so the ledger reads as one row.',
+        );
+      },
+    );
+
+    testWidgets(
+      'stacked layout: at the 320 dp minimum viewport the offers panel '
+      'sits below the bids panel (no overflow)',
+      (tester) async {
+        // 320 dp wide × 640 dp tall — below the 600 dp threshold so the
+        // panels stack vertically to keep the 320 dp viewport overflow-safe.
+        tester.view.physicalSize = const Size(320 * 3, 640 * 3);
+        tester.view.devicePixelRatio = 3.0;
+        addTearDown(() {
+          tester.view.resetPhysicalSize();
+          tester.view.resetDevicePixelRatio();
+        });
+
+        await _pumpDealBookTab(tester, game: _buildGame());
+
+        expect(tester.takeException(), isNull);
+
+        final Offset bidsTopLeft =
+            tester.getTopLeft(find.byKey(TradeScreen.dealBookBidsPanelKey));
+        final Offset offersTopLeft =
+            tester.getTopLeft(find.byKey(TradeScreen.dealBookOffersPanelKey));
+        expect(
+          offersTopLeft.dy,
+          greaterThan(bidsTopLeft.dy),
+          reason:
+              'Below dealBookTwoPanelMinWidth the panels stack so the '
+              'Deal Book stays overflow-safe at the 320 dp pin.',
+        );
+      },
+    );
+  });
+}

--- a/app/test/trade_screen_scaffold_test.dart
+++ b/app/test/trade_screen_scaffold_test.dart
@@ -381,8 +381,8 @@ void main() {
     );
 
     testWidgets(
-      'Deal Book tab body still renders its dark editorial-monocle '
-      'placeholder title — Deal Book (after tap)',
+      'Deal Book tab body mounts the live ledger content (Refs #2993 E6) '
+      'after the user taps the Deal Book label',
       (tester) async {
         await tester.pumpWidget(buildTradeRouteHost());
         await pumpSettleCapped(tester);
@@ -399,16 +399,35 @@ void main() {
         await tester.tap(dealBookLabel);
         await pumpSettleCapped(tester);
 
-        // After tap, the Deal Book tab body is on stage and its
-        // placeholder title renders inside the tab body keyed
-        // tradeScreenDealBookTabBody (Refs #2993 E6 follow-up replaces
-        // this placeholder with the live ledger).
-        final dealBookTitle = find.descendant(
-          of: find.byKey(TradeScreen.dealBookTabBodyKey),
-          // ignore: avoid_hardcoded_strings_in_widgets
-          matching: find.text('Deal Book'),
+        // After tap, the Deal Book tab body is on stage and renders the
+        // live ledger content root keyed `tradeScreenDealBookContent`
+        // (Refs #2993 E6) under the same `tradeScreenDealBookTabBody`
+        // body root — the tab-body key remained stable so existing
+        // tab-switch tests continue to pin the same affordance.
+        expect(find.byKey(TradeScreen.dealBookTabBodyKey), findsOneWidget);
+        expect(
+          find.descendant(
+            of: find.byKey(TradeScreen.dealBookTabBodyKey),
+            matching: find.byKey(TradeScreen.dealBookContentKey),
+          ),
+          findsOneWidget,
         );
-        expect(dealBookTitle, findsOneWidget);
+        // Both bids and offers panel containers are always present in
+        // the live content; their per-row contents are exercised by the
+        // dedicated E6 panel tests in trade_screen_deal_book_tab_e6_test.dart.
+        expect(find.byKey(TradeScreen.dealBookBidsPanelKey), findsOneWidget);
+        expect(
+          find.byKey(TradeScreen.dealBookOffersPanelKey),
+          findsOneWidget,
+        );
+        expect(
+          find.byKey(TradeScreen.dealBookBidsTotalsKey),
+          findsOneWidget,
+        );
+        expect(
+          find.byKey(TradeScreen.dealBookOffersTotalsKey),
+          findsOneWidget,
+        );
       },
     );
   });

--- a/packages/colonizethis_logic/lib/src/turn/phases/world_market_phase.dart
+++ b/packages/colonizethis_logic/lib/src/turn/phases/world_market_phase.dart
@@ -354,9 +354,11 @@ Map<CommodityId, MarketActivity> _buildActivity({
   required Map<CommodityId, double> newPrices,
 }) {
   final filledByCommodity = <CommodityId, int>{};
+  final dealsByCommodity = <CommodityId, List<FilledDeal>>{};
   for (final deal in matchResult.filledDeals) {
     filledByCommodity[deal.commodityId] =
         (filledByCommodity[deal.commodityId] ?? 0) + deal.quantity;
+    (dealsByCommodity[deal.commodityId] ??= <FilledDeal>[]).add(deal);
   }
   final commodityIds = <CommodityId>{
     ...newQuantitiesByCommodity.keys,
@@ -371,11 +373,15 @@ Map<CommodityId, MarketActivity> _buildActivity({
     final oldPrice = priorPrices[id] ?? 0.0;
     final newPrice = newPrices[id] ?? oldPrice;
     final percent = oldPrice > 0 ? (newPrice / oldPrice) - 1.0 : 0.0;
+    final deals = dealsByCommodity[id];
     activity[id] = MarketActivity(
       totalBidQuantity: pair.bid,
       totalOfferQuantity: pair.offer,
       filledQuantity: filled,
       priceChangePercent: percent,
+      deals: deals == null
+          ? const <FilledDeal>[]
+          : List<FilledDeal>.unmodifiable(deals),
     );
   }
   return activity;

--- a/packages/colonizethis_logic/test/turn/world_market_phase_deal_book_emission_test.dart
+++ b/packages/colonizethis_logic/test/turn/world_market_phase_deal_book_emission_test.dart
@@ -1,0 +1,322 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/src/turn/phases/world_market_phase.dart';
+import 'package:colonizethis_logic/src/turn/turn_pipeline_state.dart';
+import 'package:colonizethis_logic/src/turn/turn_resolver_config.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+/// Per-commodity Deal Book ledger emission tests for the World Market phase
+/// handler (Refs #2993 E6 / #2988 § UI Design — Deal Book).
+///
+/// SPEC anchors:
+/// - `SPEC/program/world-market-resolution.md` § Step F Activity rollup
+///   (`MarketActivity.deals` carries the per-commodity `FilledDeal` list).
+/// - `SPEC/ui/trade-screen.md` § Deal Book tab (consumes
+///   `Game.worldMarketState.lastTurnActivity[commodity].deals`).
+void main() {
+  group(
+    'worldMarketTurnPhaseHandler — Deal Book ledger emission '
+    '(Refs #2993 E6, SPEC/program/world-market-resolution.md § Step F)',
+    () {
+      test(
+        'GP↔GP fill emits a FilledDeal on the resolved commodity activity',
+        () {
+          final acc = TurnPipelineState(
+            game: _gameWithTwoGps(
+              sellerStockpile: const Stockpile().applyDelta('timber', 10),
+              sellerTreasury: 0,
+              buyerTreasury: 1000,
+              marketPrices: const {'timber': 30.0},
+            ),
+          );
+          final config = TurnResolverConfig(
+            topology: const MapTopology(nodes: [], edges: []),
+            orders: Orders(
+              tradeOrdersByPlayerId: {
+                'gpSeller': [
+                  TradeOrder(
+                    commodityId: 'timber',
+                    type: TradeOrderType.offer,
+                    quantity: 5,
+                    priority: 1,
+                  ),
+                ],
+                'gpBuyer': [
+                  TradeOrder(
+                    commodityId: 'timber',
+                    type: TradeOrderType.bid,
+                    quantity: 5,
+                    priority: 1,
+                  ),
+                ],
+              },
+            ),
+          );
+
+          final next = (worldMarketTurnPhaseHandler(acc, config, 3)
+                  as TurnPhaseStepContinue)
+              .pipeline
+              .game;
+
+          final activity = next.worldMarketState.lastTurnActivity['timber']!;
+          expect(activity.deals, hasLength(1));
+          final deal = activity.deals.single;
+          expect(deal.sellerFactionId, 'gpSeller');
+          expect(deal.buyerFactionId, 'gpBuyer');
+          expect(deal.commodityId, 'timber');
+          expect(deal.quantity, 5);
+          expect(deal.pricePerUnit, closeTo(30.0, 1e-9));
+          expect(deal.isFirstRightOfRefusalMatch, isFalse);
+          expect(deal.isFtpMatch, isFalse);
+        },
+      );
+
+      test(
+        'multi-commodity matching emits deals scoped to each commodity',
+        () {
+          final acc = TurnPipelineState(
+            game: _gameWithTwoGps(
+              sellerStockpile: const Stockpile()
+                  .applyDelta('timber', 10)
+                  .applyDelta('iron', 4),
+              sellerTreasury: 0,
+              buyerTreasury: 10000,
+              marketPrices: const {'timber': 30.0, 'iron': 80.0},
+            ),
+          );
+          final config = TurnResolverConfig(
+            topology: const MapTopology(nodes: [], edges: []),
+            orders: Orders(
+              tradeOrdersByPlayerId: {
+                'gpSeller': [
+                  TradeOrder(
+                    commodityId: 'timber',
+                    type: TradeOrderType.offer,
+                    quantity: 5,
+                    priority: 1,
+                  ),
+                  TradeOrder(
+                    commodityId: 'iron',
+                    type: TradeOrderType.offer,
+                    quantity: 3,
+                    priority: 1,
+                  ),
+                ],
+                'gpBuyer': [
+                  TradeOrder(
+                    commodityId: 'timber',
+                    type: TradeOrderType.bid,
+                    quantity: 5,
+                    priority: 1,
+                  ),
+                  TradeOrder(
+                    commodityId: 'iron',
+                    type: TradeOrderType.bid,
+                    quantity: 3,
+                    priority: 1,
+                  ),
+                ],
+              },
+            ),
+          );
+
+          final next = (worldMarketTurnPhaseHandler(acc, config, 3)
+                  as TurnPhaseStepContinue)
+              .pipeline
+              .game;
+
+          final timberDeals =
+              next.worldMarketState.lastTurnActivity['timber']!.deals;
+          final ironDeals =
+              next.worldMarketState.lastTurnActivity['iron']!.deals;
+          expect(timberDeals, hasLength(1));
+          expect(timberDeals.single.commodityId, 'timber');
+          expect(timberDeals.single.quantity, 5);
+          expect(ironDeals, hasLength(1));
+          expect(ironDeals.single.commodityId, 'iron');
+          expect(ironDeals.single.quantity, 3);
+          // Each commodity activity only carries its own deals — no
+          // cross-commodity leakage.
+          expect(
+            timberDeals.map((d) => d.commodityId).toSet(),
+            equals(<String>{'timber'}),
+          );
+          expect(
+            ironDeals.map((d) => d.commodityId).toSet(),
+            equals(<String>{'iron'}),
+          );
+        },
+      );
+
+      test(
+        'commodity with no fills carries empty deals list',
+        () {
+          // Offer-only turn: the matcher emits no fills, so the activity
+          // entry for the commodity must carry an empty deals list (not
+          // null, not absent — the UI iterates deals.where(buyer/seller)).
+          final acc = TurnPipelineState(
+            game: _gameWithTwoGps(
+              sellerStockpile: const Stockpile().applyDelta('timber', 10),
+              sellerTreasury: 0,
+              buyerTreasury: 0,
+              marketPrices: const {'timber': 30.0},
+            ),
+          );
+          final config = TurnResolverConfig(
+            topology: const MapTopology(nodes: [], edges: []),
+            orders: Orders(
+              tradeOrdersByPlayerId: {
+                'gpSeller': [
+                  TradeOrder(
+                    commodityId: 'timber',
+                    type: TradeOrderType.offer,
+                    quantity: 5,
+                    priority: 1,
+                  ),
+                ],
+              },
+            ),
+          );
+
+          final next = (worldMarketTurnPhaseHandler(acc, config, 3)
+                  as TurnPhaseStepContinue)
+              .pipeline
+              .game;
+
+          final activity = next.worldMarketState.lastTurnActivity['timber']!;
+          expect(activity.filledQuantity, 0);
+          expect(activity.deals, isEmpty);
+          // The default `MarketActivity()` deals constant is the canonical
+          // shared const; emitted activity must also expose an empty (not
+          // null) list with `==` semantics matching the empty default.
+          expect(
+            activity.deals,
+            equals(const <FilledDeal>[]),
+          );
+        },
+      );
+
+      test(
+        'partial fill emits one deal at the matched quantity, residual '
+        'carries forward but no extra deal appears',
+        () {
+          // Seller has only 3 timber for a 10-bid: matcher emits a single
+          // FilledDeal of 3 units; the bid's residual 7 carries forward via
+          // `unfilledBidsByFactionId`. The activity deal list must contain
+          // exactly the matched portion, not the residual.
+          final acc = TurnPipelineState(
+            game: _gameWithTwoGps(
+              sellerStockpile: const Stockpile().applyDelta('timber', 3),
+              sellerTreasury: 0,
+              buyerTreasury: 1000,
+              marketPrices: const {'timber': 30.0},
+            ),
+          );
+          final config = TurnResolverConfig(
+            topology: const MapTopology(nodes: [], edges: []),
+            orders: Orders(
+              tradeOrdersByPlayerId: {
+                'gpSeller': [
+                  TradeOrder(
+                    commodityId: 'timber',
+                    type: TradeOrderType.offer,
+                    quantity: 3,
+                    priority: 1,
+                  ),
+                ],
+                'gpBuyer': [
+                  TradeOrder(
+                    commodityId: 'timber',
+                    type: TradeOrderType.bid,
+                    quantity: 10,
+                    priority: 1,
+                  ),
+                ],
+              },
+            ),
+          );
+
+          final next = (worldMarketTurnPhaseHandler(acc, config, 3)
+                  as TurnPhaseStepContinue)
+              .pipeline
+              .game;
+
+          final activity = next.worldMarketState.lastTurnActivity['timber']!;
+          expect(activity.filledQuantity, 3);
+          expect(activity.deals, hasLength(1));
+          expect(activity.deals.single.quantity, 3);
+          // Residual is on the carry-forward queue, not in the deal list.
+          final carriedBids = next
+              .worldMarketState
+              .carryForwardBidsByFactionId['gpBuyer'];
+          expect(carriedBids, isNotNull);
+          expect(carriedBids!.single.quantity, 7);
+        },
+      );
+
+      test(
+        'empty-turn semantics: no activity entries, no deals',
+        () {
+          final priorMarket = WorldMarketState.empty.copyWith(
+            prices: const {'timber': 30.0},
+          );
+          final acc = TurnPipelineState(
+            game: _gameWithTwoGps(
+              sellerStockpile: Stockpile.empty,
+              sellerTreasury: 0,
+              buyerTreasury: 0,
+              marketPrices: const {'timber': 30.0},
+            ).copyWith(worldMarketState: priorMarket),
+          );
+          final config = TurnResolverConfig(
+            topology: const MapTopology(nodes: [], edges: []),
+            orders: const Orders(),
+          );
+
+          final next = (worldMarketTurnPhaseHandler(acc, config, 3)
+                  as TurnPhaseStepContinue)
+              .pipeline
+              .game;
+
+          expect(next.worldMarketState.lastTurnActivity, isEmpty);
+        },
+      );
+    },
+  );
+}
+
+Game _gameWithTwoGps({
+  required Stockpile sellerStockpile,
+  required int sellerTreasury,
+  required int buyerTreasury,
+  required Map<CommodityId, double> marketPrices,
+}) {
+  return Game(
+    id: 'g1',
+    players: [
+      Player(
+        id: 'gpSeller',
+        displayName: 'Seller',
+        isHuman: false,
+        stockpile: sellerStockpile,
+        treasury: sellerTreasury,
+      ),
+      Player(
+        id: 'gpBuyer',
+        displayName: 'Buyer',
+        isHuman: false,
+        stockpile: Stockpile.empty,
+        treasury: buyerTreasury,
+      ),
+    ],
+    worldState: const WorldState(
+      turnState: TurnState(
+        phase: TurnPhase.worldMarket,
+        turnNumber: 3,
+      ),
+      oldWorld: RegionData(),
+      newWorld: RegionData(),
+    ),
+    worldMarketState: WorldMarketState.empty.copyWith(prices: marketPrices),
+  );
+}

--- a/packages/colonizethis_models/lib/src/world_market.dart
+++ b/packages/colonizethis_models/lib/src/world_market.dart
@@ -231,18 +231,28 @@ const Object _copyWithUnset = Object();
 /// quantities for the resolved turn (carry-forwards excluded), matching the
 /// price discovery aggregation contract in
 /// `SPEC/game/world-market.md` § Price discovery.
+///
+/// `deals` carries the per-commodity sequence of [FilledDeal] entries that
+/// the deal matcher produced for the resolved turn (see
+/// `SPEC/program/world-market-resolution.md` § Step F Activity rollup and
+/// § Data model). The Deal Book UI (`#2993` E6) consumes this list,
+/// filtered by buyer/seller faction id, to render the player's ledger.
+/// The list is **always** stored unmodifiable; callers must not mutate it
+/// in place.
 class MarketActivity {
   const MarketActivity({
     this.totalBidQuantity = 0,
     this.totalOfferQuantity = 0,
     this.filledQuantity = 0,
     this.priceChangePercent = 0.0,
+    this.deals = const <FilledDeal>[],
   });
 
   final int totalBidQuantity;
   final int totalOfferQuantity;
   final int filledQuantity;
   final double priceChangePercent;
+  final List<FilledDeal> deals;
 
   static const empty = MarketActivity();
 
@@ -251,6 +261,8 @@ class MarketActivity {
     'totalOfferQuantity': totalOfferQuantity,
     'filledQuantity': filledQuantity,
     'priceChangePercent': priceChangePercent,
+    if (deals.isNotEmpty)
+      'deals': [for (final d in deals) d.toJson()],
   };
 
   static MarketActivity fromJson(Map<String, dynamic> json) {
@@ -261,11 +273,24 @@ class MarketActivity {
       return double.tryParse(v?.toString() ?? '') ?? 0.0;
     }
 
+    final dealsRaw = json['deals'];
+    final deals = <FilledDeal>[];
+    if (dealsRaw is List<dynamic>) {
+      for (final entry in dealsRaw) {
+        if (entry is Map<dynamic, dynamic>) {
+          deals.add(FilledDeal.fromJson(Map<String, dynamic>.from(entry)));
+        }
+      }
+    }
+
     return MarketActivity(
       totalBidQuantity: intOrZero(json['totalBidQuantity']),
       totalOfferQuantity: intOrZero(json['totalOfferQuantity']),
       filledQuantity: intOrZero(json['filledQuantity']),
       priceChangePercent: doubleOrZero(json['priceChangePercent']),
+      deals: deals.isEmpty
+          ? const <FilledDeal>[]
+          : List<FilledDeal>.unmodifiable(deals),
     );
   }
 
@@ -277,7 +302,8 @@ class MarketActivity {
           totalBidQuantity == other.totalBidQuantity &&
           totalOfferQuantity == other.totalOfferQuantity &&
           filledQuantity == other.filledQuantity &&
-          priceChangePercent == other.priceChangePercent;
+          priceChangePercent == other.priceChangePercent &&
+          _listEquals(deals, other.deals);
 
   @override
   int get hashCode => Object.hash(
@@ -285,6 +311,7 @@ class MarketActivity {
     totalOfferQuantity,
     filledQuantity,
     priceChangePercent,
+    Object.hashAll(deals),
   );
 }
 

--- a/packages/colonizethis_models/test/world_market_test.dart
+++ b/packages/colonizethis_models/test/world_market_test.dart
@@ -307,6 +307,78 @@ void main() {
       final restored = MarketActivity.fromJson(original.toJson());
       expect(restored, equals(original));
     });
+
+    test('deals defaults to empty list and is omitted from JSON when empty', () {
+      const m = MarketActivity(
+        totalBidQuantity: 5,
+        totalOfferQuantity: 5,
+        filledQuantity: 5,
+      );
+      expect(m.deals, isEmpty);
+      expect(m.toJson().containsKey('deals'), isFalse);
+    });
+
+    test(
+      'round-trips through JSON with deals (preserves order and FRR flag — '
+      'Refs #2993 E6 ledger surface)',
+      () {
+        const original = MarketActivity(
+          totalBidQuantity: 12,
+          totalOfferQuantity: 12,
+          filledQuantity: 12,
+          priceChangePercent: 0.0,
+          deals: <FilledDeal>[
+            FilledDeal(
+              sellerFactionId: 'gpA',
+              buyerFactionId: 'gpB',
+              commodityId: 'timber',
+              quantity: 5,
+              pricePerUnit: 30.0,
+            ),
+            FilledDeal(
+              sellerFactionId: 'M1',
+              buyerFactionId: 'gpA',
+              commodityId: 'timber',
+              quantity: 7,
+              pricePerUnit: 30.0,
+              isFirstRightOfRefusalMatch: true,
+              sellerOriginTileKey: 'oldWorld|M1|0|0',
+            ),
+          ],
+        );
+        final restored = MarketActivity.fromJson(original.toJson());
+        expect(restored, equals(original));
+        expect(restored.deals, hasLength(2));
+        expect(restored.deals.first.buyerFactionId, 'gpB');
+        expect(restored.deals.last.isFirstRightOfRefusalMatch, isTrue);
+      },
+    );
+
+    test('equality reflects deals differences', () {
+      const a = MarketActivity(
+        deals: <FilledDeal>[
+          FilledDeal(
+            sellerFactionId: 'gpA',
+            buyerFactionId: 'gpB',
+            commodityId: 'timber',
+            quantity: 5,
+            pricePerUnit: 30.0,
+          ),
+        ],
+      );
+      const b = MarketActivity(
+        deals: <FilledDeal>[
+          FilledDeal(
+            sellerFactionId: 'gpA',
+            buyerFactionId: 'gpB',
+            commodityId: 'timber',
+            quantity: 6, // different quantity
+            pricePerUnit: 30.0,
+          ),
+        ],
+      );
+      expect(a, isNot(equals(b)));
+    });
   });
 
   group('WorldMarketState', () {


### PR DESCRIPTION
## Summary

Wire the data dependency for the Trade Screen Deal Book tab (`SPEC/ui/trade-screen.md` § Deal Book, `#2993` E6) without yet shipping the UI: each World Market turn now stores its `FilledDeal` sequence on `MarketActivity.deals`, scoped per commodity, so the upcoming Deal Book ledger can filter by buyer/seller faction id in a pure read.

This is a small focused slice; the actual two-panel ledger render lands as the follow-up E6 UI commit.

## Changes

- **Model — `MarketActivity.deals`** (`packages/colonizethis_models/lib/src/world_market.dart`)
  - New `List<FilledDeal> deals` field (default `const <FilledDeal>[]`); JSON key omitted when empty; equality/`hashCode` include the list.
- **Logic — phase-handler ledger emission** (`packages/colonizethis_logic/lib/src/turn/phases/world_market_phase.dart`)
  - `_buildActivity` groups `DealMatchResult.filledDeals` by commodity and writes each list onto its `MarketActivity` via `List.unmodifiable(...)`, preserving the matcher's emission order (FRR pre-pass → priority tiers → FTP → fallback).
- **SPEC** (`SPEC/program/world-market-resolution.md`)
  - Added `deals` and `notes` to the Dart `MarketActivity` shape.
  - New "Phase-handler activity rollup — `deals` ledger" subsection documenting the writer (phase handler), order, immutability, and Deal Book UI consumer.
  - Three new phase-resolution ACs: ledger emitted per commodity in order, empty list when no fills, JSON round-trip with FRR flag.
- **Tests**
  - `packages/colonizethis_models/test/world_market_test.dart`: empty-default omission, JSON round-trip with FRR flag, equality reflects `deals` differences.
  - `packages/colonizethis_logic/test/turn/world_market_phase_deal_book_emission_test.dart` (new): single fill, multi-commodity scoping, no-fill empty list, partial-fill (residual on carry-forward, not in `deals`), empty-turn no activity.

## SPEC anchors

- `SPEC/program/world-market-resolution.md` § Data model / Step F Activity rollup / new phase-handler subsection / new ACs.
- `SPEC/ui/trade-screen.md` § Deal Book tab (consumer; UI follow-up).

## Test plan

- [x] `dart test packages/colonizethis_models/test/world_market_test.dart` (36/36)
- [x] `dart test packages/colonizethis_logic/test/turn/` from package cwd (58/58 incl. 5 new Deal Book emission tests)
- [x] `dart analyze` on touched files: no issues
- [x] `dart run tool/ct_repo_lint.dart` (49/49 rules)

## Notes

Refs #2993 (E6 data slice; UI ledger render lands as the follow-up commit on this issue).

Made with [Cursor](https://cursor.com)