### PR TITLE
fix: render pixelArt main menu chrome in live shell (S8) (#2860)

### DIFF
--- a/SPEC/ui/shell-screen.md
+++ b/SPEC/ui/shell-screen.md
@@ -12,7 +12,7 @@
 
 | Aspect | Value | Description |
 |--------|-------|-------------|
-| `variant` | `MainMenuVariant.plain` | Always passes `plain` — the pixel-art variant is owned by the menu spec. |
+| `variant` | `MainMenuVariant.pixelArt` | Always passes `pixelArt` so the live shell renders the mockup chrome (`SHEL10002-main-menu.html`) per [`main-menu.md`](main-menu.md) § Variant rendering. `MainMenuVariant.plain` is retained in the widget API as a minimal fallback variant but is not used by the running shell. |
 | `state` | `MainMenuState.default_` | Always passes `default_`; the post-victory subtitle is owned by [`victory-overlay.md`](victory-overlay.md) follow-up flow, not by this shell. |
 | `version` | `appDisplayVersion()` | Reads `appDisplayVersion()` from `app/lib/config/app_display_strings.dart` so `CT_DEBUG_CONSOLE` formatting works unchanged. |
 | `resumeGameVisible` | `mainMenuAutoSaveAvailableProvider` | Watches `mainMenuAutoSaveAvailableProvider` from `app/lib/providers/games_provider.dart`; recomputes whenever the games box changes per [`save-load.md`](../program/save-load.md). |
@@ -36,7 +36,7 @@ The shell does not own the menu UI: visual layout, asset choices, and per-state 
 | Shell (Routes.shell)                                 |
 | +--------------------------------------------------+ |
 | | CtMainMenu                                       | |
-| |   variant: plain                                 | |
+| |   variant: pixelArt                              | |
 | |   state:   default                               | |
 | |   version: appDisplayVersion()                   | |
 | |   resumeGameVisible: <auto-save available?>      | |
@@ -100,7 +100,11 @@ All cross-screen transitions use `AppEventBus` per [`app-ui-wiring.md`](../progr
 
 - Given the app navigator is at `Routes.shell` and `mainMenuAutoSaveAvailableProvider` returns `false`,
   When `ShellScreen.build` runs,
-  Then the widget tree contains exactly one `CtMainMenu` with `variant == MainMenuVariant.plain`, `state == MainMenuState.default_`, and `resumeGameVisible == false`.
+  Then the widget tree contains exactly one `CtMainMenu` with `variant == MainMenuVariant.pixelArt`, `state == MainMenuState.default_`, and `resumeGameVisible == false`.
+
+- Given the app navigator is at `Routes.shell` (the sole production caller of `CtMainMenu`),
+  When `ShellScreen` is mounted and laid out,
+  Then the live menu renders the `pixelArt` mockup chrome — exactly one `CtCompassRose`, at least one `CtFleurDeLisOrnament`, the eyebrow blurb "A Game of Empire & Discovery" (upper-cased), and the footer Quit chip keyed `kMainMenuFooterQuitKey` — and does not fall back to the bare `plain` variant.
 
 - Given the app navigator is at `Routes.shell` and `mainMenuAutoSaveAvailableProvider` returns `true`,
   When `ShellScreen.build` runs,

--- a/app/lib/features/shell/shell_screen.dart
+++ b/app/lib/features/shell/shell_screen.dart
@@ -25,7 +25,10 @@ class ShellScreen extends ConsumerWidget {
     final bus = ref.watch(appEventBusProvider);
     final resumeAvailable = ref.watch(mainMenuAutoSaveAvailableProvider);
     return CtMainMenu(
-      variant: MainMenuVariant.plain,
+      // S8 (#2860): the live shell renders the mockup-matching pixelArt
+      // chrome (compass rose, fleur-de-lis, wood-panel buttons, quit chip).
+      // MainMenuVariant.plain is retained as a minimal fallback variant.
+      variant: MainMenuVariant.pixelArt,
       state: MainMenuState.default_,
       version: appDisplayVersion(),
       onNewGame: () =>

--- a/app/test/shell_game_screen_specs_test.dart
+++ b/app/test/shell_game_screen_specs_test.dart
@@ -110,7 +110,9 @@ void main() {
       final ctMainMenuFinder = find.byType(CtMainMenu);
       expect(ctMainMenuFinder, findsOneWidget);
       final ctMainMenu = tester.widget<CtMainMenu>(ctMainMenuFinder);
-      expect(ctMainMenu.variant, MainMenuVariant.plain);
+      // S8 (#2860): the live shell renders the mockup-matching pixelArt
+      // variant; plain remains available only as a fallback variant.
+      expect(ctMainMenu.variant, MainMenuVariant.pixelArt);
       expect(ctMainMenu.state, MainMenuState.default_);
       expect(ctMainMenu.resumeGameVisible, isFalse);
     });

--- a/app/test/shell_screen_pixelart_chrome_test.dart
+++ b/app/test/shell_screen_pixelart_chrome_test.dart
@@ -1,0 +1,104 @@
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:colonizethis_app/app.dart';
+import 'package:colonizethis_app/config/constants.dart';
+import 'package:colonizethis_app/config/routes.dart';
+import 'package:colonizethis_app/core/services/app_event_handler_scope.dart';
+import 'package:colonizethis_app/core/services/game_service.dart';
+import 'package:colonizethis_app/features/shell/shell_screen.dart';
+import 'package:colonizethis_app/providers/app_event_bus_provider.dart';
+import 'package:colonizethis_app/providers/game_service_provider.dart';
+import 'package:colonizethis_app/providers/games_box_provider.dart';
+import 'package:colonizethis_app/widgets/ct_compass_rose.dart';
+import 'package:colonizethis_app/widgets/ct_fleur_de_lis_ornament.dart';
+import 'package:colonizethis_app/widgets/main_menu.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_save/colonizethis_save.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive/hive.dart';
+
+class _NoSavesGameService extends GameService {
+  _NoSavesGameService(super.box, super.adapter);
+
+  @override
+  List<String> listGameIds() => const [];
+}
+
+/// S8 (#2860) live-shell regression coverage: the running app's sole
+/// production caller of [CtMainMenu] ([ShellScreen]) must render the
+/// mockup-matching `pixelArt` chrome, not the bare `plain` fallback. The
+/// Widgetbook-only pins do not exercise the live shell entry point.
+void main() {
+  suppressLogsForTests();
+
+  late Box<dynamic> gamesBox;
+  late _NoSavesGameService dummyService;
+
+  setUp(() {
+    AppEventBus.reset();
+  });
+
+  setUpAll(() async {
+    Hive.init('./.dart_tool/test_hive_shell_pixelart');
+    gamesBox = await Hive.openBox<dynamic>(HiveBoxNames.games);
+    dummyService = _NoSavesGameService(gamesBox, GameSaveAdapter());
+  });
+
+  Widget buildApp() {
+    return ProviderScope(
+      overrides: [
+        gamesBoxProvider.overrideWith((ref) => gamesBox),
+        gameServiceProvider.overrideWith((ref) => dummyService),
+        appEventBusProvider.overrideWith((ref) => AppEventBus.create()),
+      ],
+      child: AppEventHandlerScope(
+        child: MaterialApp(
+          navigatorKey: appNavigatorKey,
+          initialRoute: Routes.shell,
+          routes: {
+            Routes.shell: (_) => const ShellScreen(),
+            Routes.game: (_) => const Scaffold(body: Text('In game')),
+          },
+        ),
+      ),
+    );
+  }
+
+  testWidgets(
+    'live ShellScreen renders the pixelArt mockup chrome (compass rose, '
+    'fleur-de-lis, eyebrow, footer quit chip)',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(buildApp());
+      await tester.pumpAndSettle();
+
+      // Compass rose emblem above the title.
+      expect(find.byType(CtCompassRose), findsOneWidget);
+      // Fleur-de-lis ornaments flank the title (one each side).
+      expect(find.byType(CtFleurDeLisOrnament), findsWidgets);
+      // Eyebrow blurb (rendered upper-cased by the pixelArt logo region).
+      expect(
+        find.text('A Game of Empire & Discovery'.toUpperCase()),
+        findsOneWidget,
+      );
+      // Footer quit chip keyed for the pixelArt variant.
+      expect(find.byKey(const Key(kMainMenuFooterQuitKey)), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'live ShellScreen does not fall back to the plain variant chrome',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(buildApp());
+      await tester.pumpAndSettle();
+
+      // The plain fallback hides all of these decorative elements; their
+      // presence proves the live shell is on the pixelArt variant.
+      final CtMainMenu menu = tester.widget<CtMainMenu>(
+        find.byType(CtMainMenu),
+      );
+      expect(menu.variant, MainMenuVariant.pixelArt);
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Closes the final remaining subtask **S8** of #2860 (owner decision A). The sole production caller of `CtMainMenu` — `ShellScreen` (`app/lib/features/shell/shell_screen.dart`) — hard-coded `MainMenuVariant.plain`, so the **running app** never rendered the mockup chrome (`SHEL10002-main-menu.html`) that S0–S7 already delivered and pinned in Widgetbook. This switches the live shell to `MainMenuVariant.pixelArt`, keeping `plain` as a minimal fallback variant (the `plain`/`pixelArt` model is unchanged).

## Done in this push

- **`app/lib/features/shell/shell_screen.dart`** — `variant: MainMenuVariant.plain` → `MainMenuVariant.pixelArt`.
- **`SPEC/ui/shell-screen.md`** — widget-contract row, wireframe, and the no-auto-save AC updated to document the live shell rendering `pixelArt` (plain retained as fallback); added a new live-shell chrome AC for S8.
- **`app/test/shell_screen_pixelart_chrome_test.dart`** (new) — regression test that pumps the **live `ShellScreen`** entry point and asserts the mockup chrome renders: `CtCompassRose`, `CtFleurDeLisOrnament`, the eyebrow blurb "A Game of Empire & Discovery", the footer quit chip (`kMainMenuFooterQuitKey`), and `variant == MainMenuVariant.pixelArt` (not the bare plain fallback). This exercises the production path the existing Widgetbook-only pins never reached.
- **`app/test/shell_game_screen_specs_test.dart`** — updated the existing shell variant assertion from `plain` to `pixelArt`.

## Acceptance criteria

Covers the open **S8** AC of #2860:
> Given the running app mounts `ShellScreen`, when the main menu is rendered, then it renders the `pixelArt` mockup chrome … and not the bare `plain` fallback.

## Tests

```
cd app && flutter test \
  test/shell_screen_pixelart_chrome_test.dart \
  test/shell_game_screen_specs_test.dart \
  test/shell_screen_test.dart
# All tests passed! (12)
```
`flutter analyze` clean on touched files.

## Scope / deferred

S0–S7 and 12 of 13 ACs were already merged (#2877, #2874, #2891, #2937, #2982). This PR lands only S8. No deferred work remains for #2860 after merge.

Refs #2860

Made with [Cursor](https://cursor.com)