### PR TITLE
feat(ai): retain produced fabric build-input for lock-recovery sellers (Refs #2847)

### DIFF
--- a/SPEC/ai/treasury-planner.md
+++ b/SPEC/ai/treasury-planner.md
@@ -422,6 +422,36 @@ feedstock lookup is a pure function of the projected `Stockpile` and the static
 `RegimentEconomyCatalog` / `ProductionRecipesCatalog`; identical inputs yield
 identical offer sets.
 
+##### Produced build-input retention (Refs #2847 H8-extraction)
+
+The feedstock reservation above keeps the recipe feedstock (`wool` / `cotton`)
+from being sold so a `fabric` run becomes feasible, and the economy-planner
+production boost then runs that recipe. But the **produced build input**
+(`fabric`) is itself an offerable commodity: a recovered below-quota zero-NW
+lock-recovery seller is a strong-cargo Path-F seller that offers its surplus
+urgently every turn, so the `fabric` the boost just produced is sold back into
+the world market before it can accumulate to the `peasant_levies` build cost.
+The seller then stays trapped at zero regiments even though feedstock extraction
+and production are working (seed-42 gp5 / gp6 reach a feasible `fabric` run on
+~40+ turns yet hold `fabric` for only a handful, build ~3 regiments, and sit at
+zero regiments 15–20 turns).
+
+Under the **same** carve-out gate as the feedstock reservation
+(`_isBelowQuotaZeroNwLockRecoverySeller(game, playerId)` is `true`,
+`player.treasury >= cheapestRegimentBuildTreasuryCost()`, and
+`regimentCountForPlayer(game, playerId) == 0`), the planner therefore also
+withholds every `peasant_levies` build-input commodity
+(`RegimentEconomyCatalog.peasantLevies.buildInputs.keys`, i.e. `fabric`) from
+its offer-`available` map. The retention adds no order — it only removes the
+build input from the offer set — so the domestically produced `fabric`
+accumulates across turns until `suggestBuildOrders` can surface the cheapest
+regiment. It is self-clearing: the enclosing `regimentCount == 0` guard releases
+the retention the turn the regiment lands. Like the feedstock reservation it is
+scoped to the below-quota zero-NW zero-regiment recovered band, so the +6 OW
+baseline GPs (gp1 / gp2, above quota and holding regiments) never withhold
+`fabric`. The build-input lookup is a pure function of the static
+`RegimentEconomyCatalog`; identical inputs yield identical offer sets.
+
 ##### Residual feedstock-acquisition dependency (disclosure)
 
 This reservation only has effect when the seller **already holds** the recipe
@@ -457,6 +487,20 @@ feedstock is on hand.
   seller) with surplus `wool` / `cotton`, when `runTreasuryPlanner` runs, then
   it emits those surplus offers as normal (the reservation is scoped to
   below-quota zero-NW sellers).
+- Given a below-quota zero-NW lock-recovery seller with
+  `player.treasury >= cheapestRegimentBuildTreasuryCost()`,
+  `regimentCountForPlayer(game, playerId) == 0`, and surplus `fabric` (the
+  cheapest regiment's build input) it would otherwise offer, when
+  `runTreasuryPlanner` runs, then it emits **no** `TradeOrderType.offer` for
+  `fabric` (the produced build input is retained for the regiment build).
+- Given an otherwise identical lock-recovery seller with
+  `regimentCountForPlayer(game, playerId) > 0` and surplus `fabric`, when
+  `runTreasuryPlanner` runs, then it emits its surplus `fabric` offer as normal
+  (the build-input retention targets the zero-regiment rebuild gap only).
+- Given an AI Great Power at or above the conquest quota (not a lock-recovery
+  seller) with surplus `fabric`, when `runTreasuryPlanner` runs, then it emits
+  that surplus `fabric` offer as normal (the retention is scoped to below-quota
+  zero-NW sellers).
 - Given identical inputs, when `runTreasuryPlanner` runs twice on the
   feedstock-reservation path, then both runs return identical
   `List<TradeOrder>` outputs (determinism).

--- a/packages/colonizethis_ai/lib/src/planning/treasury_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/treasury_planner.dart
@@ -418,6 +418,27 @@ void _applyLockRecoverySellerRegimentRebuildBids({
       regimentCountForPlayer(game, playerId) != 0) {
     return;
   }
+  // Refs #2847 § H8-extraction build-input retention: a recovered zero-regiment
+  // lock-recovery seller produces the cheapest regiment's build input
+  // (`fabric`) domestically via the economy planner's regiment build-input
+  // production boost (economy-planner.md § Regiment build-input production
+  // priority). Withhold that produced build input from the offer set for the
+  // whole rebuild carve-out so the seller retains the `fabric` it needs to
+  // build the regiment instead of selling it back into the world market as
+  // surplus — the same retention the feedstock loop below already applies to
+  // the `wool` / `cotton` feedstock. Without this the boosted recipe's output
+  // is offered every turn (the seller is a strong-cargo Path-F seller, so any
+  // surplus is sold urgently) and `fabric` never accumulates to the
+  // `peasant_levies` build cost, leaving the recovered seller trapped at zero
+  // regiments. The enclosing `regimentCount == 0` guard self-clears the
+  // reservation the turn the regiment lands, and the gate only fires for a
+  // below-quota zero-NW lock-recovery seller, so the +6 OW baseline GPs
+  // (gp1 / gp2) are never affected. SPEC/ai/treasury-planner.md
+  // § Produced build-input retention.
+  for (final buildInputId
+      in RegimentEconomyCatalog.peasantLevies.buildInputs.keys) {
+    available.remove(buildInputId);
+  }
   // Refs #2847 H8-extraction: improvement-input prerequisite. The seller's
   // routed Builder cannot extract its owned feedstock tile until it holds the
   // level-0 `build_improvement` material (lumber + cast iron) it has zero of —

--- a/packages/colonizethis_ai/test/planning/treasury_planner_regiment_input_retention_test.dart
+++ b/packages/colonizethis_ai/test/planning/treasury_planner_regiment_input_retention_test.dart
@@ -1,0 +1,180 @@
+/// Lock-recovery seller produced build-input retention
+/// (Refs #2847 § H8-extraction).
+///
+/// The feedstock reservation (treasury-planner.md § Build-input feedstock
+/// reservation) keeps the recipe feedstock (`wool` / `cotton`) from being sold
+/// so a `fabric` run becomes feasible, and the economy-planner production boost
+/// then runs that recipe. But the **produced build input** (`fabric`) is itself
+/// an offerable commodity: a recovered below-quota zero-NW lock-recovery seller
+/// is a strong-cargo Path-F seller that offers its surplus urgently every turn,
+/// so the `fabric` the boost just produced is sold back into the world market
+/// before it can accumulate to the `peasant_levies` build cost. These tests pin
+/// the narrow offer-side carve-out that withholds the produced `fabric` build
+/// input from the offer set while — and only while — the zero-regiment rebuild
+/// carve-out is active.
+library;
+
+import 'package:colonizethis_ai/src/planning/treasury_planner.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+const _fabricId = 'fabric';
+const _woolId = 'wool';
+
+Game _lockRecoverySellerGame({
+  required int treasury,
+  required int fabricHeld,
+  int woolHeld = 20,
+  int owProvinces = 3,
+  bool hasRegiment = false,
+}) {
+  const ow = 'oldWorld';
+  var stockpile = const Stockpile().applyDelta('grain', 80);
+  if (woolHeld > 0) {
+    stockpile = stockpile.applyDelta(_woolId, woolHeld);
+  }
+  if (fabricHeld > 0) {
+    stockpile = stockpile.applyDelta(_fabricId, fabricHeld);
+  }
+  return Game(
+    id: 'g-regiment-input-retention',
+    worldState: WorldState(
+      turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 50),
+      oldWorld: RegionData(
+        provinces: [
+          for (var i = 0; i < owProvinces; i++)
+            Province(id: '$ow|p_$i', regionId: ow, ownerId: 'gp1'),
+        ],
+      ),
+      newWorld: const RegionData(provinces: []),
+      armies: [
+        if (hasRegiment)
+          const Army(
+            id: 'army-gp1-field',
+            ownerId: 'gp1',
+            regionId: ow,
+            stationedProvinceId: '$ow|p_0',
+            regimentUnitIds: ['reg-1'],
+          ),
+      ],
+    ),
+    players: [
+      Player(
+        id: 'gp1',
+        displayName: 'GP1',
+        isHuman: false,
+        capitalProvinceId: '$ow|p_0',
+        stockpile: stockpile,
+        treasury: treasury,
+      ),
+    ],
+    worldMarketState: WorldMarketState.withDefaultPrices(const {
+      'grain': 10,
+      _woolId: 20,
+      _fabricId: 40,
+    }),
+  );
+}
+
+List<TradeOrder> _run(Game game) => runTreasuryPlanner(
+      game: game,
+      playerId: 'gp1',
+      stockpile: game.players.first.stockpile,
+      productionAssignments: const [],
+      treasury: game.players.first.treasury,
+    );
+
+List<TradeOrder> _fabricOffers(List<TradeOrder> orders) => orders
+    .where((o) => o.type == TradeOrderType.offer && o.commodityId == _fabricId)
+    .toList();
+
+void main() {
+  group(
+      'lock-recovery seller produced build-input retention '
+      '(Refs #2847 H8-extraction)', () {
+    final threshold = cheapestRegimentBuildTreasuryCost();
+    // A large surplus the seller would otherwise offer absent the retention.
+    const surplusFabric = 60;
+
+    test('fabric is a peasant_levies build input (guards the fixture)', () {
+      expect(
+        RegimentEconomyCatalog.peasantLevies.buildInputs.containsKey(_fabricId),
+        isTrue,
+        reason:
+            'This slice assumes the cheapest regiment consumes fabric, which '
+            'the lock-recovery seller produces domestically.',
+      );
+    });
+
+    test(
+      'recovered-treasury seller with zero regiments withholds its surplus '
+      'fabric from offers',
+      () {
+        final game = _lockRecoverySellerGame(
+          treasury: threshold,
+          fabricHeld: surplusFabric,
+        );
+        expect(
+          _fabricOffers(_run(game)),
+          isEmpty,
+          reason:
+              'The domestically produced build input must be retained so it '
+              'accumulates to the peasant_levies build cost rather than being '
+              'sold back into the world market as surplus.',
+        );
+      },
+    );
+
+    test('seller still below the regiment threshold keeps offering fabric', () {
+      // The retention shares the bootstrap gate: a broke seller is not yet
+      // rebuilding, so it keeps selling its surplus for liquidity.
+      final game = _lockRecoverySellerGame(
+        treasury: threshold - 1,
+        fabricHeld: surplusFabric,
+      );
+      expect(
+        _fabricOffers(_run(game)),
+        isNotEmpty,
+        reason:
+            'A still-broke seller keeps selling surplus for liquidity; the '
+            'retention only applies once treasury recovers.',
+      );
+    });
+
+    test('seller that already holds a regiment keeps offering fabric', () {
+      final game = _lockRecoverySellerGame(
+        treasury: threshold,
+        fabricHeld: surplusFabric,
+        hasRegiment: true,
+      );
+      expect(
+        _fabricOffers(_run(game)),
+        isNotEmpty,
+        reason: 'The retention targets the zero-regiment rebuild gap only.',
+      );
+    });
+
+    test('quota-met (non-seller) GP above threshold keeps offering fabric', () {
+      // owProvinces >= 10 lifts the GP out of the below-quota seller band.
+      final game = _lockRecoverySellerGame(
+        treasury: threshold,
+        fabricHeld: surplusFabric,
+        owProvinces: 12,
+      );
+      expect(
+        _fabricOffers(_run(game)),
+        isNotEmpty,
+        reason: 'The retention is scoped to below-quota zero-NW sellers.',
+      );
+    });
+
+    test('build-input retention path is deterministic', () {
+      final game = _lockRecoverySellerGame(
+        treasury: threshold,
+        fabricHeld: surplusFabric,
+      );
+      expect(_run(game), equals(_run(game)));
+    });
+  });
+}

--- a/packages/colonizethis_ai/test/seed42_observer_conquest_s7d_diagnostic_test.dart
+++ b/packages/colonizethis_ai/test/seed42_observer_conquest_s7d_diagnostic_test.dart
@@ -877,6 +877,47 @@ import 'support/faithful_full_ai_test_handoff.dart';
 /// `iron` > 0 simultaneously) then `gpCastIronProductionAssignedTurns` rise for
 /// gp3 / gp5 / gp6 before expecting OW gain to move.
 ///
+/// ### H8-extraction produced build-input retention (this slice, Refs #2847)
+///
+/// This slice closes the offer-side **symmetry gap** in the lock-recovery
+/// seller carve-out: the planner already withholds the fabric **feedstock**
+/// (`wool` / `cotton`) from a recovered zero-regiment seller's offers
+/// (treasury-planner.md § Build-input feedstock reservation), but it did **not**
+/// withhold the **produced build input** (`fabric`) itself. A recovered
+/// below-quota zero-NW seller is a strong-cargo Path-F seller that offers its
+/// surplus urgently every turn, so the `fabric` the economy-planner production
+/// boost produced was sold back into the world market before it could
+/// accumulate to the `peasant_levies` build cost. The fix withholds every
+/// `peasant_levies` build-input commodity under the **same** rebuild gate
+/// (below-quota zero-NW lock-recovery seller, `treasury >= cheapest cost`,
+/// zero regiments); it self-clears the turn a regiment lands. See
+/// treasury-planner.md § Produced build-input retention.
+///
+/// **Effect on the seed-42 surface (post-fix refresh):** the +6 OW baseline is
+/// preserved (gp1 = +6, gp2 = +6, gpRegimentPeak gp1 / gp2 = 5 / 5 unchanged)
+/// and behaviour is no longer byte-identical to the post-waiver baseline
+/// (gp5 / gp6 swap +2 / +1 → +1 / +2; gp5 now spends 15 colonial turns vs 1),
+/// but **no failing GP reaches the +3 floor** — the turn-100 OW gate stays
+/// open (gp3 = +2, gp4 = +1, gp5 = +1, gp6 = +2).
+///
+/// **Re-localization (binding constraint after this slice):** retention is
+/// **necessary but not sufficient** — it keeps produced `fabric`, but `fabric`
+/// is not *produced* on most feasible turns. For gp5 / gp6 the fabric recipe is
+/// feasible ~44 turns (`gpFabricRecipeFeasibleTurns` = 46 / 42, feedstock on
+/// hand 48 / 43) yet `gpRebuildReadyNoBuildMissingInputTurns` stays 7 / 11 and
+/// gp3 = 29 (and `gpRebuildReadyNoBuildInputsPresentTurns` = 0 for all — when
+/// the input *is* present they build). So on most rebuild-ready turns `fabric`
+/// is missing despite a feasible recipe: the economy-planner regiment
+/// build-input production boost is not actually assigning the `fabricFrom*`
+/// recipe. gp3 additionally never accumulates feedstock
+/// (`gpFeedstockInStockpileTurns` = 1 despite `gpFeedstockGateImprovedTileOwnedTurns`
+/// = 27). The next slice must target **fabric production allocation** (make the
+/// economy planner run the `fabricFrom*` recipe on feasible rebuild turns for
+/// the lock-recovery seller), not the offer side (feedstock reservation and
+/// build-input retention are both now in place). Verify by re-running this
+/// diagnostic and confirming `gpRebuildReadyNoBuildMissingInputTurns` falls for
+/// gp5 / gp6 before expecting OW gain to move.
+///
 /// ## How to refresh
 ///
 /// Skipped by default (long-running, ~4 minutes on the project


### PR DESCRIPTION
## Summary

Incremental slice on the long-running seed-42 turn-100 conquest gate (#2847). Closes the **offer-side symmetry gap** in the lock-recovery seller rebuild carve-out in `treasury_planner.dart`.

The planner already withholds the fabric **feedstock** (`wool` / `cotton`) from a recovered zero-regiment lock-recovery seller's offers (treasury-planner.md § Build-input feedstock reservation), but it did **not** withhold the **produced build input** (`fabric`) itself. A recovered below-quota zero-NW seller is a strong-cargo Path-F seller that offers surplus urgently every turn, so the `fabric` the economy-planner production boost produces was sold back into the world market before it could accumulate to the `peasant_levies` build cost — leaving the seller trapped at zero regiments.

This withholds every `peasant_levies` build-input commodity under the **same** rebuild gate (`_isBelowQuotaZeroNwLockRecoverySeller`, `treasury >= cheapestRegimentBuildTreasuryCost()`, zero regiments). It is self-clearing (releases the turn a regiment lands) and scoped so the +6 OW baseline GPs (gp1 / gp2, above quota and holding regiments) are never affected.

## Changes

- **SPEC** `SPEC/ai/treasury-planner.md`: new § Produced build-input retention with positive / negative / determinism ACs.
- **Impl** `treasury_planner.dart`: withhold `peasant_levies` build inputs from the offer set inside the existing rebuild carve-out.
- **Tests** `treasury_planner_regiment_input_retention_test.dart`: 6 cases (retention fires; self-clears below threshold / with a regiment / for quota-met GPs; determinism).
- **Diagnostic** `seed42_observer_conquest_s7d_diagnostic_test.dart`: refreshed findings + re-localization comment.

## Honest scope / verification

This is a **correct-by-construction increment, not a gate close.** S7-D refresh (100-turn seed-42, run locally):

- +6 OW baseline preserved: gp1 = +6, gp2 = +6 (`gpRegimentPeak` 5 / 5 unchanged).
- Behaviour changes in the intended direction (no longer byte-identical to the post-waiver baseline; gp5 spends 15 colonial turns vs 1), but **no failing GP reaches the +3 floor** — the turn-100 OW gate stays open (gp3 / gp4 / gp5 / gp6 = +2 / +1 / +1 / +2).
- **Re-localization for the next slice:** retention is necessary-but-not-sufficient. `fabric` is feasible ~44 turns for gp5 / gp6 (feedstock on hand 48 / 43) yet `gpRebuildReadyNoBuildMissingInputTurns` stays 7 / 11 (gp3 = 29) — so `fabric` is not *produced* on most feasible turns. The next slice must target **fabric production allocation** (make the economy-planner build-input boost run the `fabricFrom*` recipe on feasible rebuild turns), not the offer side (feedstock reservation + build-input retention are both now in place).

## Test plan

- [x] `dart analyze` clean on touched files
- [x] New retention test (6 cases) green
- [x] Full `colonizethis_ai` planning suite green (1310 tests)
- [x] S7-D diagnostic re-run (gp1/gp2 +6 preserved; gate localization refreshed)

Refs #2847

Made with [Cursor](https://cursor.com)