### PR TITLE
test(logic): pin world-market treasury-conservation invariant (Refs #2924)

### DIFF
--- a/SPEC/ai/treasury-planner.md
+++ b/SPEC/ai/treasury-planner.md
@@ -533,6 +533,12 @@ The seed-42 budget test mirrors `full_ai_first_turn_wall_clock_budget_test.dart`
 - Given the same seed-42 turn-1 init, when `generateOrdersForGameFullAI` and `validateOrdersAndResolveTurnFromTrustedOrders` run end-to-end inside a single `Stopwatch`, then the combined `Stopwatch().elapsedMilliseconds` is less than or equal to `kTurnProcessingWallClockBudgetMs` (15 000 ms).
 - Given a failing budget assertion, when the test reports the failure, then the assertion `reason` contains the structured row `total_ms=<int> full_ai_ms=<int> resolve_ms=<int> trade_orders=<int> budget_ms=15000` so a regression surfaces which phase exceeded the envelope and whether the trade-orders path was exercised in that envelope.
 
+## Conservation bound on Path F (Refs #2924)
+
+The lock-recovery liquidity work above (F10–F14) redistributes treasury between Great Powers; it cannot create net Great-Power treasury. Per [world-market-resolution.md](../program/world-market-resolution.md) § Treasury conservation invariant, phase 13 only ever holds the Great-Power treasury pool constant (GP↔GP trade) or reduces it (purchases from minor/tribe auto-offers leak to the treasury sink). The sum of all Great-Power treasuries is therefore **non-increasing** across the World Market phase.
+
+Consequently, a structurally broke peer set (every Great Power below `cheapestRegimentBuildTreasuryCost()`) cannot trade its way above the regiment-build threshold *in aggregate*: the planner can shift which GP holds the limited pool, but the pool itself only grows from a net treasury source outside the market (NW riches conversion via colonial acquisition — "Path E"). Treasury-planner tuning alone cannot close #2924 for seed 42 when the aggregate pool is already below `players × cheapestRegimentBuildTreasuryCost()`; the diagnostic below records the chain links so a tuning slice can confirm whether the gap is liquidity (Path F, in scope here) or aggregate insufficiency (Path E, out of scope for this planner).
+
 ## Seed-42 100-turn per-turn World-Market lock-recovery diagnostic (Refs #2924)
 
 #2924 (EXPAND geographic peer-war lock at `treasury == 0`) requires verifying

--- a/SPEC/program/world-market-resolution.md
+++ b/SPEC/program/world-market-resolution.md
@@ -177,6 +177,18 @@ Minor Nations and Tribes never hold treasury (see [factions.md](../game/factions
 
 The treasury sink is recorded as a `MarketActivityNote` (`treasury_sink_minor_tribe`) so the Deal Book and observer tools can audit the flow.
 
+### Treasury conservation invariant (Refs #2924)
+
+Step D transfers are the only way phase 13 mutates `Player.treasury`. Every Great-Power-seller fill moves exactly `quantity × pricePerUnit` from the buyer to the seller (a transfer **within** the Great-Power pool), and every Minor/Tribe-seller fill debits the buyer with no offsetting credit (a leak **out** of the pool to the sink). No phase-13 path credits a Great Power without an equal Great-Power debit. Therefore the **sum of all Great-Power treasuries is non-increasing across the World Market phase**: GP↔GP trade only *redistributes* the existing pool, and GP purchases from minor/tribe auto-offers *reduce* it. Phase 13 never *creates* net Great-Power treasury — that is the role of separate treasury-source phases (riches conversion, subsidies), not the market.
+
+This invariant is the mechanical reason the [treasury-planner](../ai/treasury-planner.md) lock-recovery path (Refs #2924 F10–F14) cannot, on its own, lift a pool of broke Great Powers above `cheapestRegimentBuildTreasuryCost()`: trading among broke GPs cannot raise their *aggregate* treasury, so unblocking regiment builds for a structurally broke peer set requires a net treasury source (NW riches acquisition), not more market liquidity.
+
+#### Acceptance criteria (Refs #2924 conservation)
+
+- Given a set of Great Powers and any merged `Orders.tradeOrdersByPlayerId` whose only sellers and buyers are Great Powers (no minor/tribe auto-offers; `tileMapByRegion` omitted), when `worldMarketTurnPhaseHandler` resolves phase 13, then the sum of `Player.treasury` over all Great Powers after the phase equals the sum before the phase (exact conservation: every buyer debit is matched by an equal Great-Power-seller credit).
+- Given a Great Power buyer with positive treasury and a matching minor/tribe auto-offer (`tileMapByRegion` supplied), when `worldMarketTurnPhaseHandler` resolves phase 13 and at least one minor/tribe deal fills, then the sum of `Player.treasury` over all Great Powers after the phase is strictly less than the sum before the phase by exactly `Σ (quantity × pricePerUnit)` over the minor/tribe fills that are not credited under first-right-of-refusal (treasury leaks to the sink).
+- Given any Great Power buyer and any combination of Great-Power and minor/tribe sellers, when `worldMarketTurnPhaseHandler` resolves phase 13, then the sum of `Player.treasury` over all Great Powers after the phase is less than or equal to the sum before the phase (the pool is never increased by the market).
+
 ### Step E — Price discovery and carry-forwards
 
 Aggregate `totalBid_new` and `totalOffer_new` per commodity from this turn's newly-submitted orders, with a bid-side asymmetry:

--- a/packages/colonizethis_logic/test/orders/order_suggestion_build_lock_recovery_affordability_guard_test.dart
+++ b/packages/colonizethis_logic/test/orders/order_suggestion_build_lock_recovery_affordability_guard_test.dart
@@ -1,0 +1,154 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+import '../test_fixtures.dart';
+
+/// Lock-recovery affordability regression guards (Refs #2924).
+///
+/// Issue #2924 rescopes lock recovery to legitimate economic paths (World
+/// Market sales / NW acquisition) and explicitly rejects any "train regiments
+/// without treasury" bypass as cheating. These tests pin the affordability
+/// contract that the lock-recovery work must never weaken:
+///
+/// - No AI exemption: a broke GP (`treasury < cheapestRegimentBuildTreasuryCost`)
+///   with no riches-to-treasury inflow gets **zero** regiment build candidates
+///   from `suggestBuildOrders`.
+/// - No human waiver: a human player at `treasury == 0` is treated identically;
+///   the normal build-validation path rejects the regiment build.
+///
+/// SPEC:
+/// - `SPEC/program/orders.md` § `BuildOrderValidator` (affordability via
+///   `ProjectedCostEngine`; no AI exemption documented or permitted).
+/// - `SPEC/program/order-suggestions.md` § Build orders (only validator-accepted
+///   candidates are surfaced).
+const _topology = MapTopology(
+  nodes: [
+    TopologyNode(
+      id: 'oldWorld|p1',
+      regionId: 'oldWorld',
+      type: TopologyNodeType.province,
+    ),
+  ],
+  edges: [],
+);
+
+/// Game with one owned province whose owner has zero treasury, fabric (the
+/// peasant_levies build input) and peasants for labour, but **no riches** in
+/// the stockpile, so no riches-to-treasury phase can fund a regiment build.
+Game _brokeNoRichesGame({required bool isHuman}) {
+  final base = TestFixtures.gameWithSingleOwnedProvince(
+    ownerPlayerId: 'p1',
+    provinceId: 'oldWorld|p1',
+    treasury: 0,
+    isHuman: isHuman,
+  );
+  final player = base.players.single;
+  return base.copyWith(
+    players: [
+      player.copyWith(
+        stockpile: const Stockpile().applyDelta(CommodityCatalog.fabric.id, 5),
+        workerPool: const WorkerPool(peasants: 5),
+      ),
+    ],
+  );
+}
+
+bool _isRegimentBuild(Object order) {
+  if (order is! BuildUnitOrder) return false;
+  return RegimentEconomyCatalog.byId.containsKey(order.unitType);
+}
+
+void main() {
+  group('suggestBuildOrders lock-recovery affordability guard (Refs #2924)', () {
+    test(
+        'positive control: a broke GP with riches CAN train the cheapest '
+        'regiment (proves the negative guard is non-vacuous)', () {
+      final base = TestFixtures.gameWithSingleOwnedProvince(
+        ownerPlayerId: 'p1',
+        provinceId: 'oldWorld|p1',
+        treasury: 0,
+        isHuman: false,
+      );
+      final player = base.players.single;
+      final game = base.copyWith(
+        players: [
+          player.copyWith(
+            stockpile: const Stockpile()
+                .applyDelta(CommodityCatalog.spices.id, 50)
+                .applyDelta(CommodityCatalog.fabric.id, 5),
+            workerPool: const WorkerPool(peasants: 5),
+          ),
+        ],
+      );
+      final view = buildPlayerView(game, _topology, 'p1');
+
+      final suggestions =
+          suggestBuildOrders(view, game, _topology, const Orders());
+
+      expect(
+        suggestions.map((o) => o.unitType),
+        contains('peasant_levies'),
+        reason: 'pending riches-to-treasury should fund the cheapest regiment',
+      );
+    });
+
+    test(
+        'affordability regression guard: AI GP at treasury 0 with no riches '
+        'gets zero regiment build candidates (no AI bypass)', () {
+      final game = _brokeNoRichesGame(isHuman: false);
+      final view = buildPlayerView(game, _topology, 'p1');
+
+      // Precondition: treasury is below the cheapest regiment build cost.
+      expect(
+        game.players.single.treasury,
+        lessThan(cheapestRegimentBuildTreasuryCost()),
+      );
+
+      final suggestions =
+          suggestBuildOrders(view, game, _topology, const Orders());
+
+      expect(
+        suggestions.where(_isRegimentBuild),
+        isEmpty,
+        reason:
+            'no regiment may be suggested when treasury < cheapest build cost '
+            'and there is no riches-to-treasury inflow (no affordability bypass)',
+      );
+    });
+
+    test(
+        'human-player guard: human at treasury 0 with no riches gets zero '
+        'regiment suggestions (no human waiver)', () {
+      final game = _brokeNoRichesGame(isHuman: true);
+      final view = buildPlayerView(game, _topology, 'p1');
+
+      final suggestions =
+          suggestBuildOrders(view, game, _topology, const Orders());
+
+      expect(suggestions.where(_isRegimentBuild), isEmpty);
+    });
+
+    test(
+        'human-player guard: the build-validation path rejects a human regiment '
+        'build at treasury 0 (UI submission path, no waiver)', () {
+      final game = _brokeNoRichesGame(isHuman: true);
+      const candidate = BuildUnitOrder(
+        unitType: 'peasant_levies',
+        isMilitary: true,
+        spawnProvinceId: 'oldWorld|p1',
+      );
+
+      final result = OrderEngine(initialOrders: const Orders())
+          .addBuildOrderWithContext(game, _topology, 'p1', candidate);
+
+      expect(
+        result.isAccepted,
+        isFalse,
+        reason: 'no waiver path may accept a regiment build at zero treasury '
+            'for any player, human or AI',
+      );
+    });
+  });
+}

--- a/packages/colonizethis_logic/test/turn/world_market_phase_treasury_conservation_test.dart
+++ b/packages/colonizethis_logic/test/turn/world_market_phase_treasury_conservation_test.dart
@@ -1,0 +1,312 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/src/turn/phases/world_market_phase.dart';
+import 'package:colonizethis_logic/src/turn/turn_pipeline_state.dart';
+import 'package:colonizethis_logic/src/turn/turn_resolver_config.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+/// Treasury-conservation coverage for the World Market phase (Refs #2924).
+///
+/// SPEC anchor: `SPEC/program/world-market-resolution.md`
+/// § Treasury conservation invariant (Refs #2924) and § Step D / Treasury sink.
+///
+/// These tests pin the mechanical reason the treasury-planner lock-recovery
+/// path (Refs #2924 F10–F14) cannot, by itself, lift a pool of broke Great
+/// Powers above `cheapestRegimentBuildTreasuryCost()`: phase 13 only ever
+/// redistributes the Great-Power treasury pool (GP↔GP fills) or leaks it to
+/// the treasury sink (minor/tribe fills). It never creates net Great-Power
+/// treasury, so the sum of all Great-Power treasuries is non-increasing across
+/// the phase.
+void main() {
+  group('worldMarketTurnPhaseHandler — treasury conservation (Refs #2924)', () {
+    test(
+      'GP↔GP-only matching exactly conserves the total Great-Power treasury '
+      'pool (every buyer debit is an equal GP-seller credit)',
+      () {
+        const prices = {'timber': 30, 'iron': 80};
+        final players = <Player>[
+          Player(
+            id: 'gp1',
+            displayName: 'GP1',
+            isHuman: false,
+            stockpile: const Stockpile().applyDelta('timber', 10),
+            treasury: 500,
+          ),
+          Player(
+            id: 'gp2',
+            displayName: 'GP2',
+            isHuman: false,
+            stockpile: const Stockpile().applyDelta('iron', 10),
+            treasury: 500,
+          ),
+          Player(
+            id: 'gp3',
+            displayName: 'GP3',
+            isHuman: false,
+            stockpile: Stockpile.empty,
+            treasury: 500,
+          ),
+        ];
+        final before = _totalGpTreasury(players);
+
+        final next = _runGpPhase(
+          players: players,
+          marketPrices: prices,
+          orders: Orders(
+            tradeOrdersByPlayerId: {
+              'gp1': [
+                _offer('timber', 5),
+                _bid('iron', 2),
+              ],
+              'gp2': [
+                _offer('iron', 5),
+                _bid('timber', 5),
+              ],
+              'gp3': [
+                _bid('timber', 1),
+              ],
+            },
+          ),
+        );
+
+        final after = _totalGpTreasury(next.players);
+        expect(after, equals(before),
+            reason: 'GP↔GP trade only redistributes the pool — total unchanged');
+
+        // Sanity: at least one deal actually filled, so the conservation
+        // assertion is exercised against real transfers rather than a no-op.
+        final gp2 = next.players.firstWhere((p) => p.id == 'gp2');
+        expect(gp2.stockpile.quantityOf('timber'), greaterThan(0),
+            reason: 'gp2 bought timber from gp1 (a real GP↔GP transfer)');
+      },
+    );
+
+    test(
+      'GP purchase from a minor/tribe auto-offer leaks treasury to the sink: '
+      'the Great-Power pool strictly decreases by the uncredited deal value',
+      () {
+        final game = _gameWithBuyerAndMinor(buyerTreasury: 1000, timberPrice: 30);
+        final before = _totalGpTreasury(game.players);
+
+        final acc = TurnPipelineState(game: game);
+        final config = TurnResolverConfig(
+          topology: const MapTopology(nodes: [], edges: []),
+          orders: Orders(
+            tradeOrdersByPlayerId: {
+              'gpBuyer': [_bid('timber', 1)],
+            },
+          ),
+          tileMapByRegion: {'oldWorld': _minorTimberTileMap()},
+        );
+
+        final next =
+            (worldMarketTurnPhaseHandler(acc, config, 3) as TurnPhaseStepContinue)
+                .pipeline
+                .game;
+
+        final after = _totalGpTreasury(next.players);
+        // One unit filled at price 30, credited to no faction (sink).
+        expect(after, equals(before - 30),
+            reason: 'minor sale value leaks out of the GP pool to the sink');
+        expect(after, lessThan(before),
+            reason: 'GP pool strictly decreases on minor/tribe purchases');
+      },
+    );
+
+    test(
+      'mixed GP↔GP and GP↔minor matching never increases the Great-Power pool '
+      '(non-increasing invariant) and is deterministic across runs',
+      () {
+        Game freshGame() {
+          final minorProvince = const Province(
+            id: 'oldWorld|m1',
+            regionId: 'oldWorld',
+            ownerId: 'm1',
+            townDevelopmentLevel: 1,
+          );
+          return Game(
+            id: 'g_mixed',
+            players: <Player>[
+              Player(
+                id: 'gpSeller',
+                displayName: 'Seller',
+                isHuman: false,
+                stockpile: const Stockpile().applyDelta('timber', 10),
+                treasury: 400,
+              ),
+              Player(
+                id: 'gpBuyer',
+                displayName: 'Buyer',
+                isHuman: false,
+                stockpile: Stockpile.empty,
+                treasury: 400,
+              ),
+            ],
+            minorNations: const [
+              MinorNation(
+                id: 'm1',
+                capitalProvinceId: 'oldWorld|m1',
+                capitalTile: CapitalTile(
+                  regionId: 'oldWorld',
+                  provinceId: 'oldWorld|m1',
+                  x: 0,
+                  y: 0,
+                ),
+              ),
+            ],
+            worldState: WorldState(
+              turnState: const TurnState(
+                phase: TurnPhase.worldMarket,
+                turnNumber: 3,
+              ),
+              oldWorld: RegionData(provinces: [minorProvince]),
+              newWorld: const RegionData(),
+              tileState: TileMapState()
+                  .setImprovement('oldWorld|m1|0|0', 1)
+                  .setRoadLevel('oldWorld|m1|0|0', 1),
+            ),
+            worldMarketState:
+                WorldMarketState.empty.copyWith(prices: const {'timber': 30}),
+          );
+        }
+
+        final orders = Orders(
+          tradeOrdersByPlayerId: {
+            'gpSeller': [_offer('timber', 5)],
+            'gpBuyer': [_bid('timber', 8)],
+          },
+        );
+        TurnResolverConfig config() => TurnResolverConfig(
+              topology: const MapTopology(nodes: [], edges: []),
+              orders: orders,
+              tileMapByRegion: {'oldWorld': _minorTimberTileMap()},
+            );
+
+        final beforeTotal = _totalGpTreasury(freshGame().players);
+
+        final runA =
+            (worldMarketTurnPhaseHandler(TurnPipelineState(game: freshGame()),
+                    config(), 3) as TurnPhaseStepContinue)
+                .pipeline
+                .game;
+        final runB =
+            (worldMarketTurnPhaseHandler(TurnPipelineState(game: freshGame()),
+                    config(), 3) as TurnPhaseStepContinue)
+                .pipeline
+                .game;
+
+        expect(_totalGpTreasury(runA.players), lessThanOrEqualTo(beforeTotal),
+            reason: 'the market never increases the Great-Power treasury pool');
+
+        expect(_treasuryByGp(runA.players), equals(_treasuryByGp(runB.players)),
+            reason: 'phase-13 treasury outcomes are deterministic');
+      },
+    );
+  });
+}
+
+int _totalGpTreasury(List<Player> players) =>
+    players.fold(0, (sum, p) => sum + p.treasury);
+
+Map<String, int> _treasuryByGp(List<Player> players) => {
+      for (final p in players) p.id: p.treasury,
+    };
+
+TradeOrder _offer(CommodityId id, int quantity) => TradeOrder(
+      commodityId: id,
+      type: TradeOrderType.offer,
+      quantity: quantity,
+      priority: 1,
+    );
+
+TradeOrder _bid(CommodityId id, int quantity) => TradeOrder(
+      commodityId: id,
+      type: TradeOrderType.bid,
+      quantity: quantity,
+      priority: 1,
+    );
+
+Game _runGpPhase({
+  required List<Player> players,
+  required Map<CommodityId, int> marketPrices,
+  required Orders orders,
+}) {
+  final game = Game(
+    id: 'g_conservation',
+    players: players,
+    worldState: const WorldState(
+      turnState: TurnState(phase: TurnPhase.worldMarket, turnNumber: 3),
+      oldWorld: RegionData(),
+      newWorld: RegionData(),
+    ),
+    worldMarketState: WorldMarketState.empty.copyWith(prices: marketPrices),
+  );
+  final acc = TurnPipelineState(game: game);
+  final config = TurnResolverConfig(
+    topology: const MapTopology(nodes: [], edges: []),
+    orders: orders,
+  );
+  return (worldMarketTurnPhaseHandler(acc, config, 3) as TurnPhaseStepContinue)
+      .pipeline
+      .game;
+}
+
+Game _gameWithBuyerAndMinor({
+  required int buyerTreasury,
+  required int timberPrice,
+}) {
+  const minorProvince = Province(
+    id: 'oldWorld|m1',
+    regionId: 'oldWorld',
+    ownerId: 'm1',
+    townDevelopmentLevel: 1,
+  );
+  return Game(
+    id: 'g_auto_offer',
+    players: [
+      Player(
+        id: 'gpBuyer',
+        displayName: 'Buyer',
+        isHuman: false,
+        stockpile: Stockpile.empty,
+        treasury: buyerTreasury,
+      ),
+    ],
+    minorNations: const [
+      MinorNation(
+        id: 'm1',
+        capitalProvinceId: 'oldWorld|m1',
+        capitalTile: CapitalTile(
+          regionId: 'oldWorld',
+          provinceId: 'oldWorld|m1',
+          x: 0,
+          y: 0,
+        ),
+      ),
+    ],
+    worldState: WorldState(
+      turnState: const TurnState(phase: TurnPhase.worldMarket, turnNumber: 3),
+      oldWorld: RegionData(provinces: [minorProvince]),
+      newWorld: const RegionData(),
+      tileState: TileMapState()
+          .setImprovement('oldWorld|m1|0|0', 1)
+          .setRoadLevel('oldWorld|m1|0|0', 1),
+    ),
+    worldMarketState: WorldMarketState.empty.copyWith(
+      prices: {'timber': timberPrice},
+    ),
+  );
+}
+
+TileMapResult _minorTimberTileMap() {
+  return TileMapResult(
+    width: 1,
+    height: 1,
+    grid: [
+      ['m1'],
+    ],
+    resourceGrid: [
+      [Resource.timber],
+    ],
+  );
+}


### PR DESCRIPTION
## Summary

Establishes the **root-cause bound** for #2924 (AI: unblock regiment builds) as an isolatable, fully unit-tested slice — no speculative AI tuning.

Investigation of `treasury_planner.dart` (F1–F14) plus the seed-42 diagnostics showed the issue's world-market lock-recovery path is **structurally incapable** of fixing the bug by a conservation argument:

- World Market phase 13 only mutates treasury in Step D. Every **GP↔GP** fill is an equal buyer-debit / seller-credit transfer (redistribution within the GP pool); every **minor/tribe** fill debits the buyer with **no** offsetting credit (a leak to the treasury sink).
- Therefore the **sum of all Great-Power treasuries is non-increasing across the phase** — the market never *creates* net GP treasury.
- Consequently a structurally broke peer set (all GPs below `cheapestRegimentBuildTreasuryCost()`) cannot trade its way above the regiment threshold *in aggregate*; that needs a net treasury source (NW riches acquisition — "Path E"), not more market liquidity. This matches the ~100× treasury gap noted in the latest #2924 diagnostic comment.

This PR documents that invariant in SPEC and pins it with deterministic tests, so future #2924 effort is correctly redirected to Path E and protected against a regression that silently lets the market mint treasury.

## Changes

- `SPEC/program/world-market-resolution.md`: new **Treasury conservation invariant (Refs #2924)** subsection with Given–When–Then ACs (exact GP↔GP conservation, strict minor/tribe sink leak, general non-increasing).
- `SPEC/ai/treasury-planner.md`: **Conservation bound on Path F** note cross-referencing the invariant and explaining why F10–F14 cannot close #2924 alone.
- `packages/colonizethis_logic/test/turn/world_market_phase_treasury_conservation_test.dart`: deterministic phase-13 tests for the three ACs above.

No `lib/` behavior change — additive SPEC + test only.

## Test plan

- [x] `dart test test/turn/world_market_phase_treasury_conservation_test.dart` — 3/3 pass
- [x] `dart analyze` on the new test — no issues
- [ ] CI: logic package suite + coverage gate

Refs #2924 (does not close — Path E NW-acquisition remains the substantive work).

Made with [Cursor](https://cursor.com)

## Update: affordability + human-player regression guards (Refs #2924)

Complements the conservation invariant above with negative guards mapped to two more #2924 acceptance criteria, locking in the owner direction that training regiments without treasury is cheating (no AI exemption, no human waiver):

- packages/colonizethis_logic/test/orders/order_suggestion_build_lock_recovery_affordability_guard_test.dart:
  - Affordability regression guard — a broke AI GP (treasury < cheapestRegimentBuildTreasuryCost()) with no riches-to-treasury inflow gets zero regiment build candidates from suggestBuildOrders.
  - Human-player guard — a human player at treasury == 0 is treated identically; both suggestBuildOrders and the build-validation path reject the regiment build.
  - Positive control — a riches-funded build is still accepted, so the negative guards cannot become vacuous if prerequisites change.

Still no lib/ behavior change — additive SPEC + tests only. dart test + dart analyze on the new file pass locally (4/4).
