### PR TITLE
refactor(app): route diplomacy action button caption through TextTheme (Refs #2914 S7)

### DIFF
--- a/app/lib/features/game/widgets/diplomacy_panel.dart
+++ b/app/lib/features/game/widgets/diplomacy_panel.dart
@@ -657,13 +657,21 @@ class _ActionButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final label = isPending ? 'Cancel' : diplomacyActionLabel(order);
+    final ThemeData theme = Theme.of(context);
+    // SPEC/ui/pixel-art-ui-catalog.md § Editorial-monocle text theme —
+    // the action-button caption resolves through the M3 `bodySmall` slot
+    // (12 dp) so font, weight, and colour flow from
+    // `AppThemes.editorialMonocle` instead of a hard-coded literal.
+    // Refs #2914 S7.
+    final TextStyle labelStyle =
+        theme.textTheme.bodySmall ?? const TextStyle(fontSize: 12);
     return SizedBox(
       height: 32,
       child: CtNinePatchButton(
         onPressed: isPending ? onCancel : onPressed,
         padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
         dangerVariant: _isWarVariant,
-        child: Text(label, style: const TextStyle(fontSize: 12)),
+        child: Text(label, style: labelStyle),
       ),
     );
   }

--- a/app/test/diplomacy_panel_action_button_text_theme_test.dart
+++ b/app/test/diplomacy_panel_action_button_text_theme_test.dart
@@ -1,0 +1,97 @@
+// Regression test for Refs #2914 S7 — diplomacy-panel action button must
+// resolve its caption text style through the M3 dark `bodySmall` slot on
+// `AppThemes.editorialMonocle.textTheme` rather than a hard-coded
+// `const TextStyle(fontSize: 12)` literal.
+//
+// SPEC:
+//  * `SPEC/ui/pixel-art-ui-catalog.md` § *Editorial-monocle palette* —
+//    canonical TextTheme contract (M3 dark slot table).
+//  * Issue #2914 § "3. Hardcoded `fontSize:` values bypassing the theme
+//    TextTheme" pins the slot → size mapping; `bodySmall == 12`.
+//
+// Source-scan style (no `WidgetTester`) is sufficient because the action
+// button's text style is constructed inline and the regression vector is
+// a `style: const TextStyle(fontSize: 12)` literal reappearing on the
+// `_ActionButton` build path. Pumping the widget would add Flame /
+// Riverpod boot scaffolding without exercising more of the contract this
+// slice closes.
+
+import 'dart:io';
+
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  suppressLogsForTests();
+
+  group(
+    'diplomacy_panel.dart _ActionButton routes caption through TextTheme '
+    '(Refs #2914 S7 regression guard)',
+    () {
+      late final String diplomacyPanelSource;
+
+      setUpAll(() {
+        // `flutter test` runs from the package root (`app/`); the source
+        // path is therefore relative to that working directory.
+        final File source =
+            File('lib/features/game/widgets/diplomacy_panel.dart');
+        expect(
+          source.existsSync(),
+          isTrue,
+          reason:
+              'Expected `app/lib/features/game/widgets/diplomacy_panel.dart` '
+              'to exist; running directory is `${Directory.current.path}`.',
+        );
+        diplomacyPanelSource = source.readAsStringSync();
+      });
+
+      test(
+          'imports `Theme.of(context).textTheme.bodySmall` fallback for the '
+          'action-button caption', () {
+        // The fallback must use the canonical M3 dark `bodySmall` slot
+        // (12 dp per the SPEC slot→size table); the regex pins the slot
+        // *and* the fallback size together so a slot rename or size
+        // change is caught even if the literal `12` is left intact.
+        final RegExp slotFallback = RegExp(
+          r'textTheme\.bodySmall\s*\?\?\s*const\s+TextStyle\s*\(\s*'
+          r'fontSize:\s*12\s*\)',
+        );
+        expect(
+          slotFallback.hasMatch(diplomacyPanelSource),
+          isTrue,
+          reason:
+              'Expected `_ActionButton.build` in `diplomacy_panel.dart` to '
+              'resolve its caption text style via '
+              '`theme.textTheme.bodySmall ?? const TextStyle(fontSize: 12)` '
+              '(Refs #2914 S7). If the slot was intentionally changed, '
+              'update both this test and the SPEC/ui/pixel-art-ui-catalog.md '
+              'slot→size table first.',
+        );
+      });
+
+      test(
+          'does not declare any inline `style: const TextStyle(fontSize: ...)` '
+          'literal on a child', () {
+        // Negative regression vector: removing the slot fallback and
+        // going back to `style: const TextStyle(fontSize: N)` reintroduces
+        // the exact hard-coded literal this slice removed.
+        final RegExp inlineHardCoded = RegExp(
+          r'style:\s*const\s+TextStyle\s*\(\s*fontSize:\s*\d+',
+        );
+        final Iterable<RegExpMatch> matches =
+            inlineHardCoded.allMatches(diplomacyPanelSource);
+        expect(
+          matches,
+          isEmpty,
+          reason:
+              'Found ${matches.length} `style: const TextStyle(fontSize: N)` '
+              'literal(s) in `diplomacy_panel.dart`. Each must route through '
+              '`Theme.of(context).textTheme.<slot> ?? const TextStyle(...)` '
+              'per Refs #2914 S7 so font, weight, and colour flow from '
+              '`AppThemes.editorialMonocle`. Offending occurrences: '
+              '${matches.map((m) => m.group(0)).join(' | ')}.',
+        );
+      });
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Closes an S7 (font-size normalization) regression in
`app/lib/features/game/widgets/diplomacy_panel.dart`: the diplomacy
panel's `_ActionButton` caption was rendered with an inline
`style: const TextStyle(fontSize: 12)` literal, bypassing the M3 dark
`bodySmall` slot on `AppThemes.editorialMonocle.textTheme`. This PR
routes the caption through `theme.textTheme.bodySmall ?? const
TextStyle(fontSize: 12)`, the same slot fallback pattern already
adopted in the rest of the panel (see existing
`textTheme.titleMedium` / `textTheme.bodyMedium` / `textTheme.bodySmall`
fallbacks elsewhere in `app/lib/features/`). Pixel size is preserved
(`bodySmall == 12 dp` per the canonical slot table); the change is
font / weight / colour flow only.

## Done in this push

- **`app/lib/features/game/widgets/diplomacy_panel.dart`** — replace
  inline `style: const TextStyle(fontSize: 12)` on `_ActionButton`'s
  caption with `theme.textTheme.bodySmall ?? const TextStyle(fontSize:
  12)`, matching the slot→size table pinned by #2914 S7.
- **`app/test/diplomacy_panel_action_button_text_theme_test.dart`** —
  new focused regression guard. Positive AC: scans the source for the
  `theme.textTheme.bodySmall ?? const TextStyle(fontSize: 12)` slot
  fallback. Negative AC: scans for any inline `style: const
  TextStyle(fontSize: ...)` literal on a child and fails if one
  reappears.

The existing `app/test/text_theme_slot_size_alignment_test.dart`
already enforces the slot→size contract for every
`theme.textTheme.<slot> ?? const TextStyle(fontSize: N)` site under
`app/lib/**`; this slice's fallback is picked up by that scan and
continues to pass.

## ACs covered now vs follow-up

| AC | Where covered |
|---|---|
| #2914 S7 — slot/size table respected for `diplomacy_panel.dart` `_ActionButton` caption | This PR (slot fallback + canonical 12 dp) |
| #2914 S7 — positive regression guard for the slot fallback | New focused test |
| #2914 S7 — negative regression guard against inline `style: const TextStyle(fontSize: ...)` literal | New focused test |
| #2914 S7 — broader slot/size canonical scan under `app/lib/**` | Existing `text_theme_slot_size_alignment_test.dart` (continues to pass) |
| #2914 S7 — full normalization of every fallback in `app/lib/**` | **Deferred** — separate slices already in flight; this PR closes a single concrete violation |

## Tests

- `flutter test test/diplomacy_panel_action_button_text_theme_test.dart` — 2 / 2 pass.
- `flutter test test/text_theme_slot_size_alignment_test.dart` — 12 / 12 pass (existing S7 slot/size scan picks up the new fallback).
- `flutter test test/diplomacy_panel_test.dart test/diplomacy_panel_chrome_test.dart test/diplomacy_panel_orders_test.dart test/diplomacy_panel_narrow_layout_test.dart` — 53 / 53 pass.
- `dart analyze lib/features/game/widgets/diplomacy_panel.dart test/diplomacy_panel_action_button_text_theme_test.dart` — clean.

Refs #2914

Made with [Cursor](https://cursor.com)