### PR TITLE
refactor(app): replace raw const Color(0x...) in 2 widget files with palette tokens (Refs #2914 S4)

### DIFF
--- a/app/lib/widgets/ct_back_button.dart
+++ b/app/lib/widgets/ct_back_button.dart
@@ -120,7 +120,11 @@ class _CtBackButtonState extends State<CtBackButton> {
         alpha: CtBackButton.hoverBackgroundAlpha,
       );
     }
-    return const Color(0x00000000);
+    // Default (not hovered, not pressed) — fully transparent so no panel
+    // is painted, while keeping the `surfaceLite` token as the animation
+    // anchor so `AnimatedContainer` can lerp alpha 0 → 0.4 → 0.6 within
+    // a single palette-bound color (Refs #2914 S4 — no raw hex literals).
+    return EditorialMonoclePalette.surfaceLite.withValues(alpha: 0);
   }
 
   @override

--- a/app/lib/widgets/gp_default_map_color_swatch.dart
+++ b/app/lib/widgets/gp_default_map_color_swatch.dart
@@ -1,8 +1,13 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:flutter/material.dart';
 
+import '../config/editorial_monocle_palette.dart';
+
 /// Small preview of a Great Power’s default map / ownership RGB from GDD 09
 /// (`greatPowerDefaultColorRgb`). Used beside nation names in pickers.
+///
+/// Unknown great-power ids fall back to [EditorialMonoclePalette.muted]
+/// (Refs #2914 S4 — no raw `const Color(0x...)` literals in `app/lib/widgets/`).
 class GpDefaultMapColorSwatch extends StatelessWidget {
   const GpDefaultMapColorSwatch({super.key, required this.greatPowerId});
 
@@ -13,7 +18,7 @@ class GpDefaultMapColorSwatch extends StatelessWidget {
     final rgb = greatPowerDefaultColorRgb[greatPowerId];
     final color = rgb != null
         ? Color.fromRGBO(rgb.$1, rgb.$2, rgb.$3, 1)
-        : const Color(0xFF9E9E9E);
+        : EditorialMonoclePalette.muted;
     return Container(
       width: 14,
       height: 14,

--- a/app/test/ct_back_button_test.dart
+++ b/app/test/ct_back_button_test.dart
@@ -66,6 +66,22 @@ void main() {
     );
 
     testWidgets(
+      'default background uses --surface-lite with alpha 0 — animation anchor '
+      '(Refs #2914 S4, no raw const Color(0x...) literal)',
+      (tester) async {
+        await pumpBackButton(tester, CtBackButton(onPressed: () {}));
+        final Color bg = bodyColor(tester);
+        final Color expected = EditorialMonoclePalette.surfaceLite.withValues(
+          alpha: 0,
+        );
+        expect(bg.r, closeTo(expected.r, 1e-6));
+        expect(bg.g, closeTo(expected.g, 1e-6));
+        expect(bg.b, closeTo(expected.b, 1e-6));
+        expect(bg.a, 0);
+      },
+    );
+
+    testWidgets(
       'hover state: glyph --accent + --surface-lite background @ 40%',
       (tester) async {
         await pumpBackButton(tester, CtBackButton(onPressed: () {}));

--- a/app/test/gp_default_map_color_swatch_test.dart
+++ b/app/test/gp_default_map_color_swatch_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:flutter/material.dart';
 
+import 'package:colonizethis_app/config/editorial_monocle_palette.dart';
 import 'package:colonizethis_app/widgets/gp_default_map_color_swatch.dart';
 
 void main() {
@@ -36,24 +37,30 @@ void main() {
       );
     });
 
-    testWidgets('falls back to grey for unknown id', (WidgetTester tester) async {
-      await tester.pumpWidget(
-        const MaterialApp(
-          home: Scaffold(
-            body: GpDefaultMapColorSwatch(greatPowerId: 'not_a_gp'),
+    testWidgets(
+      'falls back to EditorialMonoclePalette.muted for unknown id (Refs #2914 S4)',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: Scaffold(
+              body: GpDefaultMapColorSwatch(greatPowerId: 'not_a_gp'),
+            ),
           ),
-        ),
-      );
+        );
 
-      final container = tester.widget<Container>(
-        find.descendant(
-          of: find.byType(GpDefaultMapColorSwatch),
-          matching: find.byType(Container),
-        ),
-      );
-      final decoration = container.decoration;
-      expect(decoration, isA<BoxDecoration>());
-      expect((decoration as BoxDecoration).color, const Color(0xFF9E9E9E));
-    });
+        final container = tester.widget<Container>(
+          find.descendant(
+            of: find.byType(GpDefaultMapColorSwatch),
+            matching: find.byType(Container),
+          ),
+        );
+        final decoration = container.decoration;
+        expect(decoration, isA<BoxDecoration>());
+        expect(
+          (decoration as BoxDecoration).color,
+          EditorialMonoclePalette.muted,
+        );
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary

Partial **S4** slice of umbrella issue **#2914** (*Refactor app/lib UI to consolidate editorial-monocle design system…*) — *Hex cleanup — Replace `const Color(0x...)` in widget files with palette tokens*.

Two of the three `const Color(0x...)` literals under `app/lib/widgets/` are removed and replaced with `EditorialMonoclePalette` tokens. No SPEC change is required for this slice — both replacements reuse the existing token table in `SPEC/ui/pixel-art-ui-catalog.md` § Editorial-monocle palette.

`Refs #2914`. Tracked by #2914 — does not auto-close.

## Done in this PR (Refs #2914 S4)

| File | Before | After | Rationale |
|------|--------|-------|-----------|
| `app/lib/widgets/ct_back_button.dart` (default-state `_backgroundColor`) | `const Color(0x00000000)` | `EditorialMonoclePalette.surfaceLite.withValues(alpha: 0)` | Keeps `AnimatedContainer` lerp anchored on the same palette color used by hover (alpha 0.4) and pressed (alpha 0.6), so the alpha fade reads as a single token modulated 0 → 0.4 → 0.6 instead of a cross-color blend. |
| `app/lib/widgets/gp_default_map_color_swatch.dart` (unknown-GP fallback) | `const Color(0xFF9E9E9E)` | `EditorialMonoclePalette.muted` | Warm neutral grey (~L=0.65); semantically matches \"muted / secondary fallback\" intent, binds the swatch to the palette token table. |

## ACs covered now (#2914 S4 — partial)

- [x] `app/lib/widgets/ct_back_button.dart` — no remaining `const Color(0x...)` literal.
- [x] `app/lib/widgets/gp_default_map_color_swatch.dart` — no remaining `const Color(0x...)` literal.
- [ ] `app/lib/widgets/ct_main_menu_collage.dart` — one `const Color(0xFFFFFFFF).withValues(alpha: _collageOpacity)` saveLayer mask remains; deferred (see below).
- [ ] Flame renderer files under `app/lib/features/game/flame/` — caveated by issue body (\"Flame renderer Colors.* calls may legitimately need palette bypass for canvas drawing\"); deferred to a later S4 / G1 slice.

The umbrella `backlog:implementation` label on **#2914** is intentionally **not** transitioned by this PR — S4 still has remaining widget-file and Flame-file scope, and S5–S9 + G1/G2 are open.

## Deferred (still on #2914 S4)

- **`ct_main_menu_collage.dart` line 122 (`saveLayer` mask):** the white tint exists purely to act as a neutral-RGB compositing mask for `srcOver` blendMode so the `_collageOpacity` (0.8) modulates the layer's alpha without tinting the underlying glyphs. No existing `EditorialMonoclePalette` token represents pure white. The cleanest follow-ups are either (a) refactor the painter to fold `_collageOpacity` into each per-glyph alpha and drop the `saveLayer` entirely (eliminating the need for any mask paint), or (b) SPEC-extend the palette with a `neutralWhite` / `compositingMask` token under `SPEC/ui/pixel-art-ui-catalog.md` § Editorial-monocle palette. Both options are larger than this slice warrants and are left as the remaining S4 widget-file item.
- **Flame renderer files** (`region_map_component_render_markers.dart`, `region_map_component_shared.dart`, `resource_icon_disc_palette.dart`, `game_region_minimap.dart`, `tech_tree_widget.dart`): the issue body explicitly notes the CI gate (G1) should either whitelist these render files or only scan `app/lib/features/` excluding `flame/`. Treating these requires a CI-gate scoping decision and palette-friendly canvas helpers — out of scope here.

## SPEC

- No SPEC change in this PR. Both replacements reuse existing `EditorialMonoclePalette` tokens already documented in `SPEC/ui/pixel-art-ui-catalog.md` § Editorial-monocle palette (\`surface-lite\`, \`muted\`).

## Implementation

- `app/lib/widgets/ct_back_button.dart`: `_backgroundColor` default branch now returns `EditorialMonoclePalette.surfaceLite.withValues(alpha: 0)`. Added a comment noting the S4 motivation (single-token animation anchor).
- `app/lib/widgets/gp_default_map_color_swatch.dart`: added the `EditorialMonoclePalette` import, fallback now uses `EditorialMonoclePalette.muted`. Class doc updated to call out the S4 binding.

## Tests

- `app/test/ct_back_button_test.dart` — **added** a positive RGB-channel pin asserting the default background equals `EditorialMonoclePalette.surfaceLite.withValues(alpha: 0)` (Refs #2914 S4); the pre-existing `bg.a == 0` assertion remains green so the hover / pressed alpha contracts (R11a) are unaffected.
- `app/test/gp_default_map_color_swatch_test.dart` — fallback test renamed and updated to assert `(decoration as BoxDecoration).color == EditorialMonoclePalette.muted` (was the hardcoded `const Color(0xFF9E9E9E)`).
- Local pass:
  - `flutter test app/test/ct_back_button_test.dart test/gp_default_map_color_swatch_test.dart --reporter=compact` → **17 / 17 passed**.
  - `dart analyze app/lib/widgets/ct_back_button.dart app/lib/widgets/gp_default_map_color_swatch.dart app/test/ct_back_button_test.dart app/test/gp_default_map_color_swatch_test.dart` → no issues.

## Notes

- No behavioral change for end users — `surfaceLite.withValues(alpha: 0)` is byte-identically transparent during default-state composition, and `EditorialMonoclePalette.muted` is the catalog's nearest neutral grey to Material's `Colors.grey.shade500` (`#9E9E9E`), so the unknown-GP swatch reads as the same muted fallback it always did.
- Architecture boundaries unchanged; no `colonizethis_logic` ↔ `colonizethis_ai` boundary touched; no new logging.
- 15-second turn-resolution budget not affected (UI-only refactor).


Made with [Cursor](https://cursor.com)