### PR TITLE
fix(e2e): stabilize panel interactions and mirror drift for full-turn E2E (#2336)

### DIFF
--- a/app/integration_test/e2e_test_shared.dart
+++ b/app/integration_test/e2e_test_shared.dart
@@ -1,5 +1,8 @@
 import 'package:colonizethis_app/config/ct_e2e.dart';
 import 'package:colonizethis_app/features/game/dialogue/game_start_intro_overlay.dart';
+import 'package:colonizethis_app/features/game/widgets/chrome/ct_nine_patch_button.dart';
+import 'package:colonizethis_app/features/game/widgets/civilian_units_panel.dart'
+    show CivilianUnitRowCard;
 import 'package:colonizethis_app/widgets/ct_dialog_shell.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -515,6 +518,231 @@ Future<void> e2eAwaitCivilianWorkMenuMounted(
 /// falls back to the raw finder, which is the canonical AC5 / AC10
 /// adaptive-pre-tap recipe documented in the e2e-ui-stability rule
 /// (Refs GitHub #2336 AC5 / AC10 / Bottleneck 6).
+/// Taps the enclosing [CtNinePatchButton] for a button [label] finder, falling
+/// back to the shared [e2eEnsureVisibleAndTapHitTestable] label recipe when no
+/// `CtNinePatchButton` ancestor resolves (for example a plain `InkWell` work-
+/// menu row from `_showOrderMenu`).
+///
+/// Why this exists (Refs GitHub #2336 AC6 / AC10): `CtNinePatchButton`
+/// (`#2859` R1) renders its label inside a `Stack` whose top child is a
+/// `Positioned.fill(IgnorePointer(_BrassCornerBrackets))` painted over the
+/// engraved-label content, wrapped by a `Material` + `InkWell`. On headless
+/// Linux a `tester.tap` aimed at the inner `Text` center resolves to the label
+/// glyph rather than the `InkWell`'s gesture region, so the `onPressed`
+/// callback (e.g. the civilian-row **Assign** → `_showOrderMenu`) never fires
+/// and the downstream work-menu wait times out. Resolving the tap to the
+/// enclosing button — the canonical interactive control per
+/// `colonizethis-e2e-ui-stability.mdc` (*scope interactions to the actual
+/// control*) — fires `onPressed` deterministically.
+///
+/// Returns `true` when a tap was issued (button ancestor or label fallback),
+/// `false` only when [label] resolves to zero elements.
+Future<bool> e2eTapEnclosingNinePatchButtonOrLabel(
+  WidgetTester tester,
+  Finder label,
+) async {
+  if (label.evaluate().isEmpty) {
+    return false;
+  }
+  final button = find.ancestor(
+    of: label,
+    matching: find.byType(CtNinePatchButton),
+  );
+  if (button.evaluate().isEmpty) {
+    return e2eEnsureVisibleAndTapHitTestable(tester, label);
+  }
+  final target = button.first;
+  await e2eScrollButtonIntoHitTestableView(tester, target);
+  final hit = target.hitTestable();
+  final resolved = hit.evaluate().isNotEmpty ? hit.first : target;
+  await tester.tap(resolved, warnIfMissed: false);
+  return true;
+}
+
+/// Best-effort scrolls [button] until it is genuinely **hit-testable**
+/// (visible inside the render-view bounds), not merely *built*.
+///
+/// Why this exists (Refs GitHub #2336 AC6 / AC7 / AC10): a `ListView` keeps
+/// rows just outside the viewport laid out (within `cacheExtent`), so they are
+/// neither `Offstage` nor removed from the element tree. As a result both
+/// `WidgetController.scrollUntilVisible` (which stops as soon as the finder
+/// `evaluate()` is non-empty) and a single `tester.ensureVisible` can no-op on
+/// a row whose center is still below the render view — e.g. the first civilian
+/// **Assign** button laid out at `y≈819` inside a `1280×720` headless view. A
+/// `tester.tap` then derives an off-screen offset, misses the hit test, never
+/// fires `onPressed`, and the downstream work-menu wait times out. Driving the
+/// enclosing `Scrollable` until the button is hit-testable makes the tap land
+/// deterministically per `colonizethis-e2e-ui-stability.mdc`
+/// (*verify visibility before interaction*).
+Future<void> e2eScrollButtonIntoHitTestableView(
+  WidgetTester tester,
+  Finder button,
+) async {
+  if (button.hitTestable().evaluate().isNotEmpty) {
+    return;
+  }
+  try {
+    await tester.ensureVisible(button);
+    await tester.pump();
+  } catch (_) {}
+  if (button.hitTestable().evaluate().isNotEmpty) {
+    return;
+  }
+  final scrollable = find.ancestor(
+    of: button,
+    matching: find.byType(Scrollable),
+  );
+  if (scrollable.evaluate().isEmpty) {
+    return;
+  }
+  const maxScrollSteps = 20;
+  for (var i = 0;
+      i < maxScrollSteps && button.hitTestable().evaluate().isEmpty;
+      i++) {
+    final dragged =
+        await e2eDragScrollableFromVisiblePoint(tester, scrollable, const Offset(0, -120));
+    if (!dragged) {
+      break;
+    }
+    await tester.pump(const Duration(milliseconds: 50));
+  }
+}
+
+/// Logical size of the test render view (for example `1280×720` on the headless
+/// Linux desktop host). Used to clamp synthetic gesture start points inside the
+/// visible bounds.
+Size e2eRenderViewSize(WidgetTester tester) {
+  return tester.view.physicalSize / tester.view.devicePixelRatio;
+}
+
+/// Drags [scrollable] by [delta] starting from a point guaranteed to lie inside
+/// both the scrollable's on-screen extent and the render view, returning `true`
+/// when a drag was issued.
+///
+/// Why this exists (Refs GitHub #2336 AC6 / AC7 / AC10): a freshly opened
+/// bottom-sheet panel can still be mid entrance-animation, so the `Scrollable`'s
+/// geometric center may sit below the render view (observed at `y≈918` in a
+/// `1280×720` headless view). A plain `tester.drag(scrollable, ...)` derives its
+/// start offset from that off-screen center, misses the hit test, and scrolls
+/// nothing — so rows below the fold stay unreachable. Grabbing the on-screen
+/// portion of the scrollable instead drives the list deterministically per
+/// `colonizethis-e2e-ui-stability.mdc` (*verify visibility before interaction*).
+/// Returns `false` when no usable on-screen portion of the scrollable exists.
+Future<bool> e2eDragScrollableFromVisiblePoint(
+  WidgetTester tester,
+  Finder scrollable,
+  Offset delta,
+) async {
+  if (scrollable.evaluate().isEmpty) {
+    return false;
+  }
+  final rect = tester.getRect(scrollable.first);
+  final view = e2eRenderViewSize(tester);
+  final top = rect.top < 0 ? 0.0 : rect.top;
+  final bottom = rect.bottom > view.height ? view.height : rect.bottom;
+  if (bottom - top < 8.0) {
+    return false;
+  }
+  final startX = rect.center.dx.clamp(8.0, view.width - 8.0).toDouble();
+  final startY = ((top + bottom) / 2).clamp(8.0, view.height - 8.0).toDouble();
+  await tester.dragFrom(Offset(startX, startY), delta);
+  return true;
+}
+
+/// Pumps until [scrollable] has a meaningful on-screen extent (a freshly opened
+/// panel has finished sliding up) or [timeout] elapses.
+///
+/// Guards interactions that target a bottom-sheet panel immediately after it is
+/// opened: without this settle the panel's `Scrollable` can still be animating
+/// up from the bottom edge, leaving its content below the render view (see
+/// [e2eDragScrollableFromVisiblePoint]). Refs GitHub #2336 AC6 / AC7 / AC10.
+Future<void> e2eWaitScrollableOnScreen(
+  WidgetTester tester,
+  Finder scrollable, {
+  Duration timeout = const Duration(seconds: 5),
+  String phaseName = 'pump_until_panel_scrollable_onscreen',
+}) async {
+  await e2ePumpUntilConditionOrIdle(
+    tester,
+    () {
+      if (scrollable.evaluate().isEmpty) {
+        return false;
+      }
+      final rect = tester.getRect(scrollable.first);
+      final view = e2eRenderViewSize(tester);
+      final top = rect.top < 0 ? 0.0 : rect.top;
+      final bottom = rect.bottom > view.height ? view.height : rect.bottom;
+      return bottom - top > 40.0;
+    },
+    timeout: timeout,
+    phaseName: phaseName,
+  );
+}
+
+double _e2eScrollPositionPixels(WidgetTester tester, Finder scrollable) {
+  final state = tester.state<ScrollableState>(scrollable.first);
+  return state.position.pixels;
+}
+
+/// Scrolls the civilian-panel [ListView] through its full extent (bottom then
+/// top) so every unit row is built before [e2eCollectTextPreorder] walks the
+/// tree.
+///
+/// Why this exists (Refs GitHub #2336 AC6 / AC7 / AC10): the bottom-sheet
+/// panel caps list height (~308 dp visible) while the E2E roster can list more
+/// units than fit on screen. `ListView` virtualization omits off-screen row
+/// `Text` nodes, so a preorder snapshot taken at scroll offset `0` can be
+/// shorter than [civilianUnitsPanelExpectedTexts] (for example the second
+/// idle `Explorer` row at indices 25–29). Driving the list to max extent and
+/// back — together with the E2E `cacheExtent` on [UnitsPanelShell] — keeps
+/// every row mounted for the assertion pass.
+Future<void> e2ePrepareCivilianPanelListForTextCollection(
+  WidgetTester tester,
+) async {
+  final root = find.byKey(kCtE2ECivilianPanelRootKey);
+  if (root.evaluate().isEmpty) {
+    return;
+  }
+  final scrollable = find.descendant(
+    of: root,
+    matching: find.byType(Scrollable),
+  );
+  if (scrollable.evaluate().isEmpty) {
+    return;
+  }
+  await e2eWaitScrollableOnScreen(tester, scrollable);
+  const maxSteps = 25;
+  for (var i = 0; i < maxSteps; i++) {
+    final before = _e2eScrollPositionPixels(tester, scrollable);
+    final dragged = await e2eDragScrollableFromVisiblePoint(
+      tester,
+      scrollable,
+      const Offset(0, -200),
+    );
+    await tester.pump(const Duration(milliseconds: 50));
+    final after = _e2eScrollPositionPixels(tester, scrollable);
+    if (!dragged || (after - before).abs() < 0.5) {
+      break;
+    }
+  }
+  for (var i = 0; i < maxSteps; i++) {
+    final before = _e2eScrollPositionPixels(tester, scrollable);
+    if (before < 0.5) {
+      break;
+    }
+    await e2eDragScrollableFromVisiblePoint(
+      tester,
+      scrollable,
+      const Offset(0, 200),
+    );
+    await tester.pump(const Duration(milliseconds: 50));
+    final after = _e2eScrollPositionPixels(tester, scrollable);
+    if ((after - before).abs() < 0.5) {
+      break;
+    }
+  }
+}
+
 Future<void> e2eTapFirstAssignInCivilianPanel(WidgetTester tester) async {
   final root = find.byKey(kCtE2ECivilianPanelRootKey);
   final listView = find.descendant(of: root, matching: find.byType(ListView));
@@ -532,7 +760,7 @@ Future<void> e2eTapFirstAssignInCivilianPanel(WidgetTester tester) async {
     120,
     scrollable: panelScrollable,
   );
-  final didTap = await e2eEnsureVisibleAndTapHitTestable(tester, firstAssign);
+  final didTap = await e2eTapEnclosingNinePatchButtonOrLabel(tester, firstAssign);
   expect(
     didTap,
     isTrue,
@@ -607,7 +835,13 @@ Future<void> e2eTapCivilianWorkOrderLabel(
   );
 }
 
-/// Taps **Assign** on a [ListTile] whose title is exactly [unitTypeTitle] (GitHub #2336 H9).
+/// Taps **Assign** on the [CivilianUnitRowCard] whose title is exactly
+/// [unitTypeTitle] (GitHub #2336 H9).
+///
+/// The civilian panel migrated its unit rows off Material `ListTile` to the
+/// bespoke [CivilianUnitRowCard] (Refs #2914 S8); this helper therefore scopes
+/// the per-row **Assign** lookup to that card so the row's `CtNinePatchButton`
+/// resolves after the migration instead of silently matching nothing.
 Future<void> e2eTapAssignOnCivilianRowWithTitle(
   WidgetTester tester,
   String unitTypeTitle,
@@ -624,10 +858,20 @@ Future<void> e2eTapAssignOnCivilianRowWithTitle(
     of: listView,
     matching: find.text(unitTypeTitle),
   );
+  // The panel may still be mid entrance-animation; settle it on-screen before
+  // dragging so gesture start points land inside the render view (#2336 AC6).
+  await e2eWaitScrollableOnScreen(tester, panelScrollable);
   final sw = Stopwatch()..start();
   while (titlesInList.evaluate().isEmpty &&
       sw.elapsed < const Duration(seconds: 20)) {
-    await tester.drag(panelScrollable, const Offset(0, -120));
+    final dragged = await e2eDragScrollableFromVisiblePoint(
+      tester,
+      panelScrollable,
+      const Offset(0, -120),
+    );
+    if (!dragged) {
+      await e2eWaitScrollableOnScreen(tester, panelScrollable);
+    }
     await e2ePumpUntilConditionOrIdle(
       tester,
       () => titlesInList.evaluate().isNotEmpty,
@@ -644,18 +888,22 @@ Future<void> e2eTapAssignOnCivilianRowWithTitle(
   final n = titlesInList.evaluate().length;
   for (var i = 0; i < n; i++) {
     final titleAt = titlesInList.at(i);
-    await tester.scrollUntilVisible(titleAt, 120, scrollable: panelScrollable);
-    await tester.ensureVisible(titleAt);
-    final listTile = find.ancestor(
+    try {
+      await tester.scrollUntilVisible(titleAt, 120, scrollable: panelScrollable);
+    } catch (_) {}
+    try {
+      await tester.ensureVisible(titleAt);
+    } catch (_) {}
+    final rowCard = find.ancestor(
       of: titleAt,
-      matching: find.byType(ListTile),
+      matching: find.byType(CivilianUnitRowCard),
     );
-    final assign = find.descendant(of: listTile, matching: find.text('Assign'));
+    final assign = find.descendant(of: rowCard, matching: find.text('Assign'));
     if (assign.evaluate().isEmpty) {
       continue;
     }
     final assignHit = assign.first;
-    final didTap = await e2eEnsureVisibleAndTapHitTestable(tester, assignHit);
+    final didTap = await e2eTapEnclosingNinePatchButtonOrLabel(tester, assignHit);
     expect(
       didTap,
       isTrue,

--- a/app/integration_test/e2e_test_shared_panel_text_match.dart
+++ b/app/integration_test/e2e_test_shared_panel_text_match.dart
@@ -82,15 +82,25 @@ Future<void> e2eExpectCivilianPanelMatchesE2eSnapshot(
   WidgetTester tester,
   AppLocalizations l10n, {
   E2ePerfLog? perf,
-}) => e2eExpectPanelTextsMatchSnapshot(
-  tester,
-  panelRootKey: kCtE2ECivilianPanelRootKey,
-  snapshotReader: () => ctE2eCivilianPanelSnapshot,
-  buildExpected: () =>
-      civilianUnitsPanelExpectedTexts(ctE2eCivilianPanelSnapshot!, l10n),
-  phaseName: kE2eExpectCivilianPanelTextsPhase,
-  perf: perf,
-);
+}) async {
+  await e2eWaitUntilFound(
+    tester,
+    find.byKey(kCtE2ECivilianPanelRootKey),
+    timeout: kE2eDefaultExpectPanelTextsTimeout,
+    perf: perf,
+    phaseName: kE2eExpectCivilianPanelTextsPhase,
+  );
+  await e2ePrepareCivilianPanelListForTextCollection(tester);
+  await e2eExpectPanelTextsMatchSnapshot(
+    tester,
+    panelRootKey: kCtE2ECivilianPanelRootKey,
+    snapshotReader: () => ctE2eCivilianPanelSnapshot,
+    buildExpected: () =>
+        civilianUnitsPanelExpectedTexts(ctE2eCivilianPanelSnapshot!, l10n),
+    phaseName: kE2eExpectCivilianPanelTextsPhase,
+    perf: perf,
+  );
+}
 
 /// Asserts the [NavalUnitsPanel] rendered tree matches
 /// [navalUnitsPanelExpectedTexts] for the currently primed

--- a/app/lib/config/ct_e2e_last_panel_snapshot.dart
+++ b/app/lib/config/ct_e2e_last_panel_snapshot.dart
@@ -119,6 +119,8 @@ class CtE2eProductionPanelSnapshot {
     required this.desiredOutputByRecipe,
     required this.netDeltasByCommodity,
     required this.topology,
+    required this.currentOrders,
+    required this.canEditLabour,
     this.tileMapByRegion,
   });
 
@@ -127,6 +129,16 @@ class CtE2eProductionPanelSnapshot {
   final Map<String, int> desiredOutputByRecipe;
   final Map<String, int> netDeltasByCommodity;
   final MapTopology topology;
+
+  /// Draft orders backing the Labour Controls section (queued recruit/train
+  /// counts) the production panel appends to the Workers section. Required so
+  /// the e2e expected-lines mirror can reproduce that section.
+  final Orders currentOrders;
+
+  /// Whether the viewed player can mutate via UI (drives the Labour Controls
+  /// stepper/disband action affordances, which add their own `Text` labels to
+  /// the rendered tree).
+  final bool canEditLabour;
   final Map<String, TileMapResult>? tileMapByRegion;
 }
 

--- a/app/lib/core/services/app_event_handler.dart
+++ b/app/lib/core/services/app_event_handler.dart
@@ -303,8 +303,12 @@ class AppEventHandler {
           final currentOrders = ref.watch(currentOrdersProvider);
           final bus = ref.watch(appEventBusProvider);
           final isNarrow = MediaQuery.sizeOf(context).width < kNarrowBreakpoint;
-          final maxHeight =
-              MediaQuery.sizeOf(context).height * (isNarrow ? 0.33 : 0.5);
+          // E2E panel-text assertions require every unit row mounted; the
+          // default 33–50 % sheet height virtualizes lower rows on the headless
+          // 1280×720 host (Refs GitHub #2336 AC6 / AC7 / AC10).
+          final maxHeight = kCtE2EEnabled
+              ? MediaQuery.sizeOf(context).height * 0.92
+              : MediaQuery.sizeOf(context).height * (isNarrow ? 0.33 : 0.5);
           return ConstrainedBox(
             constraints: BoxConstraints(maxHeight: maxHeight),
             child: CivilianUnitsPanel(

--- a/app/lib/features/game/screens/production_screen.dart
+++ b/app/lib/features/game/screens/production_screen.dart
@@ -208,6 +208,8 @@ class ProductionScreen extends ConsumerWidget {
               desiredOutputByRecipe: desiredOutputByRecipe,
               netDeltasByCommodity: netDeltasByCommodity,
               topology: panelTopology,
+              currentOrders: currentOrders,
+              canEditLabour: canEdit,
               tileMapByRegion: panelTileMaps,
             ),
           );

--- a/app/lib/features/game/widgets/units/shared/units_panel_shell.dart
+++ b/app/lib/features/game/widgets/units/shared/units_panel_shell.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../../../../config/ct_e2e.dart';
 import '../../../../../config/editorial_monocle_palette.dart';
 import '../../../../../widgets/ct_panel.dart';
 import '../../../../../widgets/ct_spacing.dart';
@@ -86,6 +87,11 @@ class UnitsPanelShell extends StatelessWidget {
                 child: hasContent
                     ? ListView(
                         shrinkWrap: true,
+                        // E2E panel-text assertions walk the full ListView
+                        // preorder; a tall unit roster virtualizes rows below the
+                        // fold. A generous cache keeps every row built once the
+                        // test helper has scrolled through the list (Refs #2336).
+                        cacheExtent: kCtE2EEnabled ? 10000 : null,
                         padding: listPadding,
                         children: listChildren,
                       )

--- a/app/lib/test_support/civilian_units_panel_e2e_expected_lines.dart
+++ b/app/lib/test_support/civilian_units_panel_e2e_expected_lines.dart
@@ -235,14 +235,6 @@ void _addUnitRowTexts({
   final showActions = !isTileScope || resolvedSelectedUnitId == unit.id;
 
   out.add(unit.type);
-  if (showActions) {
-    if (_isIdleNoPending(unit, currentOrders, humanPlayerId)) {
-      out.add(l10n.civilian_units_assign);
-    }
-    if (_hasWork(unit, currentOrders, humanPlayerId)) {
-      out.add(l10n.common_cancel);
-    }
-  }
   out.add(l10n.civilian_units_status(statusLabel));
   out.add(
     l10n.civilian_units_location(
@@ -258,6 +250,19 @@ void _addUnitRowTexts({
     provinceNames,
     l10n,
   );
+  // Action labels render in the row card's trailing slot, after the details
+  // column (type/status/location/assignedTo) — see _UnitRow.build /
+  // CivilianUnitRowCard in civilian_units_panel_support.dart (Refs #2866 R30
+  // card layout). The Locate action is icon-only and contributes no Text, so
+  // it is intentionally omitted here (Refs #2336).
+  if (showActions) {
+    if (_isIdleNoPending(unit, currentOrders, humanPlayerId)) {
+      out.add(l10n.civilian_units_assign);
+    }
+    if (_hasWork(unit, currentOrders, humanPlayerId)) {
+      out.add(l10n.common_cancel);
+    }
+  }
 }
 
 /// In-order [Text.data] strings for [CivilianUnitsPanel] preorder traversal.
@@ -331,7 +336,11 @@ List<String> civilianUnitsPanelExpectedTexts(
   }
 
   if (scopedOw.isNotEmpty) {
-    out.add(unitsPanelRegionLabel('oldWorld'));
+    // Region section headers render via RegionSectionHeader -> CtSectionLabel
+    // under the dark editorial-monocle theme (Refs #2859 R9 / #2866 S1-S3),
+    // which upper-cases the label (`Text(text.toUpperCase())`). The expected
+    // mirror must upper-case to match the rendered Text.data (Refs #2336).
+    out.add(unitsPanelRegionLabel('oldWorld').toUpperCase());
     for (final u in scopedOw) {
       _addUnitRowTexts(
         out: out,
@@ -352,7 +361,9 @@ List<String> civilianUnitsPanelExpectedTexts(
     }
   }
   if (scopedNw.isNotEmpty) {
-    out.add(unitsPanelRegionLabel('newWorld'));
+    // Upper-cased to match the RegionSectionHeader -> CtSectionLabel render
+    // (see oldWorld header above; Refs #2859 R9 / #2866 S1-S3 / #2336).
+    out.add(unitsPanelRegionLabel('newWorld').toUpperCase());
     for (final u in scopedNw) {
       _addUnitRowTexts(
         out: out,

--- a/app/lib/test_support/naval_units_panel_e2e_expected_lines.dart
+++ b/app/lib/test_support/naval_units_panel_e2e_expected_lines.dart
@@ -32,13 +32,15 @@ void _addFleetRowTexts({
     // Mockup `.home-tag` rendered next to the name (Refs #2866 S8 R26).
     out.add(l10n.naval_units_homeFleetChip);
   }
-  // UnitsEntityActionRow (dense): label (details) then Move (when allowed),
-  // Split, and the icon-only Locate control (no text label). Refs #2866 S8
-  // R25 + R27.
-  if (!row.isHomeFleet) {
-    out.add(l10n.common_move);
+  // UnitsEntityActionRow (dense): trailing Move / Split / Locate cluster.
+  // Non-home fleets on the headless 1280×720 E2E host fall below
+  // `_denseIconOnlyBreakpoint`, so Move and Split are icon-only (no `Text`
+  // labels in preorder traversal). Home Fleet keeps a visible Split label at
+  // default panel width. Locate is always icon-only. Refs #2866 S8 R25 + R27;
+  // GitHub #2336 panel-text mirror drift.
+  if (row.isHomeFleet) {
+    out.add(l10n.common_split);
   }
-  out.add(l10n.common_split);
   out.add(row.locationLabel);
   out.add(l10n.naval_units_mission(row.missionLabel));
   if (row.draftNavalMoveLine != null) {

--- a/app/lib/test_support/naval_units_panel_e2e_expected_lines.dart
+++ b/app/lib/test_support/naval_units_panel_e2e_expected_lines.dart
@@ -117,7 +117,12 @@ List<String> navalUnitsPanelExpectedTexts(
   }
 
   for (final group in tree) {
-    out.add(unitsPanelRegionLabel(group.regionId));
+    // Region section headers render via RegionSectionHeader -> CtSectionLabel
+    // under the dark editorial-monocle theme (Refs #2859 R9 / #2866 S1-S3),
+    // which upper-cases the label (`Text(text.toUpperCase())`). The location
+    // header line below (LocationSectionHeader) renders as-is, so only the
+    // region group header is upper-cased here (Refs #2336).
+    out.add(unitsPanelRegionLabel(group.regionId).toUpperCase());
     if (group.homeFleet != null) {
       _addFleetRowTexts(
         out: out,

--- a/app/lib/test_support/production_panel_e2e_expected_lines.dart
+++ b/app/lib/test_support/production_panel_e2e_expected_lines.dart
@@ -9,8 +9,10 @@
 
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_app/config/ct_e2e_last_panel_snapshot.dart';
 import 'package:colonizethis_app/features/game/production_recipe_affordance.dart';
+import 'package:colonizethis_app/features/game/widgets/production_labour_helpers.dart';
 import 'package:colonizethis_app/l10n/l10n.dart';
 import 'package:colonizethis_app/widgets/ct_resource_cell.dart';
 
@@ -165,6 +167,60 @@ void _addAllocationTexts(
   }
 }
 
+String _labourTierDisplayName(WorkerTier tier, AppLocalizations l10n) {
+  switch (tier) {
+    case WorkerTier.peasant:
+      return l10n.production_workers_peasants;
+    case WorkerTier.apprentice:
+      return l10n.production_workers_apprentices;
+    case WorkerTier.journeyman:
+      return l10n.production_workers_journeymen;
+    case WorkerTier.master:
+      return l10n.production_workers_masters;
+  }
+}
+
+/// Expected in-order [Text.data] for the Labour Controls section the
+/// production panel appends to the Workers section (`ProductionPanel`
+/// `_buildWorkerSection`, gated on a non-null `currentOrders`). Mirrors the
+/// `CtSectionLabel` header plus one [ProductionLabourSection] row per tier.
+///
+/// Per-row order matches `_ProductionLabourTierRow.build`: the tier label, an
+/// optional `Queued: N` segment (only when `queuedCount > 0`), then — when
+/// [canEdit] is true — the `Disband` label. The Disband label is emitted for
+/// every tier: trained tiers render a real [CtDangerTextButton] and the
+/// peasant row reserves an opacity-0 [CtDangerTextButton] placeholder that the
+/// pre-order text collector still visits. `CtSectionLabel` upper-cases its
+/// text, matching the other section headers in this mirror.
+List<String> productionLabourControlsExpectedTexts({
+  required Player player,
+  required Orders currentOrders,
+  required bool canEdit,
+  required AppLocalizations l10n,
+}) {
+  final out = <String>[];
+  out.add(l10n.production_labourControlsSectionLabel.toUpperCase());
+  final rows = buildProductionLabourRowData(
+    player: player,
+    currentOrders: currentOrders,
+    canEdit: canEdit,
+  );
+  for (final row in rows) {
+    final tierName = _labourTierDisplayName(row.tier, l10n);
+    final state = row.techUnlocked
+        ? l10n.production_labourTierUnlocked
+        : l10n.production_labourTierLocked;
+    out.add(l10n.production_labourTierLabel(tierName, state));
+    if (row.queuedCount > 0) {
+      out.add(l10n.production_labourQueued(row.queuedCount));
+    }
+    if (canEdit) {
+      out.add(l10n.production_labourDisband);
+    }
+  }
+  return out;
+}
+
 /// In-order [Text.data] for wide [ProductionPanel] preorder traversal.
 List<String> productionPanelWideExpectedTexts(
   CtE2eProductionPanelSnapshot snap,
@@ -187,6 +243,14 @@ List<String> productionPanelWideExpectedTexts(
 
   final out = <String>[];
   _addAvailableTexts(out, snap, l10n, effectiveLabour);
+  out.addAll(
+    productionLabourControlsExpectedTexts(
+      player: snap.player,
+      currentOrders: snap.currentOrders,
+      canEdit: snap.canEditLabour,
+      l10n: l10n,
+    ),
+  );
   _addAllocationTexts(out, snap, l10n, effectiveLabour);
   return out;
 }

--- a/app/test/e2e_tap_assign_on_civilian_row_with_title_test.dart
+++ b/app/test/e2e_tap_assign_on_civilian_row_with_title_test.dart
@@ -6,10 +6,13 @@
 // The helper is non-trivial: when multiple civilian rows share the same unit
 // title (`Builder`, `Merchant`, etc.), the panel may already have one of
 // them assigned to a work order (no `Assign` button) while another idle
-// row is still actionable. The helper must skip rows whose `ListTile`
-// subtree no longer contains a tappable `Assign` and pick the first row
-// that does — otherwise scenarios that exercise multi-unit panels would
-// fail mid-test when the first match is already busy.
+// row is still actionable. The helper must skip rows whose
+// `CivilianUnitRowCard` subtree no longer contains a tappable `Assign` and
+// pick the first row that does — otherwise scenarios that exercise
+// multi-unit panels would fail mid-test when the first match is already
+// busy. The civilian panel migrated its rows off Material `ListTile` to the
+// bespoke `CivilianUnitRowCard` (Refs #2914 S8), so this synthetic host
+// renders the same card the production helper now scopes to.
 //
 // The sibling helper `e2eTapFirstAssignInCivilianPanel` shares the
 // downstream "wait until work menu" contract; pinning both helpers in one
@@ -36,6 +39,11 @@
 library;
 
 import 'package:colonizethis_app/config/ct_e2e.dart';
+import 'package:colonizethis_app/config/themes.dart' show AppThemes;
+import 'package:colonizethis_app/features/game/widgets/civilian_units_panel.dart'
+    show CivilianUnitRowCard;
+import 'package:colonizethis_app/features/game/widgets/units/shared/units_entity_action_row.dart'
+    show UnitsEntityAction;
 import 'package:colonizethis_models/colonizethis_models.dart'
     show kUnitTypeBuilder, kUnitTypeMerchant;
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
@@ -69,6 +77,10 @@ class _CivilianPanelHostState extends State<_CivilianPanelHost> {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
+      // CtNinePatchButton (the Assign control rendered inside
+      // CivilianUnitRowCard) resolves its palette from the editorial-monocle
+      // theme; the production civilian panel runs under the same theme.
+      theme: AppThemes.editorialMonocle,
       home: Scaffold(
         body: Container(
           key: kCtE2ECivilianPanelRootKey,
@@ -77,19 +89,31 @@ class _CivilianPanelHostState extends State<_CivilianPanelHost> {
               Expanded(
                 child: ListView(
                   children: [
+                    // The civilian panel migrated its unit rows off Material
+                    // `ListTile` to the bespoke `CivilianUnitRowCard`
+                    // (Refs #2914 S8). The title-scoped Assign helper now
+                    // scopes its per-row lookup to that card, so the synthetic
+                    // host must host its rows in the same widget for the pin to
+                    // exercise the real lookup path (#2336 H9).
                     for (var i = 0; i < widget.rows.length; i++)
-                      ListTile(
-                        title: Text(widget.rows[i].title),
-                        trailing: widget.rows[i].hasAssign
-                            ? TextButton(
-                                onPressed: () {
-                                  setState(() {
-                                    _tappedRowIndex = i;
-                                  });
-                                },
-                                child: const Text('Assign'),
-                              )
-                            : const Text('Busy'),
+                      CivilianUnitRowCard(
+                        details: Text(widget.rows[i].title),
+                        selected: false,
+                        onTap: () {},
+                        actions: widget.rows[i].hasAssign
+                            ? [
+                                UnitsEntityAction(
+                                  tooltip: 'Assign',
+                                  icon: Icons.add,
+                                  label: 'Assign',
+                                  onPressed: () {
+                                    setState(() {
+                                      _tappedRowIndex = i;
+                                    });
+                                  },
+                                ),
+                              ]
+                            : const <UnitsEntityAction>[],
                       ),
                   ],
                 ),

--- a/app/test/production_labour_controls_expected_lines_test.dart
+++ b/app/test/production_labour_controls_expected_lines_test.dart
@@ -1,0 +1,244 @@
+// Pins the Labour Controls portion of the production-panel e2e expected-lines
+// mirror (`productionLabourControlsExpectedTexts` in
+// `app/lib/test_support/production_panel_e2e_expected_lines.dart`) against the
+// real `ProductionLabourSection` widget + its `CtSectionLabel` header.
+//
+// The full `productionPanelWideExpectedTexts` mirror is exercised only by the
+// integration-test scenario in `new_game_full_turn_e2e_test.dart`, which is a
+// CI no-op per `SPEC/program/e2e-integration-tests.md` § CI. Before this pin
+// the Labour Controls section was absent from the mirror, so its rendered
+// `LABOUR CONTROLS` header drifted silently against the expected `Allocation`
+// header until the slow E2E lane caught it. This widget-test layer asserts the
+// mirror reproduces the section's pre-order `Text` data exactly, so drift
+// surfaces at `flutter test` time.
+//
+// Refs GitHub #2336 (E2E expected-lines mirror alignment).
+
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:colonizethis_app/features/game/widgets/production_labour_helpers.dart';
+import 'package:colonizethis_app/features/game/widgets/production_labour_section.dart';
+import 'package:colonizethis_app/l10n/l10n.dart';
+import 'package:colonizethis_app/test_support/production_panel_e2e_expected_lines.dart';
+import 'package:colonizethis_app/widgets/ct_section_label.dart';
+
+import '../integration_test/e2e_helpers.dart' show collectTextPreorder;
+import 'widget_test_pumps.dart';
+
+const _playerId = 'gp_labour_mirror_test';
+const _rootKey = ValueKey<String>('labour_controls_mirror_root');
+
+Player _player({
+  int peasants = 0,
+  int apprentices = 0,
+  int journeymen = 0,
+  int masters = 0,
+  int treasury = 0,
+  Map<String, int> stockpile = const {},
+  Map<String, bool>? techUnlocked,
+}) {
+  return Player(
+    id: _playerId,
+    displayName: 'Labour mirror GP',
+    isHuman: true,
+    workerPool: WorkerPool(
+      peasants: peasants,
+      apprentices: apprentices,
+      journeymen: journeymen,
+      masters: masters,
+    ),
+    stockpile: Stockpile(quantities: Map<String, int>.from(stockpile)),
+    treasury: treasury,
+    techUnlocked: techUnlocked,
+  );
+}
+
+ProductionLabourCallbacks _noopCallbacks() => ProductionLabourCallbacks(
+  onAppendRecruitOrder: (_) {},
+  onPopLastRecruitOrder: (_) {},
+  onDisband: (_) {},
+);
+
+/// Mirrors how `ProductionPanel._buildWorkerSection` appends the Labour
+/// Controls block: a `CtSectionLabel` header immediately followed by the
+/// `ProductionLabourSection`. The intervening `SizedBox`es render no `Text`
+/// so they do not affect the pre-order text collection.
+Widget _mount({
+  required Player player,
+  required Orders currentOrders,
+  required bool canEdit,
+}) {
+  return MaterialApp(
+    localizationsDelegates: AppLocalizationsBinding.localizationsDelegates,
+    supportedLocales: const [Locale('en')],
+    home: Scaffold(
+      body: SizedBox(
+        width: 800,
+        height: 600,
+        child: KeyedSubtree(
+          key: _rootKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              CtSectionLabel(
+                lookupAppLocalizations(
+                  const Locale('en'),
+                ).production_labourControlsSectionLabel,
+              ),
+              ProductionLabourSection(
+                player: player,
+                currentOrders: currentOrders,
+                canEdit: canEdit,
+                callbacks: _noopCallbacks(),
+              ),
+            ],
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+List<String> _collected(WidgetTester tester) {
+  final out = <String>[];
+  collectTextPreorder(tester.element(find.byKey(_rootKey)), out);
+  return out;
+}
+
+void main() {
+  suppressLogsForTests();
+
+  late AppLocalizations l10n;
+
+  setUpAll(() {
+    l10n = lookupAppLocalizations(const Locale('en'));
+  });
+
+  group('productionLabourControlsExpectedTexts', () {
+    testWidgets(
+      'mirror reproduces the rendered Labour Controls pre-order text '
+      '(canEdit=true, mixed pool + queued + locked/unlocked tiers)',
+      (tester) async {
+        final player = _player(
+          peasants: 2,
+          apprentices: 1,
+          journeymen: 1,
+          masters: 1,
+          treasury: 500,
+          stockpile: {CommodityCatalog.paper.id: 50},
+          // Unlock only the apprentice tier so the mirror's (unlocked)/(locked)
+          // branch is exercised on both legs.
+          techUnlocked: const {
+            kTechIdApprenticeWorkers: true,
+            kTechIdSugarRefining: true,
+          },
+        );
+        final orders = Orders(
+          recruitWorkerOrdersByPlayerId: {
+            _playerId: const [
+              RecruitWorkerOrder(targetTier: WorkerTier.peasant),
+              RecruitWorkerOrder(targetTier: WorkerTier.peasant),
+            ],
+          },
+        );
+
+        await tester.pumpWidget(
+          _mount(player: player, currentOrders: orders, canEdit: true),
+        );
+        await pumpSettleCapped(tester);
+
+        final expected = productionLabourControlsExpectedTexts(
+          player: player,
+          currentOrders: orders,
+          canEdit: true,
+          l10n: l10n,
+        );
+
+        expect(
+          _collected(tester),
+          orderedEquals(expected),
+          reason:
+              'The expected-lines mirror must reproduce the rendered Labour '
+              'Controls section pre-order Text data exactly; any drift here '
+              'is the same drift the slow E2E lane would catch.',
+        );
+
+        // Absolute sanity pins on the values the mirror is built from.
+        expect(
+          expected.first,
+          'LABOUR CONTROLS',
+          reason: 'CtSectionLabel upper-cases the header text.',
+        );
+        expect(
+          expected.where((t) => t == l10n.production_labourDisband).length,
+          4,
+          reason:
+              'Disband label appears once per tier (3 trained buttons + the '
+              'opacity-0 peasant reserved slot the collector still visits).',
+        );
+        expect(
+          expected.contains(l10n.production_labourQueued(2)),
+          isTrue,
+          reason: 'Two queued peasant recruit orders render a Queued: 2 badge.',
+        );
+      },
+    );
+
+    testWidgets(
+      'mirror reproduces the rendered section with no action labels when '
+      'canEdit=false (negative: the canEdit=true mirror does not match)',
+      (tester) async {
+        final player = _player(peasants: 2, journeymen: 1);
+        const orders = Orders();
+
+        await tester.pumpWidget(
+          _mount(player: player, currentOrders: orders, canEdit: false),
+        );
+        await pumpSettleCapped(tester);
+
+        final collected = _collected(tester);
+
+        expect(
+          collected,
+          orderedEquals(
+            productionLabourControlsExpectedTexts(
+              player: player,
+              currentOrders: orders,
+              canEdit: false,
+              l10n: l10n,
+            ),
+          ),
+          reason:
+              'Read-only mode omits every action button, so no Disband label '
+              'is emitted; the mirror must match that.',
+        );
+        expect(
+          collected.contains(l10n.production_labourDisband),
+          isFalse,
+          reason: 'No Disband label renders when the panel is read-only.',
+        );
+        expect(
+          collected,
+          isNot(
+            orderedEquals(
+              productionLabourControlsExpectedTexts(
+                player: player,
+                currentOrders: orders,
+                canEdit: true,
+                l10n: l10n,
+              ),
+            ),
+          ),
+          reason:
+              'The canEdit=true mirror adds Disband labels absent from the '
+              'read-only render, so it must not match — guarding against the '
+              'mirror ignoring the canEdit flag.',
+        );
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Continues GitHub #2336 (E2E integration-test refactor / panel mirror drift) on branch `fix/issue-2336-e2e-panel-mirror-drift`.

### Done in latest push

- **Production-panel Labour Controls mirror.** The wide expected-lines mirror (`production_panel_e2e_expected_lines.dart`) omitted the Labour Controls section the panel appends to the Workers section, causing the full-turn E2E production-snapshot drift (`LABOUR CONTROLS` vs expected `Allocation`).
  - `CtE2eProductionPanelSnapshot` now carries `currentOrders` + `canEditLabour` (populated at the `production_screen.dart` capture site) so the mirror can reproduce the section.
  - New `productionLabourControlsExpectedTexts` reproduces the `CtSectionLabel` header (upper-cased) + one row per tier (tier label, optional `Queued: N`, and the `Disband` label emitted for every tier — trained buttons plus the opacity-0 peasant reserved slot the pre-order collector still visits).
  - New fast widget-test `app/test/production_labour_controls_expected_lines_test.dart` pins the mirror against the real `ProductionLabourSection` (+ header), positive (mixed pool / queued / locked+unlocked tiers) and negative (`canEdit=false`) cases. The full `productionPanelWideExpectedTexts` mirror is otherwise exercised only by the CI no-op E2E lane, so this layer catches drift at `flutter test` time.
- Brought the branch current with base `dev`.

### Earlier fixes in this PR

1. **Civilian Assign tap stability (headless Linux)** — `e2eTapEnclosingNinePatchButtonOrLabel`, `e2eTapAssignOnCivilianRowWithTitle` scoped to `CivilianUnitRowCard`, panel entrance settle + `e2eDragScrollableFromVisiblePoint`.
2. **Civilian panel text collection** — E2E-only civilian sheet height (92%), `ListView.cacheExtent`, `e2ePrepareCivilianPanelListForTextCollection`.
3. **Naval panel mirror drift** — omit Move/Split `Text` labels for non-home fleets under dense icon-only rendering; keep Home Fleet `Split` label.

### Verification

- `flutter test test/production_labour_controls_expected_lines_test.dart` -> pass (mirror == rendered `ProductionLabourSection`).
- `flutter test test/production_labour_section_test.dart` -> pass (20/20, unaffected).
- `flutter analyze` on touched lib/test files -> no issues.

### Remaining for #2336 (follow-up)

- `attempt_first_fleet_move` reports `no_move_button` (icon-only Move) — may need a naval interaction helper similar to the civilian nine-patch tap.
- AC8 baseline timing table + AC9 25% wall-clock reduction measurement (not captured in this PR).
- Re-run the full-turn E2E on headless Linux to confirm the production-panel snapshot now matches end-to-end (the wide mirror is not exercised by required PR checks per `SPEC/program/e2e-integration-tests.md`).

Refs #2336

Made with [Cursor](https://cursor.com)
