### PR TITLE
fix(ai): reserve regiment build-input feedstock from lock-recovery seller offers (Refs #2847)

### DIFF
--- a/SPEC/ai/treasury-planner.md
+++ b/SPEC/ai/treasury-planner.md
@@ -385,6 +385,82 @@ no hot-path logging, well inside the 15-second turn-resolution budget.
   build-input bootstrap path, then both runs return identical
   `List<TradeOrder>` outputs (determinism).
 
+### Build-input feedstock reservation (offer side, Refs #2847 H8-supply)
+
+The bootstrap bid above creates **demand** for the missing build input, and
+the economy-planner production boost ([economy-planner.md](economy-planner.md)
+§ Regiment build-input production priority) creates **domestic supply** — but
+only when the build input's recipe feedstock is on hand. `fabric` is produced
+from `wool` (`fabricFromWool`) or `cotton` (`fabricFromCotton`), each requiring
+two units of feedstock per run. A below-quota zero-NW lock-recovery seller that
+has recovered treasury otherwise sells its surplus `wool` / `cotton` into the
+world market every turn, so the feedstock never accumulates to a feasible
+fabric run and the production boost has nothing to convert. The seller then
+holds zero regiments indefinitely even though it can afford one (seed-42
+gp3 / gp5 / gp6 hold `fabric` for only ~2 of 100 turns).
+
+Under the **same** carve-out gate as the bootstrap bid
+(`_isBelowQuotaZeroNwLockRecoverySeller(game, playerId)` is `true`,
+`player.treasury >= cheapestRegimentBuildTreasuryCost()`, and
+`regimentCountForPlayer(game, playerId) == 0`), the planner withholds the
+build-input feedstock from its offer set: for every `peasant_levies` build
+input the projected stockpile is short of, the input commodities of every
+production recipe that outputs that build input are removed from the
+offer-`available` map. The reservation does not add any order — it only
+suppresses surplus offers for the feedstock commodities — so the retained
+feedstock accumulates across turns until a fabric recipe becomes feasible and
+the economy planner's boost runs it. It is self-clearing: once the build input
+lands in the stockpile (so the build input is no longer missing) or the GP owns
+a regiment, no feedstock is reserved and the seller resumes offering its
+surplus.
+
+The reservation never weakens a healthy GP: it is gated to the below-quota
+zero-NW seller band (gp1 / gp2 are above quota), to the zero-regiment rebuild
+case (a seller already holding regiments keeps selling feedstock), and to a
+recovered treasury (a still-broke seller keeps selling for liquidity). The
+feedstock lookup is a pure function of the projected `Stockpile` and the static
+`RegimentEconomyCatalog` / `ProductionRecipesCatalog`; identical inputs yield
+identical offer sets.
+
+##### Residual feedstock-acquisition dependency (disclosure)
+
+This reservation only has effect when the seller **already holds** the recipe
+feedstock as surplus — it prevents that feedstock from being sold before it can
+accumulate to a feasible run. It does **not** acquire feedstock for a seller
+that holds none. On seed 42 the failing below-quota Great Powers (gp3 / gp5 /
+gp6) extract no `wool` / `cotton` and the world market carries no `fabric`
+seller supply, so they remain unable to source the cheapest regiment's build
+input and the turn-100 conquest gate (`SPEC` seed-42 regression) stays open on
+the feedstock-acquisition axis. Closing that axis (feedstock extraction routing
+or a market `fabric`/feedstock seller) is tracked as separate #2847 work; this
+reservation is the offer-side invariant that keeps the production path
+(`economy-planner.md` § Regiment build-input production priority) viable once
+feedstock is on hand.
+
+#### Acceptance criteria (H8-supply)
+
+- Given a below-quota zero-NW lock-recovery seller with
+  `player.treasury >= cheapestRegimentBuildTreasuryCost()`,
+  `regimentCountForPlayer(game, playerId) == 0`, a projected stockpile missing
+  the cheapest regiment's `fabric` build input, and surplus `wool` (or
+  `cotton`) it would otherwise offer, when `runTreasuryPlanner` runs, then it
+  emits **no** `TradeOrderType.offer` for that feedstock commodity.
+- Given an otherwise identical lock-recovery seller that already holds at least
+  one `fabric`, when `runTreasuryPlanner` runs, then it emits its surplus
+  `wool` / `cotton` offers as normal (the feedstock reservation self-clears once
+  the build input is on hand).
+- Given an otherwise identical lock-recovery seller with
+  `regimentCountForPlayer(game, playerId) > 0`, when `runTreasuryPlanner` runs,
+  then it emits its surplus feedstock offers as normal (the reservation targets
+  the zero-regiment rebuild gap only).
+- Given an AI Great Power at or above the conquest quota (not a lock-recovery
+  seller) with surplus `wool` / `cotton`, when `runTreasuryPlanner` runs, then
+  it emits those surplus offers as normal (the reservation is scoped to
+  below-quota zero-NW sellers).
+- Given identical inputs, when `runTreasuryPlanner` runs twice on the
+  feedstock-reservation path, then both runs return identical
+  `List<TradeOrder>` outputs (determinism).
+
 ---
 
 ## Treasury-budget-aware bid sizing (Refs #3122)

--- a/packages/colonizethis_ai/lib/src/planning/treasury_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/treasury_planner.dart
@@ -271,6 +271,23 @@ List<TradeOrder> runTreasuryPlanner({
         need[input.key] = input.value - held;
       }
     }
+    // Refs #2847 § H8-supply: the bootstrap bid above cannot fill when no
+    // world-market seller offers the build input (seed-42 `fabric` has zero GP
+    // / minor / tribe supply), so the recovered seller must *produce* the input
+    // domestically. The economy planner already boosts feasible recipes that
+    // output a missing build input (economy-planner.md § Regiment build-input
+    // production priority), but those recipes only become feasible once their
+    // feedstock (e.g. `wool` / `cotton` for `fabric`) reaches the per-run input
+    // requirement in the stockpile. A lock-recovery seller otherwise sells that
+    // feedstock as surplus every turn, so it never accumulates to a feasible
+    // run. Withhold the feedstock from the offer set while the rebuild carve-out
+    // is active so it accumulates; the reservation self-clears once the build
+    // input lands or the GP owns a regiment.
+    // SPEC/ai/treasury-planner.md
+    // § Lock-recovery seller build-input feedstock reservation.
+    for (final feedstockId in _regimentBuildInputFeedstockIds(projected)) {
+      available.remove(feedstockId);
+    }
   }
 
   if (available.isEmpty && need.isEmpty) {
@@ -640,6 +657,33 @@ bool _isBelowQuotaZeroNwLockRecoverySeller({
   // Mid-below-quota EXPAND band (seed-42 gp3–gp6); excludes minimal
   // single-province test fixtures that are not Path F lock-recovery sellers.
   return ow >= 2;
+}
+
+/// Feedstock commodity ids consumed by production recipes whose output is a
+/// currently-missing cheapest-regiment (`peasant_levies`) build input.
+///
+/// Refs #2847 § H8-supply. The cheapest regiment needs `fabric`, which is
+/// produced from `wool` (`fabricFromWool`) or `cotton` (`fabricFromCotton`).
+/// When the projected stockpile is short of a build input, this returns the
+/// input commodities of every recipe that outputs that build input so a
+/// lock-recovery seller can retain the feedstock instead of selling it as
+/// surplus. Pure function of the projected [Stockpile] and the static
+/// `RegimentEconomyCatalog` / `ProductionRecipesCatalog`; returns the empty
+/// set once every build input is on hand (the reservation self-clears).
+Set<CommodityId> _regimentBuildInputFeedstockIds(Stockpile projected) {
+  final missingInputs = <CommodityId>{
+    for (final entry
+        in RegimentEconomyCatalog.peasantLevies.buildInputs.entries)
+      if (projected.quantityOf(entry.key) < entry.value) entry.key,
+  };
+  if (missingInputs.isEmpty) return const <CommodityId>{};
+  final feedstock = <CommodityId>{};
+  for (final recipe in ProductionRecipesCatalog.all) {
+    if (missingInputs.contains(recipe.outputCommodityId)) {
+      feedstock.addAll(recipe.inputQuantities.keys);
+    }
+  }
+  return feedstock;
 }
 
 /// Sorted Great Power ids for deterministic per-turn buyer rotation.

--- a/packages/colonizethis_ai/test/planning/treasury_planner_regiment_input_feedstock_test.dart
+++ b/packages/colonizethis_ai/test/planning/treasury_planner_regiment_input_feedstock_test.dart
@@ -1,0 +1,194 @@
+/// Lock-recovery seller build-input feedstock reservation
+/// (Refs #2847 § H8-supply).
+///
+/// The H8 bootstrap bid creates demand for the cheapest regiment's missing
+/// build input (`fabric`), but on seed 42 no world-market seller offers
+/// `fabric`, so the recovered seller must produce it domestically from `wool`
+/// or `cotton`. A lock-recovery seller otherwise sells that feedstock as
+/// surplus every turn, so it never accumulates to a feasible fabric run and the
+/// economy planner's build-input production boost has nothing to convert. These
+/// tests pin the narrow offer-side carve-out that withholds the fabric feedstock
+/// from the offer set while — and only while — the zero-regiment rebuild
+/// carve-out is active.
+library;
+
+import 'package:colonizethis_ai/src/planning/treasury_planner.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+const _fabricId = 'fabric';
+const _woolId = 'wool';
+
+Game _lockRecoverySellerGame({
+  required int treasury,
+  required int fabricHeld,
+  int woolHeld = 20,
+  int owProvinces = 3,
+  bool hasRegiment = false,
+}) {
+  const ow = 'oldWorld';
+  var stockpile = const Stockpile().applyDelta('grain', 80);
+  if (woolHeld > 0) {
+    stockpile = stockpile.applyDelta(_woolId, woolHeld);
+  }
+  if (fabricHeld > 0) {
+    stockpile = stockpile.applyDelta(_fabricId, fabricHeld);
+  }
+  return Game(
+    id: 'g-regiment-input-feedstock',
+    worldState: WorldState(
+      turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 50),
+      oldWorld: RegionData(
+        provinces: [
+          for (var i = 0; i < owProvinces; i++)
+            Province(id: '$ow|p_$i', regionId: ow, ownerId: 'gp1'),
+        ],
+      ),
+      newWorld: const RegionData(provinces: []),
+      armies: [
+        if (hasRegiment)
+          const Army(
+            id: 'army-gp1-field',
+            ownerId: 'gp1',
+            regionId: ow,
+            stationedProvinceId: '$ow|p_0',
+            regimentUnitIds: ['reg-1'],
+          ),
+      ],
+    ),
+    players: [
+      Player(
+        id: 'gp1',
+        displayName: 'GP1',
+        isHuman: false,
+        capitalProvinceId: '$ow|p_0',
+        stockpile: stockpile,
+        treasury: treasury,
+      ),
+    ],
+    worldMarketState: WorldMarketState.withDefaultPrices(const {
+      'grain': 10,
+      _woolId: 20,
+      _fabricId: 40,
+    }),
+  );
+}
+
+List<TradeOrder> _run(Game game) => runTreasuryPlanner(
+      game: game,
+      playerId: 'gp1',
+      stockpile: game.players.first.stockpile,
+      productionAssignments: const [],
+      treasury: game.players.first.treasury,
+    );
+
+List<TradeOrder> _woolOffers(List<TradeOrder> orders) => orders
+    .where((o) => o.type == TradeOrderType.offer && o.commodityId == _woolId)
+    .toList();
+
+void main() {
+  group('lock-recovery seller build-input feedstock reservation (Refs #2847 H8-supply)',
+      () {
+    final threshold = cheapestRegimentBuildTreasuryCost();
+    final fabricInput =
+        RegimentEconomyCatalog.peasantLevies.buildInputs[_fabricId];
+
+    test('fabric is produced from wool/cotton (guards the fixture assumption)',
+        () {
+      expect(
+        fabricInput,
+        isNotNull,
+        reason:
+            'This slice assumes the cheapest regiment consumes fabric and that '
+            'fabric is produced from a feedstock recipe.',
+      );
+      final fabricFeedstock = ProductionRecipesCatalog.all
+          .where((r) => r.outputCommodityId == _fabricId)
+          .expand((r) => r.inputQuantities.keys)
+          .toSet();
+      expect(
+        fabricFeedstock,
+        contains(_woolId),
+        reason: 'A fabric recipe must consume wool for this fixture to hold.',
+      );
+    });
+
+    test(
+      'recovered-treasury seller with zero fabric and zero regiments '
+      'withholds its surplus wool from offers',
+      () {
+        final game = _lockRecoverySellerGame(
+          treasury: threshold,
+          fabricHeld: 0,
+        );
+        expect(
+          _woolOffers(_run(game)),
+          isEmpty,
+          reason:
+              'The feedstock for the missing fabric build input must be '
+              'retained so it accumulates to a feasible production run rather '
+              'than being sold as surplus.',
+        );
+      },
+    );
+
+    test('seller still below the regiment threshold keeps offering wool', () {
+      // The reservation shares the bootstrap gate: a broke seller is not yet
+      // rebuilding, so it must keep selling its surplus for liquidity.
+      final game = _lockRecoverySellerGame(
+        treasury: threshold - 1,
+        fabricHeld: 0,
+      );
+      expect(
+        _woolOffers(_run(game)),
+        isNotEmpty,
+        reason:
+            'A still-broke seller keeps selling surplus feedstock for '
+            'liquidity; the reservation only applies once treasury recovers.',
+      );
+    });
+
+    test('seller already holding the fabric input keeps offering wool', () {
+      final game = _lockRecoverySellerGame(
+        treasury: threshold,
+        fabricHeld: fabricInput!,
+      );
+      expect(
+        _woolOffers(_run(game)),
+        isNotEmpty,
+        reason:
+            'Once the build input is on hand the reservation self-clears and '
+            'the seller resumes offering its surplus feedstock.',
+      );
+    });
+
+    test('seller that already holds a regiment keeps offering wool', () {
+      final game = _lockRecoverySellerGame(
+        treasury: threshold,
+        fabricHeld: 0,
+        hasRegiment: true,
+      );
+      expect(
+        _woolOffers(_run(game)),
+        isNotEmpty,
+        reason: 'The reservation targets the zero-regiment rebuild gap only.',
+      );
+    });
+
+    test('quota-met (non-seller) GP above threshold keeps offering wool', () {
+      // owProvinces >= 10 lifts the GP out of the below-quota seller band.
+      final game = _lockRecoverySellerGame(
+        treasury: threshold,
+        fabricHeld: 0,
+        owProvinces: 12,
+      );
+      expect(_woolOffers(_run(game)), isNotEmpty);
+    });
+
+    test('feedstock-reservation path is deterministic', () {
+      final game = _lockRecoverySellerGame(treasury: threshold, fabricHeld: 0);
+      expect(_run(game), equals(_run(game)));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Refs #2847 — offer-side slice of the H8 regiment-rebuild conversion gap.

A below-quota zero-NW lock-recovery seller that has recovered treasury to the cheapest-regiment threshold but owns **zero regiments** and holds **no `fabric`** is trapped:

- The merged H8 bootstrap bid creates demand for `fabric`, but on seed 42 no world-market seller offers `fabric`, so the seller must produce it domestically.
- The merged economy-planner boost (#3229) prioritizes feasible recipes that output the missing build input — but a fabric recipe is only feasible once its feedstock (`wool`/`cotton`) reaches the per-run requirement in the stockpile.
- A lock-recovery seller otherwise **sells that feedstock as surplus every turn**, so it never accumulates to a feasible run.

This PR adds the missing offer-side invariant: under the **same** carve-out gate as the H8 bootstrap bid (below-quota zero-NW lock-recovery seller, `treasury >= cheapestRegimentBuildTreasuryCost()`, `regimentCountForPlayer == 0`), the planner withholds the build-input feedstock from the seller's offer set so it can accumulate. No order is added — only surplus feedstock offers are suppressed. The reservation self-clears once the build input lands or the GP owns a regiment.

## Changes

- `treasury_planner.dart`: `_regimentBuildInputFeedstockIds(projected)` (pure; recipe feedstock of any currently-missing `peasant_levies` build input) and removal of its members from the offer `available` map inside the existing rebuild carve-out.
- `SPEC/ai/treasury-planner.md`: authorize the offer-side reservation, acceptance criteria, and an honest residual feedstock-acquisition disclosure.
- New deterministic unit tests (`treasury_planner_regiment_input_feedstock_test.dart`): positive (reservation active) + negatives (below threshold, input on hand, has a regiment, quota-met non-seller) + determinism.

## Scope / disclosure

This is the **offer-side** invariant complementing the merged #3229 production boost and the H8 bid. Verified via the seed-42 S7-D diagnostic: the failing GPs (gp3/gp5/gp6) extract **no** wool/cotton and the market carries **no** fabric supply, so this slice **alone does not close** the seed-42 turn-100 conquest gate. Feedstock acquisition (extraction routing or a market fabric/feedstock seller) remains separate #2847 work and is disclosed in SPEC. This slice hardens the production path so retained feedstock is not sold away once acquisition is solved.

## Test plan

- [x] `dart analyze` clean on touched files (2 remaining warnings are pre-existing in unrelated files).
- [x] New unit tests pass (7/7).
- [x] `test/planning/`, economy build-input production, and seed-42 regression suites pass (1277 pass, 1 known seed-42 skip) — no regressions.
- [x] seed-42 S7-D diagnostic re-run: no regression on gp1/gp2; failing-GP metrics unchanged (feedstock-acquisition blocker is upstream, as disclosed).

Made with [Cursor](https://cursor.com)