### PR TITLE
fix(e2e): align civilian/naval panel expected-line mirrors with rendered headers (#2336)

### DIFF
--- a/app/lib/test_support/civilian_units_panel_e2e_expected_lines.dart
+++ b/app/lib/test_support/civilian_units_panel_e2e_expected_lines.dart
@@ -235,14 +235,6 @@ void _addUnitRowTexts({
   final showActions = !isTileScope || resolvedSelectedUnitId == unit.id;
 
   out.add(unit.type);
-  if (showActions) {
-    if (_isIdleNoPending(unit, currentOrders, humanPlayerId)) {
-      out.add(l10n.civilian_units_assign);
-    }
-    if (_hasWork(unit, currentOrders, humanPlayerId)) {
-      out.add(l10n.common_cancel);
-    }
-  }
   out.add(l10n.civilian_units_status(statusLabel));
   out.add(
     l10n.civilian_units_location(
@@ -258,6 +250,19 @@ void _addUnitRowTexts({
     provinceNames,
     l10n,
   );
+  // Action labels render in the row card's trailing slot, after the details
+  // column (type/status/location/assignedTo) — see _UnitRow.build /
+  // CivilianUnitRowCard in civilian_units_panel_support.dart (Refs #2866 R30
+  // card layout). The Locate action is icon-only and contributes no Text, so
+  // it is intentionally omitted here (Refs #2336).
+  if (showActions) {
+    if (_isIdleNoPending(unit, currentOrders, humanPlayerId)) {
+      out.add(l10n.civilian_units_assign);
+    }
+    if (_hasWork(unit, currentOrders, humanPlayerId)) {
+      out.add(l10n.common_cancel);
+    }
+  }
 }
 
 /// In-order [Text.data] strings for [CivilianUnitsPanel] preorder traversal.
@@ -331,7 +336,11 @@ List<String> civilianUnitsPanelExpectedTexts(
   }
 
   if (scopedOw.isNotEmpty) {
-    out.add(unitsPanelRegionLabel('oldWorld'));
+    // Region section headers render via RegionSectionHeader -> CtSectionLabel
+    // under the dark editorial-monocle theme (Refs #2859 R9 / #2866 S1-S3),
+    // which upper-cases the label (`Text(text.toUpperCase())`). The expected
+    // mirror must upper-case to match the rendered Text.data (Refs #2336).
+    out.add(unitsPanelRegionLabel('oldWorld').toUpperCase());
     for (final u in scopedOw) {
       _addUnitRowTexts(
         out: out,
@@ -352,7 +361,9 @@ List<String> civilianUnitsPanelExpectedTexts(
     }
   }
   if (scopedNw.isNotEmpty) {
-    out.add(unitsPanelRegionLabel('newWorld'));
+    // Upper-cased to match the RegionSectionHeader -> CtSectionLabel render
+    // (see oldWorld header above; Refs #2859 R9 / #2866 S1-S3 / #2336).
+    out.add(unitsPanelRegionLabel('newWorld').toUpperCase());
     for (final u in scopedNw) {
       _addUnitRowTexts(
         out: out,

--- a/app/lib/test_support/naval_units_panel_e2e_expected_lines.dart
+++ b/app/lib/test_support/naval_units_panel_e2e_expected_lines.dart
@@ -117,7 +117,12 @@ List<String> navalUnitsPanelExpectedTexts(
   }
 
   for (final group in tree) {
-    out.add(unitsPanelRegionLabel(group.regionId));
+    // Region section headers render via RegionSectionHeader -> CtSectionLabel
+    // under the dark editorial-monocle theme (Refs #2859 R9 / #2866 S1-S3),
+    // which upper-cases the label (`Text(text.toUpperCase())`). The location
+    // header line below (LocationSectionHeader) renders as-is, so only the
+    // region group header is upper-cased here (Refs #2336).
+    out.add(unitsPanelRegionLabel(group.regionId).toUpperCase());
     if (group.homeFleet != null) {
       _addFleetRowTexts(
         out: out,


### PR DESCRIPTION
## Summary

While running the `app/integration_test/` E2E suite on a Linux desktop (xvfb) to work `Refs #2336`, the `new_game_full_turn_e2e_test` failed early on stale expected-line **mirror drift** — the `app/lib/test_support/*_e2e_expected_lines.dart` fixtures no longer matched the live panel widgets. This PR aligns the civilian and naval mirrors with the rendered text, the same maintenance pattern already applied to the province panel in #3221.

### Done in this push

- **Region section header casing.** `RegionSectionHeader` renders via `CtSectionLabel`, which upper-cases its label (`Text(text.toUpperCase())`, Refs #2859 R9 / #2866 S1–S3). The civilian (`oldWorld`/`newWorld`) and naval (group) region headers in the mirrors emitted the non-upper-cased label (`"Old World"` vs rendered `"OLD WORLD"`). Now upper-cased to match.
- **Civilian row action ordering.** The civilian row card (`CivilianUnitRowCard` / `_UnitRow.build` in `civilian_units_panel_support.dart`) renders action labels (`Assign`/`Cancel`) in the trailing slot, **after** the details column (`type/status/location/assigned-to`) per the #2866 R30 card layout. The mirror emitted them right after the unit type. Reordered to emit action labels last (the `Locate` action is icon-only → contributes no `Text`).

### Verification (Linux desktop, `~/development/flutter`, xvfb-run, `--dart-define=CT_E2E=true`)

- `new_game_capital_panel_e2e_test.dart` → **All tests passed** (no regression from the mirror edits).
- `new_game_full_turn_e2e_test.dart` → the civilian-panel ordered-text assertion now **advances past** the region-header (`[2]`) and unit-row action-order (`[4]`) mismatches that previously failed it.
- `flutter analyze` (touched mirrors) → no issues. `dart format --set-exit-if-changed` → clean.
- Widget pins green: `app/test/e2e_expect_panel_texts_match_snapshot_test.dart`, `e2e_collect_text_preorder_test.dart`, `units_panel_shared_widgets_test.dart`.

### Deferred (separate, not mirror drift — follow-up)

Running the full suite surfaced **interaction-stability** failures that are unrelated to expected-line drift and are not addressed here:

- `new_game_full_turn_e2e_test`: after tapping the first **Assign**, the work-order menu does not surface its option labels within the 5 s budget (the menu does not open; deterministic across reruns). Likely tied to the #2866 row-card layout (row-level `InkWell` vs trailing action button tap routing).
- `new_game_fleet_reaches_new_world_e2e_test`: `"Move"` button not found in the naval panel within the 3 s budget.

These need a dedicated diagnostic slice (dump the post-tap tree, confirm tap routing / panel-close) and are out of scope for this mirror-alignment fix. Because `new_game_full_turn` still fails on that separate interaction issue, the AC8–AC10 wall-clock measurement (which requires the full suite green) is **not** included in this PR.

`Refs #2336`

Made with [Cursor](https://cursor.com)