### PR TITLE
refactor(app): adopt CtSpacing in production_allocation_row_chrome and production_commodity_breakdown_dialog (Refs #2914 S5)

### DIFF
--- a/app/lib/features/game/widgets/production_allocation_row_chrome.dart
+++ b/app/lib/features/game/widgets/production_allocation_row_chrome.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../../../config/editorial_monocle_palette.dart';
 import '../../../widgets/ct_gradients.dart';
+import '../../../widgets/ct_spacing.dart';
 
 /// Dark editorial-monocle row chrome for a production allocation row.
 ///
@@ -18,7 +19,10 @@ class ProductionAllocationRowChrome extends StatelessWidget {
   const ProductionAllocationRowChrome({
     super.key,
     required this.child,
-    this.padding = const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
+    this.padding = const EdgeInsets.symmetric(
+      horizontal: CtSpacing.m,
+      vertical: CtSpacing.m,
+    ),
   });
 
   final Widget child;

--- a/app/lib/features/game/widgets/production_commodity_breakdown_dialog.dart
+++ b/app/lib/features/game/widgets/production_commodity_breakdown_dialog.dart
@@ -12,6 +12,7 @@ import '../../../providers/production_allocation_provider.dart';
 import '../../../widgets/ct_dialog_shell.dart';
 import '../../../widgets/ct_nine_patch_button.dart';
 import '../../../widgets/ct_resource_cell.dart';
+import '../../../widgets/ct_spacing.dart';
 import '../../../widgets/resource_icon.dart';
 
 /// Minimum viewport width at which the breakdown dialog drops the
@@ -158,7 +159,7 @@ class _ProductionCommodityBreakdownDialogState
         ),
       ),
       child: Padding(
-        padding: const EdgeInsets.only(bottom: 2),
+        padding: const EdgeInsets.only(bottom: CtSpacing.xs),
         child: Text(
           label.toUpperCase(),
           style: _sectionHeaderStyle(context),

--- a/app/test/ct_spacing_features_adoption_test.dart
+++ b/app/test/ct_spacing_features_adoption_test.dart
@@ -197,6 +197,8 @@ const List<String> _migratedFeatureFiles = <String>[
   'lib/features/game/widgets/military_units_panel.dart',
   'lib/features/game/widgets/observe_mode_not_defined_panel.dart',
   'lib/features/game/widgets/pause_menu_panel.dart',
+  'lib/features/game/widgets/production_allocation_row_chrome.dart',
+  'lib/features/game/widgets/production_commodity_breakdown_dialog.dart',
   'lib/features/game/widgets/production_panel.dart',
   'lib/features/game/widgets/province_sea_zone_detail_overlay.dart',
   'lib/features/game/widgets/split_army_dialog.dart',


### PR DESCRIPTION
## Summary

`Refs #2914` S5 follow-up slice: extend `CtSpacing` adoption to two production-panel chrome files so per-component padding flows from the SPEC-pinned spacing scale instead of raw magic numbers, and pin both files in the per-file adoption invariants test.

Companion to the in-flight S5 slices #3149 (train dialogs) and #3151 (diplomacy panel chrome); touches a disjoint code surface (production-panel chrome) so it can land independently. The only test-file overlap is the `_migratedFeatureFiles` list additions, which are append-only and trivial to resolve.

## Done in this push

- **production_allocation_row_chrome.dart** — import `widgets/ct_spacing.dart`; replace the `ProductionAllocationRowChrome` default `padding` of `EdgeInsets.symmetric(horizontal: 8, vertical: 8)` with `EdgeInsets.symmetric(horizontal: CtSpacing.m, vertical: CtSpacing.m)`.
- **production_commodity_breakdown_dialog.dart** — import `widgets/ct_spacing.dart`; replace the `_sectionHeaderCell` `EdgeInsets.only(bottom: 2)` with `EdgeInsets.only(bottom: CtSpacing.xs)`.
- **ct_spacing_features_adoption_test.dart** — add both files to `_migratedFeatureFiles` so the three per-file invariants (parent-library import via `part of` or direct, at least one `CtSpacing.<token>` reference, no raw `EdgeInsets.all(N)` for `N ∈ {8, 12, 16, 20, 24}`) are pinned.

Visible layout is preserved: `8 → CtSpacing.m`, `2 → CtSpacing.xs` per the canonical table in `SPEC/ui/pixel-art-ui-catalog.md` § *Spacing tokens*.

## Intentionally left raw

No other `EdgeInsets.*` literals in either file use values from the SPEC-pinned scale (the breakdown dialog has no further padding callsites with `{2, 6, 8, 12, 16, 20, 24}` after this slice; the row chrome has only the migrated default).

## SPEC alignment

- `SPEC/ui/pixel-art-ui-catalog.md` § *Spacing tokens* — canonical table (`xs=2`, `s=6`, `m=8`, `ml=12`, `l=16`, `xl=20`, `xxl=24`).
- `SPEC/ui/pixel-art-ui-catalog.md` § *Acceptance criteria (Spacing and radius tokens)* — per-feature padding callsites adopted.
- `SPEC/ui/production-panel.md` § *Allocation row chrome* — unchanged.
- `SPEC/ui/production-commodity-breakdown-dialog.md` — unchanged.

## Tests

Commands run from `app/`:

- `flutter test test/ct_spacing_features_adoption_test.dart` — **82/82 passing** (79 → 82 with +6 new invariant assertions for the two new files; the +3rd is the pre-existing sanity assertion for the token table itself).
- `flutter test test/production_allocation_row_chrome_test.dart test/production_allocation_row_buttons_test.dart test/production_commodity_breakdown_dialog_spec_test.dart test/production_commodity_breakdown_dialog_320dp_min_viewport_test.dart` — **21/21 passing**; chrome + min-viewport + spec contracts unchanged.
- `dart analyze lib/features/game/widgets/production_allocation_row_chrome.dart lib/features/game/widgets/production_commodity_breakdown_dialog.dart test/ct_spacing_features_adoption_test.dart` — **No issues found**.

## Scope

This is one S5 slice. The umbrella `#2914` issue (S1–S9, G1–G2) stays open; other feature files continue to land slice-by-slice on their own PRs.

`Refs #2914`

Made with [Cursor](https://cursor.com)