### PR TITLE
feat(logic): reserve OW feedstock Builder + Explorer under H8 gate (#2847)

### DIFF
--- a/SPEC/program/order-suggestions.md
+++ b/SPEC/program/order-suggestions.md
@@ -251,6 +251,30 @@ The boost is **gated** by the same self-clearing feedstock set: for every ordina
 
 ---
 
+## Old World feedstock unit reservation (Refs #2847 H8-extraction)
+
+The co-availability ordering and mineral-prospecting boosts above can only re-rank suggestions that **exist** for a unit, and the feedstock `build_improvement` / `prospect` boosts can only select a unit that is **available** (idle, in the Old World where the feedstock tile is). On seed 42 the affluent supplier owns an unimproved Old World `iron` / `timber` feedstock tile on every gate-active turn, but each idle Builder and Explorer scores higher on **New World** owned-resource colonial work (the New World bonuses in `_buildImprovementWorkScore` / `_eScore`) and migrates there, so no unit is ever positioned to prospect or improve the Old World feedstock tile (`gpFeedstockGateIdleBuilderPresentTurns == 0` for the suppliers).
+
+To close this, `selectFullAiCivilianWorkOrders` (`packages/colonizethis_logic/lib/src/ai/full_ai_civilian_work_selection.dart`) reserves, per active player, **at most one** idle Builder and **at most one** idle Explorer for Old World feedstock work when the player's `feedstockExtractionResourceIdsForPlayer` gate is active:
+
+- The reserved Builder is the lexicographically-smallest idle (`currentWork == null`) Builder, reserved **only** when the player owns an **unimproved Old World** tile hosting a gate feedstock resource.
+- The reserved Explorer is the lexicographically-smallest idle Explorer, reserved **only** when the player owns an **unprospected Old World mineral** tile hosting a gate feedstock resource.
+- For a reserved unit, every work order whose `targetTileKey` is in the New World region (`Unit.regionIdFromTileKey == kNewWorldRegionId`) is dropped from its candidate list before scoring. The unit therefore keeps only its Old World candidates (and is selected onto the feedstock tile by the existing boosts), or — when it has no Old World candidate this turn — stays idle in the Old World rather than migrating to the New World.
+
+The reservation is **gated** by the same self-clearing feedstock set: for every ordinary player it is empty and selection is unchanged; it self-clears once the feedstock tiles are improved/prospected or the gate clears. It only ever holds back **one** Builder and **one** Explorer, leaving every other idle unit free for New World work, so it does not regress New World colonial throughput beyond a single reserved unit of each type. It adds **no** new work order, bypasses **no** suggestion/visibility/order-engine gate, and introduces **no** `ai_victory_config.dart` constant. It is a pure, deterministic function of `(game, view.ownUnits, feedstock set)`.
+
+**Acceptance criteria (Old World feedstock unit reservation)**
+
+- Given a player whose feedstock-extraction gate is active for `{timber, iron}`, who owns an unimproved Old World `iron` tile, and whose lone idle Builder has both a New World `build_improvement` order and an Old World `iron` `build_improvement` order, when `selectFullAiCivilianWorkOrders` runs, then the Builder is assigned the Old World `iron` order.
+- Given the same gate and two idle Builders each with only a New World `build_improvement` order, when `selectFullAiCivilianWorkOrders` runs, then the lexicographically-smallest Builder is left idle (no work order; `no_suggestions` idle event) and the other Builder keeps its New World order.
+- Given the same gate, an owned unprospected Old World `iron` mineral tile, and a lone idle Explorer with both a New World `explore` order and an Old World `iron` `prospect` order, when `selectFullAiCivilianWorkOrders` runs, then the Explorer is assigned the Old World `iron` `prospect` order.
+- Given the same gate and two idle Explorers each with only a New World `explore` order, when `selectFullAiCivilianWorkOrders` runs, then the lexicographically-smallest Explorer is left idle and the other Explorer keeps its New World order.
+- Given the feedstock-extraction gate is **inactive** (peer seller at quota), a Builder with only a New World `build_improvement` order, when `selectFullAiCivilianWorkOrders` runs, then no reservation applies and the Builder is assigned the New World order (negative control).
+- Given the gate active but the supplier's Old World feedstock tiles are all already improved, a Builder with only a New World `build_improvement` order, when `selectFullAiCivilianWorkOrders` runs, then no reservation applies and the Builder is assigned the New World order (negative control).
+- Given identical inputs with the gate active, when `selectFullAiCivilianWorkOrders` runs twice, then both runs produce the same work-order list (determinism).
+
+---
+
 ## Feedstock bootstrap `castIron` waiver for level-0 `build_improvement` (Refs #2847 H8-extraction)
 
 When the feedstock-extraction gate is active and a Builder targets an **unimproved** feedstock resource tile, the order engine and work application use the **effective** material cost from `WorkOrderCostCalculator` (player-scoped), which may omit **cast iron** for the level-0 improvement while the stockpile holds enough **lumber** but not enough **cast iron** (see [extraction-and-improvements.md](../game/extraction-and-improvements.md) § Improvement Build Costs (Builder) — H8 feedstock bootstrap). This makes feedstock-priority suggestions **affordable** on seed 42 where `gpFeedstockGateImprovementCostAffordableTurns` stayed zero solely because of the circular cast-iron dependency; it does not bypass visibility, probe budget, tech cap, or non-material validation gates.

--- a/packages/colonizethis_logic/lib/src/ai/full_ai_civilian_work_selection.dart
+++ b/packages/colonizethis_logic/lib/src/ai/full_ai_civilian_work_selection.dart
@@ -753,6 +753,150 @@ Set<String> _peerLockRecoverySellerNeededProducibleImprovementInputs(
   return result;
 }
 
+/// True iff [playerId] owns at least one **Old World** province tile hosting a
+/// resource in [feedstockIds] that is still unimproved (`improvementLevel < 1`)
+/// — the `build_improvement` target a supplier (or seller) must keep an idle
+/// Builder in the Old World to extract (Refs #2847 § H8-extraction supplier
+/// Old World feedstock unit reservation). Old World is every region that is not
+/// [kNewWorldRegionId], derived from the tile key alone so the scan works from
+/// `WorldState.resourceByTileKey`. Read-only and deterministic.
+bool _ownsUnimprovedOldWorldFeedstockTile(
+  Game game,
+  String playerId,
+  Set<String> feedstockIds,
+) {
+  if (feedstockIds.isEmpty) return false;
+  final ws = game.worldState;
+  for (final entry in ws.resourceByTileKey.entries) {
+    if (!feedstockIds.contains(entry.value)) continue;
+    if (Unit.regionIdFromTileKey(entry.key) == kNewWorldRegionId) continue;
+    final provinceId = Unit.provinceIdFromTileKey(entry.key);
+    if (provinceId == null) continue;
+    final province = tryGetProvince(ws, provinceId);
+    if (province == null || province.ownerId != playerId) continue;
+    if (ws.tileState.improvementLevel(entry.key) < 1) return true;
+  }
+  return false;
+}
+
+/// True iff [playerId] owns at least one **Old World** province tile hosting an
+/// **unprospected mineral** feedstock resource in [feedstockIds] — the
+/// `prospect` target a supplier (or seller) must keep an idle Explorer in the
+/// Old World to expose before the Builder can improve it (Refs #2847
+/// § H8-extraction supplier Old World feedstock unit reservation). Read-only
+/// and deterministic.
+bool _ownsUnprospectedOldWorldMineralFeedstockTile(
+  Game game,
+  String playerId,
+  Set<String> feedstockIds,
+) {
+  if (feedstockIds.isEmpty) return false;
+  final ws = game.worldState;
+  for (final entry in ws.resourceByTileKey.entries) {
+    if (!feedstockIds.contains(entry.value)) continue;
+    if (Unit.regionIdFromTileKey(entry.key) == kNewWorldRegionId) continue;
+    final provinceId = Unit.provinceIdFromTileKey(entry.key);
+    if (provinceId == null) continue;
+    final province = tryGetProvince(ws, provinceId);
+    if (province == null || province.ownerId != playerId) continue;
+    if (_isUnprospectedMineralFeedstockTile(
+      game,
+      playerId,
+      entry.key,
+      feedstockIds,
+    )) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/// The (at most) one idle Builder and one idle Explorer the active player must
+/// keep in the Old World for H8 feedstock prospecting + extraction, instead of
+/// letting them migrate to New World colonial work (Refs #2847 § H8-extraction
+/// supplier Old World feedstock unit reservation).
+///
+/// The seed-42 affluent suppliers own an unimproved Old World `iron` / `timber`
+/// feedstock tile on every gate-active turn, yet every idle Builder / Explorer
+/// is routed to higher-scoring **New World** owned-resource work (the New World
+/// bonuses in [_buildImprovementWorkScore] / [_eScore]), so the now-correct
+/// prospecting / co-availability ordering chain never gets a unit positioned on
+/// the Old World feedstock tile. Holding one idle Builder and one idle Explorer
+/// out of New World work keeps them available for the Old World feedstock
+/// `prospect` + `build_improvement` the existing
+/// [kFeedstockMineralProspectScoreBoost] /
+/// [kRegimentBuildInputFeedstockExtractionScoreBoost] boosts then select.
+class _OwFeedstockReservation {
+  const _OwFeedstockReservation({this.builderUnitId, this.explorerUnitId});
+
+  final String? builderUnitId;
+  final String? explorerUnitId;
+
+  static const none = _OwFeedstockReservation();
+
+  bool reserves(String unitId) =>
+      unitId == builderUnitId || unitId == explorerUnitId;
+}
+
+/// Resolves the [_OwFeedstockReservation] for the active player.
+///
+/// Returns [_OwFeedstockReservation.none] unless the feedstock-extraction gate
+/// is active ([feedstockExtractionResourceIds] non-empty). When active, reserves
+/// the lexicographically-smallest idle (`currentWork == null`) Builder iff the
+/// player owns an unimproved Old World feedstock tile, and the
+/// lexicographically-smallest idle Explorer iff the player owns an unprospected
+/// Old World mineral feedstock tile. Deterministic over
+/// `(view.ownUnits, game, feedstockExtractionResourceIds)`.
+_OwFeedstockReservation _resolveOwFeedstockReservation(
+  PlayerView view,
+  Game game,
+  Set<String> feedstockExtractionResourceIds,
+) {
+  if (feedstockExtractionResourceIds.isEmpty) {
+    return _OwFeedstockReservation.none;
+  }
+  final playerId = view.playerId;
+  final reserveBuilder = _ownsUnimprovedOldWorldFeedstockTile(
+    game,
+    playerId,
+    feedstockExtractionResourceIds,
+  );
+  final reserveExplorer = _ownsUnprospectedOldWorldMineralFeedstockTile(
+    game,
+    playerId,
+    feedstockExtractionResourceIds,
+  );
+  if (!reserveBuilder && !reserveExplorer) return _OwFeedstockReservation.none;
+  final idleBuilders = <String>[];
+  final idleExplorers = <String>[];
+  for (final unit in view.ownUnits) {
+    if (unit.currentWork != null) continue;
+    if (reserveBuilder && unit.type == kUnitTypeBuilder) {
+      idleBuilders.add(unit.id);
+    }
+    if (reserveExplorer && isExplorerUnit(unit.type)) {
+      idleExplorers.add(unit.id);
+    }
+  }
+  idleBuilders.sort();
+  idleExplorers.sort();
+  return _OwFeedstockReservation(
+    builderUnitId: idleBuilders.isEmpty ? null : idleBuilders.first,
+    explorerUnitId: idleExplorers.isEmpty ? null : idleExplorers.first,
+  );
+}
+
+/// Drops every New World `targetTileKey` work order from [orders] so a reserved
+/// Old World feedstock unit is not routed to New World colonial work. Leaves the
+/// unit with only its Old World candidates (or none, in which case it stays idle
+/// in the Old World). Refs #2847 § H8-extraction supplier Old World feedstock
+/// unit reservation.
+void _dropNewWorldWorkOrders(List<WorkOrder> orders) {
+  orders.removeWhere(
+    (w) => Unit.regionIdFromTileKey(w.targetTileKey) == kNewWorldRegionId,
+  );
+}
+
 WorkOrder? _bestBuildImprovementRow(
   List<WorkOrder> candidates,
   Game game, {
@@ -986,6 +1130,7 @@ void _appendSelectionForUnitId({
   required List<WorkOrder> workOrders,
   required List<FullAiCivilianWorkIdle> idleEvents,
   Set<String> feedstockExtractionResourceIds = const <String>{},
+  _OwFeedstockReservation reservation = _OwFeedstockReservation.none,
 }) {
   final W = List<WorkOrder>.from(byUnit[unitId] ?? const <WorkOrder>[]);
   _sortWorkOrdersLex(W);
@@ -994,6 +1139,14 @@ void _appendSelectionForUnitId({
   if (unit != null &&
       (unit.currentWork != null || !_civilianWorkCapableType(unit.type))) {
     return;
+  }
+
+  // Refs #2847 § H8-extraction: a reserved Old World feedstock unit keeps only
+  // its Old World candidates so it is not routed to higher-scoring New World
+  // colonial work, staying available for the Old World feedstock prospect /
+  // build_improvement the feedstock score boosts then select.
+  if (reservation.reserves(unitId)) {
+    _dropNewWorldWorkOrders(W);
   }
 
   final isExplorerCase = unit != null && isExplorerUnit(unit.type);
@@ -1079,6 +1232,11 @@ FullAiCivilianWorkSelectionResult selectFullAiCivilianWorkOrders({
     game,
     view.playerId,
   );
+  final reservation = _resolveOwFeedstockReservation(
+    view,
+    game,
+    feedstockExtractionResourceIds,
+  );
 
   for (final unitId in allUnitIds) {
     _appendSelectionForUnitId(
@@ -1091,6 +1249,7 @@ FullAiCivilianWorkSelectionResult selectFullAiCivilianWorkOrders({
       workOrders: workOrders,
       idleEvents: idleEvents,
       feedstockExtractionResourceIds: feedstockExtractionResourceIds,
+      reservation: reservation,
     );
   }
 

--- a/packages/colonizethis_logic/test/full_ai_civilian_work_ow_feedstock_reservation_test.dart
+++ b/packages/colonizethis_logic/test/full_ai_civilian_work_ow_feedstock_reservation_test.dart
@@ -1,0 +1,295 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/ai_api.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+import 'full_ai_civilian_work_supplier_feedstock_extraction_fixtures.dart';
+
+// Refs #2847 § H8-extraction supplier Old World feedstock unit reservation.
+//
+// The affluent supplier owns an unimproved Old World `iron` (mineral) tile and
+// `timber` tile on every gate-active turn, but its idle Builders / Explorers
+// migrate to higher-scoring New World colonial work, so the feedstock tile is
+// never prospected / improved. `selectFullAiCivilianWorkOrders` must hold one
+// idle Builder and one idle Explorer out of New World work so they stay
+// available for the Old World feedstock `prospect` / `build_improvement`.
+
+const _supplierIronTile = 'oldWorld|s0|2|0';
+const _newWorldTile = 'newWorld|n0|0|0';
+
+Game _ironFeedstockGame({
+  int sellerOw = 5,
+  TileMapState? tileState,
+}) {
+  return twoPlayerSupplierFeedstockGame(
+    sellerOw: sellerOw,
+    resourceByTileKey: const {
+      supplierTimberTile: 'timber',
+      _supplierIronTile: 'iron',
+      supplierGrainTile: 'grain',
+      sellerWoolTile: 'wool',
+      _newWorldTile: 'iron',
+    },
+    tileState: tileState,
+  );
+}
+
+PlayerView _supplierView(Game game, List<Unit> units) {
+  return PlayerView(
+    playerId: supplierFeedstockId,
+    player: game.players.firstWhere((p) => p.id == supplierFeedstockId),
+    ownUnitsById: {for (final u in units) u.id: u},
+    provincesById: const {},
+    visibilityByTile: const {},
+    prospectedTiles: const {},
+    diplomacyByOtherId: const {},
+  );
+}
+
+Unit _idleBuilder(String id) => Unit(
+  id: id,
+  type: kUnitTypeBuilder,
+  ownerId: supplierFeedstockId,
+  locationProvinceId: 'oldWorld|s0',
+);
+
+Unit _idleExplorer(String id) => Unit(
+  id: id,
+  type: kUnitTypeExplorer,
+  ownerId: supplierFeedstockId,
+  locationProvinceId: 'oldWorld|s0',
+);
+
+void main() {
+  group(
+    'selectFullAiCivilianWorkOrders Old World feedstock unit reservation '
+    '(Refs #2847 H8-extraction)',
+    () {
+      test(
+        'reserved Builder routes to Old World feedstock tile, not New World',
+        () {
+          final game = _ironFeedstockGame();
+          final view = _supplierView(game, [_idleBuilder('b1')]);
+          final suggestions = [
+            const WorkOrder(
+              unitId: 'b1',
+              target: kWorkTargetBuildImprovement,
+              targetTileKey: _newWorldTile,
+            ),
+            const WorkOrder(
+              unitId: 'b1',
+              target: kWorkTargetBuildImprovement,
+              targetTileKey: _supplierIronTile,
+            ),
+          ];
+          final r = selectFullAiCivilianWorkOrders(
+            workSuggestions: suggestions,
+            view: view,
+            game: game,
+          );
+          expect(r.workOrders, hasLength(1));
+          expect(r.workOrders.single.targetTileKey, _supplierIronTile);
+        },
+      );
+
+      test(
+        'lex-first idle Builder is held out of New World; the next Builder '
+        'still takes New World work',
+        () {
+          final game = _ironFeedstockGame();
+          final view = _supplierView(game, [
+            _idleBuilder('b1'),
+            _idleBuilder('b2'),
+          ]);
+          final suggestions = [
+            const WorkOrder(
+              unitId: 'b1',
+              target: kWorkTargetBuildImprovement,
+              targetTileKey: _newWorldTile,
+            ),
+            const WorkOrder(
+              unitId: 'b2',
+              target: kWorkTargetBuildImprovement,
+              targetTileKey: _newWorldTile,
+            ),
+          ];
+          final r = selectFullAiCivilianWorkOrders(
+            workSuggestions: suggestions,
+            view: view,
+            game: game,
+          );
+          // b1 (reserved) drops its only (New World) candidate and goes idle;
+          // b2 keeps the New World improvement.
+          expect(r.workOrders, hasLength(1));
+          expect(r.workOrders.single.unitId, 'b2');
+          expect(r.workOrders.single.targetTileKey, _newWorldTile);
+          expect(
+            r.idleEvents.map((e) => e.unitId),
+            contains('b1'),
+          );
+        },
+      );
+
+      test(
+        'reserved Explorer prospects Old World mineral feedstock tile, not '
+        'New World explore',
+        () {
+          final game = _ironFeedstockGame();
+          final view = _supplierView(game, [_idleExplorer('e1')]);
+          final suggestions = [
+            const WorkOrder(
+              unitId: 'e1',
+              target: kWorkTargetExplore,
+              targetTileKey: _newWorldTile,
+            ),
+            const WorkOrder(
+              unitId: 'e1',
+              target: kWorkTargetProspect,
+              targetTileKey: _supplierIronTile,
+            ),
+          ];
+          final r = selectFullAiCivilianWorkOrders(
+            workSuggestions: suggestions,
+            view: view,
+            game: game,
+          );
+          expect(r.workOrders, hasLength(1));
+          expect(r.workOrders.single.target, kWorkTargetProspect);
+          expect(r.workOrders.single.targetTileKey, _supplierIronTile);
+        },
+      );
+
+      test(
+        'lex-first idle Explorer is held out of New World; the next Explorer '
+        'still explores New World',
+        () {
+          final game = _ironFeedstockGame();
+          final view = _supplierView(game, [
+            _idleExplorer('e1'),
+            _idleExplorer('e2'),
+          ]);
+          final suggestions = [
+            const WorkOrder(
+              unitId: 'e1',
+              target: kWorkTargetExplore,
+              targetTileKey: _newWorldTile,
+            ),
+            const WorkOrder(
+              unitId: 'e2',
+              target: kWorkTargetExplore,
+              targetTileKey: _newWorldTile,
+            ),
+          ];
+          final r = selectFullAiCivilianWorkOrders(
+            workSuggestions: suggestions,
+            view: view,
+            game: game,
+          );
+          expect(r.workOrders, hasLength(1));
+          expect(r.workOrders.single.unitId, 'e2');
+          expect(r.workOrders.single.targetTileKey, _newWorldTile);
+          expect(r.idleEvents.map((e) => e.unitId), contains('e1'));
+        },
+      );
+
+      test(
+        'off-gate (no peer demand): no reservation, Builder takes New World '
+        'work',
+        () {
+          // Seller at quota → not a below-quota lock-recovery seller → the
+          // supplier feedstock gate is inactive, so no reservation applies.
+          final game = _ironFeedstockGame(
+            sellerOw: kObserverConquestMinOwProvincesPerGp,
+          );
+          final view = _supplierView(game, [_idleBuilder('b1')]);
+          final suggestions = [
+            const WorkOrder(
+              unitId: 'b1',
+              target: kWorkTargetBuildImprovement,
+              targetTileKey: _newWorldTile,
+            ),
+          ];
+          final r = selectFullAiCivilianWorkOrders(
+            workSuggestions: suggestions,
+            view: view,
+            game: game,
+          );
+          expect(r.workOrders, hasLength(1));
+          expect(r.workOrders.single.unitId, 'b1');
+          expect(r.workOrders.single.targetTileKey, _newWorldTile);
+        },
+      );
+
+      test(
+        'no reservation when the supplier Old World feedstock tiles are all '
+        'improved (gate self-clears)',
+        () {
+          final improved = TileMapState()
+              .setImprovement(supplierTimberTile, 1)
+              .setImprovement(_supplierIronTile, 1);
+          final game = _ironFeedstockGame(tileState: improved);
+          final view = _supplierView(game, [_idleBuilder('b1')]);
+          final suggestions = [
+            const WorkOrder(
+              unitId: 'b1',
+              target: kWorkTargetBuildImprovement,
+              targetTileKey: _newWorldTile,
+            ),
+          ];
+          final r = selectFullAiCivilianWorkOrders(
+            workSuggestions: suggestions,
+            view: view,
+            game: game,
+          );
+          expect(r.workOrders, hasLength(1));
+          expect(r.workOrders.single.unitId, 'b1');
+          expect(r.workOrders.single.targetTileKey, _newWorldTile);
+        },
+      );
+
+      test('reservation selection is deterministic', () {
+        final game = _ironFeedstockGame();
+        final view = _supplierView(game, [
+          _idleBuilder('b1'),
+          _idleBuilder('b2'),
+          _idleExplorer('e1'),
+          _idleExplorer('e2'),
+        ]);
+        final suggestions = [
+          const WorkOrder(
+            unitId: 'b1',
+            target: kWorkTargetBuildImprovement,
+            targetTileKey: _supplierIronTile,
+          ),
+          const WorkOrder(
+            unitId: 'b2',
+            target: kWorkTargetBuildImprovement,
+            targetTileKey: _newWorldTile,
+          ),
+          const WorkOrder(
+            unitId: 'e1',
+            target: kWorkTargetProspect,
+            targetTileKey: _supplierIronTile,
+          ),
+          const WorkOrder(
+            unitId: 'e2',
+            target: kWorkTargetExplore,
+            targetTileKey: _newWorldTile,
+          ),
+        ];
+        final a = selectFullAiCivilianWorkOrders(
+          workSuggestions: suggestions,
+          view: view,
+          game: game,
+        );
+        final b = selectFullAiCivilianWorkOrders(
+          workSuggestions: suggestions,
+          view: view,
+          game: game,
+        );
+        expect(a.workOrders, equals(b.workOrders));
+      });
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Follow-up slice for **#2847** after PR #3256 merged (co-availability ordering + mineral prospecting boosts). Closes the **unit-allocation** gap: affluent suppliers own an unimproved Old World `iron` / `timber` feedstock tile every gate-active turn, but idle Builders / Explorers score higher on New World colonial work and migrate there, so the prospecting / ordering chain never gets a unit on the Old World feedstock tile.

Refs #2847

## Done in this push

1. **Old World feedstock unit reservation** (`full_ai_civilian_work_selection.dart`). When `feedstockExtractionResourceIdsForPlayer` is active:
   - Reserve the lex-first idle Builder (if an unimproved OW feedstock tile exists).
   - Reserve the lex-first idle Explorer (if an unprospected OW mineral feedstock tile exists).
   - For reserved units, drop all New World `targetTileKey` candidates before scoring so they stay on OW feedstock `prospect` / `build_improvement` (or idle in OW if no OW candidate this turn).
   - At most one Builder and one Explorer held back; all other idle units remain free for New World work.

### Tests

- `full_ai_civilian_work_ow_feedstock_reservation_test.dart`: 7 cases (Builder/Explorer OW routing, multi-unit lex-first holdback, off-gate negative, improved-tile self-clear, determinism).
- Related feedstock tests (24) + civilian-work selection suite (24) pass; `dart analyze` clean.

### Verification on seed 42 (S7-D diagnostic)

Ran `seed42_observer_conquest_s7d_diagnostic_test.dart --run-skipped`:

| Metric | Result |
|--------|--------|
| **OW gain** | gp1/gp2 **+6** (PASS baseline preserved); gp3 +2, gp4 +1, gp5 +2, gp6 +1 — byte-identical to post-#3256 baseline |
| **gpCastIronProductionAssignedTurns** | 0 for every GP (headline gate still inert) |
| **gpCastIronFeedstockHeldAtTurn99** | gp2 `{timber: 3, iron: 0}` — `iron` still not co-held |
| **Seller-side progress** | `gpFeedstockGateImprovedTileOwnedTurns` rises for gp3 (27), gp5 (6), gp6 (9); `gpFeedstockGateValidBuildImprovementCandidateTurns` > 0 for locked sellers |
| **Supplier idle Builder turns** | gp1/gp2 `gpFeedstockGateIdleBuilderPresentTurns` = 0 (all Builders busy every gate-active turn — reservation + assignment consuming units) |

**Honest disclosure:** Reservation is a necessary prerequisite and shows seller-side feedstock improvement progress, but **`castIron` production and OW conquest headline gates are still flat** within 100 turns because suppliers still do not co-hold `timber` + `iron` simultaneously and the full `extract → produce → build` chain has not completed.

### SPEC

- `SPEC/program/order-suggestions.md`: new § Old World feedstock unit reservation (+ ACs).

## Remaining for #2847 (recommended next slice)

Once `gpCastIronFeedstockHeldAtTurn99` shows `timber` **and** `iron` > 0 for a supplier, verify `gpCastIronProductionAssignedTurns` rises. If reservation alone does not achieve co-hold, the next slice likely needs **movement/staging** (recall or home-province assignment) so the reserved Builder/Explorer can reach the OW feedstock tile physically, not only avoid NW work in selection.

## Deferred

- Full turn-100 conquest gate green (`--verify-conquest`) — still blocked on completing the H8 `castIron` chain.
- Issues **#2848** / **#2852** remain blocked on #2847 landing meaningful OW gains for gp3–gp6.

Made with [Cursor](https://cursor.com)