### PR TITLE
refactor(ui): debug console overlay adopts palette tokens + CtIconAction (Refs #2914 S3 + S8)

### DIFF
--- a/SPEC/ui/debug-console-panel.md
+++ b/SPEC/ui/debug-console-panel.md
@@ -51,6 +51,33 @@
 
 ---
 
+## Visual chrome
+
+The panel renders against the canonical dark editorial-monocle palette
+(`SPEC/ui/pixel-art-ui-catalog.md` § Editorial-monocle palette). No raw
+Material color literals appear in feature code; every surface, glyph,
+and text colour resolves through an `EditorialMonoclePalette` token.
+
+| Region | Token / catalog primitive |
+|--------|---------------------------|
+| Outer panel surface | `EditorialMonoclePalette.bgDeep` at `0.85` alpha |
+| Header title text | `EditorialMonoclePalette.fg` (weight `w700`) |
+| Header close affordance | `CtIconAction` (`Refs #2914` S8 — replaces banned `IconButton`) with `iconColor = EditorialMonoclePalette.fg` |
+| Log readout background | `EditorialMonoclePalette.dialogScrim` |
+| Log readout text | `EditorialMonoclePalette.fg` |
+| Input field text | `EditorialMonoclePalette.fg` |
+| Input field hint | `EditorialMonoclePalette.muted` at `0.6` alpha |
+| Input field fill | `EditorialMonoclePalette.dialogScrim` |
+
+### Acceptance criteria — Visual chrome
+
+- Given the debug console overlay is mounted, when the panel builds, then The UI layer renders the header close affordance as a `CtIconAction` (catalog primitive) and renders **no** Material `IconButton` widgets inside the panel subtree.
+- Given the debug console overlay is mounted, when the panel builds, then The UI layer resolves the header title text colour to `EditorialMonoclePalette.fg`, the input style colour to `EditorialMonoclePalette.fg`, and the input hint colour to `EditorialMonoclePalette.muted` at `0.6` alpha.
+- Given the debug console overlay is mounted, when the panel builds, then The UI layer resolves the outer `Material` surface colour to `EditorialMonoclePalette.bgDeep` at `0.85` alpha and the input fill colour to `EditorialMonoclePalette.dialogScrim`.
+- Given the user taps the header close affordance, when the tap is committed, then the system invokes the panel `onClose` callback exactly once.
+
+---
+
 ## Acceptance Criteria (Given–When–Then)
 
 - Given `CT_DEBUG_CONSOLE=false`, when `GameMapEmpireLeftRail` is rendered, then the UI layer does not render a debug-console icon.

--- a/app/lib/features/game/flame/debug_console_overlay_panel.dart
+++ b/app/lib/features/game/flame/debug_console_overlay_panel.dart
@@ -1,14 +1,22 @@
 import 'package:colonizethis_app/config/editorial_monocle_palette.dart';
 import 'package:colonizethis_app/l10n/l10n.dart';
+import 'package:colonizethis_app/widgets/ct_icon_action.dart';
 import 'package:colonizethis_app/widgets/ct_radius.dart';
 import 'package:colonizethis_app/widgets/ct_spacing.dart';
 import 'package:colonizethis_debug_console/colonizethis_debug_console.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 
 import 'debug_console_controller.dart';
 
+/// `SYS20001` Debug console overlay panel.
+///
+/// Visual chrome resolves through [EditorialMonoclePalette] tokens — no
+/// hard-coded Material color literals — and the close affordance is the
+/// [CtIconAction] catalog primitive (no banned Material [IconButton]).
+/// Implements `Refs #2914` S3 (Material color cleanup) and S8 (Material
+/// widget ban) for the dev-tooling debug console surface
+/// (`SPEC/ui/debug-console-panel.md` § Visual chrome).
 class DebugConsoleOverlayPanel extends StatefulWidget {
   const DebugConsoleOverlayPanel({
     required this.bus,
@@ -22,6 +30,25 @@ class DebugConsoleOverlayPanel extends StatefulWidget {
   final String humanPlayerId;
   final DebugConsoleReadOnlyContext? Function() readOnlyContextProvider;
   final VoidCallback onClose;
+
+  /// Stable key for the panel close affordance ([CtIconAction]). Exposed
+  /// for widget tests that pin the editorial-monocle chrome contract
+  /// (Refs #2914 S8 — no banned Material [IconButton]).
+  static const ValueKey<String> closeButtonKey = ValueKey<String>(
+    'debug-console-close',
+  );
+
+  /// Alpha applied to [EditorialMonoclePalette.bgDeep] for the outer
+  /// panel surface. Kept at the prior `0.85` value the panel used
+  /// against the now-removed `Colors.black` literal so the visual
+  /// density on top of the in-map overlay stack does not regress.
+  static const double panelBackgroundAlpha = 0.85;
+
+  /// Alpha applied to [EditorialMonoclePalette.muted] for the
+  /// `TextField` hint text. Kept at the prior `0.6` value the panel
+  /// used against the now-removed `Colors.white.withValues(alpha: 0.6)`
+  /// literal for hint legibility parity.
+  static const double hintTextAlpha = 0.6;
 
   @override
   State<DebugConsoleOverlayPanel> createState() =>
@@ -63,7 +90,9 @@ class _DebugConsoleOverlayPanelState extends State<DebugConsoleOverlayPanel> {
   Widget build(BuildContext context) {
     final l10n = appL10n(context);
     return Material(
-      color: Colors.black.withValues(alpha: 0.85),
+      color: EditorialMonoclePalette.bgDeep.withValues(
+        alpha: DebugConsoleOverlayPanel.panelBackgroundAlpha,
+      ),
       borderRadius: BorderRadius.circular(CtRadius.large),
       child: SizedBox(
         width: 420,
@@ -96,13 +125,18 @@ class _DebugConsoleOverlayPanelState extends State<DebugConsoleOverlayPanel> {
         Expanded(
           child: Text(
             l10n.debugConsole_title,
-            style: TextStyle(color: Colors.white, fontWeight: FontWeight.w700),
+            style: TextStyle(
+              color: EditorialMonoclePalette.fg,
+              fontWeight: FontWeight.w700,
+            ),
           ),
         ),
-        IconButton(
+        CtIconAction(
+          key: DebugConsoleOverlayPanel.closeButtonKey,
           tooltip: 'Close debug console',
+          icon: Icons.close,
+          iconColor: EditorialMonoclePalette.fg,
           onPressed: widget.onClose,
-          icon: const Icon(Icons.close, color: Colors.white),
         ),
       ],
     );
@@ -114,8 +148,8 @@ class _DebugConsoleOverlayPanelState extends State<DebugConsoleOverlayPanel> {
           .map(
             (line) => Text(
               line,
-              style: const TextStyle(
-                color: Colors.white,
+              style: TextStyle(
+                color: EditorialMonoclePalette.fg,
                 fontFamily: 'monospace',
                 fontSize: 12,
               ),
@@ -133,11 +167,15 @@ class _DebugConsoleOverlayPanelState extends State<DebugConsoleOverlayPanel> {
         focusNode: _controller.focusNode,
         controller: _controller.textController,
         onSubmitted: (_) => _submit(),
-        style: const TextStyle(color: Colors.white),
+        style: TextStyle(color: EditorialMonoclePalette.fg),
         decoration: InputDecoration(
           isDense: true,
           hintText: l10n.debugConsole_hintSpawnCivilian,
-          hintStyle: TextStyle(color: Colors.white.withValues(alpha: 0.6)),
+          hintStyle: TextStyle(
+            color: EditorialMonoclePalette.muted.withValues(
+              alpha: DebugConsoleOverlayPanel.hintTextAlpha,
+            ),
+          ),
           filled: true,
           fillColor: EditorialMonoclePalette.dialogScrim,
           border: OutlineInputBorder(

--- a/app/test/debug_console_overlay_panel_test.dart
+++ b/app/test/debug_console_overlay_panel_test.dart
@@ -1,4 +1,6 @@
+import 'package:colonizethis_app/config/editorial_monocle_palette.dart';
 import 'package:colonizethis_app/features/game/flame/debug_console_overlay_panel.dart';
+import 'package:colonizethis_app/widgets/ct_icon_action.dart';
 import 'package:colonizethis_debug_console/colonizethis_debug_console.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
@@ -495,5 +497,181 @@ void main() {
       expect(snackbars.last.message, contains('player_id: p1'));
       expect(events, isEmpty);
     });
+  });
+
+  group('DebugConsoleOverlayPanel dark editorial-monocle chrome (Refs #2914 '
+      'S3 + S8)', () {
+    Future<void> pumpPanel(
+      WidgetTester tester, {
+      required AppEventBus bus,
+      VoidCallback? onClose,
+    }) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: DebugConsoleOverlayPanel(
+              bus: bus,
+              humanPlayerId: 'human_1',
+              readOnlyContextProvider: () =>
+                  const DebugConsoleReadOnlyContext(),
+              onClose: onClose ?? () {},
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+    }
+
+    testWidgets(
+      'panel close affordance is a CtIconAction (no Material IconButton)',
+      (tester) async {
+        final bus = AppEventBus.create();
+        addTearDown(bus.dispose);
+        await pumpPanel(tester, bus: bus);
+
+        final closeFinder = find.byKey(
+          DebugConsoleOverlayPanel.closeButtonKey,
+        );
+        expect(
+          closeFinder,
+          findsOneWidget,
+          reason:
+              'Refs #2914 S8 requires the catalog CtIconAction primitive '
+              '(not the banned Material IconButton) for the close affordance.',
+        );
+        // The keyed widget itself must be the CtIconAction catalog primitive.
+        expect(
+          tester.widget(closeFinder),
+          isA<CtIconAction>(),
+        );
+        expect(
+          find.descendant(
+            of: find.byType(DebugConsoleOverlayPanel),
+            matching: find.byType(CtIconAction),
+          ),
+          findsOneWidget,
+        );
+        expect(
+          find.descendant(
+            of: find.byType(DebugConsoleOverlayPanel),
+            matching: find.byType(IconButton),
+          ),
+          findsNothing,
+          reason:
+              'Banned Material IconButton must not appear in the panel '
+              'subtree (Refs #2914 S8 / SPEC/ui/pixel-art-ui-catalog.md '
+              '\u00a7 Material design ban).',
+        );
+      },
+    );
+
+    testWidgets(
+      'tapping the CtIconAction close affordance invokes onClose',
+      (tester) async {
+        final bus = AppEventBus.create();
+        addTearDown(bus.dispose);
+        var closeCount = 0;
+        await pumpPanel(tester, bus: bus, onClose: () => closeCount += 1);
+
+        await tester.tap(
+          find.byKey(DebugConsoleOverlayPanel.closeButtonKey),
+        );
+        await tester.pump();
+
+        expect(closeCount, 1);
+      },
+    );
+
+    testWidgets(
+      'header title text style colour resolves to '
+      'EditorialMonoclePalette.fg (no Material Colors.white)',
+      (tester) async {
+        final bus = AppEventBus.create();
+        addTearDown(bus.dispose);
+        await pumpPanel(tester, bus: bus);
+
+        final headerText = tester.widget<Text>(
+          find.text('Debug Console'),
+        );
+        expect(headerText.style?.color, EditorialMonoclePalette.fg);
+        expect(headerText.style?.fontWeight, FontWeight.w700);
+      },
+    );
+
+    testWidgets(
+      'TextField input style colour resolves to '
+      'EditorialMonoclePalette.fg (no Material Colors.white)',
+      (tester) async {
+        final bus = AppEventBus.create();
+        addTearDown(bus.dispose);
+        await pumpPanel(tester, bus: bus);
+
+        final input = tester.widget<TextField>(
+          find.byKey(const ValueKey<String>('debug-console-input')),
+        );
+        expect(input.style?.color, EditorialMonoclePalette.fg);
+      },
+    );
+
+    testWidgets(
+      'TextField hint style colour resolves to EditorialMonoclePalette.muted '
+      'with the documented hint alpha (no Material Colors.white)',
+      (tester) async {
+        final bus = AppEventBus.create();
+        addTearDown(bus.dispose);
+        await pumpPanel(tester, bus: bus);
+
+        final input = tester.widget<TextField>(
+          find.byKey(const ValueKey<String>('debug-console-input')),
+        );
+        final hintColor = input.decoration?.hintStyle?.color;
+        final expectedHint = EditorialMonoclePalette.muted.withValues(
+          alpha: DebugConsoleOverlayPanel.hintTextAlpha,
+        );
+        expect(hintColor, expectedHint);
+      },
+    );
+
+    testWidgets(
+      'TextField fill colour resolves to EditorialMonoclePalette.dialogScrim',
+      (tester) async {
+        final bus = AppEventBus.create();
+        addTearDown(bus.dispose);
+        await pumpPanel(tester, bus: bus);
+
+        final input = tester.widget<TextField>(
+          find.byKey(const ValueKey<String>('debug-console-input')),
+        );
+        expect(input.decoration?.filled, isTrue);
+        expect(
+          input.decoration?.fillColor,
+          EditorialMonoclePalette.dialogScrim,
+        );
+      },
+    );
+
+    testWidgets(
+      'outer Material surface colour resolves to '
+      'EditorialMonoclePalette.bgDeep at the documented panel alpha '
+      '(no Material Colors.black)',
+      (tester) async {
+        final bus = AppEventBus.create();
+        addTearDown(bus.dispose);
+        await pumpPanel(tester, bus: bus);
+
+        final panelMaterial = tester.widget<Material>(
+          find
+              .descendant(
+                of: find.byType(DebugConsoleOverlayPanel),
+                matching: find.byType(Material),
+              )
+              .first,
+        );
+        final expectedSurface = EditorialMonoclePalette.bgDeep.withValues(
+          alpha: DebugConsoleOverlayPanel.panelBackgroundAlpha,
+        );
+        expect(panelMaterial.color, expectedSurface);
+      },
+    );
   });
 }

--- a/test/check_app_editorial_monocle_colors_test.dart
+++ b/test/check_app_editorial_monocle_colors_test.dart
@@ -217,12 +217,10 @@ const fallback = TextStyle(color: Colors.white);
           'app/lib/features/game/flame/region_map_component_render_core.dart';
       const palette =
           'app/lib/features/game/flame/resource_icon_disc_palette.dart';
-      const debugConsole =
-          'app/lib/features/game/flame/debug_console_overlay_panel.dart';
       const debugViewer =
           'app/lib/features/debug_log/debug_log_viewer_screen.dart';
 
-      for (final rel in [flameRenderer, palette, debugConsole, debugViewer]) {
+      for (final rel in [flameRenderer, palette, debugViewer]) {
         File('${temp.path}/$rel')
           ..createSync(recursive: true)
           ..writeAsStringSync('''
@@ -241,6 +239,43 @@ const debug = TextStyle(color: Colors.white);
 
       expect(code, 0);
     });
+
+    test(
+      'no longer allowlists debug_console_overlay_panel.dart (Refs #2914 S3 + S8 '
+      'token adoption + CtIconAction migration)',
+      () {
+        final temp = Directory.systemTemp.createTempSync(
+          'check_app_editorial_monocle_colors_debug_console_promoted_',
+        );
+        addTearDown(() => temp.deleteSync(recursive: true));
+
+        const debugConsole =
+            'app/lib/features/game/flame/debug_console_overlay_panel.dart';
+        File('${temp.path}/$debugConsole')
+          ..createSync(recursive: true)
+          ..writeAsStringSync('''
+import 'package:flutter/material.dart';
+
+const sample = TextStyle(color: Colors.white);
+''');
+
+        final logs = <String>[];
+        final code = runCheckAppEditorialMonocleColors(
+          temp.path,
+          info: logs.add,
+          err: logs.add,
+        );
+
+        expect(code, 1);
+        expect(
+          logs.join('\n'),
+          contains(
+            'app/lib/features/game/flame/debug_console_overlay_panel.dart:3: '
+            'Colors.white',
+          ),
+        );
+      },
+    );
 
     test(
       'does not scan test files inside features/ (production surface only)',
@@ -557,7 +592,6 @@ class Clean extends StatelessWidget {
         'app/lib/features/game/flame/game_region_minimap.dart',
         'app/lib/features/game/flame/resource_icon_disc_palette.dart',
         'app/lib/features/debug_log/debug_log_viewer_screen.dart',
-        'app/lib/features/game/flame/debug_console_overlay_panel.dart',
       ];
       for (final path in skipped) {
         expect(
@@ -567,6 +601,19 @@ class Clean extends StatelessWidget {
         );
       }
     });
+
+    test(
+      'does not skip debug_console_overlay_panel.dart (in scope for the '
+      'check after Refs #2914 S3 + S8 token adoption)',
+      () {
+        expect(
+          shouldSkipAppEditorialMonocleColorsFile(
+            'app/lib/features/game/flame/debug_console_overlay_panel.dart',
+          ),
+          isFalse,
+        );
+      },
+    );
 
     test(
       'skips app/lib/widgets/ canvas-compositing files (Refs #2914 §S4 '

--- a/test/check_app_no_material_iconbutton_test.dart
+++ b/test/check_app_no_material_iconbutton_test.dart
@@ -209,26 +209,22 @@ Widget fallback() => IconButton(icon: const Icon(Icons.menu), onPressed: () {});
       },
     );
 
-    test('allowlists dev-tooling screens (SYS10001, SYS20001)', () {
+    test('allowlists the Debug Log Viewer dev-tooling screen (SYS10001)', () {
       final temp = Directory.systemTemp.createTempSync(
         'check_app_no_material_iconbutton_devtools_',
       );
       addTearDown(() => temp.deleteSync(recursive: true));
 
-      const debugConsole =
-          'app/lib/features/game/flame/debug_console_overlay_panel.dart';
       const debugViewer =
           'app/lib/features/debug_log/debug_log_viewer_screen.dart';
 
-      for (final rel in [debugConsole, debugViewer]) {
-        File('${temp.path}/$rel')
-          ..createSync(recursive: true)
-          ..writeAsStringSync('''
+      File('${temp.path}/$debugViewer')
+        ..createSync(recursive: true)
+        ..writeAsStringSync('''
 import 'package:flutter/material.dart';
 
 Widget bypass() => IconButton(icon: const Icon(Icons.close), onPressed: () {});
 ''');
-      }
 
       final code = runCheckAppNoMaterialIconButton(
         temp.path,
@@ -238,6 +234,43 @@ Widget bypass() => IconButton(icon: const Icon(Icons.close), onPressed: () {});
 
       expect(code, 0);
     });
+
+    test(
+      'no longer allowlists the Debug Console Overlay (SYS20001) after the '
+      'Refs #2914 S8 CtIconAction migration',
+      () {
+        final temp = Directory.systemTemp.createTempSync(
+          'check_app_no_material_iconbutton_debug_console_promoted_',
+        );
+        addTearDown(() => temp.deleteSync(recursive: true));
+
+        const debugConsole =
+            'app/lib/features/game/flame/debug_console_overlay_panel.dart';
+        File('${temp.path}/$debugConsole')
+          ..createSync(recursive: true)
+          ..writeAsStringSync('''
+import 'package:flutter/material.dart';
+
+Widget bypass() => IconButton(icon: const Icon(Icons.close), onPressed: () {});
+''');
+
+        final logs = <String>[];
+        final code = runCheckAppNoMaterialIconButton(
+          temp.path,
+          info: logs.add,
+          err: logs.add,
+        );
+
+        expect(code, 1);
+        expect(
+          logs.join('\n'),
+          contains(
+            'app/lib/features/game/flame/debug_console_overlay_panel.dart:3: '
+            'IconButton(',
+          ),
+        );
+      },
+    );
 
     test(
       'does not scan test files inside features/ (production surface only)',
@@ -363,7 +396,6 @@ Widget probe() => IconButton(icon: const Icon(Icons.bug_report), onPressed: () {
     test('skips canonical dev-tooling screens', () {
       const skipped = <String>[
         'app/lib/features/debug_log/debug_log_viewer_screen.dart',
-        'app/lib/features/game/flame/debug_console_overlay_panel.dart',
       ];
       for (final path in skipped) {
         expect(
@@ -373,6 +405,19 @@ Widget probe() => IconButton(icon: const Icon(Icons.bug_report), onPressed: () {
         );
       }
     });
+
+    test(
+      'does not skip debug_console_overlay_panel.dart (in scope for the '
+      'check after Refs #2914 S8 CtIconAction migration)',
+      () {
+        expect(
+          shouldSkipAppNoMaterialIconButtonFile(
+            'app/lib/features/game/flame/debug_console_overlay_panel.dart',
+          ),
+          isFalse,
+        );
+      },
+    );
 
     test(
       'does not skip ordinary feature widgets (in scope for the check)',

--- a/tool/check_app_editorial_monocle_colors.dart
+++ b/tool/check_app_editorial_monocle_colors.dart
@@ -31,9 +31,14 @@ import 'package:path/path.dart' as p;
 ///    colors (per-resource hue references) keyed by id; the table values are
 ///    the palette source for those resources rather than a bypass of the
 ///    editorial-monocle theme.
-/// 3. **Dev-tooling screens** — `SYS10001` Debug Log Viewer and `SYS20001`
-///    Debug Console Overlay are operator-only surfaces; implementing Ct-*
-///    catalog widgets there is low-value (see #2914 Risks / edge cases).
+/// 3. **Dev-tooling screens** — `SYS10001` Debug Log Viewer is an
+///    operator-only surface; implementing Ct-* catalog widgets there
+///    remains low-value (see #2914 Risks / edge cases). `SYS20001`
+///    Debug Console Overlay (`debug_console_overlay_panel.dart`) was
+///    promoted out of the allowlist after adopting
+///    [EditorialMonoclePalette] tokens and replacing its `IconButton`
+///    close affordance with `CtIconAction`; see
+///    `SPEC/ui/debug-console-panel.md` § Visual chrome.
 /// 4. **`app/lib/features/game/widgets/chrome/**`** — Ct-* catalog widget
 ///    implementations. These widgets implement the design-system primitives
 ///    consumed by the rest of the feature tree and may declare `const`
@@ -205,10 +210,13 @@ const Set<String> _appEditorialMonocleColorsAllowedFiles = <String>{
   'app/lib/features/game/flame/game_region_minimap.dart',
   // Pixel-art palette data (per-resource hue lookup table).
   'app/lib/features/game/flame/resource_icon_disc_palette.dart',
-  // Dev-tooling screens — SYS10001 (Debug Log Viewer) and SYS20001
-  // (Debug Console Overlay). Relaxed per #2914 Risks / edge cases.
+  // Dev-tooling screens — SYS10001 (Debug Log Viewer). Relaxed per
+  // #2914 Risks / edge cases. SYS20001 (Debug Console Overlay) was
+  // promoted out of the allowlist by the S3 + S8 token-adoption slice;
+  // see `SPEC/ui/debug-console-panel.md` § Visual chrome and the dark
+  // editorial-monocle chrome tests in
+  // `app/test/debug_console_overlay_panel_test.dart`.
   'app/lib/features/debug_log/debug_log_viewer_screen.dart',
-  'app/lib/features/game/flame/debug_console_overlay_panel.dart',
   // app/lib/widgets/ canvas-compositing files — the color literal is a
   // compositing argument (alpha multiplier in `Paint.color` for a
   // `saveLayer` decorative overlay, or the `ColorFilter.mode` blend

--- a/tool/check_app_no_material_iconbutton.dart
+++ b/tool/check_app_no_material_iconbutton.dart
@@ -23,11 +23,14 @@ import 'package:path/path.dart' as p;
 /// `SPEC/program/repo-lint.md` § "Policy: no violation allowlists"):
 ///
 /// 1. **Dev-tooling screens** — `SYS10001` Debug Log Viewer
-///    (`app/lib/features/debug_log/debug_log_viewer_screen.dart`) and
-///    `SYS20001` Debug Console Overlay
-///    (`app/lib/features/game/flame/debug_console_overlay_panel.dart`) are
-///    operator-only surfaces; implementing Ct-* catalog widgets there is
-///    low-value (see #2914 Risks / edge cases).
+///    (`app/lib/features/debug_log/debug_log_viewer_screen.dart`) is an
+///    operator-only surface; implementing Ct-* catalog widgets there
+///    remains low-value (see #2914 Risks / edge cases). `SYS20001`
+///    Debug Console Overlay
+///    (`app/lib/features/game/flame/debug_console_overlay_panel.dart`)
+///    was promoted out of the allowlist after migrating its close
+///    affordance to `CtIconAction`; see
+///    `SPEC/ui/debug-console-panel.md` § Visual chrome.
 /// 2. **`app/lib/features/game/widgets/chrome/**`** — Ct-* catalog widget
 ///    implementations. These widgets implement the design-system
 ///    primitives consumed by the rest of the feature tree and may
@@ -151,10 +154,13 @@ final RegExp bannedIconButtonConstructionPattern = RegExp(
 );
 
 const Set<String> _appNoMaterialIconButtonAllowedFiles = <String>{
-  // Dev-tooling screens — SYS10001 (Debug Log Viewer) and SYS20001
-  // (Debug Console Overlay). Relaxed per #2914 Risks / edge cases.
+  // Dev-tooling screens — SYS10001 (Debug Log Viewer) is still relaxed
+  // per #2914 Risks / edge cases. SYS20001 (Debug Console Overlay) was
+  // promoted out of the allowlist by the Refs #2914 S8 token + catalog
+  // adoption slice (see SPEC/ui/debug-console-panel.md § Visual chrome
+  // and the dark editorial-monocle chrome tests in
+  // app/test/debug_console_overlay_panel_test.dart).
   'app/lib/features/debug_log/debug_log_viewer_screen.dart',
-  'app/lib/features/game/flame/debug_console_overlay_panel.dart',
 };
 
 const Set<String> _appNoMaterialIconButtonAllowedDirPrefixes = <String>{


### PR DESCRIPTION
## Summary

Promotes `SYS20001` Debug Console Overlay
(`app/lib/features/game/flame/debug_console_overlay_panel.dart`) out of
the dev-tooling lint allowlists by adopting the canonical
editorial-monocle dark theme tokens and the catalog primitive
replacement for the banned Material `IconButton`. The file was
previously allowlisted as "dev-tooling, low value to refactor" — this
slice does the refactor and promotes the file into full G1 + G2 lint
enforcement so future regressions trip CI.

The umbrella issue **#2914 §S3 (color cleanup)** and **§S8 (Material
widget ban)** explicitly target *every* file under `app/lib/features/`
(excluding only flame render files); this slice closes the SYS20001
gap.

Refs #2914 (does not auto-close; #2914 is an umbrella tracking many
sub-slices).

## Done in this push

### Code

`app/lib/features/game/flame/debug_console_overlay_panel.dart`

- All `Colors.white` / `Colors.black` text and icon literals now
  resolve through `EditorialMonoclePalette` tokens:
  - Outer `Material` surface: `EditorialMonoclePalette.bgDeep` at
    `0.85` alpha (was `Colors.black.withValues(alpha: 0.85)`).
  - Header title, log readout text, `TextField` input style:
    `EditorialMonoclePalette.fg` (was `Colors.white`).
  - `TextField` hint: `EditorialMonoclePalette.muted` at `0.6` alpha
    (was `Colors.white.withValues(alpha: 0.6)`).
  - `TextField` fill: `EditorialMonoclePalette.dialogScrim`
    (unchanged — already on-token).
- Header close affordance is now `CtIconAction` (catalog primitive)
  keyed by `DebugConsoleOverlayPanel.closeButtonKey`, with
  `iconColor: EditorialMonoclePalette.fg` and the existing tooltip
  preserved (Refs #2914 §S8 — replaces banned Material
  `IconButton`).
- New public surface (test-pinnable):
  `DebugConsoleOverlayPanel.closeButtonKey`,
  `panelBackgroundAlpha` (`0.85`), `hintTextAlpha` (`0.6`).
- Removed unnecessary `dart:io`/`services.dart` imports (analyzer
  clean).

### SPEC

`SPEC/ui/debug-console-panel.md` § **Visual chrome** (new) — adds the
token / catalog primitive table and four Given–When–Then ACs:

1. Close affordance is `CtIconAction`; no Material `IconButton` in
   the panel subtree.
2. Header / input / hint colours resolve to the documented tokens.
3. Outer `Material` surface and input fill resolve to the documented
   tokens.
4. Tapping the close affordance invokes `onClose` exactly once.

### Lint promotions (G1 + G2)

- `tool/check_app_editorial_monocle_colors.dart` — removes
  `debug_console_overlay_panel.dart` from
  `_appEditorialMonocleColorsAllowedFiles`; doc-comment updated.
- `tool/check_app_no_material_iconbutton.dart` — removes the file
  from `_appNoMaterialIconButtonAllowedFiles`; doc-comment updated.
- `test/check_app_editorial_monocle_colors_test.dart` — drops the
  file from the Flame/debug allowlist pin and adds a new positive
  regression test asserting the file is now in scope (a `Colors.white`
  there fails the check). Scope-predicate test now asserts the file
  is **not** skipped.
- `test/check_app_no_material_iconbutton_test.dart` — same shape:
  drops the file from the "dev-tooling" allowlist pin and adds a new
  regression test asserting `IconButton(` in this file now trips the
  check. Scope predicate updated.

The other Material widget ban lints (`AlertDialog`, `FilterChip`,
`Scaffold`, `SwitchListTile`, `TextButton`) keep their allowlist
entry for this file: the panel currently uses none of those widgets,
so the promotion is correctness-neutral and intentionally deferred to
a follow-up slice to keep this PR focused on the two lints that
actually fired against the panel.

## Tests

`app/test/debug_console_overlay_panel_test.dart` — new test group
**`DebugConsoleOverlayPanel dark editorial-monocle chrome (Refs
#2914 S3 + S8)`** with 7 widget tests pinning:

1. Close affordance is a `CtIconAction` (no Material `IconButton`
   anywhere in the panel subtree) — positive type pin + negative
   regression sweep.
2. Tapping the close affordance fires `onClose` exactly once.
3. Header title text colour resolves to `EditorialMonoclePalette.fg`
   with weight `w700` (negative pin against `Colors.white`).
4. `TextField` input style colour resolves to
   `EditorialMonoclePalette.fg`.
5. `TextField` hint style colour resolves to
   `EditorialMonoclePalette.muted` at `hintTextAlpha` (`0.6`).
6. `TextField` fill colour resolves to
   `EditorialMonoclePalette.dialogScrim`.
7. Outer `Material` surface colour resolves to
   `EditorialMonoclePalette.bgDeep` at `panelBackgroundAlpha`
   (`0.85`) — negative pin against `Colors.black`.

All 12 pre-existing behavior tests in this file (spawn / treasury /
flip / list_players / history / escape) continue to pass unchanged.

### Tests run

- `cd app && flutter test test/debug_console_overlay_panel_test.dart` — **19/19 pass** (12 pre-existing + 7 new).
- `cd app && flutter test test/issue_2914_s1_debug_console_dialog_scrim_test.dart` — **2/2 pass** (`dialogScrim` token still referenced; no `Colors.black54` reintroduced).
- `dart test test/check_app_editorial_monocle_colors_test.dart` — **28/28 pass** (includes new "no longer allowlists" positive regression + new "does not skip" scope predicate test).
- `dart test test/check_app_no_material_iconbutton_test.dart` — **19/19 pass** (same shape: new positive regression + new scope predicate test).
- `dart run tool/check_app_editorial_monocle_colors.dart` — `no violations found`.
- `dart run tool/check_app_no_material_iconbutton.dart` — `no violations found`.
- `flutter analyze lib/features/game/flame/debug_console_overlay_panel.dart test/debug_console_overlay_panel_test.dart` — clean.

## ACs covered (umbrella #2914)

This slice contributes to:

- [ ] **S3** — Zero `Colors.white` / `Colors.black` in
      `app/lib/features/game/flame/debug_console_overlay_panel.dart`
      (file-level: closed by this PR; umbrella S3 stays open for
      the still-allowlisted SYS10001 Debug Log Viewer).
- [ ] **S8** — Zero Material `IconButton` in
      `debug_console_overlay_panel.dart` (file-level: closed by
      this PR; umbrella S8 stays open for SYS10001).
- [ ] **G1** — `check_app_editorial_monocle_colors` now scans this
      file (one fewer dev-tooling allowlist entry).
- [ ] **G2** — `check_app_no_material_iconbutton` now scans this
      file (one fewer dev-tooling allowlist entry).

## Deferred for follow-up slices on #2914

- Promote `debug_console_overlay_panel.dart` out of the **other 5**
  Material widget ban allowlists (`AlertDialog`, `FilterChip`,
  `Scaffold`, `SwitchListTile`, `TextButton`). The panel uses none
  of those widgets, so this is a 5-line mechanical cleanup; left
  out here to keep the PR scoped to the lints that actually fired.
- `SYS10001` Debug Log Viewer (`debug_log_viewer_screen.dart`) — a
  bigger refactor (Scaffold + IconButton + 2 FilterChips +
  `Colors.red`/`orange`/`blue`/`grey`); left intentionally
  allowlisted per #2914 § Risks ("enforcement can be relaxed for
  debug UI").

Made with [Cursor](https://cursor.com)