### PR TITLE
feat(ai): reserve castIron feedstock from competing recipes for co-availability (#2847)

### DIFF
--- a/SPEC/ai/economy-planner.md
+++ b/SPEC/ai/economy-planner.md
@@ -165,6 +165,23 @@ The supplier feedstock ids are **unioned** with the seller-side `regimentBuildIn
 
 ---
 
+## Improvement-input feedstock co-availability reservation (Refs #2847 H8-extraction feedstock co-availability)
+
+Companion to § Supplier improvement-input over-production for release and § Supplier improvement-input feedstock extraction. Even once the Builder is routed onto a `timber` / `iron` tile, the `castIron_from_timber_iron_coal` recipe needs `timber` **and** `iron` together (2 + 2), while the single-input `lumber_from_timber` recipe (2 `timber`) is feasible as soon as 2 `timber` are on hand. Because the Builder extracts at most one feedstock tile per turn, the feasible `lumber` recipe drains the partial `timber` before `iron` accumulates, so `feasibleRuns(castIron) == 0` every turn and the `kSupplierBuildInputReleaseProductionScoreBoost` / `kRegimentBuildInputProductionScoreBoost` are never consulted (the boost is applied only to recipes that already clear `feasibleRuns > 0`).
+
+`_allocateLabour` (`economy_planner.dart`) therefore **reserves one production run's feedstock** for each domestically-produced improvement input the GP is actively producing — the union of its own seller-side need (`domesticImprovementInputOutputs`, the `kDomesticProductionImprovementInputIds` outputs the GP itself is short of) and the peer supplier-release need (`supplierReleaseImprovementInputs`). The reserve is the summed one-run `inputQuantities` of the lowest-`id` recipe producing each targeted output (`{timber: 2, iron: 2}` for `castIron`). When evaluating feasibility, a **reserve-target** recipe sees the full stockpile (it consumes its own reserved feedstock), while every **other** recipe sees the reserved quantities withheld (clamped at zero), so it cannot run on the reserved `timber` / `iron`. The withheld feedstock therefore carries across turns until the multi-input recipe accumulates a full run, at which point the boosted target recipe is assigned.
+
+The reserve is **bounded to one run per targeted output** and applies only while the GP is actively producing the improvement input, so it withholds at most 2 `timber` + 2 `iron` from competing recipes — negligible against the healthy supplier's throughput, keeping the +6 Old World conquest baseline for gp1/gp2 safe by construction. It is **self-clearing**: when neither set targets a domestic improvement input (a healthy GP, or once `castIron` is on hand), `feedstockReserveOutputIds` is empty, the reserve map is empty, and feasibility falls back to the unreduced stockpile (behaviour-equal to the prior allocator). Planner-internal (no `ai_victory_config.dart` constant); the reserve is a pure function of the targeted output ids and the static `ProductionRecipesCatalog`, so identical inputs yield identical allocations.
+
+### Acceptance criteria (H8-extraction feedstock co-availability)
+
+- Given an AI GP actively producing a domestic improvement input (`castIron`) whose targeted output set is non-empty, that holds exactly 2 `timber` and 0 `iron` (enough `timber` for one `lumber_from_timber` run but not yet a `castIron` run) and positive effective labour, when `runEconomyPlanner` runs, then no production assignment references `lumber_from_timber` (the 2 reserved `timber` are withheld from the competing recipe).
+- Given an otherwise identical GP that is **not** producing any domestic improvement input (the reserve-target set is empty — for example a healthy at-quota GP or a GP already holding `castIron`), when `runEconomyPlanner` runs with the same seed and the same 2 `timber` / 0 `iron` stockpile, then a production assignment references `lumber_from_timber` (negative control — with no reservation the feasible `lumber` recipe consumes the `timber`).
+- Given an AI GP actively producing `castIron` that holds 2 `timber` and 2 `iron` (one full `castIron` run) and positive effective labour, when `runEconomyPlanner` runs, then a production assignment references `castIron_from_timber_iron_coal` (the reserved feedstock co-availability lets the boosted multi-input recipe run).
+- Given identical inputs, when `runEconomyPlanner` runs twice for a reserve-target GP, then both runs return identical production assignments (determinism).
+
+---
+
 ## Integration
 
 - **Caller:** Strategic AI (e.g. `generateStrategicOrders`) calls the economy planner for each AI GP first, then passes the resulting **economy plan** (including `cargoPreference`) into the domain planners so the build step can weight ship vs land builds. Production assignments are collected per player and passed to the turn resolver as **per-player default production assignments** (resolver must accept `Map<String, List<AssignedRecipe>>` or equivalent for multi-player).

--- a/packages/colonizethis_ai/lib/src/planning/economy_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/economy_planner.dart
@@ -175,6 +175,23 @@ EconomyPlan runEconomyPlanner({
           ? kDomesticProductionImprovementInputIds
           : const <String>{};
 
+  // Refs #2847 H8-extraction feedstock co-availability: the multi-input
+  // `castIron` recipe needs `timber` + `iron` together, but the single-input
+  // `lumber_from_timber` recipe drains `timber` every turn, so the feedstock
+  // never co-accumulates for one `castIron` run and the production boost above
+  // is consulted only after `feasibleRuns(castIron) > 0`. Reserve one run's
+  // feedstock for each domestically-produced improvement input the GP is
+  // actively producing — its own seller-side need
+  // (`domesticImprovementInputOutputs`) and the peer supplier-release need
+  // (`supplierReleaseImprovementInputs`) — so competing recipes cannot consume
+  // the reserved `timber` / `iron` while the multi-input recipe is still
+  // assembling its feedstock. The reserve is bounded to one run and
+  // self-clears when neither set targets `castIron`.
+  final feedstockReserveOutputIds = <String>{
+    ...domesticImprovementInputOutputs,
+    ...supplierReleaseImprovementInputs,
+  };
+
   final assignments = _allocateLabour(
     stockpile: stockpile,
     workers: workers,
@@ -185,6 +202,7 @@ EconomyPlan runEconomyPlanner({
     regimentBuildInputProductionBoost: regimentBuildInputProductionBoost,
     missingRegimentBuildInputIds: boostedBuildInputOutputs,
     supplierReleaseImprovementInputIds: supplierReleaseImprovementInputs,
+    feedstockReserveOutputIds: feedstockReserveOutputIds,
   );
 
   final cargoPref = _cargoPreference(
@@ -288,6 +306,7 @@ List<AssignedRecipe> _allocateLabour({
   bool regimentBuildInputProductionBoost = false,
   Set<String> missingRegimentBuildInputIds = const {},
   Set<String> supplierReleaseImprovementInputIds = const {},
+  Set<String> feedstockReserveOutputIds = const {},
 }) {
   final recipes = ProductionRecipesCatalog.all;
   final agendaId = config.hiddenAgendaId;
@@ -295,14 +314,28 @@ List<AssignedRecipe> _allocateLabour({
   var remainingLabour = effectiveLabour;
   final result = <AssignedRecipe>[];
 
+  // One production run's feedstock reserved for the multi-input improvement
+  // recipes the GP is actively producing (Refs #2847 H8-extraction feedstock
+  // co-availability). Empty when no such recipe is targeted, in which case
+  // feasibility falls back to the unreduced stockpile (behaviour-equal).
+  final feedstockReserve =
+      _feedstockReserveForOutputs(feedstockReserveOutputIds);
+
   // Build feasible recipes with scores. Feasible = can run at least 1 full run.
   final candidates = <ScoredRecipe>[];
   for (final recipe in recipes) {
     final labourPerOutput = recipe.labourPerOutput;
     if (labourPerOutput <= 0) continue;
+    // A reserve-target recipe consumes its own reserved feedstock, so it sees
+    // the full stockpile; every other recipe sees the reserve withheld so it
+    // cannot drain the feedstock the target recipe is assembling.
+    final feasibilityStock =
+        feedstockReserveOutputIds.contains(recipe.outputCommodityId)
+            ? virtual
+            : _stockpileWithReserve(virtual, feedstockReserve);
     final runs = feasibleRuns(
       recipe: recipe,
-      stockpile: virtual,
+      stockpile: feasibilityStock,
       remainingLabour: remainingLabour,
     );
     if (runs <= 0) continue;
@@ -347,9 +380,13 @@ List<AssignedRecipe> _allocateLabour({
   for (final scored in candidates) {
     if (remainingLabour <= 0) break;
     final recipe = scored.recipe;
+    final feasibilityStock =
+        feedstockReserveOutputIds.contains(recipe.outputCommodityId)
+            ? virtual
+            : _stockpileWithReserve(virtual, feedstockReserve);
     final runs = feasibleRuns(
       recipe: recipe,
-      stockpile: virtual,
+      stockpile: feasibilityStock,
       remainingLabour: remainingLabour,
     );
     if (runs <= 0) continue;
@@ -377,6 +414,46 @@ List<AssignedRecipe> _allocateLabour({
     'labourByRecipe=$labourByRecipe assignmentsCount=${result.length}',
   );
   return result;
+}
+
+/// One production run's input requirements for each output id in
+/// [outputIds], summed across outputs. Used to reserve the multi-input
+/// feedstock (`timber` + `iron` for `castIron`) a domestically-produced
+/// improvement input needs so single-input competitors (`lumber_from_timber`)
+/// cannot drain it before the multi-input recipe accumulates a full run
+/// (Refs #2847 H8-extraction feedstock co-availability). Deterministic: the
+/// lowest-`id` recipe is chosen per output, and the catalog is iterated in a
+/// fixed order. Returns an empty map when [outputIds] is empty.
+Map<CommodityId, int> _feedstockReserveForOutputs(Set<String> outputIds) {
+  if (outputIds.isEmpty) return const {};
+  final reserve = <CommodityId, int>{};
+  final seenOutputs = <String>{};
+  final sorted = [...ProductionRecipesCatalog.all]
+    ..sort((a, b) => a.id.compareTo(b.id));
+  for (final recipe in sorted) {
+    final out = recipe.outputCommodityId;
+    if (!outputIds.contains(out)) continue;
+    if (!seenOutputs.add(out)) continue;
+    for (final entry in recipe.inputQuantities.entries) {
+      reserve[entry.key] = (reserve[entry.key] ?? 0) + entry.value;
+    }
+  }
+  return reserve;
+}
+
+/// [base] with each [reserve] quantity withheld (clamped at zero). The
+/// reserved feedstock is invisible to non-target recipes so they cannot
+/// consume it (Refs #2847 H8-extraction feedstock co-availability). Returns
+/// [base] unchanged when [reserve] is empty.
+Stockpile _stockpileWithReserve(Stockpile base, Map<CommodityId, int> reserve) {
+  if (reserve.isEmpty) return base;
+  var adjusted = base;
+  for (final entry in reserve.entries) {
+    final have = adjusted.quantityOf(entry.key);
+    final reduce = entry.value < have ? entry.value : have;
+    if (reduce > 0) adjusted = adjusted.applyDelta(entry.key, -reduce);
+  }
+  return adjusted;
 }
 
 bool _isMilitaryInputRecipe(ProductionRecipe recipe) {

--- a/packages/colonizethis_ai/test/economy_planner_regiment_build_input_production_test.dart
+++ b/packages/colonizethis_ai/test/economy_planner_regiment_build_input_production_test.dart
@@ -166,6 +166,53 @@ Game _supplierCastIronSourceGame({
   );
 }
 
+/// A below-quota zero-NW lock-recovery seller whose castIron improvement-input
+/// gate is active, with **configurable** `timber` / `iron` feedstock so a test
+/// can pin the partial-feedstock state where the single-input
+/// `lumber_from_timber` recipe would otherwise drain the `timber` the
+/// multi-input `castIron_from_timber_iron_coal` recipe is assembling
+/// (Refs #2847 § H8-extraction feedstock co-availability). When [gateActive] is
+/// false the unimproved feedstock tile is removed, so the seller is no longer a
+/// reserve-target GP (negative control — no feedstock reservation).
+Game _castIronFeedstockCoavailabilityGame({
+  required int treasury,
+  required int timber,
+  required int iron,
+  bool gateActive = true,
+}) {
+  const ow = 'oldWorld';
+  return Game(
+    id: 'g-h8-castiron-coavailability',
+    worldState: WorldState(
+      turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 50),
+      oldWorld: RegionData(
+        provinces: [
+          for (var i = 0; i < 3; i++)
+            Province(id: '$ow|seller_$i', regionId: ow, ownerId: 'gp_seller'),
+        ],
+      ),
+      newWorld: const RegionData(provinces: []),
+      resourceByTileKey: gateActive
+          ? const {'oldWorld|seller_0|1|0': 'wool'}
+          : const {},
+    ),
+    players: [
+      Player(
+        id: 'gp_seller',
+        displayName: 'Seller',
+        isHuman: false,
+        capitalProvinceId: '$ow|seller_0',
+        treasury: treasury,
+        stockpile: const Stockpile()
+            .applyDelta(CommodityCatalog.grain.id, 30)
+            .applyDelta(CommodityCatalog.timber.id, timber)
+            .applyDelta(CommodityCatalog.iron.id, iron),
+        workerPool: const WorkerPool(peasants: 12),
+      ),
+    ],
+  );
+}
+
 PhasePlanOutcome _expandForceRegimentBuildPlan({
   required bool forceCheapestRegimentBuild,
 }) {
@@ -445,6 +492,123 @@ void main() {
               'castIron labour; the supplier-release boost only fires while a '
               'peer needs the improvement input.',
         );
+      },
+    );
+
+    int lumberLabour(EconomyPlan plan) => plan.productionAssignments
+        .where((a) => a.recipeId == ProductionRecipesCatalog.lumberFromTimber.id)
+        .fold<int>(0, (sum, a) => sum + a.assignedLabour);
+
+    test(
+      'reserve-target GP withholds timber from the competing lumber recipe '
+      'while assembling a castIron run (Refs #2847 H8-extraction feedstock '
+      'co-availability)',
+      () {
+        // 2 timber + 0 iron: enough timber for one lumber_from_timber run but
+        // not yet a castIron run. The reserve must withhold the 2 timber so the
+        // single-input lumber recipe cannot drain it.
+        final game = _castIronFeedstockCoavailabilityGame(
+          treasury: threshold,
+          timber: 2,
+          iron: 0,
+        );
+        final view = buildPlayerView(game, _topology, 'gp_seller');
+        final plan = runEconomyPlanner(
+          game: game,
+          view: view,
+          config: config,
+          seeds: seeds,
+        );
+        expect(
+          lumberLabour(plan),
+          0,
+          reason:
+              'With the castIron reserve active, the 2 held timber are withheld '
+              'from lumber_from_timber so they carry over toward a castIron run.',
+        );
+      },
+    );
+
+    test(
+      'non-reserve GP consumes the same timber via the lumber recipe '
+      '(negative control — no feedstock reservation when castIron is not '
+      'targeted)',
+      () {
+        // gateActive: false removes the feedstock tile, so the GP is not a
+        // castIron reserve target; the feasible lumber recipe consumes timber.
+        final game = _castIronFeedstockCoavailabilityGame(
+          treasury: threshold,
+          timber: 2,
+          iron: 0,
+          gateActive: false,
+        );
+        final view = buildPlayerView(game, _topology, 'gp_seller');
+        final plan = runEconomyPlanner(
+          game: game,
+          view: view,
+          config: config,
+          seeds: seeds,
+        );
+        expect(
+          lumberLabour(plan),
+          greaterThan(0),
+          reason:
+              'Without a castIron reserve target, the feasible lumber_from_timber '
+              'recipe consumes the 2 held timber (the reservation is the only '
+              'differing behaviour).',
+        );
+      },
+    );
+
+    test(
+      'reserve-target GP assigns the castIron recipe once a full run of '
+      'feedstock co-accumulates (Refs #2847 H8-extraction feedstock '
+      'co-availability)',
+      () {
+        // 2 timber + 2 iron: one full castIron run is now co-available, so the
+        // boosted multi-input recipe runs.
+        final game = _castIronFeedstockCoavailabilityGame(
+          treasury: threshold,
+          timber: 2,
+          iron: 2,
+        );
+        final view = buildPlayerView(game, _topology, 'gp_seller');
+        final plan = runEconomyPlanner(
+          game: game,
+          view: view,
+          config: config,
+          seeds: seeds,
+        );
+        expect(
+          _assignedRecipeIds(plan),
+          contains(ProductionRecipesCatalog.castIronFromTimberIronCoal.id),
+          reason:
+              'With timber + iron co-available the reserved feedstock lets the '
+              'boosted castIron recipe run.',
+        );
+      },
+    );
+
+    test(
+      'reserve-target allocation is deterministic across identical runs',
+      () {
+        Set<String> run() {
+          final game = _castIronFeedstockCoavailabilityGame(
+            treasury: threshold,
+            timber: 2,
+            iron: 0,
+          );
+          return _assignedRecipeIds(
+            runEconomyPlanner(
+              game: game,
+              view: buildPlayerView(game, _topology, 'gp_seller'),
+              config: config,
+              seeds: seeds,
+            ),
+          );
+        }
+
+        expect(run(), equals(run()));
       },
     );
   });


### PR DESCRIPTION
## Summary

`Refs #2847` (foundational soft-phase / OW-conquest gate; H8-extraction castIron sub-chain).

This is the next incremental slice on the H8-extraction castIron supply chain, implementing the **option-1** fix the most recent S7-D diagnostic comment recommended ("reserve the supplier's extracted timber/iron from competing feasible recipes (lumber) while a peer locked seller needs castIron").

### Problem (from the latest S7-D diagnostic)

The multi-input `castIron_from_timber_iron_coal` recipe needs **2 timber + 2 iron together**, but the single-input `lumber_from_timber` recipe (2 timber) is feasible as soon as 2 timber are on hand. Because the routed Builder extracts at most one feedstock tile per turn, `lumber` drains the partial `timber` before `iron` accumulates, so `feasibleRuns(castIron) == 0` every turn and the existing supplier/seller `castIron` production boost — applied only to recipes that already clear `feasibleRuns > 0` — is never consulted.

### Done in this push

- `_allocateLabour` (`economy_planner.dart`) reserves **one production run's feedstock** for each domestically-produced improvement input the GP is actively producing — the union of its own seller-side need (`domesticImprovementInputOutputs`) and the peer supplier-release need (`supplierReleaseImprovementInputs`). Reserve-target recipes see the full stockpile; every other recipe sees the reserved `timber`/`iron` withheld (clamped at zero), so the feedstock carries across turns until the multi-input recipe can run.
- Reserve is **bounded to one run** (`{timber: 2, iron: 2}` for `castIron`), **self-clearing** (empty for healthy/at-quota GPs, so behaviour-equal to the prior allocator and the +6 OW baseline for gp1/gp2 is preserved by construction), and **deterministic** (pure function of the targeted outputs + `ProductionRecipesCatalog`).
- New normative SPEC section `SPEC/ai/economy-planner.md` § *Improvement-input feedstock co-availability reservation* + Given-When-Then ACs.
- 4 new discriminating tests (positive: lumber withheld while assembling, and castIron assigned once co-available; negative control: lumber consumed when castIron is not a reserve target; determinism).

### Scope honesty — remaining for #2847

Ran `seed42_observer_conquest_s7d_diagnostic_test.dart --run-skipped` on this branch:

- **+6 OW baseline preserved** (gp1/gp2 = +6); turn-100 gate **unchanged** (gp3=+2, gp4=+1, gp5=+1, gp6=+2 — still FAIL).
- `gpCastIronProductionAssignedTurns` is still **0** for every GP. The diagnostic shows the binding residual has moved **one stage upstream**: the affluent suppliers (gp1/gp2) run the feedstock-extraction gate 52 turns each and hold `timber` (gp2 lumber=44 at turn 99) but **never co-hold `iron`** for a `castIron` run, so the reservation has no *net* seed-42 effect yet. The next slice must guarantee the supplier actually sources/extracts `iron` alongside `timber` (option-2: bias the Builder onto the deficient feedstock; or relax the level-0 `build_improvement` `castIron` requirement for the first bootstrap), at which point this reservation becomes load-bearing.

This slice removes the recipe-ordering / co-availability dead-end definitively so the next slice can target iron sourcing without ambiguity. It does not close the turn-100 gate on its own.

### Tests

- `cd packages/colonizethis_ai && dart test test/economy_planner_regiment_build_input_production_test.dart` → **11/11 pass** (7 existing + 4 new).
- Regression check: `economy_planner_test.dart`, `economy_planner_phase_plan_injection_test.dart`, `treasury_planner_supplier_castiron_source_test.dart`, `treasury_planner_regiment_input_castiron_production_test.dart`, `recipe_scoring_test.dart` → all pass.
- `dart analyze lib/src/planning/economy_planner.dart` → no issues.
- `seed42_observer_conquest_s7d_diagnostic_test.dart --run-skipped` → passes (diagnostic; gate semantics unchanged).

### Notes

- No new/changed `ai_victory_config.dart` constants (planner-internal only).
- No change to the regiment build-input / supplier-release boosts; the regression-test skip is **retained** (not all six GPs pass).
- Agent-run artifacts cleaned (`/tmp/s7d_2847.log` removed).

Made with [Cursor](https://cursor.com)