### PR TITLE
feat(ai): recompute trade orders after domain planning so pending costs feed the bid budget (Refs #3122)

### DIFF
--- a/SPEC/ai/treasury-planner.md
+++ b/SPEC/ai/treasury-planner.md
@@ -88,12 +88,16 @@ The bias never affects `defend`, `expand`, `conquer`, `tech`, or `diplomacy`; th
 ### Module
 
 - `packages/colonizethis_ai/lib/src/planning/treasury_planner.dart` — `runTreasuryPlanner(...)`.
-- Called from `runEconomyPlanner` after production assignments are chosen; results are stored on `EconomyPlan.tradeOrders` and merged into `Orders.tradeOrdersByPlayerId` by `runDomainPlannersWithOutcome` (F7 wiring) so every orchestrator caller — including the strategic-AI entry `generateStrategicOrdersWithTrace` and the simpler `runDomainPlanners` test entrypoint — surfaces the same trade output without duplicating the merge.
+- Called from `runEconomyPlanner` after production assignments are chosen by default; results are stored on `EconomyPlan.tradeOrders` and merged into `Orders.tradeOrdersByPlayerId` by `runDomainPlannersWithOutcome` (F7 wiring) so every orchestrator caller — including the strategic-AI entry `generateStrategicOrdersWithTrace` and the simpler `runDomainPlanners` test entrypoint — surfaces the same trade output without duplicating the merge.
+- **Refs #3122 orchestrator wiring** — the strategic-AI production entry sets `runEconomyPlanner(skipTradeOrderGeneration: true)` and `runDomainPlannersWithOutcome(recomputeTradeOrdersWithPendingCosts: true)` so the orchestrator re-invokes `runTreasuryPlanner` at the tail of the domain pipeline (after work, build, recruit, research, naval, and diplomacy passes) with `currentOrders = ctx.orders`. This makes `pendingTreasuryCostsForTurn` see the AI's own pending build / recruit / research orders so the bid budget is shaped to the same treasury the matcher (#3115) will enforce at phase 13. Callers that do not opt in (existing `runDomainPlanners` test entrypoints, the wiring test fixture) continue to consume `economyPlan.tradeOrders` unchanged.
 
-### Orchestrator wiring (Refs #2994 F7)
+### Orchestrator wiring (Refs #2994 F7 / Refs #3122)
 
-- After all other domain planners run, the orchestrator appends `economyPlan.tradeOrders` (when non-empty) to `ctx.orders.tradeOrdersByPlayerId[nationId]` via `Orders.appendTradeOrders`. The append is skipped when the list is empty, so `tradeOrdersByPlayerId` stays absent for that player and downstream `MapEquality` checks in tests remain stable.
-- The orchestrator records a `tradePlannerRan` boolean on `DomainGateData` (`true` iff at least one trade order was emitted by the treasury planner). This field is emitted under `thresholds.domainGates.tradePlannerRan` in the AI trace alongside the existing per-domain `*PlannerRan` flags, so an analyst can distinguish "treasury planner produced zero orders" from "treasury planner did not run for this player turn" without consulting per-player JSON.
+- After all other domain planners run, the orchestrator merges trade orders into `ctx.orders.tradeOrdersByPlayerId[nationId]` via `Orders.appendTradeOrders`. The append is skipped when the resolved list is empty, so `tradeOrdersByPlayerId` stays absent for that player and downstream `MapEquality` checks in tests remain stable.
+- Source of the merged list:
+  - **Default path** (`recomputeTradeOrdersWithPendingCosts == false`, Refs #2994 F7) — the orchestrator uses `economyPlan.tradeOrders` exactly as supplied. The wiring contract preserves prior behaviour for `runDomainPlanners` test entrypoints and the F7 fixture.
+  - **Pending-cost projector path** (`recomputeTradeOrdersWithPendingCosts == true`, Refs #3122) — the orchestrator calls `runTreasuryPlanner(game, playerId, stockpile, productionAssignments, treasury, currentOrders: ctx.orders, tileMapByRegion, topology)` using the inputs already present on `economyPlan` plus the live `game.playerById(nationId)` stockpile and treasury. `economyPlan.tradeOrders` is **ignored** in this mode; `runEconomyPlanner(skipTradeOrderGeneration: true)` returns the empty list so no work is duplicated.
+- The orchestrator records a `tradePlannerRan` boolean on `DomainGateData` (`true` iff at least one trade order was emitted in the resolved list). This field is emitted under `thresholds.domainGates.tradePlannerRan` in the AI trace alongside the existing per-domain `*PlannerRan` flags, so an analyst can distinguish "treasury planner produced zero orders" from "treasury planner did not run for this player turn" without consulting per-player JSON.
 - `ai_order_reporting.orderCountsByDomain` and `finalAggregatedOrders` include trade entries (`domain: 'trade'`, with `commodityId`, `type`, `quantity`, `priority`) so the trace's `domainOutputs.trade` count and `finalAggregatedOrders` array reflect the merged trade orders. This keeps counts symmetric with every other domain (move/build/work/diplomatic/research/navalMove/navalMission) the orchestrator already reports.
 - Strategic-AI (`generateStrategicOrdersWithTrace`) consumes the orchestrator's `outcome.orders` directly without re-merging trade orders; the in-function `tradeOrdersByPlayerId` `copyWith` block previously responsible for the merge is retired by F7.
 
@@ -376,6 +380,33 @@ well inside the 15-second turn-resolution envelope per
   `pendingTreasuryCostsForTurn(game, playerId, currentOrders)` is
   called, then it returns `treasuryCostForFunding(L) + C_b + C_r`
   exactly (the `WorkOrder` is excluded because it is stockpile-only).
+- Given `runEconomyPlanner` is called with
+  `skipTradeOrderGeneration: true`, when the planner returns, then
+  `EconomyPlan.tradeOrders` is the empty list (no
+  `runTreasuryPlanner` call is made and no stale planner pass is
+  embedded in the plan).
+- Given `runDomainPlannersWithOutcome` is called with
+  `recomputeTradeOrdersWithPendingCosts: true`, an `economyPlan`
+  with non-empty `tradeOrders`, and a `nationId` whose
+  `game.playerById(nationId)` is non-`null`, when the orchestrator
+  reaches the trade-merge step, then it ignores
+  `economyPlan.tradeOrders` and instead emits whatever
+  `runTreasuryPlanner` returns when called with
+  `currentOrders = ctx.orders` (the orders accumulated by every
+  upstream domain planner in this pipeline).
+- Given the orchestrator runs with
+  `recomputeTradeOrdersWithPendingCosts: true`, the AI's build pass
+  has already appended a `BuildUnitOrder` whose
+  `buildTreasuryCost == C_b` for `nationId`, and
+  `game.playerById(nationId).treasury == T`, when the orchestrator's
+  trade recompute runs and emits a bid `b`, then
+  `b.quantity × effectiveMarketPriceForCommodityId(b.commodityId)`
+  plus the cumulative notional of every other recomputed bid plus
+  `carryForwardBidNotionalByPlayer(...)` plus the same fixture's
+  `pendingTreasuryCostsForTurn` (which now includes `C_b`) is less
+  than or equal to `T`. The recompute therefore never authorises an
+  AI bid the matcher (#3115) would have to truncate against the
+  same `T`.
 
 ---
 

--- a/packages/colonizethis_ai/lib/src/planning/domain_planner_orchestrator.dart
+++ b/packages/colonizethis_ai/lib/src/planning/domain_planner_orchestrator.dart
@@ -22,6 +22,7 @@ import 'move_planner.dart';
 import 'naval_planner.dart';
 import 'planner_context.dart';
 import 'research_planner.dart';
+import 'treasury_planner.dart';
 
 final _log = packageLogger();
 
@@ -47,6 +48,7 @@ Orders runDomainPlanners({
   Map<String, TileMapResult>? tileMapByRegion,
   void Function(String phaseId)? onStagedPlannerProgress,
   PhasePlanOutcome? phasePlan,
+  bool recomputeTradeOrdersWithPendingCosts = false,
 }) {
   return runDomainPlannersWithOutcome(
     game: game,
@@ -62,6 +64,8 @@ Orders runDomainPlanners({
     tileMapByRegion: tileMapByRegion,
     onStagedPlannerProgress: onStagedPlannerProgress,
     phasePlan: phasePlan,
+    recomputeTradeOrdersWithPendingCosts:
+        recomputeTradeOrdersWithPendingCosts,
   ).orders;
 }
 
@@ -91,6 +95,7 @@ DomainPlannerOutcome runDomainPlannersWithOutcome({
   void Function(String phaseId)? onStagedPlannerProgress,
   Orders? sameTurnPriorDiplomaticOrders,
   PhasePlanOutcome? phasePlan,
+  bool recomputeTradeOrdersWithPendingCosts = false,
 }) {
   void emit(String phaseId) => onStagedPlannerProgress?.call(phaseId);
 
@@ -229,16 +234,42 @@ DomainPlannerOutcome runDomainPlannersWithOutcome({
   ctx = ctx.withOrders(runResearchPlanner(ctx: ctx));
   emit('aiStageG');
 
-  // Refs #2994 F7: merge treasury-planner trade orders into the orchestrator
-  // output so every caller (strategic-AI entry + the simpler
-  // [runDomainPlanners] test entrypoint) surfaces trade alongside the other
-  // domain order families. Skip the append when the list is empty so
+  // Refs #2994 F7 / Refs #3122 orchestrator wiring: merge treasury-planner
+  // trade orders into the orchestrator output so every caller (strategic-AI
+  // entry + the simpler [runDomainPlanners] test entrypoint) surfaces trade
+  // alongside the other domain order families. When
+  // [recomputeTradeOrdersWithPendingCosts] is set, the orchestrator
+  // re-invokes [runTreasuryPlanner] at this tail position with
+  // `currentOrders = ctx.orders` so the treasury budget subtracts the
+  // pending build / recruit / research costs emitted earlier in this
+  // pipeline (Refs #3122 pending-cost projector). Otherwise the
+  // orchestrator falls back to the pre-baked `economyPlan.tradeOrders` so
+  // existing callers and the F7 wiring contract stay behaviour-equal.
+  // Skip the append when the resolved list is empty so
   // `tradeOrdersByPlayerId` stays absent for that player and existing
   // `MapEquality` assertions remain stable.
-  final tradePlannerRan = economyPlan.tradeOrders.isNotEmpty;
+  final List<TradeOrder> resolvedTradeOrders;
+  if (recomputeTradeOrdersWithPendingCosts) {
+    final player = game.playerById(nationId);
+    resolvedTradeOrders = player == null
+        ? const <TradeOrder>[]
+        : runTreasuryPlanner(
+            game: game,
+            playerId: nationId,
+            stockpile: player.stockpile,
+            productionAssignments: economyPlan.productionAssignments,
+            treasury: player.treasury,
+            tileMapByRegion: tileMapByRegion,
+            topology: topology,
+            currentOrders: ctx.orders,
+          );
+  } else {
+    resolvedTradeOrders = economyPlan.tradeOrders;
+  }
+  final tradePlannerRan = resolvedTradeOrders.isNotEmpty;
   if (tradePlannerRan) {
     ctx = ctx.withOrders(
-      ctx.orders.appendTradeOrders(nationId, economyPlan.tradeOrders),
+      ctx.orders.appendTradeOrders(nationId, resolvedTradeOrders),
     );
   }
 

--- a/packages/colonizethis_ai/lib/src/planning/economy_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/economy_planner.dart
@@ -41,6 +41,7 @@ EconomyPlan runEconomyPlanner({
   PhasePlanOutcome? phasePlan,
   Map<String, TileMapResult>? tileMapByRegion,
   MapTopology? topology,
+  bool skipTradeOrderGeneration = false,
 }) {
   final player = game.playerById(view.playerId);
   if (player == null) {
@@ -84,15 +85,22 @@ EconomyPlan runEconomyPlanner({
         colonial: colonial,
         belowQuotaPeaceTreasuryRecovery: belowQuotaPeaceTreasuryRecovery,
       ),
-      tradeOrders: runTreasuryPlanner(
-        game: game,
-        playerId: view.playerId,
-        stockpile: stockpile,
-        productionAssignments: const [],
-        treasury: player.treasury,
-        tileMapByRegion: tileMapByRegion,
-        topology: topology,
-      ),
+      // Refs #3122 orchestrator wiring: when the orchestrator will
+      // recompute trade orders after domain planning (so pending
+      // build / recruit / research costs feed the treasury budget),
+      // return the empty list here to avoid emitting a stale planner
+      // pass whose results would be discarded.
+      tradeOrders: skipTradeOrderGeneration
+          ? const <TradeOrder>[]
+          : runTreasuryPlanner(
+              game: game,
+              playerId: view.playerId,
+              stockpile: stockpile,
+              productionAssignments: const [],
+              treasury: player.treasury,
+              tileMapByRegion: tileMapByRegion,
+              topology: topology,
+            ),
     );
   }
 
@@ -118,15 +126,22 @@ EconomyPlan runEconomyPlanner({
     colonial: colonial,
     belowQuotaPeaceTreasuryRecovery: belowQuotaPeaceTreasuryRecovery,
   );
-  final tradeOrders = runTreasuryPlanner(
-    game: game,
-    playerId: view.playerId,
-    stockpile: stockpile,
-    productionAssignments: assignments,
-    treasury: player.treasury,
-    tileMapByRegion: tileMapByRegion,
-    topology: topology,
-  );
+  // Refs #3122 orchestrator wiring: when the orchestrator will
+  // recompute trade orders after domain planning, the planner pass
+  // here would run with an empty `currentOrders` and any pending
+  // build / recruit / research costs would contribute zero to the
+  // budget. Skipping the call in that mode avoids the wasted work.
+  final tradeOrders = skipTradeOrderGeneration
+      ? const <TradeOrder>[]
+      : runTreasuryPlanner(
+          game: game,
+          playerId: view.playerId,
+          stockpile: stockpile,
+          productionAssignments: assignments,
+          treasury: player.treasury,
+          tileMapByRegion: tileMapByRegion,
+          topology: topology,
+        );
   _log.i(
     'economy plan playerId=${view.playerId} '
     'cargoPreference=$cargoPref productionAssignmentsCount=${assignments.length} '

--- a/packages/colonizethis_ai/lib/src/planning/strategic_ai.dart
+++ b/packages/colonizethis_ai/lib/src/planning/strategic_ai.dart
@@ -158,6 +158,13 @@ StrategicOrderTraceResult generateStrategicOrdersWithTrace({
     snapshot: planningSnapshot,
     personalityId: config.personalityId,
   );
+  // Refs #3122 orchestrator wiring: the production strategic-AI entry
+  // skips trade-order generation inside [runEconomyPlanner] so the
+  // orchestrator can re-invoke [runTreasuryPlanner] after every other
+  // domain planner has had a chance to emit pending orders. That way
+  // pending build / recruit / research treasury costs feed the
+  // `pendingTreasuryCostsForTurn` projector and the bid budget reflects
+  // the real treasury the matcher will see at phase 13.
   final economyPlan = runEconomyPlanner(
     game: planningGame,
     view: planningView,
@@ -168,6 +175,7 @@ StrategicOrderTraceResult generateStrategicOrdersWithTrace({
     phasePlan: phasePlan,
     tileMapByRegion: tileMapByRegion,
     topology: topology,
+    skipTradeOrderGeneration: true,
   );
   final plannerOutcome = runDomainPlannersWithOutcome(
     game: planningGame,
@@ -184,6 +192,7 @@ StrategicOrderTraceResult generateStrategicOrdersWithTrace({
     onStagedPlannerProgress: onStagedPlannerProgress,
     sameTurnPriorDiplomaticOrders: sameTurnPriorDiplomaticOrders,
     phasePlan: phasePlan,
+    recomputeTradeOrdersWithPendingCosts: true,
   );
   // Trade orders are merged into [Orders.tradeOrdersByPlayerId] inside the
   // domain orchestrator (Refs #2994 F7) so all orchestrator callers see the

--- a/packages/colonizethis_ai/test/domain_planner_orchestrator_pending_cost_trade_test.dart
+++ b/packages/colonizethis_ai/test/domain_planner_orchestrator_pending_cost_trade_test.dart
@@ -1,0 +1,376 @@
+// Pins the Refs #3122 orchestrator wiring for the
+// `recomputeTradeOrdersWithPendingCosts` flag on
+// `runDomainPlannersWithOutcome`:
+//
+//   - When set to `true`, the orchestrator MUST recompute trade
+//     orders at the tail of the domain pipeline via
+//     `runTreasuryPlanner(..., currentOrders: ctx.orders)` and merge
+//     those orders into `outcome.orders.tradeOrdersByPlayerId[nationId]`.
+//     `economyPlan.tradeOrders` is ignored in this mode.
+//   - The recomputed trade orders MUST reflect pending treasury
+//     costs from build / recruit / research orders that earlier
+//     domain planners appended to `ctx.orders` — the bid budget
+//     equals `max(0, treasury - pendingTreasuryCostsForTurn(...)
+//     - carryForwardBidNotional(...))`, mirroring the matcher-side
+//     per-buyer clamp introduced by #3115.
+//   - When the flag is `false` (existing F7 contract) the
+//     orchestrator MUST continue to consume `economyPlan.tradeOrders`
+//     verbatim so prior behaviour stays preserved.
+
+import 'package:colonizethis_test/test.dart';
+
+import 'package:colonizethis_ai/colonizethis_ai.dart';
+import 'package:colonizethis_ai/src/planning/domain_planner_outcome.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import 'domain_planner_test_fake_api.dart';
+
+const String _nationId = 'gp1';
+const String _minorId = 'minor1';
+const String _owMinorProvince = 'oldWorld|minor1';
+const String _owHomeProvince = 'oldWorld|gp1_0';
+
+const List<String> _gp1OwProvincesBelowQuota = <String>[
+  _owHomeProvince,
+  'oldWorld|gp1_1',
+  'oldWorld|gp1_2',
+  'oldWorld|gp1_3',
+  'oldWorld|gp1_4',
+  'oldWorld|gp1_5',
+  'oldWorld|gp1_6',
+];
+
+const _embassyOverture = OvertureState(
+  gpId: _nationId,
+  targetId: _minorId,
+  stage: OvertureStage.embassy,
+  sinceTurn: 0,
+);
+
+/// Builds an EXPAND below-quota scenario where:
+/// - gp1 owns 7 OW provinces with a single invadable minor (forces
+///   `needRegimentsToExpand` because `regimentCount == 0`).
+/// - gp1's home army has no regiment unit ids so `regimentCount == 0`
+///   and `forceRegimentRebuild` triggers in `_appendEconomyBuildOrders`.
+/// - gp1's treasury is well above the cheapest regiment build cost so
+///   the build planner can actually pick a regiment.
+/// - WorldMarketState has integer prices so the treasury planner's
+///   per-bid clamp resolves a non-null effective price for fabric.
+Game _scenarioGame({
+  required int treasury,
+  required Stockpile stockpile,
+}) {
+  return Game(
+    id: 'g-3122-orchestrator-pending-cost',
+    worldState: WorldState(
+      turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 30),
+      oldWorld: RegionData(
+        provinces: [
+          for (final id in _gp1OwProvincesBelowQuota)
+            Province(id: id, regionId: 'oldWorld', ownerId: _nationId),
+          const Province(
+            id: _owMinorProvince,
+            regionId: 'oldWorld',
+            ownerId: _minorId,
+          ),
+        ],
+      ),
+      newWorld: const RegionData(provinces: []),
+      armies: const [
+        // Empty regiment ids → regimentCount == 0 →
+        // forceRegimentRebuild fires under expand quota pressure.
+        Army(
+          id: 'home_a',
+          ownerId: _nationId,
+          regionId: 'oldWorld',
+          stationedProvinceId: _owHomeProvince,
+          regimentUnitIds: <String>[],
+          isHomeArmy: true,
+        ),
+      ],
+    ),
+    players: [
+      Player(
+        id: _nationId,
+        displayName: 'GP1',
+        isHuman: false,
+        leaderKey: 'napoleon',
+        capitalProvinceId: _owHomeProvince,
+        stockpile: stockpile,
+        workerPool: const WorkerPool(peasants: 5),
+        treasury: treasury,
+      ),
+    ],
+    minorNations: const [
+      MinorNation(id: _minorId, displayName: 'Minor One'),
+    ],
+    overtureStates: const [_embassyOverture],
+    diplomacyRelations: const [
+      DiplomacyRelation(
+        factionId1: _nationId,
+        factionId2: _minorId,
+        state: RelationState.atWar,
+        score: -100,
+      ),
+    ],
+    worldMarketState: WorldMarketState.withDefaultPrices(const {
+      'timber': 20,
+      'iron': 20,
+      // Fabric price (10) is strictly below the recipe's input cost
+      // when valued at the wool price (50), so the F3 price gate in
+      // `runTreasuryPlanner` admits a fabric bid for the deficit.
+      'fabric': 10,
+      'wool': 50,
+      'cotton': 50,
+    }),
+  );
+}
+
+const AIConfig _aiConfig = AIConfig(
+  leaderId: 'napoleon',
+  personalityId: 'napoleon',
+  hiddenAgendaId: 'warmonger',
+);
+
+AIWorldSnapshot _expandSnapshot() {
+  return const AIWorldSnapshot(
+    playerId: _nationId,
+    threats: ThreatSummary(atWarWith: [_minorId]),
+    opportunities: OpportunitySummary(),
+    conquest: ConquestSummary(
+      oldWorldProvincesOwned: 7,
+      invadableProvinceIdsSorted: [_owMinorProvince],
+      adjacentOwnerFactionIdsSorted: [_minorId],
+    ),
+    economy: EconomySummary(ownProvinceCount: 7),
+    relations: {
+      _minorId: DiplomacyRelation(
+        factionId1: _nationId,
+        factionId2: _minorId,
+        state: RelationState.atWar,
+        score: -100,
+      ),
+    },
+  );
+}
+
+DomainPlannerOutcome _runOrchestrator({
+  required EconomyPlan economyPlan,
+  required Game game,
+  required FakeOrderSuggestionAPIForDomainPlannerTests api,
+  required bool recompute,
+}) {
+  const topology = MapTopology(nodes: [], edges: []);
+  final view = buildPlayerView(game, topology, _nationId);
+  final snapshot = _expandSnapshot();
+  return runDomainPlannersWithOutcome(
+    game: game,
+    topology: topology,
+    nationId: _nationId,
+    view: view,
+    snapshot: snapshot,
+    config: _aiConfig,
+    primaryGoal: StrategicGoal.expand,
+    seeds: AISeedBundle.fromTurnSeed(3122700),
+    suggestionAPI: api,
+    economyPlan: economyPlan,
+    recomputeTradeOrdersWithPendingCosts: recompute,
+  );
+}
+
+void main() {
+  group(
+    'Refs #3122 — orchestrator trade-order recompute with pending costs',
+    () {
+      test(
+        'when the flag is set, the orchestrator picks a peasant_levies '
+        'regiment build and the recomputed trade-order bid budget '
+        'subtracts that pending treasury cost',
+        () {
+          // Fabric deficit driver: wool=4 + fabric_from_wool recipe.
+          // Stockpile fabric=1 satisfies the regiment build input
+          // affordability gate so the build planner accepts the
+          // candidate.
+          final stockpile = const Stockpile()
+              .applyDelta('wool', 4)
+              .applyDelta('fabric', 1);
+          final game = _scenarioGame(treasury: 4000, stockpile: stockpile);
+          const peasantBuild = BuildUnitOrder(
+            unitType: 'peasant_levies',
+            isMilitary: true,
+            spawnProvinceId: _owHomeProvince,
+          );
+          const api = FakeOrderSuggestionAPIForDomainPlannerTests(
+            work: [],
+            build: [peasantBuild],
+            move: [],
+            research: [],
+            navalMove: [],
+            navalMission: [],
+          );
+          final outcome = _runOrchestrator(
+            economyPlan: const EconomyPlan(
+              productionAssignments: [
+                AssignedRecipe(
+                  recipeId: 'fabric_from_wool',
+                  assignedLabour: 4,
+                ),
+              ],
+              cargoPreference: CargoPreference.none,
+              tradeOrders: <TradeOrder>[],
+            ),
+            game: game,
+            api: api,
+            recompute: true,
+          );
+          // The orchestrator's build pass must have appended the
+          // peasant_levies candidate so the pending-cost projector
+          // sees `buildTreasuryCost == 2000`.
+          final builds =
+              outcome.orders.buildUnitOrdersByPlayerId[_nationId];
+          expect(builds, isNotNull);
+          expect(builds!, hasLength(1));
+          expect(builds.first.unitType, 'peasant_levies');
+
+          // The recomputed trade orders must respect the budget
+          // invariant: cumulative bid notional <= treasury - pending
+          // build cost.
+          const cheapestRegimentBuildTreasuryCost = 2000;
+          final trades =
+              outcome.orders.tradeOrdersByPlayerId[_nationId] ?? const [];
+          final bidNotional = trades
+              .where((o) => o.type == TradeOrderType.bid)
+              .fold<int>(
+                0,
+                (sum, b) =>
+                    sum +
+                    b.quantity *
+                        (game.worldMarketState.prices[b.commodityId] ?? 0)
+                            .toInt(),
+              );
+          expect(
+            bidNotional,
+            lessThanOrEqualTo(4000 - cheapestRegimentBuildTreasuryCost),
+            reason: 'Pending peasant_levies build (treasuryCost 2000) must '
+                'reduce the recomputed trade-order bid budget below the '
+                'remaining treasury of 2000.',
+          );
+          // The recompute path also flips tradePlannerRan exactly when
+          // it produced any orders, mirroring the F7 wiring contract.
+          expect(
+            outcome.domainGateData?.tradePlannerRan,
+            trades.isNotEmpty,
+          );
+        },
+      );
+
+      test(
+        'when the flag is set, mock economyPlan.tradeOrders are ignored '
+        'and the orchestrator emits its own recomputed list',
+        () {
+          // Mock trade orders that have no relation to the actual game
+          // state: a fabricated grain bid at quantity 99. The flag
+          // requires the orchestrator to discard this and recompute.
+          final mockTrade = <TradeOrder>[
+            TradeOrder(
+              commodityId: 'grain',
+              type: TradeOrderType.bid,
+              quantity: 99,
+              priority: 1,
+            ),
+          ];
+          // Tiny treasury so no bid budget remains for any commodity;
+          // every recomputed bid is clamped to zero and the recomputed
+          // list cannot equal the mock list.
+          final game = _scenarioGame(
+            treasury: 0,
+            stockpile: const Stockpile().applyDelta('timber', 80),
+          );
+          const api = FakeOrderSuggestionAPIForDomainPlannerTests(
+            work: [],
+            build: [],
+            move: [],
+            research: [],
+            navalMove: [],
+            navalMission: [],
+          );
+          final outcome = _runOrchestrator(
+            economyPlan: EconomyPlan(
+              productionAssignments: const [],
+              cargoPreference: CargoPreference.none,
+              tradeOrders: mockTrade,
+            ),
+            game: game,
+            api: api,
+            recompute: true,
+          );
+          final trades =
+              outcome.orders.tradeOrdersByPlayerId[_nationId] ?? const [];
+          // The mock 99-quantity grain bid must not survive a recompute
+          // pass that runs with `treasury == 0` (per-bid clamp drops
+          // every priced bid).
+          final survivedMock = trades.any(
+            (o) =>
+                o.commodityId == 'grain' &&
+                o.type == TradeOrderType.bid &&
+                o.quantity == 99,
+          );
+          expect(
+            survivedMock,
+            isFalse,
+            reason:
+                'recomputeTradeOrdersWithPendingCosts: true must ignore '
+                'economyPlan.tradeOrders and call runTreasuryPlanner '
+                'directly.',
+          );
+        },
+      );
+
+      test(
+        'when the flag is unset (default), mock economyPlan.tradeOrders '
+        'still flow through unchanged (existing F7 wiring contract)',
+        () {
+          final mockTrade = <TradeOrder>[
+            TradeOrder(
+              commodityId: 'fabric',
+              type: TradeOrderType.offer,
+              quantity: 3,
+              priority: 5,
+            ),
+          ];
+          final game = _scenarioGame(
+            treasury: 0,
+            stockpile: const Stockpile(),
+          );
+          const api = FakeOrderSuggestionAPIForDomainPlannerTests(
+            work: [],
+            build: [],
+            move: [],
+            research: [],
+            navalMove: [],
+            navalMission: [],
+          );
+          final outcome = _runOrchestrator(
+            economyPlan: EconomyPlan(
+              productionAssignments: const [],
+              cargoPreference: CargoPreference.none,
+              tradeOrders: mockTrade,
+            ),
+            game: game,
+            api: api,
+            recompute: false,
+          );
+          final trades =
+              outcome.orders.tradeOrdersByPlayerId[_nationId];
+          expect(trades, isNotNull);
+          expect(trades, hasLength(1));
+          expect(trades!.first.commodityId, 'fabric');
+          expect(trades.first.type, TradeOrderType.offer);
+          expect(trades.first.quantity, 3);
+        },
+      );
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Closes the orchestrator wiring gap disclosed in PR #3128: `runTreasuryPlanner` already consumes `currentOrders` and subtracts `pendingTreasuryCostsForTurn`, but the strategic-AI production path called the planner inside `runEconomyPlanner` **before** the build / recruit / research planners, so `currentOrders` was always empty at planner entry and pending costs contributed `0` to the budget in the standard AI flow (#3128 PR description, *"What is deferred"*).

This PR moves trade-order generation to the **tail** of `runDomainPlannersWithOutcome` (after every other domain planner has had a chance to append to `ctx.orders`) for the production strategic-AI entry, so the bid budget reflects the matcher-side treasury clamp introduced by #3115.

Refs #3122 (do not auto-close — tracked for verification after merge).

## What landed in this PR

- **SPEC** — extends `SPEC/ai/treasury-planner.md` § Orchestrator wiring with the **Refs #3122 orchestrator wiring** contract: the two new opt-in flags (`skipTradeOrderGeneration` on `runEconomyPlanner`, `recomputeTradeOrdersWithPendingCosts` on `runDomainPlannersWithOutcome`), the recompute call signature, and the AC pinning that the orchestrator's tail-recompute respects the same `treasury − pendingCosts − carryForwardNotional` budget the matcher enforces at phase 13.
- **`runEconomyPlanner`** — new `skipTradeOrderGeneration: false` parameter. When `true`, both the labour=0 early-return path and the standard path emit `EconomyPlan.tradeOrders = const []` instead of invoking `runTreasuryPlanner`. No effect on production assignments or cargo preference.
- **`runDomainPlannersWithOutcome`** (and its `runDomainPlanners` wrapper) — new `recomputeTradeOrdersWithPendingCosts: false` parameter. When `true`, the orchestrator calls `runTreasuryPlanner` at the tail of the domain pipeline (after work / build / recruit / research / naval / diplomacy passes) with `currentOrders = ctx.orders`, using the live `game.playerById(nationId)` stockpile + treasury and `economyPlan.productionAssignments`. The recomputed list replaces `economyPlan.tradeOrders` for that player.
- **`generateStrategicOrdersWithTrace`** — opts into both flags so the production strategic-AI path now sees the pending-cost-aware bid budget. The simpler `runDomainPlanners` test entrypoint and the explicit-mock wiring fixture (`domain_planner_orchestrator_trade_orders_wiring_test.dart`) keep their prior behaviour byte-for-byte because they leave the flags at their defaults.
- **Tests** — new file `domain_planner_orchestrator_pending_cost_trade_test.dart` covers three orchestrator-level cases:
  - **Positive (pending-cost wiring)** — EXPAND below-quota peer-war lock fixture with `treasury == 4000`, fabric deficit, peasant_levies (`buildTreasuryCost == 2000`) as the sole build candidate. With the recompute flag set, the orchestrator picks the regiment build *and* the recomputed bid notional respects `<= 4000 - 2000`.
  - **Positive (mock-ignored)** — with the recompute flag set and a fabricated mock `tradeOrders` (`grain x 99 @ priority 1`), the orchestrator must discard the mock list. A zero-treasury setup makes the per-bid clamp drop every priced bid, so the 99-quantity mock cannot survive.
  - **Negative (F7 wiring preserved)** — with the recompute flag unset (default), the existing mock-pass-through contract still holds (covers regression risk for callers that did not opt in).

## ACs covered now (from #3122)

| Issue AC | Covered |
|---|---|
| `treasury == 0` emits no bids (per-bid clamp drops every bid to 0) | ✅ existing test in #3128 |
| Pending `BuildUnitOrder` reduces budget when `currentOrders` is threaded | ✅ direct planner test in #3128 |
| Carry-forward bid notional reduces remaining budget | ✅ existing test in #3128 |
| Treasury below pricePerUnit drops the bid | ✅ existing test in #3128 |
| Lock-recovery designated buyer respects budget | ✅ existing test in #3128 |
| `pendingTreasuryCostsForTurn` returns expected sum | ✅ existing logic test in #3128 |
| Determinism preserved | ✅ existing test in #3128 + `full_ai_planner_determinism_test` still green |
| **Orchestrator wiring** — pending build cost feeds the recomputed bid budget in production AI flow | ✅ new positive test in this PR |
| **Orchestrator wiring** — flag opts in cleanly without breaking the F7 mock-pass-through contract | ✅ new negative test in this PR |

## What is deferred

Nothing on #3122 itself remains open as far as I can see. Once this PR merges, an AC↔implementation closure pass via `verify-github-issue` is the appropriate next step. The issue stays under `backlog:implementation` until that verification runs (per the backlog skill).

## Tests run locally

- `flutter test packages/colonizethis_ai/test/domain_planner_orchestrator_pending_cost_trade_test.dart` — 3/3 pass.
- `flutter test packages/colonizethis_ai/test/economy_planner_test.dart packages/colonizethis_ai/test/economy_planner_phase_plan_injection_test.dart packages/colonizethis_ai/test/domain_planner_orchestrator_trade_orders_wiring_test.dart packages/colonizethis_ai/test/planning/treasury_planner_test.dart packages/colonizethis_ai/test/planning/treasury_planner_treasury_budget_test.dart` — 36/36 pass.
- `flutter test packages/colonizethis_ai/test/seed42_observer_treasury_planner_trade_emission_test.dart packages/colonizethis_ai/test/full_ai_planner_determinism_test.dart` — 8/8 pass (F9 turn-1 emission contract + full-AI determinism unchanged with the new tail-recompute).
- `flutter test packages/colonizethis_ai/test/` — 1689/1689 pass (8 skipped — long-running diagnostics, pre-existing).
- `dart analyze packages/colonizethis_ai/lib/src/planning/ packages/colonizethis_ai/test/domain_planner_orchestrator_pending_cost_trade_test.dart` — only pre-existing `unnecessary_null_comparison` warnings on dev (verified by stash-and-rerun against `origin/dev`).

Tracked by #3122 (do not auto-close).

Made with [Cursor](https://cursor.com)