### PR TITLE
refactor(app): adopt CtRadius tokens in 2 feature-tree sites (Refs #2914 S6)

### DIFF
--- a/app/lib/features/game/widgets/diplomacy_panel.dart
+++ b/app/lib/features/game/widgets/diplomacy_panel.dart
@@ -13,6 +13,7 @@ import '../../../core/services/app_event_handler_scope.dart';
 import '../../../core/services/subscription_tracker.dart';
 import '../../../l10n/l10n.dart';
 import '../../../widgets/ct_nine_patch_button.dart';
+import '../../../widgets/ct_radius.dart';
 import 'diplomacy_order_helpers.dart';
 import 'diplomacy_panel_rows.dart';
 import 'fnv1a_hash_constants.dart';

--- a/app/lib/features/game/widgets/diplomacy_panel_mode_bar.dart
+++ b/app/lib/features/game/widgets/diplomacy_panel_mode_bar.dart
@@ -88,7 +88,7 @@ class _DiplomacyModeButton extends StatelessWidget {
         padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
         decoration: BoxDecoration(
           border: border,
-          borderRadius: BorderRadius.circular(2),
+          borderRadius: BorderRadius.circular(CtRadius.small),
         ),
         child: Text(
           label,

--- a/app/lib/features/game/widgets/train_dialog_chrome.dart
+++ b/app/lib/features/game/widgets/train_dialog_chrome.dart
@@ -4,6 +4,7 @@ import '../../../config/editorial_monocle_palette.dart';
 import '../../../widgets/ct_brass_divider.dart';
 import '../../../widgets/ct_gradients.dart';
 import '../../../widgets/ct_nine_patch_button.dart';
+import '../../../widgets/ct_radius.dart';
 
 /// Locked train-dialog row opacity per `SPEC/ui/train-civilians-dialog.md` /
 /// `SPEC/ui/train-military-dialog.md` and #2866 AC (0.4).
@@ -114,7 +115,7 @@ class TrainDialogResourceChip extends StatelessWidget {
           color: EditorialMonoclePalette.accentDim,
           width: 1,
         ),
-        borderRadius: BorderRadius.circular(4),
+        borderRadius: BorderRadius.circular(CtRadius.medium),
       ),
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 4),

--- a/app/test/ct_radius_adoption_test.dart
+++ b/app/test/ct_radius_adoption_test.dart
@@ -1,0 +1,146 @@
+import 'dart:io' show File;
+
+import 'package:colonizethis_app/features/game/widgets/train_dialog_chrome.dart';
+import 'package:colonizethis_app/widgets/ct_radius.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Pinning tests for `CtRadius` adoption in feature widgets that previously
+/// hard-coded a `BorderRadius.circular(N)` magic number matching a SPEC
+/// token (Refs #2914 S6).
+///
+/// SPEC: `SPEC/ui/pixel-art-ui-catalog.md` § *Radius tokens* —
+/// authoritative table. The token scale (`small: 2`, `medium: 4`,
+/// `large: 8`, `xl: 12`) is intentionally non-linear; the prose
+/// explicitly calls out `1`, `6`, and `24` as out-of-scale per-component
+/// overrides that adoption review (S6) leaves as literals. This slice
+/// covers the two remaining feature-tree sites whose previous literal
+/// (`2`, `4`) exactly matches a SPEC token (`CtRadius.small`,
+/// `CtRadius.medium`) so the migration preserves the legacy visible
+/// inset while routing through the canonical token.
+///
+/// Asserts both:
+///   1. the rendered `BorderRadius.circular(CtRadius.*)` form, so
+///      future refactors that rename or drop the token trip the test;
+///   2. the equivalent literal form (`circular(2)` / `circular(4)`), so
+///      visible layout is preserved and a future drift in the token
+///      value also trips the test.
+void main() {
+  suppressLogsForTests();
+
+  group('CtRadius constants pin the SPEC table', () {
+    test('CtRadius.small == 2 (matches SPEC § Radius tokens row "small")', () {
+      expect(CtRadius.small, 2);
+    });
+
+    test('CtRadius.medium == 4 (matches SPEC § Radius tokens row "medium")', () {
+      expect(CtRadius.medium, 4);
+    });
+  });
+
+  group(
+    'TrainDialogResourceChip border resolves through CtRadius.medium '
+    '(Refs #2914 S6 adoption)',
+    () {
+      testWidgets('uses BorderRadius.circular(CtRadius.medium)', (
+        WidgetTester tester,
+      ) async {
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: Scaffold(
+              body: TrainDialogResourceChip(child: Text('Wool')),
+            ),
+          ),
+        );
+
+        final DecoratedBox decorated = tester.widget(
+          find.byType(DecoratedBox),
+        );
+        final BoxDecoration decoration =
+            decorated.decoration as BoxDecoration;
+        expect(
+          decoration.borderRadius,
+          BorderRadius.circular(CtRadius.medium),
+        );
+      });
+
+      testWidgets(
+        'preserves the legacy circular(4) inset so visible layout '
+        'does not shift',
+        (WidgetTester tester) async {
+          await tester.pumpWidget(
+            const MaterialApp(
+              home: Scaffold(
+                body: TrainDialogResourceChip(child: Text('Wool')),
+              ),
+            ),
+          );
+
+          final DecoratedBox decorated = tester.widget(
+            find.byType(DecoratedBox),
+          );
+          final BoxDecoration decoration =
+              decorated.decoration as BoxDecoration;
+          expect(decoration.borderRadius, BorderRadius.circular(4));
+        },
+      );
+    },
+  );
+
+  group(
+    '_DiplomacyModeButton border resolves through CtRadius.small '
+    '(Refs #2914 S6 adoption; private widget — file-text guard)',
+    () {
+      // `_DiplomacyModeButton` is a library-private widget inside the
+      // `diplomacy_panel.dart` part library, so it cannot be pumped from a
+      // public-API test without exporting an internal symbol. A
+      // file-text guard is the lightest-touch regression for this site:
+      // the positive guard asserts the SPEC token is the active form;
+      // the negative guard asserts the legacy literal `circular(2)`
+      // does not reappear in the file (mirrors the "preserves legacy
+      // inset" half of the widget-level pair).
+      final File modeBarSource = File(
+        'lib/features/game/widgets/diplomacy_panel_mode_bar.dart',
+      );
+
+      test(
+        'diplomacy_panel_mode_bar.dart uses '
+        'BorderRadius.circular(CtRadius.small)',
+        () {
+          expect(
+            modeBarSource.existsSync(),
+            isTrue,
+            reason:
+                'source file must remain at its canonical path so the '
+                'regression guard keeps pinning the adoption.',
+          );
+          final source = modeBarSource.readAsStringSync();
+          expect(
+            source,
+            contains('BorderRadius.circular(CtRadius.small)'),
+            reason:
+                'the SPEC-pinned token form must remain present so '
+                'reverting it to a magic-number literal trips this guard.',
+          );
+        },
+      );
+
+      test(
+        'diplomacy_panel_mode_bar.dart no longer hard-codes '
+        'BorderRadius.circular(2)',
+        () {
+          final source = modeBarSource.readAsStringSync();
+          expect(
+            source,
+            isNot(contains('BorderRadius.circular(2)')),
+            reason:
+                'legacy magic-number form must not reappear; the file '
+                'must keep routing through CtRadius.small per Refs '
+                '#2914 S6.',
+          );
+        },
+      );
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Adopts the canonical `CtRadius.small` / `CtRadius.medium` tokens at the two remaining `app/lib/features/` sites whose previous `BorderRadius.circular(N)` literal exactly matches a SPEC-pinned row in `SPEC/ui/pixel-art-ui-catalog.md` § *Radius tokens*. Per-component corner rounding now flows from the authoritative scale instead of magic numbers, and visible layout is preserved (each replacement keeps the same physical radius).

Continues #2914 S6 (`CtRadius` defined and adopted) on the umbrella tracking issue.

## Changes

- `app/lib/features/game/widgets/diplomacy_panel.dart` — adds `ct_radius.dart` import for the part library.
- `app/lib/features/game/widgets/diplomacy_panel_mode_bar.dart` — `BorderRadius.circular(2)` → `BorderRadius.circular(CtRadius.small)` on `_DiplomacyModeButton` chip frame.
- `app/lib/features/game/widgets/train_dialog_chrome.dart` — adds `ct_radius.dart` import; `BorderRadius.circular(4)` → `BorderRadius.circular(CtRadius.medium)` on `TrainDialogResourceChip`.

## SPEC alignment

Authoritative table is unchanged. Per the SPEC § *Radius tokens* prose ("The scale stops at 12. Observed `BorderRadius.circular(24)` and `BorderRadius.circular(1)` / `BorderRadius.circular(6)` call sites are out-of-scale per-component overrides; they are intentionally **not** promoted to a global token"), the remaining literal `circular(1)` (diplomacy_panel_chrome / fleet_expansion_tile), `circular(6)` (tech_tree_widget_nodes), and `circular(24)` (game_map_canvas_stack) call sites in features are left as explicit per-component overrides. This PR migrates only the two sites whose literal already matches a token.

## Tests

New `app/test/ct_radius_adoption_test.dart` (6 tests, all passing locally):

- 2 SPEC-pin checks: `CtRadius.small == 2`, `CtRadius.medium == 4`.
- 2 widget-level checks on `TrainDialogResourceChip` (positive `circular(CtRadius.medium)` + negative legacy `circular(4)` form, so future drift in either the token form or its value trips the test).
- 2 file-text guards for the private `_DiplomacyModeButton` (positive `CtRadius.small` token form present + negative `BorderRadius.circular(2)` literal absent).

Existing impacted tests still pass: `train_dialog_chrome_test`, `diplomacy_panel_test`, `diplomacy_panel_chrome_test`, `diplomacy_panel_narrow_layout_test`.

```
$ flutter test test/ct_radius_adoption_test.dart
00:01 +6: All tests passed!

$ flutter test test/train_dialog_chrome_test.dart test/diplomacy_panel_test.dart \
    test/diplomacy_panel_chrome_test.dart test/diplomacy_panel_narrow_layout_test.dart
00:42 +53: All tests passed!

$ dart run tool/check_app_editorial_monocle_colors.dart
check_app_editorial_monocle_colors: no violations found.

$ dart analyze (touched files)
No issues found!
```

## Scope deferred to follow-up commits / PRs (Refs #2914)

- `circular(1)`, `circular(6)`, `circular(24)` sites — explicit per-component overrides per SPEC; would require per-component pixel-art review to either keep as override or update SPEC table first.
- `Radius.circular(_barCornerRadius)` in `main_menu.dart` custom painter (value 2) — local named constant; not a clear win to migrate.

Tracked by #2914.

Refs #2914

Made with [Cursor](https://cursor.com)