### PR TITLE
docs(spec): UnitsPanelShell composite-component spec (Refs #2914 S9)

### DIFF
--- a/SPEC/ui/civilian-units-panel.md
+++ b/SPEC/ui/civilian-units-panel.md
@@ -43,7 +43,7 @@ The civilian units panel gives the player a single place to see every civilian u
 
 ## Layout / wireframe
 
-Bottom sheet (up to ~⅓ screen height); scrollable grouped list by region; per-unit rows with locate and assign actions on the right.
+Bottom sheet (up to ~⅓ screen height); scrollable grouped list by region; per-unit rows with locate and assign actions on the right. The outer chrome (`ConstrainedBox` + `CtPanel` + `CtTopBar` + scrollable list / empty state) is the shared **[`UnitsPanelShell`](components/units-panel-shell.md)** composite.
 
 ---
 

--- a/SPEC/ui/components/README.md
+++ b/SPEC/ui/components/README.md
@@ -13,3 +13,4 @@ Create `<kebab-name>.md` before duplicating composite layout in multiple screen 
 | `CtFullScreenDialogueShell` | [`ct-full-screen-dialogue-shell.md`](ct-full-screen-dialogue-shell.md) | `OVL10001` (game-start intro), `OVL30001` (overture), `OVL40001` (call-to-arms), `OVL50001` (pending intervention). |
 | `CtGameFeatureScreenShell` | [`ct-game-feature-screen-shell.md`](ct-game-feature-screen-shell.md) | `GAME20001` (production), `GAME30001` (diplomacy), `GAME40001` (technology), `GAME60001` (trade). |
 | `CtTransferList` | [`ct-transfer-list.md`](ct-transfer-list.md) | `DLG40001` (transfer to home fleet), Split Fleet dialog, Split Army dialog. |
+| `UnitsPanelShell` | [`units-panel-shell.md`](units-panel-shell.md) | `UNIT10001` (civilian units panel), `UNIT20001` (military units panel), `UNIT30001` (naval units panel). |

--- a/SPEC/ui/components/units-panel-shell.md
+++ b/SPEC/ui/components/units-panel-shell.md
@@ -1,0 +1,111 @@
+# UnitsPanelShell (component)
+
+**SPEC/ui/components** — Reusable scaffold for human-player unit panels (civilian, military, naval). Implementation: [`app/lib/features/game/widgets/units/shared/units_panel_shell.dart`](../../../app/lib/features/game/widgets/units/shared/units_panel_shell.dart). Catalog atoms: [`pixel-art-ui-catalog.md`](../pixel-art-ui-catalog.md) § *CtPanel*, § *CtTopBar*, § *Editorial-monocle palette*.
+
+This composite is **not** a screen and has **no** stable screen ID. It is the canonical chrome for the three unit-panel screen specs listed under [Consumers](#consumers).
+
+---
+
+## Purpose
+
+Consolidates the constrained-panel + `CtPanel` + `CtTopBar` + scrollable-list / empty-state chrome shared by the Civilian, Military, and Naval unit panels so each panel composes only its row content. Callers supply a title, optional trailing actions, the `hasContent` predicate, list children for the populated branch, and the `emptyMessage` for the empty branch; the composite owns the `ConstrainedBox`, outer `Padding`, `CtPanel`, `CtTopBar` (no back button), `ListView`, and the muted-italic empty-state copy. Tracking issue: [#2914](https://github.com/waigore/colonizethisv3/issues/2914) S9.
+
+---
+
+## Widget contract
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `title` | `String` | required | Title rendered by the inner `CtTopBar` (back button suppressed). |
+| `actions` | `List<Widget>` | `const []` | Trailing widgets for the `CtTopBar` trailing slot. Zero widgets → no trailing; one → the widget; ≥2 → `Row(mainAxisSize: min)` separated by 4 dp `SizedBox` gaps. |
+| `hasContent` | `bool` | required | Predicate selecting between the populated `ListView` branch and the empty branch. |
+| `listChildren` | `List<Widget>` | required | Children mounted into the `ListView(shrinkWrap: true)` when `hasContent == true`. |
+| `emptyMessage` | `String` | required | Copy rendered (muted italic) in the empty branch. |
+| `listPadding` | `EdgeInsets` | `EdgeInsets.fromLTRB(8, 0, 8, 8)` | Padding applied to the `ListView` in the populated branch. |
+| `panelConstraints` | `BoxConstraints` | `UnitsPanelShell.defaultPanelConstraints` | Outer `ConstrainedBox` bounds. Default `maxWidth: 400` / `maxHeight: 500` mirrors the bottom-sheet sizing pinned by every consumer panel today. |
+
+Exposed constant: `UnitsPanelShell.defaultPanelConstraints = BoxConstraints(maxWidth: 400, maxHeight: 500)`.
+
+---
+
+## Layout / wireframe
+
+```text
+ConstrainedBox(panelConstraints)                 -- default 400 × 500 dp
+  Padding(EdgeInsets.all(8))
+    CtPanel(padding: EdgeInsets.zero)
+      Column(min, stretch)
+        CtTopBar(title, showBackButton: false, trailing?)
+        Flexible
+          hasContent
+            ? ListView(shrinkWrap, padding: listPadding, children)
+            : Padding(EdgeInsets.all(24))
+                Center
+                  Text(emptyMessage,
+                       style: theme.bodyMedium.copyWith(
+                         color: EditorialMonoclePalette.muted,
+                         fontStyle: italic))
+```
+
+The outer 8 dp padding is a transparent gutter so the inner `CtPanel` border never touches the host edge. The `CtTopBar` always renders without the leading back button — every consumer is hosted in a side panel, bottom sheet, or rail surface that owns its own back/close affordance.
+
+---
+
+## Behavior
+
+1. **Trailing-actions layout.** Zero actions → `CtTopBar.trailing == null`; one action → that widget; two or more → a `Row(mainAxisSize: min)` with 4 dp `SizedBox` separators. Consumers that need additional spacing wrap their actions before passing them in.
+2. **Populated branch.** With `hasContent == true`, the body is a `ListView(shrinkWrap: true)` with the supplied `listPadding`. The shell mounts no Material elevation, divider, or row of its own; row chrome is the consumer's responsibility.
+3. **Empty branch.** With `hasContent == false`, the body is a centered `Text(emptyMessage)` in `EditorialMonoclePalette.muted` italic so the empty surface honours the editorial-monocle dark contract instead of the default Material `onSurfaceVariant` token.
+4. **No internal state.** The composite is a `StatelessWidget`. Every consumer-driven mutation (selection, expansion, sort) re-runs `build` from the parent.
+5. **Constraints owner.** The outer `ConstrainedBox` defaults to `defaultPanelConstraints`. The Naval panel widens it on `>= 1280` dp viewports per [naval-units-panel.md](../naval-units-panel.md); every consumer falls back to `defaultPanelConstraints` at narrower viewports so the same 320 dp pin contract applies (see [mobile-adaptation.md](../mobile-adaptation.md) § 7).
+
+---
+
+## States and variants
+
+The composite has no internal state. Variants are driven entirely by `panelConstraints` and `hasContent`:
+
+| Variant | `panelConstraints` | `hasContent` | Body |
+|---------|---------------------|--------------|------|
+| Default populated | `defaultPanelConstraints` | `true` | `ListView` |
+| Default empty | `defaultPanelConstraints` | `false` | Muted-italic empty text |
+| Wide populated | naval `>= 1280` dp override | `true` | `ListView` |
+
+---
+
+## Consumers
+
+| Screen ID | Spec | Notes |
+|-----------|------|-------|
+| `UNIT10001` | [`civilian-units-panel.md`](../civilian-units-panel.md) | Bottom-sheet host; trailing actions include sort + scope toggles. |
+| `UNIT20001` | [`military-units-panel.md`](../military-units-panel.md) | Side-panel host; trailing includes the **Train** entry-point. |
+| `UNIT30001` | [`naval-units-panel.md`](../naval-units-panel.md) | Side-panel host; widens `panelConstraints` on `>= 1280` dp viewports. |
+
+Each consumer spec links back here for the chrome contract instead of redeclaring the `ConstrainedBox` + `CtPanel` + `CtTopBar` + `ListView` hierarchy.
+
+---
+
+## Acceptance criteria (Given–When–Then)
+
+- **Given** a `UnitsPanelShell` mounted with `title = 'Civilian Units'`, `hasContent = true`, and a single-child `listChildren`, **When** the tree settles, **Then** exactly one `CtPanel` and exactly one `CtTopBar` with `title == 'Civilian Units'` and `showBackButton == false` are mounted, and the supplied child is reachable inside a `ListView` descendant.
+- **Given** a `UnitsPanelShell` mounted with `hasContent = false` and `emptyMessage = 'No civilian units.'`, **When** the tree settles, **Then** no `ListView` is mounted, the empty message renders, and its resolved `TextStyle.color` equals `EditorialMonoclePalette.muted` with `fontStyle == FontStyle.italic`.
+- **Given** `actions = const []`, **When** the shell builds, **Then** `CtTopBar.trailing == null` in the rendered subtree.
+- **Given** `actions = [a, b]`, **When** the shell builds, **Then** the trailing slot mounts a `Row(mainAxisSize: MainAxisSize.min)` with a 4 dp `SizedBox` between the two children.
+- **Given** the host pumps the shell with no override, **When** the outer `ConstrainedBox` resolves, **Then** its `constraints.maxWidth == 400` and `constraints.maxHeight == 500`.
+- **Given** the source `app/lib/features/game/widgets/units/shared/units_panel_shell.dart`, **When** read, **Then** it contains `defaultPanelConstraints` with `maxWidth: 400` / `maxHeight: 500` and references `EditorialMonoclePalette.muted` (canonical chrome regression guard).
+
+---
+
+## Tests
+
+- `app/test/units_panel_shared_widgets_test.dart` — widget-level contract tests pinning the trailing-actions layout, populated vs empty branches, and the default panel constraints.
+- `app/test/unit_panels_320dp_min_viewport_test.dart` — pins the three hosted panels at `kMinViewportWidth = 320` dp without horizontal overflow inside `defaultPanelConstraints`.
+- `app/test/spec_components_units_panel_shell_test.dart` — spec-pinning tests asserting this spec exists, declares the canonical sections, enumerates the three consumers by stable screen id, and restates the `maxWidth: 400` / `maxHeight: 500` default constraints.
+
+---
+
+## Related
+
+- Catalog: [`pixel-art-ui-catalog.md`](../pixel-art-ui-catalog.md) § *CtPanel*, § *CtTopBar*, § *Editorial-monocle palette*.
+- Hosting surfaces: [`empire-overview.md`](../empire-overview.md), [`in-game-shell-narrow.md`](../in-game-shell-narrow.md), [`mobile-adaptation.md`](../mobile-adaptation.md) § 7.
+- Tracking issue: [#2914](https://github.com/waigore/colonizethisv3/issues/2914) S9.

--- a/SPEC/ui/military-units-panel.md
+++ b/SPEC/ui/military-units-panel.md
@@ -50,7 +50,7 @@ Unchanged from [naval-units-panel.md](naval-units-panel.md): same grouping (regi
 
 ## Layout / wireframe
 
-Side panel or bottom sheet (viewport-dependent); **Land** and **Naval** branches; expandable army/fleet rows with row actions on the right.
+Side panel or bottom sheet (viewport-dependent); **Land** and **Naval** branches; expandable army/fleet rows with row actions on the right. The outer chrome (`ConstrainedBox` + `CtPanel` + `CtTopBar` + scrollable list / empty state) is the shared **[`UnitsPanelShell`](components/units-panel-shell.md)** composite.
 
 ---
 

--- a/SPEC/ui/naval-units-panel.md
+++ b/SPEC/ui/naval-units-panel.md
@@ -77,7 +77,7 @@ When the shell opens the panel via **`OpenNavalUnitsPanelEvent`** with `location
 
 ## Layout / wireframe
 
-Side panel (CtPanel) beside map on wide viewports; scrollable fleet tree grouped by region → Home Fleet → ports → sea zones.
+Side panel (CtPanel) beside map on wide viewports; scrollable fleet tree grouped by region → Home Fleet → ports → sea zones. The outer chrome (`ConstrainedBox` + `CtPanel` + `CtTopBar` + scrollable list / empty state) is the shared **[`UnitsPanelShell`](components/units-panel-shell.md)** composite (with the panel widening its `panelConstraints` on `>= 1280` dp viewports).
 
 ---
 

--- a/app/test/spec_components_units_panel_shell_test.dart
+++ b/app/test/spec_components_units_panel_shell_test.dart
@@ -1,0 +1,244 @@
+/// Pins the [`SPEC/ui/components/units-panel-shell.md`](
+/// ../../../SPEC/ui/components/units-panel-shell.md) component spec
+/// authored as part of issue #2914 S9 (Refactor app/lib UI to consolidate
+/// editorial-monocle design system — Phase 1 step S9: populate
+/// `SPEC/ui/components/` with composite-component specs for shared
+/// abstractions).
+///
+/// `UnitsPanelShell` is the shared chrome consumed by three player-unit
+/// screen specs (stable ids `UNIT10001`, `UNIT20001`, `UNIT30001`). Per
+/// `colonizethis-ui-documentation.mdc` § *Component specs*, a composite
+/// that is reused by multiple screen specs must have its own
+/// `kebab-name.md` under `SPEC/ui/components/` rather than duplicating
+/// the layout in each screen spec.
+///
+/// These tests are deliberately static-text checks (file reads + regex
+/// searches): the canonical Given–When–Then runtime contract for the
+/// widget itself is exercised by the existing
+/// `app/test/units_panel_shared_widgets_test.dart` widget tests and the
+/// `app/test/unit_panels_320dp_min_viewport_test.dart` viewport pin;
+/// the goal here is to ensure the SPEC stays present and aligned with
+/// the documentation rule even if future refactors move the widget
+/// around.
+///
+/// Refs #2914.
+library;
+
+import 'dart:io' show File;
+
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter_test/flutter_test.dart';
+
+const String _kSpecPath = '../SPEC/ui/components/units-panel-shell.md';
+const String _kComponentsReadmePath = '../SPEC/ui/components/README.md';
+
+String _readSpec() => File(_kSpecPath).readAsStringSync();
+
+void main() {
+  suppressLogsForTests();
+  group(
+    'SPEC/ui/components/units-panel-shell.md (#2914 S9)',
+    () {
+      test(
+        'spec file exists and is non-empty',
+        () {
+          final file = File(_kSpecPath);
+          expect(
+            file.existsSync(),
+            isTrue,
+            reason:
+                'The composite-component spec for UnitsPanelShell must live '
+                'at SPEC/ui/components/units-panel-shell.md per '
+                'colonizethis-ui-documentation.mdc § Component specs and '
+                'issue #2914 S9.',
+          );
+          final body = file.readAsStringSync();
+          expect(
+            body.trim(),
+            isNotEmpty,
+            reason: 'spec must not be empty',
+          );
+        },
+      );
+
+      test(
+        'spec declares all canonical sections required by the components '
+        'README template (Purpose / Widget contract / Layout / Behavior / '
+        'Consumers / Acceptance criteria / Tests / Related)',
+        () {
+          final body = _readSpec();
+          for (final heading in <String>[
+            '## Purpose',
+            '## Widget contract',
+            '## Layout / wireframe',
+            '## Behavior',
+            '## Consumers',
+            '## Acceptance criteria (Given–When–Then)',
+            '## Tests',
+            '## Related',
+          ]) {
+            expect(
+              body,
+              contains(heading),
+              reason:
+                  'composite-component spec must declare the canonical '
+                  '"$heading" section.',
+            );
+          }
+        },
+      );
+
+      test(
+        'spec lists all three unit-panel consumers by stable screen ID',
+        () {
+          final body = _readSpec();
+          for (final consumerId in <String>[
+            'UNIT10001',
+            'UNIT20001',
+            'UNIT30001',
+          ]) {
+            expect(
+              body,
+              contains(consumerId),
+              reason:
+                  'spec must enumerate consumer screen ID $consumerId so '
+                  'future refactors can reverse-trace the unit panels that '
+                  'depend on this composite.',
+            );
+          }
+          for (final consumerSpecFile in <String>[
+            'civilian-units-panel.md',
+            'military-units-panel.md',
+            'naval-units-panel.md',
+          ]) {
+            expect(
+              body,
+              contains(consumerSpecFile),
+              reason:
+                  'spec must link to the consumer screen spec '
+                  '$consumerSpecFile so reviewers can navigate to the '
+                  'host wireframes.',
+            );
+          }
+        },
+      );
+
+      test(
+        'spec encodes the canonical default panel constraints and the '
+        'EditorialMonoclePalette.muted empty-state contract',
+        () {
+          final body = _readSpec();
+          expect(
+            body,
+            contains('maxWidth: 400'),
+            reason:
+                'spec must restate the canonical maxWidth: 400 default so '
+                'future readers do not have to cross-reference the source '
+                'to confirm the bottom-sheet sizing contract.',
+          );
+          expect(
+            body,
+            contains('maxHeight: 500'),
+            reason:
+                'spec must restate the canonical maxHeight: 500 default '
+                'matching UnitsPanelShell.defaultPanelConstraints.',
+          );
+          expect(
+            body,
+            contains('defaultPanelConstraints'),
+            reason:
+                'spec must mention the exposed '
+                'UnitsPanelShell.defaultPanelConstraints constant so the '
+                'consumer override path (naval >= 1280 dp) is traceable.',
+          );
+          expect(
+            body,
+            contains('EditorialMonoclePalette.muted'),
+            reason:
+                'spec must reference the canonical muted palette token '
+                'used by the empty-state copy so the editorial-monocle '
+                'dark contract is documented at the SPEC level.',
+          );
+        },
+      );
+
+      test(
+        'spec links to the catalog atoms and tracking issue #2914',
+        () {
+          final body = _readSpec();
+          expect(
+            body,
+            contains('pixel-art-ui-catalog.md'),
+            reason:
+                'spec must link back to the catalog so reviewers can '
+                'cross-reference the CtPanel / CtTopBar atoms.',
+          );
+          expect(
+            body,
+            contains('#2914'),
+            reason:
+                'spec must reference tracking issue #2914 so progress on '
+                'the umbrella S9 step is discoverable from the file.',
+          );
+        },
+      );
+
+      test(
+        'spec is at most 1000 words (colonizethis-spec-required.mdc § Layout)',
+        () {
+          final body = _readSpec();
+          final words = body
+              .split(RegExp(r'\s+'))
+              .where((token) => token.isNotEmpty)
+              .toList();
+          expect(
+            words.length <= 1000,
+            isTrue,
+            reason:
+                'SPEC documents must stay under the 1000-word ceiling per '
+                'colonizethis-spec-required.mdc § Layout. Current word '
+                'count is ${words.length}.',
+          );
+        },
+      );
+
+      test(
+        'components README index lists the UnitsPanelShell row (negative '
+        'regression guard — README must continue to enumerate every '
+        'composite spec under it)',
+        () {
+          final readme = File(_kComponentsReadmePath);
+          expect(
+            readme.existsSync(),
+            isTrue,
+            reason:
+                'SPEC/ui/components/README.md must remain in place so '
+                'authoring rules for new composite specs stay discoverable.',
+          );
+          final body = readme.readAsStringSync();
+          expect(
+            body,
+            contains('SPEC/ui/components/'),
+            reason:
+                'README must continue to introduce the components/ '
+                'directory.',
+          );
+          expect(
+            body,
+            contains('UnitsPanelShell'),
+            reason:
+                'README index must enumerate UnitsPanelShell so the '
+                'composite is discoverable from the directory landing '
+                'page (issue #2914 S9).',
+          );
+          expect(
+            body,
+            contains('units-panel-shell.md'),
+            reason:
+                'README index row must link to the spec file path.',
+          );
+        },
+      );
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Authors the fourth composite-component spec under `SPEC/ui/components/` per issue #2914 S9 (populate `SPEC/ui/components/` with composite-component specs for shared abstractions reused across multiple screen specs).

`UnitsPanelShell` is the shared chrome consumed by three player-unit screen specs (stable ids `UNIT10001` civilian, `UNIT20001` military, `UNIT30001` naval). Before this slice, every consumer screen spec had to re-imply the shared `ConstrainedBox(maxWidth: 400, maxHeight: 500)` + `CtPanel` + `CtTopBar(showBackButton: false)` + `ListView` / empty-state hierarchy from the implementation file (`app/lib/features/game/widgets/units/shared/units_panel_shell.dart`).

## Done in this PR

### Slice — `UnitsPanelShell` composite spec

- **`SPEC/ui/components/units-panel-shell.md`** — new component spec following the established composite template (Purpose, Widget contract, Layout / wireframe, Behavior, States and variants, Consumers, Acceptance criteria, Tests, Related). Pins:
  - The canonical default panel constraints `UnitsPanelShell.defaultPanelConstraints = BoxConstraints(maxWidth: 400, maxHeight: 500)` and the naval `>= 1280` dp wide override.
  - The trailing-actions layout contract (zero → null; one → widget; `>=2` → `Row(mainAxisSize: min)` with 4 dp `SizedBox` separators).
  - The muted-italic empty-state copy contract using `EditorialMonoclePalette.muted`, so the dark editorial-monocle contract is documented at the SPEC level instead of the default Material `onSurfaceVariant` token.
  - All seven core props (`title`, `actions`, `hasContent`, `listChildren`, `emptyMessage`, `listPadding`, `panelConstraints`).
  - Under the 1000-word ceiling per `colonizethis-spec-required.mdc` § Layout (986 words).
- **`SPEC/ui/components/README.md`** — new index row introducing `UnitsPanelShell` with its three consumer screen specs (`UNIT10001`, `UNIT20001`, `UNIT30001`).
- **Cross-references in 3 consumer screen specs** — `civilian-units-panel.md`, `military-units-panel.md`, and `naval-units-panel.md` each gain a one-line link back to the shared composite spec instead of redeclaring the chrome.
- **Tests** — `app/test/spec_components_units_panel_shell_test.dart` (7 tests): spec file presence, canonical sections, consumer enumeration by stable screen id and by spec link, the `maxWidth: 400` / `maxHeight: 500` / `defaultPanelConstraints` / `EditorialMonoclePalette.muted` regression guards, catalog / tracking-issue cross-links, the 1000-word ceiling, and a README regression guard. All 7 pass locally (`cd app && flutter test test/spec_components_units_panel_shell_test.dart`). All 21 tests across the three pre-existing composite specs continue to pass after the README edit. Repo lint convention check passes locally (`bash tool/check_test_imports.sh`).

## Scope

| AC covered now | AC deferred (separate slices on #2914 S9) |
|----------------|--------------------------------------------|
| `SPEC/ui/components/` populated with the `UnitsPanelShell` composite spec, README index, three consumer cross-references, and a spec-pinning test guard (#2914 S9 — fourth composite in series after #3047 `CtFullScreenDialogueShell` + `CtGameFeatureScreenShell` and #3070 `CtTransferList`). | Remaining composite-component specs for other shared abstractions (e.g. production allocation rows, tab panels, expansion-tile row chrome) stay open on #2914 S9; no implementation changes shipped in this PR. |

`Refs #2914`. Tracked by #2914 — does not auto-close.

## Test plan

- [x] `cd app && flutter test test/spec_components_units_panel_shell_test.dart` (7 tests pass)
- [x] `cd app && flutter test test/spec_components_ct_transfer_list_test.dart test/spec_components_ct_full_screen_dialogue_shell_test.dart test/spec_components_ct_game_feature_screen_shell_test.dart` (21 tests pass — no regression in peer composite specs after the README edit)
- [x] `bash tool/check_test_imports.sh` (Test import convention check passed)
- [ ] Quality (lint, analyze, observer) — pending remote CI confirmation

Made with [Cursor](https://cursor.com)