### PR TITLE
refactor(app): adopt CtSpacing in production_labour_section.dart (Refs #2914 S5)

### DIFF
--- a/app/lib/features/game/widgets/production_labour_section.dart
+++ b/app/lib/features/game/widgets/production_labour_section.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 
 import '../../../config/app_assets.dart';
 import '../../../l10n/l10n.dart';
+import '../../../widgets/ct_spacing.dart';
 import 'chrome/ct_danger_text_button.dart';
 import 'production_allocation_row_buttons.dart';
 import 'production_labour_helpers.dart';
@@ -109,7 +110,7 @@ class _ProductionLabourTierRow extends StatelessWidget {
       return const SizedBox.shrink();
     }
     return Padding(
-      padding: const EdgeInsets.only(left: 8),
+      padding: const EdgeInsets.only(left: CtSpacing.m),
       child: Text(
         l10n.production_labourQueued(data.queuedCount),
         style: theme.textTheme.labelSmall,
@@ -208,7 +209,7 @@ class _DisbandTierButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.only(left: 6),
+      padding: const EdgeInsets.only(left: CtSpacing.s),
       child: CtDangerTextButton(
         key: ValueKey<String>('production_labour_disband_${tier.id}'),
         enabled: enabled,
@@ -249,7 +250,7 @@ class _DisbandReservedSlot extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.only(left: 6),
+      padding: const EdgeInsets.only(left: CtSpacing.s),
       child: ExcludeSemantics(
         child: IgnorePointer(
           child: Opacity(
@@ -313,10 +314,7 @@ class _LabourIconButton extends StatelessWidget {
         message: tooltip,
         child: Material(
           color: Colors.transparent,
-          child: InkWell(
-            onTap: enabled ? onPressed : null,
-            child: surface,
-          ),
+          child: InkWell(onTap: enabled ? onPressed : null, child: surface),
         ),
       ),
     );


### PR DESCRIPTION
Refs #2914

## Summary

Single-file S5 spacing slice on `production_labour_section.dart`. Replaces three raw `EdgeInsets.only(left: …)` literals with the canonical `CtSpacing.s` / `CtSpacing.m` tokens introduced by #3053, mirroring the per-file pattern from #3118 (`trade_screen_deal_book.dart`), #3121 (`pause_menu_panel.dart`), and #3101 (`trade_screen.dart`).

## What landed

- **`_buildQueuedSegment`** — `EdgeInsets.only(left: 8)` → `EdgeInsets.only(left: CtSpacing.m)`.
- **`_DisbandTierButton`** build padding — `EdgeInsets.only(left: 6)` → `EdgeInsets.only(left: CtSpacing.s)`.
- **`_DisbandReservedSlot`** build padding — `EdgeInsets.only(left: 6)` → `EdgeInsets.only(left: CtSpacing.s)` (keeps the reserved-slot width identity-equal to the real Disband button so the trailing −/+ alignment contract in `SPEC/ui/production-panel.md` § Labour Controls (12-A) > Trailing alignment / Refs #2862 S8a stays intact).
- New import: `app/lib/widgets/ct_spacing.dart`.

`CtSpacing.m == 8` and `CtSpacing.s == 6`, so the rendered geometry is identity-preserved (no visual or behavioural change).

## What was deliberately left as a raw literal

`EdgeInsets.only(top: 4)` on the per-row outer `Padding` stays unchanged. `CtSpacing` intentionally skips `4` (documented in `SPEC/ui/pixel-art-ui-catalog.md` § Spacing tokens and `app/lib/widgets/ct_spacing.dart`), and the SPEC explicitly carves out per-component overrides for that band. Adding a `top: 4` row-gap token would land in the SPEC table first per the umbrella issue's Phase 0 rule.

## ACs covered (from #2914)

- **S5** — Adopt `CtSpacing` constants in feature files (this PR ticks one more file off the umbrella's S5 surface).
- **No regressions** — All 24 `production_labour_section*` widget tests pass; `check_app_editorial_monocle_colors` reports no violations; `dart analyze` is clean on the touched file.

## What is deferred

- Other feature files with non-canonical `EdgeInsets` literals (e.g. `military_units_panel.dart`, `production_panel.dart`, dialogs) — separate per-file slices following the same pattern.
- The `EdgeInsets.only(top: 4)` row-gap in this file (per § What was deliberately left).
- Issue #2914 stays under `backlog:implementation` because the umbrella has many open sub-issues (S5 not yet complete across all files, S6 / S7 / S9 etc. ongoing).

## Tests run locally

- `flutter test app/test/production_labour_section_test.dart app/test/production_labour_section_step_surface_test.dart` — 24/24 pass.
- `dart analyze app/lib/features/game/widgets/production_labour_section.dart` — `No issues found!`.
- `dart run tool/check_app_editorial_monocle_colors.dart` — `no violations found.`
- `dart format` — no further changes needed (the formatter collapsed one unrelated `InkWell(...)` constructor to single-line after the import addition shifted line widths; preserved here to keep `--set-exit-if-changed` green in CI).

Tracked by #2914 (do not auto-close).

Made with [Cursor](https://cursor.com)