### PR TITLE
refactor(app): adopt CtSpacing in train_dialog_chrome.dart (Refs #2914 S5)

### DIFF
--- a/app/lib/features/game/widgets/train_dialog_chrome.dart
+++ b/app/lib/features/game/widgets/train_dialog_chrome.dart
@@ -5,6 +5,7 @@ import '../../../widgets/ct_brass_divider.dart';
 import '../../../widgets/ct_gradients.dart';
 import '../../../widgets/ct_nine_patch_button.dart';
 import '../../../widgets/ct_radius.dart';
+import '../../../widgets/ct_spacing.dart';
 
 /// Locked train-dialog row opacity per `SPEC/ui/train-civilians-dialog.md` /
 /// `SPEC/ui/train-military-dialog.md` and #2866 AC (0.4).
@@ -58,7 +59,7 @@ class TrainDialogSectionDivider extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return const Padding(
-      padding: EdgeInsets.symmetric(vertical: 8),
+      padding: EdgeInsets.symmetric(vertical: CtSpacing.m),
       child: CtBrassDivider(),
     );
   }
@@ -87,7 +88,7 @@ class TrainDialogResourceBar extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Wrap(
-          spacing: 16,
+          spacing: CtSpacing.l,
           runSpacing: 4,
           children: [for (final line in lines) Text(line, style: lineStyle)],
         ),
@@ -133,7 +134,7 @@ class TrainDialogUnitRowSurface extends StatelessWidget {
   const TrainDialogUnitRowSurface({
     super.key,
     required this.child,
-    this.margin = const EdgeInsets.only(bottom: 6),
+    this.margin = const EdgeInsets.only(bottom: CtSpacing.s),
   });
 
   final Widget child;
@@ -152,7 +153,10 @@ class TrainDialogUnitRowSurface extends StatelessWidget {
           ),
         ),
         child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          padding: const EdgeInsets.symmetric(
+            horizontal: CtSpacing.ml,
+            vertical: CtSpacing.m,
+          ),
           child: child,
         ),
       ),

--- a/app/test/ct_spacing_features_adoption_test.dart
+++ b/app/test/ct_spacing_features_adoption_test.dart
@@ -203,6 +203,7 @@ const List<String> _migratedFeatureFiles = <String>[
   'lib/features/game/widgets/split_fleet_dialog.dart',
   'lib/features/game/widgets/technology_panel.dart',
   'lib/features/game/widgets/technology_panel_orders.dart',
+  'lib/features/game/widgets/train_dialog_chrome.dart',
   'lib/features/game/widgets/transfer_to_home_fleet_dialog.dart',
   'lib/features/game/widgets/units/shared/units_panel_shell.dart',
   'lib/features/shell/new_game_setup_flow.dart',


### PR DESCRIPTION
## Summary

Migrates four CtSpacing-eligible literals on the shared train-dialog chrome
(`TrainDialogSectionDivider`, `TrainDialogResourceBar`, `TrainDialogUnitRowSurface`)
to the SPEC-pinned token scale per **#2914 S5** and
[`SPEC/ui/pixel-art-ui-catalog.md` § *Spacing tokens*](SPEC/ui/pixel-art-ui-catalog.md).

The shared chrome powers `TrainCiviliansDialog` (DLG70001a) and
`TrainMilitaryDialog` (DLG70001b), so a single migration here lights up
both dialogs against the canonical spacing scale.

## Done in this push

- `TrainDialogSectionDivider`: `EdgeInsets.symmetric(vertical: 8)` →
  `CtSpacing.m`.
- `TrainDialogResourceBar` outer `Wrap`: `spacing: 16` → `CtSpacing.l`.
  `runSpacing: 4` is preserved as an explicit per-component override
  per SPEC prose ("scale is intentionally non-linear: it skips over `4`, `10`, and `14`").
- `TrainDialogUnitRowSurface.margin` default:
  `EdgeInsets.only(bottom: 6)` → `CtSpacing.s`.
- `TrainDialogUnitRowSurface` inner padding:
  `EdgeInsets.symmetric(horizontal: 12, vertical: 8)` →
  `CtSpacing.ml` / `CtSpacing.m`.

Out-of-scale per-component overrides are deliberately preserved:

- `TrainDialogHeader` close-button `EdgeInsets.symmetric(horizontal: 10,
  vertical: 6)` — `10` is SPEC-omitted from the scale; the row stays
  as a pixel-art override.
- `TrainDialogResourceChip` `EdgeInsets.symmetric(horizontal: 6,
  vertical: 4)` — `4` is SPEC-omitted; keeping the chip's
  pixel-tight breathing room intact.

## Tests

- `cd app && flutter test test/train_dialog_chrome_test.dart test/spec_components_train_dialog_chrome_test.dart test/train_dialogs_320dp_min_viewport_test.dart` → 15/15 pass (≈25 s).
- `cd app && flutter test test/ct_spacing_features_adoption_test.dart` → 76/76 pass (the new `train_dialog_chrome.dart` row + the existing 24 migrated files; three adoption invariants per file).
- `cd app && flutter test test/ct_radius_adoption_test.dart` → 6/6 pass (touches `TrainDialogResourceChip` so worth re-running; unaffected by this diff).
- `cd app && flutter analyze lib/features/game/widgets/train_dialog_chrome.dart test/ct_spacing_features_adoption_test.dart` → no issues.

## Scope coverage

| AC (Refs #2914 § Acceptance criteria) | Where covered |
|---|---|
| **S5** — `CtSpacing` constants adopted in feature padding callsites where the literal maps cleanly to a token row. | This PR adopts `CtSpacing.m / ml / l / s` on `train_dialog_chrome.dart`; locked by `ct_spacing_features_adoption_test.dart` row. |

## Visible layout

Preserved end-to-end (`CtSpacing.m == 8`, `ml == 12`, `l == 16`,
`s == 6`).

Refs #2914

Made with [Cursor](https://cursor.com)