### PR TITLE
refactor(app): tech tree nodes + edges use EditorialMonoclePalette (Refs #2914 S3)

### DIFF
--- a/app/lib/features/game/widgets/tech_tree_widget.dart
+++ b/app/lib/features/game/widgets/tech_tree_widget.dart
@@ -8,6 +8,7 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 
 import '../../../config/app_assets.dart';
+import '../../../config/editorial_monocle_palette.dart';
 import '../../../l10n/l10n.dart';
 import '../utils/tech_ui_helpers.dart';
 import '../../../widgets/ct_dialog_shell.dart';

--- a/app/lib/features/game/widgets/tech_tree_widget_nodes.dart
+++ b/app/lib/features/game/widgets/tech_tree_widget_nodes.dart
@@ -23,7 +23,7 @@ class _TechTreeEdgePainter extends CustomPainter {
   void paint(Canvas canvas, Size size) {
     final posByTech = {for (final p in positions) p.techId: p};
     final paint = Paint()
-      ..color = Colors.grey.shade600
+      ..color = EditorialMonoclePalette.border
       ..strokeWidth = _edgeStrokeWidth
       ..style = PaintingStyle.stroke;
 
@@ -96,7 +96,7 @@ class _TechNode extends StatelessWidget {
   }
 
   _TechNodeStyle _nodeStyle() {
-    final color = _categoryColors[tech.category] ?? Colors.grey;
+    final color = _categoryColors[tech.category] ?? EditorialMonoclePalette.muted;
     final locked = !state.researched && !state.inProgress && !state.available;
     if (state.researched) {
       return _TechNodeStyle(
@@ -123,8 +123,8 @@ class _TechNode extends StatelessWidget {
       );
     }
     return _TechNodeStyle(
-      fillColor: Colors.grey.shade200,
-      borderColor: Colors.grey.shade400,
+      fillColor: EditorialMonoclePalette.surface,
+      borderColor: EditorialMonoclePalette.border,
       borderWidth: 1,
       locked: locked,
     );
@@ -151,7 +151,7 @@ class _TechNode extends StatelessWidget {
             overflow: TextOverflow.ellipsis,
             style: TextStyle(
               fontSize: 10,
-              color: locked ? Colors.grey : null,
+              color: locked ? EditorialMonoclePalette.muted : null,
               fontWeight: state.researched ? FontWeight.w600 : null,
             ),
           ),

--- a/app/test/tech_tree_widget_palette_test.dart
+++ b/app/test/tech_tree_widget_palette_test.dart
@@ -1,0 +1,137 @@
+// Regression test for #2914 S3: tech-tree node and edge chrome must
+// resolve through `EditorialMonoclePalette` tokens rather than the
+// pre-#2858 `Colors.grey.shade*` legacy fallbacks.
+//
+// SPEC: `SPEC/ui/tech-tree-widget.md` § Node states ("Locked: Greyed
+// out or dimmed") and `SPEC/ui/pixel-art-ui-catalog.md` § Editorial
+// monocle palette (single-source palette tokens).
+
+import 'package:colonizethis_data/colonizethis_data.dart'
+    show kTechIdWindSawMill, techCatalog;
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:colonizethis_app/config/editorial_monocle_palette.dart';
+import 'package:colonizethis_app/features/game/widgets/tech_tree_widget.dart';
+import 'package:colonizethis_app/widgets/debug_init_game.dart';
+
+void main() {
+  suppressLogsForTests();
+
+  late Game game;
+  late Player player;
+
+  setUpAll(() {
+    final result = getDebugInitGameResult();
+    game = result.game;
+    player = game.players.first;
+  });
+
+  // Tech tree nodes render inside a `Container` with
+  // `BorderRadius.circular(6)`. The legend's state samples also render
+  // _TechNode widgets, so we pick the first node from the scrollable
+  // tree area (not the legend wrap) by anchoring on a node's display
+  // text and walking up to the nearest decorated container.
+  Finder nodeContainerForText(String techDisplayName) {
+    return find.ancestor(
+      of: find.text(techDisplayName).first,
+      matching: find.byWidgetPredicate((widget) {
+        if (widget is! Container) return false;
+        final decoration = widget.decoration;
+        if (decoration is! BoxDecoration) return false;
+        final radius = decoration.borderRadius;
+        return radius is BorderRadius &&
+            radius.topLeft == const Radius.circular(6);
+      }),
+    );
+  }
+
+  testWidgets(
+    'locked tech node uses EditorialMonoclePalette.surface fill + '
+    'border (#2914 S3 — no Colors.grey.shade* fallback)',
+    (WidgetTester tester) async {
+      final emptyPlayer = player.copyWith(techUnlocked: <String, bool>{});
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TechTreeWidget(game: game, player: emptyPlayer),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      const lockedTechName = 'Wind Saw Mill';
+      expect(
+        techCatalog.values.any((t) => t.id == kTechIdWindSawMill),
+        isTrue,
+        reason: 'Fixture: $lockedTechName must exist in techCatalog so '
+            'the locked-state assertion has a target.',
+      );
+      final containers = nodeContainerForText(lockedTechName);
+      expect(containers, findsWidgets);
+
+      final container = tester.widgetList<Container>(containers).first;
+      final decoration = container.decoration! as BoxDecoration;
+      expect(
+        decoration.color,
+        equals(EditorialMonoclePalette.surface),
+        reason: 'Locked tech node fill must resolve through '
+            'EditorialMonoclePalette.surface (was Colors.grey.shade200).',
+      );
+      final border = decoration.border! as Border;
+      expect(
+        border.top.color,
+        equals(EditorialMonoclePalette.border),
+        reason: 'Locked tech node border must resolve through '
+            'EditorialMonoclePalette.border (was Colors.grey.shade400).',
+      );
+    },
+  );
+
+  testWidgets(
+    'tech tree edge painter is mounted alongside the dark-palette '
+    'nodes (#2914 S3 — painter chrome resolves through palette tokens)',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TechTreeWidget(game: game, player: player),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Pin that the tech tree still mounts a `_TechTreeEdgePainter`
+      // under a `CustomPaint`; the painter's stroke colour is read
+      // from `EditorialMonoclePalette.border` (refactored from
+      // `Colors.grey.shade600`). The source-level grep in #2914 G1
+      // covers the literal-color regression; here we only pin the
+      // structural presence so the file is exercised in CI.
+      final customPaints = find.byWidgetPredicate(
+        (widget) =>
+            widget is CustomPaint &&
+            widget.painter.runtimeType.toString() == '_TechTreeEdgePainter',
+      );
+      expect(
+        customPaints,
+        findsWidgets,
+        reason: 'TechTreeWidget should host at least one CustomPaint '
+            'with the edge painter so the palette migration is exercised '
+            'whenever the tree mounts.',
+      );
+
+      // Sanity: the palette token must not collapse to the legacy
+      // `Colors.grey.shade600` value, otherwise the refactor would be
+      // a no-op and the regression bar would be vacuous.
+      expect(
+        EditorialMonoclePalette.border,
+        isNot(equals(Colors.grey.shade600)),
+        reason: 'EditorialMonoclePalette.border must be visually distinct '
+            'from the legacy Colors.grey.shade600 so the migration is '
+            'observable in the rendered tree.',
+      );
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Migrates the **last four `Colors.grey.shade*` references** in the non-flame, non-debug `app/lib/features/` surface to semantic `EditorialMonoclePalette` tokens, narrowing the gap on **#2914 S3 (color cleanup)**.

`app/lib/features/game/widgets/tech_tree_widget_nodes.dart`:

| Before | After | Site |
|---|---|---|
| `Colors.grey.shade600` | `EditorialMonoclePalette.border` | `_TechTreeEdgePainter` stroke |
| `Colors.grey.shade200` | `EditorialMonoclePalette.surface` | Locked-state node fill |
| `Colors.grey.shade400` | `EditorialMonoclePalette.border` | Locked-state node border |
| `Colors.grey` | `EditorialMonoclePalette.muted` | Locked-state label text |
| `Colors.grey` | `EditorialMonoclePalette.muted` | Category-color fallback |

Side-effect bug fix: the previous `Colors.grey.shade200` rendered locked nodes as a **near-white panel** against the dark editorial-monocle map / tab chrome — visually inconsistent with the rest of the dark theme (#2858). The palette `surface` token brings the locked chrome inline with `SPEC/ui/pixel-art-ui-catalog.md` § Editorial-monocle palette and the spec's "Locked: Greyed out or dimmed" language in `SPEC/ui/tech-tree-widget.md` § Node states.

## Scope

- **Not in scope** for this slice (separate #2914 sub-slices):
  - `const Color(0xFF...)` literals in `_categoryColors` (covered by S4 hex cleanup).
  - `debug_console_overlay_panel.dart`, `debug_log_viewer_screen.dart` (dev-tooling files; issue notes enforcement may be relaxed there).
  - Flame renderer `Colors.*` calls in `region_map_component_render_*` (issue allows palette bypass for canvas drawing).
  - `Colors.transparent` in the `Material` host (semantic primitive, not a color choice).

## SPEC alignment

- `SPEC/ui/tech-tree-widget.md` § Node states: "Locked: Greyed out or dimmed" — preserved (no colour pinned).
- `SPEC/ui/pixel-art-ui-catalog.md` § Editorial-monocle palette — authoritative source for the migrated tokens (no SPEC change required).

## Tests

New `app/test/tech_tree_widget_palette_test.dart` (2 widget tests):

1. **Locked node fill + border** — pumps the tree with empty `techUnlocked`, finds the locked `Wind Saw Mill` node by display text, walks to the decorated `Container`, asserts `decoration.color == EditorialMonoclePalette.surface` **and** `border.top.color == EditorialMonoclePalette.border`. Pins the regression against the legacy `shade200` / `shade400` literals.
2. **Edge painter mounted + token sanity** — pins that `_TechTreeEdgePainter` is hosted under a `CustomPaint`, and sanity-asserts `EditorialMonoclePalette.border != Colors.grey.shade600` so the migration is observable and the assertion is non-vacuous.

Existing tests in `tech_tree_widget_core_test.dart` and `tech_tree_widget_description_batches_test.dart` continue to pass (verified locally — 28 tests).

## Verification

- `dart analyze` on touched files + new test: clean.
- `flutter test test/tech_tree_widget_*test.dart`: 30 tests pass (28 existing + 2 new).
- `dart run tool/ct_repo_lint.dart`: all **49 rules pass**.

Refs #2914

Made with [Cursor](https://cursor.com)