### PR TITLE
feat(trade): sectioned Market tab layout (Food / Raw Materials / Manufactured) (Refs #3093)

### DIFF
--- a/SPEC/ui/trade-screen.md
+++ b/SPEC/ui/trade-screen.md
@@ -25,6 +25,9 @@ The screen exposes static keys consumed by widget tests:
 - `TradeScreen.tabsBodyKey` — `ValueKey<String>('tradeScreenTabsBody')` (root of the two-tab Market + Deal Book body; replaces the prior `placeholderBodyKey` from the E1+E2+E3 scaffold and remains stable when E5/E6 swap each tab's body for the live content).
 - `TradeScreen.marketTabBodyKey` — `ValueKey<String>('tradeScreenMarketTabBody')` (Market tab body root; visible by default; spans the placeholder, the read-only commodity table from `#2993` E5a, and the future interactive controls).
 - `TradeScreen.marketCommodityListKey` — `ValueKey<String>('tradeScreenMarketCommodityList')` (scrollable container inside the Market tab body hosting the per-commodity rows; introduced by `#2993` E5a).
+- `TradeScreen.marketSectionFoodKey` — `ValueKey<String>('tradeScreenMarketSection:food')` (per-section `CtSectionLabel` header for the Food category inside the Market tab commodity list — Refs `#3093` § Layout & grouping — sectioned grouping slice).
+- `TradeScreen.marketSectionRawMaterialsKey` — `ValueKey<String>('tradeScreenMarketSection:rawMaterials')` (per-section `CtSectionLabel` header for the Raw Materials category — Refs `#3093` § Layout & grouping — sectioned grouping slice).
+- `TradeScreen.marketSectionManufacturedKey` — `ValueKey<String>('tradeScreenMarketSection:manufactured')` (per-section `CtSectionLabel` header for the Manufactured category — Refs `#3093` § Layout & grouping — sectioned grouping slice).
 - `TradeScreen.marketCommodityRowKey(CommodityId)` — `ValueKey<String>('tradeScreenMarketRow:<commodityId>')` (per-row key so widget tests can pin a specific commodity without text matching; introduced by `#2993` E5a).
 - `TradeScreen.marketRowNoneChipKey(CommodityId)` — `ValueKey<String>('tradeScreenMarketRow:<id>:none')` (per-row `None` direction chip; tap removes any staged trade order for the commodity — Refs `#2993` E5b).
 - `TradeScreen.marketRowBidChipKey(CommodityId)` — `ValueKey<String>('tradeScreenMarketRow:<id>:bid')` (per-row `Bid` direction chip; tap stages a `TradeOrderType.bid` for the commodity, replacing any prior offer — Refs `#2993` E5b).
@@ -84,9 +87,22 @@ Padding (16 dp)
             │           │     bodySmall, --danger — only when remainingCargo == 0
             │           │     AND totalStagedBidQuantity > 0)
             │           └── SingleChildScrollView (keyed `tradeScreenMarketCommodityList`)
-            │               └── Column (one row per tradeable commodity, 22 rows)
+            │               └── Column (one section per CommodityCategory,
+            │                          22 rows total across 3 sections —
+            │                          Refs #3093 sectioned grouping)
+            │                   ├── CtSectionLabel "Food"           (`tradeScreenMarketSection:food`)
+            │                   ├── Padding (keyed `tradeScreenMarketRow:<id>`)
+            │                   │   └── _MarketCommodityRow            // food rows in catalog order
+            │                   │       ... (per food commodity)
+            │                   ├── SizedBox(height: 12)
+            │                   ├── CtSectionLabel "Raw Materials"   (`tradeScreenMarketSection:rawMaterials`)
+            │                   ├── Padding (keyed `tradeScreenMarketRow:<id>`)
+            │                   │   └── _MarketCommodityRow            // rawMaterial rows in catalog order
+            │                   │       ... (per raw-material commodity)
+            │                   ├── SizedBox(height: 12)
+            │                   ├── CtSectionLabel "Manufactured"    (`tradeScreenMarketSection:manufactured`)
             │                   └── Padding (keyed `tradeScreenMarketRow:<id>`)
-            │                       └── _MarketCommodityRow
+            │                       └── _MarketCommodityRow            // manufactured rows in catalog order
             │                           ├── Row
             │                           │   ├── Text <displayName> (titleSmall, --accent)
             │                           │   └── Text <price | "—"> (titleSmall, --accentBright)
@@ -148,7 +164,7 @@ _DealBookPanel (keyed `tradeScreenDealBookBidsPanel` / `tradeScreenDealBookOffer
 
 The two-tab body is the durable structure each follow-up Market slice (E5b interactive controls, E5c cargo indicator) and Deal Book slice (E6) keep building inside. The `CtTabStrip` widget owns the dark-chrome label band (selected = `--accentBright` text on `--accentDim` 25 % alpha background; unselected = `--muted` text on `--surface` 50 % alpha background; 1 px `--accent` / `--accentDim` border per `pixel-art-ui-catalog.md` § `CtTabStrip`) and the `IndexedStack` that mounts both tab bodies so widget tests can reach either tab via `find.byKey` regardless of which is currently visible. Default selection is the **Market** tab (index 0).
 
-The Market tab body is the read-only commodity table (`#2993` E5a). It iterates `CommodityCatalog.all` filtered to the tradeable subset — every commodity whose `CommodityCategory` is **not** `riches` and whose id is **not** `spices` (22 rows total per [`world-market.md`](../game/world-market.md) §Tradeable commodities). Rows are sorted alphabetically by display name (case-insensitive) so the order is deterministic for widget tests and Widgetbook stories. Each row reads:
+The Market tab body is the read-only commodity table (`#2993` E5a). It iterates `CommodityCatalog.all` filtered to the tradeable subset — every commodity whose `CommodityCategory` is **not** `riches` and whose id is **not** `spices` (22 rows total per [`world-market.md`](../game/world-market.md) §Tradeable commodities). Rows are grouped by `CommodityCategory` under `CtSectionLabel` headers — **Food → Raw Materials → Manufactured** — with within-section rows following `CommodityCatalog.all` iteration order so the Market tab mirrors the Production panel Available subpanel ordering (Refs `#3093` § Layout & grouping). Per-section detail and the prior alphabetical-sort fallback are documented in [§ Market tab — sectioned grouping (`#3093` slice)](#market-tab--sectioned-grouping-3093-slice). Each row reads:
 
 - the **commodity display name** in `--accent` (`titleSmall`),
 - the **last market price** from `Game.worldMarketState.prices[commodityId]` in `--accentBright` (`titleSmall`), formatted as a whole integer (prices on `Game.worldMarketState.prices` are integer treasury units per [`world-market.md`](../game/world-market.md) § Price discovery). When the commodity is absent from `prices`, the row falls back to the published default market price from `ResourceRules.defaultRules.defaultMarketPriceForCommodityId(commodityId)` so first-load Market tab sessions never render the em-dash for raw resources whose catalog default price is known. The canonical em-dash glyph `—` renders only when neither the market state nor the catalog has a value (manufactured commodities and other commodities whose first market price is discovered in-game),
@@ -193,6 +209,26 @@ The per-row bid stepper and direction chips honour the cross-commodity cap:
 - **Toggle a row to `Offer` / `None`:** never blocked by cargo (offers and `None` free or don't consume cargo).
 
 `tradeCargoCapacity == 0` is a valid state: the indicator renders `Cargo remaining: 0`, no bids can be staged via direction toggle or increment, and the warning row is absent until at least one bid is staged (which itself is impossible at capacity 0, so the warning row never mounts at capacity 0 — the indicator alone communicates the no-cargo state).
+
+### Market tab — sectioned grouping (`#3093` slice)
+
+The Market tab body groups the 22 tradeable rows under three `CtSectionLabel` headers so the surface mirrors the Production panel's Available subpanel (Refs `#3093` § Layout & grouping). The headers and their backing widget keys are:
+
+| Section header | Widget key | l10n source (English fallback) | Catalog filter |
+|---|---|---|---|
+| Food | `TradeScreen.marketSectionFoodKey` | `l10n.production_food` (`"Food"`) | `CommodityCategory.food` |
+| Raw Materials | `TradeScreen.marketSectionRawMaterialsKey` | `l10n.production_rawMaterials` (`"Raw Materials"`) | `CommodityCategory.rawMaterial` |
+| Manufactured | `TradeScreen.marketSectionManufacturedKey` | `l10n.production_manufactured` (`"Manufactured"`) | `CommodityCategory.manufactured` |
+
+Section ordering and within-section ordering:
+
+- The three sections always render in the fixed order **Food → Raw Materials → Manufactured**; the first non-empty section snugs against the cargo indicator header and each subsequent section is separated by a 12 dp `SizedBox` (mirroring the Production panel's between-section gap).
+- Within each section the rows iterate `CommodityCatalog.all` filtered by category, preserving catalog order. The Market tab does **not** apply an alphabetical sort within or across sections (this supersedes the prior `#2993` E5a alphabetical contract).
+- The Riches set (`gold`, `silver`, `gems`, `diamonds`) and the `spices` advanced commodity are still excluded entirely — they do not contribute a row to any section.
+- An empty section is suppressed (header omitted) so a future ruleset that thins a category cannot leak an orphan header above zero rows. Today's catalog has at least one commodity per section (2 / 11 / 9), so all three headers are always mounted on the live screen.
+- `CtSectionLabel` renders its text in upper-case small-caps per `SPEC/ui/pixel-art-ui-catalog.md` § *CtSectionLabel visual contract*, so the visible labels read `FOOD`, `RAW MATERIALS`, and `MANUFACTURED` regardless of the source locale's casing.
+
+The section headers are scoped to the Market tab body subtree (`tradeScreenMarketTabBody`); they never appear under the off-stage Deal Book tab body (`tradeScreenDealBookTabBody`), matching the rest of the Market tab content.
 
 ### Market tab — sellable readout + offer-side clamp (`#3093` slice)
 
@@ -289,6 +325,7 @@ The Deal Book ledger described in [§ Deal Book ledger content (`#2993` E6)](#de
 - `StrictAssetIcon` (`app/lib/widgets/strict_asset_icon.dart`) — renders the 32 × 32 source PNG at the 18 × 18 top-bar size.
 - `CtPanel` (`SPEC/ui/pixel-art-ui-catalog.md` § `CtPanel`) — outer surface for the tabs body and inner surface for each tab placeholder.
 - `CtTabStrip` (`SPEC/ui/pixel-art-ui-catalog.md` § `CtTabStrip`) — dark editorial-monocle tab strip hosting the `Market` and `Deal Book` labels above the `IndexedStack` of tab bodies.
+- `CtSectionLabel` (`app/lib/widgets/ct_section_label.dart`; `SPEC/ui/pixel-art-ui-catalog.md` § *CtSectionLabel visual contract*) — small-caps section header used by the Market tab to group commodity rows under Food / Raw Materials / Manufactured (Refs `#3093` sectioned grouping slice). Same component the Production panel's Available subpanel uses.
 - `ObserveModeNotDefinedPanel` (`app/lib/features/game/widgets/observe_mode_not_defined_panel.dart`) — shared observe-mode sentinel.
 - `_DealBookTabContent` (`app/lib/features/game/screens/trade_screen.dart`) — read-only two-panel ledger (Refs `#2993` E6) hosting both `_DealBookPanel` instances under a `LayoutBuilder` that picks `Row` vs `Column` based on `dealBookTwoPanelMinWidth`.
 - `_DealBookPanel` (`app/lib/features/game/screens/trade_screen.dart`) — single ledger panel; renders panel title, optional empty-state copy, the Filled / Unfilled sections, and the always-mounted totals row.
@@ -344,7 +381,7 @@ Follow-up E5b cont. slices append `Market tab — priority dropdown` as the prio
 ### Market tab — read-only commodity table (`#2993` E5a)
 
 - **Given** the `TradeScreen` is mounted with a human player, observe mode is **not** active, and `Game.worldMarketState` is otherwise unconstrained, **then** the Market tab body keyed `tradeScreenMarketTabBody` contains exactly one `tradeScreenMarketCommodityList` widget that hosts exactly 22 rows keyed `tradeScreenMarketRow:<commodityId>` — one row for every `Commodity` in `CommodityCatalog.all` whose `category` is not `CommodityCategory.riches` and whose `id` is not `'spices'`.
-- **Given** the same conditions, **then** the row order inside `tradeScreenMarketCommodityList` is the deterministic alphabetical order of the tradeable commodities by display name (case-insensitive; falling back to commodity id when the display name is null) — every row's `Offset.dy` is strictly greater than the previous row's `Offset.dy`.
+- **Given** the same conditions, **then** the row order inside `tradeScreenMarketCommodityList` is the deterministic sectioned order documented in § Market tab — sectioned grouping (`#3093` slice): rows are grouped under three `CtSectionLabel` headers (Food → Raw Materials → Manufactured), within-section rows follow `CommodityCatalog.all` iteration order, and every row's `Offset.dy` is strictly greater than the previous row's `Offset.dy` within the same section (the prior `#2993` E5a alphabetical contract is superseded).
 - **Given** the same conditions and `Game.worldMarketState.prices` contains an entry `{'timber': 30}` (and no entry for `'iron'`, whose published default market price per `ResourceRules.defaultRules` is the integer `80`), **when** the Market tab body renders, **then** the `tradeScreenMarketRow:timber` row contains the text `30` (the integer market value) and the `tradeScreenMarketRow:iron` row contains the text `80` (the catalog default-market-price fallback for raw resources absent from `Game.worldMarketState.prices`).
 - **Given** the same conditions and `Game.worldMarketState.prices` is empty and the row is a manufactured commodity (e.g. `'lumber'`) whose id is not enumerated in `ResourceRules.defaultRules.defaultMarketPrice`, **when** the Market tab body renders, **then** the row's price cell contains the canonical em-dash glyph `—` (`priceUnknownGlyph`) because neither the market state nor the catalog has a published default price for that commodity (manufactured-commodity defaults are tracked as follow-up to `#3093`).
 - **Given** the same conditions and `Game.worldMarketState.lastTurnActivity` contains `{'timber': MarketActivity(totalBidQuantity: 12, totalOfferQuantity: 8)}` (and no entry for `'fabric'`), **when** the Market tab body renders, **then** the `tradeScreenMarketRow:timber` row contains the text `Bids 12 / Offers 8` and the `tradeScreenMarketRow:fabric` row contains the text `Bids 0 / Offers 0` (zero-default for commodities absent from the activity map).
@@ -375,6 +412,16 @@ Follow-up E5b cont. slices append `Market tab — priority dropdown` as the prio
 - **Given** the player has `tradeCargoCapacity = 10`, has staged `Bid` timber qty 10 (cargo remaining 0), **when** the user taps the `−` button on timber (`marketRowDecrementKey('timber')`), **then** the staged `TradeOrder.quantity` for timber decrements to 9, the cargo indicator updates to `Cargo remaining: 1`, and the warning row keyed `TradeScreen.marketCargoWarningKey` is removed from the widget tree.
 - **Given** the player has `tradeCargoCapacity = 10`, has staged `Bid` timber qty 10, **when** the user taps the `None` chip on timber (`marketRowNoneChipKey('timber')`), **then** the staged `TradeOrder` for timber is removed, the cargo indicator updates to `Cargo remaining: 10`, and the warning row is removed (because `totalStagedBidQuantity == 0`).
 - **Given** the `TradeScreen` is mounted with `shellPlayerContextProvider.canMutateViaUi == false`, **then** the cargo indicator and (when applicable) warning row remain mounted with the same text values as in the editable case (they read directly from `Game` + `currentOrdersProvider` regardless of the observe-mode `IgnorePointer`).
+
+### Market tab — sectioned grouping (`#3093` slice)
+
+- **Given** the `TradeScreen` is mounted with a human player and observe mode is **not** active, **then** the widget tree contains exactly one widget keyed `TradeScreen.marketSectionFoodKey`, exactly one widget keyed `TradeScreen.marketSectionRawMaterialsKey`, and exactly one widget keyed `TradeScreen.marketSectionManufacturedKey`, each scoped under the `tradeScreenMarketTabBody` subtree (the three `CtSectionLabel` headers for the Food, Raw Materials, and Manufactured commodity categories).
+- **Given** the same conditions, **when** the section header positions are measured, **then** `tester.getTopLeft(find.byKey(marketSectionRawMaterialsKey)).dy` is strictly greater than `tester.getTopLeft(find.byKey(marketSectionFoodKey)).dy` and `tester.getTopLeft(find.byKey(marketSectionManufacturedKey)).dy` is strictly greater than `tester.getTopLeft(find.byKey(marketSectionRawMaterialsKey)).dy` (the fixed Food → Raw Materials → Manufactured ordering).
+- **Given** the same conditions, **when** each section's commodity rows are measured in `CommodityCatalog.all` iteration order filtered by that section's `CommodityCategory`, **then** every row's `Offset.dy` is strictly greater than its predecessor's (within-section catalog order is preserved); for the Food section this pins `grain` above `meat`, for the Raw Materials section this pins `timber, iron, wool, cotton, coal, sugarCane, tobacco, furs, copper, tin, horses` in that exact order, and for the Manufactured section this pins `lumber, castIron, fabric, refinedSugar, cigars, furHats, steel, paper, bronze` in that exact order.
+- **Given** the same conditions, **when** cross-section row positions are measured, **then** the last Food row sits strictly above the Raw Materials section header, the Raw Materials section header sits strictly above the first Raw Materials row, the last Raw Materials row sits strictly above the Manufactured section header, and the Manufactured section header sits strictly above the first Manufactured row (no commodity row leaks across a section boundary).
+- **Given** the same conditions, **then** the visible text rendered under `marketSectionFoodKey` reads `FOOD` (upper-case via `CtSectionLabel`), under `marketSectionRawMaterialsKey` reads `RAW MATERIALS`, and under `marketSectionManufacturedKey` reads `MANUFACTURED` (resolved from `l10n.production_food` / `production_rawMaterials` / `production_manufactured` with the English-fallback path when the host `MaterialApp` has no localizations delegates).
+- **Given** the same conditions, **then** none of the section header keys appear under the off-stage Deal Book tab body subtree (`find.descendant(of: find.byKey(dealBookTabBodyKey, skipOffstage: false), matching: find.byKey(marketSectionFoodKey))` resolves to zero widgets; same for the other two section keys) — the section headers are scoped to the Market tab body.
+- **Given** the `TradeScreen` is mounted and `shellPanelsNotDefined(ref)` returns `true` (global observe mode), **then** none of `marketSectionFoodKey`, `marketSectionRawMaterialsKey`, or `marketSectionManufacturedKey` appear in the widget tree (only the `ObserveModeNotDefinedPanel` and the dark `CtTopBar` are mounted; section headers ride along with the Market tab body which is not rendered in observe mode).
 
 ### Market tab — sellable readout + offer-side clamp (`#3093` slice)
 

--- a/app/lib/features/game/screens/trade_screen.dart
+++ b/app/lib/features/game/screens/trade_screen.dart
@@ -68,10 +68,12 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../config/app_constants.dart';
 import '../../../config/editorial_monocle_palette.dart';
 import '../../../config/ui_screen_ids.dart';
+import '../../../l10n/l10n.dart';
 import '../../../providers/games_provider.dart';
 import '../../../widgets/ct_choice_chip.dart';
 import '../../../widgets/ct_game_feature_screen_shell.dart';
 import '../../../widgets/ct_panel.dart';
+import '../../../widgets/ct_section_label.dart';
 import '../../../widgets/ct_spacing.dart';
 import '../../../widgets/ct_tab_strip.dart';
 import '../../../widgets/ct_top_bar.dart';
@@ -156,6 +158,31 @@ class TradeScreen extends ConsumerWidget {
   /// the row identities themselves.
   static const Key marketCommodityListKey =
       ValueKey<String>('tradeScreenMarketCommodityList');
+
+  /// Stable widget key for the `Food` category section header inside
+  /// the Market tab commodity list (Refs `#3093` § Layout & grouping
+  /// — sectioned grouping slice). Pin point for widget tests asserting
+  /// the Food section label is mounted at the top of the list with
+  /// the food commodities beneath it. The widget at this key is a
+  /// `CtSectionLabel` whose visible text resolves from
+  /// `l10n.production_food` (English fallback `Food`) so the trade
+  /// screen reuses the existing Production-panel l10n surface.
+  static const Key marketSectionFoodKey =
+      ValueKey<String>('tradeScreenMarketSection:food');
+
+  /// Stable widget key for the `Raw Materials` category section header
+  /// inside the Market tab commodity list (Refs `#3093` § Layout &
+  /// grouping — sectioned grouping slice). Visible text resolves from
+  /// `l10n.production_rawMaterials` (English fallback `Raw Materials`).
+  static const Key marketSectionRawMaterialsKey =
+      ValueKey<String>('tradeScreenMarketSection:rawMaterials');
+
+  /// Stable widget key for the `Manufactured` category section header
+  /// inside the Market tab commodity list (Refs `#3093` § Layout &
+  /// grouping — sectioned grouping slice). Visible text resolves from
+  /// `l10n.production_manufactured` (English fallback `Manufactured`).
+  static const Key marketSectionManufacturedKey =
+      ValueKey<String>('tradeScreenMarketSection:manufactured');
 
   /// Per-row key for a Market tab commodity row. Deterministic so widget
   /// tests can pin a specific commodity (e.g. `timber`) without relying
@@ -600,7 +627,9 @@ class _MarketTabContent extends ConsumerWidget {
         (theme.textTheme.bodySmall ?? const TextStyle(fontSize: 12))
             .copyWith(color: EditorialMonoclePalette.danger);
 
-    final List<Commodity> rows = _tradeableCommoditiesSortedByDisplayName();
+    final _SectionedTradeableCommodities sectioned =
+        _tradeableCommoditiesByCategory();
+    final AppLocalizations l10n = appL10n(context);
     final WorldMarketState market = game.worldMarketState;
     final Orders orders = ref.watch(currentOrdersProvider);
 
@@ -633,53 +662,68 @@ class _MarketTabContent extends ConsumerWidget {
     // by the catalog size (22) so the eager build cost is negligible
     // and the deterministic ordering survives Widgetbook stories that
     // render the screen inside a non-scrollable container.
+    //
+    // Refs `#3093` — sectioned grouping slice. Rows are grouped by
+    // commodity category (Food → Raw Materials → Manufactured) under
+    // `CtSectionLabel` headers, mirroring the Production panel's
+    // Available subpanel so the two surfaces read consistently. Within
+    // each section, rows follow `CommodityCatalog.all` catalog order
+    // (no per-section alphabetical sort); this matches the Production
+    // panel's intra-section ordering.
+    final List<Widget> sectionWidgets = <Widget>[
+      ..._buildCommoditySectionWidgets(
+        sectionKey: TradeScreen.marketSectionFoodKey,
+        sectionLabel: l10n.production_food,
+        commodities: sectioned.food,
+        offerCap: offerCap,
+        stagedOffers: stagedOffers,
+        market: market,
+        orders: orders,
+        nameStyle: nameStyle,
+        priceStyle: priceStyle,
+        volumeStyle: volumeStyle,
+        quantityStyle: quantityStyle,
+        ref: ref,
+      ),
+      ..._buildCommoditySectionWidgets(
+        sectionKey: TradeScreen.marketSectionRawMaterialsKey,
+        sectionLabel: l10n.production_rawMaterials,
+        commodities: sectioned.rawMaterials,
+        offerCap: offerCap,
+        stagedOffers: stagedOffers,
+        market: market,
+        orders: orders,
+        nameStyle: nameStyle,
+        priceStyle: priceStyle,
+        volumeStyle: volumeStyle,
+        quantityStyle: quantityStyle,
+        ref: ref,
+        isFirstSection: false,
+      ),
+      ..._buildCommoditySectionWidgets(
+        sectionKey: TradeScreen.marketSectionManufacturedKey,
+        sectionLabel: l10n.production_manufactured,
+        commodities: sectioned.manufactured,
+        offerCap: offerCap,
+        stagedOffers: stagedOffers,
+        market: market,
+        orders: orders,
+        nameStyle: nameStyle,
+        priceStyle: priceStyle,
+        volumeStyle: volumeStyle,
+        quantityStyle: quantityStyle,
+        ref: ref,
+        isFirstSection: false,
+      ),
+    ];
+
     final Widget list = SingleChildScrollView(
       key: TradeScreen.marketCommodityListKey,
       padding: EdgeInsets.zero,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         mainAxisSize: MainAxisSize.min,
-        children: <Widget>[
-          for (int index = 0; index < rows.length; index++)
-            Padding(
-              key: TradeScreen.marketCommodityRowKey(rows[index].id),
-              padding: EdgeInsets.only(top: index == 0 ? 0 : 12),
-              child: _MarketCommodityRow(
-                commodityId: rows[index].id,
-                commodityDisplayName:
-                    rows[index].displayName ?? rows[index].id,
-                priceText: _formatPrice(
-                  market.prices[rows[index].id],
-                  commodityId: rows[index].id,
-                ),
-                volumeText: _volumeText(
-                  market.lastTurnActivity[rows[index].id] ??
-                      MarketActivity.empty,
-                ),
-                stagedOrder: tradeOrderForPlayerCommodity(
-                  orders,
-                  playerId,
-                  rows[index].id,
-                ),
-                sellableHeadroom: _sellableHeadroomFor(
-                  offerCap: offerCap,
-                  stagedOffers: stagedOffers,
-                  commodityId: rows[index].id,
-                ),
-                offerCap: offerCap[rows[index].id] ?? 0,
-                nameStyle: nameStyle,
-                priceStyle: priceStyle,
-                volumeStyle: volumeStyle,
-                quantityStyle: quantityStyle,
-                onDirectionChanged: (TradeOrderType? next) =>
-                    _handleDirectionChanged(ref, rows[index].id, next),
-                onIncrement: () =>
-                    _handleQuantityDelta(ref, rows[index].id, 1),
-                onDecrement: () =>
-                    _handleQuantityDelta(ref, rows[index].id, -1),
-              ),
-            ),
-        ],
+        children: sectionWidgets,
       ),
     );
 
@@ -993,21 +1037,114 @@ class _MarketTabContent extends ConsumerWidget {
         '$offersLabel ${activity.totalOfferQuantity}';
   }
 
-  /// Returns the tradeable commodities (catalog minus riches + spices)
-  /// sorted alphabetically by display name (case-insensitive). Spices
-  /// are excluded explicitly per Refs #2988 §UI Design — the Market tab
-  /// shows 22 tradeable rows (full catalog minus riches and spices).
-  static List<Commodity> _tradeableCommoditiesSortedByDisplayName() {
-    final List<Commodity> filtered = <Commodity>[
-      for (final Commodity c in CommodityCatalog.all)
-        if (c.category != CommodityCategory.riches && c.id != 'spices') c,
+  /// Returns the tradeable commodities grouped by their
+  /// [CommodityCategory] in catalog order (Refs `#3093` § Layout &
+  /// grouping — sectioned grouping slice). Spices and riches are
+  /// excluded per `SPEC/game/world-market.md` § Tradeable commodities,
+  /// leaving 22 rows split across three sections (food / raw materials
+  /// / manufactured). Within each section the per-commodity order
+  /// preserves `CommodityCatalog.all` iteration order so this surface
+  /// matches the Production panel's Available subpanel (which iterates
+  /// the same catalog list filtered by category).
+  static _SectionedTradeableCommodities _tradeableCommoditiesByCategory() {
+    final List<Commodity> food = <Commodity>[];
+    final List<Commodity> rawMaterials = <Commodity>[];
+    final List<Commodity> manufactured = <Commodity>[];
+    for (final Commodity c in CommodityCatalog.all) {
+      if (c.category == CommodityCategory.riches) continue;
+      if (c.id == 'spices') continue;
+      switch (c.category) {
+        case CommodityCategory.food:
+          food.add(c);
+        case CommodityCategory.rawMaterial:
+          rawMaterials.add(c);
+        case CommodityCategory.manufactured:
+          manufactured.add(c);
+        case CommodityCategory.luxury:
+        case CommodityCategory.riches:
+        case CommodityCategory.advanced:
+          break;
+      }
+    }
+    return _SectionedTradeableCommodities(
+      food: food,
+      rawMaterials: rawMaterials,
+      manufactured: manufactured,
+    );
+  }
+
+  /// Builds the widget list that renders one Market commodity category
+  /// section: a `CtSectionLabel` header keyed by [sectionKey] followed
+  /// by the per-commodity rows for [commodities] in their input order.
+  /// Returns an empty list when [commodities] is empty so an absent
+  /// category does not leak an orphan header (defensive — every
+  /// section is non-empty on the live catalog today; a future ruleset
+  /// could thin them out).
+  ///
+  /// [isFirstSection] controls the leading vertical gap so the first
+  /// section snugs against the cargo header without leaving extra
+  /// whitespace, and subsequent sections get a 12 dp separator that
+  /// matches the Production panel's between-section gap.
+  List<Widget> _buildCommoditySectionWidgets({
+    required Key sectionKey,
+    required String sectionLabel,
+    required List<Commodity> commodities,
+    required Map<CommodityId, int> offerCap,
+    required Map<CommodityId, int> stagedOffers,
+    required WorldMarketState market,
+    required Orders orders,
+    required TextStyle nameStyle,
+    required TextStyle priceStyle,
+    required TextStyle volumeStyle,
+    required TextStyle quantityStyle,
+    required WidgetRef ref,
+    bool isFirstSection = true,
+  }) {
+    if (commodities.isEmpty) return const <Widget>[];
+    return <Widget>[
+      if (!isFirstSection) const SizedBox(height: 12),
+      CtSectionLabel(sectionLabel, key: sectionKey),
+      const SizedBox(height: 6),
+      for (int index = 0; index < commodities.length; index++)
+        Padding(
+          key: TradeScreen.marketCommodityRowKey(commodities[index].id),
+          padding: EdgeInsets.only(top: index == 0 ? 0 : 12),
+          child: _MarketCommodityRow(
+            commodityId: commodities[index].id,
+            commodityDisplayName:
+                commodities[index].displayName ?? commodities[index].id,
+            priceText: _formatPrice(
+              market.prices[commodities[index].id],
+              commodityId: commodities[index].id,
+            ),
+            volumeText: _volumeText(
+              market.lastTurnActivity[commodities[index].id] ??
+                  MarketActivity.empty,
+            ),
+            stagedOrder: tradeOrderForPlayerCommodity(
+              orders,
+              playerId,
+              commodities[index].id,
+            ),
+            sellableHeadroom: _sellableHeadroomFor(
+              offerCap: offerCap,
+              stagedOffers: stagedOffers,
+              commodityId: commodities[index].id,
+            ),
+            offerCap: offerCap[commodities[index].id] ?? 0,
+            nameStyle: nameStyle,
+            priceStyle: priceStyle,
+            volumeStyle: volumeStyle,
+            quantityStyle: quantityStyle,
+            onDirectionChanged: (TradeOrderType? next) =>
+                _handleDirectionChanged(ref, commodities[index].id, next),
+            onIncrement: () =>
+                _handleQuantityDelta(ref, commodities[index].id, 1),
+            onDecrement: () =>
+                _handleQuantityDelta(ref, commodities[index].id, -1),
+          ),
+        ),
     ];
-    filtered.sort((Commodity a, Commodity b) {
-      final String an = (a.displayName ?? a.id).toLowerCase();
-      final String bn = (b.displayName ?? b.id).toLowerCase();
-      return an.compareTo(bn);
-    });
-    return filtered;
   }
 
   /// Formats the per-commodity market price for the Market tab row.
@@ -1032,6 +1169,23 @@ class _MarketTabContent extends ConsumerWidget {
     if (effective == null) return priceUnknownGlyph;
     return effective.toString();
   }
+}
+
+/// Pre-grouped tradeable commodities passed from
+/// `_tradeableCommoditiesByCategory()` to the section builder. Holds
+/// the three Market tab sections (food / raw materials / manufactured)
+/// in catalog order so the renderer does not re-iterate
+/// [CommodityCatalog.all] per section.
+class _SectionedTradeableCommodities {
+  const _SectionedTradeableCommodities({
+    required this.food,
+    required this.rawMaterials,
+    required this.manufactured,
+  });
+
+  final List<Commodity> food;
+  final List<Commodity> rawMaterials;
+  final List<Commodity> manufactured;
 }
 
 /// One row of the Market tab commodity table. Lays the read-only

--- a/app/test/trade_screen_market_tab_commodity_table_test.dart
+++ b/app/test/trade_screen_market_tab_commodity_table_test.dart
@@ -1,5 +1,5 @@
 // Widget tests for the Market tab read-only commodity table
-// (Refs #2993 E5a + #3093 integer-price refresh).
+// (Refs #2993 E5a + #3093 integer-price refresh + sectioned grouping).
 // SPEC/ui/trade-screen.md § Body — Market tab.
 //
 // Exercises the durable contract for the Market tab body:
@@ -7,8 +7,11 @@
 //  * one row per tradeable commodity (full CommodityCatalog minus
 //    riches and `spices` — 22 rows total per SPEC/game/world-market.md
 //    §Tradeable commodities),
-//  * deterministic alphabetical sort by display name so widget tests
-//    and Widgetbook stories pin the same ordering,
+//  * Production-style sectioned grouping (`#3093` § Layout & grouping):
+//    the rows are grouped by [CommodityCategory] under `CtSectionLabel`
+//    headers — Food → Raw Materials → Manufactured — and within each
+//    section the rows follow `CommodityCatalog.all` catalog order
+//    (mirroring the Production panel's Available subpanel),
 //  * last market price sourced from `Game.worldMarketState.prices`
 //    (integer, post-#3093). Rows fall back to
 //    `ResourceRules.defaultMarketPrice` when the prices map lacks an
@@ -164,60 +167,239 @@ void main() {
       );
 
       testWidgets(
-        'rows are sorted alphabetically by display name (case-insensitive) '
-        '— deterministic order pin',
+        'rows are grouped under Food / Raw Materials / Manufactured '
+        'CtSectionLabel headers in catalog order — deterministic order '
+        'pin (#3093 sectioned grouping)',
         (tester) async {
           await _pumpTradeScreen(tester, game: _buildGame());
 
-          final List<Commodity> tradeable = <Commodity>[
+          // All three section headers mounted in order Food → Raw
+          // Materials → Manufactured. The pin verifies their vertical
+          // positions in the parent column, which guarantees the
+          // expected reading order.
+          final Offset foodHeaderOffset = tester.getTopLeft(
+            find.byKey(TradeScreen.marketSectionFoodKey),
+          );
+          final Offset rawMaterialsHeaderOffset = tester.getTopLeft(
+            find.byKey(TradeScreen.marketSectionRawMaterialsKey),
+          );
+          final Offset manufacturedHeaderOffset = tester.getTopLeft(
+            find.byKey(TradeScreen.marketSectionManufacturedKey),
+          );
+
+          expect(
+            rawMaterialsHeaderOffset.dy,
+            greaterThan(foodHeaderOffset.dy),
+            reason:
+                'SPEC/ui/trade-screen.md § Market tab — sectioned '
+                'grouping (#3093): the Raw Materials section header must '
+                'appear below the Food section header.',
+          );
+          expect(
+            manufacturedHeaderOffset.dy,
+            greaterThan(rawMaterialsHeaderOffset.dy),
+            reason:
+                'SPEC/ui/trade-screen.md § Market tab — sectioned '
+                'grouping (#3093): the Manufactured section header must '
+                'appear below the Raw Materials section header.',
+          );
+
+          // Each section contains its category's commodities in
+          // CommodityCatalog.all iteration order (the same order the
+          // Production panel uses). Build the expected per-section
+          // lists from the live catalog so a future ruleset extension
+          // automatically reflects in the assertion without manual
+          // edits.
+          final List<Commodity> foodCommodities = <Commodity>[
             for (final Commodity c in CommodityCatalog.all)
-              if (c.category != CommodityCategory.riches && c.id != 'spices') c,
+              if (c.category == CommodityCategory.food && c.id != 'spices') c,
           ];
-          final List<Commodity> expectedOrder = List<Commodity>.of(tradeable)
-            ..sort((Commodity a, Commodity b) {
-              final String an = (a.displayName ?? a.id).toLowerCase();
-              final String bn = (b.displayName ?? b.id).toLowerCase();
-              return an.compareTo(bn);
-            });
-
-          final List<Offset> positions = <Offset>[
-            for (final Commodity c in expectedOrder)
-              tester.getTopLeft(
-                find.byKey(TradeScreen.marketCommodityRowKey(c.id)),
-              ),
+          final List<Commodity> rawMaterialCommodities = <Commodity>[
+            for (final Commodity c in CommodityCatalog.all)
+              if (c.category == CommodityCategory.rawMaterial &&
+                  c.id != 'spices')
+                c,
+          ];
+          final List<Commodity> manufacturedCommodities = <Commodity>[
+            for (final Commodity c in CommodityCatalog.all)
+              if (c.category == CommodityCategory.manufactured &&
+                  c.id != 'spices')
+                c,
           ];
 
-          for (int i = 1; i < positions.length; i++) {
-            expect(
-              positions[i].dy,
-              greaterThan(positions[i - 1].dy),
-              reason:
-                  'Row `${expectedOrder[i].id}` must appear below row '
-                  '`${expectedOrder[i - 1].id}` (alphabetical by display '
-                  'name, case-insensitive).',
-            );
+          for (final List<Commodity> sectionRows in <List<Commodity>>[
+            foodCommodities,
+            rawMaterialCommodities,
+            manufacturedCommodities,
+          ]) {
+            for (int i = 1; i < sectionRows.length; i++) {
+              final Offset prior = tester.getTopLeft(
+                find.byKey(
+                  TradeScreen.marketCommodityRowKey(sectionRows[i - 1].id),
+                ),
+              );
+              final Offset current = tester.getTopLeft(
+                find.byKey(
+                  TradeScreen.marketCommodityRowKey(sectionRows[i].id),
+                ),
+              );
+              expect(
+                current.dy,
+                greaterThan(prior.dy),
+                reason:
+                    'Row `${sectionRows[i].id}` must appear below row '
+                    '`${sectionRows[i - 1].id}` (catalog order within '
+                    'its category section).',
+              );
+            }
           }
 
-          // Concrete spot-check: `Cast iron` precedes `Cigars` precedes
-          // `Coal` (deterministic alphabetical pin so a regression in
-          // the comparator surfaces with a readable failure).
-          final castIron = tester.getTopLeft(
+          // Cross-section pin: the last food row must precede the Raw
+          // Materials header which must precede the first raw-material
+          // row; likewise for the manufactured boundary. This catches
+          // regressions where a single commodity slips out of its
+          // section into the wrong bucket.
+          final Offset lastFoodRow = tester.getTopLeft(
             find.byKey(
-              TradeScreen.marketCommodityRowKey(CommodityCatalog.castIron.id),
+              TradeScreen.marketCommodityRowKey(foodCommodities.last.id),
             ),
           );
-          final cigars = tester.getTopLeft(
+          final Offset firstRawMaterialRow = tester.getTopLeft(
             find.byKey(
-              TradeScreen.marketCommodityRowKey(CommodityCatalog.cigars.id),
+              TradeScreen.marketCommodityRowKey(
+                rawMaterialCommodities.first.id,
+              ),
             ),
           );
-          final coal = tester.getTopLeft(
+          expect(
+            lastFoodRow.dy,
+            lessThan(rawMaterialsHeaderOffset.dy),
+            reason:
+                'The last Food row (`${foodCommodities.last.id}`) must '
+                'sit above the Raw Materials section header.',
+          );
+          expect(
+            rawMaterialsHeaderOffset.dy,
+            lessThan(firstRawMaterialRow.dy),
+            reason:
+                'The Raw Materials section header must sit above the '
+                'first Raw Materials row '
+                '(`${rawMaterialCommodities.first.id}`).',
+          );
+
+          final Offset lastRawMaterialRow = tester.getTopLeft(
             find.byKey(
-              TradeScreen.marketCommodityRowKey(CommodityCatalog.coal.id),
+              TradeScreen.marketCommodityRowKey(
+                rawMaterialCommodities.last.id,
+              ),
             ),
           );
-          expect(castIron.dy, lessThan(cigars.dy));
-          expect(cigars.dy, lessThan(coal.dy));
+          final Offset firstManufacturedRow = tester.getTopLeft(
+            find.byKey(
+              TradeScreen.marketCommodityRowKey(
+                manufacturedCommodities.first.id,
+              ),
+            ),
+          );
+          expect(
+            lastRawMaterialRow.dy,
+            lessThan(manufacturedHeaderOffset.dy),
+            reason:
+                'The last Raw Materials row '
+                '(`${rawMaterialCommodities.last.id}`) must sit above '
+                'the Manufactured section header.',
+          );
+          expect(
+            manufacturedHeaderOffset.dy,
+            lessThan(firstManufacturedRow.dy),
+            reason:
+                'The Manufactured section header must sit above the '
+                'first Manufactured row '
+                '(`${manufacturedCommodities.first.id}`).',
+          );
+        },
+      );
+
+      testWidgets(
+        'CtSectionLabel headers render their localized labels '
+        '(Food / Raw Materials / Manufactured)',
+        (tester) async {
+          await _pumpTradeScreen(tester, game: _buildGame());
+
+          // Section labels rendered as upper-case small-caps by
+          // CtSectionLabel; pin the visible (upper-cased) literal.
+          expect(
+            find.descendant(
+              of: find.byKey(TradeScreen.marketSectionFoodKey),
+              // ignore: avoid_hardcoded_strings_in_widgets
+              matching: find.text('FOOD'),
+            ),
+            findsOneWidget,
+            reason:
+                'CtSectionLabel renders its text in upper-case so the '
+                'Food header should read `FOOD` (l10n English fallback '
+                'when the host MaterialApp has no l10n delegates).',
+          );
+          expect(
+            find.descendant(
+              of: find.byKey(TradeScreen.marketSectionRawMaterialsKey),
+              // ignore: avoid_hardcoded_strings_in_widgets
+              matching: find.text('RAW MATERIALS'),
+            ),
+            findsOneWidget,
+            reason:
+                'CtSectionLabel renders its text in upper-case so the '
+                'Raw Materials header should read `RAW MATERIALS`.',
+          );
+          expect(
+            find.descendant(
+              of: find.byKey(TradeScreen.marketSectionManufacturedKey),
+              // ignore: avoid_hardcoded_strings_in_widgets
+              matching: find.text('MANUFACTURED'),
+            ),
+            findsOneWidget,
+            reason:
+                'CtSectionLabel renders its text in upper-case so the '
+                'Manufactured header should read `MANUFACTURED`.',
+          );
+        },
+      );
+
+      testWidgets(
+        'every section header is mounted inside the Market tab body '
+        '(not under the off-stage Deal Book tab body)',
+        (tester) async {
+          await _pumpTradeScreen(tester, game: _buildGame());
+
+          for (final Key sectionKey in <Key>[
+            TradeScreen.marketSectionFoodKey,
+            TradeScreen.marketSectionRawMaterialsKey,
+            TradeScreen.marketSectionManufacturedKey,
+          ]) {
+            expect(
+              find.descendant(
+                of: find.byKey(TradeScreen.marketTabBodyKey),
+                matching: find.byKey(sectionKey),
+              ),
+              findsOneWidget,
+              reason:
+                  'Section header `$sectionKey` must be mounted inside '
+                  'the Market tab body keyed `marketTabBodyKey`.',
+            );
+            expect(
+              find.descendant(
+                of: find.byKey(
+                  TradeScreen.dealBookTabBodyKey,
+                  skipOffstage: false,
+                ),
+                matching: find.byKey(sectionKey),
+              ),
+              findsNothing,
+              reason:
+                  'Section header `$sectionKey` must NOT leak into the '
+                  'off-stage Deal Book tab body subtree.',
+            );
+          }
         },
       );
 


### PR DESCRIPTION
## Summary

Replaces the prior alphabetical sort on the Trade screen Market tab commodity list with a Production-panel-style sectioned grouping. Rows are now grouped under three `CtSectionLabel` headers — **Food → Raw Materials → Manufactured** — and within each section follow `CommodityCatalog.all` iteration order. Section headers reuse the existing `l10n.production_food` / `_rawMaterials` / `_manufactured` strings so the Market tab reads consistently with the Production panel's Available subpanel.

Riches and spices remain excluded (22 rows total: 2 / 11 / 9 across the three sections).

This is the **deferred sectioned-layout follow-up slice** explicitly called out in PR #3102 (row icons) under "Deferred to follow-up slices on #3093". It is otherwise additive: no behavior or wiring change to bid / offer / quantity controls, sellable-headroom clamp, treasury bid cap, or Deal Book content.

## Coordination with PR #3102 (Refs #3093, row icons)

- **Disjoint widget surface.** PR #3102 modifies `_MarketCommodityRow` internals (per-row layout). This PR modifies `_MarketTabContent` section composition (between-row grouping). Both touch `trade_screen.dart` and the SPEC, but in non-overlapping spans.
- **Merge order.** Either PR can merge first. After #3102 lands, this branch will be rebased onto `dev` and pick up the row icons automatically per row.

## SPEC

- `SPEC/ui/trade-screen.md`:
  - Adds `marketSectionFoodKey`, `marketSectionRawMaterialsKey`, `marketSectionManufacturedKey` to the widget contract.
  - Updates the Market tab wireframe + prose to describe the sectioned grouping in place of the alphabetical sort.
  - Adds a new "Market tab — sectioned grouping (`#3093` slice)" section detailing the three headers, fixed Food → Raw Materials → Manufactured ordering, within-section catalog order, empty-section suppression, and Market-tab scoping (vs Deal Book).
  - Adds **seven Given–When–Then ACs** covering header presence, inter-section ordering, intra-section catalog order, cross-section row positioning, localized small-caps text, Market-tab-only scoping, and observe-mode header absence.
  - Updates the existing `#2993` E5a "row order" AC to point at the sectioned-grouping contract instead of the alphabetical pin (the prior contract is explicitly superseded by this slice).
  - Adds `CtSectionLabel` to the Components list.

## Implementation

- `app/lib/features/game/screens/trade_screen.dart`:
  - Imports `l10n/l10n.dart` and `widgets/ct_section_label.dart`.
  - Adds the three keyed section constants (public `static const Key`).
  - Replaces `_tradeableCommoditiesSortedByDisplayName()` with `_tradeableCommoditiesByCategory()` returning a `_SectionedTradeableCommodities` value object (catalog-ordered lists for food / rawMaterials / manufactured).
  - Extracts `_buildCommoditySectionWidgets(...)` so each section renders a keyed `CtSectionLabel` header + per-commodity rows with the same row contract as before; first section snugs against the cargo header, subsequent sections get a 12 dp separator matching the Production panel.
  - The category switch is **exhaustive** over `CommodityCategory` (food / rawMaterial / manufactured used; luxury / riches / advanced `break`) so a future ruleset that adds a category surfaces as an analyzer error rather than a silent UI drop.

## Tests

- `app/test/trade_screen_market_tab_commodity_table_test.dart`:
  - Replaces the alphabetical order pin with a **sectioned order pin**: asserts the vertical order Food → Raw Materials → Manufactured, within-section catalog order, and cross-section row positioning (last food row above the Raw Materials header).
  - Adds a **header text test** asserting `FOOD` / `RAW MATERIALS` / `MANUFACTURED` render via `CtSectionLabel` small-caps.
  - Adds a **scoping test** asserting every section header is mounted inside `tradeScreenMarketTabBody` and never under `tradeScreenDealBookTabBody`.

## Verification

\`\`\`bash
cd app && flutter test test/trade_screen_*.dart
# 86/86 pass — no regression in scaffold, commodity table (sectioned),
# E5b/E5c controls + cargo cap, sellable clamp, treasury bid cap,
# Deal Book, 320 dp min viewport, E7 initial tab index.

cd app && flutter test test/production_panel_test.dart
# 40/40 pass — shared l10n reuse does not regress production-panel ordering.

cd app && flutter analyze lib/features/game/screens/trade_screen.dart \
  test/trade_screen_market_tab_commodity_table_test.dart
# clean — no analyzer issues.
\`\`\`

## Issue scope (#3093)

**Done in this PR:** Sectioned Market tab layout slice — three `CtSectionLabel` headers (Food / Raw Materials / Manufactured), within-section catalog order, SPEC update + 7 ACs, breaking-test refit and 2 new tests.

**Already on `dev` (prior merged PRs):** Integer world-market prices + catalog fallback (#3098), Market-tab treasury bid budget cap (#3099), sellable clamp + offer-side UI clamp (sellable-clamp slice).

**Open companion PR:** #3102 — row icons (leading 20 dp `ResourceIcon` + trailing 14 dp treasury-coin `StrictAssetIcon`).

**Still deferred on #3093:**
- Production panel cross-talk: subtract staged trade offers from the Production Available subpanel's affordability preview (touches `production_panel.dart` and the shared sellable helpers).
- Validator-side treasury bid enforcement for unpriced commodities (`SPEC/game/world-market.md` § Validation rules follow-up — today the UI clamp skips unpriced rows; the validator currently relies on the cargo cap alone for those rows).

Refs #3093

Made with [Cursor](https://cursor.com)