### PR TITLE
refactor(ui): debug log viewer adopts palette tokens (Refs #2914 S3)

### DIFF
--- a/SPEC/program/debug-log-viewer.md
+++ b/SPEC/program/debug-log-viewer.md
@@ -49,6 +49,36 @@
 
 ---
 
+## 5a. Visual chrome
+
+The viewer renders against the canonical dark editorial-monocle palette
+(`SPEC/ui/pixel-art-ui-catalog.md` § Editorial-monocle palette). Per-level
+row tints resolve through `EditorialMonoclePalette` tokens rather than raw
+Material `Colors.*` values. The first line of each log entry receives a
+`0.08`-alpha background wash in the colour returned by the table below; all
+subsequent lines of the same entry render without a wash.
+
+| `Level` | Token | Rationale |
+|---------|-------|-----------|
+| `error` | `EditorialMonoclePalette.danger` | Warm-red alert; highest severity. |
+| `warning` | `EditorialMonoclePalette.accent` | Warm-yellow accent; secondary alert. |
+| `info` | `EditorialMonoclePalette.accentDim` | Dimmer warm accent; notable but non-alert. |
+| default (`debug`, `trace`) | `EditorialMonoclePalette.muted` | Neutral wash; low-signal noise. |
+
+The editorial-monocle palette is intentionally warm-monochromatic and does
+not define a "blue/info" token; the four-tier warm gradient above conveys
+severity without re-introducing Material's blue/orange palette.
+
+### Acceptance criteria (Visual chrome)
+
+- Given the debug log viewer is mounted with a buffered `Level.error` entry, when the viewer builds its list, then the UI layer renders the first line of that entry inside a `Container` whose `BoxDecoration.color` equals `EditorialMonoclePalette.danger` with `alpha = 0.08`.
+- Given the debug log viewer is mounted with a buffered `Level.warning` entry, when the viewer builds its list, then the UI layer renders the first line of that entry inside a `Container` whose `BoxDecoration.color` equals `EditorialMonoclePalette.accent` with `alpha = 0.08`.
+- Given the debug log viewer is mounted with a buffered `Level.info` entry, when the viewer builds its list, then the UI layer renders the first line of that entry inside a `Container` whose `BoxDecoration.color` equals `EditorialMonoclePalette.accentDim` with `alpha = 0.08`.
+- Given the debug log viewer is mounted with a buffered `Level.debug` entry and the user has toggled the `debug` level filter on, when the viewer builds its list, then the UI layer renders the first line of that entry inside a `Container` whose `BoxDecoration.color` equals `EditorialMonoclePalette.muted` with `alpha = 0.08`.
+- Given the debug log viewer source file `app/lib/features/debug_log/debug_log_viewer_screen.dart`, when `tool/check_app_editorial_monocle_colors.dart` runs against the repository tree, then the checker does not allowlist this file and reports any raw Material `Colors.*` regression introduced after the Refs #2914 S3 token-adoption slice.
+
+---
+
 ## 6. Coexistence with Sim Log
 
 - The ctdev **Sim Log** (last 10 lines, info+, cleared each turn) is unchanged and remains on the Running Game screen. The debug log viewer is separate: it shows the full session buffer with no turn-based clear and includes debug level. No behavioural change to Sim Log.

--- a/app/lib/features/debug_log/debug_log_viewer_screen.dart
+++ b/app/lib/features/debug_log/debug_log_viewer_screen.dart
@@ -3,6 +3,7 @@
 import 'package:flutter/material.dart';
 import 'package:logger/logger.dart';
 import 'package:session_log_buffer/session_log_buffer.dart';
+import 'package:colonizethis_app/config/editorial_monocle_palette.dart';
 import 'package:colonizethis_app/config/ui_screen_ids.dart';
 import 'package:colonizethis_app/l10n/l10n.dart';
 
@@ -153,16 +154,27 @@ class _DebugLogViewerScreenState extends State<DebugLogViewerScreen> {
     );
   }
 
+  /// Row-tint colour per log level, resolved through canonical
+  /// [EditorialMonoclePalette] tokens. The viewer applies the returned colour
+  /// with an `0.08` alpha to the first line of each entry as a subtle
+  /// background wash; the four-tier warm gradient (`danger` → `accent` →
+  /// `accentDim` → `muted`) signals severity within the editorial-monocle
+  /// dark theme without resorting to Material's blue/orange tones, which
+  /// the theme does not define.
+  ///
+  /// SPEC: `SPEC/program/debug-log-viewer.md` § Visual chrome, palette tokens
+  /// per `SPEC/ui/pixel-art-ui-catalog.md` § Editorial-monocle palette.
+  /// Refs #2914 S3 (token adoption / G1 allowlist promotion).
   Color _levelColor(Level level) {
     switch (level) {
       case Level.error:
-        return Colors.red;
+        return EditorialMonoclePalette.danger;
       case Level.warning:
-        return Colors.orange;
+        return EditorialMonoclePalette.accent;
       case Level.info:
-        return Colors.blue;
+        return EditorialMonoclePalette.accentDim;
       default:
-        return Colors.grey;
+        return EditorialMonoclePalette.muted;
     }
   }
 }

--- a/app/test/debug_log_viewer_test.dart
+++ b/app/test/debug_log_viewer_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:logger/logger.dart';
 import 'package:session_log_buffer/session_log_buffer.dart';
 
+import 'package:colonizethis_app/config/editorial_monocle_palette.dart';
 import 'package:colonizethis_app/config/themes.dart';
 import 'package:colonizethis_app/features/debug_log/debug_log_viewer_screen.dart';
 
@@ -16,6 +17,25 @@ FilterChip _chipWithLabel(WidgetTester tester, String label) {
       matching: find.byType(FilterChip),
     ),
   );
+}
+
+/// Returns the resolved row-tint Color for the first line of the matching
+/// log entry, or `null` when no tinted container is found. The viewer wraps
+/// each line in a `Container` and only the first line of each entry receives
+/// a `BoxDecoration` with the level row tint.
+Color? _rowTintColorContaining(WidgetTester tester, String pattern) {
+  final containerFinder = find.ancestor(
+    of: find.textContaining(pattern),
+    matching: find.byType(Container),
+  );
+  for (final element in containerFinder.evaluate()) {
+    final container = element.widget as Container;
+    final decoration = container.decoration;
+    if (decoration is BoxDecoration && decoration.color != null) {
+      return decoration.color;
+    }
+  }
+  return null;
 }
 
 void main() {
@@ -150,5 +170,160 @@ void main() {
 
       expect(find.textContaining('test message'), findsOneWidget);
     });
+
+    // Refs #2914 S3 — level row tints resolve through canonical
+    // [EditorialMonoclePalette] tokens, not raw Material `Colors.*`.
+    // SPEC: `SPEC/program/debug-log-viewer.md` § Visual chrome.
+    group('level row tint resolves through EditorialMonoclePalette', () {
+      testWidgets(
+        'Level.error → EditorialMonoclePalette.danger',
+        (WidgetTester tester) async {
+          SessionLogBuffer.instance.add(
+            LogEvent(Level.error, 'app: tint_error_token'),
+          );
+          await _pumpEditorialMonocleViewer(tester);
+          expect(_chipWithLabel(tester, 'error').selected, isTrue);
+
+          _expectTintMatches(
+            _rowTintColorContaining(tester, 'tint_error_token'),
+            EditorialMonoclePalette.danger,
+            reason: 'Level.error must tint with EditorialMonoclePalette.danger',
+          );
+        },
+      );
+
+      testWidgets(
+        'Level.warning → EditorialMonoclePalette.accent',
+        (WidgetTester tester) async {
+          SessionLogBuffer.instance.add(
+            LogEvent(Level.warning, 'app: tint_warning_token'),
+          );
+          await _pumpEditorialMonocleViewer(tester);
+          expect(_chipWithLabel(tester, 'warning').selected, isTrue);
+
+          _expectTintMatches(
+            _rowTintColorContaining(tester, 'tint_warning_token'),
+            EditorialMonoclePalette.accent,
+            reason:
+                'Level.warning must tint with EditorialMonoclePalette.accent',
+          );
+        },
+      );
+
+      testWidgets(
+        'Level.info → EditorialMonoclePalette.accentDim',
+        (WidgetTester tester) async {
+          SessionLogBuffer.instance.add(
+            LogEvent(Level.info, 'app: tint_info_token'),
+          );
+          await _pumpEditorialMonocleViewer(tester);
+          expect(_chipWithLabel(tester, 'info').selected, isTrue);
+
+          _expectTintMatches(
+            _rowTintColorContaining(tester, 'tint_info_token'),
+            EditorialMonoclePalette.accentDim,
+            reason:
+                'Level.info must tint with EditorialMonoclePalette.accentDim',
+          );
+        },
+      );
+
+      testWidgets(
+        'Level.debug → EditorialMonoclePalette.muted (default branch)',
+        (WidgetTester tester) async {
+          SessionLogBuffer.instance.add(
+            LogEvent(Level.debug, 'app: tint_default_token'),
+          );
+          await _pumpEditorialMonocleViewer(tester);
+
+          await tester.ensureVisible(find.text('debug'));
+          await tester.pumpAndSettle();
+          await tester.tap(find.text('debug'));
+          await tester.pumpAndSettle();
+
+          _expectTintMatches(
+            _rowTintColorContaining(tester, 'tint_default_token'),
+            EditorialMonoclePalette.muted,
+            reason: 'Level.debug (default branch) must tint with '
+                'EditorialMonoclePalette.muted',
+          );
+        },
+      );
+
+      testWidgets(
+        'level row tints do not use raw Material Colors.* values',
+        (WidgetTester tester) async {
+          SessionLogBuffer.instance.add(
+            LogEvent(Level.error, 'app: not_raw_material_red'),
+          );
+          SessionLogBuffer.instance.add(
+            LogEvent(Level.warning, 'app: not_raw_material_orange'),
+          );
+          SessionLogBuffer.instance.add(
+            LogEvent(Level.info, 'app: not_raw_material_blue'),
+          );
+          await _pumpEditorialMonocleViewer(tester);
+
+          const bannedSamples = <Color>[
+            Colors.red,
+            Colors.orange,
+            Colors.blue,
+            Colors.grey,
+          ];
+          for (final pattern in <String>[
+            'not_raw_material_red',
+            'not_raw_material_orange',
+            'not_raw_material_blue',
+          ]) {
+            final tint = _rowTintColorContaining(tester, pattern);
+            expect(
+              tint,
+              isNotNull,
+              reason: 'expected a tinted row for $pattern',
+            );
+            for (final banned in bannedSamples) {
+              final bannedAt08 = banned.withValues(alpha: _expectedRowAlpha);
+              final close = (tint!.r - bannedAt08.r).abs() < 0.005 &&
+                  (tint.g - bannedAt08.g).abs() < 0.005 &&
+                  (tint.b - bannedAt08.b).abs() < 0.005;
+              expect(
+                close,
+                isFalse,
+                reason: '$pattern must not tint with raw Material $banned',
+              );
+            }
+          }
+        },
+      );
+    });
   });
+}
+
+const double _expectedRowAlpha = 0.08;
+
+Future<void> _pumpEditorialMonocleViewer(WidgetTester tester) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      theme: AppThemes.editorialMonocle,
+      home: const DebugLogViewerScreen(),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void _expectTintMatches(
+  Color? actual,
+  Color base, {
+  required String reason,
+}) {
+  expect(actual, isNotNull, reason: reason);
+  final expected = base.withValues(alpha: _expectedRowAlpha);
+  expect(actual!.r, closeTo(expected.r, 0.01), reason: '$reason (r)');
+  expect(actual.g, closeTo(expected.g, 0.01), reason: '$reason (g)');
+  expect(actual.b, closeTo(expected.b, 0.01), reason: '$reason (b)');
+  expect(
+    actual.a,
+    closeTo(_expectedRowAlpha, 0.005),
+    reason: '$reason (a)',
+  );
 }

--- a/test/check_app_editorial_monocle_colors_test.dart
+++ b/test/check_app_editorial_monocle_colors_test.dart
@@ -217,10 +217,8 @@ const fallback = TextStyle(color: Colors.white);
           'app/lib/features/game/flame/region_map_component_render_core.dart';
       const palette =
           'app/lib/features/game/flame/resource_icon_disc_palette.dart';
-      const debugViewer =
-          'app/lib/features/debug_log/debug_log_viewer_screen.dart';
 
-      for (final rel in [flameRenderer, palette, debugViewer]) {
+      for (final rel in [flameRenderer, palette]) {
         File('${temp.path}/$rel')
           ..createSync(recursive: true)
           ..writeAsStringSync('''
@@ -272,6 +270,43 @@ const sample = TextStyle(color: Colors.white);
           contains(
             'app/lib/features/game/flame/debug_console_overlay_panel.dart:3: '
             'Colors.white',
+          ),
+        );
+      },
+    );
+
+    test(
+      'no longer allowlists debug_log_viewer_screen.dart (Refs #2914 S3 '
+      'token adoption: level row tints resolve through EditorialMonoclePalette)',
+      () {
+        final temp = Directory.systemTemp.createTempSync(
+          'check_app_editorial_monocle_colors_debug_log_promoted_',
+        );
+        addTearDown(() => temp.deleteSync(recursive: true));
+
+        const debugLog =
+            'app/lib/features/debug_log/debug_log_viewer_screen.dart';
+        File('${temp.path}/$debugLog')
+          ..createSync(recursive: true)
+          ..writeAsStringSync('''
+import 'package:flutter/material.dart';
+
+const sample = TextStyle(color: Colors.red);
+''');
+
+        final logs = <String>[];
+        final code = runCheckAppEditorialMonocleColors(
+          temp.path,
+          info: logs.add,
+          err: logs.add,
+        );
+
+        expect(code, 1);
+        expect(
+          logs.join('\n'),
+          contains(
+            'app/lib/features/debug_log/debug_log_viewer_screen.dart:3: '
+            'Colors.red',
           ),
         );
       },
@@ -584,14 +619,13 @@ class Clean extends StatelessWidget {
       );
     });
 
-    test('skips canonical Flame renderer + debug + palette files', () {
+    test('skips canonical Flame renderer + palette files', () {
       const skipped = <String>[
         'app/lib/features/game/flame/region_map_component_render_core.dart',
         'app/lib/features/game/flame/region_map_component_render_political.dart',
         'app/lib/features/game/flame/region_map_component_render_markers.dart',
         'app/lib/features/game/flame/game_region_minimap.dart',
         'app/lib/features/game/flame/resource_icon_disc_palette.dart',
-        'app/lib/features/debug_log/debug_log_viewer_screen.dart',
       ];
       for (final path in skipped) {
         expect(
@@ -609,6 +643,20 @@ class Clean extends StatelessWidget {
         expect(
           shouldSkipAppEditorialMonocleColorsFile(
             'app/lib/features/game/flame/debug_console_overlay_panel.dart',
+          ),
+          isFalse,
+        );
+      },
+    );
+
+    test(
+      'does not skip debug_log_viewer_screen.dart (in scope for the '
+      'check after Refs #2914 S3 token adoption: level row tints resolve '
+      'through EditorialMonoclePalette)',
+      () {
+        expect(
+          shouldSkipAppEditorialMonocleColorsFile(
+            'app/lib/features/debug_log/debug_log_viewer_screen.dart',
           ),
           isFalse,
         );

--- a/tool/check_app_editorial_monocle_colors.dart
+++ b/tool/check_app_editorial_monocle_colors.dart
@@ -31,14 +31,18 @@ import 'package:path/path.dart' as p;
 ///    colors (per-resource hue references) keyed by id; the table values are
 ///    the palette source for those resources rather than a bypass of the
 ///    editorial-monocle theme.
-/// 3. **Dev-tooling screens** — `SYS10001` Debug Log Viewer is an
-///    operator-only surface; implementing Ct-* catalog widgets there
-///    remains low-value (see #2914 Risks / edge cases). `SYS20001`
-///    Debug Console Overlay (`debug_console_overlay_panel.dart`) was
-///    promoted out of the allowlist after adopting
-///    [EditorialMonoclePalette] tokens and replacing its `IconButton`
-///    close affordance with `CtIconAction`; see
-///    `SPEC/ui/debug-console-panel.md` § Visual chrome.
+/// 3. **Dev-tooling screens** — both `SYS10001` Debug Log Viewer
+///    (`debug_log_viewer_screen.dart`) and `SYS20001` Debug Console
+///    Overlay (`debug_console_overlay_panel.dart`) were promoted out
+///    of the allowlist after adopting [EditorialMonoclePalette]
+///    tokens for their per-feature colour bypasses. SYS10001's
+///    level→token row tint mapping is pinned in
+///    `SPEC/program/debug-log-viewer.md` § Visual chrome; SYS20001's
+///    chrome contract lives in `SPEC/ui/debug-console-panel.md` §
+///    Visual chrome. Implementing the rest of the Ct-* catalog widget
+///    suite for these operator-only surfaces (banned Material widgets
+///    other than colour tokens) remains low-value per #2914 Risks /
+///    edge cases and is not required for the colour gate.
 /// 4. **`app/lib/features/game/widgets/chrome/**`** — Ct-* catalog widget
 ///    implementations. These widgets implement the design-system primitives
 ///    consumed by the rest of the feature tree and may declare `const`
@@ -210,13 +214,12 @@ const Set<String> _appEditorialMonocleColorsAllowedFiles = <String>{
   'app/lib/features/game/flame/game_region_minimap.dart',
   // Pixel-art palette data (per-resource hue lookup table).
   'app/lib/features/game/flame/resource_icon_disc_palette.dart',
-  // Dev-tooling screens — SYS10001 (Debug Log Viewer). Relaxed per
-  // #2914 Risks / edge cases. SYS20001 (Debug Console Overlay) was
-  // promoted out of the allowlist by the S3 + S8 token-adoption slice;
-  // see `SPEC/ui/debug-console-panel.md` § Visual chrome and the dark
-  // editorial-monocle chrome tests in
-  // `app/test/debug_console_overlay_panel_test.dart`.
-  'app/lib/features/debug_log/debug_log_viewer_screen.dart',
+  // Dev-tooling screens previously allowlisted under #2914 Risks / edge cases:
+  // SYS10001 (Debug Log Viewer, `debug_log_viewer_screen.dart`) was promoted
+  // out of the allowlist by this slice (Refs #2914 S3 — `_levelColor` row
+  // tints now resolve through [EditorialMonoclePalette.danger / .accent /
+  // .accentDim / .muted]); SYS20001 (Debug Console Overlay) was promoted by
+  // the parallel S3 + S8 slice. Both are in scope for the colour gate.
   // app/lib/widgets/ canvas-compositing files — the color literal is a
   // compositing argument (alpha multiplier in `Paint.color` for a
   // `saveLayer` decorative overlay, or the `ColorFilter.mode` blend


### PR DESCRIPTION
## Summary

Promote **SYS10001 Debug Log Viewer**
(`app/lib/features/debug_log/debug_log_viewer_screen.dart`) out of the
G1 editorial-monocle colour allowlist by resolving its per-level row
tint mapping through `EditorialMonoclePalette` tokens instead of raw
Material `Colors.red / .orange / .blue / .grey`.

Mirrors the S3 + S8 promotion already applied to SYS20001 Debug Console
Overlay in #3114; brings the dev-tooling colour allowlist down to zero
entries (only Flame canvas renderers, the per-resource hue palette
data file, and `app/lib/widgets/` canvas-compositing files remain).

`Refs #2914` (does not auto-close — umbrella issue still tracks S2
overlay-shell extraction, S5/S6 token adoption follow-up, S7 font-size
normalisation, and S8 banned-Material widget migrations).

## Scope

- **Source**: `_levelColor` returns `danger / accent / accentDim /
  muted` (warm four-tier severity gradient; editorial-monocle has no
  info blue token by design — documented in SPEC).
- **G1 gate**: `tool/check_app_editorial_monocle_colors.dart` removes
  `app/lib/features/debug_log/debug_log_viewer_screen.dart` from
  `_appEditorialMonocleColorsAllowedFiles` and updates the header
  narrative to reflect that both SYS10001 and SYS20001 are now
  in-scope for the gate.
- **Checker tests** (`test/check_app_editorial_monocle_colors_test.dart`):
  drop the old debug-viewer entry from the bulk Flame-allowlist case
  (renamed to *"allowlists Flame canvas renderers and palette data
  files"*) and add a new positive AC *"no longer allowlists
  `debug_log_viewer_screen.dart`"* plus the matching scope-predicate
  negative AC.
- **Widget tests** (`app/test/debug_log_viewer_test.dart`): five new
  cases under group *"level row tint resolves through
  EditorialMonoclePalette"* pin each `Level` to its expected
  palette token via the rendered `BoxDecoration.color` of the first
  line container, against `AppThemes.editorialMonocle`; a regression
  case asserts the tints never match raw `Colors.red / .orange / .blue
  / .grey` at the same `0.08` alpha.
- **SPEC**: `SPEC/program/debug-log-viewer.md` gains a new §5a
  *"Visual chrome"* section with the canonical level → token table
  and four Given-When-Then ACs (one per `Level`) plus a fifth AC
  pinning the file-out-of-allowlist contract.

### Not in scope

- Other SYS10001 Material widget violations (`FilterChip`, `Scaffold`,
  `AppBar`, `IconButton`, `Divider`) — covered by umbrella issue
  #2914 §S8 and the §Risks/edge-cases relaxation for dev-tooling Ct-*
  catalogisation.
- Extending the banned-colour regex with `Colors.orange` / `.blue` —
  not in #2914 §S3 enumeration; orthogonal future slice if the umbrella
  scope expands.

## Test plan

- [x] `dart test test/check_app_editorial_monocle_colors_test.dart`
      — **30 tests pass** (2 new).
- [x] `dart run tool/check_app_editorial_monocle_colors.dart` against
      the working tree — *no violations found*.
- [x] `cd app && flutter test test/debug_log_viewer_test.dart`
      — **12 tests pass** (5 new under the level-tint group).
- [x] `cd app && flutter analyze lib/features/debug_log/
      test/debug_log_viewer_test.dart` — *No issues found*.
- [x] `dart analyze tool/check_app_editorial_monocle_colors.dart
      test/check_app_editorial_monocle_colors_test.dart` — *No issues
      found*.

## Acceptance criteria covered

From `SPEC/program/debug-log-viewer.md` §5a Visual chrome (new):
- `Level.error` → `EditorialMonoclePalette.danger` @ α=0.08
- `Level.warning` → `EditorialMonoclePalette.accent` @ α=0.08
- `Level.info` → `EditorialMonoclePalette.accentDim` @ α=0.08
- `Level.debug` (default branch) → `EditorialMonoclePalette.muted`
  @ α=0.08
- `debug_log_viewer_screen.dart` is in-scope for
  `check_app_editorial_monocle_colors`

From #2914 umbrella target state §1 / §S3:
- Zero `Colors.green / .red / .grey / .white / .black / .redAccent`
  in `app/lib/features/debug_log/`.

Made with [Cursor](https://cursor.com)