### PR TITLE
refactor(app): adopt CtSpacing in diplomacy_panel_chrome.dart (Refs #2914 S5)

### DIFF
--- a/app/lib/features/game/widgets/diplomacy_panel_chrome.dart
+++ b/app/lib/features/game/widgets/diplomacy_panel_chrome.dart
@@ -45,7 +45,7 @@ class _DiplomacySectionHeader extends StatelessWidget {
       letterSpacing: 0.5,
     );
     return Padding(
-      padding: const EdgeInsets.only(top: 16, bottom: 8),
+      padding: const EdgeInsets.only(top: CtSpacing.l, bottom: CtSpacing.m),
       child: DecoratedBox(
         decoration: BoxDecoration(
           border: Border(
@@ -56,7 +56,7 @@ class _DiplomacySectionHeader extends StatelessWidget {
           ),
         ),
         child: Padding(
-          padding: const EdgeInsets.only(bottom: 6),
+          padding: const EdgeInsets.only(bottom: CtSpacing.s),
           child: Text(title, style: headingStyle),
         ),
       ),
@@ -104,7 +104,10 @@ class _FactionKindBadge extends StatelessWidget {
       ),
     };
     return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      padding: const EdgeInsets.symmetric(
+        horizontal: CtSpacing.s,
+        vertical: CtSpacing.xs,
+      ),
       decoration: BoxDecoration(
         color: spec.background,
         border: spec.border == null

--- a/app/test/ct_spacing_features_adoption_test.dart
+++ b/app/test/ct_spacing_features_adoption_test.dart
@@ -194,6 +194,7 @@ const List<String> _migratedFeatureFiles = <String>[
   'lib/features/game/widgets/civilian_units_panel.dart',
   'lib/features/game/widgets/civilian_units_panel_support.dart',
   'lib/features/game/widgets/diplomacy_panel.dart',
+  'lib/features/game/widgets/diplomacy_panel_chrome.dart',
   'lib/features/game/widgets/military_units_panel.dart',
   'lib/features/game/widgets/observe_mode_not_defined_panel.dart',
   'lib/features/game/widgets/pause_menu_panel.dart',


### PR DESCRIPTION
## Summary

Adopts the SPEC-pinned `CtSpacing.{xs,s,m,l}` tokens in the section header / faction-kind badge chrome of the diplomacy panel by migrating `app/lib/features/game/widgets/diplomacy_panel_chrome.dart` (a `part of 'diplomacy_panel.dart'`) away from raw `EdgeInsets` magic numbers.

`Refs #2914` S5 follow-up to PRs #3146 / #3142 / #3137 / #3136 / #3131 / #3121 / #3118 / #3097 / #3085.

## What landed

- `_DiplomacySectionHeader`: `EdgeInsets.only(top: 16, bottom: 8)` → `EdgeInsets.only(top: CtSpacing.l, bottom: CtSpacing.m)` and `EdgeInsets.only(bottom: 6)` → `EdgeInsets.only(bottom: CtSpacing.s)`.
- `_FactionKindBadge`: `EdgeInsets.symmetric(horizontal: 6, vertical: 2)` → `EdgeInsets.symmetric(horizontal: CtSpacing.s, vertical: CtSpacing.xs)`.
- `app/test/ct_spacing_features_adoption_test.dart`: add `lib/features/game/widgets/diplomacy_panel_chrome.dart` to `_migratedFeatureFiles` so the three per-file adoption invariants (parent-library import via `part of`, at least one `CtSpacing.<token>` reference, no raw `EdgeInsets.all(N)` for `N ∈ {8,12,16,20,24}`) are pinned for this file too.

Visible layout is preserved: `16 → CtSpacing.l`, `8 → CtSpacing.m`, `6 → CtSpacing.s`, `2 → CtSpacing.xs` per the canonical table in `SPEC/ui/pixel-art-ui-catalog.md` § *Spacing tokens*.

## What was intentionally left raw

The `_RelationStateBadge` `EdgeInsets.symmetric(horizontal: 5, vertical: 1)` literal stays as-is. `5` and `1` are outside the SPEC token scale (`CtSpacing.dart` docstring: the scale intentionally skips `4`, `5`, `10`, `14` because those values are rare and either approximate or better expressed per-component). Migrating them would require a SPEC extension first per the S5 adoption rule.

## SPEC alignment

- `SPEC/ui/pixel-art-ui-catalog.md` § *Spacing tokens* — canonical table.
- `SPEC/ui/diplomacy-panel.md` § Section headings / § Per-faction row → Type badge colors — unchanged.

## Tests

- `app/test/ct_spacing_features_adoption_test.dart` — all 79 cases pass (was 76; +3 for the new file: import via parent, at least one token reference, no raw `EdgeInsets.all(N)`).
- `app/test/diplomacy_panel_chrome_test.dart` + `app/test/diplomacy_panel_test.dart` — 45 cases pass; section header / kind badge AC contracts (--accent text, --accent-dim 2 px bottom border, GP / Minor / Tribe badge colors) all green.

Commands run:

- `cd app && flutter test test/ct_spacing_features_adoption_test.dart`
- `cd app && flutter test test/diplomacy_panel_chrome_test.dart test/diplomacy_panel_test.dart`
- `cd app && dart format --output=none --set-exit-if-changed lib/features/game/widgets/diplomacy_panel_chrome.dart test/ct_spacing_features_adoption_test.dart`
- `cd app && dart analyze lib/features/game/widgets/diplomacy_panel_chrome.dart test/ct_spacing_features_adoption_test.dart`

## Scope

This is one S5 slice. The umbrella `#2914` issue (multiple sub-tasks: S1–S9, G1–G2) stays open; `_RelationStateBadge` raw `5/1` literals are deferred (out of scope for the current SPEC scale) and other feature files continue to land slice-by-slice on their own PRs.

Refs #2914


Made with [Cursor](https://cursor.com)