### PR TITLE
feat(ai): prioritize regiment build-input production under EXPAND rebuild (#2847)

### DIFF
--- a/SPEC/ai/economy-planner.md
+++ b/SPEC/ai/economy-planner.md
@@ -83,6 +83,18 @@ Naval planner and build planner consume this preference; the economy planner onl
 
 ---
 
+## Regiment build-input production priority (Refs #2847 H8)
+
+Companion to [treasury-planner.md](treasury-planner.md) § Lock-recovery seller regiment build-input bootstrap. The treasury planner can emit a world-market **bid** for the cheapest regiment's missing `buildInputs`, but on seed 42 there is often **no matching offer supply** for `fabric`, so the bid does not fill. When the EXPAND economy directive `forceCheapestRegimentBuild` is active, the GP holds `player.treasury >= cheapestRegimentBuildTreasuryCost()`, owns **zero** regiments, and the projected stockpile is short at least one `peasant_levies` build-input commodity, the economy planner adds `kRegimentBuildInputProductionScoreBoost` (`50.0`) to every **feasible** recipe whose `outputCommodityId` supplies a missing input. The boost is planner-internal (not a new `ai_victory_config.dart` constant). Labour is still capped by effective labour and integer runs; no affordability rule is bypassed.
+
+### Acceptance criteria (H8 production)
+
+- Given an AI GP with positive effective labour, a feasible `fabric_from_wool` (or `fabric_from_cotton`) recipe, `regimentCountForPlayer == 0`, `player.treasury >= cheapestRegimentBuildTreasuryCost()`, zero `fabric` in the stockpile, and a dispatched `PhasePlanOutcome` whose `expandEconomyPlan.forceCheapestRegimentBuild == true`, when `runEconomyPlanner` runs, then at least one production assignment references a recipe whose `outputCommodityId` is `fabric`.
+- Given the same inputs except `expandEconomyPlan.forceCheapestRegimentBuild == false`, when `runEconomyPlanner` runs with the same seed, then no assignment is required solely because of the H8 boost (the fabric recipe may still win from ordinary shortage scoring).
+- Given `forceCheapestRegimentBuild == true` but `player.treasury < cheapestRegimentBuildTreasuryCost()`, when `runEconomyPlanner` runs, then the H8 production boost does not apply (negative control — treasury must be recovered first).
+
+---
+
 ## Integration
 
 - **Caller:** Strategic AI (e.g. `generateStrategicOrders`) calls the economy planner for each AI GP first, then passes the resulting **economy plan** (including `cargoPreference`) into the domain planners so the build step can weight ship vs land builds. Production assignments are collected per player and passed to the turn resolver as **per-player default production assignments** (resolver must accept `Map<String, List<AssignedRecipe>>` or equivalent for multi-player).

--- a/SPEC/ai/treasury-planner.md
+++ b/SPEC/ai/treasury-planner.md
@@ -337,12 +337,14 @@ the offers-only Path-F behaviour.
 The bootstrap converts recovered treasury into **demand** for the build
 input, but a deal only clears when matching **supply** exists on the world
 market that turn. On seed 42 the cheapest regiment's build input (`fabric`)
-has no Great-Power or minor/tribe offer supply, so the emitted bid does not
-fill and the seed-42 gp5/gp6 zero-regiment tail persists until a separate
-production-side change (out of scope for the treasury planner) puts that
-commodity on the market. This section authorises and pins the **bid-emission**
-behaviour only; closing the seed-42 regiment-build tail end to end requires
-the input-supply work tracked under #2847's remaining scope.
+often has no Great-Power or minor/tribe offer supply, so the emitted bid may
+not fill. The companion **production-side** slice in
+[economy-planner.md](economy-planner.md) § Regiment build-input production
+priority (Refs #2847 H8) prioritizes feasible recipes that output missing
+`peasant_levies` build inputs when `forceCheapestRegimentBuild` is active and
+treasury has recovered. This treasury section authorises and pins the
+**bid-emission** behaviour; the economy-planner section authorises domestic
+production when market supply is absent.
 
 ### Determinism and budget
 

--- a/packages/colonizethis_ai/lib/src/planning/economy_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/economy_planner.dart
@@ -5,11 +5,17 @@ import 'army_conquest_prep.dart';
 import 'expand_phase_planner.dart' hide cheapestRegimentBuildTreasuryCost;
 import 'phase_planner_dispatch.dart';
 import 'phase_planner_economy_filter.dart';
+import 'phase_planner_expand_economy.dart';
 import 'planning_imports.dart';
 import 'recipe_scoring.dart';
 import 'treasury_planner.dart';
 
 final _log = packageLogger('economy_planner');
+
+/// Recipe-score boost for outputs that supply a missing cheapest-regiment
+/// build input when the EXPAND regiment-rebuild directive is active
+/// (Refs #2847 H8 production companion).
+const double kRegimentBuildInputProductionScoreBoost = 50.0;
 
 /// Runs the economy planner for one AI-controlled player. Deterministic given
 /// [game], [view], [config], and [seeds]. Returns production assignments and
@@ -110,6 +116,17 @@ EconomyPlan runEconomyPlanner({
       regimentCountForPlayer(game, view.playerId) <
           kStalledMinRegimentCountWhenAtWar;
 
+  final expandEconomy = phasePlan != null
+      ? expandEconomyPlanFromPhasePlan(phasePlan)
+      : ExpandEconomyPlan.defaultPlan;
+  final missingRegimentBuildInputs =
+      _missingCheapestRegimentBuildInputIds(stockpile);
+  final regimentBuildInputProductionBoost =
+      expandEconomy.forceCheapestRegimentBuild &&
+      player.treasury >= cheapestRegimentBuildTreasuryCost() &&
+      regimentCountForPlayer(game, view.playerId) == 0 &&
+      missingRegimentBuildInputs.isNotEmpty;
+
   final assignments = _allocateLabour(
     stockpile: stockpile,
     workers: workers,
@@ -117,6 +134,8 @@ EconomyPlan runEconomyPlanner({
     config: config,
     seeds: seeds,
     militaryRebuildCrisis: militaryRebuildCrisis,
+    regimentBuildInputProductionBoost: regimentBuildInputProductionBoost,
+    missingRegimentBuildInputIds: missingRegimentBuildInputs,
   );
 
   final cargoPref = _cargoPreference(
@@ -198,6 +217,18 @@ CargoPreference _cargoPreference(
   return pref;
 }
 
+/// Commodity ids the cheapest regiment still needs in the stockpile before
+/// `suggestBuildOrders` will surface it (Refs #2847 H8).
+Set<String> _missingCheapestRegimentBuildInputIds(Stockpile stockpile) {
+  final missing = <String>{};
+  for (final entry in RegimentEconomyCatalog.peasantLevies.buildInputs.entries) {
+    if (stockpile.quantityOf(entry.key) < entry.value) {
+      missing.add(entry.key);
+    }
+  }
+  return missing;
+}
+
 List<AssignedRecipe> _allocateLabour({
   required Stockpile stockpile,
   required WorkerPool workers,
@@ -205,6 +236,8 @@ List<AssignedRecipe> _allocateLabour({
   required AIConfig config,
   required AISeedBundle seeds,
   bool militaryRebuildCrisis = false,
+  bool regimentBuildInputProductionBoost = false,
+  Set<String> missingRegimentBuildInputIds = const {},
 }) {
   final recipes = ProductionRecipesCatalog.all;
   final agendaId = config.hiddenAgendaId;
@@ -232,6 +265,10 @@ List<AssignedRecipe> _allocateLabour({
     );
     if (militaryRebuildCrisis && _isMilitaryInputRecipe(recipe)) {
       score += 40;
+    }
+    if (regimentBuildInputProductionBoost &&
+        missingRegimentBuildInputIds.contains(recipe.outputCommodityId)) {
+      score += kRegimentBuildInputProductionScoreBoost;
     }
     candidates.add(ScoredRecipe(recipe: recipe, score: score));
   }

--- a/packages/colonizethis_ai/test/economy_planner_regiment_build_input_production_test.dart
+++ b/packages/colonizethis_ai/test/economy_planner_regiment_build_input_production_test.dart
@@ -1,0 +1,189 @@
+/// Regiment build-input production priority (Refs #2847 H8 production companion).
+library;
+
+import 'package:colonizethis_ai/colonizethis_ai.dart';
+import 'package:colonizethis_ai/src/planning/expand_phase_planner.dart'
+    hide cheapestRegimentBuildTreasuryCost;
+import 'package:colonizethis_ai/src/planning/observer_goal_phase.dart';
+import 'package:colonizethis_ai/src/planning/phase_planner_dispatch.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+const _topology = MapTopology(nodes: [], edges: []);
+
+Game _regimentRebuildProductionGame({required int treasury}) {
+  return Game(
+    id: 'g-h8-production',
+    worldState: const WorldState(
+      turnState: TurnState(phase: TurnPhase.orders, turnNumber: 50),
+      oldWorld: RegionData(
+        provinces: [
+          Province(
+            id: 'oldWorld|p0',
+            regionId: 'oldWorld',
+            ownerId: 'gp1',
+          ),
+          Province(
+            id: 'oldWorld|p1',
+            regionId: 'oldWorld',
+            ownerId: 'gp1',
+          ),
+        ],
+      ),
+      newWorld: RegionData(),
+      armies: [],
+    ),
+    players: [
+      Player(
+        id: 'gp1',
+        displayName: 'GP1',
+        isHuman: false,
+        capitalProvinceId: 'oldWorld|p0',
+        treasury: treasury,
+        stockpile: const Stockpile()
+            .applyDelta(CommodityCatalog.grain.id, 30)
+            .applyDelta(CommodityCatalog.wool.id, 10)
+            .applyDelta(CommodityCatalog.timber.id, 30)
+            .applyDelta(CommodityCatalog.iron.id, 10),
+        workerPool: const WorkerPool(peasants: 12),
+      ),
+    ],
+  );
+}
+
+PhasePlanOutcome _expandForceRegimentBuildPlan({
+  required bool forceCheapestRegimentBuild,
+}) {
+  return PhasePlanOutcome(
+    phase: ObserverGoalPhase.expand,
+    expandEconomyPlan: ExpandEconomyPlan(
+      forceCheapestRegimentBuild: forceCheapestRegimentBuild,
+      boostTreasuryRecoveryCargo: false,
+    ),
+  );
+}
+
+Set<String> _assignedRecipeIds(EconomyPlan plan) =>
+    plan.productionAssignments.map((a) => a.recipeId).toSet();
+
+void main() {
+  group('regiment build-input production priority (Refs #2847 H8)', () {
+    const config = AIConfig(
+      leaderId: 'victoria',
+      personalityId: 'victoria',
+      hiddenAgendaId: 'peacemaker',
+    );
+    final seeds = AISeedBundle.fromTurnSeed(42);
+    final threshold = cheapestRegimentBuildTreasuryCost();
+
+    test(
+      'forceCheapestRegimentBuild prioritizes a fabric recipe when fabric is '
+      'missing and treasury has recovered',
+      () {
+        final game = _regimentRebuildProductionGame(treasury: threshold);
+        final view = buildPlayerView(game, _topology, 'gp1');
+
+        final withBoost = runEconomyPlanner(
+          game: game,
+          view: view,
+          config: config,
+          seeds: seeds,
+          phasePlan: _expandForceRegimentBuildPlan(
+            forceCheapestRegimentBuild: true,
+          ),
+        );
+
+        final fabricRecipeIds = {
+          ProductionRecipesCatalog.fabricFromWool.id,
+          ProductionRecipesCatalog.fabricFromCotton.id,
+        };
+        expect(
+          _assignedRecipeIds(withBoost).intersection(fabricRecipeIds),
+          isNotEmpty,
+          reason:
+              'H8 production boost should assign labour to a fabric recipe '
+              'when wool/cotton inputs are available and fabric is missing',
+        );
+      },
+    );
+
+    test(
+      'forceCheapestRegimentBuild does not apply when treasury is below the '
+      'regiment threshold',
+      () {
+        final game = _regimentRebuildProductionGame(treasury: threshold - 1);
+        final view = buildPlayerView(game, _topology, 'gp1');
+
+        final plan = runEconomyPlanner(
+          game: game,
+          view: view,
+          config: config,
+          seeds: seeds,
+          phasePlan: _expandForceRegimentBuildPlan(
+            forceCheapestRegimentBuild: true,
+          ),
+        );
+
+        expect(
+          _assignedRecipeIds(plan).intersection({
+            ProductionRecipesCatalog.fabricFromWool.id,
+            ProductionRecipesCatalog.fabricFromCotton.id,
+          }),
+          isEmpty,
+          reason:
+              'without recovered treasury the H8 boost must not fire even when '
+              'the EXPAND directive is set',
+        );
+      },
+    );
+
+    test(
+      'same seed without forceCheapestRegimentBuild may omit fabric when '
+      'competing recipes score higher',
+      () {
+        final game = _regimentRebuildProductionGame(treasury: threshold);
+        final view = buildPlayerView(game, _topology, 'gp1');
+
+        final withoutBoost = runEconomyPlanner(
+          game: game,
+          view: view,
+          config: config,
+          seeds: seeds,
+          phasePlan: _expandForceRegimentBuildPlan(
+            forceCheapestRegimentBuild: false,
+          ),
+        );
+
+        // Pin only that the H8-boosted path is strictly stronger for fabric:
+        // turning the directive on must not reduce fabric labour vs off when
+        // fabric was already assigned.
+        final withBoost = runEconomyPlanner(
+          game: game,
+          view: view,
+          config: config,
+          seeds: seeds,
+          phasePlan: _expandForceRegimentBuildPlan(
+            forceCheapestRegimentBuild: true,
+          ),
+        );
+
+        int fabricLabour(EconomyPlan plan) {
+          final fabricIds = {
+            ProductionRecipesCatalog.fabricFromWool.id,
+            ProductionRecipesCatalog.fabricFromCotton.id,
+          };
+          return plan.productionAssignments
+              .where((a) => fabricIds.contains(a.recipeId))
+              .fold<int>(0, (sum, a) => sum + a.assignedLabour);
+        }
+
+        expect(
+          fabricLabour(withBoost),
+          greaterThanOrEqualTo(fabricLabour(withoutBoost)),
+        );
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Implements the **H8 production companion** for #2847: when the EXPAND economy directive `forceCheapestRegimentBuild` is active, treasury has recovered to at least `cheapestRegimentBuildTreasuryCost()`, and the GP owns zero regiments, the economy planner boosts feasible recipes that output missing `peasant_levies` build inputs (notably `fabric`).

This pairs with the merged treasury-planner H8 slice (#3226), which emits world-market bids for missing inputs but often cannot fill on seed 42 because there is no fabric offer supply. Domestic production is the authorized supply path per SPEC disclosure.

## Done in this push

- `economy_planner.dart`: `kRegimentBuildInputProductionScoreBoost` (+50) when the H8 predicate holds; uses dispatched `expandEconomyPlan.forceCheapestRegimentBuild`.
- `SPEC/ai/economy-planner.md`: new § Regiment build-input production priority with ACs.
- `SPEC/ai/treasury-planner.md`: cross-reference updated (bid + production).
- `economy_planner_regiment_build_input_production_test.dart`: positive, negative (treasury below threshold), and monotonic fabric-labour pins.

## Deferred for #2847

- S7-D re-run to confirm `gpMilitaryBuildOrdersEmitted` / `gpRegimentTurnsAtZero` improve on seed 42 (not run in this push — ~4 min diagnostic).
- `seed42_observer_conquest_regression_test` skip remains; gate still requires gp3–gp6 ≥3 OW.
- H4-b minor-transit reach extension for gp4 (regiment-holding failure mode) remains open.

## Test plan

- [x] `dart test test/economy_planner_regiment_build_input_production_test.dart`
- [x] `dart test test/economy_planner_test.dart`
- [x] `dart analyze` on touched files

Refs #2847


Made with [Cursor](https://cursor.com)