### PR TITLE
refactor(app): adopt CtSpacing in units_panel_row_chrome.dart (Refs #2914 S5)

### DIFF
--- a/app/lib/features/game/widgets/units/shared/units_panel_row_chrome.dart
+++ b/app/lib/features/game/widgets/units/shared/units_panel_row_chrome.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../../../../../config/editorial_monocle_palette.dart';
 import '../../../../../widgets/ct_gradients.dart';
+import '../../../../../widgets/ct_spacing.dart';
 
 /// Dark editorial-monocle row surface for unit / army / fleet rows.
 ///
@@ -9,12 +10,22 @@ import '../../../../../widgets/ct_gradients.dart';
 /// with a 1 px `--accent-dim` border. Hover is not modeled here (Flutter web
 /// hover would require a [MouseRegion] parent); panel rows use the static
 /// accent-dim border per the issue AC.
+///
+/// Default `margin` / `padding` resolve through [CtSpacing] tokens
+/// (`SPEC/ui/pixel-art-ui-catalog.md` § *Spacing tokens*, Refs #2914 S5):
+/// the bottom margin uses [CtSpacing.s] (6 dp) and the inner padding uses
+/// [CtSpacing.m] (8 dp horizontal) × [CtSpacing.s] (6 dp vertical). The
+/// physical geometry is preserved end-to-end so this is a token-renaming
+/// migration only.
 class UnitsPanelRowChrome extends StatelessWidget {
   const UnitsPanelRowChrome({
     super.key,
     required this.child,
-    this.margin = const EdgeInsets.only(bottom: 6),
-    this.padding = const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+    this.margin = const EdgeInsets.only(bottom: CtSpacing.s),
+    this.padding = const EdgeInsets.symmetric(
+      horizontal: CtSpacing.m,
+      vertical: CtSpacing.s,
+    ),
   });
 
   final Widget child;

--- a/app/test/ct_spacing_features_adoption_test.dart
+++ b/app/test/ct_spacing_features_adoption_test.dart
@@ -204,6 +204,7 @@ const List<String> _migratedFeatureFiles = <String>[
   'lib/features/game/widgets/technology_panel.dart',
   'lib/features/game/widgets/technology_panel_orders.dart',
   'lib/features/game/widgets/transfer_to_home_fleet_dialog.dart',
+  'lib/features/game/widgets/units/shared/units_panel_row_chrome.dart',
   'lib/features/game/widgets/units/shared/units_panel_shell.dart',
   'lib/features/shell/new_game_setup_flow.dart',
 ];


### PR DESCRIPTION
## Summary

Migrates the default `margin` / `padding` literals on `UnitsPanelRowChrome`
to the SPEC-pinned `CtSpacing` token scale per **#2914 S5** and
[`SPEC/ui/pixel-art-ui-catalog.md` § *Spacing tokens*](SPEC/ui/pixel-art-ui-catalog.md).

`UnitsPanelRowChrome` powers `UnitsEntityActionRow` (and through it the
civilian / military / naval unit panels), so a single migration here
threads the canonical spacing scale through every unit-panel row default.

Mirrors the per-file pattern from the prior S5 slices (#3145 train chrome,
#3142 move-fleet, #3137 move-army, #3136 military-units, #3131
production-labour, etc.).

## Done in this push

- `UnitsPanelRowChrome.margin` default:
  `EdgeInsets.only(bottom: 6)` -> `EdgeInsets.only(bottom: CtSpacing.s)`.
- `UnitsPanelRowChrome.padding` default:
  `EdgeInsets.symmetric(horizontal: 8, vertical: 6)` ->
  `EdgeInsets.symmetric(horizontal: CtSpacing.m, vertical: CtSpacing.s)`.

`CtSpacing.s == 6` and `CtSpacing.m == 8`, so the rendered geometry is
identity-preserved (no visual or behavioural change).

Adoption-test pinning: `lib/features/game/widgets/units/shared/units_panel_row_chrome.dart`
is added to `_migratedFeatureFiles` in `ct_spacing_features_adoption_test.dart`,
locking the three S5 invariants per file (import in place, at least one
`CtSpacing.<token>` reference, no raw `EdgeInsets.all(N)` for `N \u2208 {8,12,16,20,24}`).

## Tests

- `cd app && flutter test test/ct_spacing_features_adoption_test.dart`
  -> 76/76 pass (was 73; +3 for the new row).
- `cd app && flutter test test/units_panel_shared_widgets_test.dart test/spec_components_units_entity_action_row_test.dart`
  -> 21/21 pass (no downstream regression on chrome consumers).
- `cd app && flutter test test/civilian_units_panel_test_part1_test.dart test/military_units_panel_test_part1_test.dart test/naval_units_panel_test_part1_test.dart`
  -> 45/45 pass.
- `cd app && flutter analyze lib/features/game/widgets/units/shared/units_panel_row_chrome.dart test/ct_spacing_features_adoption_test.dart`
  -> no issues.

## Scope coverage

| AC (Refs #2914 \u00a7 Acceptance criteria) | Where covered |
|---|---|
| **S5** \u2014 `CtSpacing` constants adopted in feature padding callsites where the literal maps cleanly to a token row. | This PR adopts `CtSpacing.s` (6 dp) and `CtSpacing.m` (8 dp) on `units_panel_row_chrome.dart`; locked by the new `ct_spacing_features_adoption_test.dart` row. |

## What is deferred

- Other unit-panel-row-adjacent files (`production_allocation_row_chrome.dart`,
  `units_entity_action_row.dart`) still carry raw `EdgeInsets.symmetric` / `EdgeInsets.only`
  literals; those are out of scope here and remain candidates for follow-up S5 slices.

## Visible layout

Preserved end-to-end (`CtSpacing.s == 6`, `CtSpacing.m == 8`).

Refs #2914

Made with [Cursor](https://cursor.com)