### PR TITLE
perf(ai): introduce OrdersBuilder and freeze economy planner slice once (#3288)

### DIFF
--- a/packages/colonizethis_ai/lib/src/planning/domain_planner_orchestrator.dart
+++ b/packages/colonizethis_ai/lib/src/planning/domain_planner_orchestrator.dart
@@ -331,7 +331,13 @@ _EconomyDomainPlannersResult _runEconomyDomainPlanners({
   Map<String, TileMapResult>? tileMapByRegion,
   required void Function(String phaseId) emit,
 }) {
-  var result = ctx.orders;
+  // Refs #3288: accumulate this slice's economy families (civilian work,
+  // peasant recruit, build) in a single mutable builder and freeze once at the
+  // tail, instead of allocating a fresh `Orders` per append. Behaviour-equal:
+  // the suggestion calls below read `ctx.orders` exactly as before (no append
+  // precedes them), and the recruit suggestion reads `builder.build()` so it
+  // still sees the post-work order set.
+  final builder = OrdersBuilder(ctx.orders);
   final domainWeights = ctx.domainWeights;
 
   emit('suggestionPools');
@@ -339,7 +345,7 @@ _EconomyDomainPlannersResult _runEconomyDomainPlanners({
     ctx.view,
     ctx.game,
     ctx.topology,
-    result,
+    ctx.orders,
     tileMapByRegion: tileMapByRegion,
   );
   workCandidates = workCandidates
@@ -349,7 +355,7 @@ _EconomyDomainPlannersResult _runEconomyDomainPlanners({
     ctx.view,
     ctx.game,
     ctx.topology,
-    result,
+    ctx.orders,
   );
   final hasSpyWork = workCandidates.any(
     (o) =>
@@ -461,7 +467,7 @@ _EconomyDomainPlannersResult _runEconomyDomainPlanners({
       );
     }
     if (selection.workOrders.isNotEmpty) {
-      result = result.appendWorkOrders(ctx.nationId, selection.workOrders);
+      builder.addWorkOrders(ctx.nationId, selection.workOrders);
     }
   } else if (workCandidates.isNotEmpty) {
     _log.d('work skipped nationId=${ctx.nationId} weight below threshold');
@@ -474,7 +480,7 @@ _EconomyDomainPlannersResult _runEconomyDomainPlanners({
       ctx.view,
       ctx.game,
       ctx.topology,
-      result,
+      builder.build(),
     );
     RecruitWorkerOrder? peasantRecruit;
     for (final candidate in recruitCandidates) {
@@ -488,7 +494,7 @@ _EconomyDomainPlannersResult _runEconomyDomainPlanners({
         'castIron labour peasant recruit nationId=${ctx.nationId} '
         'targetTier=${peasantRecruit.targetTier.name}',
       );
-      result = result.appendRecruitWorkerOrders(ctx.nationId, [peasantRecruit]);
+      builder.addRecruitWorkerOrders(ctx.nationId, [peasantRecruit]);
     }
   }
 
@@ -497,15 +503,14 @@ _EconomyDomainPlannersResult _runEconomyDomainPlanners({
     snapshot: snapshot,
     phasePlan: phasePlan,
     economyPlan: economyPlan,
-    orders: result,
+    builder: builder,
     colonialPressure: colonialPressure,
     buildCandidates: buildCandidates,
     domainEconomyWeight: domainWeights.economy,
   );
-  result = buildResult.orders;
   emit('aiStageB');
   return _EconomyDomainPlannersResult(
-    ctx: ctx.withOrders(result),
+    ctx: ctx.withOrders(builder.build()),
     gate: EconomyGateRecord(
       workPlannerRan: runFullAiCivilianWork,
       buildPlannerRan: buildResult.buildPlannerRan,
@@ -516,14 +521,16 @@ _EconomyDomainPlannersResult _runEconomyDomainPlanners({
 }
 
 /// Build pass outcome plus the resolved build-threshold gate decision.
+///
+/// The chosen build order (if any) is appended directly into the shared
+/// [OrdersBuilder] passed to [_appendEconomyBuildOrders] (Refs #3288), so this
+/// result carries only the gate signals.
 class _BuildPassResult {
   const _BuildPassResult({
-    required this.orders,
     required this.buildPlannerRan,
     required this.buildThreshold,
   });
 
-  final Orders orders;
   final bool buildPlannerRan;
   final int buildThreshold;
 }
@@ -533,7 +540,7 @@ _BuildPassResult _appendEconomyBuildOrders({
   required AIWorldSnapshot snapshot,
   required PhasePlanOutcome phasePlan,
   required EconomyPlan economyPlan,
-  required Orders orders,
+  required OrdersBuilder builder,
   required bool colonialPressure,
   required List<BuildUnitOrder> buildCandidates,
   required int domainEconomyWeight,
@@ -699,7 +706,6 @@ _BuildPassResult _appendEconomyBuildOrders({
       _log.d('build skipped nationId=${ctx.nationId} weight below threshold');
     }
     return _BuildPassResult(
-      orders: orders,
       buildPlannerRan: false,
       buildThreshold: buildThreshold,
     );
@@ -756,14 +762,13 @@ _BuildPassResult _appendEconomyBuildOrders({
   );
   if (chosen == null) {
     return _BuildPassResult(
-      orders: orders,
       buildPlannerRan: true,
       buildThreshold: buildThreshold,
     );
   }
   _log.i('build chosen nationId=${ctx.nationId} unitType=${chosen.unitType}');
+  builder.addBuildOrders(ctx.nationId, [chosen]);
   return _BuildPassResult(
-    orders: orders.appendBuildOrders(ctx.nationId, [chosen]),
     buildPlannerRan: true,
     buildThreshold: buildThreshold,
   );

--- a/packages/colonizethis_ai/lib/src/util/orders_extensions.dart
+++ b/packages/colonizethis_ai/lib/src/util/orders_extensions.dart
@@ -8,7 +8,155 @@ _OrdersByPlayer<T> _appendOrdersByPlayer<T>(
   List<T> list,
 ) {
   final existing = source[playerId] ?? const [];
-  return {...source, playerId: [...existing, ...list]};
+  return {
+    ...source,
+    playerId: [...existing, ...list],
+  };
+}
+
+/// Mutable accumulator for one AI player turn's order families (Refs #3288).
+///
+/// The spread-copy [OrdersAppendExtension] helpers each allocate a fresh
+/// immutable [Orders] (`copyWith` over ten family maps) on every append. When
+/// a planner appends several families in sequence (for example the economy
+/// domain-planner slice: civilian work, peasant recruit, then build) that is
+/// one full [Orders] allocation per append. [OrdersBuilder] instead mutates a
+/// per-family overlay in place and materialises a single [Orders] once via
+/// [build], eliminating the intermediate copies while preserving the exact
+/// append-order semantics: for each touched family, `build()` yields the same
+/// map the equivalent chain of `appendXxxOrders` calls would have produced
+/// (base entries preserved, the accumulating player's list = existing ++ the
+/// appended lists in call order). Untouched families keep the seed [Orders]
+/// maps unchanged, so `OrdersBuilder(base).build()` equals `base` for the
+/// `MapEquality`-style comparisons the planners rely on.
+///
+/// This is an internal allocation optimisation only — it changes no emitted
+/// orders. See `SPEC/program/turn-resolution.md` (wall-clock budget) and
+/// `.cursor/rules/colonizethis-turn-resolution-budget.mdc`.
+class OrdersBuilder {
+  /// Seeds the builder from [base] (defaults to an empty [Orders]). The seed
+  /// maps are never mutated; [build] copies a family map lazily only when that
+  /// family is appended to.
+  OrdersBuilder([Orders base = const Orders()]) : _base = base;
+
+  final Orders _base;
+
+  Map<String, List<MoveOrder>>? _move;
+  Map<String, List<ArmyMoveOrder>>? _armyMove;
+  Map<String, List<BuildUnitOrder>>? _build;
+  Map<String, List<WorkOrder>>? _work;
+  Map<String, List<RecruitWorkerOrder>>? _recruit;
+  Map<String, List<DiplomaticOrder>>? _diplomatic;
+  Map<String, List<ResearchOrder>>? _research;
+  Map<String, List<NavalMoveOrder>>? _navalMove;
+  Map<String, List<NavalMissionOrder>>? _navalMission;
+  Map<String, List<TradeOrder>>? _trade;
+
+  static Map<String, List<T>> _mutableAppend<T>(
+    Map<String, List<T>> overlay,
+    String playerId,
+    List<T> list,
+  ) {
+    overlay[playerId] = [...(overlay[playerId] ?? const []), ...list];
+    return overlay;
+  }
+
+  void addMoveOrders(String playerId, List<MoveOrder> list) {
+    _move = _mutableAppend(
+      _move ??= {..._base.moveOrdersByPlayerId},
+      playerId,
+      list,
+    );
+  }
+
+  void addArmyMoveOrders(String playerId, List<ArmyMoveOrder> list) {
+    _armyMove = _mutableAppend(
+      _armyMove ??= {..._base.armyMoveOrdersByPlayerId},
+      playerId,
+      list,
+    );
+  }
+
+  void addBuildOrders(String playerId, List<BuildUnitOrder> list) {
+    _build = _mutableAppend(
+      _build ??= {..._base.buildUnitOrdersByPlayerId},
+      playerId,
+      list,
+    );
+  }
+
+  void addWorkOrders(String playerId, List<WorkOrder> list) {
+    _work = _mutableAppend(
+      _work ??= {..._base.workOrdersByPlayerId},
+      playerId,
+      list,
+    );
+  }
+
+  void addRecruitWorkerOrders(String playerId, List<RecruitWorkerOrder> list) {
+    _recruit = _mutableAppend(
+      _recruit ??= {..._base.recruitWorkerOrdersByPlayerId},
+      playerId,
+      list,
+    );
+  }
+
+  void addDiplomaticOrders(String playerId, List<DiplomaticOrder> list) {
+    _diplomatic = _mutableAppend(
+      _diplomatic ??= {..._base.diplomaticOrdersByPlayerId},
+      playerId,
+      list,
+    );
+  }
+
+  void addResearchOrders(String playerId, List<ResearchOrder> list) {
+    _research = _mutableAppend(
+      _research ??= {..._base.researchOrdersByPlayerId},
+      playerId,
+      list,
+    );
+  }
+
+  void addNavalMoveOrders(String playerId, List<NavalMoveOrder> list) {
+    _navalMove = _mutableAppend(
+      _navalMove ??= {..._base.navalMoveOrdersByPlayerId},
+      playerId,
+      list,
+    );
+  }
+
+  void addNavalMissionOrders(String playerId, List<NavalMissionOrder> list) {
+    _navalMission = _mutableAppend(
+      _navalMission ??= {..._base.navalMissionOrdersByPlayerId},
+      playerId,
+      list,
+    );
+  }
+
+  void addTradeOrders(String playerId, List<TradeOrder> list) {
+    _trade = _mutableAppend(
+      _trade ??= {..._base.tradeOrdersByPlayerId},
+      playerId,
+      list,
+    );
+  }
+
+  /// Materialises the accumulated orders into a single immutable [Orders].
+  ///
+  /// Families never appended to fall through to the seed maps (via the
+  /// `null`-keeps-existing semantics of [Orders.copyWith]).
+  Orders build() => _base.copyWith(
+    moveOrdersByPlayerId: _move,
+    armyMoveOrdersByPlayerId: _armyMove,
+    buildUnitOrdersByPlayerId: _build,
+    workOrdersByPlayerId: _work,
+    recruitWorkerOrdersByPlayerId: _recruit,
+    diplomaticOrdersByPlayerId: _diplomatic,
+    researchOrdersByPlayerId: _research,
+    navalMoveOrdersByPlayerId: _navalMove,
+    navalMissionOrdersByPlayerId: _navalMission,
+    tradeOrdersByPlayerId: _trade,
+  );
 }
 
 extension OrdersAppendExtension on Orders {

--- a/packages/colonizethis_ai/test/orders_extensions_test.dart
+++ b/packages/colonizethis_ai/test/orders_extensions_test.dart
@@ -1,4 +1,5 @@
 import 'package:colonizethis_ai/src/util/orders_extensions.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart';
 
@@ -27,7 +28,13 @@ void main() {
         'p2': [MoveOrder(unitId: 'm2', destinationTileKey: 'r1|b')],
       },
       workOrdersByPlayerId: {
-        'p2': [WorkOrder(unitId: 'w0', target: 'explore', targetTileKey: 't0')],
+        'p2': [
+          WorkOrder(
+            unitId: 'w0',
+            target: kWorkTargetExplore,
+            targetTileKey: 't0',
+          ),
+        ],
       },
     );
 

--- a/packages/colonizethis_ai/test/orders_extensions_test.dart
+++ b/packages/colonizethis_ai/test/orders_extensions_test.dart
@@ -19,4 +19,231 @@ void main() {
     expect(updated.moveOrdersByPlayerId['p2'], base.moveOrdersByPlayerId['p2']);
     expect(base.moveOrdersByPlayerId['p1']?.length, 1);
   });
+
+  group('OrdersBuilder (Refs #3288)', () {
+    Orders nonEmptyBase() => const Orders(
+      moveOrdersByPlayerId: {
+        'p1': [MoveOrder(unitId: 'm1', destinationTileKey: 'r1|a')],
+        'p2': [MoveOrder(unitId: 'm2', destinationTileKey: 'r1|b')],
+      },
+      workOrdersByPlayerId: {
+        'p2': [WorkOrder(unitId: 'w0', target: 'explore', targetTileKey: 't0')],
+      },
+    );
+
+    test('empty builder reproduces the seed orders', () {
+      final base = nonEmptyBase();
+      final built = OrdersBuilder(base).build();
+      expect(built, base);
+      // Untouched family maps fall through to the seed references.
+      expect(
+        identical(built.moveOrdersByPlayerId, base.moveOrdersByPlayerId),
+        isTrue,
+      );
+    });
+
+    test('default builder builds an empty Orders', () {
+      expect(OrdersBuilder().build(), const Orders());
+    });
+
+    test('single add per family equals the spread-append helper', () {
+      final base = nonEmptyBase();
+
+      void check(Orders viaBuilder, Orders viaAppend) {
+        expect(viaBuilder, viaAppend);
+      }
+
+      check(
+        (OrdersBuilder(base)..addMoveOrders('p1', const [
+              MoveOrder(unitId: 'm3', destinationTileKey: 'r1|c'),
+            ]))
+            .build(),
+        base.appendMoveOrders('p1', const [
+          MoveOrder(unitId: 'm3', destinationTileKey: 'r1|c'),
+        ]),
+      );
+
+      check(
+        (OrdersBuilder(base)..addBuildOrders('p1', const [
+              BuildUnitOrder(
+                unitType: 'soldier',
+                isMilitary: true,
+                spawnProvinceId: 'r1|x',
+              ),
+            ]))
+            .build(),
+        base.appendBuildOrders('p1', const [
+          BuildUnitOrder(
+            unitType: 'soldier',
+            isMilitary: true,
+            spawnProvinceId: 'r1|x',
+          ),
+        ]),
+      );
+
+      check(
+        (OrdersBuilder(base)..addWorkOrders('p1', const [
+              WorkOrder(unitId: 'w1', target: 'build', targetTileKey: 't1'),
+            ]))
+            .build(),
+        base.appendWorkOrders('p1', const [
+          WorkOrder(unitId: 'w1', target: 'build', targetTileKey: 't1'),
+        ]),
+      );
+
+      check(
+        (OrdersBuilder(base)..addRecruitWorkerOrders('p1', const [
+              RecruitWorkerOrder(targetTier: WorkerTier.peasant),
+            ]))
+            .build(),
+        base.appendRecruitWorkerOrders('p1', const [
+          RecruitWorkerOrder(targetTier: WorkerTier.peasant),
+        ]),
+      );
+
+      check(
+        (OrdersBuilder(base)..addDiplomaticOrders('p1', const [
+              DiplomaticOrder(
+                type: DiplomaticOrderType.offerPeace,
+                targetFactionId: 'gp2',
+              ),
+            ]))
+            .build(),
+        base.appendDiplomaticOrders('p1', const [
+          DiplomaticOrder(
+            type: DiplomaticOrderType.offerPeace,
+            targetFactionId: 'gp2',
+          ),
+        ]),
+      );
+
+      check(
+        (OrdersBuilder(base)..addResearchOrders('p1', const [
+              ResearchOrder(
+                slotIndex: 0,
+                techId: 'tech',
+                funding: ResearchFundingLevel.low,
+              ),
+            ]))
+            .build(),
+        base.appendResearchOrders('p1', const [
+          ResearchOrder(
+            slotIndex: 0,
+            techId: 'tech',
+            funding: ResearchFundingLevel.low,
+          ),
+        ]),
+      );
+
+      check(
+        (OrdersBuilder(base)..addNavalMoveOrders('p1', const [
+              NavalMoveOrder(fleetId: 'f1', destinationSeaZoneId: 's1'),
+            ]))
+            .build(),
+        base.appendNavalMoveOrders('p1', const [
+          NavalMoveOrder(fleetId: 'f1', destinationSeaZoneId: 's1'),
+        ]),
+      );
+
+      check(
+        (OrdersBuilder(base)..addNavalMissionOrders('p1', const [
+              NavalMissionOrder(fleetId: 'f1', mission: 'patrol'),
+            ]))
+            .build(),
+        base.appendNavalMissionOrders('p1', const [
+          NavalMissionOrder(fleetId: 'f1', mission: 'patrol'),
+        ]),
+      );
+
+      check(
+        (OrdersBuilder(base)..addTradeOrders('p1', [
+              TradeOrder(
+                commodityId: 'grain',
+                type: TradeOrderType.bid,
+                quantity: 2,
+                priority: 1,
+              ),
+            ]))
+            .build(),
+        base.appendTradeOrders('p1', [
+          TradeOrder(
+            commodityId: 'grain',
+            type: TradeOrderType.bid,
+            quantity: 2,
+            priority: 1,
+          ),
+        ]),
+      );
+    });
+
+    test('addArmyMoveOrders matches an equivalent copyWith append', () {
+      const base = Orders(
+        armyMoveOrdersByPlayerId: {
+          'p1': [ArmyMoveOrder(armyId: 'a0', destinationProvinceId: 'r1|p0')],
+        },
+      );
+      final built =
+          (OrdersBuilder(base)..addArmyMoveOrders('p1', const [
+                ArmyMoveOrder(armyId: 'a1', destinationProvinceId: 'r1|p1'),
+              ]))
+              .build();
+      expect(built.armyMoveOrdersByPlayerId['p1'], const [
+        ArmyMoveOrder(armyId: 'a0', destinationProvinceId: 'r1|p0'),
+        ArmyMoveOrder(armyId: 'a1', destinationProvinceId: 'r1|p1'),
+      ]);
+    });
+
+    test('sequential multi-family adds equal the chained append pipeline and '
+        'leave the seed unmutated', () {
+      final base = nonEmptyBase();
+
+      final viaBuilder =
+          (OrdersBuilder(base)
+                ..addWorkOrders('p1', const [
+                  WorkOrder(unitId: 'w1', target: 'build', targetTileKey: 't1'),
+                ])
+                ..addWorkOrders('p1', const [
+                  WorkOrder(unitId: 'w2', target: 'build', targetTileKey: 't2'),
+                ])
+                ..addRecruitWorkerOrders('p1', const [
+                  RecruitWorkerOrder(targetTier: WorkerTier.peasant),
+                ])
+                ..addBuildOrders('p1', const [
+                  BuildUnitOrder(
+                    unitType: 'soldier',
+                    isMilitary: true,
+                    spawnProvinceId: 'r1|x',
+                  ),
+                ]))
+              .build();
+
+      final viaAppend = base
+          .appendWorkOrders('p1', const [
+            WorkOrder(unitId: 'w1', target: 'build', targetTileKey: 't1'),
+          ])
+          .appendWorkOrders('p1', const [
+            WorkOrder(unitId: 'w2', target: 'build', targetTileKey: 't2'),
+          ])
+          .appendRecruitWorkerOrders('p1', const [
+            RecruitWorkerOrder(targetTier: WorkerTier.peasant),
+          ])
+          .appendBuildOrders('p1', const [
+            BuildUnitOrder(
+              unitType: 'soldier',
+              isMilitary: true,
+              spawnProvinceId: 'r1|x',
+            ),
+          ]);
+
+      expect(viaBuilder, viaAppend);
+      // Two appends to the same family/player concatenate in call order.
+      expect(
+        viaBuilder.workOrdersByPlayerId['p1']?.map((o) => o.unitId).toList(),
+        ['w1', 'w2'],
+      );
+      // Seed maps are never mutated by the builder.
+      expect(base.workOrdersByPlayerId['p1'], isNull);
+      expect(base.workOrdersByPlayerId['p2']?.length, 1);
+    });
+  });
 }


### PR DESCRIPTION
## Summary

Implements the **mutable `OrdersBuilder`** acceptance criterion of #3288 (AC6 / proposed-work step 6) and adopts it at the economy domain-planner slice — the one site that appends several order families in sequence.

- Adds `OrdersBuilder` to `packages/colonizethis_ai/lib/src/util/orders_extensions.dart`: a mutable per-family accumulator (`addMoveOrders`, `addBuildOrders`, `addWorkOrders`, `addRecruitWorkerOrders`, `addDiplomaticOrders`, `addResearchOrders`, `addNavalMove/MissionOrders`, `addTradeOrders`, `addArmyMoveOrders`) that materialises a single immutable `Orders` via `build()`. It seeds from a base `Orders`, copies a family map lazily only when that family is appended to, and never mutates the seed maps.
- Adopts it in `runDomainPlannersWithOutcome` → `_runEconomyDomainPlanners` / `_appendEconomyBuildOrders`: civilian-work, peasant-recruit, and build orders now accumulate in one builder and **freeze once at the tail**, instead of allocating a fresh `Orders` (`copyWith` over ten family maps) on every `appendXxxOrders`.

### Behaviour preservation
- The work and build suggestion calls still read `ctx.orders` (no append precedes them), and the recruit suggestion reads `builder.build()` so it observes the same post-work order set as before.
- For each touched family, `build()` yields exactly the map the equivalent chain of `appendXxxOrders` calls produced (base entries preserved; the accumulating player's list = existing ++ appended lists in call order). Untouched families fall through to the seed maps via `Orders.copyWith`'s null-keeps-existing semantics.

## Scope (one slice of #3288)

**Done in this push**
- AC6: `OrdersBuilder` introduced; `runDomainPlannersWithOutcome` uses it; intermediate `Orders` copies in the economy slice eliminated; final `Orders` equality identical to current output (test-proven).

**Deferred (disclosed)**
- Pipeline-wide single-freeze across *all* domain planners is **not** pursued here: each sub-planner (`move`, `diplomacy`, `naval`, `research`, conquest army-move) emits at most one family per call and reads the materialised `ctx.orders` for suggestion suppression between steps, so a single end-of-pipeline freeze would require changing every sub-planner's return contract and a cheap snapshot for the suggestion API (cross-cutting, higher risk for marginal allocation savings). Tracking under #3288; this PR delivers the reusable abstraction plus the highest-value sequential-append site.
- AC2 (`AIWorldSnapshot` province counts) and AC4-residual aggregate single-pass remain as noted in the issue; the major perf ACs (recipe index, `playerById`, log guards, lint gates, file split, riverpod) already landed in merged PRs #3291/#3293/#3294/#3302.

## Test plan
- [x] `dart analyze` on changed files — clean (only the pre-existing `unnecessary_null_comparison` warning at the GP-blocker branch, present on `dev`).
- [x] New `OrdersBuilder` equality tests in `test/orders_extensions_test.dart` (empty/default, per-family vs `appendXxxOrders`, multi-family + repeated same-family chain, seed-not-mutated) — pass.
- [x] Economy/orchestrator regression tests (`domain_planner_orchestrator_*`, `build_planner`, `castiron_peasant_recruit`, civilian-work logging) — pass.
- [x] Perf gates `full_ai_first_turn_wall_clock_budget_test.dart` and `seed42_first_turn_trade_enabled_wall_clock_budget_test.dart` — pass (≤ 15 000 ms each) when run without `-j` CPU contention.
- [x] Treasury lint gates `repo.ai_no_repeated_game_players_scan` and `repo.ai_no_repeated_production_recipes_catalog_scan` — no violations.

Refs #3288

Made with [Cursor](https://cursor.com)