### PR TITLE
test(ai): localize #3303 castIron peasant-recruit as circular-fabric no-op (#2847)

### DIFF
--- a/packages/colonizethis_ai/test/seed42_observer_conquest_regression_test.dart
+++ b/packages/colonizethis_ai/test/seed42_observer_conquest_regression_test.dart
@@ -106,12 +106,23 @@ void main() {
         'acquisition. gp4 is distinct: input-rich (inputs in stockpile 61 '
         'turns, zero-regiment only 1 turn) but locked in attritional war '
         '(gpAtWarTurnsByPeer minor1 99, tribe8 50, tribe2 45, gp3 22) and '
-        'converts few regiments into OW gains. Next levers (out of scope for a '
-        'single non-regressive slice; must hold the gp1/gp2 +6 baseline per '
-        'requirement clarification #8): castIron labour / population for gp3/'
-        'gp5/gp6 (worker growth or labour reservation) and attrition-war escape '
-        '/ OW target conversion for gp4. Skip removal awaits the diagnostic '
-        'confirming gp3-gp6 reach the >=3 OW floor (Refs #2847).',
+        'converts few regiments into OW gains. The #3303 worker-growth attempt '
+        '(recruit a peasant when castIron labour is population-bound) is now '
+        'localized as a STRUCTURAL NO-OP: its gate fires only for gp5 (37 '
+        'turns) and on EVERY one the seller cannot pay the peasant recruit cost '
+        'row of 2 fabric (gpCastIronLabourPeasantRecruitAffordableTurns == 0, '
+        'FabricStarvedTurns == 37) — a circular dependency, since the peasant '
+        'that would grow castIron labour is itself bought with fabric, the very '
+        'downstream commodity the castIron chain exists to unblock. Next levers '
+        '(out of scope for a single non-regressive slice; must hold the gp1/gp2 '
+        '+6 baseline per requirement clarification #8): a fabric-free or '
+        'fabric-self-funded labour-growth path for gp5 (it already shows '
+        'gpFabricRecipeFeasibleTurns == 48, so routing a domestic fabric '
+        'assignment before the recruit is a candidate), castIron MATERIAL '
+        'feasibility for gp3/gp6 (gpCastIronRecipeFeasibleTurns == 0), and '
+        'attrition-war escape / OW target conversion for gp4. Skip removal '
+        'awaits the diagnostic confirming gp3-gp6 reach the >=3 OW floor '
+        '(Refs #2847).',
     timeout: const Timeout(Duration(minutes: 15)),
   );
 }

--- a/packages/colonizethis_ai/test/seed42_observer_conquest_s7d_diagnostic_test.dart
+++ b/packages/colonizethis_ai/test/seed42_observer_conquest_s7d_diagnostic_test.dart
@@ -3,8 +3,6 @@ import 'dart:convert';
 import 'package:colonizethis_ai/colonizethis_ai.dart';
 import 'package:colonizethis_ai/src/planning/army_conquest_prep.dart'
     show regimentCountForPlayer;
-import 'package:colonizethis_ai/src/planning/cast_iron_labour_gate.dart'
-    show isCastIronLabourPopulationBoundForLockRecoverySeller;
 import 'package:colonizethis_ai/src/planning/expand_phase_planner.dart'
     show
         cheapestRegimentBuildTreasuryCost,
@@ -2015,9 +2013,6 @@ void main() {
       final castIronLabourPeasantRecruitFabricStarvedTurns = <String, int>{
         for (final gpId in gpIds) gpId: 0,
       };
-      const peasantRecruitProbeOrder = RecruitWorkerOrder(
-        targetTier: WorkerTier.peasant,
-      );
       // Minimum `labourPerOutput` across the castIron recipes — the cheapest
       // single run's effective-labour requirement, used as the food-starved /
       // population-bound fork threshold above.
@@ -2430,114 +2425,60 @@ void main() {
             }
           }
           if (player != null) {
-            // Refs #2847 — localize the #3303 castIron-labour peasant-recruit
-            // boost. Measure the boost's gate predicate and, when it holds,
-            // whether the seller can actually afford the peasant recruit cost
-            // row (2 fabric). The fabric-starved subset isolates the suspected
-            // circular dependency that renders the boost a no-op.
-            if (isCastIronLabourPopulationBoundForLockRecoverySeller(
+            // Refs #2847 — per-turn castIron-labour stage localization. The
+            // measure bundles the read-only flags (the #3303 peasant-recruit
+            // gate + affordability, fabric feedstock/recipe feasibility, and
+            // the castIron material/labour/food/tile fork); the caller only
+            // applies counter bumps. The fabric-starved peasant-recruit subset
+            // isolates the suspected circular dependency that renders the
+            // #3303 boost a no-op.
+            final ci = seed42S7dCastIronLabourTurnMeasure(
               game: game,
               playerId: gpId,
-            )) {
-              castIronLabourPeasantRecruitGateTurns[gpId] =
-                  (castIronLabourPeasantRecruitGateTurns[gpId] ?? 0) + 1;
-              final canAfford = canAffordRecruitWorker(
-                player,
-                peasantRecruitProbeOrder,
-                player.workerPool,
-                player.stockpile,
-                player.treasury,
-              ).canAfford;
-              if (canAfford) {
-                castIronLabourPeasantRecruitAffordableTurns[gpId] =
-                    (castIronLabourPeasantRecruitAffordableTurns[gpId] ?? 0) + 1;
+              fabricFeedstockIds: fabricFeedstockIds,
+              fabricRecipes: fabricRecipes,
+              castIronRecipes: castIronRecipes,
+              castIronFeedstockIds: castIronFeedstockIds,
+              castIronMinLabourPerOutput: castIronMinLabourPerOutput,
+            );
+            if (ci.peasantRecruitGate) {
+              bumpCounter(castIronLabourPeasantRecruitGateTurns, gpId);
+              if (ci.peasantRecruitAffordable) {
+                bumpCounter(castIronLabourPeasantRecruitAffordableTurns, gpId);
               } else {
-                castIronLabourPeasantRecruitFabricStarvedTurns[gpId] =
-                    (castIronLabourPeasantRecruitFabricStarvedTurns[gpId] ?? 0) +
-                    1;
+                bumpCounter(castIronLabourPeasantRecruitFabricStarvedTurns, gpId);
               }
             }
-            final holdsFeedstock = fabricFeedstockIds.any(
-              (id) => player.stockpile.quantityOf(id) > 0,
-            );
-            if (holdsFeedstock) {
-              feedstockInStockpileTurns[gpId] =
-                  (feedstockInStockpileTurns[gpId] ?? 0) + 1;
+            if (ci.holdsFabricFeedstock) {
+              bumpCounter(feedstockInStockpileTurns, gpId);
             }
-            final recipeFeasible = fabricRecipes.any(
-              (recipe) => recipe.inputQuantities.entries.every(
-                (e) => player.stockpile.quantityOf(e.key) >= e.value,
-              ),
-            );
-            if (recipeFeasible) {
-              fabricRecipeFeasibleTurns[gpId] =
-                  (fabricRecipeFeasibleTurns[gpId] ?? 0) + 1;
+            if (ci.fabricRecipeFeasible) {
+              bumpCounter(fabricRecipeFeasibleTurns, gpId);
             }
-            if (stockpileAffordsAnyProductionRecipe(
-              player.stockpile,
-              castIronRecipes,
-            )) {
-              castIronRecipeFeasibleTurns[gpId] =
-                  (castIronRecipeFeasibleTurns[gpId] ?? 0) + 1;
+            if (ci.castIronMaterialFeasible) {
+              bumpCounter(castIronRecipeFeasibleTurns, gpId);
               // Split the material-feasible turns by the planner's labour gate
               // and by the staging gate's tile-ownership precondition.
-              if (stockpileAndLabourAffordAnyProductionRecipe(
-                game,
-                gpId,
-                castIronRecipes,
-              )) {
-                castIronRecipeLabourFeasibleTurns[gpId] =
-                    (castIronRecipeLabourFeasibleTurns[gpId] ?? 0) + 1;
-              } else if (castIronMinLabourPerOutput > 0) {
-                // Material-feasible but labour-infeasible: fork the cause into
-                // food-starved (fully-fed ceiling would fund a run) vs
-                // population-bound (ceiling itself below one run).
-                if (playerRawLabourSupply(game, gpId) >=
-                    castIronMinLabourPerOutput) {
-                  castIronLabourFoodStarvedTurns[gpId] =
-                      (castIronLabourFoodStarvedTurns[gpId] ?? 0) + 1;
-                } else {
-                  castIronLabourPopulationBoundTurns[gpId] =
-                      (castIronLabourPopulationBoundTurns[gpId] ?? 0) + 1;
-                }
+              if (ci.castIronLabourFeasible) {
+                bumpCounter(castIronRecipeLabourFeasibleTurns, gpId);
+              } else if (ci.castIronLabourFoodStarved) {
+                bumpCounter(castIronLabourFoodStarvedTurns, gpId);
+              } else if (ci.castIronLabourPopulationBound) {
+                bumpCounter(castIronLabourPopulationBoundTurns, gpId);
               }
-              if (ownsFeedstockResourceTileAnyLevel(
-                game,
-                gpId,
-                castIronFeedstockIds,
-              )) {
-                castIronFeasibleOwnsFeedstockTileTurns[gpId] =
-                    (castIronFeasibleOwnsFeedstockTileTurns[gpId] ?? 0) + 1;
+              if (ci.castIronOwnsFeedstockTile) {
+                bumpCounter(castIronFeasibleOwnsFeedstockTileTurns, gpId);
               }
             }
           }
           // Cache the turn-99 snapshot fields for the final rollup.
           if (t == 99) {
-            lastSnapshotFields[gpId] = <String, Object?>{
-              'oldWorldProvincesOwned': snap.conquest.oldWorldProvincesOwned,
-              'invadableProvinceCount':
-                  snap.conquest.invadableProvinceIdsSorted.length,
-              'nwInvadableCount':
-                  snap.colonial.invadableNewWorldProvinceIdsSorted.length,
-              'atWarWith': snap.threats.atWarWith.toList()..sort(),
-              'adjacentOwnerFactionIdsSorted':
-                  snap.conquest.adjacentOwnerFactionIdsSorted,
-              'treasury': player?.treasury,
-              'regimentCount': regimentCountForPlayer(game, gpId),
-              'cheapestRegimentBuildTreasuryCost':
-                  cheapestRegimentBuildTreasuryCost(),
-              // Refs #2847 H8 castIron labour-starvation corroboration: the
-              // effective (food-fed) labour, the raw (fully-fed) ceiling, and
-              // the food on hand at the terminal turn for the food-starved vs
-              // population-bound read.
-              'effectiveLabour': playerEffectiveLabour(game, gpId),
-              'rawLabourSupply': playerRawLabourSupply(game, gpId),
-              'foodOnHand': playerFoodOnHand(
-                game,
-                gpId,
-                castIronLabourFoodCommodityIds,
-              ),
-            };
+            lastSnapshotFields[gpId] = seed42S7dTurn99SnapshotFields(
+              game: game,
+              playerId: gpId,
+              snap: snap,
+              foodCommodityIds: castIronLabourFoodCommodityIds,
+            );
           }
         }
 

--- a/packages/colonizethis_ai/test/seed42_observer_conquest_s7d_diagnostic_test.dart
+++ b/packages/colonizethis_ai/test/seed42_observer_conquest_s7d_diagnostic_test.dart
@@ -3,6 +3,8 @@ import 'dart:convert';
 import 'package:colonizethis_ai/colonizethis_ai.dart';
 import 'package:colonizethis_ai/src/planning/army_conquest_prep.dart'
     show regimentCountForPlayer;
+import 'package:colonizethis_ai/src/planning/cast_iron_labour_gate.dart'
+    show isCastIronLabourPopulationBoundForLockRecoverySeller;
 import 'package:colonizethis_ai/src/planning/expand_phase_planner.dart'
     show
         cheapestRegimentBuildTreasuryCost,
@@ -1466,6 +1468,53 @@ import 'support/seed42_s7d_feedstock_helpers.dart';
 /// three helpers `playerEffectiveLabour` / `playerRawLabourSupply` /
 /// `playerFoodOnHand` in `seed42_s7d_feedstock_helpers_test.dart`).
 ///
+/// ## Refs #2847 — #3303 peasant-recruit effectiveness (circular fabric lock)
+///
+/// #3303 acted on the population-bound finding above: it wired an EXPAND
+/// orchestrator pass that emits one peasant `RecruitWorkerOrder` whenever
+/// `isCastIronLabourPopulationBoundForLockRecoverySeller` holds, so the seller
+/// can grow raw labour toward one `castIron` run. The S7-D refresh **after
+/// #3303 landed** shows it did not move the conquest gate (OW gain unchanged:
+/// gp1/gp2 +6, gp3 +2, gp4 +1, gp5 +1, gp6 +2) and that
+/// `gpCastIronRecipeLabourFeasibleTurns` / `gpCastIronProductionAssignedTurns`
+/// are **still 0 for every GP**. Three read-only counters localize why by
+/// splitting the boost's gate-active turns on peasant-recruit affordability
+/// (`canAffordRecruitWorker` against `WorkerActionEconomyCatalog.peasant`,
+/// whose cost row is **2 `fabric`**):
+///
+///   * `gpCastIronLabourPeasantRecruitGateTurns` = **gp5 = 37**, every other
+///     GP = 0. Only gp5 ever satisfies the #3303 gate: gp3/gp4/gp6 are never
+///     even castIron material-feasible (`gpCastIronRecipeFeasibleTurns == 0`),
+///     and gp1 holds regiments (the gate is scoped to `regimentCount == 0`).
+///   * `gpCastIronLabourPeasantRecruitAffordableTurns` = **0 for every GP**.
+///   * `gpCastIronLabourPeasantRecruitFabricStarvedTurns` = **gp5 = 37**
+///     (== its gate-active total).
+///
+/// **#3303 is a structural no-op.** On every turn its gate fires (gp5, 37
+/// turns) the seller cannot pay the peasant recruit's 2-`fabric` cost, so the
+/// orchestrator probes a recruit the validator must reject — raw labour never
+/// grows, the castIron run never becomes labour-feasible. This is a **circular
+/// dependency**: the peasant that would grow castIron labour is itself bought
+/// with `fabric`, the very downstream commodity the castIron → improvement →
+/// feedstock-extraction chain exists to unblock. A fabric-starved
+/// lock-recovery seller can never bootstrap out of the lock through peasant
+/// recruitment.
+///
+/// **Re-pointed next slice (supersedes the peasant-recruit hypothesis):** the
+/// labour-growth lever must not consume the scarce end-of-chain commodity.
+/// gp5 already shows `gpFabricRecipeFeasibleTurns == 48` (it can run the fabric
+/// recipe from owned cotton/wool feedstock), so a viable direction is to route
+/// a domestic `fabric` production assignment for the lock-recovery seller
+/// *before* the peasant recruit so the 2-`fabric` cost is payable from own
+/// output rather than from the (absent) market — or to grow labour through a
+/// fabric-free path. Verify by confirming
+/// `gpCastIronLabourPeasantRecruitAffordableTurns` rises above 0, then
+/// `gpCastIronRecipeLabourFeasibleTurns` and `gpCastIronProductionAssigned
+/// Turns` rise above 0 for gp5, while the gp1/gp2 +6 baseline holds. This
+/// slice is read-only diagnostic instrumentation (no behaviour change, no
+/// config constants, no gate-threshold changes; the three counters partition
+/// the gate-active turns under a structural-invariant assertion).
+///
 /// ## Refs #2924 Step 0 — world-market lock-recovery metrics
 ///
 /// The same run now also emits a separate
@@ -1935,6 +1984,40 @@ void main() {
       final castIronLabourPopulationBoundTurns = <String, int>{
         for (final gpId in gpIds) gpId: 0,
       };
+      // Refs #2847 — peasant-recruit effectiveness localization for the
+      // #3303 castIron-labour boost. #3303 wired an EXPAND orchestrator pass
+      // that emits one peasant `RecruitWorkerOrder` whenever
+      // `isCastIronLabourPopulationBoundForLockRecoverySeller` holds (the
+      // lock-recovery seller is material-feasible for one castIron run yet its
+      // raw population ceiling supplies < `labourPerOutput` labour). The S7-D
+      // refresh after #3303 shows `gpCastIronRecipeLabourFeasibleTurns` is
+      // STILL 0 for every GP, i.e. the boost never makes a castIron run
+      // labour-feasible. These counters localize *why* by measuring, per GP:
+      //   * `castIronLabourPeasantRecruitGateTurns` — turns the #3303 gate
+      //     predicate itself holds (the boost's distinguishing condition);
+      //   * `castIronLabourPeasantRecruitAffordableTurns` — of those, turns the
+      //     seller can actually pay the peasant recruit cost row
+      //     (`WorkerActionEconomyCatalog.peasant`, which costs 2 `fabric`);
+      //   * `castIronLabourPeasantRecruitFabricStarvedTurns` — of those, turns
+      //     it CANNOT (the suspected circular dependency: recruiting the
+      //     peasant that would grow castIron labour itself needs `fabric`, the
+      //     very downstream commodity the castIron chain exists to unblock).
+      // If FabricStarved == GateTurns the #3303 boost is a structural no-op:
+      // every gate-active turn it probes a peasant recruit the validator must
+      // reject for want of fabric. Read-only; counts move freely as later
+      // slices land.
+      final castIronLabourPeasantRecruitGateTurns = <String, int>{
+        for (final gpId in gpIds) gpId: 0,
+      };
+      final castIronLabourPeasantRecruitAffordableTurns = <String, int>{
+        for (final gpId in gpIds) gpId: 0,
+      };
+      final castIronLabourPeasantRecruitFabricStarvedTurns = <String, int>{
+        for (final gpId in gpIds) gpId: 0,
+      };
+      const peasantRecruitProbeOrder = RecruitWorkerOrder(
+        targetTier: WorkerTier.peasant,
+      );
       // Minimum `labourPerOutput` across the castIron recipes — the cheapest
       // single run's effective-labour requirement, used as the food-starved /
       // population-bound fork threshold above.
@@ -2347,6 +2430,33 @@ void main() {
             }
           }
           if (player != null) {
+            // Refs #2847 — localize the #3303 castIron-labour peasant-recruit
+            // boost. Measure the boost's gate predicate and, when it holds,
+            // whether the seller can actually afford the peasant recruit cost
+            // row (2 fabric). The fabric-starved subset isolates the suspected
+            // circular dependency that renders the boost a no-op.
+            if (isCastIronLabourPopulationBoundForLockRecoverySeller(
+              game: game,
+              playerId: gpId,
+            )) {
+              castIronLabourPeasantRecruitGateTurns[gpId] =
+                  (castIronLabourPeasantRecruitGateTurns[gpId] ?? 0) + 1;
+              final canAfford = canAffordRecruitWorker(
+                player,
+                peasantRecruitProbeOrder,
+                player.workerPool,
+                player.stockpile,
+                player.treasury,
+              ).canAfford;
+              if (canAfford) {
+                castIronLabourPeasantRecruitAffordableTurns[gpId] =
+                    (castIronLabourPeasantRecruitAffordableTurns[gpId] ?? 0) + 1;
+              } else {
+                castIronLabourPeasantRecruitFabricStarvedTurns[gpId] =
+                    (castIronLabourPeasantRecruitFabricStarvedTurns[gpId] ?? 0) +
+                    1;
+              }
+            }
             final holdsFeedstock = fabricFeedstockIds.any(
               (id) => player.stockpile.quantityOf(id) > 0,
             );
@@ -2732,6 +2842,12 @@ void main() {
         'gpCastIronLabourFoodStarvedTurns': castIronLabourFoodStarvedTurns,
         'gpCastIronLabourPopulationBoundTurns':
             castIronLabourPopulationBoundTurns,
+        'gpCastIronLabourPeasantRecruitGateTurns':
+            castIronLabourPeasantRecruitGateTurns,
+        'gpCastIronLabourPeasantRecruitAffordableTurns':
+            castIronLabourPeasantRecruitAffordableTurns,
+        'gpCastIronLabourPeasantRecruitFabricStarvedTurns':
+            castIronLabourPeasantRecruitFabricStarvedTurns,
         'castIronMinLabourPerOutput': castIronMinLabourPerOutput,
         'gpTurn99Snapshot': lastSnapshotFields,
       };
@@ -2902,6 +3018,26 @@ void main() {
           lessThanOrEqualTo(100),
           reason:
               '$gpId acquisition-target-active turns cannot exceed the '
+              '100-turn run length',
+        );
+        // Refs #2847 peasant-recruit localization: the affordable and
+        // fabric-starved sub-counters partition the #3303 gate-active turns,
+        // and the gate total cannot exceed the 100-turn run. Guards the
+        // instrumentation gating itself without pinning the (freely tunable)
+        // per-GP counts.
+        expect(
+          castIronLabourPeasantRecruitAffordableTurns[gpId]! +
+              castIronLabourPeasantRecruitFabricStarvedTurns[gpId]!,
+          castIronLabourPeasantRecruitGateTurns[gpId],
+          reason:
+              '$gpId peasant-recruit gate-active turns must split into '
+              'affordable + fabric-starved sub-causes',
+        );
+        expect(
+          castIronLabourPeasantRecruitGateTurns[gpId]!,
+          lessThanOrEqualTo(100),
+          reason:
+              '$gpId peasant-recruit gate-active turns cannot exceed the '
               '100-turn run length',
         );
       }

--- a/packages/colonizethis_ai/test/support/seed42_s7d_feedstock_helpers.dart
+++ b/packages/colonizethis_ai/test/support/seed42_s7d_feedstock_helpers.dart
@@ -4,9 +4,18 @@
 // that diagnostic test file at or below the repo non-comment line limit
 // (`repo.dart_file_non_comment_line_size`). These are pure read-only scans over
 // game state used by the H8-supply / H8-extraction stage-localization counters.
+import 'package:colonizethis_ai/src/perception/perception_snapshot.dart'
+    show AIWorldSnapshot;
+import 'package:colonizethis_ai/src/planning/army_conquest_prep.dart'
+    show regimentCountForPlayer;
+import 'package:colonizethis_ai/src/planning/cast_iron_labour_gate.dart'
+    show isCastIronLabourPopulationBoundForLockRecoverySeller;
+import 'package:colonizethis_ai/src/planning/expand_phase_planner.dart'
+    show cheapestRegimentBuildTreasuryCost;
 import 'package:colonizethis_ai/src/planning/recipe_scoring.dart'
     show feasibleRuns;
-import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_data/colonizethis_data.dart'
+    hide cheapestRegimentBuildTreasuryCost;
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
@@ -319,6 +328,183 @@ int playerFoodOnHand(
     total += player.stockpile.quantityOf(id);
   }
   return total;
+}
+
+/// Increments the per-GP [key] entry of a `<String, int>` diagnostic [counter]
+/// by one, treating an absent entry as zero. Shared by the S7-D diagnostic to
+/// keep its many per-turn counter bumps to a single line each.
+void bumpCounter(Map<String, int> counter, String key) =>
+    counter[key] = (counter[key] ?? 0) + 1;
+
+/// Per-turn castIron-labour stage-localization measurement for one GP (Refs
+/// #2847). Pure read-only over `(game, playerId)`: bundles the boolean flags
+/// the S7-D diagnostic increments each turn so the caller only applies counter
+/// bumps. Mirrors the inline measurement it replaced exactly —
+///
+///   * `peasantRecruitGate` / `peasantRecruitAffordable` —
+///     [castIronLabourPeasantRecruitProbe] (the #3303 boost localization).
+///   * `holdsFabricFeedstock` — any [fabricFeedstockIds] held in the stockpile.
+///   * `fabricRecipeFeasible` — any [fabricRecipes] materially runnable.
+///   * `castIronMaterialFeasible` — any [castIronRecipes] materially runnable
+///     ([stockpileAffordsAnyProductionRecipe]); the labour / food / tile flags
+///     below are only meaningful (non-false) when this holds.
+///   * `castIronLabourFeasible` — material-feasible **and** labour-feasible
+///     ([stockpileAndLabourAffordAnyProductionRecipe]).
+///   * `castIronLabourFoodStarved` / `castIronLabourPopulationBound` — the
+///     material-feasible-but-labour-infeasible fork keyed on
+///     [castIronMinLabourPerOutput] vs [playerRawLabourSupply] (fully-fed
+///     ceiling would fund a run vs ceiling itself below one run); both false
+///     when [castIronMinLabourPerOutput] is not positive.
+///   * `castIronOwnsFeedstockTile` — owns a castIron feedstock tile at any
+///     level ([ownsFeedstockResourceTileAnyLevel]).
+///
+/// All flags are false for an unknown player. No game-state mutation.
+({
+  bool peasantRecruitGate,
+  bool peasantRecruitAffordable,
+  bool holdsFabricFeedstock,
+  bool fabricRecipeFeasible,
+  bool castIronMaterialFeasible,
+  bool castIronLabourFeasible,
+  bool castIronLabourFoodStarved,
+  bool castIronLabourPopulationBound,
+  bool castIronOwnsFeedstockTile,
+})
+seed42S7dCastIronLabourTurnMeasure({
+  required Game game,
+  required String playerId,
+  required Set<String> fabricFeedstockIds,
+  required List<ProductionRecipe> fabricRecipes,
+  required List<ProductionRecipe> castIronRecipes,
+  required Set<String> castIronFeedstockIds,
+  required int castIronMinLabourPerOutput,
+}) {
+  const none = (
+    peasantRecruitGate: false,
+    peasantRecruitAffordable: false,
+    holdsFabricFeedstock: false,
+    fabricRecipeFeasible: false,
+    castIronMaterialFeasible: false,
+    castIronLabourFeasible: false,
+    castIronLabourFoodStarved: false,
+    castIronLabourPopulationBound: false,
+    castIronOwnsFeedstockTile: false,
+  );
+  final player = game.playerById(playerId);
+  if (player == null) return none;
+  final recruit = castIronLabourPeasantRecruitProbe(game, playerId);
+  final holdsFabricFeedstock = fabricFeedstockIds.any(
+    (id) => player.stockpile.quantityOf(id) > 0,
+  );
+  final fabricRecipeFeasible = fabricRecipes.any(
+    (recipe) => recipe.inputQuantities.entries.every(
+      (e) => player.stockpile.quantityOf(e.key) >= e.value,
+    ),
+  );
+  final castIronMaterialFeasible = stockpileAffordsAnyProductionRecipe(
+    player.stockpile,
+    castIronRecipes,
+  );
+  var castIronLabourFeasible = false;
+  var foodStarved = false;
+  var populationBound = false;
+  var ownsTile = false;
+  if (castIronMaterialFeasible) {
+    castIronLabourFeasible = stockpileAndLabourAffordAnyProductionRecipe(
+      game,
+      playerId,
+      castIronRecipes,
+    );
+    if (!castIronLabourFeasible && castIronMinLabourPerOutput > 0) {
+      if (playerRawLabourSupply(game, playerId) >= castIronMinLabourPerOutput) {
+        foodStarved = true;
+      } else {
+        populationBound = true;
+      }
+    }
+    ownsTile = ownsFeedstockResourceTileAnyLevel(
+      game,
+      playerId,
+      castIronFeedstockIds,
+    );
+  }
+  return (
+    peasantRecruitGate: recruit.gateActive,
+    peasantRecruitAffordable: recruit.affordable,
+    holdsFabricFeedstock: holdsFabricFeedstock,
+    fabricRecipeFeasible: fabricRecipeFeasible,
+    castIronMaterialFeasible: castIronMaterialFeasible,
+    castIronLabourFeasible: castIronLabourFeasible,
+    castIronLabourFoodStarved: foodStarved,
+    castIronLabourPopulationBound: populationBound,
+    castIronOwnsFeedstockTile: ownsTile,
+  );
+}
+
+/// Builds the per-GP turn-99 snapshot field map cached for the S7-D
+/// diagnostic rollup (Refs #2847). Pure read-only construction over
+/// `(game, playerId, snap)`: the conquest/colonial/threat snapshot fields, the
+/// treasury and regiment trajectory, the cheapest-regiment treasury floor, and
+/// the castIron labour-starvation corroboration trio (effective food-fed
+/// labour, raw fully-fed ceiling, and [foodCommodityIds] on hand at the
+/// terminal turn). Extracted to keep the diagnostic test file at or below the
+/// repo non-comment line limit; no game-state mutation.
+Map<String, Object?> seed42S7dTurn99SnapshotFields({
+  required Game game,
+  required String playerId,
+  required AIWorldSnapshot snap,
+  required Set<String> foodCommodityIds,
+}) {
+  final player = game.playerById(playerId);
+  return <String, Object?>{
+    'oldWorldProvincesOwned': snap.conquest.oldWorldProvincesOwned,
+    'invadableProvinceCount': snap.conquest.invadableProvinceIdsSorted.length,
+    'nwInvadableCount': snap.colonial.invadableNewWorldProvinceIdsSorted.length,
+    'atWarWith': snap.threats.atWarWith.toList()..sort(),
+    'adjacentOwnerFactionIdsSorted': snap.conquest.adjacentOwnerFactionIdsSorted,
+    'treasury': player?.treasury,
+    'regimentCount': regimentCountForPlayer(game, playerId),
+    'cheapestRegimentBuildTreasuryCost': cheapestRegimentBuildTreasuryCost(),
+    'effectiveLabour': playerEffectiveLabour(game, playerId),
+    'rawLabourSupply': playerRawLabourSupply(game, playerId),
+    'foodOnHand': playerFoodOnHand(game, playerId, foodCommodityIds),
+  };
+}
+
+/// Read-only probe for the #3303 castIron-labour peasant-recruit boost
+/// localization (Refs #2847). Returns whether the boost's distinguishing gate
+/// predicate `isCastIronLabourPopulationBoundForLockRecoverySeller` holds for
+/// [playerId] this turn, and — when it does — whether the seller can actually
+/// pay the peasant `RecruitWorkerOrder` cost row
+/// (`WorkerActionEconomyCatalog.peasant`, which costs 2 `fabric`) via
+/// `canAffordRecruitWorker`.
+///
+/// The `affordable == false` branch (gate active yet cost unpayable) isolates
+/// the suspected circular dependency that renders the #3303 boost a structural
+/// no-op: recruiting the peasant that would grow castIron labour itself needs
+/// `fabric`, the very downstream commodity the castIron chain exists to
+/// unblock. `affordable` is `false` when the gate is inactive. Pure read-only
+/// over `(game, playerId)`; no game-state mutation.
+({bool gateActive, bool affordable}) castIronLabourPeasantRecruitProbe(
+  Game game,
+  String playerId,
+) {
+  if (!isCastIronLabourPopulationBoundForLockRecoverySeller(
+    game: game,
+    playerId: playerId,
+  )) {
+    return (gateActive: false, affordable: false);
+  }
+  final player = game.playerById(playerId);
+  if (player == null) return (gateActive: true, affordable: false);
+  final affordable = canAffordRecruitWorker(
+    player,
+    const RecruitWorkerOrder(targetTier: WorkerTier.peasant),
+    player.workerPool,
+    player.stockpile,
+    player.treasury,
+  ).canAfford;
+  return (gateActive: true, affordable: affordable);
 }
 
 /// True iff [playerId] owns at least one province tile hosting one of


### PR DESCRIPTION
## Summary

Adds read-only S7-D diagnostic instrumentation that localizes why the most
recent #2847 slice (#3303 — recruit a peasant when castIron labour is
population-bound) did **not** move the seed-42 turn-100 conquest gate. No
production behaviour, config, or gate-threshold changes.

Three new per-GP counters partition the #3303 boost's gate-active turns by
peasant-recruit affordability (`WorkerActionEconomyCatalog.peasant` costs
**2 `fabric`**), under a structural-invariant assertion:

- `gpCastIronLabourPeasantRecruitGateTurns`
- `gpCastIronLabourPeasantRecruitAffordableTurns`
- `gpCastIronLabourPeasantRecruitFabricStarvedTurns`

invariant: `affordable + fabricStarved == gate` and `gate <= 100`.

## Finding (seed 42, turn 100, after #3303 landed)

- OW gain unchanged: gp1/gp2 **+6**, gp3 **+2**, gp4 **+1**, gp5 **+1**, gp6 **+2**.
- `gpCastIronRecipeLabourFeasibleTurns` / `gpCastIronProductionAssignedTurns` still **0 for every GP**.
- `GateTurns`: **gp5 = 37**, all other GPs 0 (gp3/gp4/gp6 are never castIron material-feasible; gp1 holds regiments and the gate is scoped to `regimentCount == 0`).
- `AffordableTurns`: **0 for every GP**.
- `FabricStarvedTurns`: **gp5 = 37** (== its gate total).

**Conclusion: #3303 is a structural no-op.** Every turn its gate fires (gp5,
37 turns) the seller cannot pay the 2-`fabric` recruit cost, so the
orchestrator probes a recruit the validator must reject — raw labour never
grows and the castIron run never becomes labour-feasible. This is a **circular
dependency**: the peasant that would grow castIron labour is itself bought with
`fabric`, the very downstream commodity the castIron → improvement →
feedstock-extraction chain exists to unblock.

## Next lever (documented, deferred)

gp5 already shows `gpFabricRecipeFeasibleTurns == 48`, so a fabric-free or
fabric-self-funded labour-growth path (e.g. routing a domestic `fabric`
production assignment before the peasant recruit) is the candidate for the next
behaviour slice. gp3/gp6 remain blocked earlier (castIron never material-
feasible); gp4 is military-conversion-bound. The diagnostic doc-comment and the
regression skip note are updated accordingly.

## Scope

- **Done in this push:** diagnostic localization + invariant assertion + doc/skip-note refresh (test-only, read-only).
- **Remaining for #2847:** the actual conquest-gate closure for gp3–gp6 (next behaviour slice per the re-pointed lever); the gate AC and `seed42_observer_conquest_regression_test` skip stay in place until gp3–gp6 reach the ≥3 OW floor.
- gp1/gp2 **+6** baseline untouched (no behaviour change).

## Tests

- `seed42_observer_conquest_s7d_diagnostic_test.dart` (`--run-skipped`): passes; new structural-invariant asserts hold; metrics captured above.
- `cast_iron_labour_gate_test.dart`, `domain_planner_orchestrator_castiron_peasant_recruit_test.dart`: pass.
- `dart analyze` clean on both changed files.

Refs #2847

Made with [Cursor](https://cursor.com)