### PR TITLE
feat(ai): supplier timber/iron feedstock extraction for H8 castIron over-production (Refs #2847)

### DIFF
--- a/SPEC/ai/economy-planner.md
+++ b/SPEC/ai/economy-planner.md
@@ -142,6 +142,29 @@ The feedstock-extraction score boost in `selectFullAiCivilianWorkOrders` has no 
 
 ---
 
+## Supplier improvement-input feedstock extraction (Refs #2847 H8-extraction supplier feedstock)
+
+Companion to § Supplier improvement-input over-production for release. The over-production boost only converts feedstock the supplier **already holds**, but on seed 42 no affluent supplier holds or extracts the `timber` / `iron` the `castIron` recipe consumes (the supplier extracts those resources only for its own `castIron` production, leaving zero true surplus). The over-production loop is therefore **infeasible regardless of boost magnitude** until a supplier gains spare `timber` / `iron`.
+
+This slice routes an affluent supplier's idle Builder onto its own unimproved `timber` / `iron` resource tile so the over-production has feedstock to run. `supplierImprovementInputFeedstockExtractionResourceIds(game, playerId)` (`packages/colonizethis_logic/lib/src/ai/full_ai_civilian_work_selection.dart`) returns the production-recipe feedstock commodities (`timber` / `iron` for `castIron`) of every recipe whose output is a producible improvement input a **peer** below-quota zero-NW lock-recovery seller still needs, only when ALL hold:
+
+- The player is **not** itself a below-quota zero-NW lock-recovery seller (`oldWorldProvinceCountOwnedBy` outside `[2, kObserverConquestMinOwProvincesPerGp)` or owns ≥1 New World province) — its own `regimentBuildInputFeedstockExtractionResourceIds` gate routes its Builder. This scopes the supplier role to healthy / above-quota Great Powers so the +6 Old World conquest baseline GPs are never starved.
+- Some **other** player **is** a below-quota zero-NW lock-recovery seller whose level-0 improvement-input gate (`regimentBuildInputFeedstockImprovementInputCost`) is active and that still lacks a **producible** improvement input (some `ProductionRecipesCatalog` recipe outputs it, and the seller's stockpile is short of it — e.g. `castIron`, which the world market structurally cannot supply on seed 42; a market-suppliable input the seller already holds such as `lumber` is excluded).
+- The player owns at least one **unimproved** (`improvementLevel < 1`) tile hosting one of those feedstock resources.
+
+The supplier feedstock ids are **unioned** with the seller-side `regimentBuildInputFeedstockExtractionResourceIds` set before the build-improvement score boost (`kRegimentBuildInputFeedstockExtractionScoreBoost`, `600`) is applied in `selectFullAiCivilianWorkOrders`, so the supplier's Builder prefers the `timber` / `iron` tile ahead of other extractable improvements. A player matches at most one gate (the supplier gate excludes locked sellers), so the union never double-counts. The orchestrator force-on for the Full-AI civilian work pass (`domain_planner_orchestrator.dart`) also fires when this supplier gate is non-empty. The boost adds no new work order, bypasses no suggestion or affordability gate (the level-0 `build_improvement` cost still applies downstream), and introduces no `ai_victory_config.dart` constant. The gate is **self-clearing**: once no locked seller needs the improvement input, or the supplier owns no unimproved feedstock tile, the set is empty and selection reverts to its ordinary deterministic ordering. The set is a pure function of `(game, playerId)` and the static catalogs; identical inputs yield identical selections.
+
+### Acceptance criteria (H8-extraction supplier feedstock)
+
+- Given a Great Power above the conquest quota (`oldWorldProvinceCountOwnedBy >= kObserverConquestMinOwProvincesPerGp`) that owns an unimproved `timber` resource tile, and a peer below-quota zero-NW lock-recovery seller whose improvement-input gate is active and that holds zero `castIron`, when `supplierImprovementInputFeedstockExtractionResourceIds(game, supplierId)` is evaluated, then it returns the `castIron` recipe feedstock ids `{timber, iron}`.
+- Given the same supplier and peer demand, when a Builder has both an unimproved `timber` feedstock tile and an unimproved non-feedstock (`grain`) tile as `build_improvement` suggestions and `selectFullAiCivilianWorkOrders` runs for the supplier, then it selects the `timber` tile.
+- Given a player that is **itself** a below-quota zero-NW lock-recovery seller (in `[2, kObserverConquestMinOwProvincesPerGp)`, zero New World provinces), when `supplierImprovementInputFeedstockExtractionResourceIds(game, playerId)` is evaluated, then it returns the empty set (negative control — its own seller-side gate routes its Builder).
+- Given a supplier with no peer below-quota zero-NW lock-recovery seller needing a producible improvement input (the would-be seller is at quota or already holds `castIron`), when `supplierImprovementInputFeedstockExtractionResourceIds(game, supplierId)` is evaluated, then it returns the empty set (negative control — the supplier extraction only fires while a peer needs the input).
+- Given a supplier with active peer demand that owns **no** unimproved `timber` / `iron` tile, when `supplierImprovementInputFeedstockExtractionResourceIds(game, supplierId)` is evaluated, then it returns the empty set (the carve-out routes existing tiles only; it acquires no tile).
+- Given identical inputs, when `supplierImprovementInputFeedstockExtractionResourceIds` and `selectFullAiCivilianWorkOrders` run twice, then both runs return identical results (determinism).
+
+---
+
 ## Integration
 
 - **Caller:** Strategic AI (e.g. `generateStrategicOrders`) calls the economy planner for each AI GP first, then passes the resulting **economy plan** (including `cargoPreference`) into the domain planners so the build step can weight ship vs land builds. Production assignments are collected per player and passed to the turn resolver as **per-player default production assignments** (resolver must accept `Map<String, List<AssignedRecipe>>` or equivalent for multi-player).

--- a/packages/colonizethis_ai/lib/src/planning/domain_planner_orchestrator.dart
+++ b/packages/colonizethis_ai/lib/src/planning/domain_planner_orchestrator.dart
@@ -413,8 +413,18 @@ _EconomyDomainPlannersResult _runEconomyDomainPlanners({
       workThreshold = math.min(workThreshold, kColonialCivilianWorkThresholdCap);
     }
   }
+  // Refs #2847 H8-extraction: force the Full-AI civilian work pass on for a
+  // locked seller routing its own fabric feedstock, AND for an affluent
+  // supplier routing its `timber` / `iron` so it can over-produce the
+  // `castIron` improvement input a peer locked seller needs (supplier feedstock
+  // extraction). Both gates only read whether their feedstock set is non-empty;
+  // no duplicate regiment-count logic and no new config constant.
   final feedstockExtractionActive =
       regimentBuildInputFeedstockExtractionResourceIds(
+        ctx.game,
+        ctx.nationId,
+      ).isNotEmpty ||
+      supplierImprovementInputFeedstockExtractionResourceIds(
         ctx.game,
         ctx.nationId,
       ).isNotEmpty;

--- a/packages/colonizethis_ai/test/seed42_observer_conquest_s7d_diagnostic_test.dart
+++ b/packages/colonizethis_ai/test/seed42_observer_conquest_s7d_diagnostic_test.dart
@@ -11,7 +11,10 @@ import 'package:colonizethis_data/colonizethis_data.dart'
     hide cheapestRegimentBuildTreasuryCost;
 import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:colonizethis_logic/ai_api.dart'
-    show allUnitsFromWorld, regimentBuildInputFeedstockExtractionResourceIds;
+    show
+        allUnitsFromWorld,
+        regimentBuildInputFeedstockExtractionResourceIds,
+        supplierImprovementInputFeedstockExtractionResourceIds;
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart';
@@ -682,6 +685,52 @@ import 'support/faithful_full_ai_test_handoff.dart';
 /// gp1 / gp2 (the suppliers), then `gpCastIronFeedstockDealsAsBuyer` and
 /// `gpFeedstockGateImprovementCostAffordableTurns` rise for gp3 / gp5 / gp6.
 ///
+/// ## S7-D refresh (captured 2026-06-04 on branch
+///     `fix/issue-2847-supplier-castiron-source`, after the supplier feedstock
+///     extraction routing added in this slice — `gpSupplierFeedstockExtraction
+///     GateActiveTurns` instrumentation added here)
+///
+/// This slice closes the post-#3244 conclusion's missing link by routing an
+/// affluent supplier's idle Builder onto its own unimproved `timber` / `iron`
+/// tile (`supplierImprovementInputFeedstockExtractionResourceIds`,
+/// `full_ai_civilian_work_selection.dart`), so the #3244 supplier `castIron`
+/// over-production + release loop finally has a feedstock source. The new
+/// supplier gate **fires** where it was structurally absent before, and there
+/// is **no regression**:
+///
+///   * **OW gain unchanged:** gp1 = +6, gp2 = +6 (PASS); gp3 = +2, gp4 = +1,
+///     gp5 = +1, gp6 = +2 (FAIL) — identical to the post-#3244 baseline. The
+///     shared civilian-work routing change does not divert the +6 baseline GPs'
+///     conquest.
+///   * **Supplier gate now active:** `gpSupplierFeedstockExtractionGateActive
+///     Turns` = **52 / 52 / 7 / 0 / 0 / 0** for gp1 / gp2 / gp3 / gp4 / gp5 /
+///     gp6. The affluent above-quota suppliers gp1 / gp2 own an unimproved
+///     `timber` / `iron` tile and a peer locked seller needs `castIron` on 52
+///     turns each, so the Builder-routing boost fires — the structural advance
+///     over the prior inert slice (the gate previously did not exist).
+///   * **But castIron production stays 0:** `gpCastIronProductionAssignedTurns`
+///     = **0** for every GP, `gpCastIronHeldAtTurn99` = **0** for every GP, and
+///     `gpCastIronFeedstockOffersEmitted` / `gpCastIronFeedstockDealsAsBuyer`
+///     stay **0**. gp2 still converts its extracted `timber` to `lumber`
+///     (`gpLumberHeldAtTurn99` gp2 = 45) rather than to `castIron`.
+///
+/// Conclusion: the supplier-extraction routing is now **structurally present,
+/// unit-tested** (`full_ai_civilian_work_supplier_feedstock_extraction_test.dart`)
+/// **and firing** (52 turns for gp1 / gp2), but the loop still does not reach
+/// `castIron` production. The break has moved one stage downstream — the routed
+/// Builder's `timber` / `iron` improvement does not convert into `castIron`
+/// over-production, because (a) the `castIron` recipe needs **both** `timber`
+/// **and** `iron` and the supplier extracts only the `timber` it routes to
+/// `lumber`, and (b) the deliberately small `+5` over-production boost loses to
+/// the supplier's shortage-driven `lumber` recipe for the extracted `timber`.
+/// The next slice must pin, with a supplier-side `castIron` feedstock-holdings
+/// counter, whether the supplier lacks an unimproved **`iron`** tile or whether
+/// the over-production boost is simply out-competed for the extracted `timber`,
+/// then either route the supplier onto an `iron` tile specifically or lift the
+/// supplier `castIron` boost above the competing `lumber` shortage score under
+/// the lock-recovery trigger. Verify by re-running this diagnostic and
+/// confirming `gpCastIronProductionAssignedTurns` rises for gp1 / gp2.
+///
 /// ## How to refresh
 ///
 /// Skipped by default (long-running, ~4 minutes on the project
@@ -1077,6 +1126,20 @@ void main() {
       final castIronHeldAtTurn99 = <String, int>{
         for (final gpId in gpIds) gpId: 0,
       };
+      // Refs #2847 H8-extraction supplier feedstock: per-GP count of turns the
+      // supplier-side castIron feedstock extraction gate is active
+      // (`supplierImprovementInputFeedstockExtractionResourceIds` non-empty) —
+      // i.e. the GP is a non-seller above the quota, a peer locked seller needs
+      // the producible `castIron` improvement input, and the GP owns an
+      // unimproved `timber` / `iron` tile to extract. A non-zero count for the
+      // supplier GPs (gp1 / gp2) paired with a rising
+      // `gpCastIronProductionAssignedTurns` confirms the supplier-extraction
+      // slice closes the over-production feedstock gap; a flat-zero count for
+      // gp1 / gp2 re-points the next slice (the suppliers own no unimproved
+      // `timber` / `iron` tile to extract). Read-only; freely tunable.
+      final supplierFeedstockExtractionGateActiveTurns = <String, int>{
+        for (final gpId in gpIds) gpId: 0,
+      };
 
       // Refs #2847 H8-supply: domestic-production feedstock-stage isolation.
       // The post-#3235 surface shows the world market never supplies fabric
@@ -1331,6 +1394,13 @@ void main() {
           )) {
             unimprovedFeedstockTileOwnedTurns[gpId] =
                 (unimprovedFeedstockTileOwnedTurns[gpId] ?? 0) + 1;
+          }
+          if (supplierImprovementInputFeedstockExtractionResourceIds(
+            game,
+            gpId,
+          ).isNotEmpty) {
+            supplierFeedstockExtractionGateActiveTurns[gpId] =
+                (supplierFeedstockExtractionGateActiveTurns[gpId] ?? 0) + 1;
           }
           if (player != null) {
             final holdsFeedstock = fabricFeedstockIds.any(
@@ -1612,6 +1682,8 @@ void main() {
         'gpCastIronFeedstockBidsEmitted': castIronFeedstockBidsEmitted,
         'gpCastIronFeedstockDealsAsBuyer': castIronFeedstockDealsAsBuyer,
         'gpCastIronProductionAssignedTurns': castIronProductionAssignedTurns,
+        'gpSupplierFeedstockExtractionGateActiveTurns':
+            supplierFeedstockExtractionGateActiveTurns,
         'gpLumberHeldAtTurn99': lumberHeldAtTurn99,
         'gpCastIronHeldAtTurn99': castIronHeldAtTurn99,
         'fabricFeedstockCommodityIds': fabricFeedstockIds.toList()..sort(),

--- a/packages/colonizethis_logic/lib/ai_api.dart
+++ b/packages/colonizethis_logic/lib/ai_api.dart
@@ -12,7 +12,8 @@ export 'src/ai/full_ai_civilian_work_selection.dart'
         kRegimentBuildInputFeedstockExtractionScoreBoost,
         regimentBuildInputFeedstockExtractionResourceIds,
         regimentBuildInputFeedstockImprovementInputCost,
-        selectFullAiCivilianWorkOrders;
+        selectFullAiCivilianWorkOrders,
+        supplierImprovementInputFeedstockExtractionResourceIds;
 export 'src/ai/simple_ai_heuristics.dart' show turnSeedForPlayer;
 export 'src/constants.dart'
     show

--- a/packages/colonizethis_logic/lib/src/ai/full_ai_civilian_work_selection.dart
+++ b/packages/colonizethis_logic/lib/src/ai/full_ai_civilian_work_selection.dart
@@ -518,6 +518,107 @@ Map<String, int> regimentBuildInputFeedstockImprovementInputCost(
   return Map<String, int>.unmodifiable(workOrderCostBuildImprovement(0));
 }
 
+/// Resource ids an affluent **supplier** should extract so it can over-produce
+/// the domestically-produced level-0 `build_improvement` input (e.g.
+/// `castIron`) a *peer* below-quota zero-NW lock-recovery seller needs but can
+/// neither mine nor buy (Refs #2847 § H8-extraction supplier feedstock).
+///
+/// Closes the upstream link the post-#3244 S7-D diagnostic pinned: the supplier
+/// `castIron` over-production (`economy_planner.dart` § Supplier improvement-
+/// input over-production) + surplus release (`treasury_planner.dart`) loop is
+/// **infeasible** while no affluent supplier holds or extracts the `timber` /
+/// `iron` the `castIron` recipe consumes. This routes the supplier's idle
+/// Builder onto its own unimproved `timber` / `iron` tile via the shared
+/// feedstock score boost in [_buildImprovementWorkScore], giving the over-
+/// production feedstock to run.
+///
+/// Returns the production-recipe feedstock commodities (e.g. `timber`, `iron`)
+/// of every recipe whose output is a producible improvement input a peer locked
+/// seller still needs, only when ALL hold:
+/// - [playerId] is NOT itself a below-quota zero-NW lock-recovery seller (its
+///   own [regimentBuildInputFeedstockExtractionResourceIds] gate already routes
+///   its Builder); this scopes the supplier role to healthy / above-quota Great
+///   Powers so the +6 Old World conquest baseline GPs are never starved,
+/// - some OTHER player IS a below-quota zero-NW lock-recovery seller whose
+///   level-0 improvement-input gate is active and is missing a producible
+///   improvement input (peer demand exists), and
+/// - [playerId] owns an unimproved tile hosting one of those feedstock
+///   resources to extract.
+/// Self-clears once no locked seller needs the improvement input or the
+/// supplier owns no unimproved feedstock tile. Pure and deterministic over
+/// `(game, playerId)` and the static `ProductionRecipesCatalog` / work-order
+/// cost table.
+Set<String> supplierImprovementInputFeedstockExtractionResourceIds(
+  Game game,
+  String playerId,
+) {
+  // The supplier role excludes a GP that is itself a locked seller — its own
+  // feedstock-extraction gate already routes its Builder. Restricting the role
+  // this way keeps it on healthy / above-quota GPs only.
+  if (_isBelowQuotaZeroNwSeller(game, playerId)) return const <String>{};
+  final neededInputs = _peerLockRecoverySellerNeededProducibleImprovementInputs(
+    game,
+    excludePlayerId: playerId,
+  );
+  if (neededInputs.isEmpty) return const <String>{};
+  final feedstock = <String>{};
+  for (final recipe in ProductionRecipesCatalog.all) {
+    if (neededInputs.contains(recipe.outputCommodityId)) {
+      feedstock.addAll(recipe.inputQuantities.keys);
+    }
+  }
+  if (feedstock.isEmpty) return const <String>{};
+  if (!_ownsUnimprovedFeedstockResourceTile(game, playerId, feedstock)) {
+    return const <String>{};
+  }
+  return feedstock;
+}
+
+/// True iff [playerId] holds Old World land below the observer conquest quota
+/// (`oldWorldProvinceCountOwnedBy` in `[2, kObserverConquestMinOwProvincesPerGp)`)
+/// and owns zero New World provinces — the Path F lock-recovery seller band the
+/// supplier role must exclude. Logic-local mirror of the AI-side predicate so
+/// the supplier gate stays computable inside the logic package.
+bool _isBelowQuotaZeroNwSeller(Game game, String playerId) {
+  final ow = oldWorldProvinceCountOwnedBy(game, playerId);
+  if (ow < 2) return false;
+  if (!isBelowObserverConquestQuota(ow)) return false;
+  return _newWorldProvinceCountOwnedBy(game, playerId) == 0;
+}
+
+/// Producible level-0 `build_improvement` input commodities still missing from
+/// at least one *other* below-quota zero-NW lock-recovery seller blocked at the
+/// improvement-cost gate (`regimentBuildInputFeedstockImprovementInputCost`
+/// non-empty). "Producible" means some `ProductionRecipesCatalog` recipe outputs
+/// the commodity, so an affluent supplier can over-produce it for release; a
+/// market-suppliable input the seller already holds (e.g. `lumber`, which the
+/// seller buys directly) is naturally excluded by the missing-stock check. Pure
+/// and deterministic over `(game)` and the static catalogs / cost table.
+Set<String> _peerLockRecoverySellerNeededProducibleImprovementInputs(
+  Game game, {
+  required String excludePlayerId,
+}) {
+  final result = <String>{};
+  for (final player in game.players) {
+    if (player.id == excludePlayerId) continue;
+    final cost = regimentBuildInputFeedstockImprovementInputCost(
+      game,
+      player.id,
+    );
+    if (cost.isEmpty) continue;
+    for (final entry in cost.entries) {
+      final producible = ProductionRecipesCatalog.all.any(
+        (r) => r.outputCommodityId == entry.key,
+      );
+      if (!producible) continue;
+      if (player.stockpile.quantityOf(entry.key) < entry.value) {
+        result.add(entry.key);
+      }
+    }
+  }
+  return result;
+}
+
 WorkOrder? _bestBuildImprovementRow(
   List<WorkOrder> candidates,
   Game game, {
@@ -837,8 +938,20 @@ FullAiCivilianWorkSelectionResult selectFullAiCivilianWorkOrders({
   final workOrders = <WorkOrder>[];
   final idleEvents = <FullAiCivilianWorkIdle>[];
   final factionMembership = DiplomacyFactionMembership.from(game);
-  final feedstockExtractionResourceIds =
-      regimentBuildInputFeedstockExtractionResourceIds(game, view.playerId);
+  // The seller-side gate routes a locked seller's own Builder onto its fabric
+  // feedstock; the supplier-side gate (Refs #2847 H8-extraction supplier
+  // feedstock) routes an affluent supplier's idle Builder onto the `timber` /
+  // `iron` the `castIron` recipe consumes so the supplier can over-produce the
+  // improvement input a peer locked seller needs. A player matches at most one
+  // gate (the supplier gate excludes locked sellers), so the union never
+  // double-counts.
+  final feedstockExtractionResourceIds = <String>{
+    ...regimentBuildInputFeedstockExtractionResourceIds(game, view.playerId),
+    ...supplierImprovementInputFeedstockExtractionResourceIds(
+      game,
+      view.playerId,
+    ),
+  };
 
   for (final unitId in allUnitIds) {
     _appendSelectionForUnitId(

--- a/packages/colonizethis_logic/test/full_ai_civilian_work_supplier_feedstock_extraction_test.dart
+++ b/packages/colonizethis_logic/test/full_ai_civilian_work_supplier_feedstock_extraction_test.dart
@@ -1,0 +1,290 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/ai_api.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+// Refs #2847 § H8-extraction supplier feedstock. Two-player fixture: an
+// above-quota affluent supplier (`_supplierId`) and a below-quota zero-NW
+// lock-recovery seller (`_sellerId`) that needs the `castIron` improvement
+// input but holds none. The supplier owns an unimproved `timber` tile (and a
+// `grain` tile) so the supplier-side extraction gate can route its Builder.
+const _supplierId = 'gp1';
+const _sellerId = 'gp2';
+
+// The grain tile key is lexicographically smaller than the timber tile key, so
+// ordinary build-improvement ordering (equal base score, lexicographic
+// tie-break) selects grain; only the active feedstock score boost flips the
+// supplier's Builder onto the timber tile.
+const _supplierGrainTile = 'oldWorld|s0|0|0';
+const _supplierTimberTile = 'oldWorld|s0|1|0';
+const _sellerWoolTile = 'oldWorld|p0|0|0';
+
+/// Builds a game with a supplier owning [supplierOw] Old World provinces and a
+/// seller owning [sellerOw] Old World provinces. The seller is configured (by
+/// default) as an active below-quota zero-NW lock-recovery seller that needs
+/// the `castIron` improvement input: recovered treasury, zero regiments, no
+/// `fabric`, `lumber` on hand (so only the `castIron` improvement input is
+/// missing) and an unimproved `wool` feedstock tile.
+Game _twoPlayerGame({
+  int supplierOw = kObserverConquestMinOwProvincesPerGp,
+  int sellerOw = 5,
+  int sellerTreasury = -1,
+  Stockpile sellerStockpile = const Stockpile(quantities: {'lumber': 1}),
+  Map<String, String> resourceByTileKey = const {
+    _supplierTimberTile: 'timber',
+    _supplierGrainTile: 'grain',
+    _sellerWoolTile: 'wool',
+  },
+  TileMapState? tileState,
+  List<Unit> extraUnits = const [],
+}) {
+  final treasury = sellerTreasury < 0
+      ? cheapestRegimentBuildTreasuryCost()
+      : sellerTreasury;
+  final provinces = <Province>[
+    for (var i = 0; i < supplierOw; i++)
+      Province(
+        id: 'oldWorld|s$i',
+        regionId: kRegionOldWorld,
+        ownerId: _supplierId,
+      ),
+    for (var i = 0; i < sellerOw; i++)
+      Province(
+        id: 'oldWorld|p$i',
+        regionId: kRegionOldWorld,
+        ownerId: _sellerId,
+      ),
+  ];
+  return Game(
+    id: 'g',
+    worldState: WorldState(
+      turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+      oldWorld: RegionData(provinces: provinces, units: extraUnits),
+      newWorld: const RegionData(),
+      resourceByTileKey: resourceByTileKey,
+      tileState: tileState ?? TileMapState(),
+    ),
+    players: [
+      Player(
+        id: _supplierId,
+        displayName: 'Supplier',
+        isHuman: false,
+        treasury: 100000,
+        // Supplier holds no timber/iron surplus — it must extract more.
+        stockpile: const Stockpile(),
+      ),
+      Player(
+        id: _sellerId,
+        displayName: 'Seller',
+        isHuman: false,
+        treasury: treasury,
+        stockpile: sellerStockpile,
+      ),
+    ],
+  );
+}
+
+PlayerView _supplierBuilderView(Game game) {
+  return PlayerView(
+    playerId: _supplierId,
+    player: game.players.firstWhere((p) => p.id == _supplierId),
+    ownUnitsById: {
+      'b1': Unit(
+        id: 'b1',
+        type: kUnitTypeBuilder,
+        ownerId: _supplierId,
+        locationProvinceId: 'oldWorld|s0',
+      ),
+    },
+    provincesById: const {},
+    visibilityByTile: const {},
+    prospectedTiles: const {},
+    diplomacyByOtherId: const {},
+  );
+}
+
+void main() {
+  group(
+    'supplierImprovementInputFeedstockExtractionResourceIds '
+    '(Refs #2847 H8-extraction supplier feedstock)',
+    () {
+      test('active peer demand returns castIron feedstock {timber, iron}', () {
+        final game = _twoPlayerGame();
+        expect(
+          supplierImprovementInputFeedstockExtractionResourceIds(
+            game,
+            _supplierId,
+          ),
+          containsAll(<String>['timber', 'iron']),
+        );
+      });
+
+      test('returns empty for a player that is itself a locked seller', () {
+        final game = _twoPlayerGame();
+        // The seller's own feedstock-extraction gate routes its Builder; the
+        // supplier role must exclude it.
+        expect(
+          supplierImprovementInputFeedstockExtractionResourceIds(
+            game,
+            _sellerId,
+          ),
+          isEmpty,
+        );
+      });
+
+      test('returns empty when no peer needs the improvement input', () {
+        // Seller at quota → not a below-quota lock-recovery seller, so no peer
+        // demand exists.
+        final game = _twoPlayerGame(sellerOw: kObserverConquestMinOwProvincesPerGp);
+        expect(
+          supplierImprovementInputFeedstockExtractionResourceIds(
+            game,
+            _supplierId,
+          ),
+          isEmpty,
+        );
+      });
+
+      test('returns empty when the peer already holds castIron', () {
+        final game = _twoPlayerGame(
+          sellerStockpile: const Stockpile(
+            quantities: {'lumber': 1, 'castIron': 1},
+          ),
+        );
+        expect(
+          supplierImprovementInputFeedstockExtractionResourceIds(
+            game,
+            _supplierId,
+          ),
+          isEmpty,
+        );
+      });
+
+      test('returns empty when the supplier owns no unimproved feedstock tile', () {
+        final game = _twoPlayerGame(
+          resourceByTileKey: const {
+            _supplierGrainTile: 'grain',
+            _sellerWoolTile: 'wool',
+          },
+        );
+        expect(
+          supplierImprovementInputFeedstockExtractionResourceIds(
+            game,
+            _supplierId,
+          ),
+          isEmpty,
+        );
+      });
+
+      test('returns empty when the supplier feedstock tile is already improved', () {
+        final game = _twoPlayerGame(
+          tileState: TileMapState().setImprovement(_supplierTimberTile, 1),
+        );
+        expect(
+          supplierImprovementInputFeedstockExtractionResourceIds(
+            game,
+            _supplierId,
+          ),
+          isEmpty,
+        );
+      });
+
+      test('evaluation is deterministic', () {
+        final game = _twoPlayerGame();
+        final a = supplierImprovementInputFeedstockExtractionResourceIds(
+          game,
+          _supplierId,
+        );
+        final b = supplierImprovementInputFeedstockExtractionResourceIds(
+          game,
+          _supplierId,
+        );
+        expect(a, equals(b));
+      });
+    },
+  );
+
+  group(
+    'selectFullAiCivilianWorkOrders supplier feedstock extraction '
+    '(Refs #2847 H8-extraction supplier feedstock)',
+    () {
+      test('supplier Builder prefers timber feedstock tile over grain', () {
+        final game = _twoPlayerGame();
+        final suggestions = [
+          const WorkOrder(
+            unitId: 'b1',
+            target: kWorkTargetBuildImprovement,
+            targetTileKey: _supplierGrainTile,
+          ),
+          const WorkOrder(
+            unitId: 'b1',
+            target: kWorkTargetBuildImprovement,
+            targetTileKey: _supplierTimberTile,
+          ),
+        ];
+        final r = selectFullAiCivilianWorkOrders(
+          workSuggestions: suggestions,
+          view: _supplierBuilderView(game),
+          game: game,
+        );
+        expect(r.workOrders, hasLength(1));
+        expect(r.workOrders.single.targetTileKey, _supplierTimberTile);
+      });
+
+      test('supplier keeps ordinary ordering when no peer needs the input', () {
+        final game = _twoPlayerGame(
+          sellerOw: kObserverConquestMinOwProvincesPerGp,
+        );
+        final suggestions = [
+          const WorkOrder(
+            unitId: 'b1',
+            target: kWorkTargetBuildImprovement,
+            targetTileKey: _supplierGrainTile,
+          ),
+          const WorkOrder(
+            unitId: 'b1',
+            target: kWorkTargetBuildImprovement,
+            targetTileKey: _supplierTimberTile,
+          ),
+        ];
+        final r = selectFullAiCivilianWorkOrders(
+          workSuggestions: suggestions,
+          view: _supplierBuilderView(game),
+          game: game,
+        );
+        // No supplier feedstock boost → ordinary deterministic ordering
+        // (lexicographically smaller grain tile key wins the tie).
+        expect(r.workOrders.single.targetTileKey, _supplierGrainTile);
+      });
+
+      test('selection is deterministic when the supplier gate is active', () {
+        final game = _twoPlayerGame();
+        final suggestions = [
+          const WorkOrder(
+            unitId: 'b1',
+            target: kWorkTargetBuildImprovement,
+            targetTileKey: _supplierGrainTile,
+          ),
+          const WorkOrder(
+            unitId: 'b1',
+            target: kWorkTargetBuildImprovement,
+            targetTileKey: _supplierTimberTile,
+          ),
+        ];
+        final view = _supplierBuilderView(game);
+        final a = selectFullAiCivilianWorkOrders(
+          workSuggestions: suggestions,
+          view: view,
+          game: game,
+        );
+        final b = selectFullAiCivilianWorkOrders(
+          workSuggestions: suggestions,
+          view: view,
+          game: game,
+        );
+        expect(a.workOrders, equals(b.workOrders));
+      });
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Advances the #2847 EXPAND-arm lock-recovery economy work by closing the upstream link the **post-#3244** S7-D diagnostic pinned: the #3244 supplier `castIron` over-production + surplus-release loop is **inert** because *no affluent supplier holds or extracts the `timber` / `iron` the `castIron` recipe consumes*, so over-production is infeasible regardless of boost magnitude. (#3244 merged into `dev` before this slice; this is the follow-up PR for the remaining work, branched from current `dev`.)

This slice routes an affluent supplier's **idle Builder** onto its own unimproved `timber` / `iron` tile so the over-production finally has feedstock:

- **logic — `full_ai_civilian_work_selection.dart`:** new `supplierImprovementInputFeedstockExtractionResourceIds(game, playerId)` returns the `castIron` production feedstock (`{timber, iron}`) for a supplier that is **not** itself a below-quota zero-NW lock-recovery seller, when a **peer** locked seller still needs a producible level-0 improvement input (`castIron`) and the supplier owns an unimproved `timber` / `iron` tile. The set is **unioned** with the seller-side feedstock set before the shared `build_improvement` score boost (`600`), routing the supplier's Builder onto the feedstock tile. A player matches at most one gate, so the union never double-counts. The cost gate still applies downstream (no affordability bypass).
- **ai — `domain_planner_orchestrator.dart`:** force the Full-AI civilian work pass on when the supplier gate is non-empty (mirrors the existing seller-gate force-on).
- **`ai_api.dart`:** export the new narrow contract.
- **SPEC `SPEC/ai/economy-planner.md`:** new § *Supplier improvement-input feedstock extraction* with six Given–When–Then ACs (positive + four negative controls + determinism).

## Verification

- **`dart analyze`** clean on all changed source/test files (the one remaining `unnecessary_null_comparison` at `domain_planner_orchestrator.dart:631` is pre-existing on `dev`, untouched here).
- **10 new logic unit tests pass** (`full_ai_civilian_work_supplier_feedstock_extraction_test.dart`): gate returns `{timber, iron}` under peer demand; empty when the player is itself a locked seller / no peer demand / peer already holds `castIron` / supplier owns no unimproved feedstock tile / tile already improved; Builder prefers the boosted `timber` tile over a lexicographically-smaller `grain` tile; negative control keeps ordinary ordering with no peer demand; determinism. Existing seller-feedstock, supplier-`castIron`, and economy-production tests still green.
- **Seed-42 S7-D diagnostic** (`dart test --run-skipped`):
  - **No regression:** gp1 = +6, gp2 = +6 (PASS); gp3 = +2, gp4 = +1, gp5 = +1, gp6 = +2 (FAIL) — identical to the post-#3244 baseline. The shared civilian-work routing change does **not** divert the +6 baseline GPs.
  - **Structural advance:** the new `gpSupplierFeedstockExtractionGateActiveTurns` = **52 / 52 / 7 / 0 / 0 / 0** (gp1–gp6) — the supplier-extraction gate now **fires** for the affluent suppliers gp1 / gp2 where it was structurally absent before.
  - **Honest residual:** `gpCastIronProductionAssignedTurns` stays **0** for every GP. The routed `timber` / `iron` improvement does not yet convert into `castIron` over-production — the recipe needs **both** `timber` **and** `iron`, and the deliberately small `+5` over-production boost loses to the supplier's shortage-driven `lumber` recipe for the extracted `timber`. The S7-D doc comment is updated to re-point the **next slice** (pin supplier `iron`-tile ownership vs. boost out-competition).

## Notes

- Non-closing reference only (`Refs #2847`); one incremental slice, the turn-100 conquest gate is not yet closed.
- Per the backlog-implement skill, #2847 stays in `backlog:implementation` (work outstanding + this PR open).

Refs #2847

Made with [Cursor](https://cursor.com)