### PR TITLE
fix(ui): stack overture overlay rows + pin 320 dp viewport (Refs #2870)

### DIFF
--- a/SPEC/ui/overture-dialogue-overlay.md
+++ b/SPEC/ui/overture-dialogue-overlay.md
@@ -66,16 +66,15 @@ Internal state ownership (phase 1 — intro):
 |             Text(game_overture_intro, bodyMedium,         |
 |                  --muted, italic)                         |
 |             ListView.builder (shrinkWrap, no scroll)      |
-|               Row                                         |
-|                 Expanded(                                 |
-|                   Row(                                    |
-|                     Text(offerer, --accent),              |
-|                     Text(": ", --muted),                  |
-|                     Text(stage, --muted)                  |
-|                   )                                       |
+|               Column(crossAxisAlignment: stretch) -- per offer
+|                 Row(                                      |
+|                   Text(offerer, --accent),                |
+|                   Text(": ", --muted),                    |
+|                   Text(stage, --muted)                    |
 |                 )                                         |
-|                 CtNinePatchButton(game_overture_accept)   |
-|                 CtNinePatchButton(game_overture_reject)   |
+|                 Wrap(alignment: end, spacing: 8)          |
+|                   CtNinePatchButton(game_overture_accept) |
+|                   CtNinePatchButton(game_overture_reject) |
 |             Align(centerRight)                            |
 |               CtNinePatchButton(game_callToArms_submit)   |
 +-----------------------------------------------------------+
@@ -90,6 +89,7 @@ Phase 2 chrome uses the dark editorial-monocle tokens from `SPEC/ui/pixel-art-ui
 - **Title → intro separator:** A `CtBrassDivider` is rendered between the title row and the intro `Text` per #2867 R21 (no extra padding inside the divider; vertical breathing room is supplied by 8 dp `SizedBox`es above and below).
 - **Intro line:** `Text(game_overture_intro)` rendered with `theme.textTheme.bodyMedium` color overridden to `EditorialMonoclePalette.muted` and `fontStyle: FontStyle.italic` per #2867 R5.
 - **Offer row label:** The offerer name and stage label are split into two `Text` widgets within a flex row so they can carry distinct colors (#2867 R22). The offerer name renders in `EditorialMonoclePalette.accent`; the stage label renders in `EditorialMonoclePalette.muted`. A `Text(": ")` separator (also `--muted`) keeps the formatted line readable. The full `game_overture_offerLine` localized template is no longer composed in the widget — the per-offer row composes the two parts directly.
+- **Offer row layout (stacked at narrow widths):** Each per-offer body is a `Column(crossAxisAlignment: stretch)` containing the labels `Row` above an end-aligned `Wrap(alignment: WrapAlignment.end, spacing: 8, runSpacing: 8)` that holds the Accept and Reject `CtNinePatchButton`s. The stacked layout mirrors `SPEC/ui/call-to-arms-dialogue-overlay.md` § Layout / wireframe so the two `CtNinePatchButton`s flow onto a second run at narrow viewports (`kMinViewportWidth` 320 dp) instead of overflowing horizontally, and the labels `Row` always has the full content column width to wrap on (issue #2870 S8 / S10; `SPEC/ui/mobile-adaptation.md` § 7).
 
 Error mode renders the same `Stack` but the `CtDialogShell` body is the localized error message (`l10n.game_overture_loadError`) plus a single Continue button (`l10n.game_intervention_continue`).
 
@@ -200,6 +200,10 @@ No direct `AppEventBus` or `Navigator` usage in the overlay.
 - Given the overlay is constructed with an empty `pendingOvertures` list,
   When the player advances the phase-1 intro to completion (or `skipIntroForTest == true`),
   Then phase 2 renders the title / intro labels and Submit, the offer list view contains zero rows, and tapping Submit invokes `onDecisions` with an empty list.
+
+- Given an `OvertureDialogueOverlay` is mounted in phase 2 (`skipIntroForTest: true`) with one or more pending overtures at a `kMinViewportWidth × 640` (320 × 640 dp) viewport,
+  When the widget tree settles,
+  Then `WidgetTester.takeException()` is `null` (no `RenderFlex` overflow exception escapes the framework — the same contract pinned by `dialogs_320dp_min_viewport_test.dart` and `call_to_arms_dialogue_overlay_320dp_min_viewport_test.dart`), every per-offer body lays out as the stacked `Column(Row(offerer + ": " + stage) + Wrap(Accept + Reject))` from § Layout / wireframe so the Accept and Reject `CtNinePatchButton`s flow onto a second run rather than overflowing horizontally, and the localized `game_overture_title`, `game_overture_accept`, `game_overture_reject`, and `game_callToArms_submit` labels still render end-to-end so the layout actually exercises the phase-2 body at the minimum viewport (`SPEC/ui/mobile-adaptation.md` § 7 / Refs #2870 S8 + S10 for OVL30001).
 
 ---
 

--- a/app/lib/features/game/dialogue/overture_dialogue_overlay.dart
+++ b/app/lib/features/game/dialogue/overture_dialogue_overlay.dart
@@ -346,7 +346,38 @@ class _OvertureOfferRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final ThemeData theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          _buildLabelsRow(Theme.of(context)),
+          const SizedBox(height: 8),
+          Wrap(
+            alignment: WrapAlignment.end,
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              CtNinePatchButton(
+                onPressed: onAccept,
+                child: Text(acceptLabel),
+              ),
+              CtNinePatchButton(
+                onPressed: onReject,
+                child: Text(rejectLabel),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// Two-tone offerer/stage labels row. Extracted so `build` stays within
+  /// the `repo.dart_file_non_comment_line_size` 60-line per-`build`
+  /// budget when the row is hosted under the stacked
+  /// `Column(Row + Wrap)` layout (issue #2870 S8 / S10).
+  Widget _buildLabelsRow(ThemeData theme) {
     final TextStyle base =
         theme.textTheme.bodyMedium ?? const TextStyle(fontSize: 14);
     final TextStyle offererStyle = base.copyWith(
@@ -359,49 +390,31 @@ class _OvertureOfferRow extends StatelessWidget {
     final TextStyle stageStyle = base.copyWith(
       color: EditorialMonoclePalette.muted,
     );
-    return Padding(
-      padding: const EdgeInsets.only(bottom: 12),
-      child: Row(
-        children: [
-          Expanded(
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Flexible(
-                  child: Text(
-                    offerer,
-                    key: const ValueKey<String>('overtureOfferOfferer'),
-                    style: offererStyle,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                ),
-                Text(
-                  ': ',
-                  key: const ValueKey<String>('overtureOfferSeparator'),
-                  style: separatorStyle,
-                ),
-                Flexible(
-                  child: Text(
-                    stageLabel,
-                    key: const ValueKey<String>('overtureOfferStage'),
-                    style: stageStyle,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                ),
-              ],
-            ),
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Flexible(
+          child: Text(
+            offerer,
+            key: const ValueKey<String>('overtureOfferOfferer'),
+            style: offererStyle,
+            overflow: TextOverflow.ellipsis,
           ),
-          CtNinePatchButton(
-            onPressed: onAccept,
-            child: Text(acceptLabel),
+        ),
+        Text(
+          ': ',
+          key: const ValueKey<String>('overtureOfferSeparator'),
+          style: separatorStyle,
+        ),
+        Flexible(
+          child: Text(
+            stageLabel,
+            key: const ValueKey<String>('overtureOfferStage'),
+            style: stageStyle,
+            overflow: TextOverflow.ellipsis,
           ),
-          const SizedBox(width: 8),
-          CtNinePatchButton(
-            onPressed: onReject,
-            child: Text(rejectLabel),
-          ),
-        ],
-      ),
+        ),
+      ],
     );
   }
 }

--- a/app/test/overture_dialogue_overlay_320dp_min_viewport_test.dart
+++ b/app/test/overture_dialogue_overlay_320dp_min_viewport_test.dart
@@ -1,0 +1,243 @@
+// Pin the 320 dp minimum-viewport contract for [OvertureDialogueOverlay]
+// (OVL30001) — sibling to
+// `call_to_arms_dialogue_overlay_320dp_min_viewport_test.dart` so each
+// dialogue overlay's pin lives in a focused file and the host
+// `dialogs_320dp_min_viewport_test.dart` stays under the
+// `repo.dart_file_non_comment_line_size` 1000 non-comment-line budget
+// (`SPEC/program/repo-lint.md`).
+//
+// `OvertureDialogueOverlay` is the blocking overture-acceptance overlay
+// shown after turn resolution when one or more pending overtures target
+// the human-controlled faction. It wraps a [CtDialogShell] inside a
+// [CtFullScreenDialogueShell] (scrim + centered shell at
+// `maxWidth: 520`, phase-2 `maxHeight: 500`); at `kMinViewportWidth`
+// (320 dp) the outer `Dialog.insetPadding` (16 dp each side) dominates
+// the configured `maxWidth`, collapsing the shell to ~288 dp content
+// width — the same budget as the simpler shells pinned in
+// `dialogs_320dp_min_viewport_test.dart`.
+//
+// The pins assert:
+//
+//  * `WidgetTester.takeException()` is `null` so no `RenderFlex`
+//    overflow exception escapes the framework — the contract the other
+//    `*_320dp_min_viewport_test.dart` files rely on.
+//  * Phase-2 body labels (title + Accept / Reject / Submit action labels)
+//    still render end-to-end so the layout actually exercises the
+//    overlay body at 320 dp rather than no-op'ing.
+//  * A wide negative control at 1024 × 768 dp pumps without exception
+//    against the same fixture so a regression in the host overflow
+//    contract upstream of the dialog itself would be caught.
+//
+// The fixture uses `skipIntroForTest: true` so the test does not depend
+// on the production `kDialogueOvertureAsset` Yarn bundle — mirroring
+// `overture_dialogue_overlay_test.dart` and the Widgetbook story.
+//
+// SPEC: `SPEC/ui/mobile-adaptation.md` § 7 (Minimum-viewport pin).
+// SPEC: `SPEC/ui/overture-dialogue-overlay.md` § Layout / wireframe + AC
+// 320 dp pin.
+// Refs #2870 S8 (dialogs scale at narrow widths) + S10 (no horizontal
+// overflow at 320 dp on every covered surface).
+
+import 'package:colonizethis_app/config/constants.dart';
+import 'package:colonizethis_app/config/themes.dart';
+import 'package:colonizethis_app/features/game/dialogue/overture_dialogue_overlay.dart';
+import 'package:colonizethis_app/l10n/l10n.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart' show OvertureOffer;
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Minimum supported viewport dimensions for SPEC/ui/mobile-adaptation.md
+/// § 7. Width matches [kMinViewportWidth]; height (640 dp) mirrors the
+/// existing screen-, panel-, and dialog-level pin files.
+const Size _kMinViewport = Size(kMinViewportWidth, 640);
+
+/// Wide regression sentinel — comfortably above every per-screen
+/// breakpoint so the same dialog renders its default layout. Mirrors
+/// the contract used by `dialogs_320dp_min_viewport_test.dart`.
+const Size _kWideRegressionViewport = Size(1024, 768);
+
+/// Pumps [dialog] at [size] under the running editorial-monocle theme.
+///
+/// Mirrors `_pumpDialogAtSize` in
+/// `call_to_arms_dialogue_overlay_320dp_min_viewport_test.dart` — sets
+/// the surface size (so the binding's render flex math sees the minimum
+/// viewport) and overrides MediaQuery so dialog code that reads
+/// `MediaQuery.sizeOf(context).width` resolves to the same value.
+///
+/// Embeds [dialog] directly in the Scaffold body rather than driving
+/// the real `showDialog` flow because the contract under test is the
+/// overlay's own [CtDialogShell] layout at the narrow viewport, not the
+/// barrier / overlay route plumbing (which is already covered by the
+/// overlay's own widget tests).
+Future<void> _pumpDialogAtSize(
+  WidgetTester tester,
+  Widget dialog, {
+  required Size size,
+}) async {
+  addTearDown(() => tester.binding.setSurfaceSize(null));
+  await tester.binding.setSurfaceSize(size);
+  await tester.pumpWidget(
+    MaterialApp(
+      theme: AppThemes.editorialMonocle,
+      localizationsDelegates: AppLocalizationsBinding.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: MediaQuery(
+        data: MediaQueryData(size: size),
+        child: Scaffold(body: Center(child: dialog)),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  suppressLogsForTests();
+
+  group('SPEC/ui/mobile-adaptation.md § 7 — OvertureDialogueOverlay @ '
+      '320 dp (Refs #2870 S8/S10)', () {
+    // Minimal Game fixture: three GPs so the `_offererDisplayName`
+    // lookup in phase-2 resolves `gp_portugal` / `gp_spain` to display
+    // names (mirrors the fixture used by
+    // `overture_dialogue_overlay_test.dart` so the narrow-pin tests
+    // exercise the same name-resolution path as the existing chrome
+    // pins).
+    Game overtureGame() {
+      return const Game(
+        id: 'overture_320',
+        worldState: WorldState(
+          turnState: TurnState(phase: TurnPhase.orders, turnNumber: 5),
+          oldWorld: RegionData(),
+          newWorld: RegionData(),
+        ),
+        players: [
+          Player(id: 'gp_player', displayName: 'Player', isHuman: true),
+          Player(id: 'gp_portugal', displayName: 'Portugal', isHuman: false),
+          Player(id: 'gp_spain', displayName: 'Spain', isHuman: false),
+        ],
+      );
+    }
+
+    const OvertureOffer singleOffer = OvertureOffer(
+      offererGpId: 'gp_portugal',
+      targetFactionId: 'gp_player',
+      stage: OvertureStage.tradeConsulate,
+    );
+
+    const OvertureOffer secondOffer = OvertureOffer(
+      offererGpId: 'gp_spain',
+      targetFactionId: 'gp_player',
+      stage: OvertureStage.embassy,
+    );
+
+    // English l10n sentinels for the phase-2 title and the three action
+    // labels (mirrors `app/lib/l10n/arb/app_en.arb` `game_overture_*` and
+    // `game_callToArms_submit` keys). Pinned here so the narrow-pin
+    // breaks if those strings change without the SPEC + this contract
+    // being refreshed in lockstep.
+    const String overtureTitle = 'Diplomatic overtures';
+    const String overtureAcceptLabel = 'Accept';
+    const String overtureRejectLabel = 'Reject';
+    const String overtureSubmitLabel = 'Submit';
+
+    testWidgets(
+      'AC (positive) OvertureDialogueOverlay (one pending offer) @ '
+      '320×640: no RenderFlex overflow exception, "Diplomatic overtures" '
+      'title + Accept / Reject / Submit action labels render — the '
+      'phase-2 Column(Row(offerer + ": " + stage) + Wrap(Accept + '
+      'Reject)) from SPEC/ui/overture-dialogue-overlay.md § Layout / '
+      'wireframe must wrap within the ~288 dp CtDialogShell content '
+      'column at kMinViewportWidth (CtFullScreenDialogueShell.maxWidth '
+      '520 is dominated by Dialog.insetPadding 16 dp each side at '
+      '320 dp; the Accept + Reject CtNinePatchButtons flow onto a '
+      'second Wrap run rather than overflowing horizontally).',
+      (WidgetTester tester) async {
+        await _pumpDialogAtSize(
+          tester,
+          OvertureDialogueOverlay(
+            game: overtureGame(),
+            pendingOvertures: const [singleOffer],
+            skipIntroForTest: true,
+            onDecisions: (_) {},
+            child: const SizedBox.expand(),
+          ),
+          size: _kMinViewport,
+        );
+
+        expect(
+          tester.takeException(),
+          isNull,
+          reason:
+              'SPEC/ui/mobile-adaptation.md § 7: OvertureDialogueOverlay '
+              'must not emit a RenderFlex overflow exception at '
+              'kMinViewportWidth (320 dp). The per-offer Column(Row('
+              'offerer + ": " + stage) + Wrap(Accept + Reject)) under '
+              'the CtFullScreenDialogueShell scrim + CtDialogShell '
+              'chrome must wrap within the ~288 dp content column.',
+        );
+        expect(find.text(overtureTitle), findsOneWidget);
+        expect(find.text(overtureAcceptLabel), findsOneWidget);
+        expect(find.text(overtureRejectLabel), findsOneWidget);
+        expect(find.text(overtureSubmitLabel), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'AC (positive) OvertureDialogueOverlay (two pending offers) @ '
+      '320×640: no RenderFlex overflow exception, both Accept + Reject '
+      'rows mount within the ~288 dp content column (the '
+      'ListView.builder shrink-wrapped body from '
+      'SPEC/ui/overture-dialogue-overlay.md § Layout / wireframe stacks '
+      'each per-offer Column(Row + Wrap) body at the narrow viewport '
+      'without horizontal overflow).',
+      (WidgetTester tester) async {
+        await _pumpDialogAtSize(
+          tester,
+          OvertureDialogueOverlay(
+            game: overtureGame(),
+            pendingOvertures: const [singleOffer, secondOffer],
+            skipIntroForTest: true,
+            onDecisions: (_) {},
+            child: const SizedBox.expand(),
+          ),
+          size: _kMinViewport,
+        );
+
+        expect(tester.takeException(), isNull);
+        expect(find.text(overtureTitle), findsOneWidget);
+        // Two rows -> two Accept buttons + two Reject buttons + one
+        // Submit action (the Submit button label is shared across the
+        // row count, mirroring the call-to-arms 320 dp pin contract).
+        expect(find.text(overtureAcceptLabel), findsNWidgets(2));
+        expect(find.text(overtureRejectLabel), findsNWidgets(2));
+        expect(find.text(overtureSubmitLabel), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'Negative control: OvertureDialogueOverlay @ 1024×768 also pumps '
+      'without exception (regression sentinel for the overflow contract '
+      '— keeps the 320 dp positive pins meaningful).',
+      (WidgetTester tester) async {
+        await _pumpDialogAtSize(
+          tester,
+          OvertureDialogueOverlay(
+            game: overtureGame(),
+            pendingOvertures: const [singleOffer],
+            skipIntroForTest: true,
+            onDecisions: (_) {},
+            child: const SizedBox.expand(),
+          ),
+          size: _kWideRegressionViewport,
+        );
+
+        expect(tester.takeException(), isNull);
+        expect(find.text(overtureTitle), findsOneWidget);
+        expect(find.text(overtureAcceptLabel), findsOneWidget);
+        expect(find.text(overtureRejectLabel), findsOneWidget);
+        expect(find.text(overtureSubmitLabel), findsOneWidget);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Stacks the `OvertureDialogueOverlay` (OVL30001) phase-2 per-offer row as `Column(Row(labels) + Wrap(Accept + Reject))` so the two `CtNinePatchButton`s flow onto a second Wrap run at `kMinViewportWidth` (320 dp) instead of overflowing the horizontal `Row(Expanded(labels) + Accept + Reject)` host. Mirrors the stacked layout that landed for `CallToArmsDialogueOverlay` in #3069 (`SPEC/ui/call-to-arms-dialogue-overlay.md` § Layout / wireframe) and the wider 12-dialog `dialogs_320dp_min_viewport_test.dart` family. Closes the `#2870 S8 + S10` gap for OVL30001 by pinning the 320 dp viewport contract with a dedicated widget-test file.

## Changes

- **`app/lib/features/game/dialogue/overture_dialogue_overlay.dart`** — phase-2 `_OvertureOfferRow.build` now returns `Padding > Column(crossAxisAlignment: stretch)` with two children: the two-tone labels `Row` (offerer in `--accent`, `": "` separator + stage in `--muted`) and an `Wrap(alignment: end, spacing: 8, runSpacing: 8)` holding the Accept + Reject `CtNinePatchButton`s. The two-tone labels `Row` was extracted into a private `_buildLabelsRow` helper so the offer-row `build` stays within the 60-line `repo.disallowed_ast_patterns.widget_build_method_too_long` budget after the layout change.
- **`SPEC/ui/overture-dialogue-overlay.md`** — § Layout / wireframe ASCII updated to describe the stacked `Column(Row + Wrap)` per-offer body; a new "Offer row layout (stacked at narrow widths)" bullet under § Style cites the matching pattern in `SPEC/ui/call-to-arms-dialogue-overlay.md` § Layout / wireframe and the `SPEC/ui/mobile-adaptation.md` § 7 minimum-viewport contract. A new Given-When-Then AC pins the 320 dp viewport contract for OVL30001, referencing both the new stacked layout and the existing sibling pin files (`dialogs_320dp_min_viewport_test.dart`, `call_to_arms_dialogue_overlay_320dp_min_viewport_test.dart`).
- **`app/test/overture_dialogue_overlay_320dp_min_viewport_test.dart`** — new test file, 3 widget tests:
  - **AC positive @ 320×640 (single pending offer)** — no `RenderFlex` overflow exception; localized `Diplomatic overtures` title + `Accept` + `Reject` + `Submit` action labels render end-to-end inside the single `CtFullScreenDialogueShell` + `CtDialogShell` content column.
  - **AC positive @ 320×640 (two pending offers)** — same contract with two Accept/Reject pairs + the shared Submit label (`findsNWidgets(2)` for the row buttons; `findsOneWidget` for Submit).
  - **Negative control @ 1024×768** — same fixture pumps without exception so the 320 dp positive pins remain meaningful.

The pin lives in a dedicated sibling file (not added to `dialogs_320dp_min_viewport_test.dart`) so the existing host stays under the `repo.dart_file_non_comment_line_size` 1000 non-comment-line budget (`SPEC/program/repo-lint.md`), mirroring the per-category split convention used by `move_dialogs_320dp_min_viewport_test.dart`, `train_dialogs_320dp_min_viewport_test.dart`, and `call_to_arms_dialogue_overlay_320dp_min_viewport_test.dart`.

## Why

`SPEC/ui/mobile-adaptation.md` § 7 requires that every modal dialog rendered via `CtDialogShell` survives the 320 dp viewport without `RenderFlex` overflow. `OvertureDialogueOverlay` (OVL30001) was not pinned alongside the other 12 dialogs covered by `dialogs_320dp_min_viewport_test.dart` and its sibling files, and inspection of the phase-2 offer row revealed a real horizontal overflow at 320 dp (`Row(Expanded(Row(offerer + ": " + stage)) + Accept + Reject)` cannot fit the two `CtNinePatchButton`s inside the ~288 dp content column). This PR fixes the overflow (stacked Column layout) and closes the missing pin so the same regression cannot land again silently.

## Scope

| AC covered now | AC deferred |
|----------------|-------------|
| `OvertureDialogueOverlay` 320 dp overflow contract for the phase-2 offer-list body with SPEC layout / AC + dedicated test file (#2870 S8 + S10 for OVL30001 phase 2). | Phase-1 Yarn intro 320 dp pin — out of scope for this slice; the phase-1 body is a `Text + CtNinePatchButton(Continue)` stack that does not exhibit the offer-row overflow class and is already covered by other narrow-shell guards. |

`Refs #2870`. Tracked by #2870 — does not auto-close.

## Test plan

- [x] `cd app && flutter test test/overture_dialogue_overlay_320dp_min_viewport_test.dart` — 3/3 pass (single-offer positive pin + two-offer positive pin + 1024×768 wide negative-control sentinel).
- [x] `cd app && flutter test test/overture_dialogue_overlay_test.dart test/overture_dialogue_intro_test.dart test/game_screen_overture_pending_test.dart` — 12/12 pass (no regression in existing overture chrome / intro / game-screen overlay tests after the stacked-Column layout change).
- [x] `cd app && flutter test test/dialogue_overlays_specs_test.dart test/dialogue_acceptance_test.dart test/ui_screen_id_bindings_test.dart` — 56/56 pass (no regression in cross-overlay spec contracts or screen-ID bindings).
- [x] `cd app && flutter analyze lib/features/game/dialogue/overture_dialogue_overlay.dart test/overture_dialogue_overlay_320dp_min_viewport_test.dart` — `No issues found!`
- [x] `bash tool/check_test_imports.sh` — `Test import convention check passed.`
- [x] `CT_REPO_LINT_INCLUDE_APP=true dart run tool/ct_repo_lint.dart` — `all 55 rule(s) passed.` (includes `repo.disallowed_ast_patterns.widget_build_method_too_long`).
- [ ] Quality (lint, analyze, observer) — pending remote CI confirmation

Made with [Cursor](https://cursor.com)