### PR TITLE
feat(ui): province detail panel slide transition on open/close (#2865)

### DIFF
--- a/SPEC/ui/game-map-narrow-detail-overlay-slot.md
+++ b/SPEC/ui/game-map-narrow-detail-overlay-slot.md
@@ -65,6 +65,14 @@ The 1.5 dp `--accent-dim` top border required by the same row is provided by `Pr
 
 ---
 
+## Open / close motion
+
+- **Enter:** When `overlayOpen` becomes `true` and a non-empty `displayId` resolves, the slot mounts `ProvinceSeaZoneDetailOverlay` with a **200 ms** `SlideTransition` from `Offset(0, 1)` → `Offset.zero` (`Curves.easeOut` on enter). The motion slides the bottom sheet **up** from below the viewport; no fade-only transition.
+- **Exit:** When `overlayOpen` becomes `false` (close control) or the slot would return `SizedBox.shrink()` for an empty `displayId`, the outgoing panel uses the reverse slide (`Offset.zero` → `Offset(0, 1)`, `Curves.easeIn`, same **200 ms** duration) before unmounting. `selectedTileKey` retention follows [`province-sea-zone-detail-overlay.md`](province-sea-zone-detail-overlay.md) § Interaction.
+- **Implementation:** Shared helper `ProvinceDetailPanelSlideTransition` in `app/lib/features/game/flame/province_detail_panel_slide_transition.dart` (`AnimatedSwitcher` + `SlideTransition`; axis `bottom` for this host).
+
+---
+
 ## Navigation and side effects
 
 - **Close control** on `ProvinceSeaZoneDetailOverlay` → `mapProvincePanelProvider.notifier.closeOverlay()` (`overlayOpen = false`).
@@ -114,6 +122,14 @@ The 1.5 dp `--accent-dim` top border required by the same row is provided by `Pr
 - Given `canMutateViaUi` is `false`,
   When the slot builds with explore state that would otherwise show an icon,
   Then the nested overlay receives `showExploreActionIcon: false` (no explore shortcut emit on tap).
+
+- Given `overlayOpen` transitions from `false` to `true` with a valid `displayId`,
+  When the slot builds,
+  Then the UI layer mounts `ProvinceDetailPanelSlideTransition` with axis `bottom` and the nested `ProvinceSeaZoneDetailOverlay` enters via a **200 ms** upward slide (`SlideTransition` from `Offset(0, 1)`).
+
+- Given `overlayOpen` transitions from `true` to `false` while the panel was visible,
+  When the close animation completes,
+  Then the slot unmounts the overlay and does not leave a hit target in the map stack.
 
 ---
 

--- a/SPEC/ui/province-sea-zone-detail-overlay.md
+++ b/SPEC/ui/province-sea-zone-detail-overlay.md
@@ -39,6 +39,7 @@ When the user **taps/clicks a map tile** (not hover), the shell shows detail for
 
 - **Open / update:** User taps/clicks a tile → provider records `selectedTileKey`, sets `overlayOpen` → panel shows that province/sea zone; **Tile** section uses the same tile key.
 - **Close:** User uses the overlay close control → `overlayOpen` false; `selectedTileKey` may remain for a later reopen. Map **orange selection** follows provider: implementation may clear or keep selection when closed; tile tap while closed should be able to **reopen** with that tile selected.
+- **Panel motion:** Panel hosts animate open/close with `ProvinceDetailPanelSlideTransition` (**200 ms**): wide [`GameMapProvinceDetailSidePanel`](../../app/lib/features/game/flame/game_map_province_detail_side_panel.dart) slides from the **end** (right); narrow [`GameMapNarrowDetailOverlaySlot`](game-map-narrow-detail-overlay-slot.md) slides from the **bottom** (`Offset(0, 1)`). Enter uses `Curves.easeOut`; exit uses `Curves.easeIn`. Content updates while open (tile/province switch) do not replay the enter animation — only `overlayOpen` false→true toggles it.
 - **Switch province/tile:** Tap another tile → new `selectedTileKey` → panel updates (including province-scoped sections for the new tile's province).
 - **Hover:** Pointer hover updates **only** map hover visuals (and optional `onProvinceHovered` / tooltips). It does **not** update `selectedTileKey` or the Tile section.
 - **Touch / mobile:** There is **no** "tap-as-hover" for **panel** content. Only **tap** commits selection for the overlay.

--- a/app/lib/features/game/flame/game_map_narrow_detail_overlay.dart
+++ b/app/lib/features/game/flame/game_map_narrow_detail_overlay.dart
@@ -12,6 +12,7 @@ import '../../../../providers/map_province_panel_provider.dart';
 import '../../../core/services/game_service.dart' show GameMapData;
 import 'game_map_area_state_logic.dart';
 import 'per_player_work_target_selection_cache.dart';
+import 'province_detail_panel_slide_transition.dart';
 import '../widgets/province_sea_zone_detail_overlay.dart';
 
 /// Narrow-layout bottom sheet host; reads [mapProvincePanelProvider] only.
@@ -51,9 +52,6 @@ class GameMapNarrowDetailOverlaySlot extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final panel = ref.watch(mapProvincePanelProvider);
     final draftOrders = ref.watch(currentOrdersProvider);
-    if (!panel.overlayOpen) {
-      return const SizedBox.shrink();
-    }
     final tileKey = panel.selectedTileKey;
     final displayId = tileKey == null || tileKey.isEmpty
         ? ''
@@ -63,8 +61,13 @@ class GameMapNarrowDetailOverlaySlot extends ConsumerWidget {
                   ) ??
                   displayProvinceOrSeaIdFromTileKey(tileKey)) ??
               '';
-    if (displayId.isEmpty) {
-      return const SizedBox.shrink();
+    final showPanel = panel.overlayOpen && displayId.isNotEmpty;
+    if (!showPanel) {
+      return ProvinceDetailPanelSlideTransition(
+        visible: false,
+        axis: ProvinceDetailPanelSlideAxis.bottom,
+        child: const SizedBox.shrink(),
+      );
     }
     GameMapData? mapData;
     try {
@@ -106,7 +109,7 @@ class GameMapNarrowDetailOverlaySlot extends ConsumerWidget {
             playerView: playerView,
             workTargetSelectionCache: workTargetSelectionCache,
           );
-    return SizedBox(
+    final overlay = SizedBox(
       width: double.infinity,
       height: MediaQuery.sizeOf(context).height * 0.33,
       child: ProvinceSeaZoneDetailOverlay(
@@ -122,15 +125,15 @@ class GameMapNarrowDetailOverlaySlot extends ConsumerWidget {
             .setSecondaryHighlight(k),
         onClose: () =>
             ref.read(mapProvincePanelProvider.notifier).closeOverlay(),
-      showProspectActionIcon: canMutateViaUi && prospectState.showIcon,
-      prospectActionEnabled: canMutateViaUi && prospectState.enabled,
-      showExploreActionIcon: canMutateViaUi && exploreState.showIcon,
-      exploreActionEnabled: canMutateViaUi && exploreState.enabled,
-      showBuildImprovementActionIcon:
-          canMutateViaUi && buildImprovementState.showIcon,
-      buildImprovementActionEnabled:
-          canMutateViaUi && buildImprovementState.enabled,
-      omniscientDetail: omniscientDetail,
+        showProspectActionIcon: canMutateViaUi && prospectState.showIcon,
+        prospectActionEnabled: canMutateViaUi && prospectState.enabled,
+        showExploreActionIcon: canMutateViaUi && exploreState.showIcon,
+        exploreActionEnabled: canMutateViaUi && exploreState.enabled,
+        showBuildImprovementActionIcon:
+            canMutateViaUi && buildImprovementState.showIcon,
+        buildImprovementActionEnabled:
+            canMutateViaUi && buildImprovementState.enabled,
+        omniscientDetail: omniscientDetail,
         onExploreWithExplorerTap:
             exploreState.enabled && panel.selectedTileKey != null
             ? () {
@@ -209,6 +212,11 @@ class GameMapNarrowDetailOverlaySlot extends ConsumerWidget {
               }
             : null,
       ),
+    );
+    return ProvinceDetailPanelSlideTransition(
+      visible: true,
+      axis: ProvinceDetailPanelSlideAxis.bottom,
+      child: overlay,
     );
   }
 }

--- a/app/lib/features/game/flame/game_map_province_detail_side_panel.dart
+++ b/app/lib/features/game/flame/game_map_province_detail_side_panel.dart
@@ -14,6 +14,7 @@ import '../../../core/services/game_service.dart' show GameMapData;
 import 'game_map_area_state_logic.dart';
 import 'game_screen_shared.dart' show kGameMapWideProvinceSidePanelWidth;
 import 'per_player_work_target_selection_cache.dart';
+import 'province_detail_panel_slide_transition.dart';
 import '../widgets/province_sea_zone_detail_overlay.dart';
 
 /// Wide-layout province / sea zone panel; reads [mapProvincePanelProvider] only.
@@ -41,12 +42,6 @@ class GameMapProvinceDetailSidePanel extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final panel = ref.watch(mapProvincePanelProvider);
     final draftOrders = ref.watch(currentOrdersProvider);
-    if (!panel.overlayOpen) {
-      if (kCtE2EEnabled) {
-        updateCtE2eLastPanelSnapshotIfEnabled(null);
-      }
-      return const SizedBox.shrink();
-    }
     final tileKey = panel.selectedTileKey;
     final displayId = tileKey == null || tileKey.isEmpty
         ? ''
@@ -56,11 +51,16 @@ class GameMapProvinceDetailSidePanel extends ConsumerWidget {
                   ) ??
                   displayProvinceOrSeaIdFromTileKey(tileKey)) ??
               '';
-    if (displayId.isEmpty) {
+    final showPanel = panel.overlayOpen && displayId.isNotEmpty;
+    if (!showPanel) {
       if (kCtE2EEnabled) {
         updateCtE2eLastPanelSnapshotIfEnabled(null);
       }
-      return const SizedBox.shrink();
+      return ProvinceDetailPanelSlideTransition(
+        visible: false,
+        axis: ProvinceDetailPanelSlideAxis.end,
+        child: const SizedBox.shrink(),
+      );
     }
     if (kCtE2EEnabled && panel.selectedTileKey != null) {
       updateCtE2eLastPanelSnapshotIfEnabled(
@@ -216,6 +216,13 @@ class GameMapProvinceDetailSidePanel extends ConsumerWidget {
     if (kCtE2EEnabled) {
       overlay = KeyedSubtree(key: kCtE2EProvincePanelRootKey, child: overlay);
     }
-    return SizedBox(width: kGameMapWideProvinceSidePanelWidth, child: overlay);
+    return ProvinceDetailPanelSlideTransition(
+      visible: true,
+      axis: ProvinceDetailPanelSlideAxis.end,
+      child: SizedBox(
+        width: kGameMapWideProvinceSidePanelWidth,
+        child: overlay,
+      ),
+    );
   }
 }

--- a/app/lib/features/game/flame/province_detail_panel_slide_transition.dart
+++ b/app/lib/features/game/flame/province_detail_panel_slide_transition.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+
+/// Slide axis for [ProvinceDetailPanelSlideTransition].
+enum ProvinceDetailPanelSlideAxis {
+  /// Bottom sheet: enters from below (`Offset(0, 1)`).
+  bottom,
+
+  /// Side panel: enters from the right (`Offset(1, 0)`).
+  end,
+}
+
+/// Animated open/close wrapper for province detail panel hosts.
+///
+/// SPEC: `SPEC/ui/province-sea-zone-detail-overlay.md` § Interaction (panel
+/// motion); `SPEC/ui/game-map-narrow-detail-overlay-slot.md` § Open / close
+/// motion. Refs #2865 S8.
+class ProvinceDetailPanelSlideTransition extends StatelessWidget {
+  const ProvinceDetailPanelSlideTransition({
+    required this.visible,
+    required this.axis,
+    required this.child,
+    super.key,
+  });
+
+  /// When `false`, the panel plays the exit slide then unmounts.
+  final bool visible;
+
+  final ProvinceDetailPanelSlideAxis axis;
+
+  /// Panel subtree when [visible] is `true` (overlay + host chrome).
+  final Widget child;
+
+  /// Enter/exit duration for both hosts (SPEC § Panel motion).
+  static const Duration kDuration = Duration(milliseconds: 200);
+
+  static const Key kTransitionHostKey = Key('province_detail_panel_slide');
+
+  Offset _beginOffset() {
+    return switch (axis) {
+      ProvinceDetailPanelSlideAxis.bottom => const Offset(0, 1),
+      ProvinceDetailPanelSlideAxis.end => const Offset(1, 0),
+    };
+  }
+
+  Alignment _stackAlignment() {
+    return switch (axis) {
+      ProvinceDetailPanelSlideAxis.bottom => Alignment.bottomCenter,
+      ProvinceDetailPanelSlideAxis.end => Alignment.centerRight,
+    };
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedSwitcher(
+      key: kTransitionHostKey,
+      duration: kDuration,
+      switchInCurve: Curves.easeOut,
+      switchOutCurve: Curves.easeIn,
+      layoutBuilder: (currentChild, previousChildren) {
+        return Stack(
+          fit: StackFit.passthrough,
+          alignment: _stackAlignment(),
+          children: [
+            ...previousChildren,
+            if (currentChild != null) currentChild,
+          ],
+        );
+      },
+      transitionBuilder: (transitionChild, animation) {
+        final offsetAnimation = Tween<Offset>(
+          begin: _beginOffset(),
+          end: Offset.zero,
+        ).animate(animation);
+        return SlideTransition(
+          position: offsetAnimation,
+          child: transitionChild,
+        );
+      },
+      child: visible
+          ? KeyedSubtree(
+              key: const ValueKey<String>('province_detail_panel_open'),
+              child: child,
+            )
+          : const SizedBox.shrink(
+              key: ValueKey<String>('province_detail_panel_closed'),
+            ),
+    );
+  }
+}

--- a/app/test/province_detail_panel_slide_transition_test.dart
+++ b/app/test/province_detail_panel_slide_transition_test.dart
@@ -1,0 +1,96 @@
+// Pins `ProvinceDetailPanelSlideTransition` (Refs #2865 S8).
+//
+// SPEC: `SPEC/ui/province-sea-zone-detail-overlay.md` § Interaction (panel
+// motion); `SPEC/ui/game-map-narrow-detail-overlay-slot.md` § Open / close
+// motion.
+
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:colonizethis_app/features/game/flame/province_detail_panel_slide_transition.dart';
+
+void main() {
+  suppressLogsForTests();
+
+  group('ProvinceDetailPanelSlideTransition (Refs #2865 S8)', () {
+    testWidgets('mounts AnimatedSwitcher with 200 ms duration', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: ProvinceDetailPanelSlideTransition(
+            visible: true,
+            axis: ProvinceDetailPanelSlideAxis.bottom,
+            child: Text('panel'),
+          ),
+        ),
+      );
+
+      final host = tester.widget<ProvinceDetailPanelSlideTransition>(
+        find.byType(ProvinceDetailPanelSlideTransition),
+      );
+      expect(host.visible, isTrue);
+      expect(host.axis, ProvinceDetailPanelSlideAxis.bottom);
+
+      final switcher = tester.widget<AnimatedSwitcher>(
+        find.byKey(ProvinceDetailPanelSlideTransition.kTransitionHostKey),
+      );
+      expect(switcher.duration, ProvinceDetailPanelSlideTransition.kDuration);
+      expect(switcher.switchInCurve, Curves.easeOut);
+      expect(switcher.switchOutCurve, Curves.easeIn);
+    });
+
+    testWidgets(
+      'visible false keeps outgoing child mounted through first exit frame',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: ProvinceDetailPanelSlideTransition(
+              visible: true,
+              axis: ProvinceDetailPanelSlideAxis.bottom,
+              child: const Text('panel-body'),
+            ),
+          ),
+        );
+        expect(find.text('panel-body'), findsOneWidget);
+
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: ProvinceDetailPanelSlideTransition(
+              visible: false,
+              axis: ProvinceDetailPanelSlideAxis.bottom,
+              child: Text('panel-body'),
+            ),
+          ),
+        );
+        await tester.pump();
+        expect(find.text('panel-body'), findsOneWidget);
+
+        await tester.pump(ProvinceDetailPanelSlideTransition.kDuration);
+      },
+    );
+
+    testWidgets('end axis aligns stack to centerRight', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: ProvinceDetailPanelSlideTransition(
+            visible: true,
+            axis: ProvinceDetailPanelSlideAxis.end,
+            child: SizedBox(width: 40, height: 40),
+          ),
+        ),
+      );
+
+      final stack = tester.widget<Stack>(
+        find.descendant(
+          of: find.byType(ProvinceDetailPanelSlideTransition),
+          matching: find.byType(Stack),
+        ),
+      );
+      expect(stack.alignment, Alignment.centerRight);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Implements **#2865 S8** — slide transitions when the province/sea-zone detail panel opens and closes.

## Done in this push

- **`ProvinceDetailPanelSlideTransition`**: shared `AnimatedSwitcher` + `SlideTransition` host (200 ms, easeOut in / easeIn out).
- **`GameMapNarrowDetailOverlaySlot`**: slides up from bottom (`Offset(0, 1)`).
- **`GameMapProvinceDetailSidePanel`**: slides in from the end (right).
- **SPEC**: `SPEC/ui/province-sea-zone-detail-overlay.md` § Interaction (panel motion); `SPEC/ui/game-map-narrow-detail-overlay-slot.md` § Open / close motion + ACs.
- **Tests**: `app/test/province_detail_panel_slide_transition_test.dart` (3 cases); existing `game_map_narrow_detail_overlay_test.dart` still passes.

## Deferred

- **#2865 S9** Widgetbook story updates for animated host (optional visual review).
- Remaining subtasks S1–S7 on #2865 (most layout/chrome already landed via prior PRs).

## Tests

```bash
cd app && flutter test \
  test/province_detail_panel_slide_transition_test.dart \
  test/game_map_narrow_detail_overlay_test.dart
```

→ 8/8 passed locally.

Refs #2865

Made with [Cursor](https://cursor.com)