### PR TITLE
feat(ui): danger-border feedback on duplicate leader slot (Refs #2867 R19)

### DIFF
--- a/SPEC/ui/new-game-leader-selection-dialog.md
+++ b/SPEC/ui/new-game-leader-selection-dialog.md
@@ -62,6 +62,7 @@ Implementation: `app/lib/features/shell/new_game_leader_selection_dialog.dart`. 
 - Infinite mode: `CheckboxListTile` with leading control; `activeColor: EditorialMonoclePalette.accent`, `checkColor: EditorialMonoclePalette.bgDeep`, idle `side: BorderSide(color: EditorialMonoclePalette.border)`; primary `shell_leaderDialog_infiniteModeLabel` (`EditorialMonoclePalette.fg`), secondary `shell_leaderDialog_infiniteModeHelper` (`EditorialMonoclePalette.muted`).
 - Terrain variation: label `shell_leaderDialog_terrainVariationLabel(percent)` (percent = `(value * 100).round()`, color `EditorialMonoclePalette.accentDim` w600), `CtSlider(min: 0.0, max: 1.0, divisions: 20)`, helper `shell_leaderDialog_terrainVariationHelper` (`EditorialMonoclePalette.muted`). Default `defaultTerrainVariation == 0.5`.
 - Footer: right-aligned `Row` with `CtNinePatchButton` Cancel (`common_cancel`) and `CtNinePatchButton` Start (`common_start`). Start enabled only when `_startEnabled == true`.
+- Duplicate slot validation feedback (#2867 R19): when the slot's currently-selected Great Power id (`_orderedGpIdsBySlot[slotIndex]`) also appears in at least one other slot's ordered list, the nation `CtDropdown<String>` is wrapped in a `DecoratedBox` keyed `ValueKey<String>('newGameLeaderDialogSlotDuplicateBorder_<slotIndex>')` whose `Border.all` resolves to `EditorialMonoclePalette.danger` at `NewGameLeaderSelectionDialog.duplicateSlotBorderWidth` (1 dp). Non-duplicate slots render the nation dropdown directly without that wrapper.
 
 ---
 
@@ -79,7 +80,7 @@ Implementation: `app/lib/features/shell/new_game_leader_selection_dialog.dart`. 
 |-------|-----------|-----|
 | Initial / default | All six slots populated with their `defaultLeaderVariantId` and the default seed | Start enabled. |
 | Slot empty | Any `_orderedGpIdsBySlot[i].isEmpty` | Start disabled (`_startEnabled == false`). |
-| Slot duplicate | Same GP id appears in more than one slot | Start disabled (`_startEnabled == false`). |
+| Slot duplicate | Same GP id appears in more than one slot | Start disabled (`_startEnabled == false`). Every duplicate slot's nation `CtDropdown<String>` is wrapped in a `DecoratedBox` keyed `ValueKey<String>('newGameLeaderDialogSlotDuplicateBorder_<slotIndex>')` that paints a `EditorialMonoclePalette.danger` `Border.all` at `NewGameLeaderSelectionDialog.duplicateSlotBorderWidth` (1 dp). |
 | Missing leader variants | `_leaderByGpId[id]` not in `gp.leaderVariants` for any slot | Start disabled (`_startEnabled == false`). |
 | Slot reassignment | User picks a new nation for slot i | `_orderedGpIdsBySlot[i]` updates; `_leaderByGpId[newId]` resets to `defaultLeaderVariantId`. |
 | Leader change | User picks a new leader variant for slot i | `_leaderByGpId[effectiveGpId]` updates only. |
@@ -144,6 +145,14 @@ Implementation: `app/lib/features/shell/new_game_leader_selection_dialog.dart`. 
 
 - Given the viewport size is exactly `Size(kMinViewportWidth, 640)` (320 × 640 dp) and the dialog is rendered with `baseConfig = GameSetupConfig.defaultConfig`, `naming = defaultNamingConfig`, and the default per-GP leader-variant map, when the dialog builds, then `WidgetTester.takeException()` returns `null` (no `RenderFlex` overflow exception surfaces through the framework), every one of the six slot rows mounts the stacked column body keyed `ValueKey<String>('newGameLeaderDialogSlotPickersColumn')` (so `find.byKey(...).evaluate().length == 6`), no slot mounts the wide row body keyed `ValueKey<String>('newGameLeaderDialogSlotPickersRow')`, the dialog title `New game — Setup`, the six slot labels `Player 1 (You)` through `Player 6 (AI)`, and the trailing `Cancel` and `Start` `CtNinePatchButton` labels all render within the ~288 dp `CtDialogShell` content column, and every rendered `CtNinePatchButton` reports a rendered height `>= kMinTouchTargetSize` (44 dp) per [mobile-adaptation.md](mobile-adaptation.md) § 1. Pinned by `app/test/mobile_320dp_min_viewport_test.dart` group `SPEC/ui/mobile-adaptation.md § 7 — NewGameLeaderSelectionDialog @ 320 dp` (Refs #2870 S7/S8/S10).
 
+### Duplicate slot validation feedback (#2867 R19)
+
+- Given the dialog is open and at least two slots share the same Great Power id (`_orderedGpIdsBySlot[i] == _orderedGpIdsBySlot[j]` for some `i != j`, ignoring empty ids), when each affected slot row builds, then the nation `CtDropdown<String>` of every duplicate slot is wrapped in a `DecoratedBox` keyed `ValueKey<String>('newGameLeaderDialogSlotDuplicateBorder_<slotIndex>')` painting a 1 dp `EditorialMonoclePalette.danger` `Border.all`, and the Start `CtNinePatchButton.enabled` remains `false` (mirrors `_startEnabled` rejecting duplicates).
+
+- Given the dialog is open and every populated slot holds a unique Great Power id, when the slot rows build, then no `DecoratedBox` keyed with the `'newGameLeaderDialogSlotDuplicateBorder_'` prefix is mounted under any slot row (negative AC: the danger border is only painted for duplicates).
+
+- Given the dialog opens with `baseConfig.selectedGreatPowerIds` containing a duplicate Great Power id, when the user changes the duplicate slot's nation to a previously unused id via the nation dropdown, then the danger-border wrapper for that slot unmounts on the next build (no `ValueKey<String>('newGameLeaderDialogSlotDuplicateBorder_<slotIndex>')` remains for the now-unique slot) and the Start `CtNinePatchButton.enabled` flips to `true` once all six slots hold unique non-empty ids.
+
 ### Dark editorial-monocle chrome (#2867 S6)
 
 - Given the dialog is open, when the title `Text` keyed `ValueKey<String>('leaderSelectionDialogTitle')` is inspected, then its `style.color` equals `EditorialMonoclePalette.accent` and `style.letterSpacing` equals `style.fontSize * 0.05` within `1e-9` (so theme text-scale overrides preserve the canonical 0.05em ratio per #2867 R2).
@@ -158,12 +167,12 @@ Implementation: `app/lib/features/shell/new_game_leader_selection_dialog.dart`. 
 
 ## Widgetbook
 
-Catalog folder: **New Game Leader Selection Dialog** (registered in `app/lib/widgetbook/catalog.dart`). Use cases:
+Catalog folder: **New Game Leader Selection Dialog** (registered in `app/lib/widgetbook/catalog.dart` via `app/lib/widgetbook/catalog_part4.dart`). Use cases:
 
 1. **Default — six slots populated:** Opens with `GameSetupConfig.defaultConfig.selectedGreatPowerIds`, default leader variants for each, seed `42`, infinite mode off, terrain variation `0.5`. Start is enabled.
-2. **Initial — empty slot regression:** Same wiring as default but with `selectedGreatPowerIds` length 0; demonstrates that Start is disabled until the user picks a nation for every slot.
+2. **Duplicate slot regression — England in slots 1 and 6:** Opens with `selectedGreatPowerIds` set to `['england', 'france', 'spain', 'portugal', 'netherlands', 'england']` so slot 1 and slot 6 share the same Great Power id. Demonstrates the duplicate slot validation feedback contract (#2867 R19): both duplicate slot rows wrap their nation `CtDropdown` in the keyed 1 dp `EditorialMonoclePalette.danger` `DecoratedBox`, and Start stays disabled until the duplicate is resolved.
 
 Automated widget tests:
 
-- `app/test/new_game_leader_selection_dialog_test.dart` — six-slot rendering, default ordering, seed parsing, infinite-mode toggle, terrain-variation slider, Cancel, slot reassignment, Start payload, and the 500 dp wide↔narrow slot-pickers boundary.
+- `app/test/new_game_leader_selection_dialog_test.dart` — six-slot rendering, default ordering, seed parsing, infinite-mode toggle, terrain-variation slider, Cancel, slot reassignment, Start payload, the 500 dp wide↔narrow slot-pickers boundary, and the duplicate slot validation feedback contract (positive: duplicate slot's nation dropdown carries the danger-border wrapper; negative: no danger-border wrapper when all six slots are unique; recovery: replacing the duplicate clears the wrapper and re-enables Start).
 - `app/test/mobile_320dp_min_viewport_test.dart` group `SPEC/ui/mobile-adaptation.md § 7 — NewGameLeaderSelectionDialog @ 320 dp` — minimum-viewport pin (Refs #2870 S7/S8/S10): no `RenderFlex` overflow at 320 × 640 dp, every slot renders the stacked column body (no wide row body), title + six slot labels + Cancel + Start labels visible, every rendered `CtNinePatchButton` ≥ 44 dp tall, and a 1024 × 768 negative regression sentinel that flips the contract so the wide row body is the only one mounted.

--- a/app/lib/features/shell/new_game_leader_selection_dialog.dart
+++ b/app/lib/features/shell/new_game_leader_selection_dialog.dart
@@ -48,6 +48,24 @@ class NewGameLeaderSelectionDialog extends StatefulWidget {
   /// Default terrain-variation slider value (matches `GameSetupConfig.terrainVariation` default).
   static const double defaultTerrainVariation = 0.5;
 
+  /// Width of the danger border painted around a slot's nation dropdown when
+  /// the slot's currently-selected Great Power id also appears in another
+  /// slot. Pinned to 1 dp so the visual cue does not shift slot layout.
+  /// SPEC: `SPEC/ui/new-game-leader-selection-dialog.md` § Duplicate slot
+  /// validation feedback (Refs #2867 R19).
+  static const double duplicateSlotBorderWidth = 1.0;
+
+  /// Stable key prefix for the danger-border wrapper rendered around the
+  /// nation dropdown of slot `slotIndex` when that slot is part of a
+  /// duplicate group. Tests pin the per-slot key
+  /// `'newGameLeaderDialogSlotDuplicateBorder_<slotIndex>'` so the positive
+  /// AC can assert that exactly the duplicate slots carry the danger
+  /// border without depending on widget tree order. The wrapper is only
+  /// mounted when the slot is detected as a duplicate; non-duplicate
+  /// slots render the nation dropdown directly without this key.
+  static String duplicateSlotBorderKey(int slotIndex) =>
+      'newGameLeaderDialogSlotDuplicateBorder_$slotIndex';
+
   /// Parses seed field text for [GameSetupConfig.seed]: empty or invalid → 42; negative → 42.
   static int parseSeedInput(String text) {
     final trimmed = text.trim();
@@ -107,6 +125,35 @@ class _NewGameLeaderSelectionDialogState
     super.dispose();
   }
 
+  /// Indices of slots whose currently-selected Great Power id also appears
+  /// in at least one other slot. Empty when every populated slot holds a
+  /// unique GP id. Empty slot ids (`''`) are ignored so unset slots do not
+  /// register as duplicates of one another.
+  ///
+  /// SPEC: `SPEC/ui/new-game-leader-selection-dialog.md` § Duplicate slot
+  /// validation feedback (Refs #2867 R19) — drives the danger border
+  /// painted around the duplicate slot's nation dropdown.
+  Set<int> _duplicateSlotIndices() {
+    final counts = <String, int>{};
+    for (final id in _orderedGpIdsBySlot) {
+      if (id.isEmpty) {
+        continue;
+      }
+      counts[id] = (counts[id] ?? 0) + 1;
+    }
+    final duplicates = <int>{};
+    for (var i = 0; i < _kNumSlots; i++) {
+      final id = _orderedGpIdsBySlot[i];
+      if (id.isEmpty) {
+        continue;
+      }
+      if ((counts[id] ?? 0) > 1) {
+        duplicates.add(i);
+      }
+    }
+    return duplicates;
+  }
+
   List<String> _availableGpIdsForSlot(int slotIndex) {
     final current = _orderedGpIdsBySlot[slotIndex];
     final takenElsewhere = <String>{};
@@ -162,8 +209,15 @@ class _NewGameLeaderSelectionDialogState
     final l10n = appL10n(context);
     final ThemeData theme = Theme.of(context);
     final _LeaderDialogTextStyles styles = _resolveTextStyles(theme);
+    final Set<int> duplicateSlots = _duplicateSlotIndices();
     final slotWidgets = <Widget>[
-      for (var i = 0; i < _kNumSlots; i++) _buildSlotRow(context, i, l10n),
+      for (var i = 0; i < _kNumSlots; i++)
+        _buildSlotRow(
+          context,
+          i,
+          l10n,
+          isDuplicate: duplicateSlots.contains(i),
+        ),
     ];
     return CtDialogShell(
       maxWidth: 480,
@@ -202,8 +256,7 @@ class _NewGameLeaderSelectionDialogState
       title: (theme.textTheme.titleMedium ?? const TextStyle(fontSize: 16))
           .copyWith(
             color: EditorialMonoclePalette.accent,
-            letterSpacing:
-                (theme.textTheme.titleMedium?.fontSize ?? 16) * 0.05,
+            letterSpacing: (theme.textTheme.titleMedium?.fontSize ?? 16) * 0.05,
             fontWeight: FontWeight.w600,
           ),
       intro: (theme.textTheme.bodyMedium ?? const TextStyle(fontSize: 14))
@@ -217,17 +270,11 @@ class _NewGameLeaderSelectionDialogState
             fontWeight: FontWeight.w600,
           ),
       helper: (theme.textTheme.bodySmall ?? const TextStyle(fontSize: 12))
-          .copyWith(
-            color: EditorialMonoclePalette.muted,
-            fontSize: 12,
-          ),
+          .copyWith(color: EditorialMonoclePalette.muted, fontSize: 12),
     );
   }
 
-  Widget _buildHeader(
-    AppLocalizations l10n,
-    _LeaderDialogTextStyles styles,
-  ) {
+  Widget _buildHeader(AppLocalizations l10n, _LeaderDialogTextStyles styles) {
     return Column(
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -319,10 +366,7 @@ class _NewGameLeaderSelectionDialogState
     );
   }
 
-  Widget _buildFooterButtons(
-    AppLocalizations l10n,
-    BuildContext context,
-  ) {
+  Widget _buildFooterButtons(AppLocalizations l10n, BuildContext context) {
     return Row(
       mainAxisAlignment: MainAxisAlignment.end,
       children: [
@@ -391,8 +435,9 @@ class _NewGameLeaderSelectionDialogState
   Widget _buildSlotRow(
     BuildContext context,
     int slotIndex,
-    AppLocalizations l10n,
-  ) {
+    AppLocalizations l10n, {
+    bool isDuplicate = false,
+  }) {
     final gpId = _orderedGpIdsBySlot[slotIndex];
     final available = _availableGpIdsForSlot(slotIndex);
     final effectiveGpId = available.contains(gpId) ? gpId : available.first;
@@ -404,7 +449,7 @@ class _NewGameLeaderSelectionDialogState
     final currentVariantId =
         _leaderByGpId[effectiveGpId] ?? gp.defaultLeaderVariantId;
 
-    final nationDropdown = CtDropdown<String>(
+    final Widget nationDropdownCore = CtDropdown<String>(
       value: effectiveGpId,
       items: available,
       hint: l10n.shell_newGame_selectNation,
@@ -424,6 +469,27 @@ class _NewGameLeaderSelectionDialogState
         });
       },
     );
+
+    // Duplicate slot validation feedback (Refs #2867 R19): wrap the nation
+    // dropdown in a 1 dp `--danger` border when this slot's GP id also
+    // appears in another slot. The wrapper is keyed by slot index so widget
+    // tests can assert that exactly the duplicate slots carry the border.
+    // Non-duplicate slots render the dropdown directly (no key) so the
+    // negative AC has a definite absence to assert.
+    final Widget nationDropdown = isDuplicate
+        ? DecoratedBox(
+            key: ValueKey<String>(
+              NewGameLeaderSelectionDialog.duplicateSlotBorderKey(slotIndex),
+            ),
+            decoration: BoxDecoration(
+              border: Border.all(
+                color: EditorialMonoclePalette.danger,
+                width: NewGameLeaderSelectionDialog.duplicateSlotBorderWidth,
+              ),
+            ),
+            child: nationDropdownCore,
+          )
+        : nationDropdownCore;
 
     final leaderDropdown = CtDropdown<String>(
       value: variants.any((v) => v.id == currentVariantId)

--- a/app/lib/widgetbook/catalog_part4.dart
+++ b/app/lib/widgetbook/catalog_part4.dart
@@ -73,10 +73,7 @@ class _CtDialogueViewStoryHarnessState
     final project = YarnProject();
     project.parse(_kCtDialogueViewStorySource);
     final view = CtDialogueView();
-    final runner = DialogueRunner(
-      yarnProject: project,
-      dialogueViews: [view],
-    );
+    final runner = DialogueRunner(yarnProject: project, dialogueViews: [view]);
     view.onStateChanged = (_, _) {
       if (mounted) setState(() {});
     };
@@ -146,7 +143,8 @@ List<WidgetbookNode> get gameStartIntroOverlayDirectories => [
         name: 'Default — single-line intro',
         builder: (context) => MaterialApp(
           theme: AppThemes.editorialMonocle,
-          localizationsDelegates: AppLocalizationsBinding.localizationsDelegates,
+          localizationsDelegates:
+              AppLocalizationsBinding.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
           home: Scaffold(
             body: GameStartIntroOverlay(
@@ -198,7 +196,8 @@ List<WidgetbookNode> get overtureDialogueOverlayDirectories => [
         name: 'Default — two pending overtures',
         builder: (context) => MaterialApp(
           theme: AppThemes.editorialMonocle,
-          localizationsDelegates: AppLocalizationsBinding.localizationsDelegates,
+          localizationsDelegates:
+              AppLocalizationsBinding.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
           home: Scaffold(
             body: OvertureDialogueOverlay(
@@ -217,9 +216,7 @@ List<WidgetbookNode> get overtureDialogueOverlayDirectories => [
               ],
               skipIntroForTest: true,
               onDecisions: (_) {},
-              child: Center(
-                child: Text(appL10n(context).widgetbook_gameShell),
-              ),
+              child: Center(child: Text(appL10n(context).widgetbook_gameShell)),
             ),
           ),
         ),
@@ -275,7 +272,8 @@ List<WidgetbookNode> get callToArmsDialogueOverlayDirectories => [
         name: 'Default — two pending calls',
         builder: (context) => MaterialApp(
           theme: AppThemes.editorialMonocle,
-          localizationsDelegates: AppLocalizationsBinding.localizationsDelegates,
+          localizationsDelegates:
+              AppLocalizationsBinding.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
           home: Scaffold(
             body: CallToArmsDialogueOverlay(
@@ -293,9 +291,7 @@ List<WidgetbookNode> get callToArmsDialogueOverlayDirectories => [
                 ),
               ],
               onDecisions: (_) {},
-              child: Center(
-                child: Text(appL10n(context).widgetbook_gameShell),
-              ),
+              child: Center(child: Text(appL10n(context).widgetbook_gameShell)),
             ),
           ),
         ),
@@ -304,15 +300,15 @@ List<WidgetbookNode> get callToArmsDialogueOverlayDirectories => [
   ),
 ];
 
-MaterialApp _moveDialogStoryFrame({required Widget Function(BuildContext) open}) {
+MaterialApp _moveDialogStoryFrame({
+  required Widget Function(BuildContext) open,
+}) {
   return MaterialApp(
     theme: AppThemes.editorialMonocle,
     localizationsDelegates: AppLocalizationsBinding.localizationsDelegates,
     supportedLocales: AppLocalizations.supportedLocales,
     home: Scaffold(
-      body: Center(
-        child: Builder(builder: open),
-      ),
+      body: Center(child: Builder(builder: open)),
     ),
   );
 }
@@ -828,6 +824,57 @@ List<WidgetbookNode> get newGameLeaderSelectionDialogDirectories => [
                 },
                 // ignore: avoid_hardcoded_strings_in_widgets
                 child: const Text('Open New Game Leader Selection'),
+              );
+            },
+          );
+        },
+      ),
+      WidgetbookUseCase(
+        name: 'Duplicate slot regression — England in slots 1 and 6',
+        builder: (context) {
+          // Two slots carry the same Great Power id ("england"). Demonstrates
+          // the duplicate slot validation feedback contract (Refs #2867
+          // R19): both duplicate slot rows wrap their nation `CtDropdown` in
+          // a 1 dp `EditorialMonoclePalette.danger` `DecoratedBox`, and the
+          // Start `CtNinePatchButton` remains disabled until the duplicate
+          // is resolved. SPEC:
+          // `SPEC/ui/new-game-leader-selection-dialog.md` § Duplicate slot
+          // validation feedback.
+          final base = GameSetupConfig(
+            selectedGreatPowerIds: const [
+              'england',
+              'france',
+              'spain',
+              'portugal',
+              'netherlands',
+              'england',
+            ],
+          );
+          final naming = defaultNamingConfig;
+          final initial = <String, String>{};
+          for (final gpId in base.selectedGreatPowerIds) {
+            final gp = naming.gpById(gpId);
+            if (gp != null && gp.leaderVariants.isNotEmpty) {
+              initial[gpId] = gp.defaultLeaderVariantId;
+            }
+          }
+          return _moveDialogStoryFrame(
+            open: (innerContext) {
+              return ElevatedButton(
+                onPressed: () {
+                  showDialog<void>(
+                    context: innerContext,
+                    builder: (_) => NewGameLeaderSelectionDialog(
+                      baseConfig: base,
+                      naming: naming,
+                      initialLeaderByGpId: initial,
+                      onCancel: () => Navigator.of(innerContext).pop(),
+                      onConfirmed: (_, _, _, _, _) {},
+                    ),
+                  );
+                },
+                // ignore: avoid_hardcoded_strings_in_widgets
+                child: const Text('Open Duplicate-Slot Leader Selection'),
               );
             },
           );

--- a/app/test/new_game_leader_selection_dialog_test.dart
+++ b/app/test/new_game_leader_selection_dialog_test.dart
@@ -79,7 +79,8 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           theme: AppThemes.colonial,
-          localizationsDelegates: AppLocalizationsBinding.localizationsDelegates,
+          localizationsDelegates:
+              AppLocalizationsBinding.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
           locale: const Locale('en'),
           home: Scaffold(
@@ -152,10 +153,7 @@ void main() {
 
         final shell = find.byType(CtDialogShell);
         expect(
-          find.descendant(
-            of: shell,
-            matching: find.byType(CustomScrollView),
-          ),
+          find.descendant(of: shell, matching: find.byType(CustomScrollView)),
           findsOneWidget,
         );
 
@@ -299,7 +297,8 @@ void main() {
       bool? gotInfiniteMode;
       await pumpDialog(
         tester,
-        onConfirmed: (_, _, _, infiniteMode, _) => gotInfiniteMode = infiniteMode,
+        onConfirmed: (_, _, _, infiniteMode, _) =>
+            gotInfiniteMode = infiniteMode,
       );
       final checkbox = find.byType(Checkbox);
       await tester.ensureVisible(checkbox);
@@ -315,10 +314,7 @@ void main() {
       (WidgetTester tester) async {
         await pumpDialog(tester, onConfirmed: (_, _, _, _, _) {});
         expect(find.byType(CtSlider), findsOneWidget);
-        expect(
-          find.textContaining('Terrain variation'),
-          findsOneWidget,
-        );
+        expect(find.textContaining('Terrain variation'), findsOneWidget);
         expect(
           find.textContaining('Higher values produce more mixed terrain'),
           findsOneWidget,
@@ -383,6 +379,259 @@ void main() {
       },
     );
 
+    // Duplicate slot validation feedback contract (#2867 R19).
+    //
+    // SPEC: `SPEC/ui/new-game-leader-selection-dialog.md`
+    // § Duplicate slot validation feedback. Positive AC pins that every
+    // duplicate slot's nation `CtDropdown<String>` is wrapped in a keyed
+    // `DecoratedBox` painting a 1 dp `EditorialMonoclePalette.danger`
+    // border. Negative AC pins the absence of that wrapper when all six
+    // slots hold unique ids. Recovery AC pins that swapping a duplicate
+    // slot to a previously unused nation unmounts the wrapper and
+    // re-enables Start.
+    group('Duplicate slot validation feedback (#2867 R19)', () {
+      Future<void> pumpDialogWithConfig(
+        WidgetTester tester, {
+        required GameSetupConfig baseConfig,
+        Size surfaceSize = const Size(900, 1600),
+        void Function(
+          List<String> orderedGreatPowerIds,
+          Map<String, String> leaderVariantByGpId,
+          int seed,
+          bool infiniteMode,
+          double terrainVariation,
+        )?
+        onConfirmed,
+      }) async {
+        addTearDown(tester.view.reset);
+        tester.view.physicalSize = surfaceSize;
+        tester.view.devicePixelRatio = 1.0;
+        await tester.pumpWidget(
+          MaterialApp(
+            theme: AppThemes.colonial,
+            localizationsDelegates:
+                AppLocalizationsBinding.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            locale: const Locale('en'),
+            home: Scaffold(
+              body: Builder(
+                builder: (context) {
+                  return TextButton(
+                    onPressed: () {
+                      final naming = defaultNamingConfig;
+                      final initial = <String, String>{};
+                      for (final gpId in baseConfig.selectedGreatPowerIds) {
+                        final gp = naming.gpById(gpId);
+                        if (gp != null && gp.leaderVariants.isNotEmpty) {
+                          initial[gpId] = gp.defaultLeaderVariantId;
+                        }
+                      }
+                      showDialog<void>(
+                        context: context,
+                        builder: (ctx) => NewGameLeaderSelectionDialog(
+                          baseConfig: baseConfig,
+                          naming: naming,
+                          initialLeaderByGpId: initial,
+                          onCancel: () => Navigator.of(ctx).pop(),
+                          onConfirmed: onConfirmed ?? (_, _, _, _, _) {},
+                        ),
+                      );
+                    },
+                    child: const Text('open'),
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('open'));
+        await tester.pumpAndSettle();
+      }
+
+      bool hasDangerBorder(WidgetTester tester, int slotIndex) {
+        final finder = find.byKey(
+          ValueKey<String>(
+            NewGameLeaderSelectionDialog.duplicateSlotBorderKey(slotIndex),
+          ),
+        );
+        if (finder.evaluate().isEmpty) {
+          return false;
+        }
+        final DecoratedBox box = tester.widget<DecoratedBox>(finder);
+        final BoxDecoration decoration = box.decoration as BoxDecoration;
+        final BoxBorder? border = decoration.border;
+        if (border is! Border) {
+          return false;
+        }
+        return border.top.color == EditorialMonoclePalette.danger &&
+            border.top.width ==
+                NewGameLeaderSelectionDialog.duplicateSlotBorderWidth;
+      }
+
+      testWidgets(
+        'positive: two slots sharing England wrap both nation dropdowns in '
+        '1 dp --danger DecoratedBox and Start stays disabled',
+        (WidgetTester tester) async {
+          // Force duplicate by repeating "england" in slots 0 and 5.
+          final config = GameSetupConfig(
+            selectedGreatPowerIds: const [
+              'england',
+              'france',
+              'spain',
+              'portugal',
+              'netherlands',
+              'england',
+            ],
+          );
+
+          await pumpDialogWithConfig(tester, baseConfig: config);
+
+          expect(
+            hasDangerBorder(tester, 0),
+            isTrue,
+            reason:
+                'Slot 0 holds the duplicate "england" id — its nation '
+                'dropdown must be wrapped in the keyed danger border per '
+                '#2867 R19.',
+          );
+          expect(
+            hasDangerBorder(tester, 5),
+            isTrue,
+            reason:
+                'Slot 5 also holds the duplicate "england" id — its '
+                'nation dropdown must carry the keyed danger border.',
+          );
+          for (final i in const [1, 2, 3, 4]) {
+            expect(
+              hasDangerBorder(tester, i),
+              isFalse,
+              reason: 'Slot $i holds a unique id; no danger border.',
+            );
+          }
+
+          final Finder startButtonText = find.text('Start');
+          await tester.ensureVisible(startButtonText);
+          await tester.pumpAndSettle();
+          final CtNinePatchButton startButton = tester
+              .widget<CtNinePatchButton>(
+                find.ancestor(
+                  of: startButtonText,
+                  matching: find.byType(CtNinePatchButton),
+                ),
+              );
+          expect(
+            startButton.enabled,
+            isFalse,
+            reason:
+                'Start must remain disabled while any slot is part of a '
+                'duplicate group (mirrors _startEnabled rejecting '
+                'duplicates).',
+          );
+        },
+      );
+
+      testWidgets('negative: default config (six unique nations) mounts no '
+          'danger-border wrapper under any slot', (WidgetTester tester) async {
+        await pumpDialogWithConfig(
+          tester,
+          baseConfig: GameSetupConfig.defaultConfig,
+        );
+
+        for (var i = 0; i < 6; i++) {
+          final finder = find.byKey(
+            ValueKey<String>(
+              NewGameLeaderSelectionDialog.duplicateSlotBorderKey(i),
+            ),
+          );
+          expect(
+            finder,
+            findsNothing,
+            reason:
+                'Slot $i: with six unique nations, no slot must carry '
+                'the duplicate-border wrapper (negative AC).',
+          );
+        }
+      });
+
+      testWidgets(
+        'recovery: replacing the duplicate nation unmounts the wrapper and '
+        're-enables Start',
+        (WidgetTester tester) async {
+          final config = GameSetupConfig(
+            selectedGreatPowerIds: const [
+              'england',
+              'france',
+              'spain',
+              'portugal',
+              'netherlands',
+              'england',
+            ],
+          );
+
+          await pumpDialogWithConfig(tester, baseConfig: config);
+
+          // Confirm initial duplicate borders are present.
+          expect(hasDangerBorder(tester, 0), isTrue);
+          expect(hasDangerBorder(tester, 5), isTrue);
+
+          // Open slot 5's nation dropdown (the second "England" instance)
+          // and pick a previously unused nation. Slot 5's dropdown is the
+          // last keyed border wrapper, so its descendant CtDropdown is
+          // unambiguous.
+          final slot5Border = find.byKey(
+            ValueKey<String>(
+              NewGameLeaderSelectionDialog.duplicateSlotBorderKey(5),
+            ),
+          );
+          final slot5Dropdown = find.descendant(
+            of: slot5Border,
+            matching: find.byType(CtDropdown<String>),
+          );
+          await tester.ensureVisible(slot5Dropdown);
+          await tester.pumpAndSettle();
+          await tester.tap(slot5Dropdown);
+          await tester.pumpAndSettle();
+
+          // Pick "Sweden" — not present in any other slot in this config.
+          await tester.tap(find.text('Sweden').last);
+          await tester.pumpAndSettle();
+
+          // Both wrappers must now be absent — slot 0's id is unique
+          // again and slot 5 holds a fresh unique id.
+          for (var i = 0; i < 6; i++) {
+            final finder = find.byKey(
+              ValueKey<String>(
+                NewGameLeaderSelectionDialog.duplicateSlotBorderKey(i),
+              ),
+            );
+            expect(
+              finder,
+              findsNothing,
+              reason:
+                  'After resolving the duplicate, no slot must carry the '
+                  'duplicate-border wrapper.',
+            );
+          }
+
+          final CtNinePatchButton startButton = tester
+              .widget<CtNinePatchButton>(
+                find.ancestor(
+                  of: find.text('Start'),
+                  matching: find.byType(CtNinePatchButton),
+                ),
+              );
+          expect(
+            startButton.enabled,
+            isTrue,
+            reason:
+                'Start must re-enable once every slot holds a unique '
+                'non-empty Great Power id (mirrors _startEnabled).',
+          );
+        },
+      );
+    });
+
     // Dark editorial-monocle chrome contract (#2867 S6 / R1 / R2 / R21).
     //
     // Pins the keyed title color + `letterSpacing == fontSize * 0.05`, the
@@ -406,70 +655,66 @@ void main() {
           expect(
             title.style?.letterSpacing,
             closeTo(fontSize * 0.05, 1e-9),
-            reason: 'letterSpacing must scale with the resolved fontSize so '
+            reason:
+                'letterSpacing must scale with the resolved fontSize so '
                 'theme text-scale overrides preserve the canonical 0.05em '
                 'ratio (#2867 R2).',
           );
         },
       );
 
-      testWidgets(
-        'renders exactly one CtBrassDivider keyed below the title',
-        (WidgetTester tester) async {
-          await pumpDialog(tester, onConfirmed: (_, _, _, _, _) {});
-          final dividerFinder = find.byKey(
-            const ValueKey<String>('leaderSelectionDialogBrassDivider'),
-          );
-          expect(dividerFinder, findsOneWidget);
-          expect(find.byType(CtBrassDivider), findsOneWidget);
-          final Rect titleRect = tester.getRect(
-            find.byKey(
-              const ValueKey<String>('leaderSelectionDialogTitle'),
-            ),
-          );
-          final Rect dividerRect = tester.getRect(dividerFinder);
-          expect(
-            dividerRect.top,
-            greaterThanOrEqualTo(titleRect.bottom),
-            reason: 'Brass divider must paint below the title band per '
-                '#2867 R21 chrome ordering.',
-          );
-        },
-      );
+      testWidgets('renders exactly one CtBrassDivider keyed below the title', (
+        WidgetTester tester,
+      ) async {
+        await pumpDialog(tester, onConfirmed: (_, _, _, _, _) {});
+        final dividerFinder = find.byKey(
+          const ValueKey<String>('leaderSelectionDialogBrassDivider'),
+        );
+        expect(dividerFinder, findsOneWidget);
+        expect(find.byType(CtBrassDivider), findsOneWidget);
+        final Rect titleRect = tester.getRect(
+          find.byKey(const ValueKey<String>('leaderSelectionDialogTitle')),
+        );
+        final Rect dividerRect = tester.getRect(dividerFinder);
+        expect(
+          dividerRect.top,
+          greaterThanOrEqualTo(titleRect.bottom),
+          reason:
+              'Brass divider must paint below the title band per '
+              '#2867 R21 chrome ordering.',
+        );
+      });
 
-      testWidgets(
-        'intro paints --muted italic body color',
-        (WidgetTester tester) async {
-          await pumpDialog(tester, onConfirmed: (_, _, _, _, _) {});
-          final introFinder = find.byKey(
-            const ValueKey<String>('leaderSelectionDialogIntro'),
-          );
-          expect(introFinder, findsOneWidget);
-          final Text intro = tester.widget<Text>(introFinder);
-          expect(intro.style?.color, EditorialMonoclePalette.muted);
-          expect(intro.style?.fontStyle, FontStyle.italic);
-        },
-      );
+      testWidgets('intro paints --muted italic body color', (
+        WidgetTester tester,
+      ) async {
+        await pumpDialog(tester, onConfirmed: (_, _, _, _, _) {});
+        final introFinder = find.byKey(
+          const ValueKey<String>('leaderSelectionDialogIntro'),
+        );
+        expect(introFinder, findsOneWidget);
+        final Text intro = tester.widget<Text>(introFinder);
+        expect(intro.style?.color, EditorialMonoclePalette.muted);
+        expect(intro.style?.fontStyle, FontStyle.italic);
+      });
 
-      testWidgets(
-        'title does NOT use the raw textTheme.titleMedium color '
-        '(regression guard against unstyled headings)',
-        (WidgetTester tester) async {
-          await pumpDialog(tester, onConfirmed: (_, _, _, _, _) {});
-          final Text title = tester.widget<Text>(
-            find.byKey(
-              const ValueKey<String>('leaderSelectionDialogTitle'),
-            ),
-          );
-          expect(
-            title.style?.color,
-            isNot(equals(AppThemes.colonial.textTheme.titleMedium?.color)),
-            reason: 'A regression that drops the EditorialMonoclePalette '
-                'override would surface the colonial titleMedium color '
-                'instead of the canonical --accent token (#2867 R1).',
-          );
-        },
-      );
+      testWidgets('title does NOT use the raw textTheme.titleMedium color '
+          '(regression guard against unstyled headings)', (
+        WidgetTester tester,
+      ) async {
+        await pumpDialog(tester, onConfirmed: (_, _, _, _, _) {});
+        final Text title = tester.widget<Text>(
+          find.byKey(const ValueKey<String>('leaderSelectionDialogTitle')),
+        );
+        expect(
+          title.style?.color,
+          isNot(equals(AppThemes.colonial.textTheme.titleMedium?.color)),
+          reason:
+              'A regression that drops the EditorialMonoclePalette '
+              'override would surface the colonial titleMedium color '
+              'instead of the canonical --accent token (#2867 R1).',
+        );
+      });
     });
   });
 
@@ -490,7 +735,8 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           theme: AppThemes.colonial,
-          localizationsDelegates: AppLocalizationsBinding.localizationsDelegates,
+          localizationsDelegates:
+              AppLocalizationsBinding.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
           locale: const Locale('en'),
           home: Scaffold(
@@ -530,82 +776,73 @@ void main() {
       await tester.pumpAndSettle();
     }
 
-    testWidgets(
-      'wide viewport (>= 500 dp): slot bodies render side-by-side row, '
-      'no stacked column body, no exception',
-      (WidgetTester tester) async {
-        await pumpDialogAt(tester, surfaceSize: const Size(800, 1300));
+    testWidgets('wide viewport (>= 500 dp): slot bodies render side-by-side row, '
+        'no stacked column body, no exception', (WidgetTester tester) async {
+      await pumpDialogAt(tester, surfaceSize: const Size(800, 1300));
 
-        expect(tester.takeException(), isNull);
-        expect(
-          find.byKey(_kSlotPickersSideBySideRowKey),
-          findsNWidgets(6),
-          reason:
-              'Wide viewport must render one side-by-side row per slot '
-              '(SPEC/ui/new-game-leader-selection-dialog.md narrow stacking AC).',
-        );
-        expect(
-          find.byKey(_kSlotPickersStackedColumnKey),
-          findsNothing,
-          reason:
-              'Wide viewport must not mount the stacked column body '
-              '(negative AC).',
-        );
-        expect(
-          find.byType(CtDropdown<String>),
-          findsAtLeast(12),
-          reason: 'Six slot rows × (nation + leader) = 12 dropdowns.',
-        );
-      },
-    );
+      expect(tester.takeException(), isNull);
+      expect(
+        find.byKey(_kSlotPickersSideBySideRowKey),
+        findsNWidgets(6),
+        reason:
+            'Wide viewport must render one side-by-side row per slot '
+            '(SPEC/ui/new-game-leader-selection-dialog.md narrow stacking AC).',
+      );
+      expect(
+        find.byKey(_kSlotPickersStackedColumnKey),
+        findsNothing,
+        reason:
+            'Wide viewport must not mount the stacked column body '
+            '(negative AC).',
+      );
+      expect(
+        find.byType(CtDropdown<String>),
+        findsAtLeast(12),
+        reason: 'Six slot rows × (nation + leader) = 12 dropdowns.',
+      );
+    });
 
-    testWidgets(
-      'narrow viewport (< 500 dp): slot bodies render stacked column, '
-      'no side-by-side row body, no exception',
-      (WidgetTester tester) async {
-        await pumpDialogAt(tester, surfaceSize: const Size(480, 1300));
+    testWidgets('narrow viewport (< 500 dp): slot bodies render stacked column, '
+        'no side-by-side row body, no exception', (WidgetTester tester) async {
+      await pumpDialogAt(tester, surfaceSize: const Size(480, 1300));
 
-        expect(tester.takeException(), isNull);
-        expect(
-          find.byKey(_kSlotPickersStackedColumnKey),
-          findsNWidgets(6),
-          reason:
-              'Narrow viewport must render one stacked column per slot '
-              '(SPEC/ui/new-game-leader-selection-dialog.md narrow stacking AC).',
-        );
-        expect(
-          find.byKey(_kSlotPickersSideBySideRowKey),
-          findsNothing,
-          reason:
-              'Narrow viewport must not mount the side-by-side row body '
-              '(negative AC).',
-        );
-        expect(
-          find.byType(CtDropdown<String>),
-          findsAtLeast(12),
-          reason:
-              'Both nation and leader dropdowns still mount in the stacked '
-              'layout — six slots × two dropdowns = 12.',
-        );
-      },
-    );
+      expect(tester.takeException(), isNull);
+      expect(
+        find.byKey(_kSlotPickersStackedColumnKey),
+        findsNWidgets(6),
+        reason:
+            'Narrow viewport must render one stacked column per slot '
+            '(SPEC/ui/new-game-leader-selection-dialog.md narrow stacking AC).',
+      );
+      expect(
+        find.byKey(_kSlotPickersSideBySideRowKey),
+        findsNothing,
+        reason:
+            'Narrow viewport must not mount the side-by-side row body '
+            '(negative AC).',
+      );
+      expect(
+        find.byType(CtDropdown<String>),
+        findsAtLeast(12),
+        reason:
+            'Both nation and leader dropdowns still mount in the stacked '
+            'layout — six slots × two dropdowns = 12.',
+      );
+    });
 
-    testWidgets(
-      'boundary: viewport exactly at 500 dp uses wide row body '
-      '(breakpoint is strict <)',
-      (WidgetTester tester) async {
-        await pumpDialogAt(tester, surfaceSize: const Size(500, 1300));
+    testWidgets('boundary: viewport exactly at 500 dp uses wide row body '
+        '(breakpoint is strict <)', (WidgetTester tester) async {
+      await pumpDialogAt(tester, surfaceSize: const Size(500, 1300));
 
-        expect(tester.takeException(), isNull);
-        expect(
-          find.byKey(_kSlotPickersSideBySideRowKey),
-          findsNWidgets(6),
-          reason:
-              '500 dp is the boundary — kGameSetupNarrowBreakpoint is a '
-              'strict less-than check, so 500 dp keeps the wide row body.',
-        );
-        expect(find.byKey(_kSlotPickersStackedColumnKey), findsNothing);
-      },
-    );
+      expect(tester.takeException(), isNull);
+      expect(
+        find.byKey(_kSlotPickersSideBySideRowKey),
+        findsNWidgets(6),
+        reason:
+            '500 dp is the boundary — kGameSetupNarrowBreakpoint is a '
+            'strict less-than check, so 500 dp keeps the wide row body.',
+      );
+      expect(find.byKey(_kSlotPickersStackedColumnKey), findsNothing);
+    });
   });
 }


### PR DESCRIPTION
## Scope

Adds the visual validation feedback contract for `NewGameLeaderSelectionDialog` (DLG10001) when two or more slots share the same Great Power id. Closes the #2867 R19 acceptance criterion that *"the duplicate slot's nation dropdown border resolves to `--danger`"* while Start stays disabled — the existing `_startEnabled` already rejected duplicates structurally, but the canonical visual cue was missing.

`Refs #2867` — does not auto-close; #2867 stays open until every R-numbered requirement / sub-screen pin is verified end-to-end.

## Done in this push (Refs #2867 R19)

### SPEC

- `SPEC/ui/new-game-leader-selection-dialog.md`:
  - § Layout / wireframe: documents the new keyed `DecoratedBox` wrapper painted around the nation `CtDropdown<String>` of every duplicate slot (1 dp `EditorialMonoclePalette.danger` `Border.all` at `NewGameLeaderSelectionDialog.duplicateSlotBorderWidth`).
  - § States and variants → **Slot duplicate** row: appends the wrapper contract to the existing "Start disabled" outcome.
  - New **§ Duplicate slot validation feedback (#2867 R19)** AC group — three Given–When–Then ACs covering positive (both duplicate slot nation dropdowns mount the keyed wrapper, Start stays disabled), negative (no wrapper when all six ids are unique), and recovery (replacing the duplicate unmounts every wrapper and re-enables Start).
  - § Widgetbook: lists the new `Duplicate slot regression — England in slots 1 and 6` story alongside the existing default.

### Implementation

- `app/lib/features/shell/new_game_leader_selection_dialog.dart`:
  - New `NewGameLeaderSelectionDialog._duplicateSlotIndices()` flags every slot whose `_orderedGpIdsBySlot[i]` value also appears in another slot (empty ids ignored).
  - `_buildSlotRow` takes a new `isDuplicate` named arg; when `true`, wraps the nation `CtDropdown<String>` in a keyed `DecoratedBox` painting a 1 dp `EditorialMonoclePalette.danger` `Border.all`. The wrapper key — `NewGameLeaderSelectionDialog.duplicateSlotBorderKey(i)` → `newGameLeaderDialogSlotDuplicateBorder_<i>` — is a stable test hook so widget tests don't depend on widget-tree order.
  - Non-duplicate slot rows render the dropdown directly (no wrapper, no key), so the negative AC has a definite absence to assert.
  - Public token surface for tests: `NewGameLeaderSelectionDialog.duplicateSlotBorderKey(int slotIndex)` + `duplicateSlotBorderWidth` (1 dp).
  - The existing `effectiveGpId` coercion (when the slot's id is filtered out by `_availableGpIdsForSlot`) is unchanged; `_startEnabled` already rejected duplicates and continues to (no semantic change to the start gate).

### Widgetbook

- `app/lib/widgetbook/catalog_part4.dart`: registers the new `Duplicate slot regression — England in slots 1 and 6` story under the existing `New Game Leader Selection Dialog` folder, mounting `selectedGreatPowerIds = [england, france, spain, portugal, netherlands, england]` so reviewers can visually inspect the danger-border wrapper under `AppThemes.editorialMonocle`.

### Test

`app/test/new_game_leader_selection_dialog_test.dart` — new group `Duplicate slot validation feedback (#2867 R19)` with three cases, all green:

1. **Positive — duplicate ids on slots 0 and 5 wrap both nation dropdowns.** `selectedGreatPowerIds = [england, france, spain, portugal, netherlands, england]`. Asserts that the keyed `DecoratedBox` wrapper is mounted under slot 0 and slot 5 (and only those slots), the wrapper's `Border.all` resolves to `EditorialMonoclePalette.danger` at 1 dp, and the Start `CtNinePatchButton.enabled` stays `false`.
2. **Negative — default config (six unique nations) mounts no wrapper under any slot.** Iterates all six slot keys and asserts each `findsNothing`.
3. **Recovery — replacing the duplicate nation clears the wrapper and re-enables Start.** Opens slot 5's nation dropdown, picks `Sweden` (not in any other slot), then asserts every duplicate-border key is absent and Start `CtNinePatchButton.enabled` flips to `true`.

## Acceptance criteria covered

| AC source | Coverage |
|---|---|
| Issue #2867 R19 — "Duplicate selection MUST be prevented (slot reset or auto-swap) **and surfaced to the user** (see AC for validation feedback)" | New positive + negative + recovery tests |
| Issue #2867 AC — *"Given the leader selection dialog is open with at least two slots filled with the same nation, when ... then validation feedback is presented (e.g. the duplicate slot's nation dropdown border resolves to --danger) and the Start Game button remains disabled until duplicates are removed."* | Positive + recovery tests |
| `SPEC/ui/new-game-leader-selection-dialog.md` § Duplicate slot validation feedback (#2867 R19) — three new ACs | All three tests map 1:1 |

## Tests

- `flutter test app/test/new_game_leader_selection_dialog_test.dart` → **25/25 pass** (3 new + 22 prior, ≈10 s wall-clock).
- `flutter test app/test/new_game_leader_selection_dialog_test.dart app/test/mobile_320dp_min_viewport_test.dart` → **40/40 pass** (no regression in the 320 dp narrow pin landed under #2870 S7/S8/S10, no exception under any narrow / wide viewport).
- `flutter test app/test/shell_screen_test.dart app/test/app_shell_routes_test.dart` → **9/9 pass** (no regression in shell new-game flow / debug-log routing).
- `flutter analyze app/lib/features/shell/new_game_leader_selection_dialog.dart app/test/new_game_leader_selection_dialog_test.dart app/lib/widgetbook/catalog_part4.dart` → **No issues found**.
- `dart format` clean on every touched file.

## Deferred / remain

This slice closes #2867 R19 only. Other R-numbered requirements / surfaces in #2867 remain tracked by the issue; the umbrella stays in `backlog:implementation` per repo policy until every R and S subtask lands or is otherwise resolved.

Refs #2867

Made with [Cursor](https://cursor.com)