### PR TITLE
perf(ai): index-backed feedstock recipe lookups in economy planner (#3288)

### DIFF
--- a/packages/colonizethis_ai/lib/src/planning/economy_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/economy_planner.dart
@@ -503,11 +503,11 @@ Set<String> _multiInputImprovementOutputs(Set<String> outputIds) {
 
 /// The production recipe with the lowest `id` whose output is [outputId], or
 /// `null` when no recipe produces it. Deterministic over the static
-/// `ProductionRecipesCatalog`.
+/// `ProductionRecipesCatalog`; uses the O(1) `producing` index instead of an
+/// O(recipes) full-catalog scan (Refs #3288 step 5).
 ProductionRecipe? _lowestIdRecipeProducingOutput(String outputId) {
   ProductionRecipe? best;
-  for (final recipe in ProductionRecipesCatalog.all) {
-    if (recipe.outputCommodityId != outputId) continue;
+  for (final recipe in ProductionRecipesCatalog.producing(outputId)) {
     if (best == null || recipe.id.compareTo(best.id) < 0) best = recipe;
   }
   return best;
@@ -519,18 +519,15 @@ ProductionRecipe? _lowestIdRecipeProducingOutput(String outputId) {
 /// improvement input needs so single-input competitors (`lumber_from_timber`)
 /// cannot drain it before the multi-input recipe accumulates a full run
 /// (Refs #2847 H8-extraction feedstock co-availability). Deterministic: the
-/// lowest-`id` recipe is chosen per output, and the catalog is iterated in a
-/// fixed order. Returns an empty map when [outputIds] is empty.
+/// lowest-`id` recipe is chosen per output via the O(1) `producing` index
+/// (Refs #3288 step 5) and reserve accumulation is order-independent. Returns
+/// an empty map when [outputIds] is empty.
 Map<CommodityId, int> _feedstockReserveForOutputs(Set<String> outputIds) {
   if (outputIds.isEmpty) return const {};
   final reserve = <CommodityId, int>{};
-  final seenOutputs = <String>{};
-  final sorted = [...ProductionRecipesCatalog.all]
-    ..sort((a, b) => a.id.compareTo(b.id));
-  for (final recipe in sorted) {
-    final out = recipe.outputCommodityId;
-    if (!outputIds.contains(out)) continue;
-    if (!seenOutputs.add(out)) continue;
+  for (final out in outputIds) {
+    final recipe = _lowestIdRecipeProducingOutput(out);
+    if (recipe == null) continue;
     for (final entry in recipe.inputQuantities.entries) {
       reserve[entry.key] = (reserve[entry.key] ?? 0) + entry.value;
     }


### PR DESCRIPTION
## Summary

Completes the recipe-index adoption (Proposed work **step 5**) of #3288 for the economy planner hot path. Replaces the two remaining `ProductionRecipesCatalog.all` full-catalog scans in `packages/colonizethis_ai/lib/src/planning/economy_planner.dart` with the existing O(1) `ProductionRecipesCatalog.producing()` output index (added earlier under #3288 in `colonizethis_data`).

`Refs #3288`

## Done in this push

- `_lowestIdRecipeProducingOutput(outputId)` now iterates only `ProductionRecipesCatalog.producing(outputId)` (recipes producing that commodity) and selects the lowest-`id` recipe, instead of an O(recipes) scan of `ProductionRecipesCatalog.all`.
- `_feedstockReserveForOutputs(outputIds)` now reuses `_lowestIdRecipeProducingOutput` per requested output, removing the per-call `[...all]..sort()` + full-catalog scan. Reserve accumulation into the map is order-independent, so the result is identical.
- Doc comments updated to reflect the index-backed, deterministic path.

This removes the last two unbounded `ProductionRecipesCatalog.all` traversals on the per-AI-player economy planning path, contributing to the hard 15 s turn-resolution budget (`colonizethis-turn-resolution-budget.mdc`, `SPEC/program/turn-resolution.md`).

## Behaviour preservation (no functional drift)

- `producing(c)` is proven equal to a full scan of `all` filtered by `outputCommodityId` (and to preserve `all`-order within a bucket) by the data-package test `packages/colonizethis_data/test/commodity_and_recipe_catalog_test.dart` § *byOutputCommodityId index (Refs #3288)*.
- Lowest-`id`-per-output selection and one-run feedstock input summation are unchanged; the only change is the iteration source (indexed subset vs. sorted full list).
- Deterministic emission contract of `SPEC/ai/economy-planner.md` is preserved.

## Tests run (green)

- `colonizethis_ai`: `economy_planner_test.dart`, `economy_planner_regiment_build_input_production_test.dart`, `domain_planner_orchestrator_h8_feedstock_civilian_work_test.dart`, `seed42_s7d_feedstock_helpers_test.dart`, `recipe_scoring_test.dart`, `economy_planner_phase_plan_injection_test.dart`, `domain_planner_orchestrator_economy_naval_research_test.dart` — all pass (positive feedstock-reserve / production and negative no-labour / missing-input paths covered).
- `colonizethis_data`: `commodity_and_recipe_catalog_test.dart` (index equivalence) — passes.
- `dart analyze` on the edited file — clean. (Two pre-existing `unnecessary_null_comparison` warnings remain in `diplomatic_candidate_scoring_declare_war.dart` and `domain_planner_orchestrator.dart`; not touched by this PR.)

No new tests added: this is a behaviour-preserving swap whose equivalence is already locked by the data-package index test plus the existing economy/feedstock AI suites.

## Scope / deferred (remaining #3288 work)

Several #3288 steps already landed on `dev` (riverpod moved to `dev_dependencies`; `_treasuryForPlayer` is O(1) via `playerById`; `OrdersBuilder` + `provinceOwner` memoization via #3307; treasury-planner split; `producing()` index in data + treasury planners). **Deferred** to follow-up commits/PRs for this issue: hot-path log-level guards (step 7) across `conquest`/`diplomacy`/`move` planners (currently only partially guarded via `_log.debugEnabled`). `_allocateLabour`'s full-catalog scan is intentionally retained (it scores every recipe, so an output index does not apply).

Made with [Cursor](https://cursor.com)