### PR TITLE
feat(ai): dispatch colonial planners under EXPAND when NW weight > 0 (Refs #2847)

### DIFF
--- a/SPEC/ai/phase-planner-architecture.md
+++ b/SPEC/ai/phase-planner-architecture.md
@@ -145,7 +145,11 @@ When both predicates fire on the same dispatch, the larger floor (`0.60`) wins. 
 - `domain_planner_orchestrator.dart` sources the weight via `resolvePhaseEconomyColonialPressureWeight(phasePlan: phasePlan)` and threads both the legacy boolean (for the null-weight fallback path) and the weight (production source of truth) into `BuildPickInput`.
 - Callers that construct `BuildPickInput` directly without supplying `colonialPressureWeight` (tests, legacy entry points) keep the legacy boolean behaviour exactly.
 
-Other scoring sites (economy civilian threshold cap) still use the Phase 2 boolean resolvers until their Phase 3 slices land. Hard structural suppression for planner-module dispatch (which modules run per phase) remains unchanged in this slice.
+Other scoring sites (economy civilian threshold cap) still use the Phase 2 boolean resolvers until their Phase 3 slices land.
+
+#### EXPAND universal colonial dispatch (Refs #2847)
+
+`runPhasePlanners` under [ObserverGoalPhase.expand] now composes the full-COLONIAL planner bundle (`planColonialAcquisition`, `planColonialPeace`, `planColonialMilitary`, `planColonialNaval`, `planColonialCivilian`) whenever `priorityWeights.newWorldAcquisition > 0.0` (the early-sprint curve floor is `0.05`, so the bundle is always populated on EXPAND dispatches today). Orchestrator adapters (`colonialMilitaryPlanFromPhasePlan`, `colonialNavalPlanFromPhasePlan`, `gpColonialDeclareWarTargetFromPhasePlan`, `civilianWorkOrdersFromPhasePlan`) gate consumption through [phasePlanFullColonialOutputsActive] instead of requiring `phase == colonial`. [ObserverGoalPhase.colonialLite] and [ObserverGoalPhase.develop] remain excluded — COLONIAL-lite safeguard and DEVELOP structural separation are unchanged.
 
 #### Phase 3 consumer wiring — naval planner colonial-pressure bonus + floor (Refs #2847)
 

--- a/packages/colonizethis_ai/lib/src/planning/phase_planner_civilian_work_orders.dart
+++ b/packages/colonizethis_ai/lib/src/planning/phase_planner_civilian_work_orders.dart
@@ -57,13 +57,11 @@ import 'phase_planner_dispatch.dart';
 /// `planDevelopCivilian`); the adapter never reorders or filters
 /// entries.
 List<WorkOrder> civilianWorkOrdersFromPhasePlan(PhasePlanOutcome outcome) {
-  switch (outcome.phase) {
-    case ObserverGoalPhase.expand:
-    case ObserverGoalPhase.colonialLite:
-      return const <WorkOrder>[];
-    case ObserverGoalPhase.colonial:
-      return outcome.colonialCivilianWorkOrders;
-    case ObserverGoalPhase.develop:
-      return outcome.developCivilianWorkOrders;
+  if (phasePlanFullColonialOutputsActive(outcome)) {
+    return outcome.colonialCivilianWorkOrders;
   }
+  if (outcome.phase == ObserverGoalPhase.develop) {
+    return outcome.developCivilianWorkOrders;
+  }
+  return const <WorkOrder>[];
 }

--- a/packages/colonizethis_ai/lib/src/planning/phase_planner_declare_war_targets.dart
+++ b/packages/colonizethis_ai/lib/src/planning/phase_planner_declare_war_targets.dart
@@ -72,7 +72,7 @@ String? gpExpandDeclareWarTargetFromPhasePlan(PhasePlanOutcome outcome) {
 ///   - Non-COLONIAL phases never populate `colonialAcquisitionTarget`
 ///     (suppression matrix), so this adapter returns `null` structurally.
 String? gpColonialDeclareWarTargetFromPhasePlan(PhasePlanOutcome outcome) {
-  if (outcome.phase != ObserverGoalPhase.colonial) {
+  if (!phasePlanFullColonialOutputsActive(outcome)) {
     return null;
   }
   final target = outcome.colonialAcquisitionTarget;

--- a/packages/colonizethis_ai/lib/src/planning/phase_planner_dispatch.dart
+++ b/packages/colonizethis_ai/lib/src/planning/phase_planner_dispatch.dart
@@ -308,6 +308,23 @@ class PhasePlanOutcome {
 /// The function is pure and deterministic — identical inputs always
 /// yield identical [PhasePlanOutcome] instances (Refs #2509 Must-have
 /// #7). It performs no I/O, no logging, and no order emission.
+/// Whether full-COLONIAL planner outputs on [outcome] may be consumed by
+/// orchestrator adapters (Refs #2847 EXPAND universal colonial dispatch).
+///
+/// [ObserverGoalPhase.colonialLite] stays excluded — the safeguard
+/// suppresses NW invasion transport and army moves per issue #2509.
+bool phasePlanFullColonialOutputsActive(PhasePlanOutcome outcome) {
+  switch (outcome.phase) {
+    case ObserverGoalPhase.colonial:
+      return true;
+    case ObserverGoalPhase.colonialLite:
+    case ObserverGoalPhase.develop:
+      return false;
+    case ObserverGoalPhase.expand:
+      return outcome.priorityWeights.newWorldAcquisition > 0.0;
+  }
+}
+
 PhasePlanOutcome runPhasePlanners({
   required Game game,
   required AIWorldSnapshot snapshot,
@@ -316,7 +333,11 @@ PhasePlanOutcome runPhasePlanners({
   final phase = observerGoalPhaseFor(snapshot: snapshot, game: game);
   switch (phase) {
     case ObserverGoalPhase.expand:
-      return _expandOutcome(game: game, snapshot: snapshot);
+      return _expandOutcome(
+        game: game,
+        snapshot: snapshot,
+        personalityId: personalityId,
+      );
     case ObserverGoalPhase.colonialLite:
       return _colonialLiteOutcome(game: game, snapshot: snapshot);
     case ObserverGoalPhase.colonial:
@@ -333,10 +354,23 @@ PhasePlanOutcome runPhasePlanners({
 PhasePlanOutcome _expandOutcome({
   required Game game,
   required AIWorldSnapshot snapshot,
+  String? personalityId,
 }) {
   final declareWarTarget = planExpandDeclareWar(game: game, snapshot: snapshot);
   final expandFrontier = _expandFrontierContext(game: game, snapshot: snapshot);
   final expandEconomyPlan = planExpandEconomy(game: game, snapshot: snapshot);
+  final priorityWeights = computePhasePriorityWeights(
+    snapshot: snapshot,
+    game: game,
+    expandEconomyPlan: expandEconomyPlan,
+  );
+  final colonial = priorityWeights.newWorldAcquisition > 0.0
+      ? _colonialPlannerBundle(
+          game: game,
+          snapshot: snapshot,
+          personalityId: personalityId,
+        )
+      : null;
   return PhasePlanOutcome(
     phase: ObserverGoalPhase.expand,
     expandDeclareWarTargetFactionId: declareWarTarget,
@@ -354,11 +388,15 @@ PhasePlanOutcome _expandOutcome({
         expandFrontier.gpOnlyInvadableFrontierActive,
     expandPrimaryInvadableGpBlockerFactionId:
         expandFrontier.primaryInvadableGpBlockerFactionId,
-    priorityWeights: computePhasePriorityWeights(
-      snapshot: snapshot,
-      game: game,
-      expandEconomyPlan: expandEconomyPlan,
-    ),
+    colonialAcquisitionTarget: colonial?.acquisition,
+    colonialPeaceTargetFactionIdsSorted:
+        colonial?.peaceTargets ?? const <String>[],
+    colonialMilitaryPlan:
+        colonial?.military ?? ColonialMilitaryPlan.defaultPlan,
+    colonialNavalPlan: colonial?.naval ?? ColonialNavalPlan.defaultPlan,
+    colonialCivilianWorkOrders:
+        colonial?.civilian ?? const <WorkOrder>[],
+    priorityWeights: priorityWeights,
   );
 }
 
@@ -402,10 +440,16 @@ PhasePlanOutcome _colonialLiteOutcome({
   );
 }
 
-PhasePlanOutcome _colonialOutcome({
+({
+  ColonialAcquisitionTarget? acquisition,
+  List<String> peaceTargets,
+  ColonialMilitaryPlan military,
+  ColonialNavalPlan naval,
+  List<WorkOrder> civilian,
+}) _colonialPlannerBundle({
   required Game game,
   required AIWorldSnapshot snapshot,
-  required String? personalityId,
+  String? personalityId,
 }) {
   final acquisition = planColonialAcquisition(
     game: game,
@@ -417,27 +461,40 @@ PhasePlanOutcome _colonialOutcome({
           acquisition.method == AcquisitionMethod.declareWar)
       ? acquisition.targetFactionId
       : null;
+  return (
+    acquisition: acquisition,
+    peaceTargets: planColonialPeace(game: game, snapshot: snapshot),
+    military: planColonialMilitary(
+      game: game,
+      snapshot: snapshot,
+      colonialDeclaredWarTargetFactionId: declaredColonialTarget,
+    ),
+    naval: planColonialNaval(
+      game: game,
+      snapshot: snapshot,
+      colonialDeclaredWarTargetFactionId: declaredColonialTarget,
+    ),
+    civilian: planColonialCivilian(game: game, snapshot: snapshot),
+  );
+}
+
+PhasePlanOutcome _colonialOutcome({
+  required Game game,
+  required AIWorldSnapshot snapshot,
+  required String? personalityId,
+}) {
+  final colonial = _colonialPlannerBundle(
+    game: game,
+    snapshot: snapshot,
+    personalityId: personalityId,
+  );
   return PhasePlanOutcome(
     phase: ObserverGoalPhase.colonial,
-    colonialAcquisitionTarget: acquisition,
-    colonialPeaceTargetFactionIdsSorted: planColonialPeace(
-      game: game,
-      snapshot: snapshot,
-    ),
-    colonialMilitaryPlan: planColonialMilitary(
-      game: game,
-      snapshot: snapshot,
-      colonialDeclaredWarTargetFactionId: declaredColonialTarget,
-    ),
-    colonialNavalPlan: planColonialNaval(
-      game: game,
-      snapshot: snapshot,
-      colonialDeclaredWarTargetFactionId: declaredColonialTarget,
-    ),
-    colonialCivilianWorkOrders: planColonialCivilian(
-      game: game,
-      snapshot: snapshot,
-    ),
+    colonialAcquisitionTarget: colonial.acquisition,
+    colonialPeaceTargetFactionIdsSorted: colonial.peaceTargets,
+    colonialMilitaryPlan: colonial.military,
+    colonialNavalPlan: colonial.naval,
+    colonialCivilianWorkOrders: colonial.civilian,
     priorityWeights: computePhasePriorityWeights(
       snapshot: snapshot,
       game: game,

--- a/packages/colonizethis_ai/lib/src/planning/phase_planner_military_plans.dart
+++ b/packages/colonizethis_ai/lib/src/planning/phase_planner_military_plans.dart
@@ -108,12 +108,8 @@ ExpandMilitaryPlan expandMilitaryPlanFromPhasePlan(PhasePlanOutcome outcome) {
 ColonialMilitaryPlan colonialMilitaryPlanFromPhasePlan(
   PhasePlanOutcome outcome,
 ) {
-  switch (outcome.phase) {
-    case ObserverGoalPhase.expand:
-    case ObserverGoalPhase.colonialLite:
-    case ObserverGoalPhase.develop:
-      return ColonialMilitaryPlan.defaultPlan;
-    case ObserverGoalPhase.colonial:
-      return outcome.colonialMilitaryPlan;
+  if (phasePlanFullColonialOutputsActive(outcome)) {
+    return outcome.colonialMilitaryPlan;
   }
+  return ColonialMilitaryPlan.defaultPlan;
 }

--- a/packages/colonizethis_ai/lib/src/planning/phase_planner_naval_plans.dart
+++ b/packages/colonizethis_ai/lib/src/planning/phase_planner_naval_plans.dart
@@ -81,14 +81,10 @@ import 'phase_planner_dispatch.dart';
 /// `planColonialNaval`; the adapter never reorders list contents or
 /// substitutes a different plan instance.
 ColonialNavalPlan colonialNavalPlanFromPhasePlan(PhasePlanOutcome outcome) {
-  switch (outcome.phase) {
-    case ObserverGoalPhase.expand:
-    case ObserverGoalPhase.colonialLite:
-    case ObserverGoalPhase.develop:
-      return ColonialNavalPlan.defaultPlan;
-    case ObserverGoalPhase.colonial:
-      return outcome.colonialNavalPlan;
+  if (phasePlanFullColonialOutputsActive(outcome)) {
+    return outcome.colonialNavalPlan;
   }
+  return ColonialNavalPlan.defaultPlan;
 }
 
 /// Returns the phase-specific [ColonialLiteNavalPlan] tribe / minor

--- a/packages/colonizethis_ai/test/planning/phase_planner_civilian_work_orders_test.dart
+++ b/packages/colonizethis_ai/test/planning/phase_planner_civilian_work_orders_test.dart
@@ -6,7 +6,8 @@
 // this slice to add the civilian work-order row):
 //
 //   civilianWorkOrdersFromPhasePlan(outcome):
-//     - EXPAND          -> const <WorkOrder>[]
+//     - EXPAND          -> colonialCivilianWorkOrders when
+//       phasePlanFullColonialOutputsActive (NW weight > 0); else const []
 //     - COLONIAL-lite   -> const <WorkOrder>[]
 //     - COLONIAL        -> outcome.colonialCivilianWorkOrders
 //     - DEVELOP         -> outcome.developCivilianWorkOrders
@@ -19,8 +20,17 @@
 import 'package:colonizethis_ai/src/planning/observer_goal_phase.dart';
 import 'package:colonizethis_ai/src/planning/phase_planner_civilian_work_orders.dart';
 import 'package:colonizethis_ai/src/planning/phase_planner_dispatch.dart';
+import 'package:colonizethis_ai/src/planning/phase_priority_weights.dart';
 import 'package:colonizethis_models/colonizethis_models.dart' show WorkOrder;
 import 'package:colonizethis_test/test.dart';
+
+/// Legacy hard-suppress contract: explicit zero NW weight (Refs #2847).
+const PhasePriorityWeights _nwAcquisitionZeroExpand = PhasePriorityWeights(
+  oldWorldConquest: 0.95,
+  newWorldAcquisition: 0.0,
+  oldWorldCivilian: 0.90,
+  newWorldCivilian: 0.10,
+);
 
 const WorkOrder _colonialWork = WorkOrder(
   unitId: 'u_merchant_1',
@@ -70,10 +80,30 @@ void main() {
       ]);
     });
 
-    test('EXPAND surfaces empty list (no civilian work orders in EXPAND)', () {
-      const outcome = PhasePlanOutcome(phase: ObserverGoalPhase.expand);
-      expect(civilianWorkOrdersFromPhasePlan(outcome), isEmpty);
-    });
+    test(
+      'EXPAND with zero NW weight surfaces empty list',
+      () {
+        const outcome = PhasePlanOutcome(
+          phase: ObserverGoalPhase.expand,
+          priorityWeights: _nwAcquisitionZeroExpand,
+        );
+        expect(civilianWorkOrdersFromPhasePlan(outcome), isEmpty);
+      },
+    );
+
+    test(
+      'EXPAND with positive NW weight surfaces colonialCivilianWorkOrders',
+      () {
+        const outcome = PhasePlanOutcome(
+          phase: ObserverGoalPhase.expand,
+          colonialCivilianWorkOrders: [_colonialWork],
+        );
+        expect(
+          civilianWorkOrdersFromPhasePlan(outcome),
+          const [_colonialWork],
+        );
+      },
+    );
 
     test(
       'COLONIAL-lite surfaces empty list (safeguard suppresses NW work)',
@@ -85,24 +115,23 @@ void main() {
   });
 
   group('civilianWorkOrdersFromPhasePlan — defensive phase suppression', () {
-    test('EXPAND surfaces empty even when COLONIAL slot non-empty', () {
-      // Defensive: the dispatcher never populates colonialCivilianWorkOrders
-      // in EXPAND, but the adapter must short-circuit on phase to defend the
-      // suppression matrix against a future regression that leaks NW work
-      // orders into the EXPAND economy pass.
-      const outcome = PhasePlanOutcome(
-        phase: ObserverGoalPhase.expand,
-        colonialCivilianWorkOrders: [_colonialWork],
-      );
-      expect(
-        civilianWorkOrdersFromPhasePlan(outcome),
-        isEmpty,
-        reason:
-            'EXPAND has no civilian work orders by spec; a non-empty '
-            'colonialCivilianWorkOrders slot must not leak NW work into '
-            'the EXPAND economy pass.',
-      );
-    });
+    test(
+      'EXPAND with zero NW weight suppresses colonial slot',
+      () {
+        const outcome = PhasePlanOutcome(
+          phase: ObserverGoalPhase.expand,
+          priorityWeights: _nwAcquisitionZeroExpand,
+          colonialCivilianWorkOrders: [_colonialWork],
+        );
+        expect(
+          civilianWorkOrdersFromPhasePlan(outcome),
+          isEmpty,
+          reason:
+              'phasePlanFullColonialOutputsActive is false when '
+              'newWorldAcquisition is zero; colonial slot must not leak.',
+        );
+      },
+    );
 
     test('COLONIAL-lite surfaces empty even when COLONIAL slot non-empty', () {
       // Defensive: COLONIAL-lite is the EXPAND safeguard that suppresses

--- a/packages/colonizethis_ai/test/planning/phase_planner_declare_war_targets_test.dart
+++ b/packages/colonizethis_ai/test/planning/phase_planner_declare_war_targets_test.dart
@@ -31,7 +31,15 @@ import 'package:colonizethis_ai/src/planning/colonial_phase_planner.dart';
 import 'package:colonizethis_ai/src/planning/observer_goal_phase.dart';
 import 'package:colonizethis_ai/src/planning/phase_planner_declare_war_targets.dart';
 import 'package:colonizethis_ai/src/planning/phase_planner_dispatch.dart';
+import 'package:colonizethis_ai/src/planning/phase_priority_weights.dart';
 import 'package:colonizethis_test/test.dart';
+
+const PhasePriorityWeights _nwAcquisitionZeroExpand = PhasePriorityWeights(
+  oldWorldConquest: 0.95,
+  newWorldAcquisition: 0.0,
+  oldWorldCivilian: 0.90,
+  newWorldCivilian: 0.10,
+);
 
 void main() {
   group('gpExpandDeclareWarTargetFromPhasePlan', () {
@@ -172,10 +180,21 @@ void main() {
       );
     });
 
-    test('EXPAND surfaces null even when acquisition target is non-null', () {
-      // Defensive: the dispatcher never populates colonialAcquisitionTarget
-      // in EXPAND, but the adapter must short-circuit on phase to defend
-      // the suppression matrix.
+    test('EXPAND with newWorldAcquisition=0 surfaces null even when '
+        'acquisition target is non-null', () {
+      const outcome = PhasePlanOutcome(
+        phase: ObserverGoalPhase.expand,
+        colonialAcquisitionTarget: ColonialAcquisitionTarget(
+          targetFactionId: 'tribe4',
+          method: AcquisitionMethod.declareWar,
+        ),
+        priorityWeights: _nwAcquisitionZeroExpand,
+      );
+      expect(gpColonialDeclareWarTargetFromPhasePlan(outcome), isNull);
+    });
+
+    test('EXPAND with newWorldAcquisition>0 surfaces declareWar target '
+        '(Refs #2847)', () {
       const outcome = PhasePlanOutcome(
         phase: ObserverGoalPhase.expand,
         colonialAcquisitionTarget: ColonialAcquisitionTarget(
@@ -183,7 +202,10 @@ void main() {
           method: AcquisitionMethod.declareWar,
         ),
       );
-      expect(gpColonialDeclareWarTargetFromPhasePlan(outcome), isNull);
+      expect(
+        gpColonialDeclareWarTargetFromPhasePlan(outcome),
+        'tribe4',
+      );
     });
 
     test(

--- a/packages/colonizethis_ai/test/planning/phase_planner_dispatch_test.dart
+++ b/packages/colonizethis_ai/test/planning/phase_planner_dispatch_test.dart
@@ -48,6 +48,8 @@
 
 import 'package:colonizethis_ai/colonizethis_ai.dart';
 import 'package:colonizethis_ai/src/planning/colonial_phase_planner.dart';
+import 'package:colonizethis_ai/src/planning/phase_planner_dispatch.dart'
+    show phasePlanFullColonialOutputsActive;
 import 'package:colonizethis_ai/src/planning/develop_phase_planner.dart';
 import 'package:colonizethis_ai/src/planning/expand_phase_planner.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
@@ -354,7 +356,8 @@ void main() {
   });
 
   group('EXPAND outcome composition', () {
-    test('EXPAND populates EXPAND slots only; other slots stay default', () {
+    test('EXPAND populates EXPAND slots and colonial bundle when NW weight > 0 '
+        '(Refs #2847)', () {
       final game = _expandGame();
       final snapshot = _expandSnapshot();
       final outcome = runPhasePlanners(game: game, snapshot: snapshot);
@@ -380,15 +383,43 @@ void main() {
           declaredWarTargetFactionId: _minor1,
         ),
       );
+      expect(outcome.priorityWeights.newWorldAcquisition, greaterThan(0.0));
+      expect(phasePlanFullColonialOutputsActive(outcome), isTrue);
 
-      // Non-EXPAND slots structurally default.
+      final colonial = planColonialAcquisition(game: game, snapshot: snapshot);
+      expect(outcome.colonialAcquisitionTarget, colonial);
+      expect(
+        outcome.colonialPeaceTargetFactionIdsSorted,
+        planColonialPeace(game: game, snapshot: snapshot),
+      );
+      final declaredColonialTarget =
+          (colonial != null && colonial.method == AcquisitionMethod.declareWar)
+          ? colonial.targetFactionId
+          : null;
+      expect(
+        outcome.colonialMilitaryPlan,
+        planColonialMilitary(
+          game: game,
+          snapshot: snapshot,
+          colonialDeclaredWarTargetFactionId: declaredColonialTarget,
+        ),
+      );
+      expect(
+        outcome.colonialNavalPlan,
+        planColonialNaval(
+          game: game,
+          snapshot: snapshot,
+          colonialDeclaredWarTargetFactionId: declaredColonialTarget,
+        ),
+      );
+      expect(
+        outcome.colonialCivilianWorkOrders,
+        planColonialCivilian(game: game, snapshot: snapshot),
+      );
+
+      // COLONIAL-lite and DEVELOP slots stay default under EXPAND.
       expect(outcome.colonialLiteOverturesSorted, isEmpty);
       expect(outcome.colonialLiteNavalPlan, ColonialLiteNavalPlan.defaultPlan);
-      expect(outcome.colonialAcquisitionTarget, isNull);
-      expect(outcome.colonialPeaceTargetFactionIdsSorted, isEmpty);
-      expect(outcome.colonialMilitaryPlan, ColonialMilitaryPlan.defaultPlan);
-      expect(outcome.colonialNavalPlan, ColonialNavalPlan.defaultPlan);
-      expect(outcome.colonialCivilianWorkOrders, isEmpty);
       expect(outcome.developPeaceTargetFactionIdsSorted, isEmpty);
       expect(outcome.developCivilianWorkOrders, isEmpty);
     });

--- a/packages/colonizethis_ai/test/planning/phase_planner_military_plans_test.dart
+++ b/packages/colonizethis_ai/test/planning/phase_planner_military_plans_test.dart
@@ -28,8 +28,17 @@ import 'package:colonizethis_ai/src/planning/expand_phase_planner.dart'
     show ExpandMilitaryPlan;
 import 'package:colonizethis_ai/src/planning/observer_goal_phase.dart';
 import 'package:colonizethis_ai/src/planning/phase_planner_dispatch.dart';
+import 'package:colonizethis_ai/src/planning/phase_priority_weights.dart';
 import 'package:colonizethis_ai/src/planning/phase_planner_military_plans.dart';
 import 'package:colonizethis_test/test.dart';
+
+/// Legacy hard-suppress contract: explicit zero NW weight (Refs #2847).
+const PhasePriorityWeights _nwAcquisitionZeroExpand = PhasePriorityWeights(
+  oldWorldConquest: 0.95,
+  newWorldAcquisition: 0.0,
+  oldWorldCivilian: 0.90,
+  newWorldCivilian: 0.10,
+);
 
 const ExpandMilitaryPlan _expandSingleOwner = ExpandMilitaryPlan(
   priorityDestinationProvinceIdsSorted: <String>['oldWorld|nation_a|p1'],
@@ -222,22 +231,28 @@ void main() {
   });
 
   group('colonialMilitaryPlanFromPhasePlan — defensive phase suppression', () {
-    test('EXPAND surfaces ColonialMilitaryPlan.defaultPlan even when '
-        'COLONIAL slot non-default', () {
-      // Defensive: the dispatcher never populates colonialMilitaryPlan
-      // in EXPAND, but the adapter must short-circuit on phase to
-      // defend the structural NW suppression matrix.
+    test('EXPAND with newWorldAcquisition=0 surfaces default even when '
+        'COLONIAL slot non-default (legacy hard suppress)', () {
+      const outcome = PhasePlanOutcome(
+        phase: ObserverGoalPhase.expand,
+        colonialMilitaryPlan: _colonialMultiOwner,
+        priorityWeights: _nwAcquisitionZeroExpand,
+      );
+      expect(
+        colonialMilitaryPlanFromPhasePlan(outcome),
+        ColonialMilitaryPlan.defaultPlan,
+      );
+    });
+
+    test('EXPAND with newWorldAcquisition>0 surfaces colonialMilitaryPlan '
+        '(Refs #2847)', () {
       const outcome = PhasePlanOutcome(
         phase: ObserverGoalPhase.expand,
         colonialMilitaryPlan: _colonialMultiOwner,
       );
       expect(
         colonialMilitaryPlanFromPhasePlan(outcome),
-        ColonialMilitaryPlan.defaultPlan,
-        reason:
-            'EXPAND must never emit NW conquest destinations; a '
-            'non-default colonialMilitaryPlan slot must not leak the '
-            'NW invasion filter into the EXPAND military pass.',
+        _colonialMultiOwner,
       );
     });
 

--- a/packages/colonizethis_ai/test/planning/phase_planner_naval_plans_test.dart
+++ b/packages/colonizethis_ai/test/planning/phase_planner_naval_plans_test.dart
@@ -26,8 +26,16 @@ import 'package:colonizethis_ai/src/planning/colonial_phase_planner.dart'
     show ColonialLiteNavalPlan, ColonialNavalPlan;
 import 'package:colonizethis_ai/src/planning/observer_goal_phase.dart';
 import 'package:colonizethis_ai/src/planning/phase_planner_dispatch.dart';
+import 'package:colonizethis_ai/src/planning/phase_priority_weights.dart';
 import 'package:colonizethis_ai/src/planning/phase_planner_naval_plans.dart';
 import 'package:colonizethis_test/test.dart';
+
+const PhasePriorityWeights _nwAcquisitionZeroExpand = PhasePriorityWeights(
+  oldWorldConquest: 0.95,
+  newWorldAcquisition: 0.0,
+  oldWorldCivilian: 0.90,
+  newWorldCivilian: 0.10,
+);
 
 const ColonialNavalPlan _colonialNavalSingleOwner = ColonialNavalPlan(
   priorityInvasionTransportProvinceIdsSorted: <String>['newWorld|tribe_a|nw1'],
@@ -119,22 +127,28 @@ void main() {
   });
 
   group('colonialNavalPlanFromPhasePlan — defensive phase suppression', () {
-    test('EXPAND surfaces ColonialNavalPlan.defaultPlan even when '
+    test('EXPAND with newWorldAcquisition=0 surfaces default even when '
         'COLONIAL slot non-default', () {
-      // Defensive: the dispatcher never populates colonialNavalPlan in
-      // EXPAND, but the adapter must short-circuit on phase to defend
-      // the structural NW suppression matrix.
+      const outcome = PhasePlanOutcome(
+        phase: ObserverGoalPhase.expand,
+        colonialNavalPlan: _colonialNavalMultiOwner,
+        priorityWeights: _nwAcquisitionZeroExpand,
+      );
+      expect(
+        colonialNavalPlanFromPhasePlan(outcome),
+        ColonialNavalPlan.defaultPlan,
+      );
+    });
+
+    test('EXPAND with newWorldAcquisition>0 surfaces colonialNavalPlan '
+        '(Refs #2847)', () {
       const outcome = PhasePlanOutcome(
         phase: ObserverGoalPhase.expand,
         colonialNavalPlan: _colonialNavalMultiOwner,
       );
       expect(
         colonialNavalPlanFromPhasePlan(outcome),
-        ColonialNavalPlan.defaultPlan,
-        reason:
-            'EXPAND must never emit NW invasion-transport directives; '
-            'a non-default colonialNavalPlan slot must not leak into '
-            'the EXPAND naval pass.',
+        _colonialNavalMultiOwner,
       );
     });
 

--- a/packages/colonizethis_ai/test/seed42_observer_conquest_regression_test.dart
+++ b/packages/colonizethis_ai/test/seed42_observer_conquest_regression_test.dart
@@ -78,12 +78,11 @@ void main() {
     }
     },
     skip:
-        'Partial AC #2509 S10: seed-42 turn-100 gate — gp1 now passes via the '
-        'EXPAND stalled-expansion own-territory frontier-march fix combined '
-        'with the planExpandDeclareWar per-arm treasury gate and the '
-        'planColonialPeace below-quota-peer exclusion (Refs #2509). '
-        'gp3/gp4/gp5/gp6 still below +3 OW vs turn-1 snapshot; remaining gap '
-        'tracks companion stalled-tuning slices (separate follow-up).',
+        'Partial AC #2509 S10 / #2847: seed-42 turn-100 gate — gp1/gp2 PASS '
+        '(+6 each). gp3 +2, gp4 +1, gp5 -7, gp6 +10 (post-PR #3179 EXPAND '
+        'colonial dispatch + World Market treasury recovery on dev, 2026-06-03 '
+        'S7-D refresh). gp3–gp5 still below ≥3 OW floor; Phase 2 weight '
+        'consumer wiring required before skip removal (Refs #2847).',
     timeout: const Timeout(Duration(minutes: 15)),
   );
 }


### PR DESCRIPTION
## Summary

- **EXPAND universal colonial dispatch (slice):** `runPhasePlanners` now composes the full COLONIAL planner bundle (`planColonialAcquisition`, peace, military, naval, civilian) whenever `priorityWeights.newWorldAcquisition > 0.0` (early-sprint floor `0.05` → always populated on EXPAND today).
- **Orchestrator adapters:** `colonialMilitaryPlanFromPhasePlan`, `colonialNavalPlanFromPhasePlan`, `gpColonialDeclareWarTargetFromPhasePlan`, and `civilianWorkOrdersFromPhasePlan` gate through `phasePlanFullColonialOutputsActive` instead of `phase == colonial`. COLONIAL-lite and DEVELOP exclusions unchanged.
- **SPEC:** Documents the slice in `SPEC/ai/phase-planner-architecture.md`.

## Deferred (same issue #2847)

- Universal dispatch for DEVELOP / full COLONIAL-lite retirement
- `seed42_observer_conquest_regression_test` skip removal (S8 gate still red)
- Weight tuning loop / S7-D refresh to close gp3–gp6 ≥+3 OW ACs
- Phase 4 SPEC alignment (ai-architecture, phase-planner-dispatch matrix)

## Tests

```bash
cd packages/colonizethis_ai
dart test test/planning/phase_planner_dispatch_test.dart \
  test/planning/phase_planner_military_plans_test.dart \
  test/planning/phase_planner_naval_plans_test.dart \
  test/planning/phase_planner_declare_war_targets_test.dart \
  test/domain_planner_orchestrator_expand_nw_declare_war_suppression_test.dart
```

Refs #2847 (does not close).

Made with [Cursor](https://cursor.com)