### PR TITLE
test(ai): seed-42 turn-1 trade-enabled wall-clock budget (Refs #2994 F10)

### DIFF
--- a/SPEC/ai/treasury-planner.md
+++ b/SPEC/ai/treasury-planner.md
@@ -222,13 +222,32 @@ COLONIAL turns.
 - Given the same seed-42 turn-1 invocation runs twice in succession, when both runs complete, then `result.orders.tradeOrdersByPlayerId` is equal across runs (determinism — mirrors the existing `generateOrdersForGameFullAI determinism` pin in `full_ai_planner_determinism_test.dart`).
 - Given a failing assertion in any of the criteria above, when the test reports the failure, then the assertion `reason` contains a per-GP trace row `gp<n>  tradeOrders=<count>  bids=<count>  offers=<count>  treasury=<int>  phase=<ObserverGoalPhase>` so a future regression in `runTreasuryPlanner` or the orchestrator F7 append surfaces structured per-GP context (matches the trace-table pattern used by `seed42_expand_phase_turn1_pin_test.dart`).
 
+## Seed-42 trade-enabled wall-clock budget (Refs #2994 F10)
+
+F10 extends the existing `kTurnProcessingWallClockBudgetMs` (15 000 ms) envelope to the **seed-42** starting state and adds an explicit **trade-orders-enabled** assertion so a regression that (a) silently disables the TreasuryPlanner integration, or (b) re-introduces market resolution work that pushes the seed-42 turn over budget, fails the same single test rather than two separate suites. F1–F5 cover the planner unit behaviour, F9 pins per-GP trade emission, and F10 pins the timed envelope.
+
+### Verification surface
+
+- Test file: `packages/colonizethis_ai/test/perf/seed42_first_turn_trade_enabled_wall_clock_budget_test.dart`.
+- Entrypoint exercised: `generateOrdersForGameFullAI(game, topology, tileMapByRegion: …)` against the seed-42 game `init.game.copyWith(aiControlByGpId: {for (final p in init.game.players) p.id: true})`, followed by `validateOrdersAndResolveTurnFromTrustedOrders` to drive the full pipeline including the World Market phase.
+- Outputs read: combined `Stopwatch().elapsedMilliseconds` for the AI + resolve span, and `result.orders.tradeOrdersByPlayerId` from the Full AI invocation.
+
+### Test structure
+
+The seed-42 budget test mirrors `full_ai_first_turn_wall_clock_budget_test.dart` (Refs #2507) — one timed `generateOrdersForGameFullAI` + `validateOrdersAndResolveTurnFromTrustedOrders` invocation per assertion — and adds an explicit `tradeOrdersByPlayerId` non-empty check so the timed envelope cannot pass on a path that silently skipped trade emission. Seed-42 GPs stay in EXPAND for the full observer horizon (see `seed42_observer_colonial_regression_test.dart` § skip rationale), so turn 1 deterministically captures the trade-enabled budget without paying the 150-turn observer-loop cost.
+
+### Acceptance criteria (F10 — seed-42 trade-enabled budget pin)
+
+- Given the seed-42 `runInitGame` output (`GameSetupConfig(seed: 42)`, default options) with every Great Power flipped to AI-controlled via `aiControlByGpId`, when `generateOrdersForGameFullAI` runs once for turn 1, then `result.orders.tradeOrdersByPlayerId.values.expand((list) => list).length` is strictly greater than `0` (the timed envelope must exercise the trade-orders code path).
+- Given the same seed-42 turn-1 init, when `generateOrdersForGameFullAI` and `validateOrdersAndResolveTurnFromTrustedOrders` run end-to-end inside a single `Stopwatch`, then the combined `Stopwatch().elapsedMilliseconds` is less than or equal to `kTurnProcessingWallClockBudgetMs` (15 000 ms).
+- Given a failing budget assertion, when the test reports the failure, then the assertion `reason` contains the structured row `total_ms=<int> full_ai_ms=<int> resolve_ms=<int> trade_orders=<int> budget_ms=15000` so a regression surfaces which phase exceeded the envelope and whether the trade-orders path was exercised in that envelope.
+
 ## Out of scope for this SPEC slice
 
 The following remain under remaining `#2994` subtasks:
 
 - Full treasury inflow/outflow forecasting (riches phase, subsidies, build/research spend) beyond the surplus/need maps and F8 offer-inflow discount above (F1 extension).
 - Observer-game seed-42 multi-turn treasury-growth + phase-varying (EXPAND vs COLONIAL) verification (F9 follow-up — gated on the seed-42 colonial-acquisition gap, Refs #2848 / #2509 S7, the same gate that keeps `seed42_observer_colonial_regression_test.dart` skipped).
-- Observer-game seed-42 budget profiling for `TreasuryPlanner + market resolution` against the 15-second `kTurnProcessingWallClockBudgetMs` envelope (F10 — extends the existing `full_ai_first_turn_wall_clock_budget_test.dart` envelope with the trade-orders-enabled assertion explicit).
 - Overseas extraction tonnage subtraction from trade cargo once extraction publishes per-player planned tonnage.
 
 ---

--- a/packages/colonizethis_ai/test/perf/seed42_first_turn_trade_enabled_wall_clock_budget_test.dart
+++ b/packages/colonizethis_ai/test/perf/seed42_first_turn_trade_enabled_wall_clock_budget_test.dart
@@ -1,0 +1,125 @@
+// Seed-42 turn-1 TreasuryPlanner + market resolution wall-clock budget pin
+// (Refs #2994 F10). SPEC/ai/treasury-planner.md
+// § "Seed-42 trade-enabled wall-clock budget (Refs #2994 F10)".
+//
+// F1–F8 ship the per-planner TreasuryPlanner behaviour; F9 pins
+// `generateOrdersForGameFullAI` turn-1 trade-order emission on a real
+// seed-42 starting state. F10 closes the timing gap: the production
+// Full AI + trusted-resolve pipeline (including the World Market
+// phase) must clear `kTurnProcessingWallClockBudgetMs` (15 000 ms)
+// on seed-42 turn 1, AND the timed envelope must actually exercise
+// the trade-orders code path (`tradeOrdersByPlayerId` non-empty).
+//
+// A silently disabled TreasuryPlanner integration or a runaway
+// market-resolution regression would otherwise pass either the
+// `defaultConfig` budget pin
+// (`full_ai_first_turn_wall_clock_budget_test.dart`, Refs #2507) or
+// the seed-42 turn-1 emission pin
+// (`seed42_observer_treasury_planner_trade_emission_test.dart`, F9)
+// in isolation. F10 keeps both signals tied to one assertion so a
+// regression on either surface fails this test rather than slipping
+// past CI on a partial signal.
+
+import 'package:colonizethis_ai/colonizethis_ai.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+import 'package:logger/logger.dart';
+
+void main() {
+  setUpAll(() {
+    CtLogger.level = Level.off;
+  });
+
+  suppressLogsForTests();
+
+  group('seed 42 turn 1 trade-enabled wall-clock budget (Refs #2994 F10)', () {
+    test(
+      'generateOrdersForGameFullAI emits TradeOrders and the AI + resolve '
+      'span clears kTurnProcessingWallClockBudgetMs',
+      () {
+        final init = runInitGame(
+          config: GameSetupConfig(seed: 42),
+          options: const InitGameOptions(
+            cellSize: 24,
+            renderPng: false,
+            skipFillLakes: false,
+          ),
+        );
+        final topology = init.combinedTopology;
+        final tileMapByRegion = init.tileMapByRegion;
+        final game = init.game.copyWith(
+          aiControlByGpId: {for (final p in init.game.players) p.id: true},
+        );
+
+        final total = Stopwatch()..start();
+        final fullAiSw = Stopwatch()..start();
+        final fullAi = generateOrdersForGameFullAI(
+          game,
+          topology,
+          tileMapByRegion: tileMapByRegion,
+        );
+        fullAiSw.stop();
+
+        final mergedOrders = mergeOrderLists(
+          humanOrders: const Orders(),
+          aiOrders: fullAi.orders,
+        );
+        final defaultAssignmentsByPlayerId =
+            fullAi.economyPlansByPlayerId.map(
+          (pid, plan) => MapEntry(pid, plan.productionAssignments),
+        );
+
+        final resolveSw = Stopwatch()..start();
+        final result = validateOrdersAndResolveTurnFromTrustedOrders(
+          game: fullAi.game,
+          topology: topology,
+          orders: mergedOrders,
+          tileMapByRegion: tileMapByRegion,
+          defaultAssignmentsByPlayerId: defaultAssignmentsByPlayerId,
+        );
+        resolveSw.stop();
+        total.stop();
+
+        requireTurnResolutionComplete(result);
+
+        final tradeOrderCount = fullAi.orders.tradeOrdersByPlayerId.values
+            .fold<int>(0, (sum, list) => sum + list.length);
+        final fullAiMs = fullAiSw.elapsedMilliseconds;
+        final resolveMs = resolveSw.elapsedMilliseconds;
+        final totalMs = total.elapsedMilliseconds;
+
+        final reason =
+            'total_ms=$totalMs full_ai_ms=$fullAiMs resolve_ms=$resolveMs '
+            'trade_orders=$tradeOrderCount '
+            'budget_ms=$kTurnProcessingWallClockBudgetMs';
+
+        // AC F10.1: the timed envelope must exercise the trade-orders
+        // code path — a silently disabled TreasuryPlanner integration
+        // would otherwise let a slow path pass this budget on a
+        // partial signal.
+        expect(
+          tradeOrderCount,
+          greaterThan(0),
+          reason:
+              'Refs #2994 F10 AC-1: seed-42 turn-1 generateOrdersForGameFullAI '
+              'must surface at least one trade order across all AI Great '
+              'Powers so the timed envelope actually covers the World Market '
+              'code path. $reason',
+        );
+
+        // AC F10.2: combined AI + resolve span clears the 15 s budget.
+        expect(
+          totalMs,
+          lessThanOrEqualTo(kTurnProcessingWallClockBudgetMs),
+          reason:
+              'Refs #2994 F10 AC-2: seed-42 turn-1 trade-enabled processing '
+              'exceeded budget. $reason',
+        );
+      },
+      timeout: Timeout.none,
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Closes the timing gap on the World Market AI work for #2994: ties the
existing 15 s `kTurnProcessingWallClockBudgetMs` envelope to the **seed-42**
starting state and pins it together with an explicit `tradeOrdersByPlayerId`
non-empty assertion so a regression that (a) silently disables the
TreasuryPlanner integration, or (b) pushes World Market resolution over
budget on seed-42 turn 1, fails this single test rather than slipping past
CI on a partial signal from the `defaultConfig` budget pin or the F9
emission pin alone.

Refs #2994

## Done in this PR

- **`SPEC/ai/treasury-planner.md`**: move F10 out of *Out of scope for this
  SPEC slice* into a new section *Seed-42 trade-enabled wall-clock budget
  (Refs #2994 F10)* with verification surface, test-structure rationale,
  and three Given-When-Then acceptance criteria (`tradeOrdersByPlayerId`
  non-empty, combined `Stopwatch().elapsedMilliseconds <=
  kTurnProcessingWallClockBudgetMs`, structured failure-row trace).
- **`packages/colonizethis_ai/test/perf/seed42_first_turn_trade_enabled_wall_clock_budget_test.dart`**:
  drive `generateOrdersForGameFullAI` + `validateOrdersAndResolveTurnFromTrustedOrders`
  on `GameSetupConfig(seed: 42)` under one `Stopwatch`, assert the combined
  `elapsed_ms` clears the 15 s budget, and assert that
  `result.orders.tradeOrdersByPlayerId` is non-empty so the timed envelope
  actually covers the trade-orders code path.

## AC / subtask coverage

| F-slice | Status |
|---------|--------|
| F1–F5 (TreasuryPlanner core + orchestrator integration) | Already merged |
| F6 (goal-score treasury-acquisition bias) | Already merged |
| F7 (`StrategicGoal.trade` orchestrator wiring) | Already merged |
| F8 (partial-fill-aware forecasting) | Already merged |
| F9 (seed-42 turn-1 trade-emission pin) | Already merged |
| **F10 (seed-42 trade-enabled wall-clock budget pin)** | **Done in this PR** |

## Deferred (same issue, follow-up PRs)

- **F1 extension** — full treasury inflow/outflow forecasting (riches phase,
  subsidies, build/research spend) beyond the surplus/need maps and F8
  offer-inflow discount.
- **F9 multi-turn extension** — phase-varying (EXPAND vs COLONIAL)
  trade-emission verification on the 150-turn observer loop. Gated on the
  seed-42 colonial-acquisition gap (Refs #2848 / #2509 S7) that keeps the
  observer colonial regression test skipped.
- **Overseas extraction tonnage subtraction** from trade cargo once
  extraction publishes per-player planned tonnage on the pipeline.

## Tests run

```bash
cd packages/colonizethis_ai
dart analyze test/perf/seed42_first_turn_trade_enabled_wall_clock_budget_test.dart
dart test test/perf/seed42_first_turn_trade_enabled_wall_clock_budget_test.dart --reporter=compact
dart test test/perf/full_ai_first_turn_wall_clock_budget_test.dart \
         test/seed42_observer_treasury_planner_trade_emission_test.dart --reporter=compact
```

All three test files pass locally on this branch; the new F10 file is
clean under `dart analyze`. Remaining `dart analyze` warnings under
`packages/colonizethis_ai/test/**` are pre-existing and unrelated to this
change.

## Label transition

Issue **not** moved to `backlog:verification` — F1 extension, the F9
multi-turn extension, and the overseas-extraction cargo subtraction
remain open on the issue, and #2994 also tracks merge of every linked
PR before the lane transitions.

Made with [Cursor](https://cursor.com)