### PR TITLE
fix(ai): release lock-recovery seller food surplus to close gp6 Path F (#2924)

### DIFF
--- a/SPEC/ai/treasury-planner.md
+++ b/SPEC/ai/treasury-planner.md
@@ -224,6 +224,68 @@ When every Great Power is below `treasuryAffluenceThreshold()` but at least one 
 
 ---
 
+## Lock-recovery seller food-surplus release (Refs #2924 F17)
+
+F17 closes the seed-42 **gp6** Path F gap where a below-quota zero-NW
+lock-recovery seller leaves its trade cargo idle for lack of offered food.
+The per-turn seller credit a broke GP can earn is bounded by how much of the
+liquidity-food commodity it ships into the net-positive minor/tribe auto-bid
+pool (F15: amplified `2×` notional plus
+`kLockRecoverySellerBonusPerLiquidityDeal`). On seed 42 the recovering GPs
+(`gp3`, `gp5`) hoard large grain stockpiles and saturate their cargo every
+turn, while `gp6` keeps only a small grain stockpile (~42) that rarely clears
+the default `2×` food safety reserve (`24` units), so it emits grain offers on
+only ~14 of 100 turns, never approaches its ~21-hold cargo ceiling, and its
+cumulative seller credit (~913) stays far below
+`cheapestRegimentBuildTreasuryCost()`.
+
+### Food safety buffer for lock-recovery sellers
+
+The F1–F5 surplus formula (§ Surplus / need maps) uses
+`safety = 2 × consumption` for food and `1 × consumption` for other
+categories. When the GP is a **below-quota zero-NW lock-recovery seller**
+(`_isBelowQuotaZeroNwLockRecoverySeller`: `oldWorldProvincesOwned >= 2`,
+`isBelowObserverConquestQuota(ow)`, and `newWorldProvincesOwned == 0`), the
+food safety buffer is **`0`**, so the food reserve collapses to
+`consumption + inputs` — one consumption cycle. The seller therefore offers
+all food beyond a single-cycle reserve, maximising the cargo it ships into the
+F15 minor/tribe liquidity instead of stranding surplus behind the precautionary
+buffer. Non-food safety buffers are unchanged, and the change applies only to
+lock-recovery sellers; every other GP keeps the `2×` food buffer. This is a
+sell-side throughput change only — no affordability rule is bypassed, and
+buyers/minors still debit per filled unit.
+
+### Determinism and budget
+
+The seller predicate and the buffer selection are pure functions of `game`,
+`playerId`, the `Stockpile`, and the static catalogs; identical inputs yield
+identical surplus maps. No hot-path logging is added; the per-turn cost is the
+existing `O(tracked commodities)` surplus pass.
+
+### Acceptance criteria (F17)
+
+- Given an AI Great Power that is a below-quota zero-NW lock-recovery seller
+  (`oldWorldProvincesOwned` in `[2, kObserverConquestMinOwProvincesPerGp)`,
+  `newWorldProvincesOwned == 0`) with `treasury == 0` and a grain stockpile of
+  `kShortageThreshold + 8` (`16`) and no production assignments, when
+  `runTreasuryPlanner` runs, then it emits at least one `TradeOrderType.offer`
+  for grain at `priority == kTreasuryOfferPriorityUrgent` (the `0` food safety
+  buffer yields a positive surplus of `8`).
+- Given an otherwise identical AI Great Power that is **not** a lock-recovery
+  seller (`oldWorldProvincesOwned == 1`) with the same `16`-unit grain
+  stockpile and `treasury == 0`, when `runTreasuryPlanner` runs, then it emits
+  **no** grain offer (the default `2×` food safety reserve of `24` exceeds the
+  stockpile, so surplus is non-positive — negative control).
+- Given a below-quota zero-NW lock-recovery seller with a non-food surplus
+  (e.g. `timber`) and the same fixture, when `runTreasuryPlanner` runs, then
+  the timber surplus is computed with the unchanged `1×` (non-food) safety
+  buffer (F17 only relaxes the food buffer).
+- Given identical inputs, when `runTreasuryPlanner` runs twice on the
+  lock-recovery seller path, then both runs return identical `List<TradeOrder>`
+  outputs (determinism).
+
+---
+
 ## Treasury-budget-aware bid sizing (Refs #3122)
 
 After the world-market matcher began clamping bid fills to per-buyer

--- a/packages/colonizethis_ai/lib/src/planning/treasury_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/treasury_planner.dart
@@ -115,6 +115,19 @@ List<TradeOrder> runTreasuryPlanner({
   final threshold = cheapestRegimentBuildTreasuryCost();
   final brokeForLockRecovery = rawTreasury < threshold;
 
+  // Refs #2924 F17: a below-quota zero-NW lock-recovery seller releases its
+  // food surplus aggressively so its trade cargo is spent selling the
+  // liquidity-food commodity into the net-positive minor/tribe auto-bid pool
+  // (F15) instead of being left idle behind a 2x food safety buffer. On seed
+  // 42 gp6 keeps only ~42 grain and rarely clears the 2x reserve (24), so it
+  // emits offers on ~14 of 100 turns and never accumulates enough seller
+  // credit to cross the regiment threshold, while gp5 — which hoards grain —
+  // recovers. Dropping the safety buffer (keeping one consumption-cycle
+  // reserve) lets the seller offer down to that floor each turn.
+  // SPEC/ai/treasury-planner.md § Lock-recovery seller food-surplus release.
+  final isLockRecoverySeller =
+      _isBelowQuotaZeroNwLockRecoverySeller(game: game, playerId: playerId);
+
   for (final id in trackedCommodityIds) {
     if (richesCommodityIds.contains(id)) continue;
     final commodity = CommodityCatalog.byId[id];
@@ -126,7 +139,7 @@ List<TradeOrder> runTreasuryPlanner({
     );
     final inputs = inputNeeds[id] ?? 0;
     final safety = commodity.category == CommodityCategory.food
-        ? consumption * 2
+        ? (isLockRecoverySeller ? 0 : consumption * 2)
         : consumption;
     final reserve = consumption + inputs + safety;
     final projectedQty = projected.quantityOf(id);
@@ -194,7 +207,7 @@ List<TradeOrder> runTreasuryPlanner({
   if (treasury >= treasuryAffluenceThreshold() &&
       !isLiquidityBuyer &&
       !isAffluentDesignatedBuyer &&
-      !_isBelowQuotaZeroNwLockRecoverySeller(game: game, playerId: playerId)) {
+      !isLockRecoverySeller) {
     _addSpeculativeBidNeeds(
       need: need,
       available: available,
@@ -228,8 +241,7 @@ List<TradeOrder> runTreasuryPlanner({
       // consumed by fabric/bronze deficits that cannot match urgent grain offers.
       need.removeWhere((id, _) => id != liquidity);
     }
-  } else if (lockRecoveryUrgent ||
-      _isBelowQuotaZeroNwLockRecoverySeller(game: game, playerId: playerId)) {
+  } else if (lockRecoveryUrgent || isLockRecoverySeller) {
     need.clear();
   }
 

--- a/packages/colonizethis_ai/test/planning/treasury_planner_test.dart
+++ b/packages/colonizethis_ai/test/planning/treasury_planner_test.dart
@@ -51,6 +51,44 @@ Game _gameWithStockpile({
   );
 }
 
+/// Builds a single-GP game where `gp1` is a below-quota zero-NW lock-recovery
+/// seller (`oldWorldProvincesOwned == owProvinces` in `[2, 10)`, no NW
+/// provinces) for the F17 food-surplus-release tests (Refs #2924).
+Game _lockRecoverySellerGame({
+  required Stockpile stockpile,
+  required int treasury,
+  int owProvinces = 3,
+}) {
+  const ow = 'oldWorld';
+  return Game(
+    id: 'g-lock-recovery-seller-f17',
+    worldState: WorldState(
+      turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 5),
+      oldWorld: RegionData(
+        provinces: [
+          for (var i = 0; i < owProvinces; i++)
+            Province(id: '$ow|p1_$i', regionId: ow, ownerId: 'gp1'),
+        ],
+      ),
+      newWorld: const RegionData(),
+    ),
+    players: [
+      Player(
+        id: 'gp1',
+        displayName: 'GP1',
+        isHuman: false,
+        capitalProvinceId: '$ow|p1_0',
+        stockpile: stockpile,
+        treasury: treasury,
+      ),
+    ],
+    worldMarketState: WorldMarketState.withDefaultPrices(const {
+      'grain': 10,
+      'timber': 20,
+    }),
+  );
+}
+
 void main() {
   group('runTreasuryPlanner (Refs #2994)', () {
     test(
@@ -538,6 +576,108 @@ void main() {
         stockpile: stockpile,
         productionAssignments: const [],
         treasury: 10,
+      );
+      expect(a, b);
+    });
+  });
+
+  group('lock-recovery seller food-surplus release (Refs #2924 F17)', () {
+    test(
+      'below-quota zero-NW seller releases food above one consumption cycle',
+      () {
+        // grain reserve for the seller is consumption (8) with the 2x safety
+        // buffer dropped, so grain 16 yields surplus 8 -> an urgent offer.
+        final stockpile = const Stockpile().applyDelta('grain', 16);
+        final game = _lockRecoverySellerGame(stockpile: stockpile, treasury: 0);
+        final orders = runTreasuryPlanner(
+          game: game,
+          playerId: 'gp1',
+          stockpile: stockpile,
+          productionAssignments: const [],
+          treasury: 0,
+        );
+        final grainOffers = orders
+            .where(
+              (o) => o.type == TradeOrderType.offer && o.commodityId == 'grain',
+            )
+            .toList();
+        expect(
+          grainOffers,
+          isNotEmpty,
+          reason: 'F17: a broke lock-recovery seller drops the 2x food safety '
+              'buffer so grain above one consumption cycle is offered.',
+        );
+        expect(grainOffers.first.priority, kTreasuryOfferPriorityUrgent);
+        expect(grainOffers.first.quantity, greaterThan(0));
+      },
+    );
+
+    test(
+      'seller food reserve floor equals one consumption cycle (no offer at 8)',
+      () {
+        // grain 8 == consumption: surplus 0, so no offer. This pins the food
+        // reserve at exactly `consumption` (safety buffer == 0) for sellers,
+        // distinguishing F17 from the 1x (reserve 16) and 2x (reserve 24)
+        // buffers.
+        final stockpile = const Stockpile().applyDelta('grain', 8);
+        final game = _lockRecoverySellerGame(stockpile: stockpile, treasury: 0);
+        final orders = runTreasuryPlanner(
+          game: game,
+          playerId: 'gp1',
+          stockpile: stockpile,
+          productionAssignments: const [],
+          treasury: 0,
+        );
+        expect(
+          orders.where(
+            (o) => o.type == TradeOrderType.offer && o.commodityId == 'grain',
+          ),
+          isEmpty,
+        );
+      },
+    );
+
+    test(
+      'non-seller GP keeps the 2x food safety buffer (negative control)',
+      () {
+        // gp1 owns a single OW province -> not a lock-recovery seller. grain 16
+        // is below the 2x reserve (24), so no offer is emitted.
+        final stockpile = const Stockpile().applyDelta('grain', 16);
+        final game = _gameWithStockpile(stockpile: stockpile, treasury: 0);
+        final orders = runTreasuryPlanner(
+          game: game,
+          playerId: 'gp1',
+          stockpile: stockpile,
+          productionAssignments: const [],
+          treasury: 0,
+        );
+        expect(
+          orders.where(
+            (o) => o.type == TradeOrderType.offer && o.commodityId == 'grain',
+          ),
+          isEmpty,
+          reason: 'A non-seller GP retains the 2x food safety buffer, so grain '
+              '16 < reserve 24 yields no surplus offer.',
+        );
+      },
+    );
+
+    test('seller food-release path is deterministic', () {
+      final stockpile = const Stockpile().applyDelta('grain', 20);
+      final game = _lockRecoverySellerGame(stockpile: stockpile, treasury: 0);
+      final a = runTreasuryPlanner(
+        game: game,
+        playerId: 'gp1',
+        stockpile: stockpile,
+        productionAssignments: const [],
+        treasury: 0,
+      );
+      final b = runTreasuryPlanner(
+        game: game,
+        playerId: 'gp1',
+        stockpile: stockpile,
+        productionAssignments: const [],
+        treasury: 0,
       );
       expect(a, b);
     });


### PR DESCRIPTION
## Summary

Closes the remaining **gp6** Path F gap deferred by the merged PR #3216 (squashed into `dev`). A **below-quota zero-NW lock-recovery seller** (`_isBelowQuotaZeroNwLockRecoverySeller`: `oldWorldProvincesOwned >= 2`, below the observer conquest quota, zero NW provinces) now drops its `2×` food **safety buffer**, keeping only a one-cycle consumption reserve. The seller therefore offers its food surplus into the net-positive minor/tribe auto-bid liquidity (F15: `2×` notional + seller bonus) instead of stranding it behind the precautionary buffer.

This is a **sell-side throughput** change only — no affordability rule is bypassed; buyers/minors still debit per filled unit.

## Root cause (from the per-turn diagnostic)

On seed 42, recovering GPs (gp3/gp5) hoard large grain stockpiles and saturate their trade cargo every turn. gp6 keeps only ~42 grain, which rarely clears the default `2×` food reserve (`24`), so it emitted grain offers on only ~14 of 100 turns and left its ~21-hold cargo idle — never accumulating enough seller credit to cross `cheapestRegimentBuildTreasuryCost()`.

## Verified result (seed-42, 100 turns)

| metric | before | after |
|---|---|---|
| gp6 offers emitted | 14 | **69** |
| gp6 seller deals | 12 | **45** |
| gp6 lifetime seller credit | 913 | **6258** |
| gp6 final treasury | **-424** | **2095** |

`seed42_observer_world_market_lock_recovery_regression_test.dart --run-skipped` now **passes**: gp3, gp4, gp5, **and gp6** each fall below the threshold, receive positive market credits, recover above `cheapestRegimentBuildTreasuryCost()`, and emit a regiment build when affordable.

## SPEC

- `SPEC/ai/treasury-planner.md` § **Lock-recovery seller food-surplus release (Refs #2924 F17)** — new section + four Given/When/Then ACs (positive, reserve-floor boundary, non-seller negative control, determinism).

## Implementation

- `treasury_planner.dart`: compute `isLockRecoverySeller` once; food `safety = isLockRecoverySeller ? 0 : consumption * 2`. Hoisted two existing inline `_isBelowQuotaZeroNwLockRecoverySeller` calls to reuse the flag.

## Tests

- `treasury_planner_test.dart`: new `F17` group — seller releases food above one cycle (urgent offer), reserve floor == one consumption cycle (no offer at 8), non-seller keeps `2×` buffer (negative control), determinism.
- Commands run (all green): `treasury_planner_test.dart` (16), full `test/planning/` (1257), `seed42_observer_world_market_lock_recovery_regression_test.dart --run-skipped`, logic affordability/no-bypass + minor-bid guards.

Refs #2924

Made with [Cursor](https://cursor.com)