### PR TITLE
fix: align province-panel e2e expected lines with Political Region/Capital rows (#2336)

### DIFF
--- a/app/lib/test_support/province_panel_e2e_expected_lines.dart
+++ b/app/lib/test_support/province_panel_e2e_expected_lines.dart
@@ -154,6 +154,16 @@ List<String> provincePanelWideLayoutExpectedTexts(
   addSection('Political', () {
     out.add('Name: ${province?.displayName ?? provinceId}');
     out.add('Owner: ${_ownerName(game, province?.ownerId)}');
+    // Region and Capital are always-exact political intel rendered alongside
+    // Name / Owner regardless of fog (Refs #2865 Political section; mirrored
+    // here so the e2e snapshot stays in sync with
+    // province_sea_zone_detail_overlay_sections.dart `_buildPoliticalSection`).
+    out.add(l10n.provinceOverlay_region(_regionLabel(l10n, regionId)));
+    out.add(
+      _isCapitalProvince(game, provinceId)
+          ? l10n.provinceOverlay_capitalYes
+          : l10n.provinceOverlay_capitalNo,
+    );
   });
 
   addSection('Tile', () {
@@ -378,6 +388,34 @@ Province? _findProvince(Game game, String provinceId) {
     if (p.id == provinceId) return p;
   }
   return null;
+}
+
+/// Mirrors `provinceOverlayRegionLabel` from
+/// province_sea_zone_detail_overlay_sections.dart (duplicated rather than
+/// imported to keep this fixture free of `@visibleForTesting` production
+/// symbols, per the file header convention).
+String _regionLabel(AppLocalizations l10n, String regionId) {
+  return switch (regionId) {
+    'oldWorld' => l10n.region_oldWorld,
+    'newWorld' => l10n.region_newWorld,
+    _ => regionId,
+  };
+}
+
+/// Mirrors `provinceOverlayIsCapital` from
+/// province_sea_zone_detail_overlay_sections.dart: a province is a capital
+/// when any faction (player, minor nation, or tribe) claims it as its capital.
+bool _isCapitalProvince(Game game, String provinceId) {
+  for (final p in game.players) {
+    if (p.capitalProvinceId == provinceId) return true;
+  }
+  for (final m in game.minorNations) {
+    if (m.capitalProvinceId == provinceId) return true;
+  }
+  for (final t in game.tribes) {
+    if (t.capitalProvinceId == provinceId) return true;
+  }
+  return false;
 }
 
 String _ownerName(Game game, String? ownerId) {


### PR DESCRIPTION
## Summary

The capital-panel E2E scenario (`app/integration_test/new_game_capital_panel_e2e_test.dart`) fails on Linux desktop because the shared province-panel expected-lines fixture had drifted from the production overlay.

- Production `ProvinceSeaZoneDetailOverlay` Political section (`province_sea_zone_detail_overlay_sections.dart` `_buildPoliticalSection`) renders **four** always-exact rows: `Name`, `Owner`, `Region`, `Capital: Yes/No` (the `Region`/`Capital` rows were added under #2865).
- The E2E mirror fixture (`app/lib/test_support/province_panel_e2e_expected_lines.dart`) still emitted only `Name` and `Owner`, so the snapshot comparison failed at the first mismatch:

```
Which: at location [5] is 'Region: Old World' instead of 'TILE'
```

This is a genuine fixture-correctness defect that blocks **#2336 AC6** (E2E tests pass locally) for the capital-panel scenario.

## Done in this push

- Mirror the `Region` and `Capital` rows in the Political section of the expected-lines fixture, using the same `provinceOverlay_region` / `provinceOverlay_capitalYes` / `provinceOverlay_capitalNo` l10n strings as production.
- Add local `_regionLabel` / `_isCapitalProvince` helpers that duplicate the production `@visibleForTesting` helpers (`provinceOverlayRegionLabel` / `provinceOverlayIsCapital`), consistent with the fixture file's documented "duplicate rather than import `@visibleForTesting` production symbols" convention.

No production UI, game-logic, or turn-resolution code changed; the diff is limited to the E2E test fixture.

## Verification

- `flutter analyze app/lib/test_support/province_panel_e2e_expected_lines.dart` → **No issues found.**
- `xvfb-run flutter test integration_test/new_game_capital_panel_e2e_test.dart -d linux --dart-define=CT_E2E=true` (non-snap Flutter 3.41.9) → **All tests passed!** (was failing on the Political-row drift before this change).
- No widget test pins the previous two-line Political output (`rg "Owner: England" app/test` → no matches), so the fixture change is isolated to the E2E snapshot path.

## Scope / deferred

- The structural #2336 refactor ACs (AC1–AC5: shared helpers, parallel asset preload, H1–H10 condition-based waits, adaptive bootstrap polling) are already complete on `dev`.
- Full AC8/AC9 baseline-vs-after wall-clock measurement still requires a maintainer Linux-desktop run (snap Flutter needs the documented `sudo ln -sf .../ld.lld` fix; a non-snap toolchain works) and is **not** included here.

Refs #2336

Made with [Cursor](https://cursor.com)