### PR TITLE
docs(spec): TrainDialogChrome composite-component spec (Refs #2914 S9)

### DIFF
--- a/SPEC/ui/components/README.md
+++ b/SPEC/ui/components/README.md
@@ -14,5 +14,6 @@ Create `<kebab-name>.md` before duplicating composite layout in multiple screen 
 | `CtGameFeatureScreenShell` | [`ct-game-feature-screen-shell.md`](ct-game-feature-screen-shell.md) | `GAME20001` (production), `GAME30001` (diplomacy), `GAME40001` (technology), `GAME60001` (trade). |
 | `CtTransferList` | [`ct-transfer-list.md`](ct-transfer-list.md) | `DLG40001` (transfer to home fleet), Split Fleet dialog, Split Army dialog. |
 | `ProductionAllocationRow` | [`production-allocation-row.md`](production-allocation-row.md) | `GAME20001` (production panel). |
+| `TrainDialogChrome` | [`train-dialog-chrome.md`](train-dialog-chrome.md) | `UNIT40001` (train civilians dialog), `UNIT50001` (train military dialog). |
 | `UnitsEntityActionRow` | [`units-entity-action-row.md`](units-entity-action-row.md) | `UNIT10001` (civilian units panel), `UNIT20001` (military units panel), `UNIT30001` (naval units panel). |
 | `UnitsPanelShell` | [`units-panel-shell.md`](units-panel-shell.md) | `UNIT10001` (civilian units panel), `UNIT20001` (military units panel), `UNIT30001` (naval units panel). |

--- a/SPEC/ui/components/train-dialog-chrome.md
+++ b/SPEC/ui/components/train-dialog-chrome.md
@@ -1,0 +1,108 @@
+# TrainDialogChrome (component)
+
+**SPEC/ui/components** — Reusable header / divider / resource-bar / row-surface chrome shared by the two train-at-capital dialogs. Implementation: [`app/lib/features/game/widgets/train_dialog_chrome.dart`](../../../app/lib/features/game/widgets/train_dialog_chrome.dart). Catalog atoms: [`pixel-art-ui-catalog.md`](../pixel-art-ui-catalog.md) § *CtNinePatchButton*, § *CtBrassDivider*, § *CtGradients*, § *Editorial-monocle palette*.
+
+This composite is **not** a screen and has **no** stable screen ID. It is the canonical chrome consumed by the two screen specs listed under [Consumers](#consumers).
+
+---
+
+## Purpose
+
+Consolidates the chrome (accent title + `×` dismiss, brass section divider, resource bar with optional deficit hint, compact resource chip, per-unit row surface) shared by Train Civilians and Train Military so each dialog composes only its body inside a single [`CtDialogShell`](../pixel-art-ui-catalog.md). The dark editorial-monocle contract (no Material `IconButton`, no Material `Divider`, no raw `Colors.*` literals) lives in one file. Tracking issue: [#2914](https://github.com/waigore/colonizethisv3/issues/2914) S9.
+
+---
+
+## Widget contract
+
+`TrainDialogHeader` — `title` (`String`) rendered in `theme.textTheme.titleMedium` with `EditorialMonoclePalette.accent`, `kTrainDialogTitleLetterSpacing` (`0.05`), and `FontWeight.w600`; `onClose` (`VoidCallback`) fires when the trailing `×` `CtNinePatchButton` (32 dp min-height; padding `10 × 6`) is tapped.
+
+`TrainDialogSectionDivider` — no props; renders `CtBrassDivider` inside `EdgeInsets.symmetric(vertical: 8)`.
+
+`TrainDialogResourceBar` — `lines` (`List<String>`) renders one `Text` per entry inside `Wrap(spacing: 16, runSpacing: 4)`, resolved to `bodyMedium.copyWith(color: EditorialMonoclePalette.fg)`; optional `deficitHint` (`String?`) appends a row in `bodySmall.copyWith(color: EditorialMonoclePalette.danger)`.
+
+`TrainDialogResourceChip` — single `child`, wrapped in a 4 dp-radius `BoxDecoration` (`CtGradients.rowGradient` + 1 dp `accentDim` border) with `EdgeInsets.symmetric(horizontal: 6, vertical: 4)`; content renders inside `DefaultTextStyle.merge(style: TextStyle(color: EditorialMonoclePalette.fg))`.
+
+`TrainDialogUnitRowSurface` — single `child`, wrapped in `CtGradients.rowGradient` + 1 dp `accentDim` border with `EdgeInsets.symmetric(horizontal: 12, vertical: 8)`. Optional `margin` defaults to `EdgeInsets.only(bottom: 6)`.
+
+Exported constants: `kTrainDialogLockedOpacity = 0.4` (per [#2866](https://github.com/waigore/colonizethisv3/issues/2866) AC); `kTrainDialogTitleLetterSpacing = 0.05`.
+
+---
+
+## Layout / wireframe
+
+```text
+CtDialogShell(maxWidth: 480, maxHeight: 600)            -- canonical dialog frame
+  Column(min, start)
+    TrainDialogHeader(title, onClose)                   -- Row(start) [Expanded(title), CtNinePatchButton('×')]
+    TrainDialogSectionDivider()                          -- Padding(8/8) CtBrassDivider
+    TrainDialogResourceBar(lines, deficitHint?)         -- Wrap(spacing 16, runSpacing 4) + optional danger hint
+    TrainDialogSectionDivider()
+    ListView/Column of TrainDialogUnitRowSurface(...)   -- per unit/regiment row
+      Row(...)                                          -- icon + name + cost / stepper / lock badge
+    Footer (consumer-owned: Reset CtNinePatchButton)
+```
+
+The chrome widgets are independent — consumers may skip the resource bar (e.g. when capital is missing) and still render unit rows.
+
+---
+
+## Behavior
+
+1. **Stateless surfaces.** Every chrome widget is a `StatelessWidget`; affordance recomputation and stepper mutation belong to the host dialog state.
+2. **Header dismiss.** `TrainDialogHeader` mounts `CtNinePatchButton` (not Material `IconButton`) so the dark button-surface contract is preserved. Tap fires `onClose`.
+3. **Divider colour.** `TrainDialogSectionDivider` always paints `CtBrassDivider` — never Material `Divider`. Guards both dialogs against the Material ban that the `check_app_no_material_*` lints enforce.
+4. **Resource bar styling.** Each `lines` entry resolves to `EditorialMonoclePalette.fg`. `deficitHint`, when supplied, uses `EditorialMonoclePalette.danger` (warm-red) so the deficit message is unambiguous on the dark surface.
+5. **Resource chip.** `TrainDialogResourceChip` wraps inline icon + numeric content; military uses six per dialog for the commodity readout (`fabric`, `castIron`, `lumber`, `horses`, `steel`, `bronze`).
+6. **Unit row surface.** `TrainDialogUnitRowSurface` paints `CtGradients.rowGradient` inside a 1 dp `accentDim` border. The consumer owns internal layout (icon, name, cost columns, stepper, lock badge) and applies `kTrainDialogLockedOpacity` (`0.4`) via its own `Opacity` wrapper when the row is tech-locked.
+7. **Letter-spacing alignment.** `kTrainDialogTitleLetterSpacing = 0.05` matches `CtTopBar` and the combat-mode choice dialog so the title rhythm aligns.
+
+---
+
+## States and variants
+
+| Widget | Variant | Trigger | Render difference |
+|--------|---------|---------|--------------------|
+| `TrainDialogResourceBar` | No-deficit | `deficitHint == null` | Hint row omitted; only the `Wrap` renders. |
+| `TrainDialogResourceBar` | Deficit | `deficitHint != null` | `SizedBox(height: 4)` + danger-coloured hint row appended. |
+| `TrainDialogUnitRowSurface` | Locked | Host wraps the row in `Opacity(opacity: kTrainDialogLockedOpacity)` | Whole surface fades to 0.4 opacity. |
+| `TrainDialogUnitRowSurface` | Custom margin | Caller overrides `margin` | Outer `Padding` adopts the caller margin (default `EdgeInsets.only(bottom: 6)`). |
+
+The chrome widgets have no theme-mode branches; the dark editorial-monocle theme is the only authorised render target.
+
+---
+
+## Consumers
+
+| Screen ID | Spec | Notes |
+|-----------|------|-------|
+| `UNIT40001` | [`train-civilians-dialog.md`](../train-civilians-dialog.md) | Civilian list + treasury / paper resource bar; six unit-type rows with optional tech-lock variant. |
+| `UNIT50001` | [`train-military-dialog.md`](../train-military-dialog.md) | Regiment list + treasury / peasants + six commodity chips; per-regiment rows with optional tech-lock variant. |
+
+Both consumer specs link back here for the chrome contract instead of redeclaring the header / divider / resource-bar / row-surface hierarchy.
+
+---
+
+## Acceptance criteria (Given–When–Then)
+
+- **Given** a `TrainDialogHeader` mounted with `title = 'Train Civilians'`, **When** the tree settles, **Then** exactly one `CtNinePatchButton` is mounted, zero Material `IconButton` widgets are mounted, `Text('Train Civilians')` renders, and its resolved `TextStyle.color` equals `EditorialMonoclePalette.accent`.
+- **Given** a `TrainDialogSectionDivider` mounted under any host, **When** the tree settles, **Then** exactly one `CtBrassDivider` is mounted and zero Material `Divider` widgets are mounted.
+- **Given** a `TrainDialogResourceBar` mounted with two lines and `deficitHint == null`, **When** the tree settles, **Then** two `Text` descendants render the line values and no descendant carries `EditorialMonoclePalette.danger`.
+- **Given** a `TrainDialogResourceBar` mounted with `deficitHint = 'Treasury low'`, **When** the tree settles, **Then** a `Text('Treasury low')` mounts whose resolved `TextStyle.color` equals `EditorialMonoclePalette.danger`.
+- **Given** a `TrainDialogUnitRowSurface` mounted around any child, **When** the inner `DecoratedBox` resolves, **Then** its `BoxDecoration.border` is `Border.all(color: EditorialMonoclePalette.accentDim, width: 1)` and its `BoxDecoration.gradient` is `CtGradients.rowGradient`.
+- **Given** the source `app/lib/features/game/widgets/train_dialog_chrome.dart`, **When** read, **Then** it declares `kTrainDialogLockedOpacity = 0.4` and `kTrainDialogTitleLetterSpacing = 0.05` (canonical regression guard).
+
+---
+
+## Tests
+
+- `app/test/train_dialog_chrome_test.dart` — widget-level pins for `TrainDialogHeader` accent title + `CtNinePatchButton` dismiss, `TrainDialogSectionDivider` `CtBrassDivider` selection, and the `kTrainDialogLockedOpacity` constant.
+- `app/test/train_dialogs_320dp_min_viewport_test.dart` — pins `TrainCiviliansDialog` and `TrainMilitaryDialog` at `kMinViewportWidth = 320` dp with the shared chrome composed inside `CtDialogShell` (Refs [#2870](https://github.com/waigore/colonizethisv3/issues/2870) S8/S10).
+- `app/test/spec_components_train_dialog_chrome_test.dart` — spec-pinning test asserting this spec exists, declares the canonical sections, enumerates the two consumers by stable screen id, restates the chrome constants, and stays under the 1000-word ceiling.
+
+---
+
+## Related
+
+- Catalog: [`pixel-art-ui-catalog.md`](../pixel-art-ui-catalog.md) § *CtDialogShell*, § *CtNinePatchButton*, § *CtBrassDivider*, § *CtGradients*, § *Editorial-monocle palette*.
+- Sibling chrome: [`production-allocation-row.md`](production-allocation-row.md) — same row-surface gradient + border pattern.
+- Tracking issue: [#2914](https://github.com/waigore/colonizethisv3/issues/2914) S9.

--- a/app/test/spec_components_train_dialog_chrome_test.dart
+++ b/app/test/spec_components_train_dialog_chrome_test.dart
@@ -1,0 +1,276 @@
+/// Pins the [`SPEC/ui/components/train-dialog-chrome.md`](
+/// ../../../SPEC/ui/components/train-dialog-chrome.md) component spec
+/// authored as part of issue #2914 S9 (Refactor app/lib UI to
+/// consolidate editorial-monocle design system — Phase 1 step S9:
+/// populate `SPEC/ui/components/` with composite-component specs for
+/// shared abstractions).
+///
+/// `TrainDialogChrome` is the canonical header / divider / resource-bar
+/// / resource-chip / row-surface chrome composed inside `CtDialogShell`
+/// by both the Train Civilians dialog (stable screen id `UNIT40001`)
+/// and the Train Military dialog (stable screen id `UNIT50001`). Per
+/// `colonizethis-ui-documentation.mdc` § *Component specs*, a composite
+/// reused by multiple screen specs must live under
+/// `SPEC/ui/components/<kebab-name>.md` rather than being duplicated in
+/// each consumer spec.
+///
+/// These tests are deliberately static-text checks (file reads + regex
+/// searches): the canonical Given–When–Then runtime contract for the
+/// individual chrome widgets is exercised by
+/// `app/test/train_dialog_chrome_test.dart`,
+/// `app/test/train_dialogs_320dp_min_viewport_test.dart`, and the two
+/// consumer-dialog widget tests. The goal here is to ensure the SPEC
+/// stays present and aligned with the documentation rule even if future
+/// refactors move the widget file around.
+///
+/// Refs #2914.
+library;
+
+import 'dart:io' show File;
+
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter_test/flutter_test.dart';
+
+const String _kSpecPath = '../SPEC/ui/components/train-dialog-chrome.md';
+const String _kComponentsReadmePath = '../SPEC/ui/components/README.md';
+
+String _readSpec() => File(_kSpecPath).readAsStringSync();
+
+void main() {
+  suppressLogsForTests();
+  group(
+    'SPEC/ui/components/train-dialog-chrome.md (#2914 S9)',
+    () {
+      test(
+        'spec file exists and is non-empty',
+        () {
+          final file = File(_kSpecPath);
+          expect(
+            file.existsSync(),
+            isTrue,
+            reason:
+                'The composite-component spec for TrainDialogChrome must '
+                'live at SPEC/ui/components/train-dialog-chrome.md per '
+                'colonizethis-ui-documentation.mdc § Component specs and '
+                'issue #2914 S9.',
+          );
+          final body = file.readAsStringSync();
+          expect(
+            body.trim(),
+            isNotEmpty,
+            reason: 'spec must not be empty',
+          );
+        },
+      );
+
+      test(
+        'spec declares all canonical sections required by the components '
+        'README template (Purpose / Widget contract / Layout / Behavior / '
+        'Consumers / Acceptance criteria / Tests / Related)',
+        () {
+          final body = _readSpec();
+          for (final heading in <String>[
+            '## Purpose',
+            '## Widget contract',
+            '## Layout / wireframe',
+            '## Behavior',
+            '## Consumers',
+            '## Acceptance criteria (Given–When–Then)',
+            '## Tests',
+            '## Related',
+          ]) {
+            expect(
+              body,
+              contains(heading),
+              reason:
+                  'composite-component spec must declare the canonical '
+                  '"$heading" section.',
+            );
+          }
+        },
+      );
+
+      test(
+        'spec enumerates the UNIT40001 + UNIT50001 consumers by stable '
+        'screen ID and spec link',
+        () {
+          final body = _readSpec();
+          expect(
+            body,
+            contains('UNIT40001'),
+            reason:
+                'spec must enumerate consumer screen ID UNIT40001 (Train '
+                'Civilians dialog) so future refactors can reverse-trace '
+                'the screen that depends on this composite.',
+          );
+          expect(
+            body,
+            contains('UNIT50001'),
+            reason:
+                'spec must enumerate consumer screen ID UNIT50001 (Train '
+                'Military dialog) so future refactors can reverse-trace '
+                'the screen that depends on this composite.',
+          );
+          expect(
+            body,
+            contains('train-civilians-dialog.md'),
+            reason:
+                'spec must link to the train-civilians-dialog.md consumer '
+                'spec so reviewers can navigate to the host dialog.',
+          );
+          expect(
+            body,
+            contains('train-military-dialog.md'),
+            reason:
+                'spec must link to the train-military-dialog.md consumer '
+                'spec so reviewers can navigate to the host dialog.',
+          );
+        },
+      );
+
+      test(
+        'spec names every chrome widget and exported constant for '
+        'regression guards',
+        () {
+          final body = _readSpec();
+          for (final symbol in <String>[
+            'TrainDialogHeader',
+            'TrainDialogSectionDivider',
+            'TrainDialogResourceBar',
+            'TrainDialogResourceChip',
+            'TrainDialogUnitRowSurface',
+            'kTrainDialogLockedOpacity = 0.4',
+            'kTrainDialogTitleLetterSpacing = 0.05',
+          ]) {
+            expect(
+              body,
+              contains(symbol),
+              reason:
+                  'spec must restate the canonical chrome symbol or '
+                  'constant "$symbol" so reviewers do not have to '
+                  'cross-reference the implementation to confirm the '
+                  'dark editorial-monocle contract.',
+            );
+          }
+        },
+      );
+
+      test(
+        'spec names the canonical catalog atoms it composes (CtDialogShell, '
+        'CtNinePatchButton, CtBrassDivider, CtGradients, '
+        'EditorialMonoclePalette)',
+        () {
+          final body = _readSpec();
+          for (final atom in <String>[
+            'CtDialogShell',
+            'CtNinePatchButton',
+            'CtBrassDivider',
+            'CtGradients',
+            'EditorialMonoclePalette',
+          ]) {
+            expect(
+              body,
+              contains(atom),
+              reason:
+                  'spec must reference the Ct-* catalog atom "$atom" so '
+                  'the composite chrome stays traceable to its '
+                  'design-system sources.',
+            );
+          }
+        },
+      );
+
+      test(
+        'spec links to the catalog and tracking issue #2914',
+        () {
+          final body = _readSpec();
+          expect(
+            body,
+            contains('pixel-art-ui-catalog.md'),
+            reason:
+                'spec must link back to the catalog so reviewers can '
+                'cross-reference the catalog atoms it composes.',
+          );
+          expect(
+            body,
+            contains('#2914'),
+            reason:
+                'spec must reference tracking issue #2914 so progress on '
+                'the umbrella S9 step is discoverable from the file.',
+          );
+        },
+      );
+
+      test(
+        'spec is at most 1000 words (colonizethis-spec-required.mdc § Layout)',
+        () {
+          final body = _readSpec();
+          final words = body
+              .split(RegExp(r'\s+'))
+              .where((token) => token.isNotEmpty)
+              .toList();
+          expect(
+            words.length <= 1000,
+            isTrue,
+            reason:
+                'SPEC documents must stay under the 1000-word ceiling per '
+                'colonizethis-spec-required.mdc § Layout. Current word '
+                'count is ${words.length}.',
+          );
+        },
+      );
+
+      test(
+        'components README index lists the TrainDialogChrome row '
+        '(negative regression guard — README must continue to enumerate '
+        'every composite spec under it)',
+        () {
+          final readme = File(_kComponentsReadmePath);
+          expect(
+            readme.existsSync(),
+            isTrue,
+            reason:
+                'SPEC/ui/components/README.md must remain in place so '
+                'authoring rules for new composite specs stay discoverable.',
+          );
+          final body = readme.readAsStringSync();
+          expect(
+            body,
+            contains('SPEC/ui/components/'),
+            reason:
+                'README must continue to introduce the components/ '
+                'directory.',
+          );
+          expect(
+            body,
+            contains('TrainDialogChrome'),
+            reason:
+                'README index must enumerate TrainDialogChrome so the '
+                'composite is discoverable from the directory landing '
+                'page (issue #2914 S9).',
+          );
+          expect(
+            body,
+            contains('train-dialog-chrome.md'),
+            reason:
+                'README index row must link to the spec file path.',
+          );
+          expect(
+            body,
+            contains('UNIT40001'),
+            reason:
+                'README index row for TrainDialogChrome must reference '
+                'the Train Civilians dialog stable screen id UNIT40001.',
+          );
+          expect(
+            body,
+            contains('UNIT50001'),
+            reason:
+                'README index row for TrainDialogChrome must reference '
+                'the Train Military dialog stable screen id UNIT50001.',
+          );
+        },
+      );
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Next slice of #2914 — **S9 (composite-component specs):** documents the shared train-dialog chrome (`TrainDialogHeader`, `TrainDialogSectionDivider`, `TrainDialogResourceBar`, `TrainDialogResourceChip`, `TrainDialogUnitRowSurface`) that lives in [`app/lib/features/game/widgets/train_dialog_chrome.dart`](../tree/dev/app/lib/features/game/widgets/train_dialog_chrome.dart) and is composed by both the **Train Civilians** dialog (`UNIT40001`) and the **Train Military** dialog (`UNIT50001`) inside a single `CtDialogShell`.

Per [`colonizethis-ui-documentation.mdc`](../tree/dev/.cursor/rules/colonizethis-ui-documentation.mdc) § *Component specs*, a composite that is reused or extracted from a screen spec must have its own `kebab-name.md` under `SPEC/ui/components/` rather than being duplicated in each consumer spec. The chrome was already referenced from [`SPEC/ui/mobile-adaptation.md`](../tree/dev/SPEC/ui/mobile-adaptation.md) (Train Civilians + Train Military 320 dp pins) but had no canonical composite spec until this PR. The two consumer screen specs ([`train-civilians-dialog.md`](../tree/dev/SPEC/ui/train-civilians-dialog.md) / [`train-military-dialog.md`](../tree/dev/SPEC/ui/train-military-dialog.md)) can now link to the new file instead of redeclaring header / divider / resource-bar / row-surface layout in two places.

`Refs #2914` — does not auto-close; the umbrella issue closes when every sub-task (S1–S9 + G1/G2) is delivered.

## Scope

### Done in this push (#2914 S9)

| Layer | Change |
|-------|--------|
| **SPEC** | New [`SPEC/ui/components/train-dialog-chrome.md`](../tree/feat/issue-2914-s9-train-dialog-chrome-spec/SPEC/ui/components/train-dialog-chrome.md) following the canonical Purpose / Widget contract / Layout / Behavior / States / Consumers / ACs / Tests / Related section order. |
| **SPEC index** | [`SPEC/ui/components/README.md`](../tree/feat/issue-2914-s9-train-dialog-chrome-spec/SPEC/ui/components/README.md) gains a `TrainDialogChrome` row referencing the new spec and the two consumer screen IDs. |
| **Tests** | New [`app/test/spec_components_train_dialog_chrome_test.dart`](../tree/feat/issue-2914-s9-train-dialog-chrome-spec/app/test/spec_components_train_dialog_chrome_test.dart) — spec-pinning regression guard mapped to S9. |

### Tests added (positive + negative regression sweep)

The new test mirrors the structure used by `spec_components_production_allocation_row_test.dart` (#2914 S9 sibling slice). Eight test cases:

1. **Positive — spec file exists and is non-empty.** Guards the spec from accidental deletion.
2. **Positive — spec declares the canonical components-template sections** (Purpose / Widget contract / Layout / Behavior / Consumers / ACs / Tests / Related). Mirrors the README template so future composite specs follow the same shape.
3. **Positive — spec enumerates both consumer screen IDs (`UNIT40001`, `UNIT50001`) and links to both consumer spec files.** Ensures reverse-traceability from chrome → host screens.
4. **Positive — spec names every chrome widget (`TrainDialogHeader`, `TrainDialogSectionDivider`, `TrainDialogResourceBar`, `TrainDialogResourceChip`, `TrainDialogUnitRowSurface`) and the canonical constants (`kTrainDialogLockedOpacity = 0.4`, `kTrainDialogTitleLetterSpacing = 0.05`)** so reviewers can confirm the contract without cross-referencing the implementation.
5. **Positive — spec references the Ct-* catalog atoms it composes** (`CtDialogShell`, `CtNinePatchButton`, `CtBrassDivider`, `CtGradients`, `EditorialMonoclePalette`).
6. **Positive — spec links to the catalog and tracking issue #2914.**
7. **Negative — spec stays under the 1000-word ceiling** mandated by [`colonizethis-spec-required.mdc`](../tree/dev/.cursor/rules/colonizethis-spec-required.mdc) § Layout. Current count: **~970 / 1000 words**.
8. **Negative — `SPEC/ui/components/README.md` index continues to enumerate the new composite** with the file path and both consumer screen IDs — guards against silent removal from the directory landing page.

### ACs covered now (#2914)

- [x] **S9 (partial)** — Composite spec added for `TrainDialogChrome` (extends prior S9 slices for `CtFullScreenDialogueShell`, `CtGameFeatureScreenShell`, `CtTransferList`, `ProductionAllocationRow`, `UnitsEntityActionRow`, `UnitsPanelShell`). Sibling composites that still lack standalone specs remain in scope for future S9 slices.
- [ ] Phase 0a / 0b, S1–S8 (residual), G1 / G2 — out of scope here; tracked under #2914 and addressed by prior / future slices.

### Out of scope (deferred to follow-ups under the same umbrella issue)

- **No source/runtime changes.** The chrome widgets in `train_dialog_chrome.dart` are untouched — this PR is documentation-only. Existing runtime behaviour pins remain with `app/test/train_dialog_chrome_test.dart` and `app/test/train_dialogs_320dp_min_viewport_test.dart`.
- **No consumer-spec rewrites.** Updating `train-civilians-dialog.md` / `train-military-dialog.md` to link back to the new composite spec is a low-risk follow-up that can land separately to keep this PR focused on the new composite spec contract.
- **Other undocumented composites** (e.g. `DiplomacyPanelChrome`, `TechTreeWidgetNodes`, `province_sea_zone_detail_overlay_sections`) — separate S9 slices.

## SPEC alignment

- [`colonizethis-ui-documentation.mdc`](../tree/dev/.cursor/rules/colonizethis-ui-documentation.mdc) § *Component specs*: a composite widget used by multiple screens MUST live under `SPEC/ui/components/<kebab-name>.md`. `TrainDialogChrome` is used by `UNIT40001` and `UNIT50001`.
- [`colonizethis-spec-required.mdc`](../tree/dev/.cursor/rules/colonizethis-spec-required.mdc) § *Layout*: sub-specs only; max 1000 words per document. Pinned by the negative-sweep test (current word count ~970).
- [`colonizethis-acceptance-criteria.mdc`](../tree/dev/.cursor/rules/colonizethis-acceptance-criteria.mdc): ACs are written as atomic Given–When–Then triplets with explicit subjects (`TrainDialogHeader`, `TrainDialogSectionDivider`, ...).

## Verification

- `flutter test app/test/spec_components_train_dialog_chrome_test.dart app/test/train_dialog_chrome_test.dart --reporter=compact` → **11/11 pass** (8 new spec-pin + 3 pre-existing widget contract tests).
- `flutter test app/test/train_dialogs_320dp_min_viewport_test.dart app/test/train_civilians_dialog_test.dart app/test/train_military_dialog_test.dart --reporter=compact` → **all pass** (no consumer regressions).
- `dart analyze app/test/spec_components_train_dialog_chrome_test.dart` → **No issues found!**
- `wc -w SPEC/ui/components/train-dialog-chrome.md` → **970** words (≤ 1000 ceiling).

## Test plan

- [x] New S9 spec-pinning test (8 cases: positive + negative sweeps) passes locally.
- [x] Existing `TrainDialogChrome` widget tests pass without modification.
- [x] Consumer dialog tests (`train_civilians_dialog_test.dart`, `train_military_dialog_test.dart`, `train_dialogs_320dp_min_viewport_test.dart`) still pass.
- [x] Static analysis clean on the new test file.
- [x] SPEC word count under 1000.
- [ ] CI on this PR.


Made with [Cursor](https://cursor.com)