### PR TITLE
fix(ai): align build-input supply offer tiers with buyer bid tiers (Refs #2847)

### DIFF
--- a/SPEC/ai/treasury-planner.md
+++ b/SPEC/ai/treasury-planner.md
@@ -583,7 +583,47 @@ unfilled (`gpRegimentInputDealsAsBuyer == 0`,
 treasury gate keeps the supplier's own consumption + production inputs reserved
 (only the extra safety buffer drops to `0`), so it cannot starve the supplier.
 
+**Supplier offer-tier alignment (order matching).** Surfacing the supply is
+necessary but not sufficient: the [DealMatcher](../program/world-market-resolution.md)
+§ Step C crosses offers and bids **only within the same integer priority tier**.
+A lock-recovery supplier emits all surplus at its general `offerPriority` — the
+urgent tier (`kTreasuryOfferPriorityUrgent` = `2`) while broke, the moderate tier
+(`kTreasuryOfferPriorityModerate` = `5`) once recovered — but the locked buyer
+bids each build input at `_bidPriorityForCommodity` (essential = `1` for the
+manufactured `lumber` / `castIron` / `fabric`, raw = `3` for `wool` / `cotton`)
+because the H8 bootstrap bid fires only **after** the seller has recovered above
+the regiment threshold (so `alignBidPriorityWithUrgentOffers` is false for it). On
+seed 42 this stranded a priority-`2` `lumber` offer and a priority-`1` `lumber`
+bid in different tiers every turn (`filledQuantity == 0` despite both standing).
+Therefore, while the supplier role is active, every offer whose commodity is in
+`_regimentBuildInputSupplyCommodityIds` is re-tagged to the **same per-commodity
+tier the buyer bids at** (`_bidPriorityForCommodity(commodityId)`) so the standing
+offer and bid land in one tier and cross. Only build-input supply commodities are
+re-tagged; the urgent liquidity-food offer and all other surplus keep their
+computed `offerPriority`. This mirrors the bid-side
+`alignBidPriorityWithUrgentOffers` tier-alignment machinery (Refs #2924 F12/F16)
+and bypasses no affordability rule (the matcher still debits the buyer's treasury
+per filled unit at phase 13).
+
+> **Residual (Refs #2847 H8, separate from this rule):** the bootstrap
+> `build_improvement` needs **both** `lumber` and `castIron`. On seed 42 no Great
+> Power ever offers a `castIron` surplus (it is consumed by Old World military
+> builds), so even with offer-tier alignment the `castIron` bid has zero market
+> supply to cross. Closing the full H8 deadlock requires a `castIron` supply or
+> production source, not a further matching change.
+
 #### Acceptance criteria (H8-extraction)
+
+- Given a lock-recovery supplier (an affluent or below-regiment-band Great Power
+  releasing surplus while another GP needs the H8 bootstrap) with a `lumber`
+  surplus, when `runTreasuryPlanner` runs for that supplier, then its emitted
+  `lumber` `TradeOrderType.offer` has `priority == kTreasuryBidPriorityEssentialInput`
+  (the same tier the recovered buyer bids `lumber` at) rather than the general
+  `offerPriority`, so the DealMatcher can cross the standing offer and bid.
+- Given the same supplier and a non-build-input surplus commodity (for example
+  `timber`), when `runTreasuryPlanner` runs, then that commodity's offer keeps the
+  general moderate offer priority (`kTreasuryOfferPriorityModerate`) — only the
+  build-input supply commodities are re-tagged.
 
 - Given a below-quota zero-NW lock-recovery seller with recovered treasury, zero
   regiments, a projected stockpile missing the cheapest regiment's `fabric`

--- a/packages/colonizethis_ai/lib/src/planning/treasury_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/treasury_planner.dart
@@ -299,7 +299,24 @@ List<TradeOrder> runTreasuryPlanner({
     ),
   );
 
-  final offers = suggestion.offers;
+  // Refs #2847 H8-supply market order matching: a lock-recovery supplier
+  // releases its surplus at the GP's general `offerPriority` (the urgent tier
+  // when broke, the moderate tier otherwise), but the locked buyer bids the
+  // build inputs at `_bidPriorityForCommodity` (essential = 1 for the
+  // manufactured `lumber` / `castIron` / `fabric` inputs) once it has recovered
+  // above the regiment threshold. The DealMatcher crosses offers and bids only
+  // **within** the same integer priority tier
+  // (SPEC/program/world-market-resolution.md § Step C), so a standing
+  // build-input offer and the buyer's standing build-input bid never pair --
+  // confirmed on seed 42: a priority-2 `lumber` offer and a priority-1 `lumber`
+  // bid coexist every turn yet `filledQuantity == 0`. Re-tag the supplier's
+  // build-input supply offers to the same per-commodity tier the buyer bids at
+  // so the two cross. Mirrors the bid-side `alignBidPriorityWithUrgentOffers`
+  // tier-alignment machinery (Refs #2924 F12/F16).
+  // SPEC/ai/treasury-planner.md § Supplier offer-tier alignment.
+  final offers = isRegimentBuildInputMarketSupplier
+      ? _alignBuildInputSupplyOfferTiers(suggestion.offers)
+      : suggestion.offers;
   // Refs #2924 F11/F12: when the designated buyer is affluent its own forecast
   // is above the regiment threshold (offerPriority == moderate); the lock-
   // recovery bid still needs to clear at the urgent integer priority tier so
@@ -888,6 +905,36 @@ const Set<CommodityId> _regimentBuildInputSupplyCommodityIds = {
   'lumber',
   'castIron',
 };
+
+/// Re-tags a lock-recovery supplier's build-input supply offers so each lands
+/// in the **same** integer priority tier the locked buyer bids that commodity
+/// at (`_bidPriorityForCommodity`), enabling the per-commodity offer/bid cross
+/// the DealMatcher otherwise blocks across mismatched tiers
+/// (SPEC/program/world-market-resolution.md § Step C; Refs #2847 H8-supply
+/// market order matching). Only offers whose commodity is in
+/// [_regimentBuildInputSupplyCommodityIds] are retuned; all other offers (for
+/// example the urgent liquidity-food offer) keep their computed priority. The
+/// original list is returned unchanged when no tier actually moves so equal
+/// inputs keep their identity (determinism).
+List<TradeOrder> _alignBuildInputSupplyOfferTiers(List<TradeOrder> offers) {
+  if (offers.isEmpty) return offers;
+  var changed = false;
+  final result = <TradeOrder>[];
+  for (final offer in offers) {
+    if (!_regimentBuildInputSupplyCommodityIds.contains(offer.commodityId)) {
+      result.add(offer);
+      continue;
+    }
+    final alignedPriority = _bidPriorityForCommodity(offer.commodityId);
+    if (alignedPriority == offer.priority) {
+      result.add(offer);
+      continue;
+    }
+    result.add(offer.copyWith(priority: alignedPriority));
+    changed = true;
+  }
+  return changed ? result : offers;
+}
 
 /// True when any below-quota zero-NW lock-recovery seller still needs the
 /// H8 regiment build-input bootstrap path (Refs #2847 H8-supply market).

--- a/packages/colonizethis_ai/test/planning/treasury_planner_regiment_input_market_supply_test.dart
+++ b/packages/colonizethis_ai/test/planning/treasury_planner_regiment_input_market_supply_test.dart
@@ -8,6 +8,7 @@ import 'package:colonizethis_test/test.dart';
 
 const _fabricId = 'fabric';
 const _woolId = 'wool';
+const _timberId = 'timber';
 
 Game _twoGpGame({
   required int sellerTreasury,
@@ -15,6 +16,7 @@ Game _twoGpGame({
   required int sellerFabricHeld,
   required int sellerWoolHeld,
   required int supplierWoolHeld,
+  int supplierTimberHeld = 0,
   int sellerOwProvinces = 3,
   int supplierOwProvinces = 12,
 }) {
@@ -29,6 +31,10 @@ Game _twoGpGame({
   var supplierStockpile = const Stockpile().applyDelta('grain', 80);
   if (supplierWoolHeld > 0) {
     supplierStockpile = supplierStockpile.applyDelta(_woolId, supplierWoolHeld);
+  }
+  if (supplierTimberHeld > 0) {
+    supplierStockpile =
+        supplierStockpile.applyDelta(_timberId, supplierTimberHeld);
   }
   return Game(
     id: 'g-h8-supply-market',
@@ -66,6 +72,7 @@ Game _twoGpGame({
       'grain': 10,
       _woolId: 20,
       _fabricId: 40,
+      _timberId: 30,
     }),
   );
 }
@@ -170,6 +177,80 @@ void main() {
         isNotEmpty,
       );
     });
+
+    test(
+      'supplier build-input offer lands in the same priority tier the buyer '
+      'bids at so the DealMatcher can cross them (Refs #2847 H8-supply market '
+      'order matching)',
+      () {
+        final game = _twoGpGame(
+          sellerTreasury: threshold,
+          supplierTreasury: threshold,
+          sellerFabricHeld: 0,
+          sellerWoolHeld: 0,
+          supplierWoolHeld: 20,
+        );
+        final supplierWoolOffer = _run(game, 'gp_supplier').firstWhere(
+          (o) => o.type == TradeOrderType.offer && o.commodityId == _woolId,
+        );
+        final sellerWoolBid = _run(game, 'gp_seller').firstWhere(
+          (o) => o.type == TradeOrderType.bid && o.commodityId == _woolId,
+        );
+        expect(
+          supplierWoolOffer.priority,
+          sellerWoolBid.priority,
+          reason:
+              'The build-input supply offer and the buyer build-input bid '
+              'must share an integer priority tier; the DealMatcher only '
+              'crosses orders within the same tier.',
+        );
+        expect(
+          supplierWoolOffer.priority,
+          kTreasuryBidPriorityRawMaterial,
+          reason:
+              'wool is a raw material; the supply offer is re-tagged to the '
+              'raw bid tier rather than the moderate offer tier.',
+        );
+      },
+    );
+
+    test(
+      'only build-input supply commodities are re-tagged; a non-build-input '
+      'surplus offer keeps the moderate offer tier (Refs #2847 H8-supply '
+      'market order matching)',
+      () {
+        final game = _twoGpGame(
+          sellerTreasury: threshold,
+          supplierTreasury: threshold,
+          sellerFabricHeld: 0,
+          sellerWoolHeld: 0,
+          supplierWoolHeld: 20,
+          supplierTimberHeld: 200,
+        );
+        final supplierOrders = _run(game, 'gp_supplier');
+        final timberOffer = supplierOrders.firstWhere(
+          (o) => o.type == TradeOrderType.offer && o.commodityId == _timberId,
+        );
+        expect(
+          timberOffer.priority,
+          kTreasuryOfferPriorityModerate,
+          reason:
+              'timber is not a regiment build-input supply commodity, so its '
+              'surplus offer keeps the general moderate offer priority and is '
+              'not re-tagged.',
+        );
+        final woolOffer = supplierOrders.firstWhere(
+          (o) => o.type == TradeOrderType.offer && o.commodityId == _woolId,
+        );
+        expect(
+          woolOffer.priority,
+          kTreasuryBidPriorityRawMaterial,
+          reason:
+              'wool is a build-input supply commodity, so it is re-tagged to '
+              'the buyer bid tier even while timber is not.',
+        );
+      },
+    );
 
     test('H8-supply market path is deterministic', () {
       final game = _twoGpGame(


### PR DESCRIPTION
## Summary

Follow-up slice for #2847 (the #3239 branch was merged; this is the next slice per the issue's remaining-work note: *world-market order matching for the improvement-input offers/bids doesn't clear*).

The `DealMatcher` crosses offers and bids **only within the same integer priority tier** (`SPEC/program/world-market-resolution.md` § Step C). A lock-recovery supplier released its build-input surplus at the GP's general `offerPriority` (urgent while broke, moderate once recovered), but the recovered buyer bids each build input at `_bidPriorityForCommodity` (essential = 1 for the manufactured `lumber`/`castIron`/`fabric`, raw = 3 for `wool`/`cotton`). On seed 42 a priority-2 `lumber` offer and a priority-1 `lumber` bid coexisted every turn yet `filledQuantity == 0`.

This re-tags a `isRegimentBuildInputMarketSupplier` GP's build-input supply offers to the same per-commodity tier the buyer bids at, so the standing offer and bid land in one tier and cross. All other surplus (e.g. the urgent liquidity-food offer) keeps its computed priority. The matcher still debits the buyer's treasury per filled unit at phase 13, so no affordability rule is bypassed.

- `treasury_planner.dart`: add `_alignBuildInputSupplyOfferTiers`, applied when the supplier role is active.
- SPEC: document the offer-tier alignment rule + ACs under `SPEC/ai/treasury-planner.md`.
- Tests: positive (supply offer lands in the buyer's bid tier) + negative (a non-build-input surplus like `timber` keeps the moderate offer tier).

**Verified end-to-end on seed 42:** the supplier's `lumber` offer is re-tagged p2 → p1, matching the buyer's p1 bid, and `filled` goes 0 → 1 at T49/T50.

## Residual (separate, disclosed)

The bootstrap `build_improvement` needs **both** `lumber` and `castIron`. On seed 42 no GP ever offers a `castIron` surplus (it is consumed by Old World military builds), so the `castIron` bid still has zero market supply to cross. Closing the full H8 deadlock requires a `castIron` supply/production source, not a further matching change. Documented as a residual in the SPEC.

## Test plan

- [x] `dart analyze` clean on touched files
- [x] `dart test test/planning/treasury_planner_regiment_input_market_supply_test.dart` (7/7, incl. 2 new)
- [x] `dart test test/planning/` regression (1291/1291 pass)

Refs #2847

Made with [Cursor](https://cursor.com)