### PR TITLE
docs(spec): Phase 0 — extend Material ban + add CtSpacing/CtRadius tokens (Refs #2914)

### DIFF
--- a/SPEC/ui/pixel-art-ui-catalog.md
+++ b/SPEC/ui/pixel-art-ui-catalog.md
@@ -6,9 +6,28 @@
 
 ## Material design ban
 
-- **No Material chrome:** The app **must not** use Material or Cupertino widgets for visible chrome: no `ElevatedButton`, `FilledButton`, `TextButton`, `OutlinedButton`, `AlertDialog`, `Dialog`, `Card`, `ChoiceChip`, `Chip`, `Slider`, `DropdownButton`, `ListTile`, `AppBar`, or Material theming for these.
-- **Plumbing only:** Material is allowed **only** where Flutter requires it for plumbing (e.g. `MaterialApp`, `DefaultTabController`, `ThemeData`, focus/overlay internals). These must not leak default Material visuals into the UI.
-- **CI/test enforcement:** Widget tests should assert against the Ct-* catalog types (e.g. `CtNinePatchButton`, `CtDropdown`, `CtSlider`, `CtScreenShell`) rather than Material button/slider types.
+- **No Material chrome:** The app **must not** use Material or Cupertino widgets for visible chrome: no `ElevatedButton`, `FilledButton`, `TextButton`, `OutlinedButton`, `AlertDialog`, `Dialog`, `Card`, `ChoiceChip`, `Chip`, `FilterChip`, `Slider`, `DropdownButton`, `ListTile`, `SwitchListTile`, generic `IconButton`, generic `Scaffold`, `AppBar`, or Material theming for these.
+- **Ct-\* counterparts (per #2914 Phase 0a):** Each banned widget MUST be replaced with the corresponding Ct-\* catalog widget below. The list below is normative for replacement direction; deviations require either an existing Ct-\* widget that already covers the use (cited in the replacement PR) or a SPEC extension adding a new Ct-\* widget before the replacement lands.
+
+| Banned Material widget | Ct-\* counterpart | Notes |
+|------------------------|-------------------|-------|
+| `ElevatedButton`, `FilledButton`, `TextButton`, `OutlinedButton` | `CtNinePatchButton` | Use `dangerVariant: true` for destructive actions. |
+| `AlertDialog`, `Dialog` | `CtDialogShell` (single dialog) or `CtFullScreenDialogueShell` (scrim + dialog scaffold) | `barrierColor` / scrim resolves through `EditorialMonoclePalette.dialogScrim`. |
+| `Card` | `CtPanel` | In-screen sections; horizontal-band visual contract. |
+| `ChoiceChip`, `Chip`, `FilterChip` | `CtChoiceChip` | Single-select toggle chips. Multi-select pickers compose `CtChoiceChip` rows; no Material `FilterChip` on visible chrome. |
+| `Slider` | `CtSlider` | Continuous and discrete (`divisions`) variants both use `CtSlider`. |
+| `DropdownButton` | `CtDropdown` | Trigger + modal picker inside `CtDialogShell`. |
+| `ListTile`, `SwitchListTile` | `CtToggleSwitch` (paired with `CtSectionLabel` or composed `Row`) | `SwitchListTile`'s combined label + switch composition is reproduced by laying out `CtSectionLabel` (or body text in the active theme `TextTheme` slot) alongside `CtToggleSwitch`; no Material `ListTile` row chrome. |
+| Generic `IconButton` | `CtBackButton` (back-affordance chrome) or `CtNinePatchButton` with an icon `child` (action affordance) | "Generic" here means an `IconButton` used as visible chrome — back arrows, glyph-only action buttons, dialog dismiss buttons. Glyph-only affordances that do not fit `CtBackButton`/`CtNinePatchButton` MUST add a new Ct-\* primitive in this catalog before implementation. |
+| Generic `Scaffold`, `AppBar` | `CtScreenShell` (which embeds `CtTopBar`) | "Generic" here means a `Scaffold` used as visible screen chrome on a route. `MaterialApp`'s internal `Scaffold` plumbing for routing/overlays remains permitted under the Plumbing-only rule below. |
+
+- **Plumbing only:** Material is allowed **only** where Flutter requires it for plumbing (e.g. `MaterialApp`, `DefaultTabController`, `ThemeData`, focus/overlay internals, the implicit `Scaffold` inside route hosts that mount a Ct-\* surface). These must not leak default Material visuals into the UI.
+- **CI/test enforcement:** Widget tests should assert against the Ct-\* catalog types (e.g. `CtNinePatchButton`, `CtDropdown`, `CtSlider`, `CtScreenShell`) rather than Material button/slider types. The `disallowed_ast_patterns` CI gate (`tool/check_disallowed_ast_patterns.dart`) is the enforcement vehicle for `app/lib/features/**` — see issue #2914 Phase 2 G2 for the gate-extension scope that picks up the additions above.
+
+### Acceptance criteria (Material design ban)
+
+- **Given** a developer reads the §Material design ban list, **when** they look for `FilterChip`, `SwitchListTile`, generic `IconButton`, or generic `Scaffold`, **then** each appears in the comma-separated banned-widget list and has a row in the Ct-\* counterparts table identifying the replacement and any usage notes.
+- **Given** a feature file under `app/lib/features/**` introduces one of the banned widgets above as visible chrome, **when** the planned `disallowed_ast_patterns` CI gate (issue #2914 Phase 2 G2) runs, **then** the gate fails the build and reports the file/line of the banned widget; until that gate lands, code review must apply the same rule manually using the table above.
 
 ---
 
@@ -138,6 +157,69 @@ needed.
 Widgetbook fallback and debug toggles, but the running app's default theme
 is `AppThemes.editorialMonocle`. No code path outside Widgetbook and debug
 toggles may render a screen in the light colonial theme.
+
+---
+
+## Spacing and radius tokens
+
+Canonical spacing and corner-radius scales for the dark `editorialMonocle`
+theme. Values are derived from observed `app/lib/widgets/**` and
+`app/lib/features/**` patterns and are formalised here so per-component
+review (issues #2914 S5 / S6) can adopt them in Ct-\* widget defaults and
+feature padding/radius callsites without re-deriving the scale per file.
+
+### Spacing tokens
+
+The Dart implementation lands as `CtSpacing` constants in
+`app/lib/widgets/ct_spacing.dart` (issue #2914 S5). Token names use a
+`xs`/`s`/`m`/`ml`/`l`/`xl`/`xxl` shorthand so callsites read as
+`EdgeInsets.all(CtSpacing.m)` rather than embedding the literal `8`.
+
+| Token | Logical px | Typical role |
+|-------|-----------|--------------|
+| `xs` | `2` | Hairline gaps inside compact widgets (e.g. `CtTransferList` per-row vertical breath, between `CtPanel` accent edge and inner content). |
+| `s` | `6` | Resource-cell horizontal padding and similar tight chrome (e.g. `CtResourceCell` default `EdgeInsets.symmetric(horizontal: s, vertical: 4)`-style usage). |
+| `m` | `8` | Default screen-shell outer padding and panel inner padding for compact surfaces (`CtScreenShell` outer body padding, `CtPanel` default inner padding). |
+| `ml` | `12` | Dialog body line breaks, button row gaps, mid-density panel insets. |
+| `l` | `16` | Standard card / dialog block padding on default-density surfaces (predominant `EdgeInsets.all(16)` usage). |
+| `xl` | `20` | Full-screen dialogue shell inner padding (`CtFullScreenDialogueShell.defaultPadding = EdgeInsets.all(xl)`). |
+| `xxl` | `24` | Roomy main-menu container padding, generous block padding for low-density surfaces. |
+
+The scale is intentionally non-linear: it skips over `4`, `10`, and `14`
+because those values are rare and either approximate (`4 ≈ s/2 or m/2`) or
+better expressed as a per-component override (`14`, used once in default
+densities, is a candidate for explicit override during S5 adoption rather
+than a global token). Per-component review (S5) MAY extend the scale with
+additional named tokens if a value occurs in three or more callsites; new
+tokens MUST land here in the SPEC table before code adoption.
+
+### Radius tokens
+
+The Dart implementation lands as `CtRadius` constants in
+`app/lib/widgets/ct_radius.dart` (issue #2914 S6) and is consumed via
+`BorderRadius.circular(CtRadius.medium)` (or an equivalent helper).
+
+| Token | Logical px | Typical role |
+|-------|-----------|--------------|
+| `small` | `2` | Hairline rounding on chip/tab corners (e.g. `BorderRadius.circular(2)` in `CtChoiceChip` / `CtTabStrip` style frames). |
+| `medium` | `4` | Default rounded chrome on resource cells, transfer list rows, compact panels. |
+| `large` | `8` | Dialog/panel outer frame rounding for default-density surfaces. |
+| `xl` | `12` | Roomy dialog frames and full-screen overlays where the corner radius reads at human scale rather than as pixel-art chamfer. |
+
+The scale stops at `12`. The single observed `BorderRadius.circular(24)`
+callsite is a per-screen affordance (not a global token); per-component
+review (S6) treats it as an explicit override rather than promoting a
+`xxl` radius token. The single observed `BorderRadius.circular(1)` and
+`BorderRadius.circular(6)` callsites are similarly out-of-scale and are
+candidates for adjustment to the nearest defined token during adoption,
+unless per-component review documents an explicit pixel-art reason to
+keep the literal.
+
+### Acceptance criteria (Spacing and radius tokens)
+
+- **Given** a developer reads the §Spacing tokens table, **when** they look for the `xs`, `s`, `m`, `ml`, `l`, `xl`, and `xxl` rows, **then** each token appears with its logical-px value (`2`, `6`, `8`, `12`, `16`, `20`, `24` respectively) and a typical-role description, and the prose around the table calls out the deliberate omissions of `4`, `10`, and `14` from the scale.
+- **Given** a developer reads the §Radius tokens table, **when** they look for the `small`, `medium`, `large`, and `xl` rows, **then** each token appears with its logical-px value (`2`, `4`, `8`, `12` respectively) and a typical-role description, and the prose around the table calls out that observed values `1`, `6`, and `24` are out-of-scale per-component overrides rather than global tokens.
+- **Given** issue #2914 S5 / S6 implements `CtSpacing` and `CtRadius` Dart constants, **when** the implementation is reviewed against this SPEC, **then** every Dart constant name and value matches a row in the corresponding token table and no extra named constants exist that are not present in the SPEC table.
 
 ---
 


### PR DESCRIPTION
## Summary

Phase 0 SPEC slice of umbrella issue **#2914** (*Refactor app/lib UI to consolidate editorial-monocle design system…*). Lands the SPEC-only updates that the issue body explicitly assigns to the umbrella itself ("Phase 0: SPEC updates (this issue; no sub-issue needed)") so that the in-flight S5 / S6 / S8 implementation slices have a single normative source of truth to reference. No Dart code changes — `app/lib/**` is untouched.

`Refs #2914`. Tracked by #2914 — does not auto-close.

## Done in this PR (Refs #2914 Phase 0a + 0b)

| Section | Change |
|---------|--------|
| `SPEC/ui/pixel-art-ui-catalog.md` § **Material design ban** | Extended the banned-widget list with `FilterChip`, `SwitchListTile`, generic `IconButton`, and generic `Scaffold`; added a normative Ct-\* counterparts table mapping each banned Material widget to its dark editorial-monocle replacement; clarified the *Plumbing only* rule to explicitly allow `MaterialApp`'s internal `Scaffold` plumbing for routing/overlays; updated the *CI/test enforcement* bullet to name `tool/check_disallowed_ast_patterns.dart` (#2914 Phase 2 G2) as the planned enforcement vehicle. |
| `SPEC/ui/pixel-art-ui-catalog.md` § **Spacing and radius tokens** (new top-level section) | Added §Spacing tokens table (`xs: 2`, `s: 6`, `m: 8`, `ml: 12`, `l: 16`, `xl: 20`, `xxl: 24`) and §Radius tokens table (`small: 2`, `medium: 4`, `large: 8`, `xl: 12`) with typical-role descriptions sourced from observed `app/lib/widgets/**` and `app/lib/features/**` patterns; documented the deliberately-skipped values (`4`, `10`, `14` for spacing; `1`, `6`, `24` for radius) and the per-component-extension policy (S5 / S6 may add rows here before code adoption). |
| `SPEC/ui/pixel-art-ui-catalog.md` Acceptance criteria | Added Given–When–Then ACs under both new/extended sections so the Phase 0a and Phase 0b ACs from issue #2914 are testable against the SPEC document itself. |

## ACs covered now (#2914 Phase 0a + 0b)

- [x] **Phase 0a:** SPEC `pixel-art-ui-catalog.md` §Material design ban extended with `FilterChip`, `SwitchListTile`, `IconButton`, `Scaffold` (and Ct-\* counterparts table cross-references each entry).
- [x] **Phase 0b:** SPEC `pixel-art-ui-catalog.md` extended with §Spacing tokens and §Radius tokens.

The umbrella `backlog:implementation` label on **#2914** is intentionally **not** transitioned by this PR — Phase 1 (S3 remaining widget files, S4 follow-ups, S5 CtSpacing adoption, S6 CtRadius adoption, S7 fontSize normalization, S8 Material ban code remediation, S9 component specs) and Phase 2 (G1 / G2 CI gates) are still open.

## Out of scope for this PR (tracked separately)

- **S5** — Define `CtSpacing` Dart constants in `app/lib/widgets/ct_spacing.dart` and adopt across Ct-\* widgets and feature files. **This PR only authorises the token table; the Dart constants and adoption are a separate slice.**
- **S6** — Define `CtRadius` Dart constants in `app/lib/widgets/ct_radius.dart` and adopt across the codebase. Same authorisation/adoption split as S5.
- **S8** — Remove banned Material widgets (`AlertDialog`, `TextButton`, `IconButton`, `FilterChip`, `SwitchListTile`, `Scaffold`) from `app/lib/features/**` and replace with the Ct-\* counterparts named in the new table.
- **G2** — Extend `tool/check_disallowed_ast_patterns.dart` with the additions above. The new SPEC AC explicitly names this gate as the future enforcement vehicle so the gate-extension PR has a clean SPEC anchor.

## SPEC

- **Updated:** `SPEC/ui/pixel-art-ui-catalog.md`
  - §Material design ban — extended banned-widget list, added Ct-\* counterparts table, refined plumbing-only and CI-enforcement bullets, added Phase 0a ACs.
  - **NEW** §Spacing and radius tokens — `## Spacing and radius tokens` section with §Spacing tokens table, §Radius tokens table, scale-design rationale, and Phase 0b ACs.

No other SPEC files modified. No GDD / TDD / AI / UI screen specs touched.

## Tests

This is a SPEC-only PR — no Dart code is added or modified, so no new unit/widget tests are added in this slice. Per `colonizethis-spec-required.mdc`, the SPEC tables themselves are normative; the Phase 0a / 0b ACs are testable by document inspection (the Given–When–Then triplets in the new Acceptance criteria sub-sections describe exactly what a reviewer/agent must verify in the SPEC text).

The downstream Dart slices that will reference these tokens (S5 / S6 / S8) carry their own positive and negative tests against `CtSpacing` / `CtRadius` constants and the AST gate; those tests are out of scope here.

## Notes

- No behavioural change for end users — UI rendering is byte-identical (no Dart code in `app/lib/**` is touched).
- Architecture boundaries unchanged (no `colonizethis_logic` ↔ `colonizethis_ai` boundary touched, no logging changes).
- 15-second turn-resolution budget not affected (SPEC-only refactor).
- The catalog file remains over the 1000-word per-document soft limit from `.cursor/rules/colonizethis-spec-required.mdc`; this PR adds ~1.1k words on top of an already-oversized document. Splitting `pixel-art-ui-catalog.md` into per-section sub-specs is a separate concern that should not gate Phase 0 SPEC authorisation, since the existing in-flight work (S1–S4, plus the open Issue C / D / F PRs) already references the catalog at its current path.


Made with [Cursor](https://cursor.com)