### PR TITLE
docs(test): refresh seed-42 World-Market lock-recovery diagnostic findings (Refs #2924)

### DIFF
--- a/packages/colonizethis_ai/test/seed42_observer_world_market_diagnostic_test.dart
+++ b/packages/colonizethis_ai/test/seed42_observer_world_market_diagnostic_test.dart
@@ -108,6 +108,57 @@
 // the urgent-offer threshold or the F8 fill-rate discount. Affordability
 // is **not** bypassed anywhere in this finding.
 //
+// ## Refreshed findings (captured 2026-06-03 against `dev` @ `3199fcd09`)
+//
+// Re-run after the bid-side liquidity tuning the 2026-06-01 finding called
+// for landed: phase-13 minor / tribe auto-bids + seller-priority matching
+// (F15, #3157), the F16 urgent-offer tier-alignment fix (#3183), and the
+// faithful Full-AI handoff pin (#3174). The failing link has shifted — the
+// lock-recovery chain now credits treasury on seed 42:
+//
+//   | GP  | offers | offerQty | bids | dealsSell | credSell | dealsBuy | zeroBidCap | turnsUnder |
+//   |-----|--------|----------|------|-----------|----------|----------|------------|------------|
+//   | gp1 |     96 |      115 |    7 |        91 |    1 381 |        2 |          0 |         93 |
+//   | gp2 |    137 |      152 |    2 |        96 |    1 456 |        0 |          0 |         98 |
+//   | gp3 |     82 |      462 |   36 |        58 |    3 757 |       32 |          0 |         56 |
+//   | gp4 |     96 |      323 |   11 |       104 |    4 076 |        3 |          0 |         87 |
+//   | gp5 |     82 |      588 |   32 |        72 |    5 812 |       86 |          0 |         63 |
+//   | gp6 |     84 |      842 |   32 |        72 |    9 538 |       26 |          0 |         67 |
+//
+// Decomposition by chain link (contrast with the 2026-06-01 table above):
+//
+//   * **Bid-side liquidity gate is now open.** `turnsZeroBidTypeCap` is `0`
+//     for every GP (was `100`). The phase-13 minor / tribe auto-bids (F15,
+//     #3157) supply the buy-side demand that the prior embassy-gated run
+//     lacked, so the suggester's bid precondition is met every turn.
+//   * **Deals clear.** `cumulativeDealsAsSeller` is now `58`–`104` per GP
+//     (was `0`), and `cumulativeBidsEmitted` is positive for every GP
+//     (gp3 `36`, gp5 `32`, gp6 `32`).
+//   * **Treasury is credited from market sales.** `cumulativeTreasuryCreditedAsSeller`
+//     rose from `0` to `1 381`–`9 538` per GP; the four failing GPs gp3–gp6
+//     each earn `3 757`–`9 538` treasury legitimately through the market
+//     over the 100-turn horizon.
+//   * **Below-threshold pressure relaxed.** `turnsTreasuryUnderCheapestRegiment`
+//     fell from `98` for every GP to `56` (gp3), `87` (gp4), `63` (gp5),
+//     `67` (gp6) — gp3 now spends 44 / 100 turns at or above the `2 000`
+//     regiment-build threshold. gp4 remains the weakest of the four.
+//   * **Smaller per-turn offer quantities** (e.g. gp6 `842` vs the prior
+//     `39 750`) reflect a *working* market: offers now clear into deals each
+//     turn instead of piling up unmatched in the carry-forward queue.
+//
+// **Headline:** Path F is no longer the failing link on seed 42. The
+// lock-recovery chain (`StrategicGoal.trade` floor F6 -> `runTreasuryPlanner`
+// surplus / offers F1-F5/F8 -> phase-13 minor auto-bids / F15 -> credited
+// treasury) now redistributes treasury to the failing GPs without any
+// affordability bypass. The residual gap — gp4 still below the regiment
+// threshold for 87 / 100 turns — is bounded by the § "Conservation bound on
+// Path F" insight: market trade redistributes but cannot grow the aggregate
+// Great-Power treasury pool, so full closure of #2924's all-four gate now
+// depends on a net treasury source outside the market (Path E NW riches
+// conversion) and/or downstream build / conquest conversion (#2925), rather
+// than further Path F offer / bid tuning. Affordability is **not** bypassed
+// anywhere in this finding.
+//
 // ## How to refresh
 //
 // Skipped by default (~4 min on the project reference host). Re-run with


### PR DESCRIPTION
## Summary

Re-ran the SPEC-prescribed seed-42 100-turn per-turn World-Market lock-recovery diagnostic and refreshed the recorded findings in `seed42_observer_world_market_diagnostic_test.dart`. The test's own *How to refresh* note (and `SPEC/ai/treasury-planner.md` § "Seed-42 100-turn per-turn World-Market lock-recovery diagnostic") direct re-running it "when the failing link shifts after a Path F tuning slice lands". Several such slices merged after the prior 2026-06-01 run: phase-13 minor/tribe auto-bids + seller-priority matching (F15, #3157), the F16 urgent-offer tier-alignment fix (#3183), and the faithful Full-AI handoff pin (#3174).

## Done in this push

- Re-ran `dart test test/seed42_observer_world_market_diagnostic_test.dart --run-skipped` (packages/colonizethis_ai) against `dev` @ `3199fcd09`; the lightweight per-GP-100-row assertion still passes.
- Added a dated **Refreshed findings (2026-06-03)** block to the test header, preserving the historical 2026-06-01 block for contrast.

## Key result (post F15/F16)

| GP  | dealsSell | credSell | zeroBidCap | turnsUnder |
|-----|-----------|----------|------------|------------|
| gp1 |        91 |    1 381 |          0 |         93 |
| gp2 |        96 |    1 456 |          0 |         98 |
| gp3 |        58 |    3 757 |          0 |         56 |
| gp4 |       104 |    4 076 |          0 |         87 |
| gp5 |        72 |    5 812 |          0 |         63 |
| gp6 |        72 |    9 538 |          0 |         67 |

The failing link has shifted from the prior run (where every GP had `zeroBidCap=100`, `dealsSell=0`, `credSell=0`, `turnsUnder=98`): the bid-side liquidity gate is now open and the lock-recovery chain credits treasury legitimately. Per § "Conservation bound on Path F", the residual gap (gp4 still under threshold 87/100 turns) is now bounded by aggregate-pool insufficiency and depends on a net treasury source outside the market (Path E NW riches) and/or downstream build/conquest conversion (#2925), not further Path F offer/bid tuning. No affordability bypass anywhere.

## Scope / deferred

- Comment-only refresh of the diagnostic test's recorded findings; no production behavior change.
- Does **not** relabel #2924 to `backlog:verification` — the all-four-GP treasury-escape gate is not yet closed (gp4 in particular remains below threshold most turns); Path E / downstream work remains.

## Test plan

- [x] `dart test test/seed42_observer_world_market_diagnostic_test.dart --run-skipped` (packages/colonizethis_ai) — passes (1 test, ~3 min).
- [x] `dart analyze` on the touched file — no issues.

Refs #2924

Made with [Cursor](https://cursor.com)