### PR TITLE
refactor(app): adopt CtSpacing in move_fleet_dialog.dart (Refs #2914 S5)

### DIFF
--- a/app/lib/features/game/widgets/move_fleet_dialog.dart
+++ b/app/lib/features/game/widgets/move_fleet_dialog.dart
@@ -12,6 +12,7 @@ import '../../../l10n/l10n.dart';
 import '../../../widgets/ct_dialog_shell.dart';
 import '../../../widgets/ct_icon_action.dart';
 import '../../../widgets/ct_section_label.dart';
+import '../../../widgets/ct_spacing.dart';
 import '../utils/map_location_resolver.dart';
 import '../utils/sea_zone_name_resolver.dart';
 import 'chrome/ct_nine_patch_button.dart';
@@ -224,13 +225,13 @@ class _MoveFleetDialogState extends State<MoveFleetDialog> {
       children: [
         if (seaPicks.isNotEmpty) ...[
           CtSectionLabel(l10n.moveFleet_seaZonesSection),
-          const SizedBox(height: 6),
+          const SizedBox(height: CtSpacing.s),
           ...seaPicks.map(_row),
         ],
         if (portPicks.isNotEmpty) ...[
-          if (seaPicks.isNotEmpty) const SizedBox(height: 12),
+          if (seaPicks.isNotEmpty) const SizedBox(height: CtSpacing.ml),
           CtSectionLabel(l10n.moveFleet_provincesDockSection),
-          const SizedBox(height: 6),
+          const SizedBox(height: CtSpacing.s),
           ...portPicks.map(_row),
         ],
       ],
@@ -241,7 +242,7 @@ class _MoveFleetDialogState extends State<MoveFleetDialog> {
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         Text(titleText, style: titleStyle),
-        const SizedBox(height: 12),
+        const SizedBox(height: CtSpacing.ml),
         if (picks.isEmpty)
           Text(l10n.moveFleet_noAdjacentSeaZones, style: emptyStyle)
         else
@@ -251,11 +252,11 @@ class _MoveFleetDialogState extends State<MoveFleetDialog> {
                   child: moveColumns,
                 )
               : moveColumns,
-        const SizedBox(height: 16),
+        const SizedBox(height: CtSpacing.l),
         Wrap(
           alignment: WrapAlignment.end,
-          spacing: 8,
-          runSpacing: 8,
+          spacing: CtSpacing.m,
+          runSpacing: CtSpacing.m,
           children: [
             CtNinePatchButton(
               onPressed: () => Navigator.pop(context, false),


### PR DESCRIPTION
## Summary

Replaces seven raw `SizedBox` / `Wrap` literals across the move-fleet dialog body (`app/lib/features/game/widgets/move_fleet_dialog.dart`) with the canonical `CtSpacing` scale tokens introduced by #3053 — `CtSpacing.s` (`6`), `CtSpacing.m` (`8`), `CtSpacing.ml` (`12`), and `CtSpacing.l` (`16`). Mirrors the per-file S5 pattern just landed for the army-side dialog in #3137 (`move_army_dialog.dart`) and earlier slices in #3136 (`military_units_panel.dart`), #3131 (`production_labour_section.dart`), #3121 (`pause_menu_panel.dart`), and #3118 (`trade_screen_deal_book.dart`).

`CtSpacing.{s,m,ml,l}` equal `{6,8,12,16}` respectively, so rendered geometry is **identity-preserved** — no visual or behavioural change. The 22-test cross-file move-dialog suite (`move_fleet_dialog_test.dart`, `move_dialogs_specs_test.dart`, `move_dialogs_320dp_min_viewport_test.dart`) still passes unmodified.

### Carve-out literals preserved as raw values

Per the SPEC carve-out documented in `SPEC/ui/pixel-art-ui-catalog.md` § Spacing tokens (the scale intentionally skips `4`, `10`, and `14`), these stay as raw literals — same handling as the parallel `move_army_dialog.dart` refactor in #3137:

- `EdgeInsets.symmetric(horizontal: 10, vertical: 8)` row outline padding in `_MoveFleetDestinationRow` (line ~355).
- `SizedBox(width: 10)` radio-dot ↔ label gap (line ~359).
- `EdgeInsets.symmetric(vertical: 3)` per-row inset (line ~343).

## SPEC

No SPEC changes. The `CtSpacing` token scale already lands in `SPEC/ui/pixel-art-ui-catalog.md` § Spacing tokens; this PR only adopts those tokens at one more callsite.

## ACs covered now (umbrella #2914 S5)

This slice closes the S5-adoption gap for `move_fleet_dialog.dart`. Each call site previously matching a CtSpacing token now reads as the named constant rather than the raw literal, matching the umbrella issue's invariant for S5 (no raw spacing literals at call sites for values in the `CtSpacing` scale).

## What is deferred

Nothing in scope for this slice. Other files with similar `EdgeInsets` / `SizedBox` patterns (e.g. `naval_units_panel.dart`, `train_civilians_dialog.dart`, …) remain to be adopted in their own per-file slices, consistent with the #2914 S5 file-at-a-time cadence.

## Test plan

- [x] \`flutter test app/test/move_fleet_dialog_test.dart\` — 7/7 pass (unchanged from pre-refactor).
- [x] \`flutter test app/test/move_dialogs_specs_test.dart app/test/move_dialogs_320dp_min_viewport_test.dart\` — 22/22 pass (covers SPEC, mobile 320 dp viewport, and \`Refs #2867 R*\` chrome contracts for both army and fleet dialogs).
- [x] \`dart analyze app/lib/features/game/widgets/move_fleet_dialog.dart\` — clean.

Refs #2914

Made with [Cursor](https://cursor.com)