### PR TITLE
refactor(app): adopt CtSpacing for SizedBox gaps in dialogue overlays (#2914)

### DIFF
--- a/SPEC/ui/pixel-art-ui-catalog.md
+++ b/SPEC/ui/pixel-art-ui-catalog.md
@@ -304,6 +304,13 @@ theme. Values are derived from observed `app/lib/widgets/**` and
 review (issues #2914 S5 / S6) can adopt them in Ct-\* widget defaults and
 feature padding/radius callsites without re-deriving the scale per file.
 
+The spacing-token adoption surface is every callsite that embeds a raw
+spacing magnitude from the scale, not only `EdgeInsets.all` / `symmetric`:
+it also covers `EdgeInsets.only` / `EdgeInsets.fromLTRB` insets and
+`SizedBox(height:)` / `SizedBox(width:)` gap dimensions (a `SizedBox`
+spacer of `12` logical px adopts `CtSpacing.ml`, etc.). Out-of-scale
+magnitudes (`4`, `10`, `14`) remain explicit per-component overrides.
+
 ### Spacing tokens
 
 The Dart implementation lands as `CtSpacing` constants in

--- a/app/lib/features/game/dialogue/call_to_arms_dialogue_overlay.dart
+++ b/app/lib/features/game/dialogue/call_to_arms_dialogue_overlay.dart
@@ -103,11 +103,11 @@ class _CallToArmsDialogueOverlayState extends State<CallToArmsDialogueOverlay> {
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           Text(l10n.game_callToArms_title, style: titleStyle),
-          const SizedBox(height: 8),
+          const SizedBox(height: CtSpacing.m),
           Text(l10n.game_callToArms_intro, style: introStyle),
-          const SizedBox(height: 12),
+          const SizedBox(height: CtSpacing.ml),
           const CtBrassDivider(),
-          const SizedBox(height: 12),
+          const SizedBox(height: CtSpacing.ml),
           ListView.builder(
             shrinkWrap: true,
             physics: const NeverScrollableScrollPhysics(),
@@ -130,7 +130,7 @@ class _CallToArmsDialogueOverlayState extends State<CallToArmsDialogueOverlay> {
               );
             },
           ),
-          const SizedBox(height: 8),
+          const SizedBox(height: CtSpacing.m),
           Align(
             alignment: Alignment.centerRight,
             child: CtNinePatchButton(
@@ -211,7 +211,7 @@ class _CallToArmsCallRow extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: <Widget>[
           _buildPrompt(theme),
-          const SizedBox(height: 8),
+          const SizedBox(height: CtSpacing.m),
           _buildDecisionRow(theme),
         ],
       ),
@@ -328,7 +328,7 @@ class _LabeledToggle extends StatelessWidget {
             onGlowColor: onGlowColor,
             onChanged: onChanged,
           ),
-          const SizedBox(width: 6),
+          const SizedBox(width: CtSpacing.s),
           Text(label, style: labelStyle),
         ],
       ),

--- a/app/lib/features/game/dialogue/game_start_intro_overlay.dart
+++ b/app/lib/features/game/dialogue/game_start_intro_overlay.dart
@@ -139,7 +139,7 @@ class _GameStartIntroOverlayState extends State<GameStartIntroOverlay> {
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
             _IntroTitle(text: l10n.gameStartIntroOverlay_title),
-            const SizedBox(height: 12),
+            const SizedBox(height: CtSpacing.ml),
             const CtBrassDivider(),
             const SizedBox(height: 14),
             Text(
@@ -149,7 +149,7 @@ class _GameStartIntroOverlayState extends State<GameStartIntroOverlay> {
               ),
               textAlign: TextAlign.center,
             ),
-            const SizedBox(height: 16),
+            const SizedBox(height: CtSpacing.l),
             Align(
               alignment: Alignment.center,
               child: CtNinePatchButton(
@@ -193,7 +193,7 @@ class _GameStartIntroOverlayState extends State<GameStartIntroOverlay> {
               ),
               textAlign: TextAlign.center,
             ),
-            const SizedBox(height: 16),
+            const SizedBox(height: CtSpacing.l),
             Align(
               alignment: Alignment.center,
               child: CtNinePatchButton(
@@ -229,7 +229,7 @@ class _GameStartIntroOverlayState extends State<GameStartIntroOverlay> {
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           _IntroTitle(text: l10n.gameStartIntroOverlay_title),
-          const SizedBox(height: 12),
+          const SizedBox(height: CtSpacing.ml),
           const CtBrassDivider(),
           const SizedBox(height: 14),
           body,

--- a/app/lib/features/game/dialogue/intervention_dialogue_overlay.dart
+++ b/app/lib/features/game/dialogue/intervention_dialogue_overlay.dart
@@ -239,12 +239,12 @@ class _InterventionDialogueOverlayState
             l10n.game_intervention_loadError(_loadError.toString()),
             style: Theme.of(context).textTheme.bodyMedium,
           ),
-          const SizedBox(height: 16),
+          const SizedBox(height: CtSpacing.l),
           Text(
             l10n.game_intervention_degradedHint,
             style: Theme.of(context).textTheme.bodySmall,
           ),
-          const SizedBox(height: 16),
+          const SizedBox(height: CtSpacing.l),
           Align(
             alignment: Alignment.centerRight,
             child: CtNinePatchButton(
@@ -280,7 +280,7 @@ class _InterventionDialogueOverlayState
         bodyChildren: [
           if (line != null) ...[
             Text(line.text, style: Theme.of(context).textTheme.bodyLarge),
-            const SizedBox(height: 16),
+            const SizedBox(height: CtSpacing.l),
             Align(
               alignment: Alignment.centerRight,
               child: CtNinePatchButton(
@@ -317,7 +317,7 @@ class _InterventionDialogueOverlayState
             ),
             style: Theme.of(context).textTheme.titleSmall,
           ),
-          const SizedBox(height: 12),
+          const SizedBox(height: CtSpacing.ml),
           Text(
             l10n.game_intervention_situation(
               _factionDisplayName(widget.game, prompt.aggressorGpId),
@@ -329,7 +329,7 @@ class _InterventionDialogueOverlayState
             ),
             style: Theme.of(context).textTheme.bodyMedium,
           ),
-          const SizedBox(height: 16),
+          const SizedBox(height: CtSpacing.l),
           InterventionChoiceButtons(onPick: _pick),
         ],
       );

--- a/app/lib/features/game/dialogue/overture_dialogue_overlay.dart
+++ b/app/lib/features/game/dialogue/overture_dialogue_overlay.dart
@@ -186,7 +186,7 @@ class _OvertureDialogueOverlayState extends State<OvertureDialogueOverlay> {
           mainAxisSize: MainAxisSize.min,
           children: [
             Text(l10n.game_overture_loadError('$_loadError')),
-            const SizedBox(height: 16),
+            const SizedBox(height: CtSpacing.l),
             CtNinePatchButton(
               onPressed: _submitErrorFallback,
               child: Text(l10n.game_intervention_continue),
@@ -207,7 +207,7 @@ class _OvertureDialogueOverlayState extends State<OvertureDialogueOverlay> {
           children: [
             if (line != null) ...[
               Text(line.text, style: Theme.of(context).textTheme.bodyLarge),
-              const SizedBox(height: 16),
+              const SizedBox(height: CtSpacing.l),
               Align(
                 alignment: Alignment.centerRight,
                 child: CtNinePatchButton(
@@ -259,7 +259,7 @@ class _OvertureDialogueOverlayState extends State<OvertureDialogueOverlay> {
             key: const ValueKey<String>('overtureIntro'),
             style: introStyle,
           ),
-          const SizedBox(height: 16),
+          const SizedBox(height: CtSpacing.l),
           ListView.builder(
             shrinkWrap: true,
             physics: const NeverScrollableScrollPhysics(),
@@ -280,7 +280,7 @@ class _OvertureDialogueOverlayState extends State<OvertureDialogueOverlay> {
               );
             },
           ),
-          const SizedBox(height: 8),
+          const SizedBox(height: CtSpacing.m),
           Align(
             alignment: Alignment.centerRight,
             child: CtNinePatchButton(
@@ -380,7 +380,7 @@ class _OvertureOfferRow extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           _buildLabelsRow(Theme.of(context)),
-          const SizedBox(height: 8),
+          const SizedBox(height: CtSpacing.m),
           _buildDecisionRow(Theme.of(context)),
         ],
       ),
@@ -506,7 +506,7 @@ class _LabeledToggle extends StatelessWidget {
             onGlowColor: onGlowColor,
             onChanged: onChanged,
           ),
-          const SizedBox(width: 6),
+          const SizedBox(width: CtSpacing.s),
           Text(label, style: labelStyle),
         ],
       ),

--- a/app/test/ct_spacing_features_adoption_test.dart
+++ b/app/test/ct_spacing_features_adoption_test.dart
@@ -253,7 +253,113 @@ void main() {
       });
     }
   });
+
+  group('CtSpacing SizedBox gap adoption (Refs #2914 S5 follow-up)', () {
+    // Visible-layout-preserving guard: a `SizedBox(height: N)` /
+    // `SizedBox(width: N)` spacer migrates to `SizedBox(height:
+    // CtSpacing.<token>)` only when `N` equals the token's logical px, so
+    // the physical gap is unchanged. This pins the contract at the slice
+    // boundary (matching the `EdgeInsets.all` guard above).
+    test('CtSpacing tokens preserve the migrated SizedBox gap sizes', () {
+      expect(CtSpacing.xs, 2);
+      expect(CtSpacing.s, 6);
+      expect(CtSpacing.m, 8);
+      expect(CtSpacing.ml, 12);
+      expect(CtSpacing.l, 16);
+      expect(CtSpacing.xl, 20);
+      expect(CtSpacing.xxl, 24);
+    });
+
+    test(
+      'the SizedBox gap detector flags raw token literals but not '
+      'migrated or out-of-scale forms',
+      () {
+        final rawGap = RegExp(
+          r'SizedBox\(\s*(?:height|width):\s*'
+          r'(?:2|6|8|12|16|20|24)(?:\.0)?\s*\)',
+        );
+        // Positive: every in-scale token literal is detected.
+        expect(rawGap.hasMatch('const SizedBox(height: 12)'), isTrue);
+        expect(rawGap.hasMatch('const SizedBox(width: 6)'), isTrue);
+        expect(rawGap.hasMatch('SizedBox(height: 16.0)'), isTrue);
+        // Negative: migrated token references are not flagged.
+        expect(
+          rawGap.hasMatch('const SizedBox(height: CtSpacing.ml)'),
+          isFalse,
+        );
+        // Negative: out-of-scale magnitudes remain legitimate overrides.
+        expect(rawGap.hasMatch('const SizedBox(height: 4)'), isFalse);
+        expect(rawGap.hasMatch('const SizedBox(width: 10)'), isFalse);
+        expect(rawGap.hasMatch('const SizedBox(height: 14)'), isFalse);
+      },
+    );
+
+    for (final relPath in _sizedBoxMigratedFiles) {
+      test(
+        '$relPath has no raw SizedBox(height|width: N) for N in the '
+        'migrated token set ({2, 6, 8, 12, 16, 20, 24})',
+        () {
+          final file = File(relPath);
+          expect(
+            file.existsSync(),
+            isTrue,
+            reason:
+                'SizedBox-migrated feature file $relPath must exist; test '
+                'was launched from ${Directory.current.path}.',
+          );
+          // Single-dimension `SizedBox(height: N)` / `SizedBox(width: N)`
+          // gap spacers. Out-of-scale literals (`4`, `10`, `14`) are
+          // intentionally NOT matched per `SPEC/ui/pixel-art-ui-catalog.md`
+          // § Spacing tokens (they remain per-component overrides). Comment
+          // lines are ignored so dartdoc can name the banned forms.
+          final rawGap = RegExp(
+            r'SizedBox\(\s*(?:height|width):\s*'
+            r'(?:2|6|8|12|16|20|24)(?:\.0)?\s*\)',
+          );
+          final lines = file.readAsStringSync().split('\n');
+          final bad = <String>[];
+          for (var i = 0; i < lines.length; i++) {
+            final raw = lines[i];
+            if (raw.trimLeft().startsWith('//')) continue;
+            if (rawGap.hasMatch(raw)) {
+              bad.add('  L${i + 1}: ${raw.trim()}');
+            }
+          }
+          expect(
+            bad,
+            isEmpty,
+            reason:
+                'Found ${bad.length} raw `SizedBox(height|width: N)` gap'
+                '${bad.length == 1 ? '' : 's'} in $relPath for '
+                'N ∈ {2, 6, 8, 12, 16, 20, 24}:\n'
+                '${bad.join('\n')}\n'
+                'Replace each token-set literal with `CtSpacing.<token>`: '
+                '2 → CtSpacing.xs, 6 → CtSpacing.s, 8 → CtSpacing.m, '
+                '12 → CtSpacing.ml, 16 → CtSpacing.l, 20 → CtSpacing.xl, '
+                '24 → CtSpacing.xxl. Out-of-scale literals (e.g. `4`, '
+                '`10`, `14`) may remain per SPEC § Spacing tokens.',
+          );
+        },
+      );
+    }
+  });
 }
+
+/// Dialogue-overlay feature files migrated to `CtSpacing` for
+/// single-dimension `SizedBox(height|width: N)` gap spacers in the Refs
+/// #2914 S5 follow-up slice (extends the `EdgeInsets.all` / `symmetric`
+/// adoption above to the `SizedBox` gap surface named in
+/// `SPEC/ui/pixel-art-ui-catalog.md` § Spacing tokens and
+/// `app/lib/widgets/ct_spacing.dart`). Each file already appears in
+/// `_migratedFeatureFiles`, so the `ct_spacing.dart` import and
+/// `CtSpacing.<token>` reference invariants are covered there; this list
+/// adds only the no-raw-`SizedBox`-token-gap invariant.
+const List<String> _sizedBoxMigratedFiles = <String>[
+  'lib/features/game/dialogue/game_start_intro_overlay.dart',
+  'lib/features/game/dialogue/intervention_dialogue_overlay.dart',
+  'lib/features/game/dialogue/overture_dialogue_overlay.dart',
+  'lib/features/game/dialogue/call_to_arms_dialogue_overlay.dart',
+];
 
 /// Feature files migrated to `CtSpacing` for `EdgeInsets.all(N)` and
 /// `EdgeInsets.symmetric(horizontal|vertical: N)` callsites in the Refs


### PR DESCRIPTION
## Summary

Advances **#2914 S5** (CtSpacing adoption) by extending the spacing-token surface to single-dimension `SizedBox(height|width: N)` gap spacers in the four dialogue overlays, which already adopt `CtSpacing` for `EdgeInsets.all` / `symmetric` / `only`.

Files migrated (all under `app/lib/features/game/dialogue/`):
- `game_start_intro_overlay.dart`
- `intervention_dialogue_overlay.dart`
- `overture_dialogue_overlay.dart`
- `call_to_arms_dialogue_overlay.dart`

Raw token literals (`2/6/8/12/16/20/24`) → `CtSpacing.{xs,s,m,ml,l,xl,xxl}`. Out-of-scale magnitudes (`4/10/14`) are intentionally left as per-component overrides per `SPEC/ui/pixel-art-ui-catalog.md` § Spacing tokens. The substitutions are **behaviour-preserving** — each token equals its prior literal px value (pinned by a guard test).

## SPEC

- `SPEC/ui/pixel-art-ui-catalog.md` § Spacing tokens: prose now states the adoption surface includes `SizedBox(height:)` / `SizedBox(width:)` gap dimensions and `EdgeInsets.only` / `fromLTRB` insets (not only `all` / `symmetric`), with out-of-scale values remaining overrides.

## Tests

- `app/test/ct_spacing_features_adoption_test.dart`: new `CtSpacing SizedBox gap adoption` group enforcing **no raw `SizedBox(height|width: N)`** token literals in the four migrated files, plus:
  - a token-value guard (`xs..xxl` == prior px), and
  - a positive/negative detector test (flags `SizedBox(height: 12)`; ignores `CtSpacing.ml` and out-of-scale `4/10/14`).
- Verified green locally:
  - `flutter test test/ct_spacing_features_adoption_test.dart` (203 passing)
  - the four overlays' suites: `*_dialogue_overlay_test`, `*_320dp_min_viewport_test`, `*_dark_chrome_test`, `dialogue_overlays_specs_test` (262 passing)
  - `ct_spacing_test` / `ct_spacing_adoption_test` (regression check)
  - `flutter analyze` on touched files: no issues.

## Scope / deferred

- This is one isolatable S5 slice (the dialogue-overlay family). `SizedBox` token gaps remain in other feature files (e.g. production / technology panels, shell screens) and `EdgeInsets.only`/`fromLTRB` token literals elsewhere — to be migrated in follow-up S5 slices on the same umbrella. No closing keyword: the umbrella issue stays open.

Refs #2914

Made with [Cursor](https://cursor.com)