### PR TITLE
refactor(app): route ConfirmDialogEvent through CtDialogShell + CtNinePatchButton (Refs #2914 S8)

### DIFF
--- a/app/lib/core/services/app_event_handler.dart
+++ b/app/lib/core/services/app_event_handler.dart
@@ -47,6 +47,7 @@ import '../../providers/game_service_provider.dart';
 import '../../providers/games_provider.dart';
 import '../../providers/observe_session_provider.dart';
 import '../../providers/turn_resolution_blocking_provider.dart';
+import '../../widgets/ct_confirm_dialog.dart';
 
 typedef DialogBuilder =
     Widget Function(BuildContext context, Map<String, Object?>? params);
@@ -190,25 +191,13 @@ class AppEventHandler {
       return false;
     }
     try {
-      final result = await showDialog<bool>(
-        context: nav.context,
-        useRootNavigator: true,
-        builder: (ctx) => AlertDialog(
-          title: Text(event.title),
-          content: Text(event.message),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.of(ctx).pop(false),
-              child: Text(event.cancelLabel),
-            ),
-            TextButton(
-              onPressed: () => Navigator.of(ctx).pop(true),
-              child: Text(event.confirmLabel),
-            ),
-          ],
-        ),
+      final confirmed = await showCtConfirmDialog(
+        nav.context,
+        title: event.title,
+        message: event.message,
+        confirmLabel: event.confirmLabel,
+        cancelLabel: event.cancelLabel,
       );
-      final confirmed = result ?? false;
       event.result(confirmed);
       return confirmed;
     } catch (e, st) {

--- a/app/lib/widgets/ct_confirm_dialog.dart
+++ b/app/lib/widgets/ct_confirm_dialog.dart
@@ -1,0 +1,140 @@
+import 'package:flutter/material.dart';
+
+import '../config/editorial_monocle_palette.dart';
+import 'ct_dialog_shell.dart';
+import 'ct_nine_patch_button.dart';
+import 'ct_spacing.dart';
+
+/// Generic dark editorial-monocle confirmation dialog.
+///
+/// Renders a [CtDialogShell]-framed prompt with a title, a body message, and
+/// two `CtNinePatchButton` actions (cancel + confirm) — the canonical
+/// editorial-monocle replacement for Material `AlertDialog` + `TextButton`
+/// pairs (per `SPEC/ui/pixel-art-ui-catalog.md` § Material design ban — Ct-\*
+/// counterparts table).
+///
+/// Returns `true` via [Navigator.pop] when the confirm button is tapped,
+/// `false` when the cancel button is tapped, and `null` when the route is
+/// dismissed by tapping the barrier (callers should treat `null` as
+/// cancellation; [showCtConfirmDialog] does this for you).
+///
+/// Visual contract (mirrors `ExitConfirmDialog`):
+///   * Title in `--accent` (display slot, bold).
+///   * Body in `--fg`.
+///   * Both actions are `CtNinePatchButton`; the destructive intent is
+///     conveyed only by the caller-chosen [confirmLabel] (e.g. `"Confirm"`,
+///     `"OK"`). Use a dedicated destructive-flow dialog (`dangerVariant`)
+///     when the confirm side is genuinely destructive — generic confirm
+///     prompts driven by [ConfirmDialogEvent](_) keep both buttons in the
+///     standard brass style so the visual language matches the simple
+///     yes/no semantics of the bus contract.
+///
+/// SPEC: `SPEC/program/app-event-bus.md` § `ConfirmDialogEvent` — bool
+/// result; `SPEC/ui/pixel-art-ui-catalog.md` § Material design ban.
+class CtConfirmDialog extends StatelessWidget {
+  const CtConfirmDialog({
+    super.key,
+    required this.title,
+    required this.message,
+    this.confirmLabel = defaultConfirmLabel,
+    this.cancelLabel = defaultCancelLabel,
+  });
+
+  /// Title text rendered at the top of the dialog body in `--accent`.
+  final String title;
+
+  /// Body message rendered under the title in `--fg`.
+  final String message;
+
+  /// Label for the confirm (right) action. Defaults to [defaultConfirmLabel]
+  /// so the bus-level `ConfirmDialogEvent` default surfaces unchanged.
+  final String confirmLabel;
+
+  /// Label for the cancel (left) action. Defaults to [defaultCancelLabel] so
+  /// the bus-level `ConfirmDialogEvent` default surfaces unchanged.
+  final String cancelLabel;
+
+  /// Default confirm-button label — matches the `ConfirmDialogEvent`
+  /// constructor default in `packages/colonizethis_models/lib/src/app_events.dart`.
+  // ignore: avoid_hardcoded_strings_in_widgets
+  static const String defaultConfirmLabel = 'OK';
+
+  /// Default cancel-button label — matches the `ConfirmDialogEvent`
+  /// constructor default in `packages/colonizethis_models/lib/src/app_events.dart`.
+  // ignore: avoid_hardcoded_strings_in_widgets
+  static const String defaultCancelLabel = 'Cancel';
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final TextStyle? titleStyle = theme.textTheme.titleMedium?.copyWith(
+      color: EditorialMonoclePalette.accent,
+      fontWeight: FontWeight.w700,
+    );
+    final TextStyle? bodyStyle = theme.textTheme.bodyMedium?.copyWith(
+      color: EditorialMonoclePalette.fg,
+    );
+
+    return CtDialogShell(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Text(title, style: titleStyle),
+          const SizedBox(height: CtSpacing.m),
+          Text(message, style: bodyStyle),
+          const SizedBox(height: CtSpacing.l),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: <Widget>[
+              CtNinePatchButton(
+                onPressed: () => Navigator.of(context).pop(false),
+                child: Text(cancelLabel),
+              ),
+              const SizedBox(width: CtSpacing.m),
+              CtNinePatchButton(
+                onPressed: () => Navigator.of(context).pop(true),
+                child: Text(confirmLabel),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Show a [CtConfirmDialog] anchored on the given [context]'s navigator with
+/// the canonical editorial-monocle dialog scrim
+/// ([EditorialMonoclePalette.dialogScrim]).
+///
+/// Resolves to `true` when the player confirms, `false` when they cancel or
+/// dismiss the barrier (mirroring the `ConfirmDialogEvent` bool contract in
+/// `SPEC/program/app-event-bus.md`).
+///
+/// [useRootNavigator] defaults to `true` so callers driven by
+/// `AppEventHandler` reach across modal bottom sheets / inner navigators —
+/// matching the existing wiring in
+/// `app/lib/core/services/app_event_handler.dart`.
+Future<bool> showCtConfirmDialog(
+  BuildContext context, {
+  required String title,
+  required String message,
+  String confirmLabel = CtConfirmDialog.defaultConfirmLabel,
+  String cancelLabel = CtConfirmDialog.defaultCancelLabel,
+  bool useRootNavigator = true,
+}) async {
+  final bool? result = await showDialog<bool>(
+    context: context,
+    barrierDismissible: true,
+    useRootNavigator: useRootNavigator,
+    barrierColor: EditorialMonoclePalette.dialogScrim,
+    builder: (BuildContext ctx) => CtConfirmDialog(
+      title: title,
+      message: message,
+      confirmLabel: confirmLabel,
+      cancelLabel: cancelLabel,
+    ),
+  );
+  return result ?? false;
+}

--- a/app/test/ct_confirm_dialog_test.dart
+++ b/app/test/ct_confirm_dialog_test.dart
@@ -1,0 +1,278 @@
+import 'package:colonizethis_app/config/editorial_monocle_palette.dart';
+import 'package:colonizethis_app/widgets/ct_confirm_dialog.dart';
+import 'package:colonizethis_app/widgets/ct_dialog_shell.dart';
+import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Widget tests for the generic dark editorial-monocle confirm dialog
+/// (`CtConfirmDialog` + `showCtConfirmDialog`). Pins #2914 S8 — the
+/// replacement of Material `AlertDialog` + `TextButton` actions in the
+/// `ConfirmDialogEvent` rendering path inside `AppEventHandler`.
+///
+/// Visual contract anchors (per `SPEC/ui/pixel-art-ui-catalog.md`
+/// § Material design ban — Ct-* counterparts):
+///   * Frame: `CtDialogShell` (no Material `AlertDialog` / `Dialog`).
+///   * Actions: `CtNinePatchButton` (no Material `TextButton`).
+///   * Title in `--accent`, body in `--fg`.
+///   * Barrier color is the canonical `EditorialMonoclePalette.dialogScrim`.
+void main() {
+  suppressLogsForTests();
+
+  Future<bool?> showFromHost(
+    WidgetTester tester, {
+    String title = 'Confirm',
+    String message = 'Proceed?',
+    String confirmLabel = CtConfirmDialog.defaultConfirmLabel,
+    String cancelLabel = CtConfirmDialog.defaultCancelLabel,
+  }) async {
+    bool? result;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (BuildContext context) => Center(
+              child: ElevatedButton(
+                key: const Key('open-dialog'),
+                onPressed: () async {
+                  result = await showCtConfirmDialog(
+                    context,
+                    title: title,
+                    message: message,
+                    confirmLabel: confirmLabel,
+                    cancelLabel: cancelLabel,
+                  );
+                },
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.byKey(const Key('open-dialog')));
+    await tester.pumpAndSettle();
+    return result;
+  }
+
+  testWidgets('renders title, message, confirm and cancel labels', (
+    WidgetTester tester,
+  ) async {
+    await showFromHost(
+      tester,
+      title: 'Confirm action',
+      message: 'Are you sure?',
+    );
+    expect(find.text('Confirm action'), findsOneWidget);
+    expect(find.text('Are you sure?'), findsOneWidget);
+    expect(find.text(CtConfirmDialog.defaultConfirmLabel), findsOneWidget);
+    expect(find.text(CtConfirmDialog.defaultCancelLabel), findsOneWidget);
+  });
+
+  testWidgets('honors custom confirm/cancel labels', (
+    WidgetTester tester,
+  ) async {
+    await showFromHost(
+      tester,
+      confirmLabel: 'Proceed',
+      cancelLabel: 'Abort',
+    );
+    expect(find.text('Proceed'), findsOneWidget);
+    expect(find.text('Abort'), findsOneWidget);
+    // Default labels are not used when overrides are supplied.
+    expect(find.text(CtConfirmDialog.defaultConfirmLabel), findsNothing);
+    expect(find.text(CtConfirmDialog.defaultCancelLabel), findsNothing);
+  });
+
+  testWidgets('uses CtNinePatchButton actions (no Material action buttons)', (
+    WidgetTester tester,
+  ) async {
+    await showFromHost(tester);
+    expect(
+      find.descendant(
+        of: find.byType(CtConfirmDialog),
+        matching: find.byType(CtNinePatchButton),
+      ),
+      findsNWidgets(2),
+    );
+    // The host's opener uses ElevatedButton; the dialog body must not.
+    expect(
+      find.descendant(
+        of: find.byType(CtConfirmDialog),
+        matching: find.byType(TextButton),
+      ),
+      findsNothing,
+    );
+    expect(
+      find.descendant(
+        of: find.byType(CtConfirmDialog),
+        matching: find.byType(ElevatedButton),
+      ),
+      findsNothing,
+    );
+    expect(
+      find.descendant(
+        of: find.byType(CtConfirmDialog),
+        matching: find.byType(OutlinedButton),
+      ),
+      findsNothing,
+    );
+    // No raw Material AlertDialog under the body either.
+    expect(
+      find.descendant(
+        of: find.byType(CtConfirmDialog),
+        matching: find.byType(AlertDialog),
+      ),
+      findsNothing,
+    );
+  });
+
+  testWidgets('frames the body in a CtDialogShell', (
+    WidgetTester tester,
+  ) async {
+    await showFromHost(tester);
+    expect(
+      find.descendant(
+        of: find.byType(CtConfirmDialog),
+        matching: find.byType(CtDialogShell),
+      ),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('title renders in --accent and message in --fg', (
+    WidgetTester tester,
+  ) async {
+    await showFromHost(
+      tester,
+      title: 'Title text',
+      message: 'Body text',
+    );
+    final Text titleText = tester.widget<Text>(find.text('Title text'));
+    expect(titleText.style?.color, EditorialMonoclePalette.accent);
+
+    final Text bodyText = tester.widget<Text>(find.text('Body text'));
+    expect(bodyText.style?.color, EditorialMonoclePalette.fg);
+  });
+
+  testWidgets('barrierColor matches the canonical dialog-scrim token', (
+    WidgetTester tester,
+  ) async {
+    await showFromHost(tester);
+    final Iterable<ModalBarrier> dimBarriers = tester
+        .widgetList<ModalBarrier>(find.byType(ModalBarrier))
+        .where((ModalBarrier b) => b.color != null);
+    expect(
+      dimBarriers.where(
+        (ModalBarrier b) => b.color == EditorialMonoclePalette.dialogScrim,
+      ),
+      isNotEmpty,
+      reason:
+          'showDialog barrierColor must resolve to the canonical '
+          '--dialog-scrim token; literal Colors.black54 is a regression.',
+    );
+  });
+
+  testWidgets('Confirm tap resolves the future to true', (
+    WidgetTester tester,
+  ) async {
+    bool? result;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (BuildContext context) => Center(
+              child: ElevatedButton(
+                key: const Key('open-dialog'),
+                onPressed: () async {
+                  result = await showCtConfirmDialog(
+                    context,
+                    title: 'Confirm',
+                    message: 'Proceed?',
+                  );
+                },
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.byKey(const Key('open-dialog')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text(CtConfirmDialog.defaultConfirmLabel));
+    await tester.pumpAndSettle();
+    expect(result, isTrue);
+  });
+
+  testWidgets('Cancel tap resolves the future to false', (
+    WidgetTester tester,
+  ) async {
+    bool? result;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (BuildContext context) => Center(
+              child: ElevatedButton(
+                key: const Key('open-dialog'),
+                onPressed: () async {
+                  result = await showCtConfirmDialog(
+                    context,
+                    title: 'Confirm',
+                    message: 'Proceed?',
+                  );
+                },
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.byKey(const Key('open-dialog')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text(CtConfirmDialog.defaultCancelLabel));
+    await tester.pumpAndSettle();
+    expect(result, isFalse);
+  });
+
+  testWidgets('Barrier tap dismisses dialog as cancel (false)', (
+    WidgetTester tester,
+  ) async {
+    bool? result;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (BuildContext context) => Center(
+              child: ElevatedButton(
+                key: const Key('open-dialog'),
+                onPressed: () async {
+                  result = await showCtConfirmDialog(
+                    context,
+                    title: 'Confirm',
+                    message: 'Proceed?',
+                  );
+                },
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.byKey(const Key('open-dialog')));
+    await tester.pumpAndSettle();
+    await tester.tapAt(const Offset(5, 5));
+    await tester.pumpAndSettle();
+    expect(
+      result,
+      isFalse,
+      reason:
+          'Barrier-dismissed confirm dialog must resolve to false to mirror '
+          'the ConfirmDialogEvent bool contract (cancel intent).',
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Replaces the banned Material `AlertDialog` + `TextButton` chrome inside
`AppEventHandler._showConfirmDialog` with a new generic
`CtConfirmDialog` widget that frames the prompt in `CtDialogShell` with
`CtNinePatchButton` actions and the canonical
`EditorialMonoclePalette.dialogScrim` barrier. Every `ConfirmDialogEvent`
emitter on the bus (diplomacy actions, civilian work cancellation,
grant/subsidy) now resolves through the dark editorial-monocle path.

This is one focused slice of **#2914 S8 — Material widget ban**, scoped to
the single remaining `AlertDialog(` / `TextButton(` call site in
`app/lib/core/services/app_event_handler.dart` (per the §
*Material widget ban violations* table in the issue body).

## Done in this push

- New `app/lib/widgets/ct_confirm_dialog.dart` (`CtConfirmDialog` widget +
  `showCtConfirmDialog` helper) — dark editorial-monocle palette, default
  `OK`/`Cancel` labels matching `ConfirmDialogEvent`, barrier dismissal maps
  to ``false`` (mirroring the bus bool contract).
- Refactor `AppEventHandler._showConfirmDialog` to call `showCtConfirmDialog`
  instead of constructing `AlertDialog` + `TextButton(...)` inline.
- New widget tests in `app/test/ct_confirm_dialog_test.dart` (9 cases):
  positive — title/message/labels render, custom labels apply,
  `CtDialogShell` frame, `CtNinePatchButton` actions count (2), title in
  `--accent`, body in `--fg`, barrier color is `dialogScrim`, confirm tap
  resolves to `true`, cancel tap resolves to `false`; negative — no Material
  `AlertDialog`/`TextButton`/`ElevatedButton`/`OutlinedButton` under the
  dialog, barrier tap dismisses to `false`.

## SPEC alignment

- `SPEC/ui/pixel-art-ui-catalog.md` § *Material design ban* — Ct-\*
  counterparts: `AlertDialog`/`Dialog` → `CtDialogShell`; `TextButton`
  → `CtNinePatchButton`; barrier resolves via
  `EditorialMonoclePalette.dialogScrim`.
- `SPEC/program/app-event-bus.md` § `ConfirmDialogEvent` — bool result
  contract (`onResult(true)` on confirm, `onResult(false)` on cancel /
  barrier dismiss) preserved; the change is implementation-only on the
  rendering side.

## Tests

- `flutter test test/ct_confirm_dialog_test.dart` — 9/9 pass.
- `flutter test test/app_event_handler_test.dart` (covers the two existing
  `ConfirmDialogEvent` cases) — 22/22 pass.
- `flutter test test/exit_confirm_dialog_test.dart` — 11/11 pass (parallel
  Ct-\* confirm dialog stays green).
- Wider sweep over ConfirmDialogEvent emitters
  (`diplomacy_panel_test.dart`, `diplomacy_panel_orders_test.dart`,
  `grant_or_subsidy_listener_test.dart`,
  `civilian_units_panel_test_part{1,2,3}_test.dart`) — 72/72 pass.

`flutter analyze` on the touched files reports only two pre-existing
warnings unrelated to this slice
(`app_event_handler.dart:313-314 dead_code` / `dead_null_aware_expression`,
present on `origin/dev`).

## Deferred (still tracked on #2914 S8)

- `app/lib/features/debug_log/debug_log_viewer_screen.dart` — `Scaffold(`,
  `IconButton(`, `FilterChip(` (dev-tooling screen; the issue body notes
  enforcement may be relaxed there but the work is not yet started).

`Refs #2914`

Made with [Cursor](https://cursor.com)