### PR TITLE
feat(logic): H8-extraction feedstock tile priority for lock-recovery sellers (#2847)

### DIFF
--- a/SPEC/ai/economy-planner.md
+++ b/SPEC/ai/economy-planner.md
@@ -95,6 +95,29 @@ Companion to [treasury-planner.md](treasury-planner.md) § Lock-recovery seller 
 
 ---
 
+## Regiment build-input feedstock extraction priority (Refs #2847 H8-extraction)
+
+Companion to § Regiment build-input production priority (Refs #2847 H8) and [treasury-planner.md](treasury-planner.md) § Lock-recovery seller regiment build-input bootstrap. The production boost only converts feedstock the GP **already holds**, and the world-market bid only fills when a seller offers the feedstock. On seed 42 the failing below-quota zero-NW Great Powers (`gp3` / `gp5` / `gp6`) hold **no** `wool` / `cotton` because their idle Builders are not routed to improve the feedstock resource tiles they own, so neither the domestic production path nor the market-supply path has any feedstock to work with (the residual disclosed in `treasury-planner.md` § Residual feedstock-acquisition dependency).
+
+This slice routes the Full-AI civilian work selection (`selectFullAiCivilianWorkOrders`, `packages/colonizethis_logic/lib/src/ai/full_ai_civilian_work_selection.dart`) toward feedstock extraction. When the **same bootstrap gate** as the treasury build-input bootstrap holds for the player — a below-quota zero-NW lock-recovery seller (`oldWorldProvinceCountOwnedBy` in `[2, kObserverConquestMinOwProvincesPerGp)`, zero New World provinces), `player.treasury >= cheapestRegimentBuildTreasuryCost()` (recovered), and `regimentCountForPlayer == 0` — the build-improvement work score adds a planner-internal `kRegimentBuildInputFeedstockExtractionScoreBoost` (`600`) to every **unimproved** (`improvementLevel < 1`) resource tile whose resource id is a production-recipe feedstock of a missing `peasant_levies` build input (`wool` / `cotton` for `fabric`; tile resource ids equal commodity ids per `resource_extractor.dart` § `_resourceToCommodityId`).
+
+The boost re-prioritises the Builder onto the feedstock tile ahead of other extractable improvements; it adds no new work order and does not bypass any suggestion or affordability gate (the tile must already be a `build_improvement` suggestion). The constant is planner-internal (not a new `ai_victory_config.dart` constant), mirroring the H8 production boost and the #2847 scope constraint. The gate is **self-clearing**: once the build input lands in the stockpile or the GP owns a regiment, the feedstock set is empty and selection reverts to its ordinary deterministic ordering. The feedstock-resource set is a pure function of `(game, playerId)` and the static `RegimentEconomyCatalog` / `ProductionRecipesCatalog`; identical inputs yield identical selections.
+
+### Residual feedstock-tile dependency (disclosure)
+
+The boost re-prioritises **existing** build-improvement suggestions; it does not acquire a feedstock resource tile for a seller that owns none. A failing GP whose Old World territory contains no `wool` / `cotton` resource tile still cannot source `fabric` domestically, and the turn-100 conquest gate stays open on that axis. Closing it (feedstock-tile acquisition or routing extraction onto purchasable land) is tracked as further #2847 work; this slice is the extraction-routing invariant that converts owned feedstock tiles into stockpiled feedstock once the bootstrap gate is active.
+
+### Acceptance criteria (H8-extraction)
+
+- Given a below-quota zero-NW lock-recovery seller (`oldWorldProvinceCountOwnedBy` in `[2, kObserverConquestMinOwProvincesPerGp)`, zero New World provinces) with `player.treasury >= cheapestRegimentBuildTreasuryCost()`, `regimentCountForPlayer == 0`, and zero `fabric` in the stockpile, when the feedstock-extraction gate is evaluated, then it returns the recipe feedstock ids `{wool, cotton}` (the inputs of every recipe whose output is the missing `peasant_levies` build input).
+- Given an otherwise identical seller whose `player.treasury < cheapestRegimentBuildTreasuryCost()`, when the gate is evaluated, then it returns the empty set (negative control — treasury must be recovered first).
+- Given an otherwise identical seller with `regimentCountForPlayer > 0` or that already holds the `fabric` build input, when the gate is evaluated, then it returns the empty set (the bootstrap targets the zero-regiment, missing-input rebuild gap only).
+- Given an AI GP at or above the conquest quota (`oldWorldProvinceCountOwnedBy >= kObserverConquestMinOwProvincesPerGp`) or that owns at least one New World province, when the gate is evaluated, then it returns the empty set (the carve-out is scoped to below-quota zero-NW sellers).
+- Given the gate is active and a Builder has both an unimproved `wool` resource tile and an unimproved non-feedstock (`grain`) resource tile as `build_improvement` suggestions, when `selectFullAiCivilianWorkOrders` runs, then it selects the `wool` tile; given the same fixture but the gate inactive (e.g. at quota), it selects by the ordinary build-improvement score ordering.
+- Given identical inputs, when the feedstock-extraction gate and `selectFullAiCivilianWorkOrders` run twice, then both runs return identical results (determinism).
+
+---
+
 ## Integration
 
 - **Caller:** Strategic AI (e.g. `generateStrategicOrders`) calls the economy planner for each AI GP first, then passes the resulting **economy plan** (including `cargoPreference`) into the domain planners so the build step can weight ship vs land builds. Production assignments are collected per player and passed to the turn resolver as **per-player default production assignments** (resolver must accept `Map<String, List<AssignedRecipe>>` or equivalent for multi-player).

--- a/packages/colonizethis_logic/lib/ai_api.dart
+++ b/packages/colonizethis_logic/lib/ai_api.dart
@@ -9,6 +9,8 @@ export 'src/ai/full_ai_civilian_work_selection.dart'
     show
         FullAiCivilianWorkIdle,
         FullAiCivilianWorkSelectionResult,
+        kRegimentBuildInputFeedstockExtractionScoreBoost,
+        regimentBuildInputFeedstockExtractionResourceIds,
         selectFullAiCivilianWorkOrders;
 export 'src/ai/simple_ai_heuristics.dart' show turnSeedForPlayer;
 export 'src/constants.dart'

--- a/packages/colonizethis_logic/lib/src/ai/full_ai_civilian_work_selection.dart
+++ b/packages/colonizethis_logic/lib/src/ai/full_ai_civilian_work_selection.dart
@@ -354,10 +354,21 @@ WorkOrder? _pickExplorerCandidateSet(
   return bestE;
 }
 
+/// Planner-internal score boost applied to an unimproved feedstock resource
+/// tile when the [regimentBuildInputFeedstockExtractionResourceIds] gate is
+/// active (Refs #2847 § H8-extraction). Sized above
+/// [kBuildImprovementExtractableResourceScore] plus the New World resource
+/// bonuses so a lock-recovery seller routes its Builder onto the feedstock
+/// tile ahead of any other extractable improvement. Planner-internal — not an
+/// `ai_victory_config.dart` constant — mirroring the economy-planner H8
+/// production boost and the #2847 "no new config constants" scope constraint.
+const int kRegimentBuildInputFeedstockExtractionScoreBoost = 600;
+
 int _buildImprovementWorkScore(
   WorkOrder w,
   Game game, {
   required String playerId,
+  Set<String> feedstockExtractionResourceIds = const <String>{},
 }) {
   if (w.target != kWorkTargetBuildImprovement) return 0;
   final level = game.worldState.tileState.improvementLevel(w.targetTileKey);
@@ -373,23 +384,113 @@ int _buildImprovementWorkScore(
       score += kBuildImprovementOwnedNewWorldResourceBonus;
     }
   }
+  if (feedstockExtractionResourceIds.contains(resourceId)) {
+    score += kRegimentBuildInputFeedstockExtractionScoreBoost;
+  }
   return score;
+}
+
+int _regimentCountForPlayer(Game game, String playerId) {
+  var count = 0;
+  void countRegiments(Iterable<Unit> units) {
+    for (final unit in units) {
+      if (unit.ownerId != playerId) continue;
+      if (RegimentEconomyCatalog.byId.containsKey(unit.type)) {
+        count++;
+      }
+    }
+  }
+
+  countRegiments(game.worldState.oldWorld.units);
+  countRegiments(game.worldState.newWorld.units);
+  return count;
+}
+
+int _newWorldProvinceCountOwnedBy(Game game, String playerId) {
+  return game.worldState
+      .provincesForRegion(kRegionNewWorld)
+      .where((p) => p.ownerId == playerId)
+      .length;
+}
+
+/// Resource ids a below-quota zero-NW lock-recovery seller should extract to
+/// domestically produce the cheapest regiment's missing build input
+/// (Refs #2847 § H8-extraction; companion to
+/// `treasury-planner.md` § Lock-recovery seller regiment build-input
+/// bootstrap).
+///
+/// Returns the empty set unless the **same bootstrap gate** as the treasury
+/// build-input bootstrap holds for [playerId]:
+///
+/// - below-quota zero-NW lock-recovery seller — `oldWorldProvinceCountOwnedBy`
+///   in `[2, kObserverConquestMinOwProvincesPerGp)` and zero New World
+///   provinces,
+/// - `player.treasury >= cheapestRegimentBuildTreasuryCost()` (recovered), and
+/// - `regimentCountForPlayer == 0` (zero-regiment rebuild gap).
+///
+/// The returned ids are the production-recipe feedstock commodities (e.g.
+/// `wool` / `cotton` for `fabric`) of every recipe whose output is a missing
+/// `peasant_levies` build input. Tile resource ids equal commodity ids for
+/// these agricultural resources (`resource_extractor.dart`
+/// § `_resourceToCommodityId`), so the set can be matched directly against
+/// `WorldState.resourceByTileKey`. Self-clears once the build input is on hand
+/// or the GP owns a regiment. Pure and deterministic over `(game, playerId)`
+/// and the static `RegimentEconomyCatalog` / `ProductionRecipesCatalog`.
+Set<String> regimentBuildInputFeedstockExtractionResourceIds(
+  Game game,
+  String playerId,
+) {
+  final player = game.playerById(playerId);
+  if (player == null) return const <String>{};
+  if (player.treasury < cheapestRegimentBuildTreasuryCost()) {
+    return const <String>{};
+  }
+  if (_regimentCountForPlayer(game, playerId) != 0) return const <String>{};
+  final ow = oldWorldProvinceCountOwnedBy(game, playerId);
+  if (ow < 2 || !isBelowObserverConquestQuota(ow)) return const <String>{};
+  if (_newWorldProvinceCountOwnedBy(game, playerId) != 0) {
+    return const <String>{};
+  }
+  final missingInputs = <CommodityId>{
+    for (final entry
+        in RegimentEconomyCatalog.peasantLevies.buildInputs.entries)
+      if (player.stockpile.quantityOf(entry.key) < entry.value) entry.key,
+  };
+  if (missingInputs.isEmpty) return const <String>{};
+  final feedstock = <String>{};
+  for (final recipe in ProductionRecipesCatalog.all) {
+    if (missingInputs.contains(recipe.outputCommodityId)) {
+      feedstock.addAll(recipe.inputQuantities.keys);
+    }
+  }
+  return feedstock;
 }
 
 WorkOrder? _bestBuildImprovementRow(
   List<WorkOrder> candidates,
   Game game, {
   required String playerId,
+  Set<String> feedstockExtractionResourceIds = const <String>{},
 }) {
   final improvements = candidates
       .where((w) => w.target == kWorkTargetBuildImprovement)
       .toList();
   if (improvements.isEmpty) return null;
   var best = improvements.first;
-  var bestScore = _buildImprovementWorkScore(best, game, playerId: playerId);
+  var bestScore = _buildImprovementWorkScore(
+    best,
+    game,
+    playerId: playerId,
+    feedstockExtractionResourceIds: feedstockExtractionResourceIds,
+  );
   for (var i = 1; i < improvements.length; i++) {
     final w = improvements[i];
-    final s = _buildImprovementWorkScore(w, game, playerId: playerId);
+    final s = _buildImprovementWorkScore(
+      w,
+      game,
+      playerId: playerId,
+      feedstockExtractionResourceIds: feedstockExtractionResourceIds,
+    );
     if (s > bestScore) {
       bestScore = s;
       best = w;
@@ -453,9 +554,15 @@ void _appendBuilderPathResult({
   required String playerId,
   required List<WorkOrder> workOrders,
   required List<FullAiCivilianWorkIdle> idleEvents,
+  Set<String> feedstockExtractionResourceIds = const <String>{},
 }) {
   final chosen =
-      _bestBuildImprovementRow(w, game, playerId: playerId) ??
+      _bestBuildImprovementRow(
+        w,
+        game,
+        playerId: playerId,
+        feedstockExtractionResourceIds: feedstockExtractionResourceIds,
+      ) ??
       _pickLexicographic(w);
   if (chosen != null) {
     workOrders.add(chosen);
@@ -589,6 +696,7 @@ void _appendSelectionForUnitId({
   required DiplomacyFactionMembership factionMembership,
   required List<WorkOrder> workOrders,
   required List<FullAiCivilianWorkIdle> idleEvents,
+  Set<String> feedstockExtractionResourceIds = const <String>{},
 }) {
   final W = List<WorkOrder>.from(byUnit[unitId] ?? const <WorkOrder>[]);
   _sortWorkOrdersLex(W);
@@ -626,6 +734,7 @@ void _appendSelectionForUnitId({
       playerId: view.playerId,
       workOrders: workOrders,
       idleEvents: idleEvents,
+      feedstockExtractionResourceIds: feedstockExtractionResourceIds,
     );
     return;
   }
@@ -676,6 +785,8 @@ FullAiCivilianWorkSelectionResult selectFullAiCivilianWorkOrders({
   final workOrders = <WorkOrder>[];
   final idleEvents = <FullAiCivilianWorkIdle>[];
   final factionMembership = DiplomacyFactionMembership.from(game);
+  final feedstockExtractionResourceIds =
+      regimentBuildInputFeedstockExtractionResourceIds(game, view.playerId);
 
   for (final unitId in allUnitIds) {
     _appendSelectionForUnitId(
@@ -687,6 +798,7 @@ FullAiCivilianWorkSelectionResult selectFullAiCivilianWorkOrders({
       factionMembership: factionMembership,
       workOrders: workOrders,
       idleEvents: idleEvents,
+      feedstockExtractionResourceIds: feedstockExtractionResourceIds,
     );
   }
 

--- a/packages/colonizethis_logic/lib/src/ai/full_ai_civilian_work_selection.dart
+++ b/packages/colonizethis_logic/lib/src/ai/full_ai_civilian_work_selection.dart
@@ -8,6 +8,7 @@ import '../diplomacy/diplomacy_resolver.dart';
 import '../orders/build_rail_work_rules.dart';
 import '../world/player_view.dart';
 import '../world/province_lookup.dart';
+import '../world/unit_lookup.dart';
 
 /// Idle civilian (no new work) for Full AI observability.
 class FullAiCivilianWorkIdle {
@@ -392,17 +393,12 @@ int _buildImprovementWorkScore(
 
 int _regimentCountForPlayer(Game game, String playerId) {
   var count = 0;
-  void countRegiments(Iterable<Unit> units) {
-    for (final unit in units) {
-      if (unit.ownerId != playerId) continue;
-      if (RegimentEconomyCatalog.byId.containsKey(unit.type)) {
-        count++;
-      }
+  for (final unit in allUnitsFromWorld(game.worldState)) {
+    if (unit.ownerId != playerId) continue;
+    if (RegimentEconomyCatalog.byId.containsKey(unit.type)) {
+      count++;
     }
   }
-
-  countRegiments(game.worldState.oldWorld.units);
-  countRegiments(game.worldState.newWorld.units);
   return count;
 }
 

--- a/packages/colonizethis_logic/test/full_ai_civilian_work_regiment_build_input_feedstock_extraction_test.dart
+++ b/packages/colonizethis_logic/test/full_ai_civilian_work_regiment_build_input_feedstock_extraction_test.dart
@@ -1,0 +1,228 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/ai_api.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+const _playerId = 'gp1';
+const _tileGrain = 'oldWorld|p0|0|0';
+const _tileWool = 'oldWorld|p0|1|0';
+
+Game _belowQuotaZeroNwSellerGame({
+  required int owOwned,
+  required int treasury,
+  Stockpile stockpile = const Stockpile(),
+  List<Unit> extraUnits = const [],
+  Map<String, String> resourceByTileKey = const {
+    _tileGrain: 'grain',
+    _tileWool: 'wool',
+  },
+}) {
+  final provinces = List.generate(
+    owOwned,
+    (i) => Province(
+      id: 'oldWorld|p$i',
+      regionId: kRegionOldWorld,
+      ownerId: _playerId,
+    ),
+  );
+  return Game(
+    id: 'g',
+    worldState: WorldState(
+      turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+      oldWorld: RegionData(provinces: provinces, units: extraUnits),
+      newWorld: const RegionData(),
+      resourceByTileKey: resourceByTileKey,
+    ),
+    players: [
+      Player(
+        id: _playerId,
+        displayName: 'GP',
+        isHuman: false,
+        treasury: treasury,
+        stockpile: stockpile,
+      ),
+    ],
+  );
+}
+
+PlayerView _builderView(Game game) {
+  return PlayerView(
+    playerId: _playerId,
+    player: game.players.single,
+    ownUnitsById: {
+      'b1': Unit(
+        id: 'b1',
+        type: kUnitTypeBuilder,
+        ownerId: _playerId,
+        locationProvinceId: 'oldWorld|p0',
+      ),
+    },
+    provincesById: const {},
+    visibilityByTile: const {},
+    prospectedTiles: const {},
+    diplomacyByOtherId: const {},
+  );
+}
+
+void main() {
+  group('regimentBuildInputFeedstockExtractionResourceIds (Refs #2847 H8-extraction)', () {
+    test('active gate returns wool and cotton feedstock ids', () {
+      final game = _belowQuotaZeroNwSellerGame(
+        owOwned: 5,
+        treasury: cheapestRegimentBuildTreasuryCost(),
+      );
+      expect(
+        regimentBuildInputFeedstockExtractionResourceIds(game, _playerId),
+        containsAll(['wool', 'cotton']),
+      );
+    });
+
+    test('returns empty when treasury below regiment threshold', () {
+      final game = _belowQuotaZeroNwSellerGame(
+        owOwned: 5,
+        treasury: cheapestRegimentBuildTreasuryCost() - 1,
+      );
+      expect(
+        regimentBuildInputFeedstockExtractionResourceIds(game, _playerId),
+        isEmpty,
+      );
+    });
+
+    test('returns empty when GP already owns a regiment', () {
+      final game = _belowQuotaZeroNwSellerGame(
+        owOwned: 5,
+        treasury: cheapestRegimentBuildTreasuryCost(),
+        extraUnits: [
+          Unit(
+            id: 'r1',
+            type: 'peasant_levies',
+            ownerId: _playerId,
+            locationProvinceId: 'oldWorld|p0',
+          ),
+        ],
+      );
+      expect(
+        regimentBuildInputFeedstockExtractionResourceIds(game, _playerId),
+        isEmpty,
+      );
+    });
+
+    test('returns empty when fabric build input is already on hand', () {
+      final game = _belowQuotaZeroNwSellerGame(
+        owOwned: 5,
+        treasury: cheapestRegimentBuildTreasuryCost(),
+        stockpile: const Stockpile(quantities: {'fabric': 1}),
+      );
+      expect(
+        regimentBuildInputFeedstockExtractionResourceIds(game, _playerId),
+        isEmpty,
+      );
+    });
+
+    test('returns empty when GP is at or above the conquest quota', () {
+      final game = _belowQuotaZeroNwSellerGame(
+        owOwned: kObserverConquestMinOwProvincesPerGp,
+        treasury: cheapestRegimentBuildTreasuryCost(),
+      );
+      expect(
+        regimentBuildInputFeedstockExtractionResourceIds(game, _playerId),
+        isEmpty,
+      );
+    });
+
+    test('gate evaluation is deterministic', () {
+      final game = _belowQuotaZeroNwSellerGame(
+        owOwned: 5,
+        treasury: cheapestRegimentBuildTreasuryCost(),
+      );
+      final a = regimentBuildInputFeedstockExtractionResourceIds(game, _playerId);
+      final b = regimentBuildInputFeedstockExtractionResourceIds(game, _playerId);
+      expect(a, equals(b));
+    });
+  });
+
+  group('selectFullAiCivilianWorkOrders feedstock extraction (Refs #2847 H8-extraction)', () {
+    test('Builder prefers wool feedstock tile over lexicographically smaller grain', () {
+      final game = _belowQuotaZeroNwSellerGame(
+        owOwned: 5,
+        treasury: cheapestRegimentBuildTreasuryCost(),
+      );
+      final suggestions = [
+        const WorkOrder(
+          unitId: 'b1',
+          target: kWorkTargetBuildImprovement,
+          targetTileKey: _tileGrain,
+        ),
+        const WorkOrder(
+          unitId: 'b1',
+          target: kWorkTargetBuildImprovement,
+          targetTileKey: _tileWool,
+        ),
+      ];
+      final r = selectFullAiCivilianWorkOrders(
+        workSuggestions: suggestions,
+        view: _builderView(game),
+        game: game,
+      );
+      expect(r.workOrders, hasLength(1));
+      expect(r.workOrders.single.targetTileKey, _tileWool);
+    });
+
+    test('at-quota GP keeps ordinary build-improvement ordering without feedstock boost', () {
+      final game = _belowQuotaZeroNwSellerGame(
+        owOwned: kObserverConquestMinOwProvincesPerGp,
+        treasury: cheapestRegimentBuildTreasuryCost(),
+      );
+      final suggestions = [
+        const WorkOrder(
+          unitId: 'b1',
+          target: kWorkTargetBuildImprovement,
+          targetTileKey: _tileGrain,
+        ),
+        const WorkOrder(
+          unitId: 'b1',
+          target: kWorkTargetBuildImprovement,
+          targetTileKey: _tileWool,
+        ),
+      ];
+      final r = selectFullAiCivilianWorkOrders(
+        workSuggestions: suggestions,
+        view: _builderView(game),
+        game: game,
+      );
+      expect(r.workOrders.single.targetTileKey, _tileGrain);
+    });
+
+    test('selection is deterministic when feedstock gate is active', () {
+      final game = _belowQuotaZeroNwSellerGame(
+        owOwned: 5,
+        treasury: cheapestRegimentBuildTreasuryCost(),
+      );
+      final suggestions = [
+        const WorkOrder(
+          unitId: 'b1',
+          target: kWorkTargetBuildImprovement,
+          targetTileKey: _tileGrain,
+        ),
+        const WorkOrder(
+          unitId: 'b1',
+          target: kWorkTargetBuildImprovement,
+          targetTileKey: _tileWool,
+        ),
+      ];
+      final view = _builderView(game);
+      final a = selectFullAiCivilianWorkOrders(
+        workSuggestions: suggestions,
+        view: view,
+        game: game,
+      );
+      final b = selectFullAiCivilianWorkOrders(
+        workSuggestions: suggestions,
+        view: view,
+        game: game,
+      );
+      expect(a.workOrders, equals(b.workOrders));
+    });
+  });
+}


### PR DESCRIPTION
Refs #2847

## Done in this push

- **SPEC** — `SPEC/ai/economy-planner.md` § Regiment build-input feedstock extraction priority (H8-extraction): documents the extraction-routing companion to the treasury H8 bootstrap / H8-supply market chain.
- **Logic** — `regimentBuildInputFeedstockExtractionResourceIds` gate (below-quota zero-NW lock-recovery seller, recovered treasury, zero regiments, missing `fabric`) and `kRegimentBuildInputFeedstockExtractionScoreBoost` (`600`) in `full_ai_civilian_work_selection.dart` so Builders prioritize unimproved `wool`/`cotton` resource tiles.
- **Exports** — gate helper + constant exported via `ai_api.dart` narrow contract.
- **Tests** — `full_ai_civilian_work_regiment_build_input_feedstock_extraction_test.dart` (9 cases: gate active/negative controls, Builder wool-over-grain selection, at-quota negative control, determinism).

## Deferred (follow-up on #2847)

- **Observer gate verification** — turn-100 `--verify-conquest` for gp3–gp6 still requires the full soft-phase + Path F chain to close in aggregate; this slice only ensures owned feedstock tiles get improved when the bootstrap gate is active.
- **Feedstock-tile acquisition** — sellers that own **no** wool/cotton resource tiles still cannot source fabric domestically (disclosed in SPEC § Residual feedstock-tile dependency).
- **`seed42_observer_conquest_regression_test` unskip** — remains blocked until all six GPs pass the OW conquest gate.

## AC coverage (this PR)

| AC | Status |
|----|--------|
| Gate returns `{wool, cotton}` for active lock-recovery seller | ✅ unit test |
| Gate empty when treasury below threshold | ✅ |
| Gate empty when regiment owned or fabric on hand | ✅ |
| Gate empty at/above conquest quota or with NW provinces | ✅ |
| Builder selects wool over lex-smaller grain when gate active | ✅ |
| Ordinary ordering when gate inactive (at quota) | ✅ |
| Determinism (gate + selection) | ✅ |

## Tests run

```
dart test packages/colonizethis_logic/test/full_ai_civilian_work_regiment_build_input_feedstock_extraction_test.dart
dart test packages/colonizethis_logic/test/full_ai_civilian_work_selection_test.dart
dart analyze packages/colonizethis_logic/lib/src/ai/full_ai_civilian_work_selection.dart packages/colonizethis_logic/lib/ai_api.dart
```

## Label transition

Not performed — #2847 remains `backlog:implementation` (soft-phase observer gates and regression unskip still outstanding).

Made with [Cursor](https://cursor.com)