### PR TITLE
fix(ui): adopt CtSpacing.l in trade_screen.dart (Refs #2914)

### DIFF
--- a/app/lib/features/game/screens/trade_screen.dart
+++ b/app/lib/features/game/screens/trade_screen.dart
@@ -72,6 +72,7 @@ import '../../../providers/games_provider.dart';
 import '../../../widgets/ct_choice_chip.dart';
 import '../../../widgets/ct_game_feature_screen_shell.dart';
 import '../../../widgets/ct_panel.dart';
+import '../../../widgets/ct_spacing.dart';
 import '../../../widgets/ct_tab_strip.dart';
 import '../../../widgets/ct_top_bar.dart';
 import '../../../widgets/strict_asset_icon.dart';
@@ -475,9 +476,9 @@ class _TradeScreenTabsBody extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.all(16),
+      padding: const EdgeInsets.all(CtSpacing.l),
       child: CtPanel(
-        padding: const EdgeInsets.all(16),
+        padding: const EdgeInsets.all(CtSpacing.l),
         child: CtTabStrip(
           initialTabIndex: initialTabIndex,
           tabLabels: const <String>[


### PR DESCRIPTION
## Summary

`trade_screen.dart` is on the `_migratedFeatureFiles` allowlist in `app/test/ct_spacing_features_adoption_test.dart` (the issue #2914 S5 adoption pin), but its two `EdgeInsets.all(16)` literals (panel outer + inner padding) were never migrated to `CtSpacing.l`. The adoption test was therefore failing on `dev` and on every PR that synced with `dev` after PR #3099 landed the Market treasury bid cap on top of these untouched literals.

This PR adopts the `CtSpacing.l` token in those two call sites:

- Adds `import '../../../widgets/ct_spacing.dart';` next to the existing `ct_panel.dart` import (alphabetic order preserved).
- Replaces `EdgeInsets.all(16)` with `EdgeInsets.all(CtSpacing.l)` on lines 478 and 480 of `trade_screen.dart`.

`CtSpacing.l == 16` (pinned in `app/lib/widgets/ct_spacing.dart` § `l = 16` and locked by the `tokens preserve the migrated physical insets` test), so visible layout is preserved bit-for-bit. No goldens or interactive tests need to be updated.

## Issue scope (#2914)

**Done in this PR:** Bring `trade_screen.dart` into compliance with the S5 adoption test invariants (import, ≥1 `CtSpacing.<token>` reference, no raw `EdgeInsets.all(N)` for `N ∈ {8, 12, 16, 20, 24}`).

**Side-effect:** Unblocks PR #3090 (Refs #2865 golden refresh) once that branch syncs with `dev`, because the failure observed in its `App tests (shard 0/2)` run came from this exact dev breakage.

**Deferred:** Adoption review for other feature files outside the current `_migratedFeatureFiles` list (separate S5/S6 follow-up slices for issue #2914).

## Tests

\`\`\`bash
cd app && flutter test test/ct_spacing_features_adoption_test.dart
# was: -3 failures on trade_screen.dart (import, reference, raw-EdgeInsets)
# now: 67/67 pass

cd app && flutter test test/trade_screen_scaffold_test.dart \\
  test/trade_screen_initial_tab_index_e7_test.dart
# 18/18 pass — no behavior regression in the trade screen scaffold or
# tab-routing surface, confirming CtSpacing.l preserves the 16px insets.
\`\`\`

Refs #2914

Made with [Cursor](https://cursor.com)