### PR TITLE
refactor(app): adopt CtSpacing in military_units_panel.dart (Refs #2914 S5)

### DIFF
--- a/app/lib/features/game/widgets/military_units_panel.dart
+++ b/app/lib/features/game/widgets/military_units_panel.dart
@@ -336,7 +336,7 @@ class _ArmyExpansionTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.only(left: 8),
+      padding: const EdgeInsets.only(left: CtSpacing.m),
       child: ExpansionTile(
         title: _buildTitleRow(),
         subtitle: Text(_subtitleText()),
@@ -426,16 +426,22 @@ class _ArmyExpansionTile extends StatelessWidget {
           if (onMove != null) ...[
             CtNinePatchButton(
               onPressed: onMove,
-              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+              padding: const EdgeInsets.symmetric(
+                horizontal: CtSpacing.ml,
+                vertical: CtSpacing.m,
+              ),
               minHeight: 36,
               child: Text(l10n.common_move),
             ),
-            const SizedBox(width: 8),
+            const SizedBox(width: CtSpacing.m),
           ],
           if (onSplit != null)
             CtNinePatchButton(
               onPressed: onSplit,
-              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+              padding: const EdgeInsets.symmetric(
+                horizontal: CtSpacing.ml,
+                vertical: CtSpacing.m,
+              ),
               minHeight: 36,
               child: Text(l10n.common_split),
             ),
@@ -455,7 +461,7 @@ class _RegimentRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.only(left: 8),
+      padding: const EdgeInsets.only(left: CtSpacing.m),
       child: ListTile(
         title: Text(
           l10n.military_units_typeCount(
@@ -486,7 +492,7 @@ class _ShipRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.only(left: 8),
+      padding: const EdgeInsets.only(left: CtSpacing.m),
       child: ListTile(
         title: Text(
           l10n.military_units_typeCount(


### PR DESCRIPTION
Refs #2914

## Summary

Single-file S5 spacing slice on `military_units_panel.dart`. Replaces six raw `EdgeInsets` / `SizedBox` literals across the `_ArmyExpansionTile`, `_RegimentRow`, and `_ShipRow` sub-widgets with the canonical `CtSpacing.m` (8) and `CtSpacing.ml` (12) tokens introduced by #3053. Mirrors the per-file pattern from #3131 (`production_labour_section.dart`), #3121 (`pause_menu_panel.dart`), #3118 (`trade_screen_deal_book.dart`), and #3101 (`trade_screen.dart`).

`CtSpacing.m == 8` and `CtSpacing.ml == 12`, so the rendered geometry is identity-preserved (no visual or behavioural change). The file already imports `CtSpacing` and already uses `CtSpacing.m` for the footer-button row padding (line 422), so this slice continues an in-file consistency pass rather than introducing the token to a fresh surface.

## What landed

- **`_ArmyExpansionTile.build` outer padding** — `EdgeInsets.only(left: 8)` -> `EdgeInsets.only(left: CtSpacing.m)`.
- **`_ArmyExpansionTile._buildFooterButtons` Move button padding** — `EdgeInsets.symmetric(horizontal: 12, vertical: 8)` -> `EdgeInsets.symmetric(horizontal: CtSpacing.ml, vertical: CtSpacing.m)`.
- **Move/Split inter-button gap** — `SizedBox(width: 8)` -> `SizedBox(width: CtSpacing.m)`.
- **`_ArmyExpansionTile._buildFooterButtons` Split button padding** — `EdgeInsets.symmetric(horizontal: 12, vertical: 8)` -> `EdgeInsets.symmetric(horizontal: CtSpacing.ml, vertical: CtSpacing.m)`.
- **`_RegimentRow.build` left padding** — `EdgeInsets.only(left: 8)` -> `EdgeInsets.only(left: CtSpacing.m)`.
- **`_ShipRow.build` left padding** — `EdgeInsets.only(left: 8)` -> `EdgeInsets.only(left: CtSpacing.m)`.

## What was deliberately left as a raw literal

- **`_buildSelectionToolbar` Combine button padding** (line 185): `EdgeInsets.symmetric(horizontal: 10, vertical: 6)`. `10` is intentionally not in the `CtSpacing` scale per the SPEC carve-out documented in `SPEC/ui/pixel-art-ui-catalog.md` § Spacing tokens and the comments on `app/lib/widgets/ct_spacing.dart` (\"skips over `4`, `10`, and `14` because those values are rare and either approximate or better expressed as a per-component override\"). Adding a new token for `10` would land in the SPEC table first per the umbrella issue's Phase 0 rule.
- **`SizedBox(width: 4)`** inter-checkbox spacing (lines 181, 361, 364): `4` is also outside the canonical scale per the same SPEC rule.

## ACs covered (from #2914)

- **S5** — Adopt `CtSpacing` constants in feature files (this PR ticks one more file off the umbrella's S5 surface; `military_units_panel.dart` is explicitly named in #3131's \"What is deferred\" follow-up list).
- **No regressions** — All 32 `military_units_panel_test_part1..5` widget tests pass; `dart analyze` is clean on the touched file; `check_app_editorial_monocle_colors` reports no violations.

## What is deferred

- Other feature files with non-canonical `EdgeInsets` literals (e.g. `production_panel.dart`, dialogs under `app/lib/features/game/dialogue/`, `province_sea_zone_detail_overlay*.dart`) — separate per-file slices following the same pattern.
- The `horizontal: 10` / `width: 4` literals in this file (per § What was deliberately left).
- Issue #2914 stays under `backlog:implementation` because the umbrella has many open sub-issues (S5 not yet complete across all files; S6 / S7 / S9 etc. ongoing).

## Tests run locally

- `flutter test app/test/military_units_panel_test_part1_test.dart app/test/military_units_panel_test_part2_test.dart app/test/military_units_panel_test_part3_test.dart app/test/military_units_panel_test_part4_test.dart app/test/military_units_panel_test_part5_test.dart` -> 32/32 pass.
- `dart analyze app/lib/features/game/widgets/military_units_panel.dart` -> \`No issues found!\`.
- `dart run tool/check_app_editorial_monocle_colors.dart` -> \`no violations found.\`.
- `dart format app/lib/features/game/widgets/military_units_panel.dart` -> no further changes needed.

Tracked by #2914 (do not auto-close).

Made with [Cursor](https://cursor.com)