### PR TITLE
refactor(app): adopt CtSpacing in train_dialog_chrome (Refs #2914 S5)

### DIFF
--- a/app/lib/features/game/widgets/train_dialog_chrome.dart
+++ b/app/lib/features/game/widgets/train_dialog_chrome.dart
@@ -5,6 +5,7 @@ import '../../../widgets/ct_brass_divider.dart';
 import '../../../widgets/ct_gradients.dart';
 import '../../../widgets/ct_nine_patch_button.dart';
 import '../../../widgets/ct_radius.dart';
+import '../../../widgets/ct_spacing.dart';
 
 /// Locked train-dialog row opacity per `SPEC/ui/train-civilians-dialog.md` /
 /// `SPEC/ui/train-military-dialog.md` and #2866 AC (0.4).
@@ -58,7 +59,7 @@ class TrainDialogSectionDivider extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return const Padding(
-      padding: EdgeInsets.symmetric(vertical: 8),
+      padding: EdgeInsets.symmetric(vertical: CtSpacing.m),
       child: CtBrassDivider(),
     );
   }
@@ -118,7 +119,10 @@ class TrainDialogResourceChip extends StatelessWidget {
         borderRadius: BorderRadius.circular(CtRadius.medium),
       ),
       child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 4),
+        padding: const EdgeInsets.symmetric(
+          horizontal: CtSpacing.s,
+          vertical: 4,
+        ),
         child: DefaultTextStyle.merge(
           style: TextStyle(color: EditorialMonoclePalette.fg),
           child: child,
@@ -133,7 +137,7 @@ class TrainDialogUnitRowSurface extends StatelessWidget {
   const TrainDialogUnitRowSurface({
     super.key,
     required this.child,
-    this.margin = const EdgeInsets.only(bottom: 6),
+    this.margin = const EdgeInsets.only(bottom: CtSpacing.s),
   });
 
   final Widget child;
@@ -152,7 +156,10 @@ class TrainDialogUnitRowSurface extends StatelessWidget {
           ),
         ),
         child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          padding: const EdgeInsets.symmetric(
+            horizontal: CtSpacing.ml,
+            vertical: CtSpacing.m,
+          ),
           child: child,
         ),
       ),

--- a/app/test/ct_spacing_features_adoption_test.dart
+++ b/app/test/ct_spacing_features_adoption_test.dart
@@ -205,6 +205,7 @@ const List<String> _migratedFeatureFiles = <String>[
   'lib/features/game/widgets/split_fleet_dialog.dart',
   'lib/features/game/widgets/technology_panel.dart',
   'lib/features/game/widgets/technology_panel_orders.dart',
+  'lib/features/game/widgets/train_dialog_chrome.dart',
   'lib/features/game/widgets/transfer_to_home_fleet_dialog.dart',
   'lib/features/game/widgets/units/shared/units_panel_row_chrome.dart',
   'lib/features/game/widgets/units/shared/units_panel_shell.dart',


### PR DESCRIPTION
## Summary

`Refs #2914` S5 follow-up slice: extend `CtSpacing` adoption to the shared train-dialog chrome module (`train_dialog_chrome.dart`) used by `train_civilians_dialog`, `train_military_dialog`, and `civilian_units_panel`.

Companion to in-flight PR #3149 (train dialog shell `fromLTRB` padding); this slice touches the disjoint shared chrome surface so it can land independently.

## Done in this push

- **train_dialog_chrome.dart** — import `widgets/ct_spacing.dart`; migrate scale-aligned insets:
  - `TrainDialogSectionDivider`: `vertical: 8` → `CtSpacing.m`
  - `TrainDialogResourceChip`: `horizontal: 6` → `CtSpacing.s` (`vertical: 4` left raw — not on the canonical scale per catalog)
  - `TrainDialogUnitRowSurface`: `bottom: 6` → `CtSpacing.s`; `horizontal: 12, vertical: 8` → `CtSpacing.ml` / `CtSpacing.m`
- **ct_spacing_features_adoption_test.dart** — add `train_dialog_chrome.dart` to `_migratedFeatureFiles` (import + token reference + no raw `EdgeInsets.all` for migrated set).

Intentionally left raw: `TrainDialogHeader` dismiss control `horizontal: 10` (not on the SPEC-pinned scale).

## SPEC alignment

- `SPEC/ui/pixel-art-ui-catalog.md` § *Spacing tokens*
- `SPEC/ui/components/train-dialog-chrome.md` — unchanged (layout preserved)

## Tests

From `app/`:

- `flutter test test/ct_spacing_features_adoption_test.dart` — 85/85 passing (+3 invariant assertions for the new file)
- `flutter test test/train_dialog_chrome_test.dart test/spec_components_train_dialog_chrome_test.dart` — 11/11 passing
- `dart analyze` on touched files — clean

## Scope

One S5 slice on the umbrella `#2914` issue (S1–S9, G1–G2). Remaining train-dialog / feature surfaces continue slice-by-slice on separate PRs.

Refs #2914


Made with [Cursor](https://cursor.com)