### PR TITLE
docs(spec): CtFullScreenDialogueShell composite-component spec (Refs #2914 S9)

### DIFF
--- a/SPEC/ui/call-to-arms-dialogue-overlay.md
+++ b/SPEC/ui/call-to-arms-dialogue-overlay.md
@@ -85,6 +85,7 @@ There are no loading, transient, or error variants; absence of a Yarn dependency
 
 ## Components
 
+- `CtFullScreenDialogueShell` ([`components/ct-full-screen-dialogue-shell.md`](components/ct-full-screen-dialogue-shell.md)) — canonical scrim + centered `CtDialogShell` scaffold reused by every blocking dialogue overlay; pins the `EditorialMonoclePalette.dialogScrim` token so individual overlays do not redeclare it (Refs #2914 S2 / S9).
 - `CtDialogShell` (`app/lib/widgets/ct_dialog_shell.dart`) — frame.
 - `CtBrassDivider` (`app/lib/widgets/ct_brass_divider.dart`) — ornamental separator between the intro line and the call-row list (issue #2867 R24 dark chrome).
 - `CtNinePatchButton` (`app/lib/widgets/ct_nine_patch_button.dart`) — Join, Refuse, Submit buttons (no Material buttons in dialogue chrome).

--- a/SPEC/ui/components/README.md
+++ b/SPEC/ui/components/README.md
@@ -5,3 +5,9 @@
 Authoring rules: [`.cursor/rules/colonizethis-ui-documentation.mdc`](../../../.cursor/rules/colonizethis-ui-documentation.mdc) (§ Component specs). Catalog atoms: [`pixel-art-ui-catalog.md`](../pixel-art-ui-catalog.md).
 
 Create `<kebab-name>.md` before duplicating composite layout in multiple screen specs.
+
+## Index
+
+| Component | File | Consumed by |
+|-----------|------|-------------|
+| `CtFullScreenDialogueShell` | [`ct-full-screen-dialogue-shell.md`](ct-full-screen-dialogue-shell.md) | `OVL10001` (game-start intro), `OVL30001` (overture), `OVL40001` (call-to-arms), `OVL50001` (pending intervention). |

--- a/SPEC/ui/components/README.md
+++ b/SPEC/ui/components/README.md
@@ -11,3 +11,4 @@ Create `<kebab-name>.md` before duplicating composite layout in multiple screen 
 | Component | File | Consumed by |
 |-----------|------|-------------|
 | `CtFullScreenDialogueShell` | [`ct-full-screen-dialogue-shell.md`](ct-full-screen-dialogue-shell.md) | `OVL10001` (game-start intro), `OVL30001` (overture), `OVL40001` (call-to-arms), `OVL50001` (pending intervention). |
+| `CtGameFeatureScreenShell` | [`ct-game-feature-screen-shell.md`](ct-game-feature-screen-shell.md) | `GAME20001` (production), `GAME30001` (diplomacy), `GAME40001` (technology), `GAME60001` (trade). |

--- a/SPEC/ui/components/ct-full-screen-dialogue-shell.md
+++ b/SPEC/ui/components/ct-full-screen-dialogue-shell.md
@@ -1,0 +1,115 @@
+# CtFullScreenDialogueShell (component)
+
+**SPEC/ui/components** — Reusable full-screen scrim + centered `CtDialogShell` wrapper for blocking dialogue overlays. Implementation: [`app/lib/widgets/ct_full_screen_dialogue_shell.dart`](../../../app/lib/widgets/ct_full_screen_dialogue_shell.dart). Catalog atoms: [`pixel-art-ui-catalog.md`](../pixel-art-ui-catalog.md) § *CtFullScreenDialogueShell* and § *Dialog scrim*.
+
+This composite is **not** a screen and has **no** stable screen ID. It is the canonical scaffolding for full-screen modal dialogue overlays referenced by the screen specs listed under [Consumers](#consumers).
+
+---
+
+## Purpose
+
+Consolidates the `Stack` → full-screen `Material(dialogScrim)` → `Center` → `CtDialogShell` → `Padding` scaffold previously inlined into four overlay files (issue [#2914](https://github.com/waigore/colonizethisv3/issues/2914) S2). Callers compose only the dialogue body; the shell guarantees the canonical editorial-monocle scrim token, dialog frame, and inner padding.
+
+---
+
+## Widget contract
+
+| Prop | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `backdrop` | `Widget` | yes | — | Painted at the bottom of the outer `Stack`; typically the underlying game canvas / app shell that the overlay is dimming. |
+| `body` | `Widget` | yes | — | Dialogue body wrapped in a single inner `Padding` and hosted inside the centered `CtDialogShell`. |
+| `maxWidth` | `double` | no | `defaultMaxWidth = 520` | Forwarded verbatim to the inner `CtDialogShell.maxWidth`. |
+| `maxHeight` | `double` | no | `defaultMaxHeight = 600` | Forwarded verbatim to the inner `CtDialogShell.maxHeight`. |
+| `padding` | `EdgeInsetsGeometry` | no | `defaultPadding = EdgeInsets.all(CtSpacing.xl)` (20 dp) | Inner `Padding` wrapping `body` inside the dialog frame. |
+
+The shell intentionally renders **no** title row, brass divider, or per-screen chrome — consumers compose those above `body` so each overlay can preserve its own title-ordering and divider placement.
+
+---
+
+## Layout / wireframe
+
+```text
+Stack
+  backdrop                                            -- bottom layer
+  Material(color: EditorialMonoclePalette.dialogScrim) -- canonical scrim token
+    Center
+      CtDialogShell(maxWidth, maxHeight)              -- accent-dim border + panel gradient
+        Padding(padding)
+          body
+```
+
+Single `Stack` with exactly two top-level children. The full-screen `Material` host paints the scrim color so the `CtDialogShell` can preserve its own (transparent or opaque) chrome without leaking light-theme defaults.
+
+---
+
+## Behavior
+
+1. **Scrim token, always.** The full-screen `Material` is painted with `EditorialMonoclePalette.dialogScrim`. Hex literals such as `Colors.black54` are forbidden in this layer per [`pixel-art-ui-catalog.md`](../pixel-art-ui-catalog.md) § *Dialog scrim*.
+2. **Dialog frame inheritance.** The inner `CtDialogShell` carries the canonical 2 px `--accent-dim` border and `CtGradients.panelGradient` background. The shell does not override either.
+3. **Render order.** The `backdrop` widget is painted first (`Stack` bottom). The scrim and dialog overlay are painted on top.
+4. **Single inner `Padding`.** The shell wraps `body` in exactly one `Padding` whose value equals the configured `padding` prop. Consumers must not add a redundant outer `Padding` of the same value.
+5. **No animation, no dismissal logic.** The shell is a pure layout composite. Show / hide animations and dismissal callbacks belong to the consuming overlay.
+
+---
+
+## States and variants
+
+The composite has no internal state and exposes no variants. Consumers drive variants by swapping the `body` widget (loading spinner, error card, decision list, etc.).
+
+---
+
+## Consumers
+
+The following screen specs use this composite as their scrim + shell scaffold:
+
+| Screen ID | Spec | Notes |
+|-----------|------|-------|
+| `OVL10001` | [`game-start-intro-overlay.md`](../game-start-intro-overlay.md) | Game-start intro Yarn overlay. |
+| `OVL30001` | [`overture-dialogue-overlay.md`](../overture-dialogue-overlay.md) | Pending-overture decision overlay. |
+| `OVL40001` | [`call-to-arms-dialogue-overlay.md`](../call-to-arms-dialogue-overlay.md) | Pending call-to-arms decision overlay. |
+| Intervention overlay | [`screens/pending-intervention-overlay.md`](../screens/pending-intervention-overlay.md) | Pending-intervention dialogue overlay. |
+
+Each consumer spec links back here for the scrim / shell / padding contract instead of duplicating the wireframe.
+
+---
+
+## Acceptance criteria (Given–When–Then)
+
+- **Given** a `CtFullScreenDialogueShell` mounted with a non-empty `backdrop` and `body` and the default theme `AppThemes.editorialMonocle`,
+  **When** the widget tree settles,
+  **Then** the `backdrop` widget mounts in the subtree, exactly one `CtDialogShell` is mounted in the subtree, and the scrim `Material` immediately above the `CtDialogShell` reports `color == EditorialMonoclePalette.dialogScrim`.
+
+- **Given** a `CtFullScreenDialogueShell` mounted with `backdrop` and `body` and the default theme,
+  **When** every `Material` widget descendant of the shell is inspected,
+  **Then** no descendant has `color == Colors.black54` (regression guard for the canonical `--dialog-scrim` token; see [`pixel-art-ui-catalog.md`](../pixel-art-ui-catalog.md) § *Dialog scrim*).
+
+- **Given** a `CtFullScreenDialogueShell` mounted with `maxWidth == 300` and `maxHeight == 240`,
+  **When** the inner `CtDialogShell` is inspected,
+  **Then** `CtDialogShell.maxWidth == 300` and `CtDialogShell.maxHeight == 240`.
+
+- **Given** a `CtFullScreenDialogueShell` mounted with a custom `padding == EdgeInsets.all(11)`,
+  **When** every `Padding` ancestor of the `body` widget is inspected,
+  **Then** exactly one ancestor `Padding` has `padding == EdgeInsets.all(11)` (the inner content padding the shell controls; the inner `CtDialogShell` may add its own outer padding which is not counted by this AC).
+
+- **Given** a `CtFullScreenDialogueShell` mounted with all default values,
+  **When** the constants are read,
+  **Then** `CtFullScreenDialogueShell.defaultMaxWidth == 520`, `CtFullScreenDialogueShell.defaultMaxHeight == 600`, and `CtFullScreenDialogueShell.defaultPadding == EdgeInsets.all(CtSpacing.xl)` (20 dp), keeping the composite aligned with the `CtSpacing` token table in [`pixel-art-ui-catalog.md`](../pixel-art-ui-catalog.md) § *Spacing tokens*.
+
+- **Given** the `CtFullScreenDialogueShell` source under `app/lib/widgets/ct_full_screen_dialogue_shell.dart`,
+  **When** the file is read as a string,
+  **Then** the source contains `EditorialMonoclePalette.dialogScrim` and does **not** contain the literal `Colors.black54` (regression guard pinning the canonical scrim token at the source level).
+
+---
+
+## Tests
+
+- `app/test/ct_full_screen_dialogue_shell_test.dart` — widget-level contract tests pinning the backdrop / scrim / dialog composition, the canonical scrim token, prop forwarding, and default values.
+- `app/test/spec_components_ct_full_screen_dialogue_shell_test.dart` — spec-pinning regression tests asserting that this component spec exists, declares the required sections (Widget contract, Layout, Acceptance criteria, Consumers), and points back to the canonical SPEC anchors.
+
+---
+
+## Related
+
+- Catalog reference: [`pixel-art-ui-catalog.md`](../pixel-art-ui-catalog.md) § *CtFullScreenDialogueShell*, § *Dialog scrim*, § *Spacing tokens*.
+- Inner shell: [`app/lib/widgets/ct_dialog_shell.dart`](../../../app/lib/widgets/ct_dialog_shell.dart).
+- Tracking issue: [#2914](https://github.com/waigore/colonizethisv3/issues/2914) S2 (extraction) and S9 (component spec authoring).

--- a/SPEC/ui/components/ct-game-feature-screen-shell.md
+++ b/SPEC/ui/components/ct-game-feature-screen-shell.md
@@ -1,0 +1,133 @@
+# CtGameFeatureScreenShell (component)
+
+**SPEC/ui/components** — Reusable host wrapper for game-bound feature screens. Implementation: [`app/lib/widgets/ct_game_feature_screen_shell.dart`](../../../app/lib/widgets/ct_game_feature_screen_shell.dart). Catalog atoms: [`pixel-art-ui-catalog.md`](../pixel-art-ui-catalog.md) § *CtTopBar*, § *CtScreenShell*.
+
+This composite is **not** a screen and has **no** stable screen ID. It is the canonical scaffolding for in-game feature surfaces (production, technology, diplomacy, trade) referenced by the screen specs listed under [Consumers](#consumers).
+
+---
+
+## Purpose
+
+Hosts game-bound feature screens with three guarantees: a live-game swap via `currentGameProvider`, optional `GameToUIBusListener` wiring, and a two-chrome-path body host (legacy `CtScreenShell` or dark `Scaffold` + `topBar`). Callers compose only the body; the shell owns the rest (issue [#2914](https://github.com/waigore/colonizethisv3/issues/2914) S9).
+
+---
+
+## Widget contract
+
+| Prop | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `game` | `Game` | yes | — | Initial game snapshot supplied by the route. Always passed to `bodyBuilder` unless a same-id live game is available. |
+| `bodyBuilder` | `GameFeatureBodyBuilder` | yes | — | Signature `Widget Function(BuildContext context, WidgetRef ref, Game displayGame)`. Receives the resolved `displayGame` (live snapshot when present, otherwise `game`). |
+| `title` | `String?` | conditional | — | Required when `topBar == null` (legacy `CtScreenShell` chrome path). Ignored when `topBar` is provided. |
+| `topBar` | `Widget?` | conditional | — | Required when `title == null`. When supplied, the shell renders a dark `Scaffold` + `SafeArea` + `Column` body host with the top bar above the body. Typically a `CtTopBar`. |
+| `showBackButton` | `bool` | no | `true` | Forwarded to the legacy `CtScreenShell`. No effect on the dark-chrome path. |
+| `attachGameToUiListener` | `bool` | no | `true` | When `true`, the body is wrapped in `GameToUIBusListener(gameId: game.id, child: shell)`. |
+
+Invariant (assertion): `topBar != null || title != null`. When both are supplied, the dark-chrome path wins.
+
+---
+
+## Layout / wireframe
+
+### Dark-chrome path (`topBar` non-null)
+
+```text
+GameToUIBusListener(gameId: game.id)?                 -- when attachGameToUiListener == true
+  Scaffold(backgroundColor: colorScheme.surface)
+    SafeArea
+      Column(crossAxisAlignment: stretch)
+        topBar                                        -- supplied CtTopBar
+        Expanded(child: bodyBuilder(context, ref, displayGame))
+```
+
+### Legacy-chrome path (`topBar == null`, `title` required)
+
+```text
+GameToUIBusListener(gameId: game.id)?                 -- when attachGameToUiListener == true
+  CtScreenShell(title: title, showBackButton: showBackButton)
+    bodyBuilder(context, ref, displayGame)
+```
+
+In both paths `displayGame` is the live `currentGameProvider` value when its `id == game.id`; otherwise the original `game` snapshot is forwarded so a stale route argument never displaces a live snapshot.
+
+---
+
+## Behavior
+
+1. **Live-game swap.** When `attachGameToUiListener == true`, the shell watches `currentGameProvider`. If the live value is non-null and `live.id == game.id`, `displayGame == live`; else `displayGame == game`.
+2. **Listener gating.** When `attachGameToUiListener == false`, the shell skips both the `currentGameProvider` watch (`displayGame == game` always) and the surrounding `GameToUIBusListener` wrapper.
+3. **Chrome is non-overlapping.** Exactly one of (`_DarkChromeShell`, `CtScreenShell`) is mounted. The dark path uses `Theme.of(context).colorScheme.surface` for the `Scaffold` background so the surface inherits the active theme (`AppThemes.editorialMonocle` in production per `colonizethis-ui-design.mdc` § *Dark theme*).
+4. **No chrome of its own.** The shell paints no borders, dividers, or titles; the supplied `topBar` or `CtScreenShell` owns all chrome.
+5. **Listener wraps outermost.** When attached, `GameToUIBusListener` wraps the entire chrome subtree so back navigation and inbound events see the listener.
+
+---
+
+## States and variants
+
+The composite has no internal state. Variants are driven entirely by `topBar` and `attachGameToUiListener`:
+
+| Variant | `topBar` | `attachGameToUiListener` | Chrome |
+|---------|----------|--------------------------|--------|
+| Dark + live | non-null | `true` | `_DarkChromeShell` inside `GameToUIBusListener` |
+| Dark, no listener | non-null | `false` | `_DarkChromeShell` directly (Widgetbook) |
+| Legacy + live | `null` | `true` | `CtScreenShell` inside `GameToUIBusListener` |
+| Legacy, no listener | `null` | `false` | `CtScreenShell` directly (Widgetbook) |
+
+---
+
+## Consumers
+
+The following screen specs use this composite as their host shell:
+
+| Screen ID | Spec | Notes |
+|-----------|------|-------|
+| `GAME20001` | [`production-panel.md`](../production-panel.md) | Dark chrome with `CtTopBar` (issue #2862 S1). |
+| `GAME40001` | [`technology-panel.md`](../technology-panel.md) | Dark chrome with `CtTopBar` (issue #2862 S2). |
+| `GAME30001` | [`diplomacy-panel.md`](../diplomacy-panel.md) | Dark chrome with `CtTopBar` (issue #2863). |
+| `GAME60001` | [`trade-screen.md`](../trade-screen.md) | Dark chrome with `CtTopBar` (issue #2993). |
+
+Each consumer spec links back here for the live-game-swap, listener-gating, and chrome-path contract instead of duplicating the wireframe.
+
+---
+
+## Acceptance criteria (Given–When–Then)
+
+- **Given** a `CtGameFeatureScreenShell` mounted with `topBar != null` and `attachGameToUiListener == true`,
+  **When** the widget tree settles,
+  **Then** exactly one `_DarkChromeShell` is mounted in the subtree, exactly one `GameToUIBusListener` is mounted with `gameId == game.id`, and the legacy `CtScreenShell` is **not** mounted in the subtree.
+
+- **Given** a `CtGameFeatureScreenShell` mounted with `topBar == null` and `title == 'Diplomacy'`,
+  **When** the widget tree settles,
+  **Then** exactly one `CtScreenShell` is mounted in the subtree with `title == 'Diplomacy'` and the `_DarkChromeShell` is **not** mounted in the subtree.
+
+- **Given** a `CtGameFeatureScreenShell` constructed with both `topBar == null` and `title == null`,
+  **When** the constructor runs in a `--enable-asserts` build,
+  **Then** the assertion `topBar != null || title != null` fails (regression guard against silent fall-through).
+
+- **Given** a `CtGameFeatureScreenShell` with `attachGameToUiListener == true` and a `currentGameProvider` whose live value has `id == game.id` and a distinct first-player `displayName`,
+  **When** `bodyBuilder` runs,
+  **Then** `displayGame.players.first.displayName` matches the live value (not the route snapshot).
+
+- **Given** a `CtGameFeatureScreenShell` with `attachGameToUiListener == true` and a `currentGameProvider` whose live value has `id != game.id`,
+  **When** `bodyBuilder` runs,
+  **Then** `displayGame` is identical to the original `game` route argument.
+
+- **Given** a `CtGameFeatureScreenShell` with `attachGameToUiListener == false`,
+  **When** the widget tree settles,
+  **Then** no `GameToUIBusListener` is mounted in the subtree.
+
+---
+
+## Tests
+
+- `app/test/ct_game_feature_screen_shell_test.dart` — widget-level contract tests pinning the live-game swap rule, listener wrapping, and chrome selection.
+- `app/test/spec_components_ct_game_feature_screen_shell_test.dart` — spec-pinning regression tests asserting that this component spec exists, declares the required sections (Widget contract, Layout, Behavior, Consumers, Acceptance criteria), and enumerates the four consumer screens by stable id.
+
+---
+
+## Related
+
+- Catalog reference: [`pixel-art-ui-catalog.md`](../pixel-art-ui-catalog.md) § *CtTopBar*, § *CtScreenShell*, § *Editorial-monocle palette*.
+- Listener helper: [`app/lib/widgets/game_to_ui_bus_listener.dart`](../../../app/lib/widgets/game_to_ui_bus_listener.dart).
+- Legacy chrome: [`app/lib/widgets/ct_screen_shell.dart`](../../../app/lib/widgets/ct_screen_shell.dart).
+- Tracking issue: [#2914](https://github.com/waigore/issues/2914) S9 (component spec authoring).

--- a/SPEC/ui/diplomacy-panel.md
+++ b/SPEC/ui/diplomacy-panel.md
@@ -36,7 +36,7 @@ A faction is **discovered** iff the player has a **diplomatic relation** with th
 
 ## Top bar (dark editorial-monocle, all viewports)
 
-The diplomacy screen renders its chrome through `CtGameFeatureScreenShell`'s opt-in `topBar` slot so the surrounding `Scaffold` + `SafeArea` + `Column` shell, `GameToUIBusListener`, and ordering of body widgets remain identical to the legacy chrome path. The legacy `CtScreenShell` parchment title bar is **not** used on this surface (R1–R3 of #2863 — full dark editorial-monocle alignment).
+The diplomacy screen renders its chrome through `CtGameFeatureScreenShell`'s opt-in `topBar` slot so the surrounding `Scaffold` + `SafeArea` + `Column` shell, `GameToUIBusListener`, and ordering of body widgets remain identical to the legacy chrome path. The legacy `CtScreenShell` parchment title bar is **not** used on this surface (R1–R3 of #2863 — full dark editorial-monocle alignment). Composite contract: [`components/ct-game-feature-screen-shell.md`](components/ct-game-feature-screen-shell.md).
 
 - **Component:** `CtTopBar` (`SPEC/ui/pixel-art-ui-catalog.md` § Pixel-art component catalog → `CtTopBar` entry), supplied through the `topBar` slot of `CtGameFeatureScreenShell`. The screen retains `GameToUIBusListener` for live game wiring (default `attachGameToUiListener: true`).
 - **Title text:** literal `Diplomacy`. The display font (`Cinzel` / `Iowan Old Style`) and `--accent` text color resolve from the dark editorial-monocle theme `titleMedium` slot per `CtTopBar` defaults.

--- a/SPEC/ui/game-start-intro-overlay.md
+++ b/SPEC/ui/game-start-intro-overlay.md
@@ -111,6 +111,7 @@ The overlay does not use `AppEventBus` or `Navigator`; host route stays mounted.
 
 ## Components
 
+- `CtFullScreenDialogueShell` ([`components/ct-full-screen-dialogue-shell.md`](components/ct-full-screen-dialogue-shell.md)) — canonical scrim + centered `CtDialogShell` scaffold reused by every blocking dialogue overlay; pins the `EditorialMonoclePalette.dialogScrim` token so individual overlays do not redeclare it (Refs #2914 S2 / S9).
 - `CtDialogShell` (`app/lib/widgets/ct_dialog_shell.dart`) — frame.
 - `CtBrassDivider` (`app/lib/widgets/ct_brass_divider.dart`) — decorative 8 px ornate divider between the title region and the dialogue / error body (per `SPEC/ui/pixel-art-ui-catalog.md` § *CtBrassDivider*).
 - `CtNinePatchButton` (`app/lib/widgets/ct_nine_patch_button.dart`) — Continue and option buttons (no Material buttons in dialogue chrome).

--- a/SPEC/ui/overture-dialogue-overlay.md
+++ b/SPEC/ui/overture-dialogue-overlay.md
@@ -132,6 +132,7 @@ No direct `AppEventBus` or `Navigator` usage in the overlay.
 
 ## Components
 
+- `CtFullScreenDialogueShell` ([`components/ct-full-screen-dialogue-shell.md`](components/ct-full-screen-dialogue-shell.md)) — canonical scrim + centered `CtDialogShell` scaffold reused by every blocking dialogue overlay; pins the `EditorialMonoclePalette.dialogScrim` token so individual overlays do not redeclare it (Refs #2914 S2 / S9).
 - `CtDialogShell` (`app/lib/widgets/ct_dialog_shell.dart`) — frame.
 - `CtBrassDivider` (`app/lib/widgets/ct_brass_divider.dart`) — phase 2 title → intro separator (#2867 R21).
 - `CtNinePatchButton` (`app/lib/widgets/ct_nine_patch_button.dart`) — Continue, option, Accept, Reject, Submit buttons (no Material buttons in dialogue chrome).

--- a/SPEC/ui/production-panel.md
+++ b/SPEC/ui/production-panel.md
@@ -32,7 +32,7 @@ Asset filenames and style for commodities and workers appear in [game-toolbar-ic
 
 ### Top bar (all viewports)
 
-- **Component:** `CtTopBar` (`SPEC/ui/pixel-art-ui-catalog.md` § Pixel-art component catalog → `CtTopBar` entry). Rendered above both subpanels via the `topBar` slot on `CtGameFeatureScreenShell`.
+- **Component:** `CtTopBar` (`SPEC/ui/pixel-art-ui-catalog.md` § Pixel-art component catalog → `CtTopBar` entry). Rendered above both subpanels via the `topBar` slot on `CtGameFeatureScreenShell` (composite contract: [`components/ct-game-feature-screen-shell.md`](components/ct-game-feature-screen-shell.md)).
 - **Back affordance:** `CtBackButton` chevron-left glyph followed by the localised muted label `Map` (issue #2862 requirement: `← Map`). Tapping pops the route via `Navigator.maybePop()` so the player returns to the game screen they came from.
 - **Icon + title:** Pixel-art production icon `assets/icons/32/ui_icon_production.png` rendered at 18×18 logical px between the back affordance and the title. Title literal **`Production`** rendered in the dark-theme `titleMedium` slot (Cinzel display family per `AppThemes.editorialMonocle`).
 - **Height + chrome:** Fixed 36 px high (`CtTopBar.height`), filled with `CtGradients.topBarGradient`, capped by a 1 px `--accent-dim` bottom border. Hard-coded colours are forbidden; all tokens resolve through `EditorialMonoclePalette` (issue #2858).

--- a/SPEC/ui/screens/pending-intervention-overlay.md
+++ b/SPEC/ui/screens/pending-intervention-overlay.md
@@ -21,7 +21,7 @@ Present **all** `InterventionPrompt` rows for the current pending batch before t
 
 ## Layout (modal)
 
-- **Frame:** `CtDialogShell` centered over the game.
+- **Frame:** `CtDialogShell` centered over the game. The scrim + centered-shell scaffold itself follows the canonical [`CtFullScreenDialogueShell` component spec](../components/ct-full-screen-dialogue-shell.md), shared with the overture, call-to-arms, and game-start intro overlays (Refs #2914 S2 / S9).
 - **Scrim:** `Material` color resolves to the canonical dark-theme dialog scrim token `EditorialMonoclePalette.dialogScrim` (`oklch(8% 0.01 30 / 0.70)` per `SPEC/ui/pixel-art-ui-catalog.md` § Dialog scrim). Hard-coded `Colors.black54` is a regression and forbidden — issue #2867 R1 (universal dialog pattern) and #2858 § Dialog scrim. The scrim token applies to every phase below (intro, situation, choice, reaction, degraded error).
 - **Chrome header (every phase):** Each `CtDialogShell` column is preceded by a small fixed header band rendered in this order:
   1. `Text` widget with the localized `Pending Intervention` title (l10n key `game_intervention_overlayTitle`) styled in `EditorialMonoclePalette.accent` with `letterSpacing = fontSize × 0.05` (canonical 0.05em per #2867 R2). The title `Text` carries the stable key `ValueKey<String>('interventionOverlayTitle')` so widget tests can locate it without matching localized strings.

--- a/SPEC/ui/technology-panel.md
+++ b/SPEC/ui/technology-panel.md
@@ -23,7 +23,7 @@ Technology screen hosts research slots UI: slot count from `player.researchSlots
 
 ### Top bar (dark editorial-monocle, all viewports)
 
-- **Component:** `CtTopBar` (`SPEC/ui/pixel-art-ui-catalog.md` § Pixel-art component catalog → `CtTopBar` entry), supplied through the `topBar` slot of `CtGameFeatureScreenShell` so the screen reuses the shared `Scaffold` + `SafeArea` + `Column` body shell and retains `GameToUIBusListener` for live game wiring.
+- **Component:** `CtTopBar` (`SPEC/ui/pixel-art-ui-catalog.md` § Pixel-art component catalog → `CtTopBar` entry), supplied through the `topBar` slot of `CtGameFeatureScreenShell` so the screen reuses the shared `Scaffold` + `SafeArea` + `Column` body shell and retains `GameToUIBusListener` for live game wiring (composite contract: [`components/ct-game-feature-screen-shell.md`](components/ct-game-feature-screen-shell.md)).
 - **Back affordance:** `CtBackButton` chevron-left glyph followed by the muted label `Map` so the affordance reads `← Map`. The button's default behaviour calls `Navigator.maybePop()` and is a no-op when there is no prior route on the stack.
 - **Icon + title:** Pixel-art technology icon `assets/icons/32/ui_icon_technology.png` rendered at 18 × 18 logical px between the back affordance and the title. The title literal is `Technology`, rendered in the dark-theme `titleMedium` slot (Cinzel display family per `AppThemes.editorialMonocle`).
 - **Height + chrome:** Fixed `CtTopBar.height` (36 px), filled with `CtGradients.topBarGradient`, capped by a 1 px `EditorialMonoclePalette.accentDim` bottom border. Hard-coded colours are forbidden; all tokens resolve through `EditorialMonoclePalette`.

--- a/SPEC/ui/trade-screen.md
+++ b/SPEC/ui/trade-screen.md
@@ -254,7 +254,7 @@ The Deal Book ledger described in [§ Deal Book ledger content (`#2993` E6)](#de
 ## Components
 
 - `TradeScreen` (`app/lib/features/game/screens/trade_screen.dart`) — top-level shell host.
-- `CtGameFeatureScreenShell` (`app/lib/widgets/ct_game_feature_screen_shell.dart`) — opt-in dark chrome wrapper that owns the `GameToUIBusListener` and live `currentGameProvider` swap.
+- `CtGameFeatureScreenShell` (`app/lib/widgets/ct_game_feature_screen_shell.dart`) — opt-in dark chrome wrapper that owns the `GameToUIBusListener` and live `currentGameProvider` swap. Composite contract: [`components/ct-game-feature-screen-shell.md`](components/ct-game-feature-screen-shell.md).
 - `CtTopBar` (`SPEC/ui/pixel-art-ui-catalog.md` § `CtTopBar`) — dark editorial-monocle top bar carrying the back affordance, icon, and title.
 - `StrictAssetIcon` (`app/lib/widgets/strict_asset_icon.dart`) — renders the 32 × 32 source PNG at the 18 × 18 top-bar size.
 - `CtPanel` (`SPEC/ui/pixel-art-ui-catalog.md` § `CtPanel`) — outer surface for the tabs body and inner surface for each tab placeholder.

--- a/app/test/spec_components_ct_full_screen_dialogue_shell_test.dart
+++ b/app/test/spec_components_ct_full_screen_dialogue_shell_test.dart
@@ -25,6 +25,7 @@ library;
 
 import 'dart:io' show File;
 
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter_test/flutter_test.dart';
 
 const String _kSpecPath =

--- a/app/test/spec_components_ct_full_screen_dialogue_shell_test.dart
+++ b/app/test/spec_components_ct_full_screen_dialogue_shell_test.dart
@@ -1,0 +1,199 @@
+/// Pins the [`SPEC/ui/components/ct-full-screen-dialogue-shell.md`](
+/// ../../../SPEC/ui/components/ct-full-screen-dialogue-shell.md) component
+/// spec authored as part of issue #2914 S9 (Refactor app/lib UI to consolidate
+/// editorial-monocle design system — Phase 1 step S9: populate
+/// `SPEC/ui/components/` with composite-component specs for shared
+/// abstractions).
+///
+/// The composite widget [CtFullScreenDialogueShell] is consumed by four
+/// dialogue overlay screen specs (`OVL10001`, `OVL30001`, `OVL40001`, and
+/// the pending-intervention overlay). Per
+/// `colonizethis-ui-documentation.mdc` § *Component specs*, a composite that
+/// is reused by multiple screen specs must have its own `kebab-name.md` under
+/// `SPEC/ui/components/` rather than duplicating the layout in each screen
+/// spec.
+///
+/// These tests are deliberately static-text checks (file reads + regex
+/// searches): the canonical Given–When–Then runtime contract for the widget
+/// itself is exercised by the existing
+/// `ct_full_screen_dialogue_shell_test.dart` widget tests; the goal here is
+/// to ensure the SPEC stays present and aligned with the documentation rule
+/// even if future refactors move the widget around.
+///
+/// Refs #2914.
+library;
+
+import 'dart:io' show File;
+
+import 'package:flutter_test/flutter_test.dart';
+
+const String _kSpecPath =
+    '../SPEC/ui/components/ct-full-screen-dialogue-shell.md';
+const String _kComponentsReadmePath = '../SPEC/ui/components/README.md';
+
+String _readSpec() => File(_kSpecPath).readAsStringSync();
+
+void main() {
+  group(
+    'SPEC/ui/components/ct-full-screen-dialogue-shell.md (#2914 S9)',
+    () {
+      test(
+        'spec file exists and is non-empty',
+        () {
+          final file = File(_kSpecPath);
+          expect(
+            file.existsSync(),
+            isTrue,
+            reason:
+                'The composite-component spec for CtFullScreenDialogueShell '
+                'must live at SPEC/ui/components/ct-full-screen-dialogue-shell.md '
+                'per colonizethis-ui-documentation.mdc § Component specs and '
+                'issue #2914 S9.',
+          );
+          final body = file.readAsStringSync();
+          expect(
+            body.trim(),
+            isNotEmpty,
+            reason: 'spec must not be empty',
+          );
+        },
+      );
+
+      test(
+        'spec declares all canonical sections required by the components '
+        'README template (Widget contract / Layout / Behavior / Consumers / '
+        'Acceptance criteria)',
+        () {
+          final body = _readSpec();
+          for (final heading in <String>[
+            '## Purpose',
+            '## Widget contract',
+            '## Layout / wireframe',
+            '## Behavior',
+            '## Consumers',
+            '## Acceptance criteria (Given–When–Then)',
+            '## Tests',
+            '## Related',
+          ]) {
+            expect(
+              body,
+              contains(heading),
+              reason:
+                  'composite-component spec must declare the canonical "$heading" section.',
+            );
+          }
+        },
+      );
+
+      test(
+        'spec lists all four overlay-screen consumers by stable screen ID',
+        () {
+          final body = _readSpec();
+          for (final consumerId in <String>['OVL10001', 'OVL30001', 'OVL40001']) {
+            expect(
+              body,
+              contains(consumerId),
+              reason:
+                  'spec must enumerate consumer screen ID $consumerId so future '
+                  'refactors can reverse-trace the dialogue overlays that '
+                  'depend on this composite.',
+            );
+          }
+          expect(
+            body,
+            contains('pending-intervention-overlay.md'),
+            reason:
+                'spec must enumerate the pending-intervention overlay (no '
+                'stable ID assigned at time of authoring) as a consumer.',
+          );
+        },
+      );
+
+      test(
+        'spec encodes the canonical scrim token + Colors.black54 ban (positive '
+        'and negative regression guards)',
+        () {
+          final body = _readSpec();
+          expect(
+            body,
+            contains('EditorialMonoclePalette.dialogScrim'),
+            reason:
+                'spec must reference the canonical scrim token so the '
+                'editorial-monocle dark contract is documented at the SPEC '
+                'level (Refs #2914 S2 / #2867 R1).',
+          );
+          expect(
+            body,
+            contains('Colors.black54'),
+            reason:
+                'spec must mention the legacy Colors.black54 literal in the '
+                'regression-guard AC so future readers understand which hex '
+                'literal is being banned.',
+          );
+        },
+      );
+
+      test(
+        'spec encodes the canonical default props and links the spacing '
+        'token table (CtSpacing.xl == 20 dp)',
+        () {
+          final body = _readSpec();
+          expect(body, contains('defaultMaxWidth = 520'));
+          expect(body, contains('defaultMaxHeight = 600'));
+          expect(body, contains('CtSpacing.xl'));
+          expect(
+            body,
+            contains('20 dp'),
+            reason:
+                'spec must restate the resolved CtSpacing.xl value so '
+                'reviewers do not have to cross-reference the catalog to '
+                'confirm the inner-padding default.',
+          );
+        },
+      );
+
+      test(
+        'spec is at most 1000 words (colonizethis-spec-required.mdc § Layout)',
+        () {
+          final body = _readSpec();
+          // Match the same word-counting heuristic as `wc -w` (whitespace
+          // split, non-empty tokens) so the budget aligns with the rule.
+          final words = body
+              .split(RegExp(r'\s+'))
+              .where((token) => token.isNotEmpty)
+              .toList();
+          expect(
+            words.length <= 1000,
+            isTrue,
+            reason:
+                'SPEC documents must stay under the 1000-word ceiling per '
+                'colonizethis-spec-required.mdc § Layout. Current word count '
+                'is ${words.length}.',
+          );
+        },
+      );
+
+      test(
+        'components README still introduces the SPEC/ui/components/ directory '
+        '(negative regression guard — components README must not be deleted '
+        'while individual specs live under it)',
+        () {
+          final readme = File(_kComponentsReadmePath);
+          expect(
+            readme.existsSync(),
+            isTrue,
+            reason:
+                'SPEC/ui/components/README.md must remain in place so '
+                'authoring rules for new composite specs stay discoverable.',
+          );
+          final body = readme.readAsStringSync();
+          expect(
+            body,
+            contains('SPEC/ui/components/'),
+            reason: 'README must continue to introduce the components/ directory.',
+          );
+        },
+      );
+    },
+  );
+}

--- a/app/test/spec_components_ct_game_feature_screen_shell_test.dart
+++ b/app/test/spec_components_ct_game_feature_screen_shell_test.dart
@@ -1,0 +1,221 @@
+/// Pins the [`SPEC/ui/components/ct-game-feature-screen-shell.md`](
+/// ../../../SPEC/ui/components/ct-game-feature-screen-shell.md) component
+/// spec authored as part of issue #2914 S9 (Refactor app/lib UI to consolidate
+/// editorial-monocle design system — Phase 1 step S9: populate
+/// `SPEC/ui/components/` with composite-component specs for shared
+/// abstractions).
+///
+/// The composite widget [CtGameFeatureScreenShell] is consumed by four
+/// game-bound feature screens (`GAME20001` production, `GAME30001`
+/// diplomacy, `GAME40001` technology, `GAME60001` trade). Per
+/// `colonizethis-ui-documentation.mdc` § *Component specs*, a composite that
+/// is reused by multiple screen specs must have its own `kebab-name.md` under
+/// `SPEC/ui/components/` rather than duplicating the layout in each screen
+/// spec.
+///
+/// These tests are deliberately static-text checks (file reads + regex
+/// searches): the canonical Given–When–Then runtime contract for the widget
+/// itself is exercised by the existing
+/// `ct_game_feature_screen_shell_test.dart` widget tests; the goal here is
+/// to ensure the SPEC stays present and aligned with the documentation rule
+/// even if future refactors move the widget around.
+///
+/// Refs #2914.
+library;
+
+import 'dart:io' show File;
+
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter_test/flutter_test.dart';
+
+const String _kSpecPath =
+    '../SPEC/ui/components/ct-game-feature-screen-shell.md';
+const String _kComponentsReadmePath = '../SPEC/ui/components/README.md';
+
+String _readSpec() => File(_kSpecPath).readAsStringSync();
+
+void main() {
+  suppressLogsForTests();
+  group(
+    'SPEC/ui/components/ct-game-feature-screen-shell.md (#2914 S9)',
+    () {
+      test(
+        'spec file exists and is non-empty',
+        () {
+          final file = File(_kSpecPath);
+          expect(
+            file.existsSync(),
+            isTrue,
+            reason:
+                'The composite-component spec for CtGameFeatureScreenShell '
+                'must live at SPEC/ui/components/ct-game-feature-screen-shell.md '
+                'per colonizethis-ui-documentation.mdc § Component specs and '
+                'issue #2914 S9.',
+          );
+          final body = file.readAsStringSync();
+          expect(
+            body.trim(),
+            isNotEmpty,
+            reason: 'spec must not be empty',
+          );
+        },
+      );
+
+      test(
+        'spec declares all canonical sections required by the components '
+        'README template (Widget contract / Layout / Behavior / Consumers / '
+        'Acceptance criteria)',
+        () {
+          final body = _readSpec();
+          for (final heading in <String>[
+            '## Purpose',
+            '## Widget contract',
+            '## Layout / wireframe',
+            '## Behavior',
+            '## Consumers',
+            '## Acceptance criteria (Given–When–Then)',
+            '## Tests',
+            '## Related',
+          ]) {
+            expect(
+              body,
+              contains(heading),
+              reason:
+                  'composite-component spec must declare the canonical "$heading" section.',
+            );
+          }
+        },
+      );
+
+      test(
+        'spec lists all four game-feature-screen consumers by stable screen ID',
+        () {
+          final body = _readSpec();
+          for (final consumerId in <String>[
+            'GAME20001',
+            'GAME30001',
+            'GAME40001',
+            'GAME60001',
+          ]) {
+            expect(
+              body,
+              contains(consumerId),
+              reason:
+                  'spec must enumerate consumer screen ID $consumerId so future '
+                  'refactors can reverse-trace the feature screens that '
+                  'depend on this composite.',
+            );
+          }
+        },
+      );
+
+      test(
+        'spec documents the live-game swap and listener-gating invariants',
+        () {
+          final body = _readSpec();
+          expect(
+            body,
+            contains('currentGameProvider'),
+            reason:
+                'spec must reference currentGameProvider so the live-game swap '
+                'invariant (displayGame == live when live.id == game.id) is '
+                'pinned at the SPEC level.',
+          );
+          expect(
+            body,
+            contains('GameToUIBusListener'),
+            reason:
+                'spec must reference GameToUIBusListener so the listener '
+                'wrapping contract is pinned (issue #2914 S9 documentation '
+                'goal).',
+          );
+          expect(
+            body,
+            contains('attachGameToUiListener'),
+            reason:
+                'spec must document the attachGameToUiListener opt-out used '
+                'by Widgetbook / static stories.',
+          );
+        },
+      );
+
+      test(
+        'spec enumerates both chrome paths (dark topBar vs legacy CtScreenShell)',
+        () {
+          final body = _readSpec();
+          expect(
+            body,
+            contains('topBar'),
+            reason:
+                'spec must document the topBar slot used by the dark editorial-'
+                'monocle chrome path.',
+          );
+          expect(
+            body,
+            contains('CtScreenShell'),
+            reason:
+                'spec must document the legacy CtScreenShell chrome path so '
+                'the two-path invariant is explicit.',
+          );
+          expect(
+            body,
+            contains('CtTopBar'),
+            reason:
+                'spec must reference CtTopBar so consumers know which catalog '
+                'atom fills the topBar slot.',
+          );
+        },
+      );
+
+      test(
+        'spec is at most 1000 words (colonizethis-spec-required.mdc § Layout)',
+        () {
+          final body = _readSpec();
+          // Match the same word-counting heuristic as `wc -w` (whitespace
+          // split, non-empty tokens) so the budget aligns with the rule.
+          final words = body
+              .split(RegExp(r'\s+'))
+              .where((token) => token.isNotEmpty)
+              .toList();
+          expect(
+            words.length <= 1000,
+            isTrue,
+            reason:
+                'SPEC documents must stay under the 1000-word ceiling per '
+                'colonizethis-spec-required.mdc § Layout. Current word count '
+                'is ${words.length}.',
+          );
+        },
+      );
+
+      test(
+        'components README index lists the new spec alongside the dialogue shell',
+        () {
+          final readme = File(_kComponentsReadmePath);
+          expect(
+            readme.existsSync(),
+            isTrue,
+            reason:
+                'SPEC/ui/components/README.md must remain in place so '
+                'authoring rules for new composite specs stay discoverable.',
+          );
+          final body = readme.readAsStringSync();
+          expect(
+            body,
+            contains('ct-game-feature-screen-shell.md'),
+            reason:
+                'components README index must reference the new component '
+                'spec so reviewers can discover it from the directory entry.',
+          );
+          expect(
+            body,
+            contains('CtGameFeatureScreenShell'),
+            reason:
+                'components README index must name the composite widget so '
+                'searches by widget name resolve to its spec.',
+          );
+        },
+      );
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Authors the first two composite-component specs under `SPEC/ui/components/` per issue #2914 S9 (Phase 1 step S9 — populate `SPEC/ui/components/` with composite-component specs for shared abstractions reused across multiple screen specs).

## Done in this PR

### Slice 1 — `CtFullScreenDialogueShell` spec

- **`SPEC/ui/components/ct-full-screen-dialogue-shell.md`** — new component spec following the `SPEC/ui/components/` template (Purpose, Widget contract, Layout, Behavior, Consumers, Acceptance criteria, Tests, Related). Pins default props (`maxWidth=520`, `maxHeight=600`, `padding=CtSpacing.xl=20 dp`) and encodes positive + negative regression guards for the canonical `EditorialMonoclePalette.dialogScrim` token (banning `Colors.black54` hex literal). 900 words.
- **`SPEC/ui/components/README.md`** — new index table introducing the directory with the dialogue-shell row and its consumers by stable screen ID.
- **Cross-references in 4 consumer screen specs** — `overture-dialogue-overlay.md`, `call-to-arms-dialogue-overlay.md`, `game-start-intro-overlay.md`, `screens/pending-intervention-overlay.md` each gain a one-line link to the shared composite spec.
- **Tests** — `app/test/spec_components_ct_full_screen_dialogue_shell_test.dart` (7 tests): spec file presence, canonical sections, consumer enumeration by screen ID (`OVL10001`, `OVL30001`, `OVL40001`, `pending-intervention-overlay.md`), scrim-token + `Colors.black54`-ban guards, default props, 1000-word ceiling, README-index regression guard.

### Slice 2 — `CtGameFeatureScreenShell` spec

- **`SPEC/ui/components/ct-game-feature-screen-shell.md`** — new component spec (980 words) capturing the canonical `ConsumerWidget` host shared by four game-bound feature screens. Pins the live-game-swap invariant (`displayGame == currentGameProvider` value when its `id == game.id`, else original snapshot), listener-gating rule (`attachGameToUiListener` wraps in `GameToUIBusListener`; opt-out yields no listener), the two non-overlapping chrome paths (dark `Scaffold + topBar` slot vs legacy `CtScreenShell + title`), and the construction-time assertion `topBar != null || title != null`.
- **`SPEC/ui/components/README.md`** — index updated with the new `CtGameFeatureScreenShell` row alongside the dialogue shell.
- **Cross-references in 4 consumer screen specs** — `production-panel.md`, `technology-panel.md`, `diplomacy-panel.md`, `trade-screen.md` each gain a one-line link to the shared composite spec from their existing `CtGameFeatureScreenShell` references.
- **Tests** — `app/test/spec_components_ct_game_feature_screen_shell_test.dart` (7 tests): spec file presence, canonical sections, consumer enumeration by stable screen ID (`GAME20001`, `GAME30001`, `GAME40001`, `GAME60001`), live-game-swap + listener-gating + chrome-path coverage, 1000-word ceiling, README-index regression guard.

### Maintenance

- **`fix(test)`** — appended the canonical `package:colonizethis_test/test.dart` import (with `show suppressLogsForTests`) to the slice-1 spec test so it satisfies `tool/check_test_imports.sh` per `SPEC/program/test-logging.md` § Import order. Matches the sibling test pattern.
- **Base merge** — merged latest `origin/dev` into the branch to keep the PR up to date (resolves the previous `BEHIND` state).

## What this PR does NOT change

- No production widget code. `CtFullScreenDialogueShell` and `CtGameFeatureScreenShell` already implement the contracts these specs document; the specs are authoritative documentation, not behavior changes.
- Pre-existing widget tests continue to pin the runtime contracts; this PR intentionally does not duplicate that coverage.

## Remaining for #2914

S9 is a populate-many-specs step. After this PR, additional composite-component specs (for example `CtTransferList`, `CtIconAction`) remain candidates for follow-up slices; the umbrella issue label remains `backlog:implementation`.

## Test plan

- [x] `cd app && flutter test test/spec_components_ct_full_screen_dialogue_shell_test.dart test/spec_components_ct_game_feature_screen_shell_test.dart` — 14/14 pass.
- [x] `cd app && flutter analyze test/spec_components_ct_game_feature_screen_shell_test.dart` — No issues found.
- [x] `bash tool/check_test_imports.sh` — Test import convention check passed.

Refs #2914

Made with [Cursor](https://cursor.com)
