### PR TITLE
fix: force-on civilian work for active H8-extraction feedstock gate (#2847)

### DIFF
--- a/SPEC/ai/economy-planner.md
+++ b/SPEC/ai/economy-planner.md
@@ -116,6 +116,15 @@ The boost re-prioritises **existing** build-improvement suggestions; it does not
 - Given the gate is active and a Builder has both an unimproved `wool` resource tile and an unimproved non-feedstock (`grain`) resource tile as `build_improvement` suggestions, when `selectFullAiCivilianWorkOrders` runs, then it selects the `wool` tile; given the same fixture but the gate inactive (e.g. at quota), it selects by the ordinary build-improvement score ordering.
 - Given identical inputs, when the feedstock-extraction gate and `selectFullAiCivilianWorkOrders` run twice, then both runs return identical results (determinism).
 
+### Orchestrator civilian-work force-on (Refs #2847 H8-extraction wiring)
+
+The feedstock-extraction score boost in `selectFullAiCivilianWorkOrders` has no effect when `_runEconomyDomainPlanners` (`packages/colonizethis_ai/lib/src/planning/domain_planner_orchestrator.dart`) skips the Full-AI civilian work pass because `domainWeights.economy < workThreshold` and `primaryGoal != StrategicGoal.expand`. Below-quota lock-recovery sellers in EXPAND often carry `StrategicGoal.conquer`, so the orchestrator forces `runFullAiCivilianWork` whenever `regimentBuildInputFeedstockExtractionResourceIds(game, nationId)` is non-empty — mirroring the DEVELOP / colonial-pressure / NW-owned force-on clauses already present in `_runEconomyDomainPlanners`. The orchestrator reuses the existing logic-side gate predicate unchanged (it only reads whether the feedstock set is non-empty); it adds no duplicate regiment-count logic and no new config constant.
+
+#### Acceptance criteria (H8-extraction orchestrator wiring)
+
+- Given a below-quota zero-NW lock-recovery seller with `primaryGoal == StrategicGoal.conquer`, `player.treasury >= cheapestRegimentBuildTreasuryCost()`, `regimentCountForPlayer == 0`, and a Builder offered both an unimproved `wool` feedstock tile and an unimproved `grain` tile as `build_improvement` suggestions, when the domain planners run via `runDomainPlannersWithOutcome`, then the work planner runs (`workPlannerRan == true`) and the single emitted `WorkOrder` targets the `wool` feedstock tile.
+- Given an otherwise identical seller whose `player.treasury < cheapestRegimentBuildTreasuryCost()` so the feedstock-extraction gate is inactive, when the domain planners run via `runDomainPlannersWithOutcome`, then no feedstock score boost fires and the single emitted `WorkOrder` targets the `grain` tile under the ordinary build-improvement ordering (negative control).
+
 ---
 
 ## Integration

--- a/packages/colonizethis_ai/lib/src/planning/domain_planner_orchestrator.dart
+++ b/packages/colonizethis_ai/lib/src/planning/domain_planner_orchestrator.dart
@@ -413,12 +413,18 @@ _EconomyDomainPlannersResult _runEconomyDomainPlanners({
       workThreshold = math.min(workThreshold, kColonialCivilianWorkThresholdCap);
     }
   }
+  final feedstockExtractionActive =
+      regimentBuildInputFeedstockExtractionResourceIds(
+        ctx.game,
+        ctx.nationId,
+      ).isNotEmpty;
   final runFullAiCivilianWork =
       developPhase ||
       ctx.primaryGoal == StrategicGoal.expand ||
       domainWeights.economy >= workThreshold ||
       colonialPressure ||
-      snapshot.colonial.newWorldProvincesOwned > 0;
+      snapshot.colonial.newWorldProvincesOwned > 0 ||
+      feedstockExtractionActive;
   _log.d(
     'work eval nationId=${ctx.nationId} workThreshold=$workThreshold '
     'domainWeights.economy=${domainWeights.economy} primaryGoal=${ctx.primaryGoal} '

--- a/packages/colonizethis_ai/test/domain_planner_orchestrator_h8_feedstock_civilian_work_test.dart
+++ b/packages/colonizethis_ai/test/domain_planner_orchestrator_h8_feedstock_civilian_work_test.dart
@@ -1,0 +1,160 @@
+import 'package:colonizethis_test/test.dart';
+
+import 'package:colonizethis_ai/colonizethis_ai.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import 'domain_planner_test_fake_api.dart';
+import 'planner_test_helpers.dart';
+
+const _nationId = 'gp_seller';
+const _tileGrain = 'oldWorld|p0|0|0';
+const _tileWool = 'oldWorld|p0|1|0';
+
+Game _lockRecoverySellerGame({required int treasury}) {
+  return Game(
+    id: 'g-h8-extraction-orchestrator',
+    worldState: WorldState(
+      turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 30),
+      oldWorld: RegionData(
+        provinces: [
+          for (var i = 0; i < 5; i++)
+            Province(
+              id: 'oldWorld|p$i',
+              regionId: kRegionOldWorld,
+              ownerId: _nationId,
+            ),
+        ],
+        units: [
+          Unit(
+            id: 'b1',
+            type: kUnitTypeBuilder,
+            ownerId: _nationId,
+            locationProvinceId: 'oldWorld|p0',
+          ),
+        ],
+      ),
+      newWorld: const RegionData(),
+      resourceByTileKey: const {_tileGrain: 'grain', _tileWool: 'wool'},
+      playerVisibilityByTile: const {
+        _nationId: {_tileGrain: 'fullyVisible', _tileWool: 'fullyVisible'},
+      },
+      tileKeysByRegionAndProvince: const {
+        kRegionOldWorld: {
+          'oldWorld|p0': [_tileGrain, _tileWool],
+        },
+      },
+    ),
+    players: [
+      Player(
+        id: _nationId,
+        displayName: 'Seller',
+        isHuman: false,
+        leaderKey: 'napoleon',
+        treasury: treasury,
+      ),
+    ],
+  );
+}
+
+void main() {
+  group('H8-extraction orchestrator civilian-work force-on (Refs #2847)', () {
+    final threshold = cheapestRegimentBuildTreasuryCost();
+    const topology = MapTopology(nodes: [], edges: []);
+    const woolImprovement = WorkOrder(
+      unitId: 'b1',
+      target: kWorkTargetBuildImprovement,
+      targetTileKey: _tileWool,
+    );
+    const grainImprovement = WorkOrder(
+      unitId: 'b1',
+      target: kWorkTargetBuildImprovement,
+      targetTileKey: _tileGrain,
+    );
+
+    test(
+      'selects wool improvement under conquer goal when feedstock gate is active',
+      () {
+        final game = _lockRecoverySellerGame(treasury: threshold);
+        final view = buildPlayerView(game, topology, _nationId);
+        final snapshot = AIWorldSnapshot.fromPlayerView(
+          view,
+          topology: topology,
+        );
+        final outcome = runDomainPlannersWithOutcome(
+          game: game,
+          topology: topology,
+          nationId: _nationId,
+          view: view,
+          snapshot: snapshot,
+          config: const AIConfig(
+            leaderId: 'napoleon',
+            personalityId: 'napoleon',
+            hiddenAgendaId: 'peacemaker',
+          ),
+          primaryGoal: StrategicGoal.conquer,
+          seeds: AISeedBundle.fromTurnSeed(284701),
+          suggestionAPI: const FakeOrderSuggestionAPIForDomainPlannerTests(
+            work: [grainImprovement, woolImprovement],
+            build: [],
+            move: [],
+            research: [],
+            navalMove: [],
+            navalMission: [],
+          ),
+          economyPlan: kTestEconomyPlan,
+        );
+
+        expect(outcome.domainGateData?.workPlannerRan, isTrue);
+        final work = outcome.orders.workOrdersByPlayerId[_nationId];
+        expect(work, isNotNull);
+        expect(work!.single.targetTileKey, _tileWool);
+      },
+    );
+
+    test(
+      'keeps legacy build-improvement ordering when feedstock gate is inactive',
+      () {
+        // Negative control: treasury below the cheapest-regiment threshold
+        // leaves the feedstock-extraction gate inactive, so no feedstock
+        // score boost fires and the Builder follows the ordinary
+        // build-improvement ordering (grain) rather than the wool feedstock
+        // tile selected when the gate is active.
+        final game = _lockRecoverySellerGame(treasury: threshold - 1);
+        final view = buildPlayerView(game, topology, _nationId);
+        final snapshot = AIWorldSnapshot.fromPlayerView(
+          view,
+          topology: topology,
+        );
+        final outcome = runDomainPlannersWithOutcome(
+          game: game,
+          topology: topology,
+          nationId: _nationId,
+          view: view,
+          snapshot: snapshot,
+          config: const AIConfig(
+            leaderId: 'napoleon',
+            personalityId: 'napoleon',
+            hiddenAgendaId: 'peacemaker',
+          ),
+          primaryGoal: StrategicGoal.conquer,
+          seeds: AISeedBundle.fromTurnSeed(284701),
+          suggestionAPI: const FakeOrderSuggestionAPIForDomainPlannerTests(
+            work: [grainImprovement, woolImprovement],
+            build: [],
+            move: [],
+            research: [],
+            navalMove: [],
+            navalMission: [],
+          ),
+          economyPlan: kTestEconomyPlan,
+        );
+
+        final work = outcome.orders.workOrdersByPlayerId[_nationId];
+        expect(work, isNotNull);
+        expect(work!.single.targetTileKey, _tileGrain);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Wires the orchestrator to the H8-extraction feedstock gate that landed in #3234. The merged feedstock score boost in `selectFullAiCivilianWorkOrders` is dead weight whenever `_runEconomyDomainPlanners` skips the Full-AI civilian-work pass — which is exactly the situation the failing seed-42 below-quota zero-NW lock-recovery sellers are in (they carry `StrategicGoal.conquer` with `domainWeights.economy < workThreshold`). This PR forces `runFullAiCivilianWork` on whenever `regimentBuildInputFeedstockExtractionResourceIds(game, nationId)` is non-empty, mirroring the existing DEVELOP / colonial-pressure / NW-owned force-on clauses.

## Done in this push

- `domain_planner_orchestrator.dart`: add `feedstockExtractionActive` clause to `runFullAiCivilianWork` (reuses the existing logic-side gate predicate; no duplicate regiment-count logic, no new config constant).
- `SPEC/ai/economy-planner.md`: new § *Orchestrator civilian-work force-on (Refs #2847 H8-extraction wiring)* with Given–When–Then ACs.
- Tests (`packages/colonizethis_ai/test/domain_planner_orchestrator_h8_feedstock_civilian_work_test.dart`):
  - **Positive** — below-quota zero-NW seller with recovered treasury + zero regiments under `conquer` goal: work planner runs and the Builder is routed to the unimproved `wool` feedstock tile.
  - **Negative control** — identical seller with treasury below the cheapest-regiment threshold (gate inactive): no boost fires; Builder follows legacy build-improvement ordering (`grain`).

## ACs covered now

- Orchestrator force-on AC (positive + negative) from the new SPEC § Orchestrator civilian-work force-on.
- Contributes to the broader #2847 H8-extraction economy bootstrap (the logic-side feedstock selection landed in #3234).

## Deferred / remaining for #2847

This PR is one economy-bootstrap slice. The bulk of #2847 — the soft-phase priority weighting system that replaces hard structural phase suppression (continuous OW-count weight curve, resource-need override, universal planner dispatch, COLONIAL-lite retirement, first-naval-transport bootstrap) and the turn-100 per-GP OW conquest gates (gp3–gp6 ≥ +3, gp1/gp2 ≥ +6) plus the skipped `seed42_observer_conquest_regression_test` — remains and is **not** addressed here.

## Verification

- `dart test packages/colonizethis_ai/test/domain_planner_orchestrator_h8_feedstock_civilian_work_test.dart` → +2 passed.
- Regression: full `domain_planner_orchestrator_*` suite green (96 + targeted 17).
- `dart analyze` clean on touched files (pre-existing unrelated `unnecessary_null_comparison` warning at orchestrator.dart:621 is present on `dev` and out of scope).

Refs #2847

Made with [Cursor](https://cursor.com)