### PR TITLE
refactor(app): adopt CtSpacing in game_map_canvas_stack (Refs #2914 S5)

### DIFF
--- a/app/lib/features/game/flame/game_map_canvas_stack.dart
+++ b/app/lib/features/game/flame/game_map_canvas_stack.dart
@@ -8,6 +8,7 @@ import 'package:colonizethis_map/colonizethis_map.dart' show RegionMapViewData;
 
 import '../../../../config/editorial_monocle_palette.dart';
 import '../../../../providers/map_province_panel_provider.dart';
+import '../../../../widgets/ct_spacing.dart';
 import '../widgets/chrome/ct_nine_patch_button.dart';
 import 'game_screen_shared.dart' show kGameMapWideProvinceSidePanelWidth;
 import 'region_map_component.dart'
@@ -173,7 +174,7 @@ class GameMapCanvasStack extends ConsumerWidget {
                   child: Padding(
                     padding: const EdgeInsets.symmetric(
                       horizontal: 14,
-                      vertical: 8,
+                      vertical: CtSpacing.m,
                     ),
                     child: Row(
                       mainAxisSize: MainAxisSize.min,
@@ -191,7 +192,7 @@ class GameMapCanvasStack extends ConsumerWidget {
                           onPressed: onWorkTargetSelectionCancelled,
                           minHeight: kMapSelectionPromptCancelMinHeight,
                           padding: const EdgeInsets.symmetric(
-                            horizontal: 12,
+                            horizontal: CtSpacing.ml,
                             vertical: 4,
                           ),
                           child: Text(

--- a/app/test/ct_spacing_features_adoption_test.dart
+++ b/app/test/ct_spacing_features_adoption_test.dart
@@ -270,6 +270,7 @@ const List<String> _migratedFeatureFiles = <String>[
   'lib/features/game/dialogue/game_start_intro_overlay.dart',
   'lib/features/game/dialogue/intervention_dialogue_overlay.dart',
   'lib/features/game/dialogue/overture_dialogue_overlay.dart',
+  'lib/features/game/flame/game_map_canvas_stack.dart',
   'lib/features/game/flame/game_side_menu.dart',
   'lib/features/game/flame/next_turn_confirmation_dialog.dart',
   'lib/features/game/flame/victory_overlay.dart',


### PR DESCRIPTION
## Summary

Migrates the two token-set `EdgeInsets.symmetric` named-arg literals
on the work-target selection prompt overlay banner in
`app/lib/features/game/flame/game_map_canvas_stack.dart` to
`CtSpacing.<token>` constants and extends the `_migratedFeatureFiles`
allowlist in `app/test/ct_spacing_features_adoption_test.dart` so the
four structural pins (import, >=1 `CtSpacing` reference, no raw
`EdgeInsets.all(N)`, no raw `EdgeInsets.symmetric(named: N)`) cover
the file going forward.

Refs #2914 S5 — Spacing tokens adoption.

## Done in this push

| File | Change |
|---|---|
| `app/lib/features/game/flame/game_map_canvas_stack.dart` | L174 selection-prompt banner `EdgeInsets.symmetric(horizontal: 14, vertical: 8)` → `vertical: CtSpacing.m`; L193 Cancel `CtNinePatchButton` `EdgeInsets.symmetric(horizontal: 12, vertical: 4)` → `horizontal: CtSpacing.ml`; new import for `widgets/ct_spacing.dart`. |
| `app/test/ct_spacing_features_adoption_test.dart` | Adds `lib/features/game/flame/game_map_canvas_stack.dart` to `_migratedFeatureFiles` (alphabetical position before `flame/game_side_menu.dart`). |

The out-of-scale `horizontal: 14` (banner padding) and `vertical: 4`
(Cancel button padding) literals stay per `SPEC/ui/pixel-art-ui-catalog.md`
§ *Spacing tokens* — the table explicitly leaves non-scale values as
per-component overrides (the example `EdgeInsets.symmetric(horizontal: s, vertical: 4)`
in the SPEC keeps the `4` as a literal).

Visible layout is preserved because `CtSpacing.m == 8` and
`CtSpacing.ml == 12` (pinned by the first guard in the adoption
test).

## What was implemented vs deferred

- **In this PR:** the two token-set `EdgeInsets.symmetric` callsites in
  `game_map_canvas_stack.dart` and the test allowlist update.
- **Deferred (separate S5 slices, by file):** Token-set adoption for
  other flame files that still need a `ct_spacing.dart` import (e.g.
  `game_map_controls.dart` only has out-of-scale `horizontal: 4` and
  needs no migration; `game_region_minimap.dart` uses `panelPadding = 2`
  which is out-of-scale too). This PR keeps scope to the single flame
  file with token-set callsites.

## ACs covered now vs follow-up

| AC | Source | Where covered now |
|---|---|---|
| **S5 — feature-file `CtSpacing` adoption for `EdgeInsets.symmetric` token-set arguments** | #2914 § Phase 1 S5; `SPEC/ui/pixel-art-ui-catalog.md` § Spacing tokens | `game_map_canvas_stack.dart` migrated (this PR); pins extended via `_migratedFeatureFiles`. |
| **Visible-layout preservation** | Same | `CtSpacing.m == 8` and `CtSpacing.ml == 12` invariants pinned in `ct_spacing_features_adoption_test.dart` (lines 51–52); physical inset unchanged. |
| Remaining S5 callsites in non-`ct_spacing`-importing feature files | #2914 § Phase 1 S5 | Deferred to per-file follow-up slices. |

## Tests

- [x] `flutter test app/test/ct_spacing_features_adoption_test.dart` — 145/145 pass (4 new pin tests covering the newly-migrated file: import + >=1 reference + no raw `EdgeInsets.all(N)` + no raw `EdgeInsets.symmetric(named: N)`).
- [x] `flutter test app/test/game_map_selection_prompt_dark_tokens_test.dart` — 6/6 pass (banner visual contract still green at the same insets).
- [x] `flutter analyze app/lib/features/game/flame/game_map_canvas_stack.dart` — no issues.

## SPEC alignment

- `SPEC/ui/pixel-art-ui-catalog.md` § *Spacing tokens* — `CtSpacing.m == 8`, `CtSpacing.ml == 12`, and the "feature padding callsite" adoption surface this PR extends.
- `SPEC/ui/map-widget.md` § *Dark-theme selection prompt overlay tokens* — banner / cancel control padding contract preserved at the migrated values.

Refs #2914 S5

Made with [Cursor](https://cursor.com)