### PR TITLE
docs(spec): ProductionAllocationRow composite-component spec (Refs #2914 S9)

### DIFF
--- a/SPEC/ui/components/README.md
+++ b/SPEC/ui/components/README.md
@@ -13,5 +13,6 @@ Create `<kebab-name>.md` before duplicating composite layout in multiple screen 
 | `CtFullScreenDialogueShell` | [`ct-full-screen-dialogue-shell.md`](ct-full-screen-dialogue-shell.md) | `OVL10001` (game-start intro), `OVL30001` (overture), `OVL40001` (call-to-arms), `OVL50001` (pending intervention). |
 | `CtGameFeatureScreenShell` | [`ct-game-feature-screen-shell.md`](ct-game-feature-screen-shell.md) | `GAME20001` (production), `GAME30001` (diplomacy), `GAME40001` (technology), `GAME60001` (trade). |
 | `CtTransferList` | [`ct-transfer-list.md`](ct-transfer-list.md) | `DLG40001` (transfer to home fleet), Split Fleet dialog, Split Army dialog. |
+| `ProductionAllocationRow` | [`production-allocation-row.md`](production-allocation-row.md) | `GAME20001` (production panel). |
 | `UnitsEntityActionRow` | [`units-entity-action-row.md`](units-entity-action-row.md) | `UNIT10001` (civilian units panel), `UNIT20001` (military units panel), `UNIT30001` (naval units panel). |
 | `UnitsPanelShell` | [`units-panel-shell.md`](units-panel-shell.md) | `UNIT10001` (civilian units panel), `UNIT20001` (military units panel), `UNIT30001` (naval units panel). |

--- a/SPEC/ui/components/production-allocation-row.md
+++ b/SPEC/ui/components/production-allocation-row.md
@@ -1,0 +1,117 @@
+# ProductionAllocationRow (component)
+
+**SPEC/ui/components** — Reusable per-recipe row inside the Production panel Allocation subpanel. Implementation: [`app/lib/features/game/widgets/production_allocation_row.dart`](../../../app/lib/features/game/widgets/production_allocation_row.dart). Catalog atoms: [`pixel-art-ui-catalog.md`](../pixel-art-ui-catalog.md) § *CtSlider*, *StrictAssetIcon*, *Editorial-monocle palette*, *CtGradients*.
+
+Not a screen; no stable screen ID. Canonical row layout referenced by the screen spec under [Consumers](#consumers).
+
+---
+
+## Purpose
+
+Consolidates the per-recipe layout used by the Allocation subpanel: a header (label + affordance readout), a body row (`Expanded` `CtSlider` + numeric desired output + four icon-only step / action buttons), and the row chrome painted by [`ProductionAllocationRowChrome`](../../../app/lib/features/game/widgets/production_allocation_row_chrome.dart). Callers supply recipe, player state, effective labour, the desired-output map, and the change callback; the composite owns affordance recomputation, the slider cap clamp, the four-button cluster footprint, and long-press repeat for the ± buttons. The inner step-button surface ([`ProductionStepButtonSurface`](../../../app/lib/features/game/widgets/production_allocation_row_buttons.dart): 26 dp `CtGradients.buttonGradient` inside a 1 dp `EditorialMonoclePalette.border` outline, 0.3 disabled opacity) is shared with the Available subpanel's per-tier Labour Controls. Tracking issue: [#2914](https://github.com/waigore/colonizethisv3/issues/2914) S9.
+
+---
+
+## Widget contract
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `recipe` | `ProductionRecipe` | Catalog recipe rendered by the row. |
+| `player` | `Player` | Human player whose stockpile + worker pool drive affordance. |
+| `effectiveLabour` | `int` | Labour pool available this turn. |
+| `desiredOutputByRecipe` | `Map<String, int>` | Desired-output map; recipes with desired `0` may be absent. |
+| `onDesiredOutputChanged` | `ValueChanged<Map<String, int>>` | Mutation callback receiving a fresh map clone. |
+| `buildRecipeLabel` | `Widget Function(ProductionRecipe)` | Builds the left header cell (icon + name + parenthesised inputs). |
+| `l10n` | `AppLocalizations` | Affordance / action / tooltip strings. |
+| `theme` | `ThemeData` | Active editorial-monocle theme; styles header right cell + read-back numeral. |
+
+All props `required`. Constants: `kProductionAllocationSliderCap = 50`, `kProductionAllocationStepButtonSize = 26`, `kProductionAllocationStepButtonDisabledOpacity = 0.3`.
+
+---
+
+## Layout / wireframe
+
+```text
+ProductionAllocationRowChrome(padding: 8/8)
+  Column(min, start)
+    Row(start)                                                  -- header
+      Expanded(flex 2, buildRecipeLabel(recipe))
+      Expanded(flex 1, Text(max · bottleneck, theme.labelSmall, right))
+    Row(center)                                                 -- body
+      Expanded(CtSlider(value, max: sliderMax, divisions,
+                        comfortHeadroomActive))
+      Row(min)                                                  -- buttons
+        SizedBox(30, Text(desired, right, theme.bodySmall))
+        ProductionAllocationStepButton(−   alloc_decrement)
+        ProductionAllocationStepButton(+   alloc_increment)
+        ProductionAllocationActionIconButton(max  alloc_maximize)
+        ProductionAllocationActionIconButton(clr  alloc_clear)
+```
+
+Buttons are separated by `SizedBox(width: 4)`. Each paints `ProductionStepButtonSurface` and fades to 0.3 opacity when disabled.
+
+---
+
+## Behavior
+
+1. **Affordance recompute.** Every `build` calls `computeRecipeAffordance(recipe, stockpile, desiredOutputByRecipe, effectiveLabour)` for `maxDesiredOutput` and the limiting label (`Labour` or input display name). Cross-row coupling re-runs the affordance pass when `desiredOutputByRecipe` mutates.
+2. **Slider clamp.** `sliderMax = maxAchievable == 0 ? 0.0 : maxAchievable.clamp(1, kProductionAllocationSliderCap).toDouble()`. Thumb is `desired.clamp(0, maxAchievable).toDouble()`. Drag callbacks round and clamp; `value == 0` removes the recipe key, otherwise sets it.
+3. **Enabled gating.** `−` iff `desired > 0`. `+` iff `maxAchievable > 0 && desired < maxAchievable`. **Maximize** iff `+` would be (`canIncrement`). **Clear** iff `desired > 0`.
+4. **Step mutations.** `±` delegate to `applyProductionRecipeIncrement` / `applyProductionRecipeDecrement` in [`production_allocation_mutations.dart`](../../../app/lib/features/game/widgets/production_allocation_mutations.dart); each returns `false` on no-change (stops repeat timers). **Maximize** writes `affordance.maxDesiredOutput`; **Clear** removes the recipe key.
+5. **Long-press repeat (± only).** `ProductionAllocationStepButton` uses `GestureDetector` long-press (~500 ms via `kProductionAllocationRepeatInitialDelay`) plus `Timer.periodic` at `kProductionAllocationRepeatInterval` (125 ms). Repeats stop at bounds, on release, or on dispose. Maximize and Clear are single-tap.
+6. **Comfort headroom.** The slider receives `comfortHeadroomActive` from `recipeAllocationComfortHeadroomActive(...)` so the thumb→max segment paints in the comfort tint per [`production-panel.md`](../production-panel.md) § *Comfort headroom (slider track)*.
+7. **Stateless.** `ProductionAllocationRow` is `StatelessWidget`; only `ProductionAllocationStepButton` carries a per-button `Timer?` for repeats.
+
+---
+
+## States and variants
+
+| `maxAchievable` | `desired` | `−` | `+` | Max | Clear |
+|-----------------|-----------|-----|-----|-----|-------|
+| `0` | `0` | off | off | off | off |
+| `> 0` | `0` | off | on | on | off |
+| `> 0` | `0 < d < max` | on | on | on | on |
+| `> 0` | `d == max` | on | off | off | on |
+
+No theme variants; always paints through `ProductionAllocationRowChrome`. Narrow / wide layout is decided by the host panel; row width tracks the host cell.
+
+---
+
+## Consumers
+
+| Screen ID | Spec | Notes |
+|-----------|------|-------|
+| `GAME20001` | [`production-panel.md`](../production-panel.md) | Allocation subpanel renders one `ProductionAllocationRow` per recipe between `CtBrassDivider` separators. |
+
+The Available subpanel's per-tier Labour Controls reuse only `ProductionStepButtonSurface`, not this row composite.
+
+---
+
+## Acceptance criteria (Given–When–Then)
+
+- **Given** a recipe with `maxAchievable > 0` and `desired = 0`, **When** the row builds, **Then** `−` is disabled, `+` and maximize are enabled, and clear is disabled.
+- **Given** the user taps `+` with `desired < maxAchievable`, **When** the gesture commits, **Then** `onDesiredOutputChanged` receives a map clone where `recipe.id` is `desired + 1` and other entries are preserved.
+- **Given** the user taps `−` with `desired = 1`, **When** the gesture commits, **Then** `onDesiredOutputChanged` receives a map clone where `recipe.id` is **removed** (zero encoded as absence).
+- **Given** the user long-presses `+`, **When** the press passes ~500 ms and is still held, **Then** the composite dispatches additional `applyProductionRecipeIncrement` invocations at `kProductionAllocationRepeatInterval` cadence until release or `false` (clamped at `maxAchievable`).
+- **Given** the user taps maximize, **When** the gesture commits, **Then** `onDesiredOutputChanged` receives a map where `recipe.id == affordance.maxDesiredOutput`.
+- **Given** the user taps clear with `desired > 0`, **When** the gesture commits, **Then** `onDesiredOutputChanged` receives a map where `recipe.id` is removed.
+- **Given** `maxAchievable == 0`, **When** the row builds, **Then** the slider renders `max == 0`, `divisions == 1`, and every action button reports `enabled == false`.
+- **Given** the row is mounted, **When** the tree settles, **Then** exactly one `ProductionAllocationRowChrome` ancestor wraps the column and paints `CtGradients.rowGradient` inside a 1 dp `EditorialMonoclePalette.accentDim` border (chrome regression guard).
+
+---
+
+## Tests
+
+- `app/test/production_allocation_row_buttons_test.dart` — ± / maximize / clear gating, long-press repeat, disabled-opacity contract.
+- `app/test/production_allocation_row_chrome_test.dart` — `CtGradients.rowGradient` + 1 dp `accentDim` border surface.
+- `app/test/production_allocation_provider_test.dart` — mutation helpers consumed by this row.
+- `app/test/spec_components_production_allocation_row_test.dart` — spec-pinning: canonical sections, `GAME20001` consumer, `kProductionAllocationSliderCap = 50`, 1000-word ceiling.
+
+---
+
+## Related
+
+- Catalog: [`pixel-art-ui-catalog.md`](../pixel-art-ui-catalog.md) § *CtSlider*, *StrictAssetIcon*, *Editorial-monocle palette*, *CtGradients*.
+- Sibling chrome: [`ProductionStepButtonSurface`](../../../app/lib/features/game/widgets/production_allocation_row_buttons.dart) — also consumed by Labour Controls in the Available subpanel.
+- Consumer: [`production-panel.md`](../production-panel.md) § *Allocation row chrome*, § *Allocation step buttons*.
+- Tracking issue: [#2914](https://github.com/waigore/colonizethisv3/issues/2914) S9.

--- a/app/test/spec_components_production_allocation_row_test.dart
+++ b/app/test/spec_components_production_allocation_row_test.dart
@@ -1,0 +1,251 @@
+/// Pins the [`SPEC/ui/components/production-allocation-row.md`](
+/// ../../../SPEC/ui/components/production-allocation-row.md) component
+/// spec authored as part of issue #2914 S9 (Refactor app/lib UI to
+/// consolidate editorial-monocle design system — Phase 1 step S9:
+/// populate `SPEC/ui/components/` with composite-component specs for
+/// shared abstractions).
+///
+/// `ProductionAllocationRow` is the canonical per-recipe row composite
+/// consumed by the Production panel (stable screen id `GAME20001`).
+/// Per `colonizethis-ui-documentation.mdc` § *Component specs*, a
+/// composite that is reused or extracted from a screen spec must have
+/// its own `kebab-name.md` under `SPEC/ui/components/` rather than
+/// duplicating the layout in the host screen spec. Issue #2914 § 6
+/// explicitly enumerates "production allocation rows" as one of the
+/// missing composite specs.
+///
+/// These tests are deliberately static-text checks (file reads + regex
+/// searches): the canonical Given–When–Then runtime contract for the
+/// widget itself is exercised by the existing
+/// `app/test/production_allocation_row_buttons_test.dart`,
+/// `app/test/production_allocation_row_chrome_test.dart`, and
+/// `app/test/production_allocation_provider_test.dart` widget tests;
+/// the goal here is to ensure the SPEC stays present and aligned with
+/// the documentation rule even if future refactors move the widget
+/// around.
+///
+/// Refs #2914.
+library;
+
+import 'dart:io' show File;
+
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter_test/flutter_test.dart';
+
+const String _kSpecPath = '../SPEC/ui/components/production-allocation-row.md';
+const String _kComponentsReadmePath = '../SPEC/ui/components/README.md';
+
+String _readSpec() => File(_kSpecPath).readAsStringSync();
+
+void main() {
+  suppressLogsForTests();
+  group(
+    'SPEC/ui/components/production-allocation-row.md (#2914 S9)',
+    () {
+      test(
+        'spec file exists and is non-empty',
+        () {
+          final file = File(_kSpecPath);
+          expect(
+            file.existsSync(),
+            isTrue,
+            reason:
+                'The composite-component spec for ProductionAllocationRow '
+                'must live at SPEC/ui/components/production-allocation-row.md '
+                'per colonizethis-ui-documentation.mdc § Component specs and '
+                'issue #2914 S9.',
+          );
+          final body = file.readAsStringSync();
+          expect(
+            body.trim(),
+            isNotEmpty,
+            reason: 'spec must not be empty',
+          );
+        },
+      );
+
+      test(
+        'spec declares all canonical sections required by the components '
+        'README template (Purpose / Widget contract / Layout / Behavior / '
+        'Consumers / Acceptance criteria / Tests / Related)',
+        () {
+          final body = _readSpec();
+          for (final heading in <String>[
+            '## Purpose',
+            '## Widget contract',
+            '## Layout / wireframe',
+            '## Behavior',
+            '## Consumers',
+            '## Acceptance criteria (Given–When–Then)',
+            '## Tests',
+            '## Related',
+          ]) {
+            expect(
+              body,
+              contains(heading),
+              reason:
+                  'composite-component spec must declare the canonical '
+                  '"$heading" section.',
+            );
+          }
+        },
+      );
+
+      test(
+        'spec enumerates the GAME20001 consumer (production-panel.md) by '
+        'stable screen ID and spec link',
+        () {
+          final body = _readSpec();
+          expect(
+            body,
+            contains('GAME20001'),
+            reason:
+                'spec must enumerate consumer screen ID GAME20001 so '
+                'future refactors can reverse-trace the screen that '
+                'depends on this composite.',
+          );
+          expect(
+            body,
+            contains('production-panel.md'),
+            reason:
+                'spec must link to the production-panel.md consumer spec '
+                'so reviewers can navigate to the host wireframe.',
+          );
+        },
+      );
+
+      test(
+        'spec encodes the canonical slider cap and step-button surface '
+        'constants for regression guards',
+        () {
+          final body = _readSpec();
+          expect(
+            body,
+            contains('kProductionAllocationSliderCap = 50'),
+            reason:
+                'spec must restate the canonical slider cap so reviewers do '
+                'not have to cross-reference the implementation to confirm '
+                'the per-recipe maxAchievable clamp contract.',
+          );
+          expect(
+            body,
+            contains('kProductionAllocationStepButtonSize = 26'),
+            reason:
+                'spec must restate the canonical 26 dp step-button surface '
+                'size shared with the Available subpanel Labour Controls.',
+          );
+          expect(
+            body,
+            contains('kProductionAllocationStepButtonDisabledOpacity'),
+            reason:
+                'spec must reference the canonical disabled-opacity '
+                'constant (0.3) so the editorial-monocle dark contract is '
+                'documented at the SPEC level.',
+          );
+          expect(
+            body,
+            contains('ProductionAllocationRowChrome'),
+            reason:
+                'spec must name ProductionAllocationRowChrome so the inner '
+                'gradient-+-border surface contract is traceable from the '
+                'composite spec.',
+          );
+          expect(
+            body,
+            contains('ProductionStepButtonSurface'),
+            reason:
+                'spec must reference ProductionStepButtonSurface so the '
+                'shared inner button chrome (also used by Labour Controls) '
+                'stays discoverable.',
+          );
+        },
+      );
+
+      test(
+        'spec links to the catalog atoms and tracking issue #2914',
+        () {
+          final body = _readSpec();
+          expect(
+            body,
+            contains('pixel-art-ui-catalog.md'),
+            reason:
+                'spec must link back to the catalog so reviewers can '
+                'cross-reference the CtSlider / StrictAssetIcon atoms.',
+          );
+          expect(
+            body,
+            contains('#2914'),
+            reason:
+                'spec must reference tracking issue #2914 so progress on '
+                'the umbrella S9 step is discoverable from the file.',
+          );
+        },
+      );
+
+      test(
+        'spec is at most 1000 words (colonizethis-spec-required.mdc § Layout)',
+        () {
+          final body = _readSpec();
+          final words = body
+              .split(RegExp(r'\s+'))
+              .where((token) => token.isNotEmpty)
+              .toList();
+          expect(
+            words.length <= 1000,
+            isTrue,
+            reason:
+                'SPEC documents must stay under the 1000-word ceiling per '
+                'colonizethis-spec-required.mdc § Layout. Current word '
+                'count is ${words.length}.',
+          );
+        },
+      );
+
+      test(
+        'components README index lists the ProductionAllocationRow row '
+        '(negative regression guard — README must continue to enumerate '
+        'every composite spec under it)',
+        () {
+          final readme = File(_kComponentsReadmePath);
+          expect(
+            readme.existsSync(),
+            isTrue,
+            reason:
+                'SPEC/ui/components/README.md must remain in place so '
+                'authoring rules for new composite specs stay discoverable.',
+          );
+          final body = readme.readAsStringSync();
+          expect(
+            body,
+            contains('SPEC/ui/components/'),
+            reason:
+                'README must continue to introduce the components/ '
+                'directory.',
+          );
+          expect(
+            body,
+            contains('ProductionAllocationRow'),
+            reason:
+                'README index must enumerate ProductionAllocationRow so '
+                'the composite is discoverable from the directory landing '
+                'page (issue #2914 S9).',
+          );
+          expect(
+            body,
+            contains('production-allocation-row.md'),
+            reason:
+                'README index row must link to the spec file path.',
+          );
+          expect(
+            body,
+            contains('GAME20001'),
+            reason:
+                'README index row for ProductionAllocationRow must '
+                'reference the Production panel stable screen id '
+                'GAME20001.',
+          );
+        },
+      );
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Authors the `ProductionAllocationRow` composite-component spec at `SPEC/ui/components/production-allocation-row.md` — the per-recipe row hosted by the Production panel (`GAME20001`) Allocation subpanel — and indexes it in `SPEC/ui/components/README.md`. Adds a spec-pinning test mirroring the other `spec_components_*_test.dart` siblings.

Closes the third of the four composite specs explicitly enumerated in issue #2914 § 6 ("dialog overlays, unit panels, production allocation rows, transfer lists"). The other three already live under `SPEC/ui/components/`:

- `ct-full-screen-dialogue-shell.md` (Refs #2914 S9, PR landed earlier)
- `units-panel-shell.md` + `units-entity-action-row.md` (Refs #2914 S9, PRs #3071 / #3072)
- `ct-transfer-list.md` (Refs #2914 S9, PR #3070)

## What the spec covers

- **Widget contract**: 8 required props (recipe, player, effectiveLabour, desiredOutputByRecipe, onDesiredOutputChanged, buildRecipeLabel, l10n, theme) and the three canonical constants (`kProductionAllocationSliderCap = 50`, `kProductionAllocationStepButtonSize = 26`, `kProductionAllocationStepButtonDisabledOpacity = 0.3`).
- **Layout / wireframe**: ASCII tree pinning the header (`Expanded(flex 2)` label + `Expanded(flex 1)` affordance text) and body (`Expanded(CtSlider)` + numeric readout + four-button cluster with `−`, `+`, maximize, clear) inside `ProductionAllocationRowChrome`.
- **Behavior**: affordance recompute on every `build`, slider clamp to `kProductionAllocationSliderCap`, four-way enabled gating, long-press repeat semantics (~500 ms recognition + 125 ms `Timer.periodic` cadence) for `±` only, comfort-headroom signal forwarding, stateless composition.
- **States and variants** table covering the four `(maxAchievable, desired)` corners.
- **Consumers**: `GAME20001` only; explicitly notes the Available subpanel's Labour Controls reuse only the inner `ProductionStepButtonSurface`, not this row composite.
- **Acceptance criteria** (8 Given–When–Then): per-button gating, ± / maximize / clear mutation effects, long-press repeat dispatch, `maxAchievable == 0` degenerate case, and the chrome regression guard (one `ProductionAllocationRowChrome` ancestor; `CtGradients.rowGradient` + 1 dp `accentDim` border).

## Test plan

- [x] `flutter test test/spec_components_production_allocation_row_test.dart` — 7 tests, all green.
- [x] `flutter analyze test/spec_components_production_allocation_row_test.dart` — clean.
- [x] Sibling spec-pinning tests still green (sanity: `test/spec_components_units_panel_shell_test.dart`).
- [x] Word count: 999 / 1000 (per `colonizethis-spec-required.mdc` § Layout).
- [ ] Remote CI quality / coverage gates (not awaited per backlog-implement workflow — running on the PR).

## Scope notes

- **Done in this PR**: `production-allocation-row.md` composite spec + README index row + spec-pinning test.
- **Deferred** (out of scope here, tracked under #2914 umbrella ACs): other S9 composites (if any further candidates surface from review); umbrella close-out remains pending the umbrella's full AC checklist (it lists G1/G2 already landed plus the four named composite specs — this PR is the last of the four).

Refs #2914

Made with [Cursor](https://cursor.com)