### PR TITLE
test(ui): pin wide-layout province overlay no-tab-strip AC (#2865)

### DIFF
--- a/app/test/province_sea_zone_overlay_detail_paths_test.dart
+++ b/app/test/province_sea_zone_overlay_detail_paths_test.dart
@@ -10,6 +10,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:colonizethis_app/features/game/widgets/province_overlay_demo_data.dart';
 import 'package:colonizethis_app/features/game/widgets/province_sea_zone_detail_overlay.dart';
+import 'package:colonizethis_app/widgets/ct_section_label.dart';
 import 'package:colonizethis_app/widgets/ct_tab_strip.dart';
 import 'package:colonizethis_app/widgets/debug_init_game.dart';
 
@@ -270,6 +271,96 @@ void main() {
 
       expect(find.byType(CtTabStrip), findsOneWidget);
     });
+
+    testWidgets(
+      'AC: Wide layout renders a single scrollable column of all six '
+      'sections without a tab strip',
+      (WidgetTester tester) async {
+        // SPEC § Layout / Acceptance criteria — "Wide viewport side panel":
+        // at viewport width >= the shell breakpoint the overlay renders the
+        // sections as a single scrollable column and **without a tab strip**.
+        // The narrow case above pins the CtTabStrip-present path; this is the
+        // complementary wide-path regression guard (CtTabStrip absent +
+        // scrollable column) so a regression that re-applies the narrow tab
+        // layout to wide hosts fails explicitly.
+        final binding = tester.view;
+        final oldSize = binding.physicalSize;
+        final oldRatio = binding.devicePixelRatio;
+        addTearDown(() {
+          binding.physicalSize = oldSize;
+          binding.devicePixelRatio = oldRatio;
+        });
+        // Width clearly >= kNarrowBreakpoint (600); tall so the wide
+        // scrollable column lays out all six sections without overflow.
+        binding.physicalSize = const Size(1200, 2000);
+        binding.devicePixelRatio = 1.0;
+
+        final game = demoGameForOverlay;
+        final region = demoRegionForOverlay;
+        final humanPlayerId = game.players.first.id;
+        final landCell = region.cells.firstWhere(
+          (c) => !c.isSea && c.visibility != TileVisibility.unrevealed,
+        );
+        final provinceId = '${region.regionId}|${landCell.regionCellId}';
+        final possibleTiles =
+            game.worldState.tileKeysByRegionAndProvince[region.regionId]?[provinceId] ??
+                const <String>[];
+        String? selectedTileKey;
+        for (final tk in possibleTiles) {
+          final c = coordsFromTileKey(tk);
+          if (c.x < 0 || c.x >= region.width || c.y < 0 || c.y >= region.height) {
+            continue;
+          }
+          final cell = region.cellAt(c.x, c.y);
+          if (cell.visibility != TileVisibility.unrevealed) {
+            selectedTileKey = tk;
+            break;
+          }
+        }
+        expect(selectedTileKey, isNotNull);
+
+        await tester.pumpWidget(
+          buildOverlay(
+            game: game,
+            region: region,
+            displayId: provinceId,
+            humanPlayerId: humanPlayerId,
+            selectedTileKey: selectedTileKey,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // Primary AC: the wide side panel must not use a tab strip.
+        expect(find.byType(CtTabStrip), findsNothing);
+        // The sections render as a single scrollable column.
+        expect(
+          find.descendant(
+            of: find.byType(ProvinceSeaZoneDetailOverlay),
+            matching: find.byType(SingleChildScrollView),
+          ),
+          findsOneWidget,
+        );
+        // All six province sections are present at once (one CtSectionLabel
+        // header each), confirming the single-column layout rather than the
+        // one-section-per-tab narrow layout.
+        expect(find.byType(CtSectionLabel), findsNWidgets(6));
+        for (final header in const <String>[
+          'POLITICAL',
+          'TILE',
+          'ECONOMIC',
+          'MILITARY',
+          'CIVILIAN',
+          'NAVAL',
+        ]) {
+          expect(
+            find.text(header),
+            findsOneWidget,
+            reason: 'Wide layout must render the $header section header in the '
+                'single scrollable column.',
+          );
+        }
+      },
+    );
   });
 }
 


### PR DESCRIPTION
## Summary

Pins the **wide-viewport side-panel layout** acceptance criterion from `SPEC/ui/province-sea-zone-detail-overlay.md` that was not yet covered by widget tests:

> Given a viewport width ≥ shell breakpoint, when the overlay mounts, then the UI layer renders the overlay in a side panel using the parent's bounded height with a **single scrollable column of sections and without a tab strip**.

The narrow-layout `CtTabStrip`-present path was already pinned in this file; this adds the complementary wide-path regression guard.

Refs #2865

## Done in this PR

- Added `AC: Wide layout renders a single scrollable column of all six sections without a tab strip` to `app/test/province_sea_zone_overlay_detail_paths_test.dart`.
- Asserts:
  - `CtTabStrip` absent on wide viewport (1200×2000, ≥ `kNarrowBreakpoint`).
  - Exactly one `SingleChildScrollView` under the overlay.
  - All six `CtSectionLabel` section headers visible simultaneously (`POLITICAL`, `TILE`, `ECONOMIC`, `MILITARY`, `CIVILIAN`, `NAVAL`).

## Deferred (still open on #2865)

- Full issue closure: S9 Widgetbook goldens for all tab variants, remaining interaction ACs, and any follow-up polish slices not yet pinned.
- Issue remains `backlog:implementation` until all subtasks/ACs are satisfied and linked PRs merge.

## SPEC

- `SPEC/ui/province-sea-zone-detail-overlay.md` § Layout / § Acceptance criteria — "Wide viewport side panel"

## Tests

```bash
cd app && flutter test test/province_sea_zone_overlay_detail_paths_test.dart --name "Wide layout renders a single scrollable column"
```

Result: **1 passed** (2026-06-04 local run).

Made with [Cursor](https://cursor.com)