### PR TITLE
refactor(app): adopt CtSpacing in debug_log_viewer_screen (Refs #2914 S5)

### DIFF
--- a/app/lib/features/debug_log/debug_log_viewer_screen.dart
+++ b/app/lib/features/debug_log/debug_log_viewer_screen.dart
@@ -6,6 +6,7 @@ import 'package:session_log_buffer/session_log_buffer.dart';
 import 'package:colonizethis_app/config/editorial_monocle_palette.dart';
 import 'package:colonizethis_app/config/ui_screen_ids.dart';
 import 'package:colonizethis_app/l10n/l10n.dart';
+import 'package:colonizethis_app/widgets/ct_spacing.dart';
 
 /// Full-screen viewer for session logs with multiselect filters by package and level.
 class DebugLogViewerScreen extends StatefulWidget {
@@ -68,12 +69,12 @@ class _DebugLogViewerScreenState extends State<DebugLogViewerScreen> {
     final l10n = appL10n(context);
     return SingleChildScrollView(
       scrollDirection: Axis.horizontal,
-      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
+      padding: const EdgeInsets.all(CtSpacing.m),
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Text(l10n.debugLog_filter_package, style: theme.textTheme.titleSmall),
-          const SizedBox(width: 8),
+          const SizedBox(width: CtSpacing.m),
           Wrap(
             spacing: 4,
             runSpacing: 4,
@@ -94,9 +95,9 @@ class _DebugLogViewerScreenState extends State<DebugLogViewerScreen> {
               );
             }).toList(),
           ),
-          const SizedBox(width: 16),
+          const SizedBox(width: CtSpacing.l),
           Text(l10n.debugLog_filter_level, style: theme.textTheme.titleSmall),
-          const SizedBox(width: 8),
+          const SizedBox(width: CtSpacing.m),
           Wrap(
             spacing: 4,
             runSpacing: 4,
@@ -136,7 +137,10 @@ class _DebugLogViewerScreenState extends State<DebugLogViewerScreen> {
           children: lines.map((line) {
             final isFirst = line == lines.first;
             return Container(
-              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 2),
+              padding: const EdgeInsets.symmetric(
+                horizontal: CtSpacing.ml,
+                vertical: 2,
+              ),
               decoration: BoxDecoration(
                 color: isFirst ? _levelColor(entry.level).withValues(alpha: 0.08) : null,
               ),

--- a/app/test/ct_spacing_features_adoption_test.dart
+++ b/app/test/ct_spacing_features_adoption_test.dart
@@ -301,4 +301,5 @@ const List<String> _migratedFeatureFiles = <String>[
   'lib/features/game/widgets/units/shared/units_panel_row_chrome.dart',
   'lib/features/game/widgets/units/shared/units_panel_shell.dart',
   'lib/features/shell/new_game_setup_flow.dart',
+  'lib/features/debug_log/debug_log_viewer_screen.dart',
 ];


### PR DESCRIPTION
## Summary

Migrates token-set `EdgeInsets` / `SizedBox` width literals in `debug_log_viewer_screen.dart` to `CtSpacing.{m,ml,l}` and extends `_migratedFeatureFiles` in `ct_spacing_features_adoption_test.dart` so the four S5 pin invariants guard the file going forward.

Refs #2914 S5 — Spacing tokens adoption (dev-tooling screen; Material `FilterChip` / `Scaffold` ban remains deferred per umbrella issue).

## Done in this push

| File | Change |
|------|--------|
| `app/lib/features/debug_log/debug_log_viewer_screen.dart` | Filter bar `EdgeInsets.all(8)` → `CtSpacing.m`; chip gaps `8`/`16` → `CtSpacing.m`/`l`; log row `horizontal: 12` → `CtSpacing.ml` (`vertical: 2` unchanged — out of scale) |
| `app/test/ct_spacing_features_adoption_test.dart` | Add debug log viewer to `_migratedFeatureFiles` |

## Deferred (still on #2914)

- Material ban on `debug_log_viewer_screen.dart` (`Scaffold`, `FilterChip`, `IconButton`) — issue notes enforcement may stay relaxed for dev tooling until a dedicated slice.
- Remaining S5 callsites in other feature files not yet on `_migratedFeatureFiles`.

## Tests

- [x] `cd app && flutter test test/ct_spacing_features_adoption_test.dart` — all pass (4 new pin tests for debug log viewer)
- [x] `dart analyze` on touched files — clean

Refs #2914. Does not auto-close the umbrella issue.


Made with [Cursor](https://cursor.com)