### PR TITLE
feat(ai): H8-supply wool market path for lock-recovery regiment rebuild (#2847)

### DIFF
--- a/SPEC/ai/treasury-planner.md
+++ b/SPEC/ai/treasury-planner.md
@@ -461,6 +461,59 @@ feedstock is on hand.
   feedstock-reservation path, then both runs return identical
   `List<TradeOrder>` outputs (determinism).
 
+### Lock-recovery regiment build-input market supply (Refs #2847 H8-supply market)
+
+The offer-side feedstock reservation (above) and the economy-planner
+production boost only help when the lock-recovery seller **already holds**
+recipe feedstock. On seed 42 the failing below-quota zero-NW sellers
+(gp3 / gp5 / gp6) extract no `wool` / `cotton`, the world market carries
+no `fabric` offers, and the H8 bootstrap **fabric** bid therefore never
+clears (`gpRegimentInputDealsAsBuyer == 0` in the S7-D diagnostic). This
+section closes the **market supply** axis so the domestic production path
+can run.
+
+**Seller-side feedstock bid (bootstrap extension).** Under the same gate as
+§ Lock-recovery seller regiment build-input bootstrap, when the projected
+stockpile is short of a `peasant_levies` build input **and** short of the
+feedstock required for one feasible `fabric_from_wool` / `fabric_from_cotton`
+run, the planner injects a **feedstock bid first** (quantity = per-run recipe
+input minus on-hand plus carry-forward). The fabric build-input bid is
+suppressed while any such feedstock deficit remains so the single
+`bidTypeCap` slot targets acquirable supply. Once feedstock is on hand, the
+existing fabric bootstrap bid and production boost resume; the feedstock
+reservation prevents selling the acquired wool / cotton before conversion.
+
+**Affluent-GP feedstock / build-input offers.** When **any** below-quota
+zero-NW lock-recovery seller in the game meets the H8 bootstrap gate
+(`player.treasury >= cheapestRegimentBuildTreasuryCost()`,
+`regimentCountForPlayer == 0`, missing a `peasant_levies` build input), every
+**other** Great Power that is **not** a lock-recovery seller and holds
+`player.treasury >= cheapestRegimentBuildTreasuryCost()` releases surplus
+`wool`, `cotton`, and `fabric` aggressively into its offer set (safety buffer
+`0` for those commodities — same release pattern as § Lock-recovery seller
+food-surplus release) so the seller's feedstock / fabric bids can match. The
+gate clears automatically once no lock-recovery seller still needs the
+bootstrap path.
+
+#### Acceptance criteria (H8-supply market)
+
+- Given a below-quota zero-NW lock-recovery seller with recovered treasury,
+  zero regiments, zero `fabric`, and zero `wool`, when `runTreasuryPlanner`
+  runs for that seller, then it emits a `TradeOrderType.bid` for `wool` (or
+  `cotton` when that is the feasible feedstock) and emits **no** `fabric`
+  bid until the feedstock deficit is cleared.
+- Given the same game state and a non-seller Great Power with surplus `wool`
+  and `player.treasury >= cheapestRegimentBuildTreasuryCost()`, when
+  `runTreasuryPlanner` runs for that affluent GP, then it emits a
+  `TradeOrderType.offer` for `wool`.
+- Given no below-quota zero-NW lock-recovery seller meets the H8 bootstrap
+  gate, when `runTreasuryPlanner` runs for an affluent non-seller, then it
+  does **not** apply the aggressive `wool` / `cotton` / `fabric` offer
+  release (steady-state surplus rules apply).
+- Given identical inputs, when `runTreasuryPlanner` runs twice on the
+  H8-supply market path, then both runs return identical
+  `List<TradeOrder>` outputs (determinism).
+
 ---
 
 ## Treasury-budget-aware bid sizing (Refs #3122)

--- a/packages/colonizethis_ai/lib/src/planning/treasury_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/treasury_planner.dart
@@ -128,6 +128,11 @@ List<TradeOrder> runTreasuryPlanner({
   // SPEC/ai/treasury-planner.md § Lock-recovery seller food-surplus release.
   final isLockRecoverySeller =
       _isBelowQuotaZeroNwLockRecoverySeller(game: game, playerId: playerId);
+  final regimentBuildInputMarketSupplyActive =
+      _anyLockRecoverySellerNeedsRegimentBuildInput(game);
+  final isRegimentBuildInputMarketSupplier = regimentBuildInputMarketSupplyActive &&
+      !isLockRecoverySeller &&
+      rawTreasury >= threshold;
 
   for (final id in trackedCommodityIds) {
     if (richesCommodityIds.contains(id)) continue;
@@ -139,9 +144,13 @@ List<TradeOrder> runTreasuryPlanner({
       inputNeeds: inputNeeds,
     );
     final inputs = inputNeeds[id] ?? 0;
-    final safety = commodity.category == CommodityCategory.food
+    var safety = commodity.category == CommodityCategory.food
         ? (isLockRecoverySeller ? 0 : consumption * 2)
         : consumption;
+    if (isRegimentBuildInputMarketSupplier &&
+        _regimentBuildInputSupplyCommodityIds.contains(id)) {
+      safety = 0;
+    }
     final reserve = consumption + inputs + safety;
     final projectedQty = projected.quantityOf(id);
     final surplus = projectedQty - reserve - (carryForwardOffers[id] ?? 0);
@@ -265,10 +274,34 @@ List<TradeOrder> runTreasuryPlanner({
   if (isLockRecoverySeller &&
       rawTreasury >= threshold &&
       regimentCountForPlayer(game, playerId) == 0) {
-    for (final input in RegimentEconomyCatalog.peasantLevies.buildInputs.entries) {
-      final held = projected.quantityOf(input.key) + (carryForwardBids[input.key] ?? 0);
-      if (held < input.value) {
-        need[input.key] = input.value - held;
+    var feedstockStillMissing = false;
+    final feedstockCandidates = _regimentBuildInputFeedstockIds(projected).toList()
+      ..sort((a, b) {
+        // Old World lock-recovery sellers extract wool, not cotton (seed-42).
+        if (a == CommodityCatalog.wool.id) return -1;
+        if (b == CommodityCatalog.wool.id) return 1;
+        return a.compareTo(b);
+      });
+    for (final feedstockId in feedstockCandidates) {
+      final qtyNeeded =
+          _feedstockQuantityForOneMissingBuildInputRun(feedstockId, projected);
+      if (qtyNeeded <= 0) continue;
+      final held =
+          projected.quantityOf(feedstockId) + (carryForwardBids[feedstockId] ?? 0);
+      if (held < qtyNeeded) {
+        need[feedstockId] = qtyNeeded - held;
+        feedstockStillMissing = true;
+      }
+      break;
+    }
+    if (!feedstockStillMissing) {
+      for (final input
+          in RegimentEconomyCatalog.peasantLevies.buildInputs.entries) {
+        final held =
+            projected.quantityOf(input.key) + (carryForwardBids[input.key] ?? 0);
+        if (held < input.value) {
+          need[input.key] = input.value - held;
+        }
       }
     }
     // Refs #2847 § H8-supply: the bootstrap bid above cannot fill when no
@@ -684,6 +717,57 @@ Set<CommodityId> _regimentBuildInputFeedstockIds(Stockpile projected) {
     }
   }
   return feedstock;
+}
+
+/// Per-run feedstock input quantity required to produce one unit of a missing
+/// `peasant_levies` build input via a production recipe consuming [feedstockId].
+int _feedstockQuantityForOneMissingBuildInputRun(
+  CommodityId feedstockId,
+  Stockpile projected,
+) {
+  var needed = 0;
+  for (final entry in RegimentEconomyCatalog.peasantLevies.buildInputs.entries) {
+    if (projected.quantityOf(entry.key) >= entry.value) continue;
+    for (final recipe in ProductionRecipesCatalog.all) {
+      if (recipe.outputCommodityId != entry.key) continue;
+      final perRun = recipe.inputQuantities[feedstockId];
+      if (perRun != null && perRun > needed) {
+        needed = perRun;
+      }
+    }
+  }
+  return needed;
+}
+
+/// Commodity ids affluent GPs release when any lock-recovery seller needs the
+/// H8 bootstrap path (Refs #2847 H8-supply market).
+const Set<CommodityId> _regimentBuildInputSupplyCommodityIds = {
+  'wool',
+  'cotton',
+  'fabric',
+};
+
+/// True when any below-quota zero-NW lock-recovery seller still needs the
+/// H8 regiment build-input bootstrap path (Refs #2847 H8-supply market).
+bool _anyLockRecoverySellerNeedsRegimentBuildInput(Game game) {
+  final threshold = cheapestRegimentBuildTreasuryCost();
+  for (final player in game.players) {
+    if (!_isBelowQuotaZeroNwLockRecoverySeller(
+      game: game,
+      playerId: player.id,
+    )) {
+      continue;
+    }
+    if (player.treasury < threshold) continue;
+    if (regimentCountForPlayer(game, player.id) > 0) continue;
+    for (final entry
+        in RegimentEconomyCatalog.peasantLevies.buildInputs.entries) {
+      if (player.stockpile.quantityOf(entry.key) < entry.value) {
+        return true;
+      }
+    }
+  }
+  return false;
 }
 
 /// Sorted Great Power ids for deterministic per-turn buyer rotation.

--- a/packages/colonizethis_ai/lib/src/planning/treasury_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/treasury_planner.dart
@@ -274,35 +274,18 @@ List<TradeOrder> runTreasuryPlanner({
   if (isLockRecoverySeller &&
       rawTreasury >= threshold &&
       regimentCountForPlayer(game, playerId) == 0) {
-    var feedstockStillMissing = false;
-    final feedstockCandidates = _regimentBuildInputFeedstockIds(projected).toList()
-      ..sort((a, b) {
-        // Old World lock-recovery sellers extract wool, not cotton (seed-42).
-        if (a == CommodityCatalog.wool.id) return -1;
-        if (b == CommodityCatalog.wool.id) return 1;
-        return a.compareTo(b);
-      });
-    for (final feedstockId in feedstockCandidates) {
-      final qtyNeeded =
-          _feedstockQuantityForOneMissingBuildInputRun(feedstockId, projected);
-      if (qtyNeeded <= 0) continue;
-      final held =
-          projected.quantityOf(feedstockId) + (carryForwardBids[feedstockId] ?? 0);
-      if (held < qtyNeeded) {
-        need[feedstockId] = qtyNeeded - held;
-        feedstockStillMissing = true;
-      }
-      break;
-    }
+    final feedstockStillMissing = _addRegimentBuildInputFeedstockBootstrapNeed(
+      feedstockCandidates: _sortedRegimentBuildInputFeedstockIds(projected),
+      projected: projected,
+      carryForwardBids: carryForwardBids,
+      need: need,
+    );
     if (!feedstockStillMissing) {
-      for (final input
-          in RegimentEconomyCatalog.peasantLevies.buildInputs.entries) {
-        final held =
-            projected.quantityOf(input.key) + (carryForwardBids[input.key] ?? 0);
-        if (held < input.value) {
-          need[input.key] = input.value - held;
-        }
-      }
+      _addRegimentBuildInputDirectNeed(
+        projected: projected,
+        carryForwardBids: carryForwardBids,
+        need: need,
+      );
     }
     // Refs #2847 § H8-supply: the bootstrap bid above cannot fill when no
     // world-market seller offers the build input (seed-42 `fabric` has zero GP
@@ -717,6 +700,55 @@ Set<CommodityId> _regimentBuildInputFeedstockIds(Stockpile projected) {
     }
   }
   return feedstock;
+}
+
+/// Build-input feedstock ids ordered so Old World lock-recovery sellers extract
+/// wool before cotton (seed-42), then alphabetically for determinism.
+List<CommodityId> _sortedRegimentBuildInputFeedstockIds(Stockpile projected) {
+  return _regimentBuildInputFeedstockIds(projected).toList()
+    ..sort((a, b) {
+      if (a == CommodityCatalog.wool.id) return -1;
+      if (b == CommodityCatalog.wool.id) return 1;
+      return a.compareTo(b);
+    });
+}
+
+/// Adds the feedstock bid for the first viable [feedstockCandidates] entry so a
+/// lock-recovery seller can domestically produce a missing regiment build input.
+/// Returns true when a feedstock bid was queued (still accumulating feedstock).
+bool _addRegimentBuildInputFeedstockBootstrapNeed({
+  required List<CommodityId> feedstockCandidates,
+  required Stockpile projected,
+  required Map<CommodityId, int> carryForwardBids,
+  required Map<CommodityId, int> need,
+}) {
+  for (final feedstockId in feedstockCandidates) {
+    final qtyNeeded =
+        _feedstockQuantityForOneMissingBuildInputRun(feedstockId, projected);
+    if (qtyNeeded <= 0) continue;
+    final held =
+        projected.quantityOf(feedstockId) + (carryForwardBids[feedstockId] ?? 0);
+    if (held >= qtyNeeded) return false;
+    need[feedstockId] = qtyNeeded - held;
+    return true;
+  }
+  return false;
+}
+
+/// Adds direct bids for any missing `peasant_levies` build input when no
+/// feedstock bootstrap bid is pending.
+void _addRegimentBuildInputDirectNeed({
+  required Stockpile projected,
+  required Map<CommodityId, int> carryForwardBids,
+  required Map<CommodityId, int> need,
+}) {
+  for (final input in RegimentEconomyCatalog.peasantLevies.buildInputs.entries) {
+    final held =
+        projected.quantityOf(input.key) + (carryForwardBids[input.key] ?? 0);
+    if (held < input.value) {
+      need[input.key] = input.value - held;
+    }
+  }
 }
 
 /// Per-run feedstock input quantity required to produce one unit of a missing

--- a/packages/colonizethis_ai/lib/src/planning/treasury_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/treasury_planner.dart
@@ -70,19 +70,12 @@ List<TradeOrder> runTreasuryPlanner({
 }) {
   final ResourceRules rules = resourceRules ?? ResourceRules.defaultRules;
   final bidTypeCap = worldMarketBidTypeCap(game, playerId);
-  final tradeCargoCapacity = tileMapByRegion != null &&
-          tileMapByRegion.isNotEmpty &&
-          topology != null
-      ? tradeCargoCapacityForGreatPower(
-          game: game,
-          playerId: playerId,
-          tileMapByRegion: tileMapByRegion,
-          topology: topology,
-        )
-      : () {
-          final homeFleetHolds = cargoHoldsForHomeFleet(game, playerId);
-          return homeFleetHolds < 0 ? 0 : homeFleetHolds;
-        }();
+  final tradeCargoCapacity = _resolveTradeCargoCapacity(
+    game: game,
+    playerId: playerId,
+    tileMapByRegion: tileMapByRegion,
+    topology: topology,
+  );
 
   final projected = _projectStockpileAfterProduction(
     stockpile: stockpile,
@@ -255,56 +248,20 @@ List<TradeOrder> runTreasuryPlanner({
     need.clear();
   }
 
-  // Refs #2847 § H8: a below-quota zero-NW lock-recovery seller accumulates
-  // treasury by selling food, but its bid `need` is cleared every turn (it is
-  // a sell-only Path-F seller), so it can never buy the cheapest regiment's
-  // build-input commodity. `peasant_levies` (the universal cheapest regiment,
-  // cost `cheapestRegimentBuildTreasuryCost()`) requires its `buildInputs`
-  // commodities in the stockpile; with zero of them on hand
-  // `suggestBuildOrders` returns no regiment candidate even when treasury is
-  // affordable and a peasant is free, so the seller that has *already*
-  // recovered treasury to/above the regiment threshold stays trapped at zero
-  // regiments (seed-42 gp5/gp6 hold treasury >= threshold yet 0 fabric for
-  // tens of turns). Inject a single build-input bid so the recovered treasury
-  // converts into the army the lock-recovery sell-down existed to fund. The
-  // carve-out fires only while the GP holds zero regiments and is missing a
-  // build input, and clears automatically once it owns a regiment or the
-  // input lands. SPEC/ai/treasury-planner.md
+  // Refs #2847 § H8: lock-recovery seller regiment build-input bootstrap bid +
+  // feedstock reservation. SPEC/ai/treasury-planner.md
   // § Lock-recovery seller regiment build-input bootstrap.
-  if (isLockRecoverySeller &&
-      rawTreasury >= threshold &&
-      regimentCountForPlayer(game, playerId) == 0) {
-    final feedstockStillMissing = _addRegimentBuildInputFeedstockBootstrapNeed(
-      feedstockCandidates: _sortedRegimentBuildInputFeedstockIds(projected),
-      projected: projected,
-      carryForwardBids: carryForwardBids,
-      need: need,
-    );
-    if (!feedstockStillMissing) {
-      _addRegimentBuildInputDirectNeed(
-        projected: projected,
-        carryForwardBids: carryForwardBids,
-        need: need,
-      );
-    }
-    // Refs #2847 § H8-supply: the bootstrap bid above cannot fill when no
-    // world-market seller offers the build input (seed-42 `fabric` has zero GP
-    // / minor / tribe supply), so the recovered seller must *produce* the input
-    // domestically. The economy planner already boosts feasible recipes that
-    // output a missing build input (economy-planner.md § Regiment build-input
-    // production priority), but those recipes only become feasible once their
-    // feedstock (e.g. `wool` / `cotton` for `fabric`) reaches the per-run input
-    // requirement in the stockpile. A lock-recovery seller otherwise sells that
-    // feedstock as surplus every turn, so it never accumulates to a feasible
-    // run. Withhold the feedstock from the offer set while the rebuild carve-out
-    // is active so it accumulates; the reservation self-clears once the build
-    // input lands or the GP owns a regiment.
-    // SPEC/ai/treasury-planner.md
-    // § Lock-recovery seller build-input feedstock reservation.
-    for (final feedstockId in _regimentBuildInputFeedstockIds(projected)) {
-      available.remove(feedstockId);
-    }
-  }
+  _applyLockRecoverySellerRegimentRebuildBids(
+    isLockRecoverySeller: isLockRecoverySeller,
+    rawTreasury: rawTreasury,
+    threshold: threshold,
+    game: game,
+    playerId: playerId,
+    projected: projected,
+    carryForwardBids: carryForwardBids,
+    need: need,
+    available: available,
+  );
 
   if (available.isEmpty && need.isEmpty) {
     return const <TradeOrder>[];
@@ -353,6 +310,90 @@ List<TradeOrder> runTreasuryPlanner({
   );
 
   return [...offers, ...bids];
+}
+
+/// Resolves this GP's per-turn trade cargo capacity. Uses the tile-map-aware
+/// [tradeCargoCapacityForGreatPower] when a tile map and topology are present;
+/// otherwise falls back to the home-fleet cargo holds (floored at 0).
+int _resolveTradeCargoCapacity({
+  required Game game,
+  required String playerId,
+  required Map<String, TileMapResult>? tileMapByRegion,
+  required MapTopology? topology,
+}) {
+  if (tileMapByRegion != null && tileMapByRegion.isNotEmpty && topology != null) {
+    return tradeCargoCapacityForGreatPower(
+      game: game,
+      playerId: playerId,
+      tileMapByRegion: tileMapByRegion,
+      topology: topology,
+    );
+  }
+  final homeFleetHolds = cargoHoldsForHomeFleet(game, playerId);
+  return homeFleetHolds < 0 ? 0 : homeFleetHolds;
+}
+
+/// Refs #2847 § H8: a below-quota zero-NW lock-recovery seller accumulates
+/// treasury by selling food, but its bid `need` is cleared every turn (it is
+/// a sell-only Path-F seller), so it can never buy the cheapest regiment's
+/// build-input commodity. `peasant_levies` (the universal cheapest regiment,
+/// cost `cheapestRegimentBuildTreasuryCost()`) requires its `buildInputs`
+/// commodities in the stockpile; with zero of them on hand
+/// `suggestBuildOrders` returns no regiment candidate even when treasury is
+/// affordable and a peasant is free, so the seller that has *already* recovered
+/// treasury to/above the regiment threshold stays trapped at zero regiments
+/// (seed-42 gp5/gp6 hold treasury >= threshold yet 0 fabric for tens of turns).
+/// Inject a single build-input bid so the recovered treasury converts into the
+/// army the lock-recovery sell-down existed to fund. The carve-out fires only
+/// while the GP holds zero regiments and is missing a build input, and clears
+/// automatically once it owns a regiment or the input lands.
+///
+/// Refs #2847 § H8-supply: the bootstrap bid cannot fill when no world-market
+/// seller offers the build input (seed-42 `fabric` has zero GP / minor / tribe
+/// supply), so the recovered seller must *produce* the input domestically. The
+/// economy planner already boosts feasible recipes that output a missing build
+/// input (economy-planner.md § Regiment build-input production priority), but
+/// those recipes only become feasible once their feedstock (e.g. `wool` /
+/// `cotton` for `fabric`) reaches the per-run input requirement in the
+/// stockpile. A lock-recovery seller otherwise sells that feedstock as surplus
+/// every turn, so it never accumulates to a feasible run. Withhold the feedstock
+/// from the offer set while the rebuild carve-out is active so it accumulates;
+/// the reservation self-clears once the build input lands or the GP owns a
+/// regiment. SPEC/ai/treasury-planner.md
+/// § Lock-recovery seller regiment build-input bootstrap +
+/// § Lock-recovery seller build-input feedstock reservation.
+void _applyLockRecoverySellerRegimentRebuildBids({
+  required bool isLockRecoverySeller,
+  required int rawTreasury,
+  required int threshold,
+  required Game game,
+  required String playerId,
+  required Stockpile projected,
+  required Map<CommodityId, int> carryForwardBids,
+  required Map<CommodityId, int> need,
+  required Map<CommodityId, int> available,
+}) {
+  if (!isLockRecoverySeller ||
+      rawTreasury < threshold ||
+      regimentCountForPlayer(game, playerId) != 0) {
+    return;
+  }
+  final feedstockStillMissing = _addRegimentBuildInputFeedstockBootstrapNeed(
+    feedstockCandidates: _sortedRegimentBuildInputFeedstockIds(projected),
+    projected: projected,
+    carryForwardBids: carryForwardBids,
+    need: need,
+  );
+  if (!feedstockStillMissing) {
+    _addRegimentBuildInputDirectNeed(
+      projected: projected,
+      carryForwardBids: carryForwardBids,
+      need: need,
+    );
+  }
+  for (final feedstockId in _regimentBuildInputFeedstockIds(projected)) {
+    available.remove(feedstockId);
+  }
 }
 
 Stockpile _projectStockpileAfterProduction({

--- a/packages/colonizethis_ai/test/planning/treasury_planner_regiment_input_bootstrap_test.dart
+++ b/packages/colonizethis_ai/test/planning/treasury_planner_regiment_input_bootstrap_test.dart
@@ -22,6 +22,7 @@ const _fabricId = 'fabric';
 Game _lockRecoverySellerGame({
   required int treasury,
   required int fabricHeld,
+  int woolHeld = 0,
   int owProvinces = 3,
   bool hasRegiment = false,
   bool zeroNewWorld = true,
@@ -29,6 +30,9 @@ Game _lockRecoverySellerGame({
   const ow = 'oldWorld';
   const nw = 'newWorld';
   var stockpile = const Stockpile().applyDelta('grain', 80);
+  if (woolHeld > 0) {
+    stockpile = stockpile.applyDelta('wool', woolHeld);
+  }
   if (fabricHeld > 0) {
     stockpile = stockpile.applyDelta(_fabricId, fabricHeld);
   }
@@ -102,8 +106,8 @@ void main() {
     });
 
     test(
-      'recovered-treasury seller holding zero fabric and zero regiments '
-      'emits a fabric build-input bid',
+      'recovered-treasury seller holding zero fabric and zero wool emits a '
+      'wool feedstock bid before fabric',
       () {
         final game = _lockRecoverySellerGame(
           treasury: threshold,
@@ -111,18 +115,39 @@ void main() {
         );
         final bids =
             _run(game).where((o) => o.type == TradeOrderType.bid).toList();
+        final woolBids =
+            bids.where((o) => o.commodityId == 'wool').toList();
         final fabricBids =
-            bids.where((o) => o.commodityId == _fabricId).toList();
+            bids.where((o) => o.commodityId == 'fabric').toList();
         expect(
-          fabricBids,
+          woolBids,
           isNotEmpty,
           reason:
               'A seller above the regiment threshold with no regiment and no '
-              'fabric must bid for the missing regiment build input.',
+              'fabric must bid for missing wool feedstock first.',
         );
-        expect(fabricBids.first.quantity, greaterThanOrEqualTo(fabricInput!));
+        expect(fabricBids, isEmpty);
       },
     );
+
+    test('seller with sufficient wool feedstock emits a fabric bid', () {
+      final game = _lockRecoverySellerGame(
+        treasury: threshold,
+        fabricHeld: 0,
+        woolHeld: 2,
+      );
+      final fabricBids = _run(game)
+          .where((o) =>
+              o.type == TradeOrderType.bid && o.commodityId == _fabricId)
+          .toList();
+      expect(fabricBids, isNotEmpty);
+      expect(
+        _run(game).where(
+          (o) => o.type == TradeOrderType.bid && o.commodityId == 'wool',
+        ),
+        isEmpty,
+      );
+    });
 
     test('seller still below the regiment threshold emits no fabric bid', () {
       final game = _lockRecoverySellerGame(

--- a/packages/colonizethis_ai/test/planning/treasury_planner_regiment_input_market_supply_test.dart
+++ b/packages/colonizethis_ai/test/planning/treasury_planner_regiment_input_market_supply_test.dart
@@ -1,0 +1,186 @@
+/// Lock-recovery regiment build-input market supply (Refs #2847 H8-supply market).
+library;
+
+import 'package:colonizethis_ai/src/planning/treasury_planner.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+const _fabricId = 'fabric';
+const _woolId = 'wool';
+
+Game _twoGpGame({
+  required int sellerTreasury,
+  required int supplierTreasury,
+  required int sellerFabricHeld,
+  required int sellerWoolHeld,
+  required int supplierWoolHeld,
+  int sellerOwProvinces = 3,
+  int supplierOwProvinces = 12,
+}) {
+  const ow = 'oldWorld';
+  var sellerStockpile = const Stockpile().applyDelta('grain', 80);
+  if (sellerWoolHeld > 0) {
+    sellerStockpile = sellerStockpile.applyDelta(_woolId, sellerWoolHeld);
+  }
+  if (sellerFabricHeld > 0) {
+    sellerStockpile = sellerStockpile.applyDelta(_fabricId, sellerFabricHeld);
+  }
+  var supplierStockpile = const Stockpile().applyDelta('grain', 80);
+  if (supplierWoolHeld > 0) {
+    supplierStockpile = supplierStockpile.applyDelta(_woolId, supplierWoolHeld);
+  }
+  return Game(
+    id: 'g-h8-supply-market',
+    worldState: WorldState(
+      turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 50),
+      oldWorld: RegionData(
+        provinces: [
+          for (var i = 0; i < sellerOwProvinces; i++)
+            Province(id: '$ow|seller_$i', regionId: ow, ownerId: 'gp_seller'),
+          for (var i = 0; i < supplierOwProvinces; i++)
+            Province(id: '$ow|supplier_$i', regionId: ow, ownerId: 'gp_supplier'),
+        ],
+      ),
+      newWorld: const RegionData(provinces: []),
+    ),
+    players: [
+      Player(
+        id: 'gp_seller',
+        displayName: 'Seller',
+        isHuman: false,
+        capitalProvinceId: '$ow|seller_0',
+        stockpile: sellerStockpile,
+        treasury: sellerTreasury,
+      ),
+      Player(
+        id: 'gp_supplier',
+        displayName: 'Supplier',
+        isHuman: false,
+        capitalProvinceId: '$ow|supplier_0',
+        stockpile: supplierStockpile,
+        treasury: supplierTreasury,
+      ),
+    ],
+    worldMarketState: WorldMarketState.withDefaultPrices(const {
+      'grain': 10,
+      _woolId: 20,
+      _fabricId: 40,
+    }),
+  );
+}
+
+List<TradeOrder> _run(Game game, String playerId) => runTreasuryPlanner(
+      game: game,
+      playerId: playerId,
+      stockpile: game.players.firstWhere((p) => p.id == playerId).stockpile,
+      productionAssignments: const [],
+      treasury: game.players.firstWhere((p) => p.id == playerId).treasury,
+    );
+
+void main() {
+  group('lock-recovery regiment build-input market supply (Refs #2847 H8-supply market)',
+      () {
+    final threshold = cheapestRegimentBuildTreasuryCost();
+
+    test(
+      'recovered lock-recovery seller missing wool bids wool before fabric',
+      () {
+        final game = _twoGpGame(
+          sellerTreasury: threshold,
+          supplierTreasury: threshold,
+          sellerFabricHeld: 0,
+          sellerWoolHeld: 0,
+          supplierWoolHeld: 20,
+        );
+        final orders = _run(game, 'gp_seller');
+        final woolBids = orders
+            .where((o) => o.type == TradeOrderType.bid && o.commodityId == _woolId)
+            .toList();
+        final fabricBids = orders
+            .where((o) =>
+                o.type == TradeOrderType.bid && o.commodityId == _fabricId)
+            .toList();
+        expect(woolBids, isNotEmpty);
+        expect(fabricBids, isEmpty);
+      },
+    );
+
+    test(
+      'affluent non-seller offers surplus wool while a lock-recovery seller '
+      'still needs the bootstrap path',
+      () {
+        final game = _twoGpGame(
+          sellerTreasury: threshold,
+          supplierTreasury: threshold,
+          sellerFabricHeld: 0,
+          sellerWoolHeld: 0,
+          supplierWoolHeld: 20,
+        );
+        final woolOffers = _run(game, 'gp_supplier')
+            .where((o) => o.type == TradeOrderType.offer && o.commodityId == _woolId)
+            .toList();
+        expect(
+          woolOffers,
+          isNotEmpty,
+          reason:
+              'An affluent GP must release wool offers so the seller feedstock '
+              'bid can clear.',
+        );
+      },
+    );
+
+    test(
+      'affluent non-seller keeps normal wool buffer when no lock-recovery seller '
+      'needs the bootstrap path',
+      () {
+        final game = _twoGpGame(
+          sellerTreasury: threshold - 1,
+          supplierTreasury: threshold,
+          sellerFabricHeld: 0,
+          sellerWoolHeld: 0,
+          supplierWoolHeld: 4,
+        );
+        final woolOffers = _run(game, 'gp_supplier')
+            .where((o) => o.type == TradeOrderType.offer && o.commodityId == _woolId)
+            .toList();
+        expect(woolOffers, isEmpty);
+      },
+    );
+
+    test('seller with sufficient wool bids fabric not wool', () {
+      final game = _twoGpGame(
+        sellerTreasury: threshold,
+        supplierTreasury: threshold,
+        sellerFabricHeld: 0,
+        sellerWoolHeld: 2,
+        supplierWoolHeld: 20,
+      );
+      final orders = _run(game, 'gp_seller');
+      expect(
+        orders.where(
+          (o) => o.type == TradeOrderType.bid && o.commodityId == _woolId,
+        ),
+        isEmpty,
+      );
+      expect(
+        orders.where(
+          (o) => o.type == TradeOrderType.bid && o.commodityId == _fabricId,
+        ),
+        isNotEmpty,
+      );
+    });
+
+    test('H8-supply market path is deterministic', () {
+      final game = _twoGpGame(
+        sellerTreasury: threshold,
+        supplierTreasury: threshold,
+        sellerFabricHeld: 0,
+        sellerWoolHeld: 0,
+        supplierWoolHeld: 20,
+      );
+      expect(_run(game, 'gp_seller'), equals(_run(game, 'gp_seller')));
+      expect(_run(game, 'gp_supplier'), equals(_run(game, 'gp_supplier')));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Closes the **H8-supply market axis** tracked in #2847 after the offer-side feedstock reservation (#3231): lock-recovery sellers can now source wool through the world market instead of bidding only for unavailable `fabric`.

- **Seller feedstock bid:** under the existing H8 bootstrap gate, bid **wool** (preferred over cotton for Old World sellers) when feedstock is short; suppress the fabric bid until wool is on hand. Fixes a regression where the single `bidTypeCap` slot targeted `cotton` (never extracted on seed 42) instead of wool.
- **Affluent supplier offers:** when any below-quota zero-NW lock-recovery seller still needs the bootstrap path, non-seller GPs at/above the regiment treasury threshold release surplus `wool` / `cotton` / `fabric` aggressively (zero safety buffer) so bids can match.

Refs #2847.

## Scope

- **Done in this push:** `treasury_planner.dart` market-supply path, SPEC § Lock-recovery regiment build-input market supply, unit tests (`treasury_planner_regiment_input_market_supply_test.dart`, bootstrap test refresh).
- **Deferred:** S7-D refresh on seed 42 still shows flat `gpRegimentInputDealsAsBuyer` and OW gains (+2/+1/+1/+2 for gp3–gp6) — affluent GPs may not hold wool surplus at the moments sellers bid, or feedstock extraction routing remains a separate axis. H4-b minor-transit reach (#3224 follow-up for gp4) and conquest regression unskip remain open.

## Test plan

- [x] `dart test test/planning/treasury_planner_regiment_input_market_supply_test.dart`
- [x] `dart test test/planning/treasury_planner_regiment_input_bootstrap_test.dart`
- [x] `dart test test/planning/treasury_planner_regiment_input_feedstock_test.dart`
- [x] S7-D diagnostic re-run (no regression; gate metrics unchanged on seed 42)


Made with [Cursor](https://cursor.com)