### PR TITLE
test(ai): fork S7-D castIron labour starvation into food vs population (Refs #2847)

### DIFF
--- a/packages/colonizethis_ai/test/seed42_observer_conquest_s7d_diagnostic_test.dart
+++ b/packages/colonizethis_ai/test/seed42_observer_conquest_s7d_diagnostic_test.dart
@@ -1418,6 +1418,54 @@ import 'support/seed42_s7d_feedstock_helpers.dart';
 /// changes; positive + negative unit tests for the two helpers in
 /// `seed42_s7d_feedstock_helpers_test.dart`).
 ///
+/// ## S7-D refresh (captured 2026-06-06 — castIron labour-starvation sub-cause
+///     fork resolved: population-bound, not food-starved; Refs #2847)
+///
+/// The prior refresh re-pointed the behaviour lever to "effective labour" but
+/// left the *sub-cause* open: is the labour shortfall a **food** problem
+/// (workers exist but too few are fed) or a **population** problem (too few
+/// workers even if all fed)? Its hypothesised lever — "reserve / free effective
+/// labour from lower-priority recipes, or a food-reservation" — assumed the
+/// former. This slice adds two read-only counters
+/// (`gpCastIronLabourFoodStarvedTurns` vs `gpCastIronLabourPopulationBoundTurns`,
+/// a partition of the material-feasible-but-labour-infeasible turns, forked on
+/// whether the food-ungated ceiling `playerRawLabourSupply` would itself fund one
+/// `castIron` run of `castIronMinLabourPerOutput == 5`) plus a turn-99
+/// effective-labour / raw-supply / food-on-hand snapshot. The fork resolves
+/// **decisively to population**, and **falsifies the food hypothesis**:
+///
+///   * `gpCastIronLabourFoodStarvedTurns` = **0 for every GP** — on no
+///     material-feasible turn would feeding more workers reach one run.
+///   * `gpCastIronLabourPopulationBoundTurns` = gp1 = 48, gp5 = 53 (**equal to
+///     the full material-feasible count**) — on *every* such turn the seller's
+///     fully-fed labour ceiling is itself below `labourPerOutput == 5`.
+///   * Turn-99 snapshot: every GP has `effectiveLabour == rawLabourSupply`
+///     (so **all** workers are already fed — food is not gating labour) while
+///     that ceiling is tiny: gp5 = **1**, gp1 / gp2 / gp3 / gp4 = **2**, far
+///     below 5. Food on hand is simultaneously **abundant** (gp5 = 289,
+///     gp3 = 203, gp6 = 193), confirming the seller is drowning in food yet
+///     starved of *workers*, not food.
+///
+/// **Re-pointed next slice (supersedes the food-reservation hypothesis):** the
+/// binding constraint is the lock-recovery seller's **worker population**, not
+/// food supply, feedstock, tile ownership, or recipe competition. A below-quota
+/// zero-NW zero-regiment seller holds only ~1-2 total labour against the
+/// `castIron` recipe's 5, with surplus food and idle feedstock — so neither
+/// freeing labour from other recipes (there is almost none to free) nor a
+/// food-reservation (food is not the gate) can ever clear `feasibleRuns > 0`.
+/// The next *behaviour* slice must grow the seller's labour pool — e.g. convert
+/// the abundant food into worker growth / peasant recruitment for the same
+/// self-clearing lock-recovery-seller cohort — until the fully-fed ceiling
+/// reaches `castIronMinLabourPerOutput`, gated to exclude the regiment-holding
+/// +6 baseline GPs (gp1 / gp2) by construction. Verify by confirming
+/// `gpCastIronLabourPopulationBoundTurns` falls as `rawLabourSupply` rises past
+/// 5, then `gpCastIronRecipeLabourFeasibleTurns` and
+/// `gpCastIronProductionAssignedTurns` rise above 0 for gp5. This slice is
+/// read-only diagnostic instrumentation (no behaviour change, no config
+/// constants, no gate-threshold changes; positive + negative unit tests for the
+/// three helpers `playerEffectiveLabour` / `playerRawLabourSupply` /
+/// `playerFoodOnHand` in `seed42_s7d_feedstock_helpers_test.dart`).
+///
 /// ## Refs #2924 Step 0 — world-market lock-recovery metrics
 ///
 /// The same run now also emits a separate
@@ -1863,6 +1911,45 @@ void main() {
       final castIronFeasibleOwnsFeedstockTileTurns = <String, int>{
         for (final gpId in gpIds) gpId: 0,
       };
+      // Refs #2847 H8 castIron labour-starvation sub-cause split (read-only).
+      // `gpCastIronRecipeLabourFeasibleTurns == 0` while
+      // `gpCastIronRecipeFeasibleTurns` / `gpCastIronFeasibleOwnsFeedstockTile
+      // Turns` are high decisively localized the binding constraint to
+      // effective labour (the seller can never fund one `castIron`
+      // `labourPerOutput` run after mandatory food upkeep). These two counters
+      // fork *why* effective labour falls short on those material-feasible
+      // turns so the next behaviour slice can pick the correct lever:
+      //   * `castIronLabourFoodStarvedTurns` — the raw (food-ungated) labour
+      //     ceiling (`playerRawLabourSupply`) **would** fund one run if every
+      //     worker were fed, but `playerEffectiveLabour` does not: workers exist
+      //     yet too few are food-fed. Lever: food supply / food-reservation.
+      //   * `castIronLabourPopulationBoundTurns` — even the fully-fed ceiling is
+      //     below one run's `labourPerOutput`: the seller simply lacks workers.
+      //     Lever: worker growth / recruitment, not food.
+      // Counted only on castIron material-feasible but labour-infeasible turns,
+      // so the two are a partition of (recipeFeasible AND NOT labourFeasible).
+      // Read-only; the (freely tunable) counts can move as later slices land.
+      final castIronLabourFoodStarvedTurns = <String, int>{
+        for (final gpId in gpIds) gpId: 0,
+      };
+      final castIronLabourPopulationBoundTurns = <String, int>{
+        for (final gpId in gpIds) gpId: 0,
+      };
+      // Minimum `labourPerOutput` across the castIron recipes — the cheapest
+      // single run's effective-labour requirement, used as the food-starved /
+      // population-bound fork threshold above.
+      final castIronMinLabourPerOutput = castIronRecipes.isEmpty
+          ? 0
+          : castIronRecipes
+                .map((recipe) => recipe.labourPerOutput)
+                .reduce((a, b) => a < b ? a : b);
+      // Food commodities (grain + meat) consumed by worker upkeep
+      // (`economy_consumption.dart`), summed for the turn-99 food-on-hand
+      // snapshot that corroborates the food-starved lever.
+      final castIronLabourFoodCommodityIds = <String>{
+        CommodityCatalog.grain.id,
+        CommodityCatalog.meat.id,
+      };
       // Refs #2847 H8-extraction execution-gap disambiguation (read-only).
       // Both are gated on a feedstock-extraction-gate-active turn so they split
       // the 29-52 gate-active turns into the proximate failure stage:
@@ -2291,6 +2378,18 @@ void main() {
               )) {
                 castIronRecipeLabourFeasibleTurns[gpId] =
                     (castIronRecipeLabourFeasibleTurns[gpId] ?? 0) + 1;
+              } else if (castIronMinLabourPerOutput > 0) {
+                // Material-feasible but labour-infeasible: fork the cause into
+                // food-starved (fully-fed ceiling would fund a run) vs
+                // population-bound (ceiling itself below one run).
+                if (playerRawLabourSupply(game, gpId) >=
+                    castIronMinLabourPerOutput) {
+                  castIronLabourFoodStarvedTurns[gpId] =
+                      (castIronLabourFoodStarvedTurns[gpId] ?? 0) + 1;
+                } else {
+                  castIronLabourPopulationBoundTurns[gpId] =
+                      (castIronLabourPopulationBoundTurns[gpId] ?? 0) + 1;
+                }
               }
               if (ownsFeedstockResourceTileAnyLevel(
                 game,
@@ -2317,6 +2416,17 @@ void main() {
               'regimentCount': regimentCountForPlayer(game, gpId),
               'cheapestRegimentBuildTreasuryCost':
                   cheapestRegimentBuildTreasuryCost(),
+              // Refs #2847 H8 castIron labour-starvation corroboration: the
+              // effective (food-fed) labour, the raw (fully-fed) ceiling, and
+              // the food on hand at the terminal turn for the food-starved vs
+              // population-bound read.
+              'effectiveLabour': playerEffectiveLabour(game, gpId),
+              'rawLabourSupply': playerRawLabourSupply(game, gpId),
+              'foodOnHand': playerFoodOnHand(
+                game,
+                gpId,
+                castIronLabourFoodCommodityIds,
+              ),
             };
           }
         }
@@ -2619,6 +2729,10 @@ void main() {
         'gpCastIronRecipeLabourFeasibleTurns': castIronRecipeLabourFeasibleTurns,
         'gpCastIronFeasibleOwnsFeedstockTileTurns':
             castIronFeasibleOwnsFeedstockTileTurns,
+        'gpCastIronLabourFoodStarvedTurns': castIronLabourFoodStarvedTurns,
+        'gpCastIronLabourPopulationBoundTurns':
+            castIronLabourPopulationBoundTurns,
+        'castIronMinLabourPerOutput': castIronMinLabourPerOutput,
         'gpTurn99Snapshot': lastSnapshotFields,
       };
 

--- a/packages/colonizethis_ai/test/seed42_s7d_feedstock_helpers_test.dart
+++ b/packages/colonizethis_ai/test/seed42_s7d_feedstock_helpers_test.dart
@@ -9,6 +9,13 @@
 // "labour-starved" vs "labour-feasible" and "owns no feedstock tile" vs "owns a
 // feedstock tile". These tests pin their pure semantics so the counters cannot
 // silently drift.
+//
+// The `playerEffectiveLabour` / `playerRawLabourSupply` / `playerFoodOnHand`
+// helpers back the `gpCastIronLabourFoodStarvedTurns` /
+// `gpCastIronLabourPopulationBoundTurns` fork that splits a labour-infeasible
+// castIron turn into "workers exist but are unfed" (food lever) vs "too few
+// workers even if fed" (recruitment lever); their tests pin the
+// food-gated-vs-raw labour distinction the fork depends on.
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart';
@@ -53,6 +60,7 @@ void main() {
   final timberId = CommodityCatalog.timber.id;
   final ironId = CommodityCatalog.iron.id;
   final grainId = CommodityCatalog.grain.id;
+  final meatId = CommodityCatalog.meat.id;
 
   group('stockpileAffordsAnyProductionRecipe', () {
     test(
@@ -278,6 +286,107 @@ void main() {
         ownsFeedstockResourceTileAnyLevel(game, _playerId, const {}),
         isFalse,
       );
+    });
+  });
+
+  group('playerRawLabourSupply', () {
+    test('positive: tier-weighted population ceiling ignores food', () {
+      // 2 peasants (1 each) + 1 journeyman (6) = 8 raw labour, regardless of an
+      // empty stockpile — this is the fully-fed ceiling.
+      final game = _game(
+        workers: const WorkerPool(peasants: 2, journeymen: 1),
+      );
+      expect(playerRawLabourSupply(game, _playerId), 8);
+    });
+
+    test('positive: counts every tier (peasant/apprentice/journeyman/master)', () {
+      // 1*1 + 1*4 + 1*6 + 1*8 = 19.
+      final game = _game(
+        workers: const WorkerPool(
+          peasants: 1,
+          apprentices: 1,
+          journeymen: 1,
+          masters: 1,
+        ),
+      );
+      expect(playerRawLabourSupply(game, _playerId), 19);
+    });
+
+    test('negative: unknown player has no labour supply', () {
+      final game = _game(workers: const WorkerPool(peasants: 10));
+      expect(playerRawLabourSupply(game, 'no_such_player'), 0);
+    });
+  });
+
+  group('playerEffectiveLabour', () {
+    test('positive: fully-fed workers supply their full labour', () {
+      // 10 peasants fed by 10 grain -> 10 effective labour (no military upkeep).
+      final game = _game(
+        workers: const WorkerPool(peasants: 10),
+        stockpile: Stockpile(quantities: {grainId: 10}),
+      );
+      expect(playerEffectiveLabour(game, _playerId), 10);
+    });
+
+    test(
+      'food-starved: raw ceiling exceeds effective labour when food is short',
+      () {
+        // 10 peasants but only 3 grain -> 3 fed -> 3 effective labour, far below
+        // the raw ceiling of 10. This is the food-starved fork condition.
+        final game = _game(
+          workers: const WorkerPool(peasants: 10),
+          stockpile: Stockpile(quantities: {grainId: 3}),
+        );
+        expect(playerRawLabourSupply(game, _playerId), 10);
+        expect(playerEffectiveLabour(game, _playerId), lessThan(10));
+        expect(playerEffectiveLabour(game, _playerId), 3);
+      },
+    );
+
+    test('negative: no food means every worker strikes (zero labour)', () {
+      final game = _game(
+        workers: const WorkerPool(peasants: 10),
+        stockpile: const Stockpile(),
+      );
+      expect(playerEffectiveLabour(game, _playerId), 0);
+    });
+
+    test('negative: unknown player has no effective labour', () {
+      final game = _game(
+        workers: const WorkerPool(peasants: 10),
+        stockpile: Stockpile(quantities: {grainId: 10}),
+      );
+      expect(playerEffectiveLabour(game, 'no_such_player'), 0);
+    });
+  });
+
+  group('playerFoodOnHand', () {
+    final foodIds = {grainId, meatId};
+
+    test('positive: sums grain and meat on hand', () {
+      final game = _game(
+        stockpile: Stockpile(quantities: {grainId: 7, meatId: 5, timberId: 9}),
+      );
+      expect(playerFoodOnHand(game, _playerId, foodIds), 12);
+    });
+
+    test('negative: empty stockpile holds no food', () {
+      final game = _game(stockpile: const Stockpile());
+      expect(playerFoodOnHand(game, _playerId, foodIds), 0);
+    });
+
+    test('negative: empty food id set returns zero', () {
+      final game = _game(
+        stockpile: Stockpile(quantities: {grainId: 7, meatId: 5}),
+      );
+      expect(playerFoodOnHand(game, _playerId, const {}), 0);
+    });
+
+    test('negative: unknown player holds no food', () {
+      final game = _game(
+        stockpile: Stockpile(quantities: {grainId: 7, meatId: 5}),
+      );
+      expect(playerFoodOnHand(game, 'no_such_player', foodIds), 0);
     });
   });
 }

--- a/packages/colonizethis_ai/test/support/seed42_s7d_feedstock_helpers.dart
+++ b/packages/colonizethis_ai/test/support/seed42_s7d_feedstock_helpers.dart
@@ -250,6 +250,77 @@ bool stockpileAndLabourAffordAnyProductionRecipe(
   return false;
 }
 
+/// Effective labour available to [playerId] this turn — the labour that
+/// **food-fed** workers actually supply after mandatory food upkeep, computed
+/// exactly as the economy planner does (`effectiveLabourForWorkers` over the
+/// player's `WorkerPool` + `Stockpile`, with land-regiment and ship upkeep food
+/// reserved first via `regimentTypeCountsForPlayer` /
+/// `shipTypeCountsForPlayer`). Unfed workers strike and contribute no labour, so
+/// this can be far below the raw population ceiling
+/// ([playerRawLabourSupply]).
+///
+/// Companion to [stockpileAndLabourAffordAnyProductionRecipe] (Refs #2847 § H8;
+/// S7-D castIron production-allocation). That boolean only reports *whether* any
+/// recipe clears `feasibleRuns > 0`; this returns the underlying scalar so a
+/// labour-starvation counter can compare it directly against a recipe's
+/// `labourPerOutput`. Pure read-only over `(game, playerId)`; no mutation.
+int playerEffectiveLabour(Game game, String playerId) {
+  final player = game.playerById(playerId);
+  if (player == null) return 0;
+  return effectiveLabourForWorkers(
+    workers: player.workerPool,
+    stockpile: player.stockpile,
+    regimentCountsById: regimentTypeCountsForPlayer(game.worldState, playerId),
+    shipCountsById: shipTypeCountsForPlayer(game.worldState, playerId),
+  );
+}
+
+/// Raw (food-ungated) labour supply ceiling for [playerId] — the labour every
+/// owned worker would contribute if **all** were fed
+/// (`WorkerPool.labourSupplyPerTurn`, the tier-weighted population sum). Unlike
+/// [playerEffectiveLabour] it ignores food upkeep and the strike gate, so it is
+/// the population ceiling against which a food shortfall is measured.
+///
+/// Used by the H8 castIron labour-starvation sub-cause split (Refs #2847): on a
+/// material-feasible but labour-infeasible castIron turn
+/// (`gpCastIronRecipeFeasibleTurns` high, `gpCastIronRecipeLabourFeasibleTurns`
+/// zero), comparing this ceiling against the recipe's `labourPerOutput` forks
+/// the cause into **food-starved** (ceiling >= one run, but
+/// [playerEffectiveLabour] < one run, so workers exist yet too few are fed — the
+/// next lever is food supply / food-reservation) versus **population-bound**
+/// (ceiling itself < one run, so even fully fed the seller lacks the workers —
+/// the next lever is worker growth / recruitment). Pure read-only.
+int playerRawLabourSupply(Game game, String playerId) {
+  final player = game.playerById(playerId);
+  if (player == null) return 0;
+  return player.workerPool.labourSupplyPerTurn;
+}
+
+/// Total quantity of the [foodCommodityIds] (e.g. `grain` + `meat`) held in
+/// [playerId]'s stockpile — the food on hand to feed workers after land-military
+/// and navy upkeep claim their share (`economy_consumption.dart` order:
+/// military -> navy -> workers Masters->Journeymen->Apprentices->Peasants).
+///
+/// Used by the H8 castIron labour-starvation snapshot (Refs #2847): captured at
+/// the terminal turn alongside [playerEffectiveLabour] /
+/// [playerRawLabourSupply], a near-zero food balance on a food-starved seller
+/// corroborates the food-supply lever over the recruitment lever. Returns 0 for
+/// an empty id set or an unknown player. Pure read-only over the stockpile.
+int playerFoodOnHand(
+  Game game,
+  String playerId,
+  Set<String> foodCommodityIds,
+) {
+  if (foodCommodityIds.isEmpty) return 0;
+  final player = game.playerById(playerId);
+  if (player == null) return 0;
+  var total = 0;
+  for (final id in foodCommodityIds) {
+    total += player.stockpile.quantityOf(id);
+  }
+  return total;
+}
+
 /// True iff [playerId] owns at least one province tile hosting one of
 /// [feedstockIds] at **any** improvement level (improved or unimproved).
 ///


### PR DESCRIPTION
## Summary

Read-only diagnostic slice for the deterministic-AI soft-phase economy gate (Refs #2847). The prior S7-D refresh localized the lock-recovery seller's missing first domestic `castIron` run to **effective-labour** starvation, but left the sub-cause open and hypothesised a food-supply / food-reservation lever. This slice adds the counters needed to resolve that fork and re-runs the seed-42 turn-100 diagnostic, which **falsifies the food hypothesis**: the seller is **population-bound**, not food-starved.

- Adds three pure read-only helpers — `playerEffectiveLabour`, `playerRawLabourSupply`, `playerFoodOnHand` — mirroring the planner's `effectiveLabourForWorkers` computation and the `WorkerPool` tier-weighted ceiling, with positive and negative unit tests.
- Adds diagnostic counters `gpCastIronLabourFoodStarvedTurns` vs `gpCastIronLabourPopulationBoundTurns` (a partition of the material-feasible-but-labour-infeasible `castIron` turns), plus a turn-99 effective-labour / raw-supply / food-on-hand snapshot.
- Refreshes the S7-D docstring with the captured result and re-points the next **behaviour** lever to worker growth / recruitment for the lock-recovery-seller cohort (superseding the food-reservation hypothesis).

## Captured fork (seed 42, turn 100)

- `gpCastIronLabourFoodStarvedTurns` = **0 for every GP**.
- `gpCastIronLabourPopulationBoundTurns` = gp1 48 / gp5 53 (= the full material-feasible count).
- Turn-99 snapshot: every GP has `effectiveLabour == rawLabourSupply` (all workers fed) at a tiny ceiling (gp5 = 1, others = 2) against `castIron`'s `labourPerOutput` = 5, while food on hand is abundant (gp5 = 289). The seller is drowning in food yet starved of workers.

## Scope / safety

- No behaviour change, no config constants, no gate-threshold changes — read-only test instrumentation only.
- The `+6` baseline (gp1 / gp2) is unaffected by construction.
- Does **not** close #2847.

## Test plan

- [x] `flutter test test/seed42_s7d_feedstock_helpers_test.dart` (27 pass, 11 new).
- [x] `flutter test --run-skipped test/seed42_observer_conquest_s7d_diagnostic_test.dart` (passes; emits the new counters).
- [x] `flutter analyze` on touched files — no issues.
- [x] `tool/check_dart_file_non_comment_line_size.dart` — no violations.

Made with [Cursor](https://cursor.com)