### PR TITLE
fix(ai): release surplus regiment build inputs regardless of supplier treasury (Refs #2847)

### DIFF
--- a/SPEC/ai/treasury-planner.md
+++ b/SPEC/ai/treasury-planner.md
@@ -483,15 +483,17 @@ suppressed while any such feedstock deficit remains so the single
 existing fabric bootstrap bid and production boost resume; the feedstock
 reservation prevents selling the acquired wool / cotton before conversion.
 
-**Affluent-GP feedstock / build-input offers.** When **any** below-quota
+**Supplier feedstock / build-input offers.** When **any** below-quota
 zero-NW lock-recovery seller in the game meets the H8 bootstrap gate
 (`player.treasury >= cheapestRegimentBuildTreasuryCost()`,
 `regimentCountForPlayer == 0`, missing a `peasant_levies` build input), every
-**other** Great Power that is **not** a lock-recovery seller and holds
-`player.treasury >= cheapestRegimentBuildTreasuryCost()` releases surplus
+**other** Great Power that is **not** a lock-recovery seller releases surplus
 `wool`, `cotton`, and `fabric` aggressively into its offer set (safety buffer
 `0` for those commodities — same release pattern as § Lock-recovery seller
-food-surplus release) so the seller's feedstock / fabric bids can match. The
+food-surplus release) so the seller's feedstock / fabric bids can match,
+**regardless of the supplier's own treasury** (see § Lock-recovery seller
+feedstock-improvement input bootstrap → Supplier improvement-input offers for
+the supply-side rationale: releasing a surplus is selling, not speculating). The
 gate clears automatically once no lock-recovery seller still needs the
 bootstrap path.
 
@@ -562,13 +564,24 @@ unit at phase 13, and the work-order validator still gates the eventual
 `build_improvement`. Once the inputs land the seller resumes the feedstock /
 fabric bootstrap bids.
 
-**Affluent-GP improvement-input offers.** `lumber` and `castIron` join `wool`,
-`cotton`, and `fabric` in the affluent-supplier release set
-(`_regimentBuildInputSupplyCommodityIds`), so while any lock-recovery seller
-needs the bootstrap path, every other Great Power with
-`player.treasury >= cheapestRegimentBuildTreasuryCost()` releases its `lumber` /
-`castIron` surplus aggressively (safety buffer `0`, production inputs still
-reserved) so the seller's improvement-input bid can match.
+**Supplier improvement-input offers (supply-side, treasury-independent).**
+`lumber` and `castIron` join `wool`, `cotton`, and `fabric` in the supplier
+release set (`_regimentBuildInputSupplyCommodityIds`), so while any lock-recovery
+seller needs the bootstrap path, every other Great Power that is **not** a
+lock-recovery seller releases its `lumber` / `castIron` (and `wool` / `cotton` /
+`fabric`) surplus aggressively (safety buffer `0`, production inputs still
+reserved) so the seller's improvement-input bid can match — **regardless of the
+supplier's own treasury**. Releasing a *surplus* (stock held above the supplier's
+own consumption + production-input reserve) is selling, not speculating, so the
+supplier role is **not** gated on `player.treasury >= cheapestRegimentBuildTreasuryCost()`.
+This is the decisive supply-side correction: on seed 42 the only GPs holding
+`lumber` / `castIron` / `fabric` surplus spend their treasury on Old World
+conquest and sit far below the regiment-affordable band, so the earlier
+treasury-gated supplier role left every lock-recovery seller bid permanently
+unfilled (`gpRegimentInputDealsAsBuyer == 0`,
+`gpFeedstockGateImprovementCostAffordableTurns == 0`). Dropping the supplier
+treasury gate keeps the supplier's own consumption + production inputs reserved
+(only the extra safety buffer drops to `0`), so it cannot starve the supplier.
 
 #### Acceptance criteria (H8-extraction)
 
@@ -597,6 +610,12 @@ reserved) so the seller's improvement-input bid can match.
   and `player.treasury >= cheapestRegimentBuildTreasuryCost()`, when
   `runTreasuryPlanner` runs for that affluent GP, then it emits a
   `TradeOrderType.offer` for `lumber`.
+- Given the same game state and a non-seller Great Power that holds a `lumber`
+  surplus above its consumption-only reserve (`kShortageThreshold ~/ 2`) but has
+  `player.treasury < cheapestRegimentBuildTreasuryCost()`, when
+  `runTreasuryPlanner` runs for that below-affordable GP, then it still emits a
+  `TradeOrderType.offer` for `lumber` (the supplier role is treasury-independent
+  because releasing a surplus is selling, not speculating).
 - Given identical inputs, when `runTreasuryPlanner` runs twice on the
   improvement-input bootstrap path, then both runs return identical
   `List<TradeOrder>` outputs (determinism).

--- a/packages/colonizethis_ai/lib/src/planning/treasury_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/treasury_planner.dart
@@ -124,9 +124,22 @@ List<TradeOrder> runTreasuryPlanner({
       _isBelowQuotaZeroNwLockRecoverySeller(game: game, playerId: playerId);
   final regimentBuildInputMarketSupplyActive =
       _anyLockRecoverySellerNeedsRegimentBuildInput(game);
-  final isRegimentBuildInputMarketSupplier = regimentBuildInputMarketSupplyActive &&
-      !isLockRecoverySeller &&
-      rawTreasury >= threshold;
+  // Refs #2847 H8-extraction supply-side fix: releasing a *surplus* (stock held
+  // above the GP's own consumption + production-input reserve) is selling, not
+  // speculating, so the supplier role must not be gated on the supplier's own
+  // treasury. On seed 42 the only GPs holding fabric / lumber / cast-iron
+  // surplus (gp1 / gp2) spend their treasury on conquest and sit far below the
+  // regiment-affordable band, so the prior `rawTreasury >= threshold` gate left
+  // every lock-recovery seller bid (fabric, then the level-0 build_improvement
+  // inputs) permanently unfilled — `gpRegimentInputDealsAsBuyer == 0` and
+  // `gpFeedstockGateImprovementCostAffordableTurns == 0` across the whole run.
+  // Releasing surplus regardless of the supplier's treasury still reserves the
+  // supplier's own consumption + production inputs (only the extra safety buffer
+  // drops to 0), so it cannot starve the supplier, while letting the needy
+  // seller's bid match. SPEC/ai/treasury-planner.md
+  // § Lock-recovery seller feedstock-improvement input bootstrap.
+  final isRegimentBuildInputMarketSupplier =
+      regimentBuildInputMarketSupplyActive && !isLockRecoverySeller;
 
   for (final id in trackedCommodityIds) {
     if (richesCommodityIds.contains(id)) continue;

--- a/packages/colonizethis_ai/test/planning/treasury_planner_regiment_input_improvement_bootstrap_test.dart
+++ b/packages/colonizethis_ai/test/planning/treasury_planner_regiment_input_improvement_bootstrap_test.dart
@@ -239,6 +239,37 @@ void main() {
       );
     });
 
+    test('below-affordable non-seller still releases surplus lumber while a '
+        'lock-recovery seller needs the improvement-input bootstrap', () {
+      // The only GPs holding lumber / cast-iron surplus on seed 42 sit far
+      // below the regiment-affordable band (they spend treasury on conquest),
+      // so the supplier role must release a true surplus regardless of the
+      // supplier's own treasury. `supplierLumberHeld: 6` is surplus above the
+      // supplier's consumption-only reserve (4 = kShortageThreshold ~/ 2) once
+      // the extra safety buffer is dropped, but is withheld under the default
+      // `2 * consumption` (= 8) buffer — so this discriminates the supply-side
+      // fix from the prior `rawTreasury >= threshold` gate.
+      final lumberOffers =
+          _run(
+            _game(
+              sellerTreasury: threshold,
+              supplierTreasury: threshold - 100,
+              supplierLumberHeld: 6,
+            ),
+            'gp_supplier',
+          ).where(
+            (o) => o.type == TradeOrderType.offer && o.commodityId == _lumberId,
+          );
+      expect(
+        lumberOffers,
+        isNotEmpty,
+        reason:
+            'A non-seller GP holding surplus lumber must release it regardless '
+            'of its own treasury so the locked seller\'s improvement-input bid '
+            'can clear.',
+      );
+    });
+
     test('improvement-input bootstrap path is deterministic', () {
       final game = _game(
         sellerTreasury: threshold,

--- a/packages/colonizethis_ai/test/seed42_observer_conquest_s7d_diagnostic_test.dart
+++ b/packages/colonizethis_ai/test/seed42_observer_conquest_s7d_diagnostic_test.dart
@@ -547,6 +547,48 @@ import 'support/faithful_full_ai_test_handoff.dart';
 ///      against the locked peer (unchanged; see #3224).
 ///   3. **H2 (still open): residual peer-war re-declare oscillation.**
 ///
+/// ## S7-D refresh (captured 2026-06-04 on branch
+///     `fix/issue-2847-h8-extraction-improvement-input`, after the lock-recovery
+///     improvement-input bid carve-out (#3238) **and** the supply-side
+///     treasury-gate removal + improvement-input localization added in this
+///     slice)
+///
+/// The improvement-input bid carve-out alone (#3238) did **not** move the
+/// binding metric: `gpFeedstockGateImprovementCostAffordableTurns` stayed
+/// **0 / 0 / 0** for gp3 / gp5 / gp6 and `gpRegimentInputDealsAsBuyer` stayed
+/// **0**, with OW gain unchanged (gp1 = +6, gp2 = +6 PASS; gp3 = +2, gp4 = +1,
+/// gp5 = +1, gp6 = +2 FAIL). The new improvement-input counters
+/// (`improvementInputCommodityIds = [castIron, lumber]`) localize the remaining
+/// break **decisively**:
+///
+///   * **Supply now exists.** Dropping the `rawTreasury >= threshold` gate on the
+///     supplier role (so a GP releasing a *surplus* sells regardless of its own
+///     treasury) lifts `gpImprovementInputOffersEmitted` for gp2 from 0 to **40**
+///     (`gpImprovementInputHeldAtTurn99` gp2 = **48**). Before this slice no GP
+///     released lumber / cast iron because the only holders (gp1 / gp2) sit far
+///     below the regiment-affordable band. The supply-side fix works as intended.
+///   * **Demand exists.** The locked sellers emit improvement-input bids:
+///     `gpImprovementInputBidsEmitted` = **13 / 0 / 22 / 22** for gp3 / gp4 / gp5 /
+///     gp6 (gp4's gate is inactive, so 0 is expected).
+///   * **Yet zero deals fill.** `gpImprovementInputDealsAsBuyer` = **0** for every
+///     GP across all 100 turns. A standing lumber / cast-iron bid (13-22 turns)
+///     and a standing offer (40 turns, 48 surplus held) **coexist** but never
+///     cross.
+///
+/// Conclusion: the break has moved one decisive step downstream — from "no
+/// supply" (the #3238 / supply-side target) to **world-market order matching**.
+/// Both sides of the lumber / cast-iron trade are present every turn yet the
+/// matcher never pairs them. This **refutes** the supply-availability framing and
+/// **also** the "seller never bids" framing (bids are emitted). The next slice
+/// must look at why the bid and offer do not cross — price crossing
+/// (`_marketPriceBelowProductionCost` / offer vs bid price), bid priority tier
+/// vs the urgent grain-liquidity bid, the per-buyer treasury clamp (#3115), or
+/// the `bidTypeCap` slot allocation — **not** supply, bid emission, the validator
+/// material-cost gate, Builder availability, or recipe scoring. Verify by
+/// re-running this diagnostic and confirming `gpImprovementInputDealsAsBuyer`
+/// then (downstream) `gpFeedstockGateImprovementCostAffordableTurns` rise for
+/// gp3 / gp5 / gp6.
+///
 /// ## How to refresh
 ///
 /// Skipped by default (long-running, ~4 minutes on the project
@@ -852,6 +894,38 @@ void main() {
         for (final gpId in gpIds) gpId: 0,
       };
       final regimentInputDealsAsBuyer = <String, int>{
+        for (final gpId in gpIds) gpId: 0,
+      };
+
+      // Refs #2847 H8-extraction supply-side localization. The level-0
+      // `build_improvement` material (lumber + cast iron) is the prerequisite a
+      // locked seller's routed Builder needs but cannot afford
+      // (`gpFeedstockGateImprovementCostAffordableTurns == 0`). The
+      // improvement-input bid carve-out and the treasury-independent supplier
+      // release set both target these commodities, yet the seller never ends up
+      // holding them. These counters split that supply gap into its proximate
+      // links so a tuning implementer can tell apart, in order: (a) no GP / tribe
+      // *offers* the inputs at all (`gpImprovementInputOffersEmitted` flat zero =>
+      // nobody holds a releasable surplus); (b) offers exist but the seller's bid
+      // never *fills* (`gpImprovementInputDealsAsBuyer` flat zero alongside
+      // non-zero offers => price / priority / bid-cap matching gap); or (c) deals
+      // fill but the input is consumed before the gate observes it
+      // (`gpImprovementInputHeldAtTurn99` zero alongside non-zero buyer deals).
+      // Read-only; the (freely tunable) counts can move as later supply slices
+      // land.
+      final improvementInputCommodityIds = workOrderCostBuildImprovement(
+        0,
+      ).keys.toSet();
+      final improvementInputOffersEmitted = <String, int>{
+        for (final gpId in gpIds) gpId: 0,
+      };
+      final improvementInputBidsEmitted = <String, int>{
+        for (final gpId in gpIds) gpId: 0,
+      };
+      final improvementInputDealsAsBuyer = <String, int>{
+        for (final gpId in gpIds) gpId: 0,
+      };
+      final improvementInputHeldAtTurn99 = <String, int>{
         for (final gpId in gpIds) gpId: 0,
       };
 
@@ -1208,11 +1282,19 @@ void main() {
                 tradeUrgentOfferCount[gpId] =
                     (tradeUrgentOfferCount[gpId] ?? 0) + 1;
               }
+              if (improvementInputCommodityIds.contains(order.commodityId)) {
+                improvementInputOffersEmitted[gpId] =
+                    (improvementInputOffersEmitted[gpId] ?? 0) + 1;
+              }
             } else if (order.type == TradeOrderType.bid) {
               tradeBidCount[gpId] = (tradeBidCount[gpId] ?? 0) + 1;
               if (regimentInputCommodityIds.contains(order.commodityId)) {
                 regimentInputBidsEmitted[gpId] =
                     (regimentInputBidsEmitted[gpId] ?? 0) + 1;
+              }
+              if (improvementInputCommodityIds.contains(order.commodityId)) {
+                improvementInputBidsEmitted[gpId] =
+                    (improvementInputBidsEmitted[gpId] ?? 0) + 1;
               }
             }
           }
@@ -1256,6 +1338,10 @@ void main() {
                 regimentInputDealsAsBuyer[buyer] =
                     (regimentInputDealsAsBuyer[buyer] ?? 0) + 1;
               }
+              if (improvementInputCommodityIds.contains(deal.commodityId)) {
+                improvementInputDealsAsBuyer[buyer] =
+                    (improvementInputDealsAsBuyer[buyer] ?? 0) + 1;
+              }
             }
           }
         }
@@ -1282,6 +1368,14 @@ void main() {
           treasuryPrevTurn[gpId] = after;
           if (t == 99) {
             treasuryAtTurn99[gpId] = after;
+            final player = game.playerById(gpId);
+            if (player != null) {
+              improvementInputHeldAtTurn99[gpId] = improvementInputCommodityIds
+                  .fold<int>(
+                    0,
+                    (sum, id) => sum + player.stockpile.quantityOf(id),
+                  );
+            }
           }
         }
       }
@@ -1331,6 +1425,12 @@ void main() {
         'regimentInputCommodityIds': regimentInputCommodityIds.toList()..sort(),
         'gpRegimentInputBidsEmitted': regimentInputBidsEmitted,
         'gpRegimentInputDealsAsBuyer': regimentInputDealsAsBuyer,
+        'improvementInputCommodityIds': improvementInputCommodityIds.toList()
+          ..sort(),
+        'gpImprovementInputOffersEmitted': improvementInputOffersEmitted,
+        'gpImprovementInputBidsEmitted': improvementInputBidsEmitted,
+        'gpImprovementInputDealsAsBuyer': improvementInputDealsAsBuyer,
+        'gpImprovementInputHeldAtTurn99': improvementInputHeldAtTurn99,
         'fabricFeedstockCommodityIds': fabricFeedstockIds.toList()..sort(),
         'gpFeedstockExtractionGateActiveTurns':
             feedstockExtractionGateActiveTurns,


### PR DESCRIPTION
## Summary

Follow-up slice for #2847 (H8-extraction lumber/castIron deadlock). The prior slice (PR #3238, now merged into `dev`) made lock-recovery sellers **bid** for `build_improvement` inputs. Diagnostics then showed the matching bids still never cleared: the GPs that actually hold the `lumber` / `castIron` surplus on seed 42 (gp1/gp2) spend their treasury on conquest and sit far below the regiment-affordable band, so the supplier-side offer was suppressed by a `rawTreasury >= threshold` gate.

This slice removes that treasury gate from `isRegimentBuildInputMarketSupplier`. Releasing a *surplus* (stock above the GP's own consumption + production-input reserve) is selling, not speculating, so it must not be gated on the supplier's treasury. The supplier's consumption + production inputs stay reserved; only the extra safety buffer drops, so this cannot starve the supplier.

## Changes

- `treasury_planner.dart`: drop `rawTreasury >= threshold` from the supplier predicate.
- New unit test: below-affordable non-seller still releases surplus lumber while a lock-recovery seller needs the bootstrap (discriminates the supply-side fix from the prior gate).
- S7-D diagnostic: added improvement-input offer/bid/deal/held counters; confirms suppliers now emit surplus offers and localizes the remaining break to **world-market order matching** (offers + bids coexist, zero deals match).
- `SPEC/ai/treasury-planner.md`: documents the supply-side rule + new AC.

## Test plan

- [x] `treasury_planner_regiment_input_improvement_bootstrap_test.dart` (9 tests, incl. new below-affordable case)
- [x] `dart analyze` clean on touched files
- [x] S7-D diagnostic runs; suppliers now offer surplus lumber/castIron

## Remaining (tracked under #2847)

Order matching for the new improvement-input offers/bids does not yet clear. Next slice targets the world-market matching stage.

Refs #2847

Made with [Cursor](https://cursor.com)