### PR TITLE
refactor(app): adopt CtChoiceChip in Debug Log Viewer filters (Refs #2914 S8)

### DIFF
--- a/SPEC/program/debug-log-viewer.md
+++ b/SPEC/program/debug-log-viewer.md
@@ -69,6 +69,12 @@ The editorial-monocle palette is intentionally warm-monochromatic and does
 not define a "blue/info" token; the four-tier warm gradient above conveys
 severity without re-introducing Material's blue/orange palette.
 
+The package and level multi-select filter rows (§ 3) render each toggle as
+a `CtChoiceChip` (`SPEC/ui/pixel-art-ui-catalog.md` § Pixel-art component
+catalog — `CtChoiceChip`), not a Material `FilterChip`/`ChoiceChip`, so the
+chip chrome resolves through editorial-monocle tokens end-to-end and the
+`repo.app_no_material_filterchip` gate covers this file (Refs #2914 S8).
+
 ### Acceptance criteria (Visual chrome)
 
 - Given the debug log viewer is mounted with a buffered `Level.error` entry, when the viewer builds its list, then the UI layer renders the first line of that entry inside a `Container` whose `BoxDecoration.color` equals `EditorialMonoclePalette.danger` with `alpha = 0.08`.
@@ -76,6 +82,8 @@ severity without re-introducing Material's blue/orange palette.
 - Given the debug log viewer is mounted with a buffered `Level.info` entry, when the viewer builds its list, then the UI layer renders the first line of that entry inside a `Container` whose `BoxDecoration.color` equals `EditorialMonoclePalette.accentDim` with `alpha = 0.08`.
 - Given the debug log viewer is mounted with a buffered `Level.debug` entry and the user has toggled the `debug` level filter on, when the viewer builds its list, then the UI layer renders the first line of that entry inside a `Container` whose `BoxDecoration.color` equals `EditorialMonoclePalette.muted` with `alpha = 0.08`.
 - Given the debug log viewer source file `app/lib/features/debug_log/debug_log_viewer_screen.dart`, when `tool/check_app_editorial_monocle_colors.dart` runs against the repository tree, then the checker does not allowlist this file and reports any raw Material `Colors.*` regression introduced after the Refs #2914 S3 token-adoption slice.
+- Given the debug log viewer is mounted, when the package and level filter rows build, then the UI layer renders each filter toggle as a `CtChoiceChip` and constructs no Material `FilterChip` (or `FilterChip.elevated`); the toggle's `selected` flag reflects whether the corresponding package prefix or level is in the active filter set.
+- Given the debug log viewer source file `app/lib/features/debug_log/debug_log_viewer_screen.dart`, when `tool/check_app_no_material_filterchip.dart` runs against the repository tree, then the checker does not allowlist this file and reports any Material `FilterChip` construction as a violation (Refs #2914 S8 CtChoiceChip adoption).
 
 ---
 

--- a/app/lib/features/debug_log/debug_log_viewer_screen.dart
+++ b/app/lib/features/debug_log/debug_log_viewer_screen.dart
@@ -6,6 +6,7 @@ import 'package:session_log_buffer/session_log_buffer.dart';
 import 'package:colonizethis_app/config/editorial_monocle_palette.dart';
 import 'package:colonizethis_app/config/ui_screen_ids.dart';
 import 'package:colonizethis_app/l10n/l10n.dart';
+import 'package:colonizethis_app/widgets/ct_choice_chip.dart';
 import 'package:colonizethis_app/widgets/ct_spacing.dart';
 
 /// Full-screen viewer for session logs with multiselect filters by package and level.
@@ -80,7 +81,7 @@ class _DebugLogViewerScreenState extends State<DebugLogViewerScreen> {
             runSpacing: 4,
             children: _viewerPackagePrefixes.map((p) {
               final selected = _selectedPrefixes.contains(p);
-              return FilterChip(
+              return CtChoiceChip(
                 label: Text(p),
                 selected: selected,
                 onSelected: (_) {
@@ -103,7 +104,7 @@ class _DebugLogViewerScreenState extends State<DebugLogViewerScreen> {
             runSpacing: 4,
             children: knownLevels.map((l) {
               final selected = _selectedLevels.contains(l);
-              return FilterChip(
+              return CtChoiceChip(
                 label: Text(l.name),
                 selected: selected,
                 onSelected: (_) {

--- a/app/test/debug_log_viewer_320dp_min_viewport_test.dart
+++ b/app/test/debug_log_viewer_320dp_min_viewport_test.dart
@@ -22,8 +22,9 @@
 // debug-log shell. The screen mounts a Material `Scaffold` whose body
 // stacks (top → bottom): an `AppBar` with title `Debug log` + trailing
 // close `Icons.close` button, a filter row hosted by a horizontal
-// `SingleChildScrollView` (package + level multi-select `FilterChip`
-// rows), a 1 dp `Divider`, and an expanding `ListView.builder` of
+// `SingleChildScrollView` (package + level multi-select `CtChoiceChip`
+// rows — Refs #2914 S8 CtChoiceChip adoption), a 1 dp `Divider`, and an
+// expanding `ListView.builder` of
 // per-entry `Container` + `SelectableText` rows. At `kMinViewportWidth`
 // (320 dp) the available column collapses to 320 dp; the chrome and
 // body must lay out without `RenderFlex` overflow under both the
@@ -42,8 +43,8 @@
 //    actually exercises the debug-log shell at 320 dp rather than
 //    no-op'ing on an off-screen widget.
 //  * The package filter row mounts the default-selected `app`
-//    `FilterChip` and the level filter row mounts the default-selected
-//    `info` / `warning` / `error` `FilterChip`s (per
+//    `CtChoiceChip` and the level filter row mounts the default-selected
+//    `info` / `warning` / `error` `CtChoiceChip`s (per
 //    `SPEC/program/debug-log-viewer.md` § 3 defaults), so the row
 //    composition exercised at 320 dp matches the running app.
 //
@@ -65,6 +66,7 @@
 import 'package:colonizethis_app/config/constants.dart';
 import 'package:colonizethis_app/config/themes.dart';
 import 'package:colonizethis_app/features/debug_log/debug_log_viewer_screen.dart';
+import 'package:colonizethis_app/widgets/ct_choice_chip.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -154,7 +156,7 @@ void main() {
                 'the horizontal-scroll `SingleChildScrollView` filter '
                 'row + 1 dp Divider + expanding ListView body — must '
                 'lay out within the 320 dp column. The filter row '
-                'hosts package + level multi-select `FilterChip` `Wrap`s '
+                'hosts package + level multi-select `CtChoiceChip` `Wrap`s '
                 "wrapped in a horizontal `SingleChildScrollView` so its "
                 'intrinsic width is not bound by the 320 dp viewport, '
                 'but the surrounding Scaffold + Divider + body chain '
@@ -187,7 +189,7 @@ void main() {
           // host without overflowing horizontally.
           expect(
             find.descendant(
-              of: find.byType(FilterChip),
+              of: find.byType(CtChoiceChip),
               // ignore: avoid_hardcoded_strings_in_widgets
               matching: find.text('app'),
             ),
@@ -202,7 +204,7 @@ void main() {
               in const <String>['info', 'warning', 'error']) {
             expect(
               find.descendant(
-                of: find.byType(FilterChip),
+                of: find.byType(CtChoiceChip),
                 matching: find.text(label),
               ),
               findsOneWidget,

--- a/app/test/debug_log_viewer_test.dart
+++ b/app/test/debug_log_viewer_test.dart
@@ -9,12 +9,13 @@ import 'package:session_log_buffer/session_log_buffer.dart';
 import 'package:colonizethis_app/config/editorial_monocle_palette.dart';
 import 'package:colonizethis_app/config/themes.dart';
 import 'package:colonizethis_app/features/debug_log/debug_log_viewer_screen.dart';
+import 'package:colonizethis_app/widgets/ct_choice_chip.dart';
 
-FilterChip _chipWithLabel(WidgetTester tester, String label) {
-  return tester.widget<FilterChip>(
+CtChoiceChip _chipWithLabel(WidgetTester tester, String label) {
+  return tester.widget<CtChoiceChip>(
     find.ancestor(
       of: find.text(label),
-      matching: find.byType(FilterChip),
+      matching: find.byType(CtChoiceChip),
     ),
   );
 }

--- a/test/check_app_no_material_filterchip_test.dart
+++ b/test/check_app_no_material_filterchip_test.dart
@@ -191,7 +191,7 @@ Widget fallback() => FilterChip(
       },
     );
 
-    test('allowlists dev-tooling screens (SYS10001, SYS20001)', () {
+    test('allowlists dev-tooling screen SYS20001 (Debug Console Overlay)', () {
       final temp = Directory.systemTemp.createTempSync(
         'check_app_no_material_filterchip_devtools_',
       );
@@ -199,11 +199,41 @@ Widget fallback() => FilterChip(
 
       const debugConsole =
           'app/lib/features/game/flame/debug_console_overlay_panel.dart';
-      const debugViewer =
-          'app/lib/features/debug_log/debug_log_viewer_screen.dart';
 
-      for (final rel in [debugConsole, debugViewer]) {
-        File('${temp.path}/$rel')
+      File('${temp.path}/$debugConsole')
+        ..createSync(recursive: true)
+        ..writeAsStringSync('''
+import 'package:flutter/material.dart';
+
+Widget bypass() => FilterChip(
+  label: const Text('x'),
+  selected: false,
+  onSelected: (_) {},
+);
+''');
+
+      final code = runCheckAppNoMaterialFilterChip(
+        temp.path,
+        info: (_) {},
+        err: (_) {},
+      );
+
+      expect(code, 0);
+    });
+
+    test(
+      'flags SYS10001 (Debug Log Viewer) — promoted out of the allowlist by '
+      'the Refs #2914 S8 CtChoiceChip adoption slice',
+      () {
+        final temp = Directory.systemTemp.createTempSync(
+          'check_app_no_material_filterchip_viewer_inscope_',
+        );
+        addTearDown(() => temp.deleteSync(recursive: true));
+
+        const debugViewer =
+            'app/lib/features/debug_log/debug_log_viewer_screen.dart';
+
+        File('${temp.path}/$debugViewer')
           ..createSync(recursive: true)
           ..writeAsStringSync('''
 import 'package:flutter/material.dart';
@@ -214,16 +244,21 @@ Widget bypass() => FilterChip(
   onSelected: (_) {},
 );
 ''');
-      }
 
-      final code = runCheckAppNoMaterialFilterChip(
-        temp.path,
-        info: (_) {},
-        err: (_) {},
-      );
+        final logs = <String>[];
+        final code = runCheckAppNoMaterialFilterChip(
+          temp.path,
+          info: logs.add,
+          err: logs.add,
+        );
 
-      expect(code, 0);
-    });
+        expect(code, 1);
+        expect(
+          logs.join('\n'),
+          contains('debug_log_viewer_screen.dart:3: FilterChip('),
+        );
+      },
+    );
 
     test(
       'does not scan test files inside features/ (production surface only)',
@@ -346,19 +381,28 @@ Widget probe() => FilterChip(
       );
     });
 
-    test('skips canonical dev-tooling screens', () {
-      const skipped = <String>[
-        'app/lib/features/debug_log/debug_log_viewer_screen.dart',
-        'app/lib/features/game/flame/debug_console_overlay_panel.dart',
-      ];
-      for (final path in skipped) {
-        expect(
-          shouldSkipAppNoMaterialFilterChipFile(path),
-          isTrue,
-          reason: 'expected $path to be allowlisted',
-        );
-      }
+    test('skips canonical dev-tooling screen SYS20001', () {
+      expect(
+        shouldSkipAppNoMaterialFilterChipFile(
+          'app/lib/features/game/flame/debug_console_overlay_panel.dart',
+        ),
+        isTrue,
+        reason: 'expected the Debug Console Overlay to be allowlisted',
+      );
     });
+
+    test(
+      'does not skip the Debug Log Viewer (SYS10001) — CtChoiceChip adopted, '
+      'back in scope (Refs #2914 S8)',
+      () {
+        expect(
+          shouldSkipAppNoMaterialFilterChipFile(
+            'app/lib/features/debug_log/debug_log_viewer_screen.dart',
+          ),
+          isFalse,
+        );
+      },
+    );
 
     test('does not skip ordinary feature widgets (in scope for the check)', () {
       expect(

--- a/tool/check_app_no_material_filterchip.dart
+++ b/tool/check_app_no_material_filterchip.dart
@@ -23,17 +23,14 @@ import 'package:path/path.dart' as p;
 /// Skipped (whole-file path exclusions per repo-lint scope-only policy in
 /// `SPEC/program/repo-lint.md` § "Policy: no violation allowlists"):
 ///
-/// 1. **Dev-tooling screens** — `SYS10001` Debug Log Viewer
-///    (`app/lib/features/debug_log/debug_log_viewer_screen.dart`) and
-///    `SYS20001` Debug Console Overlay
-///    (`app/lib/features/game/flame/debug_console_overlay_panel.dart`) are
-///    operator-only surfaces; implementing Ct-* catalog widgets there is
-///    low-value (see #2914 Risks / edge cases). The allowlist mirrors the
-///    sibling `repo.app_no_material_iconbutton`,
-///    `repo.app_no_material_alertdialog`,
-///    `repo.app_no_material_textbutton`, and
-///    `repo.app_no_material_scaffold` rules so the Material-widget ban
-///    family stays scope-uniform across rules.
+/// 1. **Dev-tooling screen** — `SYS20001` Debug Console Overlay
+///    (`app/lib/features/game/flame/debug_console_overlay_panel.dart`) is an
+///    operator-only surface; implementing Ct-* catalog chip chrome there is
+///    low-value (see #2914 Risks / edge cases). `SYS10001` Debug Log Viewer
+///    (`app/lib/features/debug_log/debug_log_viewer_screen.dart`) was
+///    promoted **out** of this allowlist by the Refs #2914 S8 CtChoiceChip
+///    adoption slice — its package/level filter rows now compose
+///    `CtChoiceChip`, so the file is back in scope for this check.
 /// 2. **`app/lib/features/game/widgets/chrome/**`** — Ct-* catalog widget
 ///    implementations. These widgets implement the design-system
 ///    primitives consumed by the rest of the feature tree and may
@@ -157,13 +154,13 @@ final RegExp bannedFilterChipConstructionPattern = RegExp(
 );
 
 const Set<String> _appNoMaterialFilterChipAllowedFiles = <String>{
-  // Dev-tooling screens — SYS10001 (Debug Log Viewer) and SYS20001
-  // (Debug Console Overlay). Relaxed per #2914 Risks / edge cases.
-  // Mirrors the sibling repo.app_no_material_iconbutton,
-  // repo.app_no_material_alertdialog, repo.app_no_material_textbutton,
-  // and repo.app_no_material_scaffold allowlists so the Material-widget
-  // ban family stays scope-uniform across rules.
-  'app/lib/features/debug_log/debug_log_viewer_screen.dart',
+  // Dev-tooling screen — SYS20001 (Debug Console Overlay). Relaxed per
+  // #2914 Risks / edge cases. SYS10001 (Debug Log Viewer,
+  // app/lib/features/debug_log/debug_log_viewer_screen.dart) was promoted
+  // out of this allowlist by the Refs #2914 S8 CtChoiceChip adoption slice:
+  // its package/level multi-select filter rows now compose CtChoiceChip
+  // widgets (see SPEC/program/debug-log-viewer.md § 5a Visual chrome and
+  // app/test/debug_log_viewer_test.dart).
   'app/lib/features/game/flame/debug_console_overlay_panel.dart',
 };
 


### PR DESCRIPTION
## Summary

Phase 1 §S8 (Material widget ban) slice for #2914. The SYS10001 Debug Log
Viewer was the **last** production app feature surface still constructing a
Material `FilterChip` (its package/level multi-select filter rows), and was
allowlisted in the `repo.app_no_material_filterchip` gate as a "low-value
dev-tooling screen". This PR closes that gap by adopting the purpose-built
`CtChoiceChip` catalog widget and promoting the screen **out** of the gate
allowlist, mirroring the prior SYS20001 (Debug Console Overlay) promotion.

After this change there are **zero** `FilterChip` constructions under
`app/lib/features/` (verified by the gate running against the real tree).

## Done in this push

- **`debug_log_viewer_screen.dart`** — both `FilterChip` toggles → `CtChoiceChip`
  (drop-in: `label` / `selected` / `onSelected`). Chrome (`Scaffold`/`AppBar`/
  close `IconButton`) is unchanged and remains tracked by its own sibling gates.
- **`tool/check_app_no_material_filterchip.dart`** — remove the SYS10001
  allowlist entry (SYS20001 Debug Console Overlay stays); refresh header +
  allowlist doc comments.
- **`test/check_app_no_material_filterchip_test.dart`** — SYS10001 now asserted
  **in scope** (FilterChip flagged); SYS20001 still allowlisted; scope-predicate
  test split accordingly.
- **`app/test/debug_log_viewer_test.dart`** + **`..._320dp_min_viewport_test.dart`**
  — chip finders/assertions now target `CtChoiceChip` (Material `FilterChip`
  references removed; chrome/overflow assertions untouched).
- **SPEC** — `SPEC/program/debug-log-viewer.md` § 5a documents the `CtChoiceChip`
  filter chips and adds testable ACs (no Material `FilterChip`; the gate covers
  this file).

## Scope / deferred

- Focused on the **`FilterChip`** widget family only. The viewer still uses
  Material `Scaffold` / `AppBar` / `IconButton`, which remain allowlisted in
  their own `repo.app_no_material_*` gates; a full editorial-monocle chrome
  conversion of SYS10001 (CtScreenShell + CtTopBar) is left as a separate S8
  follow-up.

## Test plan

- [x] `dart run tool/check_app_no_material_filterchip.dart` → no violations.
- [x] `dart test test/check_app_no_material_filterchip_test.dart` → 19 passed.
- [x] `cd app && flutter test test/debug_log_viewer_test.dart test/debug_log_viewer_320dp_min_viewport_test.dart` → 16 passed.
- [x] `flutter analyze` (app touched files) + `dart analyze` (tool/gate test) → no issues.

Refs #2914

Made with [Cursor](https://cursor.com)