### PR TITLE
feat(ai): supplier castIron over-production + seller direct-bid for H8 lock-recovery (Refs #2847)

### DIFF
--- a/SPEC/ai/economy-planner.md
+++ b/SPEC/ai/economy-planner.md
@@ -99,6 +99,17 @@ Companion to [treasury-planner.md](treasury-planner.md) § Lock-recovery seller 
 
 ---
 
+### Supplier improvement-input over-production for release (Refs #2847 H8-supply castIron source)
+
+The domestic improvement-input boost above only fires for the locked seller that owns the unimproved feedstock tile — and that seller cannot produce `castIron` because it holds no `timber` / `iron` (the extraction deadlock). To create a *first* `castIron` source, an affluent **supplier** over-produces `castIron` for release. When the player is **not** itself a below-quota zero-NW lock-recovery seller (`isBelowQuotaZeroNwLockRecoverySeller(game, playerId) == false`) and `anyLockRecoverySellerNeedsCastIronImprovementInput(game)` is `true`, every `kDomesticProductionImprovementInputIds` output (`castIron`) joins a **supplier-release** boosted set and receives `kSupplierBuildInputReleaseProductionScoreBoost` (`5.0`) in `_allocateLabour`.
+
+The boost is deliberately small — far below the shortage-driven score of the supplier's own essential recipes (`kShortageWeight * kShortageThreshold == 16`) — so the supplier converts only **leftover** labour/feedstock into a releasable `castIron` surplus and never starves its own conquest economy. This keeps the +6 OW baseline for the healthy GPs (gp1/gp2) safe by construction. The treasury planner then releases the surplus and re-tags its offer tier (see [treasury-planner.md](treasury-planner.md) § Lock-recovery castIron improvement-input supplier source). Planner-internal constant (no `ai_victory_config.dart` change); self-clearing once no locked seller needs `castIron`.
+
+#### Acceptance criteria (H8-supply castIron source)
+
+- Given a non-seller Great Power above the conquest quota with `timber` + `iron` feedstock, ample labour, and no competing output shortage, and a peer below-quota zero-NW lock-recovery seller that needs the `castIron` improvement input, when `runEconomyPlanner` runs for the non-seller, then at least one production assignment references the `castIron_from_timber_iron_coal` recipe.
+- Given the same non-seller but with no peer lock-recovery seller needing the `castIron` improvement input (the would-be seller is at quota or already holds `castIron`), when `runEconomyPlanner` runs for the non-seller with the same seed, then its assigned `castIron` labour is **not greater** than in the active case (negative control — the supplier-release boost only fires while a peer needs the input, so the +6 baseline GPs are unaffected).
+
 ## Regiment build-input feedstock extraction priority (Refs #2847 H8-extraction)
 
 Companion to § Regiment build-input production priority (Refs #2847 H8) and [treasury-planner.md](treasury-planner.md) § Lock-recovery seller regiment build-input bootstrap. The production boost only converts feedstock the GP **already holds**, and the world-market bid only fills when a seller offers the feedstock. On seed 42 the failing below-quota zero-NW Great Powers (`gp3` / `gp5` / `gp6`) hold **no** `wool` / `cotton` because their idle Builders are not routed to improve the feedstock resource tiles they own, so neither the domestic production path nor the market-supply path has any feedstock to work with (the residual disclosed in `treasury-planner.md` § Residual feedstock-acquisition dependency).

--- a/SPEC/ai/treasury-planner.md
+++ b/SPEC/ai/treasury-planner.md
@@ -516,6 +516,75 @@ bootstrap path.
   H8-supply market path, then both runs return identical
   `List<TradeOrder>` outputs (determinism).
 
+### Lock-recovery castIron improvement-input supplier source (Refs #2847 H8-supply castIron source)
+
+The H8-supply market path above releases `wool` / `cotton` / `fabric` and the
+directly-buyable `lumber` improvement input. It does **not** create a source for
+`castIron`, the second level-0 `build_improvement` input: `castIron` has no
+native world-market supply on seed 42 (every Great Power consumes the `castIron`
+it produces), so a locked seller is stuck at the extraction gate — it cannot
+mine the recipe feedstock without first raising its tile, and raising the tile
+costs `castIron` it can neither buy nor produce. This section opens a *first*
+`castIron` source.
+
+**Supplier activation trigger.** `anyLockRecoverySellerNeedsCastIronImprovementInput(game)`
+is `true` when any below-quota zero-NW lock-recovery seller's
+`regimentBuildInputFeedstockImprovementInputCost` includes a
+`kDomesticProductionImprovementInputIds` commodity (`castIron`) the seller does
+not hold. This trigger is OR-ed into the H8-supply-market supplier role
+(`regimentBuildInputMarketSupplyActive`), so the supplier release activates one
+stage earlier than the regiment build-input (fabric) gate — at the `castIron`
+improvement-input gate where seed-42 sellers actually stall.
+
+**Supplier offer (offer side).** An affluent non-seller over-produces `castIron`
+(see [economy-planner.md](economy-planner.md) § Supplier improvement-input
+over-production for release) and releases the resulting surplus with the
+build-input safety buffer dropped to `0`, re-tagged to the essential bid tier by
+`_alignBuildInputSupplyOfferTiers` so the locked seller's `castIron` bid can
+cross.
+
+**Buyer direct bid (bid side).** A `castIron` improvement-input is normally
+produced from feedstock (the production route). Once a supplier offer **stands**
+in the market (`WorldMarketState.carryForwardOffersByFactionId` carries a
+`castIron` offer from another faction with `quantity > 0`), the locked seller
+bids `castIron` **directly** in the improvement-input bootstrap (Pass 1) instead
+of routing to the feedstock it cannot mine. Absent standing supply, the seller
+keeps the existing domestic-production feedstock route unchanged.
+
+No new `ai_victory_config.dart` constants. The trigger and supply detection are
+pure functions of `(game)` / `(WorldMarketState)` and the static catalogs;
+identical inputs yield identical orders. The path self-clears once no locked
+seller still lacks `castIron`.
+
+#### Acceptance criteria (H8-supply castIron source)
+
+- Given a below-quota zero-NW lock-recovery seller that owns an unimproved
+  feedstock tile, has recovered treasury, holds zero regiments, and holds zero
+  `castIron`, when `anyLockRecoverySellerNeedsCastIronImprovementInput` is
+  evaluated, then it returns `true`.
+- Given the same game except the seller holds `castIron >= 1`, when
+  `anyLockRecoverySellerNeedsCastIronImprovementInput` is evaluated, then it
+  returns `false` (negative control).
+- Given a locked seller needing `castIron` and a non-seller Great Power holding
+  6 `castIron` (surplus above the consumption-only reserve of 4 once the
+  build-input safety buffer drops to 0), when `runTreasuryPlanner` runs for the
+  non-seller, then it emits a `TradeOrderType.offer` for `castIron`.
+- Given no below-quota zero-NW lock-recovery seller needs the `castIron`
+  improvement input, when `runTreasuryPlanner` runs for a non-seller holding 6
+  `castIron`, then it emits **no** `castIron` offer (the default consumption
+  safety buffer of 8 withholds it) (negative control).
+- Given a locked seller and a standing `castIron` offer from another faction in
+  `WorldMarketState.carryForwardOffersByFactionId`, when `runTreasuryPlanner`
+  runs for the seller, then it emits a `TradeOrderType.bid` for `castIron` and
+  **no** `timber` / `iron` feedstock bid.
+- Given a locked seller and **no** standing `castIron` offer in the market, when
+  `runTreasuryPlanner` runs for the seller, then it emits **no** `castIron` bid
+  and bids the production feedstock (`timber` / `iron`) instead (negative
+  control — existing behavior preserved).
+- Given identical inputs, when `runTreasuryPlanner` runs twice on the
+  H8-supply castIron source path, then both runs return identical
+  `List<TradeOrder>` outputs (determinism).
+
 ### Lock-recovery seller feedstock-improvement input bootstrap (Refs #2847 H8-extraction)
 
 The H8-supply paths above let a recovered lock-recovery seller acquire or retain

--- a/packages/colonizethis_ai/lib/src/planning/economy_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/economy_planner.dart
@@ -17,6 +17,18 @@ final _log = packageLogger('economy_planner');
 /// (Refs #2847 H8 production companion).
 const double kRegimentBuildInputProductionScoreBoost = 50.0;
 
+/// Recipe-score boost an **affluent supplier** applies to a domestically
+/// produced improvement input (e.g. `castIron`) that a *peer* lock-recovery
+/// seller needs but the world market structurally cannot supply (Refs #2847
+/// H8-supply castIron source). Deliberately **small** — far below the
+/// shortage-driven score of the supplier's own essential recipes
+/// (`kShortageWeight * kShortageThreshold == 16`) — so the supplier only
+/// converts **leftover** labour/feedstock into a releasable surplus and never
+/// starves its own conquest economy. This keeps the +6 OW baseline for the
+/// healthy GPs (gp1/gp2) safe by construction. Planner-internal (not a new
+/// `ai_victory_config.dart` constant).
+const double kSupplierBuildInputReleaseProductionScoreBoost = 5.0;
+
 /// Runs the economy planner for one AI-controlled player. Deterministic given
 /// [game], [view], [config], and [seeds]. Returns production assignments and
 /// cargo preference. SPEC/ai/economy-planner.md.
@@ -148,6 +160,21 @@ EconomyPlan runEconomyPlanner({
     ...domesticImprovementInputOutputs,
   };
 
+  // Refs #2847 H8-supply castIron source: an affluent supplier over-produces
+  // the domestically-produced improvement inputs a *peer* lock-recovery seller
+  // needs (e.g. `castIron`, which has no world-market supply on seed 42) so the
+  // treasury planner can release the resulting surplus into the seller's bid.
+  // The supplier role excludes a GP that is itself a locked seller (its own
+  // self-path boost already covers it) and the boost is intentionally small so
+  // only spare labour/feedstock is consumed — the +6 OW baseline GPs are never
+  // starved. SPEC/ai/economy-planner.md § Supplier improvement-input
+  // over-production for release.
+  final supplierReleaseImprovementInputs =
+      (!isBelowQuotaZeroNwLockRecoverySeller(game, view.playerId) &&
+              anyLockRecoverySellerNeedsCastIronImprovementInput(game))
+          ? kDomesticProductionImprovementInputIds
+          : const <String>{};
+
   final assignments = _allocateLabour(
     stockpile: stockpile,
     workers: workers,
@@ -157,6 +184,7 @@ EconomyPlan runEconomyPlanner({
     militaryRebuildCrisis: militaryRebuildCrisis,
     regimentBuildInputProductionBoost: regimentBuildInputProductionBoost,
     missingRegimentBuildInputIds: boostedBuildInputOutputs,
+    supplierReleaseImprovementInputIds: supplierReleaseImprovementInputs,
   );
 
   final cargoPref = _cargoPreference(
@@ -259,6 +287,7 @@ List<AssignedRecipe> _allocateLabour({
   bool militaryRebuildCrisis = false,
   bool regimentBuildInputProductionBoost = false,
   Set<String> missingRegimentBuildInputIds = const {},
+  Set<String> supplierReleaseImprovementInputIds = const {},
 }) {
   final recipes = ProductionRecipesCatalog.all;
   final agendaId = config.hiddenAgendaId;
@@ -290,6 +319,9 @@ List<AssignedRecipe> _allocateLabour({
     if (regimentBuildInputProductionBoost &&
         missingRegimentBuildInputIds.contains(recipe.outputCommodityId)) {
       score += kRegimentBuildInputProductionScoreBoost;
+    }
+    if (supplierReleaseImprovementInputIds.contains(recipe.outputCommodityId)) {
+      score += kSupplierBuildInputReleaseProductionScoreBoost;
     }
     candidates.add(ScoredRecipe(recipe: recipe, score: score));
   }

--- a/packages/colonizethis_ai/lib/src/planning/treasury_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/treasury_planner.dart
@@ -122,8 +122,17 @@ List<TradeOrder> runTreasuryPlanner({
   // SPEC/ai/treasury-planner.md § Lock-recovery seller food-surplus release.
   final isLockRecoverySeller =
       _isBelowQuotaZeroNwLockRecoverySeller(game: game, playerId: playerId);
+  // Refs #2847 H8-supply castIron source: the supplier release also activates
+  // when a peer lock-recovery seller is stuck one stage earlier — at the
+  // level-0 build_improvement gate whose `castIron` input the world market
+  // structurally cannot supply. Activating the release here lets an affluent
+  // supplier's over-produced `castIron` surplus reach the locked seller before
+  // the seller ever reaches the regiment build-input (fabric) stage.
+  // SPEC/ai/treasury-planner.md § Lock-recovery castIron improvement-input
+  // supplier source.
   final regimentBuildInputMarketSupplyActive =
-      _anyLockRecoverySellerNeedsRegimentBuildInput(game);
+      _anyLockRecoverySellerNeedsRegimentBuildInput(game) ||
+          anyLockRecoverySellerNeedsCastIronImprovementInput(game);
   // Refs #2847 H8-extraction supply-side fix: releasing a *surplus* (stock held
   // above the GP's own consumption + production-input reserve) is selling, not
   // speculating, so the supplier role must not be gated on the supplier's own
@@ -597,6 +606,29 @@ Map<CommodityId, int> _carryForwardQuantitiesByCommodity({
   return result;
 }
 
+/// True when some faction other than [excludePlayerId] holds a standing
+/// (carry-forward) offer for [commodityId] in the world market — i.e. real
+/// supply the buyer can bid against. Refs #2847 H8-supply castIron source:
+/// once an affluent supplier's over-produced `castIron` surplus stands in the
+/// market, a locked seller bids `castIron` **directly** instead of routing to
+/// domestic production from feedstock it cannot extract. Pure read of
+/// [WorldMarketState.carryForwardOffersByFactionId]; deterministic.
+bool _marketHasStandingOfferSupplyFromOthers({
+  required WorldMarketState state,
+  required CommodityId commodityId,
+  required String excludePlayerId,
+}) {
+  for (final entry in state.carryForwardOffersByFactionId.entries) {
+    if (entry.key == excludePlayerId) continue;
+    for (final order in entry.value) {
+      if (order.commodityId == commodityId && order.quantity > 0) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 /// Discounts forecasted treasury inflow from this turn's offers by the
 /// prior-turn offer-side fill rate per commodity, rounded to an integer
 /// treasury unit. A first-ever market turn (no prior activity) returns the
@@ -856,7 +888,20 @@ bool _addRegimentFeedstockImprovementInputNeed({
   // feedstock bid would otherwise crowd out the essential `lumber` bid).
   var queued = false;
   for (final inputId in inputIds) {
-    if (kDomesticProductionImprovementInputIds.contains(inputId)) continue;
+    // Refs #2847 H8-supply castIron source: a domestic-production improvement
+    // input (e.g. `castIron`) is normally produced from feedstock (Pass 2)
+    // because the world market structurally lacks supply. Once an affluent
+    // supplier over-produces and offers it (a standing carry-forward offer
+    // exists), bid it **directly** here so the deal can cross — breaking the
+    // extraction deadlock without waiting on feedstock the seller cannot mine.
+    if (kDomesticProductionImprovementInputIds.contains(inputId) &&
+        !_marketHasStandingOfferSupplyFromOthers(
+          state: game.worldMarketState,
+          commodityId: inputId,
+          excludePlayerId: playerId,
+        )) {
+      continue;
+    }
     final held =
         projected.quantityOf(inputId) + (carryForwardBids[inputId] ?? 0);
     final missing = cost[inputId]! - held;
@@ -1034,6 +1079,47 @@ bool _anyLockRecoverySellerNeedsRegimentBuildInput(Game game) {
     if (regimentCountForPlayer(game, player.id) > 0) continue;
     for (final entry
         in RegimentEconomyCatalog.peasantLevies.buildInputs.entries) {
+      if (player.stockpile.quantityOf(entry.key) < entry.value) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/// Public accessor for the below-quota zero-NW lock-recovery seller predicate
+/// (Refs #2847 H8-supply castIron source). The economy planner uses it to keep
+/// the supplier `castIron` over-production off for a GP that is itself a locked
+/// seller (its own self-path boost already covers it).
+bool isBelowQuotaZeroNwLockRecoverySeller(Game game, String playerId) =>
+    _isBelowQuotaZeroNwLockRecoverySeller(game: game, playerId: playerId);
+
+/// True when any below-quota zero-NW lock-recovery seller still lacks a
+/// domestically-produced level-0 `build_improvement` input (a
+/// [kDomesticProductionImprovementInputIds] commodity such as `castIron`) the
+/// world market structurally cannot supply on seed 42 (Refs #2847 H8-supply
+/// castIron source). When true, an affluent supplier over-produces that input
+/// for release (`economy_planner.dart`) and this planner releases the resulting
+/// surplus + aligns its offer tier so the locked seller's bid can cross.
+/// Pure function of `(game)` and the static catalogs; returns `false` once no
+/// locked seller still needs the improvement input (self-clearing).
+bool anyLockRecoverySellerNeedsCastIronImprovementInput(Game game) {
+  for (final player in game.players) {
+    if (!_isBelowQuotaZeroNwLockRecoverySeller(
+      game: game,
+      playerId: player.id,
+    )) {
+      continue;
+    }
+    final cost = regimentBuildInputFeedstockImprovementInputCost(
+      game,
+      player.id,
+    );
+    if (cost.isEmpty) continue;
+    for (final entry in cost.entries) {
+      if (!kDomesticProductionImprovementInputIds.contains(entry.key)) {
+        continue;
+      }
       if (player.stockpile.quantityOf(entry.key) < entry.value) {
         return true;
       }

--- a/packages/colonizethis_ai/test/economy_planner_regiment_build_input_production_test.dart
+++ b/packages/colonizethis_ai/test/economy_planner_regiment_build_input_production_test.dart
@@ -98,6 +98,74 @@ Game _castIronImprovementInputGame({
   );
 }
 
+/// A two-GP game pairing a locked seller (castIron improvement-input gate
+/// active, like [_castIronImprovementInputGame]) with an affluent supplier
+/// (`gp_supplier`) holding `timber` + `iron` feedstock and ample labour, above
+/// the conquest quota so it is **not** a lock-recovery seller. Refs #2847
+/// H8-supply castIron source. When [sellerGateActive] is false the seller holds
+/// `castIron`, so no locked seller needs the improvement input and the supplier
+/// over-production trigger is off (negative control).
+Game _supplierCastIronSourceGame({
+  required int treasury,
+  bool sellerGateActive = true,
+}) {
+  const ow = 'oldWorld';
+  return Game(
+    id: 'g-h8-castiron-supplier-source',
+    worldState: WorldState(
+      turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 50),
+      oldWorld: RegionData(
+        provinces: [
+          for (var i = 0; i < 3; i++)
+            Province(id: '$ow|seller_$i', regionId: ow, ownerId: 'gp_seller'),
+          for (var i = 0; i < 12; i++)
+            Province(
+              id: '$ow|supplier_$i',
+              regionId: ow,
+              ownerId: 'gp_supplier',
+            ),
+        ],
+      ),
+      newWorld: const RegionData(provinces: []),
+      resourceByTileKey: const {'oldWorld|seller_0|1|0': 'wool'},
+    ),
+    players: [
+      Player(
+        id: 'gp_seller',
+        displayName: 'Seller',
+        isHuman: false,
+        capitalProvinceId: '$ow|seller_0',
+        treasury: treasury,
+        stockpile: sellerGateActive
+            ? const Stockpile().applyDelta(CommodityCatalog.grain.id, 30)
+            : const Stockpile()
+                .applyDelta(CommodityCatalog.grain.id, 30)
+                .applyDelta(CommodityCatalog.castIron.id, 1),
+        workerPool: const WorkerPool(peasants: 12),
+      ),
+      Player(
+        id: 'gp_supplier',
+        displayName: 'Supplier',
+        isHuman: false,
+        capitalProvinceId: '$ow|supplier_0',
+        treasury: treasury,
+        // Ample feedstock + labour and no competing output shortage (every
+        // feasible output held at the shortage threshold, 8) so the supplier
+        // has genuine spare capacity: the small leftover-capacity castIron
+        // release boost is the differentiator, not shortage scoring.
+        stockpile: const Stockpile()
+            .applyDelta(CommodityCatalog.grain.id, 80)
+            .applyDelta(CommodityCatalog.timber.id, 40)
+            .applyDelta(CommodityCatalog.iron.id, 40)
+            .applyDelta(CommodityCatalog.castIron.id, 8)
+            .applyDelta(CommodityCatalog.lumber.id, 8)
+            .applyDelta(CommodityCatalog.paper.id, 8),
+        workerPool: const WorkerPool(peasants: 40),
+      ),
+    ],
+  );
+}
+
 PhasePlanOutcome _expandForceRegimentBuildPlan({
   required bool forceCheapestRegimentBuild,
 }) {
@@ -304,6 +372,78 @@ void main() {
               'Activating the improvement-input gate must not reduce castIron '
               'labour; the gate-inactive path receives no domestic-production '
               'boost.',
+        );
+      },
+    );
+
+    int castIronLabour(EconomyPlan plan) => plan.productionAssignments
+        .where(
+          (a) =>
+              a.recipeId == ProductionRecipesCatalog.castIronFromTimberIronCoal.id,
+        )
+        .fold<int>(0, (sum, a) => sum + a.assignedLabour);
+
+    test(
+      'affluent supplier over-produces castIron when a peer lock-recovery '
+      'seller needs the castIron improvement input (Refs #2847 H8-supply '
+      'castIron source)',
+      () {
+        final game = _supplierCastIronSourceGame(treasury: threshold);
+        final supplierView = buildPlayerView(game, _topology, 'gp_supplier');
+        final plan = runEconomyPlanner(
+          game: game,
+          view: supplierView,
+          config: config,
+          seeds: seeds,
+        );
+        expect(
+          _assignedRecipeIds(plan),
+          contains(ProductionRecipesCatalog.castIronFromTimberIronCoal.id),
+          reason:
+              'A supplier that is not a locked seller must over-produce castIron '
+              'for release while a peer lock-recovery seller still needs the '
+              'castIron improvement input.',
+        );
+      },
+    );
+
+    test(
+      'supplier castIron over-production is off when no peer needs the castIron '
+      'improvement input (negative control — +6 baseline GPs unaffected)',
+      () {
+        final active = runEconomyPlanner(
+          game: _supplierCastIronSourceGame(treasury: threshold),
+          view: buildPlayerView(
+            _supplierCastIronSourceGame(treasury: threshold),
+            _topology,
+            'gp_supplier',
+          ),
+          config: config,
+          seeds: seeds,
+        );
+        final inactive = runEconomyPlanner(
+          game: _supplierCastIronSourceGame(
+            treasury: threshold,
+            sellerGateActive: false,
+          ),
+          view: buildPlayerView(
+            _supplierCastIronSourceGame(
+              treasury: threshold,
+              sellerGateActive: false,
+            ),
+            _topology,
+            'gp_supplier',
+          ),
+          config: config,
+          seeds: seeds,
+        );
+        expect(
+          castIronLabour(inactive),
+          lessThanOrEqualTo(castIronLabour(active)),
+          reason:
+              'Removing the peer locked seller must not increase the supplier '
+              'castIron labour; the supplier-release boost only fires while a '
+              'peer needs the improvement input.',
         );
       },
     );

--- a/packages/colonizethis_ai/test/planning/treasury_planner_supplier_castiron_source_test.dart
+++ b/packages/colonizethis_ai/test/planning/treasury_planner_supplier_castiron_source_test.dart
@@ -1,0 +1,312 @@
+/// Lock-recovery castIron improvement-input supplier source
+/// (Refs #2847 H8-supply castIron source).
+///
+/// `castIron` has no native world-market supply on seed 42, so a locked seller
+/// is stuck at the level-0 `build_improvement` gate it needs to extract recipe
+/// feedstock. This slice opens a *first* `castIron` source: an affluent
+/// supplier over-produces `castIron` and releases the surplus (offer side), and
+/// once that supply stands in the market the locked seller bids `castIron`
+/// **directly** instead of routing to feedstock it cannot mine.
+library;
+
+import 'package:colonizethis_ai/src/planning/treasury_planner.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+const _woolId = 'wool';
+const _fabricId = 'fabric';
+const _lumberId = 'lumber';
+const _castIronId = 'castIron';
+const _timberId = 'timber';
+const _ironId = 'iron';
+// Unimproved wool resource tile in the seller's capital province so the
+// improvement-input (castIron) gate is active by default.
+const _sellerWoolTile = 'oldWorld|seller_0|1|0';
+
+Game _game({
+  required int sellerTreasury,
+  required int supplierTreasury,
+  int sellerLumberHeld = 1,
+  int sellerCastIronHeld = 0,
+  int supplierCastIronHeld = 0,
+  bool sellerOwnsFeedstockTile = true,
+  bool supplierStandingCastIronOffer = false,
+  int sellerOwProvinces = 3,
+  int supplierOwProvinces = 12,
+}) {
+  const ow = 'oldWorld';
+  var sellerStockpile = const Stockpile().applyDelta('grain', 80);
+  if (sellerLumberHeld > 0) {
+    sellerStockpile = sellerStockpile.applyDelta(_lumberId, sellerLumberHeld);
+  }
+  if (sellerCastIronHeld > 0) {
+    sellerStockpile =
+        sellerStockpile.applyDelta(_castIronId, sellerCastIronHeld);
+  }
+  var supplierStockpile = const Stockpile().applyDelta('grain', 80);
+  if (supplierCastIronHeld > 0) {
+    supplierStockpile =
+        supplierStockpile.applyDelta(_castIronId, supplierCastIronHeld);
+  }
+  final resourceByTileKey = <String, String>{
+    if (sellerOwnsFeedstockTile) _sellerWoolTile: _woolId,
+  };
+  var marketState = WorldMarketState.withDefaultPrices(const {
+    'grain': 10,
+    _woolId: 20,
+    _fabricId: 40,
+    _lumberId: 15,
+    _castIronId: 30,
+    _timberId: 8,
+    _ironId: 12,
+  });
+  if (supplierStandingCastIronOffer) {
+    marketState = marketState.copyWith(
+      carryForwardOffersByFactionId: {
+        'gp_supplier': [
+          TradeOrder(
+            commodityId: _castIronId,
+            type: TradeOrderType.offer,
+            quantity: 4,
+            priority: kTreasuryBidPriorityEssentialInput,
+          ),
+        ],
+      },
+    );
+  }
+  return Game(
+    id: 'g-h8-castiron-source',
+    worldState: WorldState(
+      turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 50),
+      oldWorld: RegionData(
+        provinces: [
+          for (var i = 0; i < sellerOwProvinces; i++)
+            Province(id: '$ow|seller_$i', regionId: ow, ownerId: 'gp_seller'),
+          for (var i = 0; i < supplierOwProvinces; i++)
+            Province(
+              id: '$ow|supplier_$i',
+              regionId: ow,
+              ownerId: 'gp_supplier',
+            ),
+        ],
+      ),
+      newWorld: const RegionData(provinces: []),
+      resourceByTileKey: resourceByTileKey,
+    ),
+    players: [
+      Player(
+        id: 'gp_seller',
+        displayName: 'Seller',
+        isHuman: false,
+        capitalProvinceId: '$ow|seller_0',
+        stockpile: sellerStockpile,
+        treasury: sellerTreasury,
+      ),
+      Player(
+        id: 'gp_supplier',
+        displayName: 'Supplier',
+        isHuman: false,
+        capitalProvinceId: '$ow|supplier_0',
+        stockpile: supplierStockpile,
+        treasury: supplierTreasury,
+      ),
+    ],
+    worldMarketState: marketState,
+  );
+}
+
+List<TradeOrder> _run(Game game, String playerId) => runTreasuryPlanner(
+      game: game,
+      playerId: playerId,
+      stockpile: game.players.firstWhere((p) => p.id == playerId).stockpile,
+      productionAssignments: const [],
+      treasury: game.players.firstWhere((p) => p.id == playerId).treasury,
+    );
+
+Iterable<TradeOrder> _bidsFor(List<TradeOrder> orders, String commodityId) =>
+    orders.where(
+      (o) => o.type == TradeOrderType.bid && o.commodityId == commodityId,
+    );
+
+Iterable<TradeOrder> _offersFor(List<TradeOrder> orders, String commodityId) =>
+    orders.where(
+      (o) => o.type == TradeOrderType.offer && o.commodityId == commodityId,
+    );
+
+void main() {
+  group('lock-recovery castIron improvement-input supplier source '
+      '(Refs #2847 H8-supply castIron source)', () {
+    final threshold = cheapestRegimentBuildTreasuryCost();
+
+    test(
+      'anyLockRecoverySellerNeedsCastIronImprovementInput is true when a locked '
+      'seller still lacks the castIron improvement input',
+      () {
+        final game = _game(
+          sellerTreasury: threshold,
+          supplierTreasury: threshold,
+        );
+        expect(
+          anyLockRecoverySellerNeedsCastIronImprovementInput(game),
+          isTrue,
+        );
+      },
+    );
+
+    test(
+      'anyLockRecoverySellerNeedsCastIronImprovementInput is false when the '
+      'seller already holds castIron (negative control)',
+      () {
+        final game = _game(
+          sellerTreasury: threshold,
+          supplierTreasury: threshold,
+          sellerCastIronHeld: 1,
+        );
+        expect(
+          anyLockRecoverySellerNeedsCastIronImprovementInput(game),
+          isFalse,
+        );
+      },
+    );
+
+    test(
+      'anyLockRecoverySellerNeedsCastIronImprovementInput is false when no GP '
+      'is a below-quota zero-NW lock-recovery seller (negative control)',
+      () {
+        final game = _game(
+          sellerTreasury: threshold,
+          supplierTreasury: threshold,
+          sellerOwnsFeedstockTile: false,
+        );
+        expect(
+          anyLockRecoverySellerNeedsCastIronImprovementInput(game),
+          isFalse,
+        );
+      },
+    );
+
+    test('the locked seller is classified as a lock-recovery seller and the '
+        'affluent supplier is not', () {
+      final game = _game(
+        sellerTreasury: threshold,
+        supplierTreasury: threshold,
+      );
+      expect(isBelowQuotaZeroNwLockRecoverySeller(game, 'gp_seller'), isTrue);
+      expect(
+        isBelowQuotaZeroNwLockRecoverySeller(game, 'gp_supplier'),
+        isFalse,
+      );
+    });
+
+    test(
+      'affluent supplier releases surplus castIron while a locked seller needs '
+      'the castIron improvement input (offer side)',
+      () {
+        // castIron held (6) is surplus above the consumption-only reserve
+        // (4 = kShortageThreshold ~/ 2) once the supplier-release safety buffer
+        // drops to 0, but withheld under the default consumption safety buffer.
+        final game = _game(
+          sellerTreasury: threshold,
+          supplierTreasury: threshold,
+          supplierCastIronHeld: 6,
+        );
+        expect(
+          _offersFor(_run(game, 'gp_supplier'), _castIronId),
+          isNotEmpty,
+          reason:
+              'An affluent supplier must release castIron surplus so the locked '
+              "seller's castIron bid can clear.",
+        );
+      },
+    );
+
+    test(
+      'supplier keeps its normal castIron buffer when no locked seller needs '
+      'the castIron improvement input (negative control)',
+      () {
+        // No below-quota zero-NW lock-recovery seller exists (the would-be
+        // seller is at quota), so neither H8 supplier trigger fires; the
+        // supplier keeps the default consumption safety buffer and withholds
+        // its 6 castIron (reserve 8 > 6).
+        final game = _game(
+          sellerTreasury: threshold,
+          supplierTreasury: threshold,
+          supplierCastIronHeld: 6,
+          sellerOwProvinces: 12,
+        );
+        expect(
+          anyLockRecoverySellerNeedsCastIronImprovementInput(game),
+          isFalse,
+        );
+        expect(_offersFor(_run(game, 'gp_supplier'), _castIronId), isEmpty);
+      },
+    );
+
+    test(
+      'locked seller bids castIron directly once a supplier offer stands in the '
+      'market (buyer side)',
+      () {
+        final game = _game(
+          sellerTreasury: threshold,
+          supplierTreasury: threshold,
+          supplierStandingCastIronOffer: true,
+        );
+        final orders = _run(game, 'gp_seller');
+        expect(
+          _bidsFor(orders, _castIronId),
+          isNotEmpty,
+          reason:
+              'With standing castIron supply the seller bids castIron directly '
+              'instead of routing to feedstock it cannot extract.',
+        );
+        expect(
+          _bidsFor(orders, _timberId),
+          isEmpty,
+          reason:
+              'The direct castIron bid replaces the production-feedstock route '
+              'while supply exists.',
+        );
+        expect(_bidsFor(orders, _ironId), isEmpty);
+      },
+    );
+
+    test(
+      'locked seller routes to castIron production feedstock when no supplier '
+      'offer stands in the market (negative control — existing behavior)',
+      () {
+        final game = _game(
+          sellerTreasury: threshold,
+          supplierTreasury: threshold,
+        );
+        final orders = _run(game, 'gp_seller');
+        expect(
+          _bidsFor(orders, _castIronId),
+          isEmpty,
+          reason:
+              'Without standing castIron supply, castIron is produced '
+              'domestically (feedstock bid), never bid directly.',
+        );
+        expect(
+          orders.where(
+            (o) =>
+                o.type == TradeOrderType.bid &&
+                (o.commodityId == _timberId || o.commodityId == _ironId),
+          ),
+          isNotEmpty,
+        );
+      },
+    );
+
+    test('castIron supplier-source path is deterministic', () {
+      final game = _game(
+        sellerTreasury: threshold,
+        supplierTreasury: threshold,
+        supplierCastIronHeld: 6,
+        supplierStandingCastIronOffer: true,
+      );
+      expect(_run(game, 'gp_seller'), equals(_run(game, 'gp_seller')));
+      expect(_run(game, 'gp_supplier'), equals(_run(game, 'gp_supplier')));
+    });
+  });
+}

--- a/packages/colonizethis_ai/test/seed42_observer_conquest_s7d_diagnostic_test.dart
+++ b/packages/colonizethis_ai/test/seed42_observer_conquest_s7d_diagnostic_test.dart
@@ -632,6 +632,56 @@ import 'support/faithful_full_ai_test_handoff.dart';
 /// `gpCastIronProductionAssignedTurns`, then
 /// `gpFeedstockGateImprovementCostAffordableTurns`, rise for gp3 / gp5 / gp6.
 ///
+/// ## S7-D refresh (captured 2026-06-04 on branch
+///     `fix/issue-2847-h8-extraction-next`, after the supplier-side castIron
+///     over-production + release + seller direct-bid loop added in this slice)
+///
+/// This slice wires a genuine first-castIron supplier source per the
+/// post-#3241 conclusion above: (A) an affluent supplier (not itself a
+/// below-quota zero-NW lock-recovery seller) over-produces `castIron` with a
+/// moderate leftover-capacity score boost
+/// ([kSupplierBuildInputReleaseProductionScoreBoost] = 5.0) whenever some
+/// lock-recovery seller needs the level-0 `castIron` improvement input
+/// ([anyLockRecoverySellerNeedsCastIronImprovementInput]); (B) the existing
+/// surplus-release path activates earlier so the supplier offers the surplus;
+/// and (C) the locked seller bids `castIron` **directly** (instead of routing
+/// to domestic `timber` / `iron` feedstock) once a standing `castIron` offer
+/// exists in the world market. The change is **safe by construction** — the
+/// moderate boost only consumes labour / feedstock left over after the
+/// supplier's own shortage-driven essentials, so gp1 / gp2 are never starved.
+///
+/// The diagnostic confirms **no regression and no emergent bite on seed-42**:
+///
+///   * **OW gain unchanged:** gp1 = +6, gp2 = +6 (PASS); gp3 = +2, gp4 = +1,
+///     gp5 = +1, gp6 = +2 (FAIL) — identical to the post-#3241 baseline. The
+///     safe-by-construction boost does not regress the passing GPs.
+///   * **`gpCastIronProductionAssignedTurns` = 0 for *every* GP** — including
+///     the boosted suppliers gp1 / gp2. The +5 boost ranks `castIron` highly,
+///     but `feasibleRuns` is still 0 because the suppliers hold **no `timber` /
+///     `iron` feedstock** to run the recipe (they extract neither — gp2's only
+///     releasable surplus is `lumber`, `gpLumberHeldAtTurn99` gp2 = 45). So no
+///     castIron is ever produced, no `castIron` offer is emitted, the seller's
+///     gated direct-`castIron` bid never activates
+///     (`gpCastIronFeedstockOffersEmitted` / `gpCastIronFeedstockDealsAsBuyer`
+///     stay 0), and `gpFeedstockGateImprovementCostAffordableTurns` stays
+///     **0 / 0 / 0** — the deadlock persists.
+///
+/// Conclusion: the supplier-castIron-source loop is now **structurally present
+/// and unit-tested** (`treasury_planner_supplier_castiron_source_test.dart`,
+/// `economy_planner_regiment_build_input_production_test.dart`), but inert on
+/// seed-42 because the missing link is one stage further upstream than a
+/// production *boost* can reach — **no affluent supplier holds or extracts the
+/// `timber` / `iron` the castIron recipe consumes**, so over-production is
+/// infeasible regardless of boost magnitude. This **refutes** the "a boost
+/// alone creates the first castIron" framing. The next slice must give an
+/// affluent supplier a genuine `timber` / `iron` source for release-driven
+/// castIron over-production (supplier feedstock extraction / improvement under
+/// the lock-recovery trigger), or relax the level-0 improvement's `castIron`
+/// requirement for the first bootstrap extraction. Verify by re-running this
+/// diagnostic and confirming `gpCastIronProductionAssignedTurns` rises for
+/// gp1 / gp2 (the suppliers), then `gpCastIronFeedstockDealsAsBuyer` and
+/// `gpFeedstockGateImprovementCostAffordableTurns` rise for gp3 / gp5 / gp6.
+///
 /// ## How to refresh
 ///
 /// Skipped by default (long-running, ~4 minutes on the project


### PR DESCRIPTION
## Summary

Advances the #2847 EXPAND-arm lock-recovery economy work by wiring a genuine **first-castIron supplier source**, the structural gap the post-#3241 S7-D diagnostic pinned ("no GP holds or can release a `castIron` / `timber` / `iron` surplus, so the locked seller can neither buy nor produce its first `castIron`").

Three coordinated, safe-by-construction parts:

- **A — supplier over-production** (`economy_planner.dart`): new `kSupplierBuildInputReleaseProductionScoreBoost` (5.0) applied to `castIron` recipes for an affluent supplier (not itself a below-quota zero-NW lock-recovery seller) when a lock-recovery seller needs the level-0 `castIron` improvement input. The **moderate, leftover-capacity** boost only claims labour/feedstock left after the supplier's own shortage-driven essentials, so passing GPs are never starved.
- **B — supplier release** (`treasury_planner.dart`): the affluent-supplier surplus-release path now activates when a locked seller needs the `castIron` improvement input (not only `fabric`), via new public predicates `anyLockRecoverySellerNeedsCastIronImprovementInput` / `isBelowQuotaZeroNwLockRecoverySeller`.
- **C — seller direct bid** (`treasury_planner.dart`): a locked seller bids `castIron` directly in Pass 1 when a standing `castIron` offer exists in the world market (`_marketHasStandingOfferSupplyFromOthers`); the domestic timber/iron feedstock route is preserved when no offer exists, so the existing castIron-production test is unaffected.

SPEC updated: `SPEC/ai/economy-planner.md`, `SPEC/ai/treasury-planner.md` (Given–When–Then ACs).

## Verification

- **`dart analyze`** clean on all changed source/test files (the two remaining `unnecessary_import` infos in `economy_planner_regiment_build_input_production_test.dart` are pre-existing on `dev`, untouched here).
- **16 unit tests pass** across the new `treasury_planner_supplier_castiron_source_test.dart` (predicates, supplier release, seller direct bid + negative controls) and the extended `economy_planner_regiment_build_input_production_test.dart` (supplier over-production positive + off control). The allocator log confirms the boost makes `castIron` production fire **when feedstock is present**.
- **Seed-42 S7-D diagnostic re-run** (`dart test --run-skipped`):
  - **No regression:** gp1 = +6, gp2 = +6 (PASS); gp3 = +2, gp4 = +1, gp5 = +1, gp6 = +2 (FAIL) — identical to the post-#3241 baseline.
  - **Honest finding:** `gpCastIronProductionAssignedTurns` = 0 for **every** GP. The loop is structurally present + tested but **inert on seed-42** because the affluent suppliers hold no `timber`/`iron` feedstock to run the recipe (gp2's only releasable surplus is `lumber`). A production *boost* alone cannot create the first castIron — re-points the **next slice** at supplier feedstock extraction (documented in the S7-D diagnostic doc comment).

## Notes

- Non-closing reference only (`Refs #2847`); this is one incremental slice, the gate is not yet closed.
- Prior instrumentation slice merged via #3243; this PR is based directly on `dev`.

Refs #2847

Made with [Cursor](https://cursor.com)