### PR TITLE
test(ai): localize S7-D castIron production-allocation fork to labour (#2847)

### DIFF
--- a/packages/colonizethis_ai/test/seed42_observer_conquest_s7d_diagnostic_test.dart
+++ b/packages/colonizethis_ai/test/seed42_observer_conquest_s7d_diagnostic_test.dart
@@ -1373,6 +1373,51 @@ import 'support/seed42_s7d_feedstock_helpers.dart';
 /// rises above 0 for gp5 before expecting OW gain to move; the +6 baseline
 /// (gp1 / gp2) stays unaffected by construction (regiment-holding gate).
 ///
+/// ## S7-D refresh (captured 2026-06-06 — castIron production-allocation fork
+///     resolved, Refs #2847, PR #3289 follow-up)
+///
+/// This slice lands the two read-only counters the prior refresh re-pointed and
+/// re-runs the diagnostic. The fork **resolves decisively to labour**, not tile
+/// ownership:
+///
+///   * `gpCastIronRecipeFeasibleTurns` (material-only): gp1 = 48, gp5 = 53,
+///     0 for every other GP — unchanged.
+///   * `gpCastIronFeasibleOwnsFeedstockTileTurns`: gp1 = 48, gp5 = 53 — **equal
+///     to the material-feasible count**, so on **every** castIron
+///     material-feasible turn the seller still owns a `timber` / `iron` resource
+///     tile. The staging gate's `_ownsFeedstockResourceTile` precondition is
+///     therefore **satisfied**; tile ownership is **not** the blocker, and
+///     broadening the staging gate to fire on held feedstock would not help.
+///   * `gpCastIronRecipeLabourFeasibleTurns`: **0 for every GP**, including
+///     gp5's 53 material-feasible turns. The castIron recipe
+///     (`labourPerOutput == 5`) is **never** labour-feasible against the
+///     seller's full `effectiveLabourForWorkers` — its effective labour, after
+///     mandatory food upkeep, never funds even one run. This is exactly the
+///     "labour-capped `feasibleRuns`" branch the prior refresh hypothesised.
+///   * `gpCastIronProductionAssignedTurns` stays 0 for every GP, now explained:
+///     the recipe is materially feasible and tile-backed but labour-starved, so
+///     the planner's own `feasibleRuns` gate never clears.
+///   * The +6 baseline is preserved (gp1 / gp2 **+6** PASS); the failing-GP gate
+///     is unchanged in kind by this read-only slice.
+///
+/// **Re-pointed next slice (supersedes the tile-ownership fork):** the binding
+/// constraint for the lock-recovery seller's first domestic `castIron` run is
+/// **effective labour**, not feedstock supply, tile ownership, or the staging
+/// boost. The next *behaviour* slice must give a below-quota zero-NW
+/// zero-regiment lock-recovery seller enough spare labour to fund one
+/// `castIron` run on a materially-feasible turn — e.g. reserving / freeing
+/// effective labour from lower-priority recipes (or a food-reservation that
+/// leaves a `labourPerOutput`-sized slice) under the same self-clearing
+/// lock-recovery-seller gate that keeps the +6 baseline GPs (gp1 / gp2,
+/// regiment-holding) out by construction. Verify by confirming
+/// `gpCastIronRecipeLabourFeasibleTurns` then `gpCastIronProductionAssignedTurns`
+/// rise above 0 for gp5 before expecting OW gain to move. Broadening the staging
+/// gate or adding feedstock supply is explicitly **not** the lever (both are
+/// already satisfied on the feasible turns). This slice is read-only diagnostic
+/// instrumentation (no behaviour change, no config constants, no gate-threshold
+/// changes; positive + negative unit tests for the two helpers in
+/// `seed42_s7d_feedstock_helpers_test.dart`).
+///
 /// ## Refs #2924 Step 0 — world-market lock-recovery metrics
 ///
 /// The same run now also emits a separate
@@ -1785,6 +1830,37 @@ void main() {
       // feasible" (a feedstock-supply gap) vs "feasible yet never assigned" (a
       // production-allocation / planner gate downstream of supply).
       final castIronRecipeFeasibleTurns = <String, int>{
+        for (final gpId in gpIds) gpId: 0,
+      };
+      // Refs #2847 H8 castIron production-allocation localization (read-only;
+      // S7-D castIron production-assignment, PR #3289 follow-up). The staging
+      // path landed in #3289 still leaves `gpCastIronProductionAssignedTurns`
+      // flat zero for every GP, including gp5 which is materially feasible for
+      // ~53 turns (`gpCastIronRecipeFeasibleTurns`). Two read-only counters
+      // split that flat residual on the material-feasible turns:
+      //   * `castIronRecipeLabourFeasibleTurns` — the castIron recipe also
+      //     clears the planner's own labour gate (`feasibleRuns(...) > 0`
+      //     against the full `effectiveLabourForWorkers`, the same compute
+      //     `economy_planner.dart` § `_allocateLabour` runs). A near-zero count
+      //     here while `gpCastIronRecipeFeasibleTurns` is high localizes the
+      //     break to **labour starvation** (effective labour, after mandatory
+      //     food upkeep, cannot fund even one `labourPerOutput` run), moving the
+      //     lever to effective-labour / food-reservation; a count close to the
+      //     material-feasible count instead clears raw labour as the cause and
+      //     re-points downstream to allocation competition / the staging gate.
+      //   * `castIronFeasibleOwnsFeedstockTileTurns` — the seller still owns a
+      //     `timber` / `iron` feedstock resource tile at any improvement level
+      //     (the staging gate's `_ownsFeedstockResourceTile` precondition). A
+      //     flat zero here while the seller *holds* `timber` / `iron`
+      //     commodities localizes the unfired staging gate to **tile
+      //     ownership** (feedstock accumulated but no resource tile owned),
+      //     re-pointing the next behaviour slice to broaden the gate to fire on
+      //     held feedstock; a non-zero count clears tile ownership as the cause.
+      // Read-only; the (freely tunable) counts can move as later slices land.
+      final castIronRecipeLabourFeasibleTurns = <String, int>{
+        for (final gpId in gpIds) gpId: 0,
+      };
+      final castIronFeasibleOwnsFeedstockTileTurns = <String, int>{
         for (final gpId in gpIds) gpId: 0,
       };
       // Refs #2847 H8-extraction execution-gap disambiguation (read-only).
@@ -2206,6 +2282,24 @@ void main() {
             )) {
               castIronRecipeFeasibleTurns[gpId] =
                   (castIronRecipeFeasibleTurns[gpId] ?? 0) + 1;
+              // Split the material-feasible turns by the planner's labour gate
+              // and by the staging gate's tile-ownership precondition.
+              if (stockpileAndLabourAffordAnyProductionRecipe(
+                game,
+                gpId,
+                castIronRecipes,
+              )) {
+                castIronRecipeLabourFeasibleTurns[gpId] =
+                    (castIronRecipeLabourFeasibleTurns[gpId] ?? 0) + 1;
+              }
+              if (ownsFeedstockResourceTileAnyLevel(
+                game,
+                gpId,
+                castIronFeedstockIds,
+              )) {
+                castIronFeasibleOwnsFeedstockTileTurns[gpId] =
+                    (castIronFeasibleOwnsFeedstockTileTurns[gpId] ?? 0) + 1;
+              }
             }
           }
           // Cache the turn-99 snapshot fields for the final rollup.
@@ -2522,6 +2616,9 @@ void main() {
         'gpFeedstockInStockpileTurns': feedstockInStockpileTurns,
         'gpFabricRecipeFeasibleTurns': fabricRecipeFeasibleTurns,
         'gpCastIronRecipeFeasibleTurns': castIronRecipeFeasibleTurns,
+        'gpCastIronRecipeLabourFeasibleTurns': castIronRecipeLabourFeasibleTurns,
+        'gpCastIronFeasibleOwnsFeedstockTileTurns':
+            castIronFeasibleOwnsFeedstockTileTurns,
         'gpTurn99Snapshot': lastSnapshotFields,
       };
 

--- a/packages/colonizethis_ai/test/seed42_s7d_feedstock_helpers_test.dart
+++ b/packages/colonizethis_ai/test/seed42_s7d_feedstock_helpers_test.dart
@@ -1,22 +1,58 @@
-// Unit coverage for the S7-D feedstock probe helper
-// `stockpileAffordsAnyProductionRecipe` (Refs #2847).
+// Unit coverage for the S7-D feedstock probe helpers (Refs #2847).
 //
-// The helper backs the diagnostic's `gpCastIronRecipeFeasibleTurns` counter,
-// which splits a flat `gpCastIronProductionAssignedTurns == 0` into "never
-// materially feasible" vs "feasible yet never assigned". These tests pin its
-// pure material-affordability semantics (every input commodity satisfied for at
-// least one recipe in the list) so the counter cannot silently drift.
+// `stockpileAffordsAnyProductionRecipe` backs the diagnostic's
+// `gpCastIronRecipeFeasibleTurns` counter (material-only). The two
+// production-allocation localization helpers added for the PR #3289 castIron
+// follow-up back the `gpCastIronRecipeLabourFeasibleTurns` and
+// `gpCastIronFeasibleOwnsFeedstockTileTurns` counters, which split a flat
+// `gpCastIronProductionAssignedTurns == 0` on the material-feasible turns into
+// "labour-starved" vs "labour-feasible" and "owns no feedstock tile" vs "owns a
+// feedstock tile". These tests pin their pure semantics so the counters cannot
+// silently drift.
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart';
 
 import 'support/seed42_s7d_feedstock_helpers.dart';
 
+const _playerId = 'gp1';
+
+Game _game({
+  WorkerPool workers = const WorkerPool(),
+  Stockpile stockpile = const Stockpile(),
+  Map<String, Map<String, List<String>>> tileKeysByRegionAndProvince =
+      const {},
+  Map<String, String> resourceByTileKey = const {},
+  List<Province> oldWorldProvinces = const [],
+}) {
+  return Game(
+    id: 'g',
+    worldState: WorldState(
+      turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+      oldWorld: RegionData(provinces: oldWorldProvinces),
+      newWorld: const RegionData(),
+      tileKeysByRegionAndProvince: tileKeysByRegionAndProvince,
+      resourceByTileKey: resourceByTileKey,
+      tileState: TileMapState(),
+    ),
+    players: [
+      Player(
+        id: _playerId,
+        displayName: 'GP',
+        isHuman: false,
+        stockpile: stockpile,
+        workerPool: workers,
+      ),
+    ],
+  );
+}
+
 void main() {
   final castIron = ProductionRecipesCatalog.castIronFromTimberIronCoal;
   final lumber = ProductionRecipesCatalog.lumberFromTimber;
   final timberId = CommodityCatalog.timber.id;
   final ironId = CommodityCatalog.iron.id;
+  final grainId = CommodityCatalog.grain.id;
 
   group('stockpileAffordsAnyProductionRecipe', () {
     test(
@@ -76,6 +112,170 @@ void main() {
       final stockpile = Stockpile(quantities: {timberId: 2, ironId: 1});
       expect(
         stockpileAffordsAnyProductionRecipe(stockpile, [castIron]),
+        isFalse,
+      );
+    });
+  });
+
+  group('stockpileAndLabourAffordAnyProductionRecipe', () {
+    test(
+      'positive: material on hand and effective labour covers one castIron run '
+      '(labourPerOutput 5)',
+      () {
+        // 10 peasants fed by 10 grain -> 10 effective labour; castIron needs 5
+        // labour and 2 timber + 2 iron, so feasibleRuns >= 1.
+        final game = _game(
+          workers: const WorkerPool(peasants: 10),
+          stockpile: Stockpile(
+            quantities: {grainId: 10, timberId: 2, ironId: 2},
+          ),
+        );
+        expect(
+          stockpileAndLabourAffordAnyProductionRecipe(game, _playerId, [
+            castIron,
+          ]),
+          isTrue,
+        );
+      },
+    );
+
+    test(
+      'negative (labour-starved): material present but effective labour below '
+      'one run is not feasible',
+      () {
+        // 1 peasant fed by 1 grain -> 1 effective labour < castIron's 5, so the
+        // recipe is materially affordable yet labour-starved. This is the
+        // decisive split the diagnostic relies on.
+        final stockpile = Stockpile(
+          quantities: {grainId: 1, timberId: 2, ironId: 2},
+        );
+        final game = _game(
+          workers: const WorkerPool(peasants: 1),
+          stockpile: stockpile,
+        );
+        expect(
+          stockpileAffordsAnyProductionRecipe(stockpile, [castIron]),
+          isTrue,
+          reason: 'control: the same turn is material-feasible',
+        );
+        expect(
+          stockpileAndLabourAffordAnyProductionRecipe(game, _playerId, [
+            castIron,
+          ]),
+          isFalse,
+        );
+      },
+    );
+
+    test('negative: missing a material input is not feasible even with labour', () {
+      final game = _game(
+        workers: const WorkerPool(peasants: 10),
+        stockpile: Stockpile(quantities: {grainId: 10, timberId: 2}),
+      );
+      expect(
+        stockpileAndLabourAffordAnyProductionRecipe(game, _playerId, [castIron]),
+        isFalse,
+      );
+    });
+
+    test('negative: empty recipe list is never feasible', () {
+      final game = _game(
+        workers: const WorkerPool(peasants: 10),
+        stockpile: Stockpile(quantities: {grainId: 10}),
+      );
+      expect(
+        stockpileAndLabourAffordAnyProductionRecipe(game, _playerId, const []),
+        isFalse,
+      );
+    });
+
+    test('negative: unknown player id is never feasible', () {
+      final game = _game(
+        workers: const WorkerPool(peasants: 10),
+        stockpile: Stockpile(
+          quantities: {grainId: 10, timberId: 2, ironId: 2},
+        ),
+      );
+      expect(
+        stockpileAndLabourAffordAnyProductionRecipe(game, 'no_such_player', [
+          castIron,
+        ]),
+        isFalse,
+      );
+    });
+  });
+
+  group('ownsFeedstockResourceTileAnyLevel', () {
+    final castIronFeedstock = {timberId, ironId};
+
+    test('positive: owns a province tile hosting a castIron feedstock', () {
+      final game = _game(
+        oldWorldProvinces: const [
+          Province(id: 'oldWorld|p0', regionId: 'oldWorld', ownerId: _playerId),
+        ],
+        tileKeysByRegionAndProvince: const {
+          'oldWorld': {
+            'oldWorld|p0': ['oldWorld|p0|2|0'],
+          },
+        },
+        resourceByTileKey: const {'oldWorld|p0|2|0': 'timber'},
+      );
+      expect(
+        ownsFeedstockResourceTileAnyLevel(game, _playerId, castIronFeedstock),
+        isTrue,
+      );
+    });
+
+    test('negative: the feedstock tile is owned by another faction', () {
+      final game = _game(
+        oldWorldProvinces: const [
+          Province(id: 'oldWorld|p0', regionId: 'oldWorld', ownerId: 'gp2'),
+        ],
+        tileKeysByRegionAndProvince: const {
+          'oldWorld': {
+            'oldWorld|p0': ['oldWorld|p0|2|0'],
+          },
+        },
+        resourceByTileKey: const {'oldWorld|p0|2|0': 'timber'},
+      );
+      expect(
+        ownsFeedstockResourceTileAnyLevel(game, _playerId, castIronFeedstock),
+        isFalse,
+      );
+    });
+
+    test('negative: owned tile hosts a non-feedstock resource', () {
+      final game = _game(
+        oldWorldProvinces: const [
+          Province(id: 'oldWorld|p0', regionId: 'oldWorld', ownerId: _playerId),
+        ],
+        tileKeysByRegionAndProvince: const {
+          'oldWorld': {
+            'oldWorld|p0': ['oldWorld|p0|0|0'],
+          },
+        },
+        resourceByTileKey: const {'oldWorld|p0|0|0': 'grain'},
+      );
+      expect(
+        ownsFeedstockResourceTileAnyLevel(game, _playerId, castIronFeedstock),
+        isFalse,
+      );
+    });
+
+    test('negative: empty feedstock set never matches', () {
+      final game = _game(
+        oldWorldProvinces: const [
+          Province(id: 'oldWorld|p0', regionId: 'oldWorld', ownerId: _playerId),
+        ],
+        tileKeysByRegionAndProvince: const {
+          'oldWorld': {
+            'oldWorld|p0': ['oldWorld|p0|2|0'],
+          },
+        },
+        resourceByTileKey: const {'oldWorld|p0|2|0': 'timber'},
+      );
+      expect(
+        ownsFeedstockResourceTileAnyLevel(game, _playerId, const {}),
         isFalse,
       );
     });

--- a/packages/colonizethis_ai/test/support/seed42_s7d_feedstock_helpers.dart
+++ b/packages/colonizethis_ai/test/support/seed42_s7d_feedstock_helpers.dart
@@ -4,6 +4,8 @@
 // that diagnostic test file at or below the repo non-comment line limit
 // (`repo.dart_file_non_comment_line_size`). These are pure read-only scans over
 // game state used by the H8-supply / H8-extraction stage-localization counters.
+import 'package:colonizethis_ai/src/planning/recipe_scoring.dart'
+    show feasibleRuns;
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
@@ -191,6 +193,102 @@ bool stockpileAffordsAnyProductionRecipe(
       (e) => stockpile.quantityOf(e.key) >= e.value,
     );
     if (affordsAll) return true;
+  }
+  return false;
+}
+
+/// True iff [playerId] can run at least one full output run of any recipe in
+/// [recipes] given **both** its stockpile inputs **and** its current effective
+/// labour — the labour-aware analogue of [stockpileAffordsAnyProductionRecipe].
+///
+/// Mirrors the economy planner's own per-recipe feasibility test
+/// (`economy_planner.dart` § `_allocateLabour` → `feasibleRuns`) by computing
+/// `effectiveLabourForWorkers` from the same inputs the planner uses (the
+/// player's `WorkerPool` + `Stockpile`, with land-regiment and ship upkeep food
+/// reserved via `regimentTypeCountsForPlayer` / `shipTypeCountsForPlayer`) and
+/// asking whether any recipe clears `feasibleRuns(...) > 0` against the **full**
+/// effective labour for the turn.
+///
+/// Used by the H8 castIron production-allocation localization (Refs #2847 § H8;
+/// S7-D castIron production-assignment, PR #3289 follow-up). The diagnostic
+/// already tracks `gpCastIronRecipeFeasibleTurns` (material-only, via
+/// [stockpileAffordsAnyProductionRecipe]). Splitting that material-feasible set
+/// with this labour-aware counter resolves a flat
+/// `gpCastIronProductionAssignedTurns == 0` on the material-feasible turns into
+/// two distinct causes: the recipe is **labour-starved** (the seller's effective
+/// labour, after mandatory food upkeep, cannot fund even one `labourPerOutput`
+/// run, so the lever is effective-labour / food-reservation) versus the recipe
+/// is **labour-feasible yet still never assigned** (an allocation-competition /
+/// staging-gate cause downstream of raw labour). Because `feasibleRuns`
+/// incorporates the stockpile material check too, a labour-feasible turn is
+/// always a subset of a material-feasible turn. Pure read-only over
+/// `(game, playerId)`; no game-state mutation.
+bool stockpileAndLabourAffordAnyProductionRecipe(
+  Game game,
+  String playerId,
+  List<ProductionRecipe> recipes,
+) {
+  if (recipes.isEmpty) return false;
+  final player = game.playerById(playerId);
+  if (player == null) return false;
+  final effectiveLabour = effectiveLabourForWorkers(
+    workers: player.workerPool,
+    stockpile: player.stockpile,
+    regimentCountsById: regimentTypeCountsForPlayer(game.worldState, playerId),
+    shipCountsById: shipTypeCountsForPlayer(game.worldState, playerId),
+  );
+  for (final recipe in recipes) {
+    if (feasibleRuns(
+          recipe: recipe,
+          stockpile: player.stockpile,
+          remainingLabour: effectiveLabour,
+        ) >
+        0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/// True iff [playerId] owns at least one province tile hosting one of
+/// [feedstockIds] at **any** improvement level (improved or unimproved).
+///
+/// This is the tile-ownership precondition the lock-recovery-seller castIron
+/// staging gate (`full_ai_civilian_work_selection_feedstock.dart` §
+/// `selfLockRecoverySellerStageableImprovementInputs` →
+/// `_ownsFeedstockResourceTile`) applies before it stages a domestic `castIron`
+/// run: a below-quota zero-NW zero-regiment seller only stages `castIron` when
+/// it still owns a `timber` / `iron` feedstock tile to extract from. The
+/// existing [ownsUnimprovedFeedstockResourceTile] /
+/// [ownsImprovedFeedstockResourceTile] probes split by improvement level; this
+/// any-level probe mirrors the staging gate's own predicate exactly.
+///
+/// Used by the H8 castIron production-allocation localization (Refs #2847): on
+/// the castIron material-feasible turns, a flat-zero count here while the seller
+/// **holds** `timber` / `iron` commodities localizes the unfired staging gate to
+/// **tile ownership** (the seller accumulated the feedstock by trade / past
+/// extraction but no longer owns a resource tile, so the staging gate stays
+/// shut), re-pointing the next behaviour slice to broaden the gate to fire on
+/// held feedstock; a non-zero count instead clears tile ownership as the cause.
+/// Read-only scan over owned provinces.
+bool ownsFeedstockResourceTileAnyLevel(
+  Game game,
+  String playerId,
+  Set<String> feedstockIds,
+) {
+  if (feedstockIds.isEmpty) return false;
+  final ws = game.worldState;
+  for (final byProvince in ws.tileKeysByRegionAndProvince.values) {
+    for (final entry in byProvince.entries) {
+      final province = tryGetProvince(ws, entry.key);
+      if (province == null || province.ownerId != playerId) continue;
+      for (final tileKey in entry.value) {
+        final resourceId = ws.resourceByTileKey[tileKey];
+        if (resourceId != null && feedstockIds.contains(resourceId)) {
+          return true;
+        }
+      }
+    }
   }
   return false;
 }


### PR DESCRIPTION
## Summary

`Refs #2847`. Tracked by #2847 (turn-100 OW conquest gate, soft-phase tuning loop). Does **not** close the issue.

Lands the two read-only S7-D diagnostic counters the prior refresh (PR #3289 follow-up comment) explicitly re-pointed, and re-runs the seed-42 turn-100 S7-D diagnostic to **resolve the castIron production-allocation fork**.

The #3289 castIron staging path is correct groundwork but `gpCastIronProductionAssignedTurns` stayed flat 0 for every GP including gp5 (materially feasible ~53 turns). The prior refresh asked: is the unfired staging due to (a) the seller not owning a `timber`/`iron` resource tile on the feasible turns, or (b) the materially-feasible turns being labour-capped? This slice answers it decisively.

## Done in this push

- **New helper `stockpileAndLabourAffordAnyProductionRecipe`** (test support) — the labour-aware analogue of `stockpileAffordsAnyProductionRecipe`, mirroring the economy planner's own `feasibleRuns(...) > 0` against the full `effectiveLabourForWorkers` (same `WorkerPool`/`Stockpile`/regiment/ship inputs). Backs new counter `gpCastIronRecipeLabourFeasibleTurns`.
- **New helper `ownsFeedstockResourceTileAnyLevel`** (test support) — mirrors the staging gate's `_ownsFeedstockResourceTile` tile-ownership precondition (any improvement level). Backs new counter `gpCastIronFeasibleOwnsFeedstockTileTurns`.
- **Two read-only counters** wired into `seed42_observer_conquest_s7d_diagnostic_test.dart` rollup, plus a documented S7-D refresh section recording the result and re-pointing the next behaviour slice.
- **Positive + negative unit tests** for both helpers in `seed42_s7d_feedstock_helpers_test.dart` (labour-starved control, missing material, unknown player, tile not owned, non-feedstock resource, empty sets).

## Decisive result (seed 42, turn 100, this branch off `dev`)

| Counter | gp1 | gp5 |
|---|---|---|
| `gpCastIronRecipeFeasibleTurns` (material) | 48 | 53 |
| `gpCastIronFeasibleOwnsFeedstockTileTurns` | 48 | **53** |
| `gpCastIronRecipeLabourFeasibleTurns` | **0** | **0** |
| `gpCastIronProductionAssignedTurns` | 0 | 0 |

Tile ownership is satisfied on **every** material-feasible turn (gp5 53/53), so broadening the staging gate is a dead-end. The recipe is **never labour-feasible** (`labourPerOutput == 5` vs the seller's small effective labour after food upkeep) → the binding blocker is **effective-labour starvation**. **+6 baseline preserved** (gp1/gp2 = +6).

**Re-pointed next (behaviour) slice:** give a below-quota zero-NW zero-regiment lock-recovery seller enough spare effective labour to fund one `castIron` run on a materially-feasible turn (labour reservation / food-reservation under the same self-clearing gate that excludes regiment-holding gp1/gp2). Not the staging gate or feedstock supply (both already satisfied).

## Scope / SPEC

Read-only diagnostic instrumentation only — **no behaviour change, no `ai_victory_config.dart` constants, no gate-threshold changes**, so no SPEC update is required (no new game/AI behaviour). The behaviour slice this re-points will carry the SPEC update.

## Tests

- `dart test test/seed42_s7d_feedstock_helpers_test.dart` — 17/17 pass (7 pre-existing + 10 new).
- `dart test test/seed42_observer_conquest_s7d_diagnostic_test.dart --run-skipped` — passes; new counters emitted in `S7D_DIAGNOSTIC_JSON_*`.
- `dart analyze` clean on all three files; `check_dart_file_non_comment_line_size` — no violations.

## Label

Left at `backlog:implementation` (gate still red; issue not fully implemented).

Made with [Cursor](https://cursor.com)