### PR TITLE
test(e2e): multi-label intro pass without 5s Continue settle (Refs #2336)

### DIFF
--- a/app/integration_test/e2e_test_shared.dart
+++ b/app/integration_test/e2e_test_shared.dart
@@ -111,6 +111,20 @@ const String kE2eDefaultAdvanceGameStartIntroPhase =
 const String kE2eAdvanceGameStartIntroIterationsCounter =
     'advance_game_start_intro_until_dismissed_iterations';
 
+/// Yarn intro control labels tried in order each loop iteration (GitHub #2336).
+const List<String> kE2eGameStartIntroControlLabels = ['Continue', 'I shall.'];
+
+/// Per-control post-tap settle budget after an intro button tap.
+///
+/// Intermediate controls (for example **Continue** before **I shall.**) do not
+/// dismiss the blocking shell; the legacy 5 s [e2ePumpUntilConditionOrIdle]
+/// cap per tap therefore burned ~5 s on every bootstrap before the next label
+/// could be tried. A shorter cap keeps frame settlement without blocking the
+/// multi-label pass (Refs GitHub #2336 AC5 / bootstrap wall-clock).
+const Duration kE2eDefaultIntroControlPostTapSettleTimeout = Duration(
+  milliseconds: 500,
+);
+
 /// Advances yarn intro lines/choices until the overlay no longer blocks taps.
 ///
 /// The spinner / no-tap-target branches previously each paid a fixed 50 ms
@@ -120,6 +134,14 @@ const String kE2eAdvanceGameStartIntroIterationsCounter =
 /// is reset to 25 ms whenever a tap advances the overlay or the loading
 /// indicator clears, mirroring the prepump-free panel openers landed in this
 /// PR. Refs GitHub #2336 AC5 / pump-reduction.
+///
+/// **Multi-label pass:** each loop iteration tries every label in
+/// [kE2eGameStartIntroControlLabels] without breaking after the first tap.
+/// Intermediate controls (for example **Continue** before **I shall.**) keep
+/// the blocking shell mounted; the per-control post-tap settle uses
+/// [kE2eDefaultIntroControlPostTapSettleTimeout] (500 ms) instead of the
+/// legacy 5 s cap so bootstrap does not burn ~5 s waiting for full dismissal
+/// before the next control is tapped.
 ///
 /// Perf attribution (Refs GitHub #2336 AC8 / baseline measurement):
 ///
@@ -169,7 +191,10 @@ Future<void> e2eAdvanceGameStartIntroUntilDismissed(
     }
     final overlay = find.byType(GameStartIntroOverlay);
     var tapped = false;
-    for (final label in ['Continue', 'I shall.']) {
+    for (final label in kE2eGameStartIntroControlLabels) {
+      if (!e2eGameStartIntroBlocksUi(tester)) {
+        break;
+      }
       final control = find
           .descendant(of: overlay, matching: find.text(label))
           .hitTestable();
@@ -180,13 +205,12 @@ Future<void> e2eAdvanceGameStartIntroUntilDismissed(
       await e2ePumpUntilConditionOrIdle(
         tester,
         () => !e2eGameStartIntroBlocksUi(tester),
-        timeout: const Duration(seconds: 5),
+        timeout: kE2eDefaultIntroControlPostTapSettleTimeout,
         perf: perf,
         phaseName: 'pump_until_intro_advance_after_$label',
       );
       tapped = true;
       idlePollMs = 25;
-      break;
     }
     if (!tapped) {
       await tester.pump(Duration(milliseconds: idlePollMs));
@@ -596,11 +620,16 @@ Future<void> e2eScrollButtonIntoHitTestableView(
     return;
   }
   const maxScrollSteps = 20;
-  for (var i = 0;
-      i < maxScrollSteps && button.hitTestable().evaluate().isEmpty;
-      i++) {
-    final dragged =
-        await e2eDragScrollableFromVisiblePoint(tester, scrollable, const Offset(0, -120));
+  for (
+    var i = 0;
+    i < maxScrollSteps && button.hitTestable().evaluate().isEmpty;
+    i++
+  ) {
+    final dragged = await e2eDragScrollableFromVisiblePoint(
+      tester,
+      scrollable,
+      const Offset(0, -120),
+    );
     if (!dragged) {
       break;
     }
@@ -760,7 +789,10 @@ Future<void> e2eTapFirstAssignInCivilianPanel(WidgetTester tester) async {
     120,
     scrollable: panelScrollable,
   );
-  final didTap = await e2eTapEnclosingNinePatchButtonOrLabel(tester, firstAssign);
+  final didTap = await e2eTapEnclosingNinePatchButtonOrLabel(
+    tester,
+    firstAssign,
+  );
   expect(
     didTap,
     isTrue,
@@ -889,7 +921,11 @@ Future<void> e2eTapAssignOnCivilianRowWithTitle(
   for (var i = 0; i < n; i++) {
     final titleAt = titlesInList.at(i);
     try {
-      await tester.scrollUntilVisible(titleAt, 120, scrollable: panelScrollable);
+      await tester.scrollUntilVisible(
+        titleAt,
+        120,
+        scrollable: panelScrollable,
+      );
     } catch (_) {}
     try {
       await tester.ensureVisible(titleAt);
@@ -903,7 +939,10 @@ Future<void> e2eTapAssignOnCivilianRowWithTitle(
       continue;
     }
     final assignHit = assign.first;
-    final didTap = await e2eTapEnclosingNinePatchButtonOrLabel(tester, assignHit);
+    final didTap = await e2eTapEnclosingNinePatchButtonOrLabel(
+      tester,
+      assignHit,
+    );
     expect(
       didTap,
       isTrue,

--- a/app/test/e2e_advance_game_start_intro_test.dart
+++ b/app/test/e2e_advance_game_start_intro_test.dart
@@ -90,6 +90,35 @@ void main() {
   // short-circuit / timeout tests at the top of this file (which all pass
   // `perf: null` by default).
 
+  group('e2eAdvanceGameStartIntroUntilDismissed multi-label pass', () {
+    test(
+      'control label order and post-tap settle cap stay pinned for bootstrap '
+      'wall-clock (#2336 AC5)',
+      () {
+        expect(
+          kE2eGameStartIntroControlLabels,
+          ['Continue', 'I shall.'],
+          reason:
+              'Yarn intro controls must be tried in narrative order so an '
+              'intermediate Continue tap can be followed by I shall. in the '
+              'same loop iteration.',
+        );
+        expect(
+          kE2eDefaultIntroControlPostTapSettleTimeout,
+          const Duration(milliseconds: 500),
+          reason:
+              'Per-control settle must stay well below the legacy 5 s cap so '
+              'bootstrap does not burn seconds waiting for full dismissal '
+              'after an intermediate control tap.',
+        );
+        expect(
+          kE2eDefaultIntroControlPostTapSettleTimeout.inMilliseconds,
+          lessThan(5000),
+        );
+      },
+    );
+  });
+
   group('e2eAdvanceGameStartIntroUntilDismissed perf attribution', () {
     test('phase constant matches the documented '
         '`advance_game_start_intro_until_dismissed` label', () {


### PR DESCRIPTION
## Summary

Bootstrap hot-path slice for #2336: `e2eAdvanceGameStartIntroUntilDismissed` no longer breaks after the first intro control tap or waits up to 5s for full dismissal when an intermediate control (Continue) keeps the blocking shell mounted.

## Changes

- **Impl** `e2e_test_shared.dart`: try every label in `kE2eGameStartIntroControlLabels` per loop iteration; cap per-control post-tap settle via `kE2eDefaultIntroControlPostTapSettleTimeout` (500 ms).
- **Tests** `e2e_advance_game_start_intro_test.dart`: pin label order + settle cap constants.

## AC coverage (this slice)

| AC | Status |
|----|--------|
| AC5 (adaptive polling / bootstrap helpers) | **Partial** — intro dismiss path no longer uses 5 s fixed settle after intermediate controls |
| AC6–AC7 (3× E2E pass) | **Partial** — `new_game_capital_panel_e2e_test.dart` 1× pass on Linux+xvfb+dev Flutter (see timing below); full 3× suite campaign still outstanding |
| AC8–AC9 (baseline table + ≥25% aggregate) | **Deferred** — needs `tool/run_e2e_timing.sh 3` on pre-slice baseline commit vs this branch for all three integration targets |

## Local timing evidence (`new_game_capital_panel_e2e_test.dart`, 1 run, Linux+xvfb)

| Phase | Before (origin/dev) | After (this PR) | Δ |
|-------|---------------------|-----------------|---|
| `pump_until_intro_advance_after_Continue` | 5065 ms (timeout) | 672 ms (timeout, 500 ms cap) | −4393 ms |
| `advance_game_start_intro_until_dismissed` | 5972 ms | 1633 ms | −4339 ms |
| `new_game_to_map` | 10909 ms | 6934 ms | −3975 ms |
| `test_total` | 13164 ms | 9172 ms | −3992 ms (~30%) |

## Deferred

- Full AC8/AC9 measurement across all three E2E targets (3 consecutive runs each) with historical baseline commit.
- Remaining bootstrap / fleet-loop optimizations not touched in this slice.

## Tests run

- `flutter analyze` on touched files — clean
- `flutter test test/e2e_advance_game_start_intro_test.dart` — 9/9 pass
- `flutter test integration_test/new_game_capital_panel_e2e_test.dart -d linux --dart-define=CT_E2E=true` (xvfb) — pass

Refs #2336

Made with [Cursor](https://cursor.com)