### PR TITLE
refactor(app): adopt CtSpacing in new-game leader dialog (#2914)

### DIFF
--- a/app/lib/features/shell/new_game_leader_selection_dialog.dart
+++ b/app/lib/features/shell/new_game_leader_selection_dialog.dart
@@ -13,6 +13,7 @@ import 'package:colonizethis_app/widgets/ct_dialog_shell.dart';
 import 'package:colonizethis_app/widgets/ct_dropdown.dart';
 import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
 import 'package:colonizethis_app/widgets/ct_slider.dart';
+import 'package:colonizethis_app/widgets/ct_spacing.dart';
 import 'package:colonizethis_app/widgets/gp_default_map_color_swatch.dart';
 
 const int _kNumSlots = 6;
@@ -227,24 +228,24 @@ class _NewGameLeaderSelectionDialogState
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           _buildHeader(l10n, styles),
-          const SizedBox(height: 16),
+          const SizedBox(height: CtSpacing.l),
           Column(
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: slotWidgets,
           ),
-          const SizedBox(height: 12),
+          const SizedBox(height: CtSpacing.ml),
           _buildSeedField(theme, l10n, styles),
-          const SizedBox(height: 12),
+          const SizedBox(height: CtSpacing.ml),
           _buildInfiniteModeTile(theme, l10n, styles),
-          const SizedBox(height: 12),
+          const SizedBox(height: CtSpacing.ml),
           _buildTerrainVariationField(
             context,
             l10n,
             fieldLabelStyle: styles.fieldLabel,
             helperStyle: styles.helper,
           ),
-          const SizedBox(height: 16),
+          const SizedBox(height: CtSpacing.l),
           _buildFooterButtons(l10n, context),
         ],
       ),
@@ -284,11 +285,11 @@ class _NewGameLeaderSelectionDialogState
           key: const ValueKey<String>('leaderSelectionDialogTitle'),
           style: styles.title,
         ),
-        const SizedBox(height: 8),
+        const SizedBox(height: CtSpacing.m),
         const CtBrassDivider(
           key: ValueKey<String>('leaderSelectionDialogBrassDivider'),
         ),
-        const SizedBox(height: 12),
+        const SizedBox(height: CtSpacing.ml),
         Text(
           l10n.shell_leaderDialog_intro,
           key: const ValueKey<String>('leaderSelectionDialogIntro'),
@@ -312,7 +313,7 @@ class _NewGameLeaderSelectionDialogState
       mainAxisSize: MainAxisSize.min,
       children: [
         Text(l10n.shell_leaderDialog_seedLabel, style: styles.fieldLabel),
-        const SizedBox(height: 4),
+        const SizedBox(height: CtSpacing.m / 2),
         TextField(
           controller: _seedController,
           keyboardType: TextInputType.number,
@@ -332,7 +333,7 @@ class _NewGameLeaderSelectionDialogState
             ),
           ),
         ),
-        const SizedBox(height: 6),
+        const SizedBox(height: CtSpacing.s),
         Text(l10n.shell_leaderDialog_seedHelper, style: styles.helper),
       ],
     );
@@ -374,7 +375,7 @@ class _NewGameLeaderSelectionDialogState
           onPressed: widget.onCancel,
           child: Text(l10n.common_cancel),
         ),
-        const SizedBox(width: 8),
+        const SizedBox(width: CtSpacing.m),
         CtNinePatchButton(
           onPressed: _startEnabled ? () => _handleStartPressed(context) : null,
           enabled: _startEnabled,
@@ -413,7 +414,7 @@ class _NewGameLeaderSelectionDialogState
           l10n.shell_leaderDialog_terrainVariationLabel(percent),
           style: fieldLabelStyle,
         ),
-        const SizedBox(height: 6),
+        const SizedBox(height: CtSpacing.s),
         CtSlider(
           value: _terrainVariation,
           min: 0.0,
@@ -423,7 +424,7 @@ class _NewGameLeaderSelectionDialogState
             setState(() => _terrainVariation = value);
           },
         ),
-        const SizedBox(height: 6),
+        const SizedBox(height: CtSpacing.s),
         Text(
           l10n.shell_leaderDialog_terrainVariationHelper,
           style: helperStyle,
@@ -506,7 +507,7 @@ class _NewGameLeaderSelectionDialogState
     );
 
     return Padding(
-      padding: const EdgeInsets.only(bottom: 12),
+      padding: const EdgeInsets.only(bottom: CtSpacing.ml),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         mainAxisSize: MainAxisSize.min,
@@ -520,7 +521,7 @@ class _NewGameLeaderSelectionDialogState
               fontWeight: slotIndex == 0 ? FontWeight.w600 : FontWeight.normal,
             ),
           ),
-          const SizedBox(height: 4),
+          const SizedBox(height: CtSpacing.m / 2),
           _SlotPickersBody(
             nationDropdown: nationDropdown,
             leaderDropdown: leaderDropdown,
@@ -564,9 +565,9 @@ class _SlotPickersBody extends StatelessWidget {
   final Widget leaderDropdown;
 
   /// Vertical gap between the nation dropdown and the leader dropdown when
-  /// the slot body is stacked (matches the existing `SizedBox(height: 4)`
-  /// gap between the slot label and pickers).
-  static const double stackedGap = 4;
+  /// the slot body is stacked (matches the slot label ↔ pickers gap of
+  /// `CtSpacing.m / 2` = 4 dp).
+  static const double stackedGap = CtSpacing.m / 2;
 
   /// Key applied to the vertically stacked `Column` body (narrow viewport).
   /// Tests pin the narrow-stacking AC by asserting one such column per slot.
@@ -601,7 +602,7 @@ class _SlotPickersBody extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.center,
       children: [
         Expanded(child: nationDropdown),
-        const SizedBox(width: 8),
+        const SizedBox(width: CtSpacing.m),
         Expanded(child: leaderDropdown),
       ],
     );

--- a/app/test/new_game_leader_dialog_ct_spacing_pin_test.dart
+++ b/app/test/new_game_leader_dialog_ct_spacing_pin_test.dart
@@ -1,0 +1,66 @@
+// Pins CtSpacing adoption for the New Game leader-selection dialog padding
+// (Refs #2914 S5).
+//
+// SPEC: SPEC/ui/pixel-art-ui-catalog.md § Spacing tokens — the shell new-game
+// leader-selection dialog (DLG10001) block gaps, header band, seed/terrain
+// fields, footer button gap, slot rows, and the narrow/wide slot pickers body
+// use the canonical scale (`l` = 16, `ml` = 12, `m` = 8, `s` = 6, `m/2` = 4)
+// instead of raw magic-number `SizedBox` / `EdgeInsets.only` literals.
+
+import 'dart:io';
+
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  suppressLogsForTests();
+
+  const path = 'lib/features/shell/new_game_leader_selection_dialog.dart';
+
+  group('New game leader dialog CtSpacing pins (Refs #2914)', () {
+    test('imports the CtSpacing token scale', () {
+      final source = File(path).readAsStringSync();
+      expect(
+        source,
+        contains("import 'package:colonizethis_app/widgets/ct_spacing.dart';"),
+      );
+    });
+
+    test('dialog body block gaps use CtSpacing tokens', () {
+      final source = File(path).readAsStringSync();
+      expect(source, contains('const SizedBox(height: CtSpacing.l)'));
+      expect(source, contains('const SizedBox(height: CtSpacing.ml)'));
+      // No raw magic-number vertical gaps remain in the body column.
+      expect(source, isNot(contains('SizedBox(height: 16)')));
+      expect(source, isNot(contains('SizedBox(height: 12)')));
+    });
+
+    test('header, seed, and terrain field gaps use CtSpacing tokens', () {
+      final source = File(path).readAsStringSync();
+      expect(source, contains('const SizedBox(height: CtSpacing.m)'));
+      expect(source, contains('const SizedBox(height: CtSpacing.s)'));
+      expect(source, contains('const SizedBox(height: CtSpacing.m / 2)'));
+      expect(source, isNot(contains('SizedBox(height: 8)')));
+      expect(source, isNot(contains('SizedBox(height: 6)')));
+      expect(source, isNot(contains('SizedBox(height: 4)')));
+    });
+
+    test('footer + slot picker horizontal gaps use CtSpacing.m', () {
+      final source = File(path).readAsStringSync();
+      expect(source, contains('const SizedBox(width: CtSpacing.m)'));
+      expect(source, isNot(contains('SizedBox(width: 8)')));
+    });
+
+    test('slot row bottom inset uses CtSpacing.ml', () {
+      final source = File(path).readAsStringSync();
+      expect(source, contains('EdgeInsets.only(bottom: CtSpacing.ml)'));
+      expect(source, isNot(contains('EdgeInsets.only(bottom: 12)')));
+    });
+
+    test('stacked slot picker gap derives from CtSpacing scale', () {
+      final source = File(path).readAsStringSync();
+      expect(source, contains('static const double stackedGap = CtSpacing.m / 2;'));
+      expect(source, isNot(contains('static const double stackedGap = 4;')));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Advances **#2914 S5** (centralized spacing-token adoption) by migrating the
shell **New Game leader-selection dialog** (`DLG10001`,
`app/lib/features/shell/new_game_leader_selection_dialog.dart`) from
magic-number `SizedBox` / `EdgeInsets.only` spacing literals to the canonical
`CtSpacing` tokens, mirroring the established adoption pattern from the
recently-merged province-overlay-chrome slice (#3206).

Token mapping (values unchanged → rendered layout is byte-identical):

| Literal | Token |
|---------|-------|
| 16 | `CtSpacing.l` |
| 12 | `CtSpacing.ml` |
| 8  | `CtSpacing.m` |
| 6  | `CtSpacing.s` |
| 4  | `CtSpacing.m / 2` |

`stackedGap` now derives from `CtSpacing.m / 2` as well. The intentionally
non-tokenized values (border widths, dialog `maxWidth`/`maxHeight`, slider
divisions) are left untouched per `SPEC/ui/pixel-art-ui-catalog.md` § Spacing
tokens (the scale deliberately skips arbitrary per-component dimensions).

## Done in this push

- `new_game_leader_selection_dialog.dart`: all body/header/field/footer/slot
  spacing literals routed through `CtSpacing`; `ct_spacing.dart` import added.
- New source-pin test `new_game_leader_dialog_ct_spacing_pin_test.dart`
  (positive: tokens present; negative: raw literals absent).

## Scope / deferred

- Single-file S5 adoption slice. Other `#2914` steps (remaining S5/S6 files,
  S7/S8 in other areas) are out of scope for this PR and continue on their own
  slices. No SPEC change needed — the spacing tokens are already specified and
  the `CtSpacing` constants already exist.

## Tests

- `flutter analyze` (edited file + new test): no issues.
- `flutter test test/new_game_leader_dialog_ct_spacing_pin_test.dart test/new_game_leader_selection_dialog_test.dart`: **31/31 passed** (6 new pin tests + 25 existing widget tests).

Refs #2914

Made with [Cursor](https://cursor.com)