### PR TITLE
refactor(app): adopt CtSpacing in dialogue overlays (#2914)

### DIFF
--- a/app/lib/features/game/dialogue/call_to_arms_dialogue_overlay.dart
+++ b/app/lib/features/game/dialogue/call_to_arms_dialogue_overlay.dart
@@ -8,6 +8,7 @@ import '../../../../l10n/l10n.dart';
 import '../../../../widgets/ct_brass_divider.dart';
 import '../../../../widgets/ct_full_screen_dialogue_shell.dart';
 import '../../../../widgets/ct_nine_patch_button.dart';
+import '../../../../widgets/ct_spacing.dart';
 import '../../../../widgets/ct_toggle_switch.dart';
 
 /// Blocking overlay: human ally accepts or refuses each pending call to arms.
@@ -205,7 +206,7 @@ class _CallToArmsCallRow extends StatelessWidget {
     // (issue #2870 S8 / S10; SPEC/ui/call-to-arms-dialogue-overlay.md
     // § Layout / wireframe; SPEC/ui/mobile-adaptation.md § 7).
     return Padding(
-      padding: const EdgeInsets.only(bottom: 12),
+      padding: const EdgeInsets.only(bottom: CtSpacing.ml),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: <Widget>[

--- a/app/lib/features/game/dialogue/game_start_intro_overlay.dart
+++ b/app/lib/features/game/dialogue/game_start_intro_overlay.dart
@@ -204,7 +204,7 @@ class _GameStartIntroOverlayState extends State<GameStartIntroOverlay> {
           ] else if (choice != null) ...[
             ...choice.options.asMap().entries.map(
               (entry) => Padding(
-                padding: const EdgeInsets.only(bottom: 8),
+                padding: const EdgeInsets.only(bottom: CtSpacing.m),
                 child: CtNinePatchButton(
                   onPressed: () => _view!.selectOption(entry.key),
                   child: Text(entry.value.text),

--- a/app/lib/features/game/dialogue/intervention_dialogue_overlay.dart
+++ b/app/lib/features/game/dialogue/intervention_dialogue_overlay.dart
@@ -291,7 +291,7 @@ class _InterventionDialogueOverlayState
           ] else if (choice != null) ...[
             ...choice.options.asMap().entries.map(
               (entry) => Padding(
-                padding: const EdgeInsets.only(bottom: 8),
+                padding: const EdgeInsets.only(bottom: CtSpacing.m),
                 child: CtNinePatchButton(
                   onPressed: () => _view!.selectOption(entry.key),
                   child: Text(entry.value.text),

--- a/app/lib/features/game/dialogue/overture_dialogue_overlay.dart
+++ b/app/lib/features/game/dialogue/overture_dialogue_overlay.dart
@@ -218,7 +218,7 @@ class _OvertureDialogueOverlayState extends State<OvertureDialogueOverlay> {
             ] else if (choice != null) ...[
               ...choice.options.asMap().entries.map(
                 (entry) => Padding(
-                  padding: const EdgeInsets.only(bottom: 8),
+                  padding: const EdgeInsets.only(bottom: CtSpacing.m),
                   child: CtNinePatchButton(
                     onPressed: () => _view!.selectOption(entry.key),
                     child: Text(entry.value.text),
@@ -375,7 +375,7 @@ class _OvertureOfferRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.only(bottom: 12),
+      padding: const EdgeInsets.only(bottom: CtSpacing.ml),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [


### PR DESCRIPTION
## Summary

Adopts the `CtSpacing` design tokens (issue #2914 S5) in the four full-screen dialogue overlays under `app/lib/features/game/dialogue/`, removing the last raw `EdgeInsets` spacing magic numbers in that module.

## Done in this push

- `game_start_intro_overlay.dart`, `intervention_dialogue_overlay.dart`, `overture_dialogue_overlay.dart`: `EdgeInsets.only(bottom: 8)` -> `EdgeInsets.only(bottom: CtSpacing.m)`.
- `overture_dialogue_overlay.dart`, `call_to_arms_dialogue_overlay.dart`: `EdgeInsets.only(bottom: 12)` -> `EdgeInsets.only(bottom: CtSpacing.ml)`.
- Added the missing `ct_spacing.dart` import to `call_to_arms_dialogue_overlay.dart`.

Behavior-preserving: `CtSpacing.m == 8` and `CtSpacing.ml == 12` match the prior literals exactly, so layout is unchanged. After this change, `app/lib/features/game/dialogue/` has no remaining raw `EdgeInsets` spacing magic numbers (`SizedBox` gaps such as `14` have no corresponding token and are intentionally left for a future SPEC/token decision).

## Scope vs #2914

- Covers part of **S5** (`CtSpacing` adoption in feature files) for the dialogue-overlay module only. Other feature files with raw `EdgeInsets` and the `BorderRadius`/`CtRadius` (S6) work remain for follow-up slices. Deliberately avoids the province-overlay files (`province_sea_zone_detail_overlay*`) to prevent conflicts with the active #2865 lane.

## Verification

- `flutter analyze lib/features/game/dialogue/` -> No issues found.
- `flutter test` on the dialogue overlay widget tests (intervention, call-to-arms, overture, game-start-intro, 320 dp min-viewport, dialogue acceptance) -> all 29 tests pass, including the 320 dp overflow pins that assert the 8 dp / 12 dp chrome gaps.

Refs #2914

Made with [Cursor](https://cursor.com)