### PR TITLE
refactor(app): adopt CtSpacing in CtMainMenu + CtGameSetup (#2914)

### DIFF
--- a/app/lib/widgets/game_setup.dart
+++ b/app/lib/widgets/game_setup.dart
@@ -1,4 +1,5 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_app/widgets/ct_spacing.dart';
 import 'package:flutter/material.dart';
 
 import '../config/constants.dart';
@@ -130,7 +131,7 @@ class _CtGameSetupState extends State<CtGameSetup> {
     return Scaffold(
       body: SafeArea(
         child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 24),
+          padding: const EdgeInsets.symmetric(horizontal: CtSpacing.xxl),
           child: Center(
             child: ConstrainedBox(
               constraints: const BoxConstraints(maxWidth: 400),
@@ -616,7 +617,10 @@ class _GameSetupCancelButtonState extends State<_GameSetupCancelButton> {
                 width: _GameSetupCancelButton.borderThickness,
               ),
             ),
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+            padding: const EdgeInsets.symmetric(
+              horizontal: CtSpacing.l,
+              vertical: CtSpacing.ml,
+            ),
             alignment: Alignment.center,
             child: Text(
               widget.label,

--- a/app/lib/widgets/main_menu.dart
+++ b/app/lib/widgets/main_menu.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:colonizethis_app/l10n/l10n.dart';
+import 'package:colonizethis_app/widgets/ct_spacing.dart';
 import '../config/editorial_monocle_palette.dart';
 import '../config/themes.dart';
 import '../config/ui_screen_ids.dart';
@@ -32,15 +33,15 @@ const double kMainMenuButtonLetterSpacingNarrow = 0.6;
 /// Menu container padding at viewports `> kMainMenuNarrowBreakpoint`.
 /// Default desktop / wide layout.
 const EdgeInsets kMainMenuBodyPaddingDefault = EdgeInsets.symmetric(
-  horizontal: 24,
+  horizontal: CtSpacing.xxl,
 );
 
 /// Menu container padding at viewports `≤ kMainMenuNarrowBreakpoint`.
 /// Compacts horizontal padding and adds explicit vertical padding to mirror
 /// the mockup `.menu-container { padding: 24px 12px; }` narrow override.
 const EdgeInsets kMainMenuBodyPaddingNarrow = EdgeInsets.symmetric(
-  horizontal: 12,
-  vertical: 24,
+  horizontal: CtSpacing.ml,
+  vertical: CtSpacing.xxl,
 );
 
 /// Stable `Key` value for the menu body `Padding` widget that owns the
@@ -639,8 +640,8 @@ class _FooterQuitButtonState extends State<_FooterQuitButton> {
               ),
               child: Padding(
                 padding: const EdgeInsets.symmetric(
-                  horizontal: 20,
-                  vertical: 8,
+                  horizontal: CtSpacing.xl,
+                  vertical: CtSpacing.m,
                 ),
                 child: Center(
                   child: Text(

--- a/app/test/ct_spacing_features_adoption_test.dart
+++ b/app/test/ct_spacing_features_adoption_test.dart
@@ -309,4 +309,10 @@ const List<String> _migratedFeatureFiles = <String>[
   'lib/features/game/widgets/units/shared/units_panel_shell.dart',
   'lib/features/shell/new_game_setup_flow.dart',
   'lib/features/debug_log/debug_log_viewer_screen.dart',
+  // Top-level shell screen widgets (`CtGameSetup` / `CtMainMenu`) under
+  // `lib/widgets/`. These are the SHEL20001 / SHEL10002 screen surfaces and
+  // are part of the same per-screen padding-token adoption surface as the
+  // `lib/features/**` entries above (Refs #2914 S5).
+  'lib/widgets/game_setup.dart',
+  'lib/widgets/main_menu.dart',
 ];


### PR DESCRIPTION
## Summary

Adopts the SPEC-pinned `CtSpacing` scale in the two remaining `app/lib/` shell screen widgets that still carried raw token-set `EdgeInsets` literals: **`CtMainMenu`** (SHEL10002) and **`CtGameSetup`** (SHEL20001). This closes the last non-Flame, non-token-definition `EdgeInsets.{all,symmetric}` magic-number callsites for `N ∈ {8,12,16,20,24}` in `lib/features` + `lib/widgets`, extending the in-flight #2914 S5 adoption (PRs #3101 / #3137 / #3155 / #3163-superseded).

## Done in this push (Refs #2914 S5)

| File | Change |
|------|--------|
| `app/lib/widgets/main_menu.dart` | `kMainMenuBodyPaddingDefault` `horizontal: 24` → `CtSpacing.xxl`; `kMainMenuBodyPaddingNarrow` `12`/`24` → `CtSpacing.ml`/`xxl`; `pixelArt` Quit chip `EdgeInsets.symmetric(horizontal: 20, vertical: 8)` → `xl`/`m` |
| `app/lib/widgets/game_setup.dart` | outer body `EdgeInsets.symmetric(horizontal: 24)` → `CtSpacing.xxl`; cancel-button `EdgeInsets.symmetric(horizontal: 16, vertical: 12)` → `l`/`ml` |
| `app/test/ct_spacing_features_adoption_test.dart` | Add both files to `_migratedFeatureFiles` so the four S5 invariants guard them going forward |

All substitutions are **physically identical** (`CtSpacing.m==8`, `ml==12`, `l==16`, `xl==20`, `xxl==24`), so visible layout is preserved — including the `kMainMenuBodyPaddingNarrow` ≤ 430 dp narrow contract pinned by the #2870 320 dp suite.

## SPEC

No SPEC change required. Authorized by `SPEC/ui/pixel-art-ui-catalog.md` § *Spacing tokens* / § *Spacing and radius tokens* (feature padding callsites are an explicit token-adoption surface).

## Tests

- `flutter test test/ct_spacing_features_adoption_test.dart` → **181/181 pass** (the four invariants now also gate `main_menu.dart` + `game_setup.dart`).
- `flutter test test/mobile_320dp_min_viewport_test.dart test/game_setup_spec_acceptance_test.dart test/main_menu_wood_panel_hover_test.dart test/widgetbook_game_setup_mobile_viewport_test.dart test/widgetbook_main_menu_mobile_viewport_test.dart test/widgetbook_main_menu_stories_editorial_monocle_test.dart` → **95/95 pass** (layout/narrow-padding contracts unchanged).
- `dart analyze` on touched files → clean.

## Scope

| Area | Status |
|------|--------|
| `CtMainMenu` / `CtGameSetup` token-set `EdgeInsets` adoption | ✅ this PR |
| Remaining #2914 categories (fontSize→TextTheme fallbacks, BorderRadius tokens, Material-widget bans, `EdgeInsets.{only,fromLTRB}` forms) | ⏸ deferred to other S-slices on the umbrella issue |

`Refs #2914` (umbrella issue stays open; does not auto-close).

Made with [Cursor](https://cursor.com)