### PR TITLE
fix(ai): break lock-recovery feedstock improvement-input deadlock (Refs #2847)

### DIFF
--- a/SPEC/ai/treasury-planner.md
+++ b/SPEC/ai/treasury-planner.md
@@ -514,6 +514,93 @@ bootstrap path.
   H8-supply market path, then both runs return identical
   `List<TradeOrder>` outputs (determinism).
 
+### Lock-recovery seller feedstock-improvement input bootstrap (Refs #2847 H8-extraction)
+
+The H8-supply paths above let a recovered lock-recovery seller acquire or retain
+the recipe **feedstock** (`wool` / `cotton`), and the economy planner routes a
+Builder onto the seller's owned unimproved feedstock tile
+([economy-planner.md](economy-planner.md) § Regiment build-input production
+priority; `regimentBuildInputFeedstockExtractionResourceIds`). But the routed
+Builder cannot start: raising an unimproved resource tile to level 1 costs the
+level-0 `build_improvement` material — **1 lumber + 1 cast iron**
+(`work_order_costs.dart` § `workOrderCostBuildImprovement(0)`) — which the locked
+seller holds zero of, and the work-order validator
+(`work_order_validator.dart` § `_validateWorkMaterialCosts`) rejects the
+`build_improvement` candidate before any selection boost applies. The seller
+cannot extract those inputs domestically either, because every other
+`build_improvement` (including a lumber or iron tile) costs the same 1 lumber +
+1 cast iron it does not hold — a self-reinforcing **lumber / cast-iron
+deadlock**. On seed 42 the diagnostic
+(`seed42_observer_conquest_s7d_diagnostic_test.dart`) pins this exactly:
+`gpFeedstockGateImprovementCostAffordableTurns == 0` on every gate-active turn
+for gp3 / gp5 / gp6. The only non-deadlocking source of the first lumber + cast
+iron is the world market.
+
+**Improvement-input bid (bootstrap extension).** The
+`regimentBuildInputFeedstockImprovementInputCost(game, playerId)` contract
+(`colonizethis_logic/ai_api.dart`) returns the level-0 `build_improvement`
+material cost map (`{lumber: 1, castIron: 1}`) **only** when, for the lock-recovery
+seller:
+
+- `regimentBuildInputFeedstockExtractionResourceIds(game, playerId)` is non-empty
+  (the same recovered-seller / zero-regiment / missing-build-input gate as the
+  bootstrap bid), **and**
+- the seller owns at least one province tile hosting one of those feedstock
+  resource ids that is still unimproved (`improvementLevel < 1`).
+
+It returns the empty map otherwise (self-clearing once the GP owns a regiment,
+holds the build input, or has improved its feedstock tile). Under the same gate
+as § Lock-recovery seller regiment build-input bootstrap, when this cost map is
+non-empty, `runTreasuryPlanner` injects a bid for each improvement-input
+commodity the projected stockpile (plus carry-forward bids) is short of
+(`need[c] = cost[c] - held` when positive), and **suppresses** the downstream
+feedstock / fabric bootstrap bids for that turn while any improvement-input
+deficit remains — the single `bidTypeCap` slot targets the prerequisite supply,
+mirroring the way the fabric bid is suppressed while a feedstock deficit remains.
+No affordability rule is bypassed: the matcher still debits treasury per filled
+unit at phase 13, and the work-order validator still gates the eventual
+`build_improvement`. Once the inputs land the seller resumes the feedstock /
+fabric bootstrap bids.
+
+**Affluent-GP improvement-input offers.** `lumber` and `castIron` join `wool`,
+`cotton`, and `fabric` in the affluent-supplier release set
+(`_regimentBuildInputSupplyCommodityIds`), so while any lock-recovery seller
+needs the bootstrap path, every other Great Power with
+`player.treasury >= cheapestRegimentBuildTreasuryCost()` releases its `lumber` /
+`castIron` surplus aggressively (safety buffer `0`, production inputs still
+reserved) so the seller's improvement-input bid can match.
+
+#### Acceptance criteria (H8-extraction)
+
+- Given a below-quota zero-NW lock-recovery seller with recovered treasury, zero
+  regiments, a projected stockpile missing the cheapest regiment's `fabric`
+  build input, an owned unimproved `wool` (or `cotton`) resource tile, and zero
+  `lumber` and zero `castIron`, when `runTreasuryPlanner` runs for that seller,
+  then it emits at least one `TradeOrderType.bid` for an improvement-input
+  commodity (`lumber` or `castIron`, bounded per turn by the player's
+  `worldMarketBidTypeCap`) and emits **no** `fabric` or feedstock (`wool` /
+  `cotton`) bid that turn (the improvement-input prerequisite is acquired
+  first).
+- Given an otherwise identical lock-recovery seller that already holds at least
+  1 `lumber` and 1 `castIron`, when `runTreasuryPlanner` runs, then it emits
+  **no** improvement-input bid (the bootstrap clears once the inputs are on
+  hand) and resumes its feedstock / fabric bootstrap bids.
+- Given an otherwise identical lock-recovery seller that owns **no** unimproved
+  feedstock resource tile, when `runTreasuryPlanner` runs, then it emits **no**
+  improvement-input bid (the bootstrap is scoped to sellers that have a
+  feedstock tile to improve).
+- Given an otherwise identical lock-recovery seller with
+  `regimentCountForPlayer(game, playerId) > 0`, when `runTreasuryPlanner` runs,
+  then it emits **no** improvement-input bid (the bootstrap targets the
+  zero-regiment rebuild gap only).
+- Given the same game state and a non-seller Great Power with surplus `lumber`
+  and `player.treasury >= cheapestRegimentBuildTreasuryCost()`, when
+  `runTreasuryPlanner` runs for that affluent GP, then it emits a
+  `TradeOrderType.offer` for `lumber`.
+- Given identical inputs, when `runTreasuryPlanner` runs twice on the
+  improvement-input bootstrap path, then both runs return identical
+  `List<TradeOrder>` outputs (determinism).
+
 ---
 
 ## Treasury-budget-aware bid sizing (Refs #3122)

--- a/packages/colonizethis_ai/lib/src/planning/treasury_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/treasury_planner.dart
@@ -8,6 +8,7 @@ import 'package:colonizethis_logic/ai_api.dart'
         effectiveMarketPriceForCommodityId,
         oldWorldProvinceCountOwnedBy,
         pendingTreasuryCostsForTurn,
+        regimentBuildInputFeedstockImprovementInputCost,
         tradeCargoCapacityForGreatPower,
         worldMarketBidTypeCap;
 import 'package:colonizethis_logic/order_suggestion_api.dart'
@@ -376,6 +377,23 @@ void _applyLockRecoverySellerRegimentRebuildBids({
   if (!isLockRecoverySeller ||
       rawTreasury < threshold ||
       regimentCountForPlayer(game, playerId) != 0) {
+    return;
+  }
+  // Refs #2847 H8-extraction: improvement-input prerequisite. The seller's
+  // routed Builder cannot extract its owned feedstock tile until it holds the
+  // level-0 `build_improvement` material (lumber + cast iron) it has zero of —
+  // a lumber / cast-iron deadlock with no domestic escape. Bid for those
+  // improvement inputs first and suppress the downstream feedstock / fabric
+  // bootstrap bids while any improvement-input deficit remains, so the single
+  // bid slot targets the prerequisite supply. Self-clears once the inputs land
+  // (or the tile is improved / a regiment is owned).
+  if (_addRegimentFeedstockImprovementInputNeed(
+    game: game,
+    playerId: playerId,
+    projected: projected,
+    carryForwardBids: carryForwardBids,
+    need: need,
+  )) {
     return;
   }
   final feedstockStillMissing = _addRegimentBuildInputFeedstockBootstrapNeed(
@@ -776,6 +794,40 @@ bool _addRegimentBuildInputFeedstockBootstrapNeed({
   return false;
 }
 
+/// Adds bids for the level-0 `build_improvement` inputs (lumber + cast iron) a
+/// lock-recovery seller must hold to extract its owned fabric feedstock tile,
+/// but does not, when the regiment build-input feedstock-extraction gate is
+/// active and a feedstock tile is owned (Refs #2847 § H8-extraction).
+///
+/// Returns true when at least one improvement-input bid was queued (a deficit
+/// remains). The caller suppresses the downstream feedstock / fabric bootstrap
+/// bids on that turn so the single `bidTypeCap` slot targets the prerequisite
+/// supply. Self-clearing: the
+/// [regimentBuildInputFeedstockImprovementInputCost] contract returns the empty
+/// map once the GP owns a regiment, holds the build input, or has improved the
+/// feedstock tile.
+bool _addRegimentFeedstockImprovementInputNeed({
+  required Game game,
+  required String playerId,
+  required Stockpile projected,
+  required Map<CommodityId, int> carryForwardBids,
+  required Map<CommodityId, int> need,
+}) {
+  final cost = regimentBuildInputFeedstockImprovementInputCost(game, playerId);
+  if (cost.isEmpty) return false;
+  var queued = false;
+  for (final entry in cost.entries) {
+    final held =
+        projected.quantityOf(entry.key) + (carryForwardBids[entry.key] ?? 0);
+    final missing = entry.value - held;
+    if (missing > 0) {
+      need[entry.key] = missing;
+      queued = true;
+    }
+  }
+  return queued;
+}
+
 /// Adds direct bids for any missing `peasant_levies` build input when no
 /// feedstock bootstrap bid is pending.
 void _addRegimentBuildInputDirectNeed({
@@ -818,6 +870,10 @@ const Set<CommodityId> _regimentBuildInputSupplyCommodityIds = {
   'wool',
   'cotton',
   'fabric',
+  // Refs #2847 H8-extraction: the level-0 build_improvement inputs the locked
+  // seller bids for to unblock domestic feedstock extraction.
+  'lumber',
+  'castIron',
 };
 
 /// True when any below-quota zero-NW lock-recovery seller still needs the

--- a/packages/colonizethis_ai/test/planning/treasury_planner_regiment_input_improvement_bootstrap_test.dart
+++ b/packages/colonizethis_ai/test/planning/treasury_planner_regiment_input_improvement_bootstrap_test.dart
@@ -1,0 +1,251 @@
+/// Lock-recovery seller feedstock-improvement input bootstrap
+/// (Refs #2847 H8-extraction).
+library;
+
+import 'package:colonizethis_ai/src/planning/treasury_planner.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+const _woolId = 'wool';
+const _fabricId = 'fabric';
+const _lumberId = 'lumber';
+const _castIronId = 'castIron';
+// Wool resource tile in the seller's capital province (`oldWorld|seller_0`),
+// unimproved by default so the build_improvement is needed.
+const _sellerWoolTile = 'oldWorld|seller_0|1|0';
+
+Game _game({
+  required int sellerTreasury,
+  required int supplierTreasury,
+  bool sellerHoldsImprovementInputs = false,
+  bool sellerOwnsFeedstockTile = true,
+  bool sellerWoolTileImproved = false,
+  List<Unit> sellerUnits = const [],
+  int supplierLumberHeld = 20,
+  int sellerOwProvinces = 3,
+  int supplierOwProvinces = 12,
+}) {
+  const ow = 'oldWorld';
+  var sellerStockpile = const Stockpile().applyDelta('grain', 80);
+  if (sellerHoldsImprovementInputs) {
+    sellerStockpile = sellerStockpile
+        .applyDelta(_lumberId, 1)
+        .applyDelta(_castIronId, 1);
+  }
+  var supplierStockpile = const Stockpile().applyDelta('grain', 80);
+  if (supplierLumberHeld > 0) {
+    supplierStockpile = supplierStockpile.applyDelta(
+      _lumberId,
+      supplierLumberHeld,
+    );
+  }
+  final resourceByTileKey = <String, String>{
+    if (sellerOwnsFeedstockTile) _sellerWoolTile: _woolId,
+  };
+  final tileState = sellerWoolTileImproved
+      ? TileMapState().setImprovement(_sellerWoolTile, 1)
+      : TileMapState();
+  return Game(
+    id: 'g-h8-improvement',
+    worldState: WorldState(
+      turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 50),
+      oldWorld: RegionData(
+        provinces: [
+          for (var i = 0; i < sellerOwProvinces; i++)
+            Province(id: '$ow|seller_$i', regionId: ow, ownerId: 'gp_seller'),
+          for (var i = 0; i < supplierOwProvinces; i++)
+            Province(
+              id: '$ow|supplier_$i',
+              regionId: ow,
+              ownerId: 'gp_supplier',
+            ),
+        ],
+        units: sellerUnits,
+      ),
+      newWorld: const RegionData(provinces: []),
+      resourceByTileKey: resourceByTileKey,
+      tileState: tileState,
+    ),
+    players: [
+      Player(
+        id: 'gp_seller',
+        displayName: 'Seller',
+        isHuman: false,
+        capitalProvinceId: '$ow|seller_0',
+        stockpile: sellerStockpile,
+        treasury: sellerTreasury,
+      ),
+      Player(
+        id: 'gp_supplier',
+        displayName: 'Supplier',
+        isHuman: false,
+        capitalProvinceId: '$ow|supplier_0',
+        stockpile: supplierStockpile,
+        treasury: supplierTreasury,
+      ),
+    ],
+    worldMarketState: WorldMarketState.withDefaultPrices(const {
+      'grain': 10,
+      _woolId: 20,
+      _fabricId: 40,
+      _lumberId: 15,
+      _castIronId: 30,
+    }),
+  );
+}
+
+List<TradeOrder> _run(Game game, String playerId) => runTreasuryPlanner(
+  game: game,
+  playerId: playerId,
+  stockpile: game.players.firstWhere((p) => p.id == playerId).stockpile,
+  productionAssignments: const [],
+  treasury: game.players.firstWhere((p) => p.id == playerId).treasury,
+);
+
+Iterable<TradeOrder> _bidsFor(List<TradeOrder> orders, String commodityId) =>
+    orders.where(
+      (o) => o.type == TradeOrderType.bid && o.commodityId == commodityId,
+    );
+
+void main() {
+  group('lock-recovery seller feedstock-improvement input bootstrap '
+      '(Refs #2847 H8-extraction)', () {
+    final threshold = cheapestRegimentBuildTreasuryCost();
+
+    test(
+      'recovered seller with owned unimproved feedstock tile but no lumber / '
+      'cast iron bids an improvement input before fabric or feedstock',
+      () {
+        final orders = _run(
+          _game(sellerTreasury: threshold, supplierTreasury: threshold),
+          'gp_seller',
+        );
+        final improvementBids = orders.where(
+          (o) =>
+              o.type == TradeOrderType.bid &&
+              (o.commodityId == _lumberId || o.commodityId == _castIronId),
+        );
+        expect(
+          improvementBids,
+          isNotEmpty,
+          reason:
+              'The locked seller must bid for the level-0 build_improvement '
+              'inputs (lumber / cast iron) it cannot afford.',
+        );
+        expect(_bidsFor(orders, _fabricId), isEmpty);
+        expect(_bidsFor(orders, _woolId), isEmpty);
+      },
+    );
+
+    test('seller already holding lumber + cast iron emits no improvement-input '
+        'bid and resumes the feedstock / fabric bootstrap', () {
+      final orders = _run(
+        _game(
+          sellerTreasury: threshold,
+          supplierTreasury: threshold,
+          sellerHoldsImprovementInputs: true,
+        ),
+        'gp_seller',
+      );
+      expect(_bidsFor(orders, _lumberId), isEmpty);
+      expect(_bidsFor(orders, _castIronId), isEmpty);
+      expect(
+        orders.where((o) => o.type == TradeOrderType.bid),
+        isNotEmpty,
+        reason:
+            'With the improvement inputs on hand the seller resumes the '
+            'feedstock / fabric bootstrap bid.',
+      );
+    });
+
+    test('seller owning no feedstock tile emits no improvement-input bid', () {
+      final orders = _run(
+        _game(
+          sellerTreasury: threshold,
+          supplierTreasury: threshold,
+          sellerOwnsFeedstockTile: false,
+        ),
+        'gp_seller',
+      );
+      expect(_bidsFor(orders, _lumberId), isEmpty);
+      expect(_bidsFor(orders, _castIronId), isEmpty);
+    });
+
+    test('seller whose feedstock tile is already improved emits no '
+        'improvement-input bid', () {
+      final orders = _run(
+        _game(
+          sellerTreasury: threshold,
+          supplierTreasury: threshold,
+          sellerWoolTileImproved: true,
+        ),
+        'gp_seller',
+      );
+      expect(_bidsFor(orders, _lumberId), isEmpty);
+      expect(_bidsFor(orders, _castIronId), isEmpty);
+    });
+
+    test(
+      'seller that already owns a regiment emits no improvement-input bid',
+      () {
+        final orders = _run(
+          _game(
+            sellerTreasury: threshold,
+            supplierTreasury: threshold,
+            sellerUnits: [
+              Unit(
+                id: 'r1',
+                type: 'peasant_levies',
+                ownerId: 'gp_seller',
+                locationProvinceId: 'oldWorld|seller_0',
+              ),
+            ],
+          ),
+          'gp_seller',
+        );
+        expect(_bidsFor(orders, _lumberId), isEmpty);
+        expect(_bidsFor(orders, _castIronId), isEmpty);
+      },
+    );
+
+    test(
+      'seller below the regiment threshold emits no improvement-input bid',
+      () {
+        final orders = _run(
+          _game(sellerTreasury: threshold - 1, supplierTreasury: threshold),
+          'gp_seller',
+        );
+        expect(_bidsFor(orders, _lumberId), isEmpty);
+        expect(_bidsFor(orders, _castIronId), isEmpty);
+      },
+    );
+
+    test('affluent non-seller releases surplus lumber while a lock-recovery '
+        'seller needs the improvement-input bootstrap', () {
+      final lumberOffers =
+          _run(
+            _game(sellerTreasury: threshold, supplierTreasury: threshold),
+            'gp_supplier',
+          ).where(
+            (o) => o.type == TradeOrderType.offer && o.commodityId == _lumberId,
+          );
+      expect(
+        lumberOffers,
+        isNotEmpty,
+        reason:
+            'An affluent GP must release lumber so the locked seller\'s '
+            'improvement-input bid can clear.',
+      );
+    });
+
+    test('improvement-input bootstrap path is deterministic', () {
+      final game = _game(
+        sellerTreasury: threshold,
+        supplierTreasury: threshold,
+      );
+      expect(_run(game, 'gp_seller'), equals(_run(game, 'gp_seller')));
+      expect(_run(game, 'gp_supplier'), equals(_run(game, 'gp_supplier')));
+    });
+  });
+}

--- a/packages/colonizethis_logic/lib/ai_api.dart
+++ b/packages/colonizethis_logic/lib/ai_api.dart
@@ -11,6 +11,7 @@ export 'src/ai/full_ai_civilian_work_selection.dart'
         FullAiCivilianWorkSelectionResult,
         kRegimentBuildInputFeedstockExtractionScoreBoost,
         regimentBuildInputFeedstockExtractionResourceIds,
+        regimentBuildInputFeedstockImprovementInputCost,
         selectFullAiCivilianWorkOrders;
 export 'src/ai/simple_ai_heuristics.dart' show turnSeedForPlayer;
 export 'src/constants.dart'

--- a/packages/colonizethis_logic/lib/src/ai/full_ai_civilian_work_selection.dart
+++ b/packages/colonizethis_logic/lib/src/ai/full_ai_civilian_work_selection.dart
@@ -462,6 +462,62 @@ Set<String> regimentBuildInputFeedstockExtractionResourceIds(
   return feedstock;
 }
 
+/// True iff [playerId] owns at least one province tile hosting a resource in
+/// [feedstockIds] that is still unimproved (`improvementLevel < 1`) — a Builder
+/// target whose `build_improvement` would extract the feedstock the
+/// `fabricFrom*` recipes consume. Province ownership is derived from the tile
+/// key (`Unit.provinceIdFromTileKey`) so the scan works from
+/// `WorldState.resourceByTileKey` alone. Read-only; Refs #2847 H8-extraction.
+bool _ownsUnimprovedFeedstockResourceTile(
+  Game game,
+  String playerId,
+  Set<String> feedstockIds,
+) {
+  if (feedstockIds.isEmpty) return false;
+  final ws = game.worldState;
+  for (final entry in ws.resourceByTileKey.entries) {
+    if (!feedstockIds.contains(entry.value)) continue;
+    final provinceId = Unit.provinceIdFromTileKey(entry.key);
+    if (provinceId == null) continue;
+    final province = tryGetProvince(ws, provinceId);
+    if (province == null || province.ownerId != playerId) continue;
+    if (ws.tileState.improvementLevel(entry.key) < 1) return true;
+  }
+  return false;
+}
+
+/// Level-0 `build_improvement` material cost (`{lumber: 1, castIron: 1}`,
+/// `work_order_costs.dart` § `workOrderCostBuildImprovement`) a below-quota
+/// zero-NW lock-recovery seller must hold to extract its own fabric feedstock
+/// tile (Refs #2847 § H8-extraction; companion to `treasury-planner.md`
+/// § Lock-recovery seller feedstock-improvement input bootstrap).
+///
+/// Returns the cost map **only** when the regiment build-input
+/// feedstock-extraction gate is active for [playerId]
+/// ([regimentBuildInputFeedstockExtractionResourceIds] non-empty) **and** the
+/// seller owns an unimproved tile hosting one of those feedstock resources —
+/// the case where the routed Builder is blocked by the lumber / cast-iron
+/// improvement cost it cannot afford. Returns the empty map otherwise, so it
+/// self-clears once the GP owns a regiment, holds the build input, or has
+/// improved the feedstock tile. The returned quantities are the **full** level-0
+/// cost; the caller nets on-hand stock and carry-forward bids to size the actual
+/// bid. Pure and deterministic over `(game, playerId)` and the static
+/// `RegimentEconomyCatalog` / `ProductionRecipesCatalog` / work-order cost table.
+Map<String, int> regimentBuildInputFeedstockImprovementInputCost(
+  Game game,
+  String playerId,
+) {
+  final feedstockIds = regimentBuildInputFeedstockExtractionResourceIds(
+    game,
+    playerId,
+  );
+  if (feedstockIds.isEmpty) return const <String, int>{};
+  if (!_ownsUnimprovedFeedstockResourceTile(game, playerId, feedstockIds)) {
+    return const <String, int>{};
+  }
+  return Map<String, int>.unmodifiable(workOrderCostBuildImprovement(0));
+}
+
 WorkOrder? _bestBuildImprovementRow(
   List<WorkOrder> candidates,
   Game game, {

--- a/packages/colonizethis_logic/test/full_ai_civilian_work_regiment_build_input_feedstock_extraction_test.dart
+++ b/packages/colonizethis_logic/test/full_ai_civilian_work_regiment_build_input_feedstock_extraction_test.dart
@@ -17,6 +17,7 @@ Game _belowQuotaZeroNwSellerGame({
     _tileGrain: 'grain',
     _tileWool: 'wool',
   },
+  TileMapState? tileState,
 }) {
   final provinces = List.generate(
     owOwned,
@@ -33,6 +34,7 @@ Game _belowQuotaZeroNwSellerGame({
       oldWorld: RegionData(provinces: provinces, units: extraUnits),
       newWorld: const RegionData(),
       resourceByTileKey: resourceByTileKey,
+      tileState: tileState ?? TileMapState(),
     ),
     players: [
       Player(
@@ -139,6 +141,95 @@ void main() {
       final a = regimentBuildInputFeedstockExtractionResourceIds(game, _playerId);
       final b = regimentBuildInputFeedstockExtractionResourceIds(game, _playerId);
       expect(a, equals(b));
+    });
+  });
+
+  group('regimentBuildInputFeedstockImprovementInputCost (Refs #2847 H8-extraction)', () {
+    test('active gate + owned unimproved feedstock tile returns level-0 cost', () {
+      final game = _belowQuotaZeroNwSellerGame(
+        owOwned: 5,
+        treasury: cheapestRegimentBuildTreasuryCost(),
+      );
+      expect(
+        regimentBuildInputFeedstockImprovementInputCost(game, _playerId),
+        equals(workOrderCostBuildImprovement(0)),
+      );
+    });
+
+    test('returns empty when no feedstock resource tile is owned', () {
+      final game = _belowQuotaZeroNwSellerGame(
+        owOwned: 5,
+        treasury: cheapestRegimentBuildTreasuryCost(),
+        resourceByTileKey: const {_tileGrain: 'grain'},
+      );
+      expect(
+        regimentBuildInputFeedstockImprovementInputCost(game, _playerId),
+        isEmpty,
+      );
+    });
+
+    test('returns empty when the feedstock tile is already improved', () {
+      final game = _belowQuotaZeroNwSellerGame(
+        owOwned: 5,
+        treasury: cheapestRegimentBuildTreasuryCost(),
+        tileState: TileMapState().setImprovement(_tileWool, 1),
+      );
+      expect(
+        regimentBuildInputFeedstockImprovementInputCost(game, _playerId),
+        isEmpty,
+      );
+    });
+
+    test('returns empty when treasury below regiment threshold', () {
+      final game = _belowQuotaZeroNwSellerGame(
+        owOwned: 5,
+        treasury: cheapestRegimentBuildTreasuryCost() - 1,
+      );
+      expect(
+        regimentBuildInputFeedstockImprovementInputCost(game, _playerId),
+        isEmpty,
+      );
+    });
+
+    test('returns empty when GP already owns a regiment', () {
+      final game = _belowQuotaZeroNwSellerGame(
+        owOwned: 5,
+        treasury: cheapestRegimentBuildTreasuryCost(),
+        extraUnits: [
+          Unit(
+            id: 'r1',
+            type: 'peasant_levies',
+            ownerId: _playerId,
+            locationProvinceId: 'oldWorld|p0',
+          ),
+        ],
+      );
+      expect(
+        regimentBuildInputFeedstockImprovementInputCost(game, _playerId),
+        isEmpty,
+      );
+    });
+
+    test('returns empty when GP is at or above the conquest quota', () {
+      final game = _belowQuotaZeroNwSellerGame(
+        owOwned: kObserverConquestMinOwProvincesPerGp,
+        treasury: cheapestRegimentBuildTreasuryCost(),
+      );
+      expect(
+        regimentBuildInputFeedstockImprovementInputCost(game, _playerId),
+        isEmpty,
+      );
+    });
+
+    test('evaluation is deterministic', () {
+      final game = _belowQuotaZeroNwSellerGame(
+        owOwned: 5,
+        treasury: cheapestRegimentBuildTreasuryCost(),
+      );
+      expect(
+        regimentBuildInputFeedstockImprovementInputCost(game, _playerId),
+        equals(regimentBuildInputFeedstockImprovementInputCost(game, _playerId)),
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

Closes the next slice of the #2847 lock-recovery economy stall pinned by the
seed-42 diagnostic (`gpFeedstockGateImprovementCostAffordableTurns == 0`): a
below-quota zero-NW lock-recovery seller that owns its fabric feedstock tile
still cannot start the routed Builder, because raising the tile to level 1 costs
the level-0 `build_improvement` material — **1 lumber + 1 cast iron** — that the
seller holds zero of and cannot produce domestically (every other
`build_improvement` costs the same), a self-reinforcing lumber / cast-iron
deadlock. The only non-deadlocking source is the world market.

This extends the existing lock-recovery regiment build-input bootstrap
(treasury planner) to acquire those improvement inputs via market bid:

- New logic contract `regimentBuildInputFeedstockImprovementInputCost(game, playerId)`
  (exported from `ai_api.dart`) returns the level-0 `build_improvement` cost map
  **only** when the feedstock-extraction gate is active **and** the seller owns an
  unimproved feedstock tile; empty otherwise (self-clears once a regiment is
  owned, the inputs are held, or the tile is improved).
- `runTreasuryPlanner` bids for the missing improvement inputs first and
  **suppresses** the downstream feedstock / fabric bootstrap bids while any
  improvement-input deficit remains, so the single `bidTypeCap` slot targets the
  prerequisite supply (mirrors the existing fabric-vs-feedstock suppression).
- `lumber` and `castIron` join the affluent-supplier release set so an affluent GP
  releases surplus for the seller's bid to match.

No affordability rule is bypassed: the matcher still debits treasury at phase 13
and the work-order validator still gates the eventual `build_improvement`.

SPEC: `SPEC/ai/treasury-planner.md` gains the **H8-extraction** subsection + ACs.

This references but does not close #2847 (foundational issue with further slices).

## Test plan

- [x] `colonizethis_logic`: `full_ai_civilian_work_regiment_build_input_feedstock_extraction_test.dart` — 7 new cases for the cost contract (active gate, no tile, improved tile, sub-threshold treasury, owns regiment, at-quota, determinism). 16/16 pass.
- [x] `colonizethis_ai`: new `treasury_planner_regiment_input_improvement_bootstrap_test.dart` — 8 cases (bids improvement input before fabric/feedstock, clears when held, no tile, improved tile, owns regiment, sub-threshold, affluent release, determinism).
- [x] All `treasury_planner*_test.dart` (64) pass; no regressions.
- [x] `dart analyze` clean on touched files.

Made with [Cursor](https://cursor.com)