### PR TITLE
perf: complete AI hot-path optimisations for turn budget (#3288)

### DIFF
--- a/SPEC/ai/treasury-planner.md
+++ b/SPEC/ai/treasury-planner.md
@@ -1332,6 +1332,14 @@ criterion in the sections above is preserved unchanged.
   planning player's perception. When `snapshot` is omitted (legacy test
   entrypoints), behaviour falls back to the prior world-state scans.
 
+### Single-pass lock-recovery aggregates
+
+- `runTreasuryPlanner` builds one `_LockRecoveryGameScan` per invocation: a single
+  `game.players` pass that precomputes sorted GP ids, the broke-GP flag, peer
+  seller bootstrap flags, per-player lock-recovery seller predicates, and the
+  designated affluent buyer rotation. Lock-recovery helpers consume the scan
+  instead of re-iterating `game.players` for each predicate.
+
 ### Determinism and budget
 
 The indices are pure functions of the static `ProductionRecipesCatalog` and the

--- a/SPEC/ai/treasury-planner.md
+++ b/SPEC/ai/treasury-planner.md
@@ -1319,6 +1319,19 @@ criterion in the sections above is preserved unchanged.
   `ai_api.dart`) instead of a linear `game.players` scan. The absent-player
   fallback (`0`) is unchanged.
 
+### Snapshot-derived province counts
+
+- `runTreasuryPlanner` accepts an optional `AIWorldSnapshot? snapshot` threaded
+  from [economy-planner.md](economy-planner.md) and the domain-planner
+  orchestrator. When `snapshot != null` and `snapshot.playerId == playerId`,
+  lock-recovery seller detection reads
+  `snapshot.conquest.oldWorldProvincesOwned` and
+  `snapshot.colonial.newWorldProvincesOwned` instead of scanning
+  `game.worldState` for the active GP. Peer-GP lock-recovery scans still use
+  `game.worldState` / `game.players` because the snapshot holds only the
+  planning player's perception. When `snapshot` is omitted (legacy test
+  entrypoints), behaviour falls back to the prior world-state scans.
+
 ### Determinism and budget
 
 The indices are pure functions of the static `ProductionRecipesCatalog` and the
@@ -1337,6 +1350,10 @@ turn-resolution budget.
 - Given any `Game` and `playerId`, when `_treasuryForPlayer(game, playerId)` is
   evaluated, then it returns `game.playerById(playerId)?.treasury ?? 0` (the
   matching player's treasury, or `0` when no player has that id).
+- Given `runTreasuryPlanner` inputs where `snapshot.playerId == playerId` and
+  the snapshot province counts match the authoritative `game.worldState` counts
+  for that GP, when `runTreasuryPlanner` runs with and without `snapshot`, then
+  both runs return identical `List<TradeOrder>` outputs.
 - Given identical inputs `(game, playerId, stockpile, productionAssignments,
   treasury, tileMapByRegion, topology, currentOrders)`, when
   `runTreasuryPlanner` runs twice after the index change, then both runs return

--- a/SPEC/program/disallowed-ast-patterns.md
+++ b/SPEC/program/disallowed-ast-patterns.md
@@ -295,6 +295,28 @@ Rule id: `nested_world_state_copywith` (`match.kind`:
 `packages/colonizethis_logic/lib/`, `match.outer_argument_name`:
 `worldState`).
 
+### Full production-recipe-catalog scans in `colonizethis_ai`
+
+In `packages/colonizethis_ai/lib/**`, accessing the static member
+**`ProductionRecipesCatalog.all`** is disallowed. AI planning must resolve
+recipes through the O(1) indexes **`ProductionRecipesCatalog.producing(commodityId)`**
+(output index) or **`ProductionRecipesCatalog.byId[recipeId]`** (id index)
+instead of iterating the whole catalog per commodity / per turn.
+
+Rationale: per-turn AI planning runs inside the 15-second next-turn-resolution
+budget. A full `ProductionRecipesCatalog.all` scan is `O(recipes)` per lookup
+and, in hot feedstock/market loops, easily becomes `O(recipes × commodities)`
+per player per turn. The index conversions in Refs #3288 removed every
+output-keyed full scan from the economy and treasury planners; this rule
+prevents silent regression. A genuine all-recipes loop (for example labour
+allocation that must score every feasible recipe, not look one up by output)
+may suppress with an inline `// ignore: disallowed_ast_ai_full_recipe_catalog_scan`
+and a rationale comment.
+
+Rule id: `ai_full_recipe_catalog_scan` (`match.kind`: `static_member_access`,
+`match.type_name`: `ProductionRecipesCatalog`, `match.member_name`: `all`,
+`match.relative_path_prefix`: `packages/colonizethis_ai/lib/`).
+
 ### Coverage
 
 Enforcement walks the same domain trees via `tool/ct_repo_lint_scan_contract.dart` (`collectRepoLintDomainDartFiles`), aligned with `SPEC/program/exception-enforcement.md` coverage:
@@ -529,3 +551,25 @@ Generated files (`*.g.dart`, `*.freezed.dart`, `*.mocks.dart`) and tests (`**/te
   `// ignore_for_file: disallowed_ast_nested_world_state_copywith` marker,
   **when** the disallowed AST checker runs, **then** it does not report
   that violation for `nested_world_state_copywith`.
+
+- **Given** runtime Dart source under `packages/colonizethis_ai/lib/`
+  that accesses `ProductionRecipesCatalog.all`, **when** the disallowed AST
+  checker runs, **then** it reports at least one violation for
+  `ai_full_recipe_catalog_scan` with the correct file and line.
+
+- **Given** runtime Dart source under `packages/colonizethis_ai/lib/`
+  that resolves recipes via `ProductionRecipesCatalog.producing(commodityId)`
+  or `ProductionRecipesCatalog.byId[recipeId]` instead of `.all`, **when** the
+  disallowed AST checker runs, **then** it does not report an
+  `ai_full_recipe_catalog_scan` violation for that access.
+
+- **Given** runtime Dart source outside `packages/colonizethis_ai/lib/`
+  that accesses `ProductionRecipesCatalog.all`, **when** the disallowed AST
+  checker runs, **then** it does not report an `ai_full_recipe_catalog_scan`
+  violation for that access.
+
+- **Given** runtime Dart source under `packages/colonizethis_ai/lib/`
+  that accesses `ProductionRecipesCatalog.all` with
+  `// ignore: disallowed_ast_ai_full_recipe_catalog_scan` on the violating
+  line or the line above, **when** the disallowed AST checker runs, **then**
+  it does not report that violation for `ai_full_recipe_catalog_scan`.

--- a/packages/colonizethis_ai/lib/src/planning/conquest_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/conquest_planner.dart
@@ -196,7 +196,9 @@ Orders runConquestArmyMovePlanner({
     ctx.orders,
   );
   if (armyMoveCandidates.isEmpty) {
-    _log.d('conquest army move nationId=${ctx.nationId} candidatesCount=0');
+    if (_log.debugEnabled) {
+      _log.d('conquest army move nationId=${ctx.nationId} candidatesCount=0');
+    }
     if (stalledExpansion) {
       return _runStalledFrontierArmyMoveFallback(
         ctx: ctx,
@@ -218,7 +220,9 @@ Orders runConquestArmyMovePlanner({
     draftOrders: ctx.orders,
   );
   if (filtered.isEmpty) {
-    _log.d('conquest army move filtered empty nationId=${ctx.nationId}');
+    if (_log.debugEnabled) {
+      _log.d('conquest army move filtered empty nationId=${ctx.nationId}');
+    }
     if (stalledExpansion) {
       return _runStalledFrontierArmyMoveFallback(
         ctx: ctx,
@@ -283,9 +287,11 @@ Orders runConquestArmyMovePlanner({
     weight = colonialPressureFloor;
   }
   if (weight < 10) {
-    _log.d(
-      'conquest army move skipped nationId=${ctx.nationId} weight=$weight',
-    );
+    if (_log.debugEnabled) {
+      _log.d(
+        'conquest army move skipped nationId=${ctx.nationId} weight=$weight',
+      );
+    }
     return ctx.orders;
   }
   // Under stalled-expansion (Refs #2509 EXPAND / COLONIAL-lite hot path) a
@@ -348,11 +354,13 @@ Orders runConquestArmyMovePlanner({
     ),
   );
   if (selected == null) return ctx.orders;
-  _log.i(
-    'conquest army move chosen nationId=${ctx.nationId} '
-    'armyId=${selected.armyId} destinationProvinceId=${selected.destinationProvinceId} '
-    'declaredWarTarget=$declaredWarTargetFactionId',
-  );
+  if (_log.infoEnabled) {
+    _log.i(
+      'conquest army move chosen nationId=${ctx.nationId} '
+      'armyId=${selected.armyId} destinationProvinceId=${selected.destinationProvinceId} '
+      'declaredWarTarget=$declaredWarTargetFactionId',
+    );
+  }
   return applyArmyMoveOrderForPlayer(ctx.orders, ctx.nationId, selected);
 }
 
@@ -442,10 +450,12 @@ Orders _applyStalledArmyMovesForAllFieldArmies({
       ),
     );
     if (best == null) continue;
-    _log.i(
-      'conquest army move stalled multi nationId=${ctx.nationId} '
-      'armyId=${best.armyId} destinationProvinceId=${best.destinationProvinceId}',
-    );
+    if (_log.infoEnabled) {
+      _log.i(
+        'conquest army move stalled multi nationId=${ctx.nationId} '
+        'armyId=${best.armyId} destinationProvinceId=${best.destinationProvinceId}',
+      );
+    }
     result = applyArmyMoveOrderForPlayer(result, ctx.nationId, best);
     armiesWithOrders.add(best.armyId);
   }
@@ -520,10 +530,12 @@ Orders _runStalledFrontierArmyMoveFallback({
   if (best == null) {
     return ctx.orders;
   }
-  _log.i(
-    'conquest army move stalled fallback nationId=${ctx.nationId} '
-    'armyId=${best.armyId} destinationProvinceId=${best.destinationProvinceId}',
-  );
+  if (_log.infoEnabled) {
+    _log.i(
+      'conquest army move stalled fallback nationId=${ctx.nationId} '
+      'armyId=${best.armyId} destinationProvinceId=${best.destinationProvinceId}',
+    );
+  }
   return applyArmyMoveOrderForPlayer(ctx.orders, ctx.nationId, best);
 }
 

--- a/packages/colonizethis_ai/lib/src/planning/diplomacy_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/diplomacy_planner.dart
@@ -310,10 +310,12 @@ DiplomacyPlannerResult? _forcedInvadableGpDeclarePlannerResultIfNeeded({
   if (target == null) {
     return null;
   }
-  _log.i(
-    'diplomacy forced declareWar nationId=${ctx.nationId} '
-    '$logLabel=$target',
-  );
+  if (_log.infoEnabled) {
+    _log.i(
+      'diplomacy forced declareWar nationId=${ctx.nationId} '
+      '$logLabel=$target',
+    );
+  }
   return DiplomacyPlannerResult(
     orders: ctx.orders.appendDiplomaticOrders(ctx.nationId, [
       DiplomaticOrder(
@@ -381,10 +383,12 @@ DiplomacyPlannerResult? _defaultStartOwMinorDeclarePlannerResultIfNeeded({
   if (minorTarget == null) {
     return null;
   }
-  _log.i(
-    'diplomacy forced declareWar nationId=${ctx.nationId} '
-    'defaultStartMinor=$minorTarget',
-  );
+  if (_log.infoEnabled) {
+    _log.i(
+      'diplomacy forced declareWar nationId=${ctx.nationId} '
+      'defaultStartMinor=$minorTarget',
+    );
+  }
   return DiplomacyPlannerResult(
     orders: ctx.orders.appendDiplomaticOrders(ctx.nationId, [
       DiplomaticOrder(
@@ -411,10 +415,12 @@ DiplomacyPlannerResult? _belowQuotaUninvadedMinorDeclarePlannerResultIfNeeded({
   if (minorTarget == null) {
     return null;
   }
-  _log.i(
-    'diplomacy forced declareWar nationId=${ctx.nationId} '
-    'belowQuotaMinor=$minorTarget',
-  );
+  if (_log.infoEnabled) {
+    _log.i(
+      'diplomacy forced declareWar nationId=${ctx.nationId} '
+      'belowQuotaMinor=$minorTarget',
+    );
+  }
   return DiplomacyPlannerResult(
     orders: ctx.orders.appendDiplomaticOrders(ctx.nationId, [
       DiplomaticOrder(
@@ -441,10 +447,12 @@ DiplomacyPlannerResult? _plateauOwMinorDeclarePlannerResultIfNeeded({
   if (minorTarget == null) {
     return null;
   }
-  _log.i(
-    'diplomacy forced declareWar nationId=${ctx.nationId} '
-    'plateauMinor=$minorTarget',
-  );
+  if (_log.infoEnabled) {
+    _log.i(
+      'diplomacy forced declareWar nationId=${ctx.nationId} '
+      'plateauMinor=$minorTarget',
+    );
+  }
   return DiplomacyPlannerResult(
     orders: ctx.orders.appendDiplomaticOrders(ctx.nationId, [
       DiplomaticOrder(
@@ -471,9 +479,11 @@ DiplomacyPlannerResult? _criticalWeakMinorDeclarePlannerResultIfNeeded({
   if (minorTarget == null) {
     return null;
   }
-  _log.i(
-    'diplomacy forced declareWar nationId=${ctx.nationId} target=$minorTarget',
-  );
+  if (_log.infoEnabled) {
+    _log.i(
+      'diplomacy forced declareWar nationId=${ctx.nationId} target=$minorTarget',
+    );
+  }
   return DiplomacyPlannerResult(
     orders: ctx.orders.appendDiplomaticOrders(ctx.nationId, [
       DiplomaticOrder(
@@ -490,10 +500,12 @@ DiplomacyPlannerResult? _forcedDeclareWarPlannerResult({
   required String target,
   required String logLabel,
 }) {
-  _log.i(
-    'diplomacy forced declareWar nationId=${ctx.nationId} '
-    '$logLabel=$target',
-  );
+  if (_log.infoEnabled) {
+    _log.i(
+      'diplomacy forced declareWar nationId=${ctx.nationId} '
+      '$logLabel=$target',
+    );
+  }
   return DiplomacyPlannerResult(
     orders: ctx.orders.appendDiplomaticOrders(ctx.nationId, [
       DiplomaticOrder(
@@ -762,7 +774,9 @@ DiplomacyPlannerResult runDiplomacyPlannerWithResult({
     pass: pass,
   );
   if (weight < 25) {
-    _log.d('diplomacy skipped nationId=${ctx.nationId} weight=$weight < 25');
+    if (_log.debugEnabled) {
+      _log.d('diplomacy skipped nationId=${ctx.nationId} weight=$weight < 25');
+    }
     return DiplomacyPlannerResult(orders: ctx.orders);
   }
 
@@ -808,10 +822,12 @@ DiplomacyPlannerResult runDiplomacyPlannerWithResult({
     scores: scores,
   );
   if (chosen == null) return DiplomacyPlannerResult(orders: ctx.orders);
-  _log.i(
-    'diplomacy chosen nationId=${ctx.nationId} '
-    'type=${chosen.type}${chosen.type == DiplomaticOrderType.declareWar ? " targetFactionId=${chosen.targetFactionId}" : ""}',
-  );
+  if (_log.infoEnabled) {
+    _log.i(
+      'diplomacy chosen nationId=${ctx.nationId} '
+      'type=${chosen.type}${chosen.type == DiplomaticOrderType.declareWar ? " targetFactionId=${chosen.targetFactionId}" : ""}',
+    );
+  }
   final nextOrders = ctx.orders.appendDiplomaticOrders(ctx.nationId, [chosen]);
   final declaredTarget = chosen.type == DiplomaticOrderType.declareWar
       ? chosen.targetFactionId

--- a/packages/colonizethis_ai/lib/src/planning/domain_planner_orchestrator.dart
+++ b/packages/colonizethis_ai/lib/src/planning/domain_planner_orchestrator.dart
@@ -259,6 +259,7 @@ DomainPlannerOutcome runDomainPlannersWithOutcome({
             stockpile: player.stockpile,
             productionAssignments: economyPlan.productionAssignments,
             treasury: player.treasury,
+            snapshot: snapshot,
             tileMapByRegion: tileMapByRegion,
             topology: topology,
             currentOrders: ctx.orders,

--- a/packages/colonizethis_ai/lib/src/planning/economy_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/economy_planner.dart
@@ -367,6 +367,10 @@ List<AssignedRecipe> _allocateLabour({
   Set<String> supplierReleaseImprovementInputIds = const {},
   Set<String> feedstockReserveOutputIds = const {},
 }) {
+  // Labour allocation scores every feasible recipe to pick the best runs, so
+  // this is an intrinsic full-catalog pass, not an output-keyed lookup that the
+  // producing()/byId index could replace (Refs #3288).
+  // ignore: disallowed_ast_ai_full_recipe_catalog_scan
   final recipes = ProductionRecipesCatalog.all;
   final agendaId = config.hiddenAgendaId;
   Stockpile virtual = stockpile;

--- a/packages/colonizethis_ai/lib/src/planning/economy_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/economy_planner.dart
@@ -116,6 +116,7 @@ EconomyPlan runEconomyPlanner({
               stockpile: stockpile,
               productionAssignments: const [],
               treasury: player.treasury,
+              snapshot: snapshot,
               tileMapByRegion: tileMapByRegion,
               topology: topology,
             ),
@@ -212,7 +213,11 @@ EconomyPlan runEconomyPlanner({
   // the +6 OW baseline GPs are never starved. SPEC/ai/economy-planner.md
   // § Supplier improvement-input over-production for release.
   final supplierReleaseImprovementInputs =
-      isBelowQuotaZeroNwLockRecoverySeller(game, view.playerId)
+      isBelowQuotaZeroNwLockRecoverySeller(
+        game,
+        view.playerId,
+        snapshot: snapshot,
+      )
           ? const <String>{}
           : peerLockRecoverySellerNeededProducibleImprovementInputs(
               game,
@@ -284,6 +289,7 @@ EconomyPlan runEconomyPlanner({
           stockpile: stockpile,
           productionAssignments: assignments,
           treasury: player.treasury,
+          snapshot: snapshot,
           tileMapByRegion: tileMapByRegion,
           topology: topology,
         );

--- a/packages/colonizethis_ai/lib/src/planning/move_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/move_planner.dart
@@ -21,12 +21,16 @@ Orders runMovePlanner({required PlannerContext ctx}) {
   );
   if (filtered.isEmpty) return ctx.orders;
   final weight = ctx.resolveMilitaryEconomyWeight();
-  _log.d(
-    'move eval nationId=${ctx.nationId} weight=$weight '
-    'filteredCount=${filtered.length}',
-  );
+  if (_log.debugEnabled) {
+    _log.d(
+      'move eval nationId=${ctx.nationId} weight=$weight '
+      'filteredCount=${filtered.length}',
+    );
+  }
   if (weight < 20) {
-    _log.d('move skipped nationId=${ctx.nationId} weight < 20');
+    if (_log.debugEnabled) {
+      _log.d('move skipped nationId=${ctx.nationId} weight < 20');
+    }
     return ctx.orders;
   }
   final selected = selectWeightedCandidate(
@@ -42,10 +46,12 @@ Orders runMovePlanner({required PlannerContext ctx}) {
     },
   );
   if (selected == null) return ctx.orders;
-  _log.i(
-    'move chosen nationId=${ctx.nationId} '
-    'unitId=${selected.unitId} destinationTileKey=${selected.destinationTileKey}',
-  );
+  if (_log.infoEnabled) {
+    _log.i(
+      'move chosen nationId=${ctx.nationId} '
+      'unitId=${selected.unitId} destinationTileKey=${selected.destinationTileKey}',
+    );
+  }
   return ctx.orders.appendMoveOrders(ctx.nationId, [selected]);
 }
 
@@ -60,7 +66,9 @@ Orders runArmyMovePlanner({
     ctx.orders,
   );
   if (armyMoveCandidates.isEmpty) {
-    _log.d('army move eval nationId=${ctx.nationId} candidatesCount=0');
+    if (_log.debugEnabled) {
+      _log.d('army move eval nationId=${ctx.nationId} candidatesCount=0');
+    }
     return ctx.orders;
   }
   final filtered = filterArmyMoveOrdersByDiplomacy(
@@ -69,7 +77,9 @@ Orders runArmyMovePlanner({
     armyMoveCandidates,
   );
   if (filtered.isEmpty) {
-    _log.d('army move filtered empty nationId=${ctx.nationId}');
+    if (_log.debugEnabled) {
+      _log.d('army move filtered empty nationId=${ctx.nationId}');
+    }
     return ctx.orders;
   }
   final weight = ctx.resolveMilitaryEconomyWeight();
@@ -78,15 +88,19 @@ Orders runArmyMovePlanner({
       ? 10
       : 20;
   if (weight < minWeight) {
-    _log.d(
-      'army move skipped nationId=${ctx.nationId} weight=$weight < $minWeight',
-    );
+    if (_log.debugEnabled) {
+      _log.d(
+        'army move skipped nationId=${ctx.nationId} weight=$weight < $minWeight',
+      );
+    }
     return ctx.orders;
   }
-  _log.d(
-    'army move eval nationId=${ctx.nationId} weight=$weight '
-    'filteredCount=${filtered.length}',
-  );
+  if (_log.debugEnabled) {
+    _log.d(
+      'army move eval nationId=${ctx.nationId} weight=$weight '
+      'filteredCount=${filtered.length}',
+    );
+  }
   final selected = selectWeightedCandidate(
     candidates: filtered,
     seed: ctx.seeds.militarySeed + 2000,
@@ -99,9 +113,11 @@ Orders runArmyMovePlanner({
     },
   );
   if (selected == null) return ctx.orders;
-  _log.i(
-    'army move chosen nationId=${ctx.nationId} '
-    'armyId=${selected.armyId} destinationProvinceId=${selected.destinationProvinceId}',
-  );
+  if (_log.infoEnabled) {
+    _log.i(
+      'army move chosen nationId=${ctx.nationId} '
+      'armyId=${selected.armyId} destinationProvinceId=${selected.destinationProvinceId}',
+    );
+  }
   return applyArmyMoveOrderForPlayer(ctx.orders, ctx.nationId, selected);
 }

--- a/packages/colonizethis_ai/lib/src/planning/treasury_lock_recovery.dart
+++ b/packages/colonizethis_ai/lib/src/planning/treasury_lock_recovery.dart
@@ -7,6 +7,103 @@ part of 'treasury_planner.dart';
 // treasury-planner library), so imports, shared helpers, and visibility are
 // unchanged.
 
+/// Per-turn lock-recovery aggregates computed in one `game.players` pass (Refs
+/// #3288). Replaces repeated O(players) scans inside the treasury hot path.
+final class _LockRecoveryGameScan {
+  _LockRecoveryGameScan._({
+    required this.sortedGpIds,
+    required this.anyBrokeGreatPower,
+    required this.anySellerNeedsRegimentBuildInput,
+    required this.anySellerNeedsCastIronImprovementInput,
+    required this.isLockRecoverySellerByPlayerId,
+    required this.designatedBuyerId,
+  });
+
+  final List<String> sortedGpIds;
+  final bool anyBrokeGreatPower;
+  final bool anySellerNeedsRegimentBuildInput;
+  final bool anySellerNeedsCastIronImprovementInput;
+  final Map<String, bool> isLockRecoverySellerByPlayerId;
+  final String designatedBuyerId;
+
+  factory _LockRecoveryGameScan.fromGame(
+    Game game, {
+    AIWorldSnapshot? snapshot,
+  }) {
+    final regimentThreshold = cheapestRegimentBuildTreasuryCost();
+    final affluenceThreshold = treasuryAffluenceThreshold();
+    final sortedGpIds = <String>[];
+    var anyBrokeGreatPower = false;
+    var anySellerNeedsRegimentBuildInput = false;
+    var anySellerNeedsCastIronImprovementInput = false;
+    final isLockRecoverySellerByPlayerId = <String, bool>{};
+    final affluentNonSellerIds = <String>[];
+
+    for (final player in game.players) {
+      sortedGpIds.add(player.id);
+      if (player.treasury < regimentThreshold) {
+        anyBrokeGreatPower = true;
+      }
+      final isSeller = _isBelowQuotaZeroNwLockRecoverySeller(
+        game: game,
+        playerId: player.id,
+        snapshot: snapshot?.playerId == player.id ? snapshot : null,
+      );
+      isLockRecoverySellerByPlayerId[player.id] = isSeller;
+      if (isSeller) {
+        if (player.treasury >= regimentThreshold &&
+            regimentCountForPlayer(game, player.id) == 0) {
+          for (final entry
+              in RegimentEconomyCatalog.peasantLevies.buildInputs.entries) {
+            if (player.stockpile.quantityOf(entry.key) < entry.value) {
+              anySellerNeedsRegimentBuildInput = true;
+              break;
+            }
+          }
+        }
+        final cost = regimentBuildInputFeedstockImprovementInputCost(
+          game,
+          player.id,
+        );
+        if (cost.isNotEmpty) {
+          for (final entry in cost.entries) {
+            if (!kDomesticProductionImprovementInputIds.contains(entry.key)) {
+              continue;
+            }
+            if (player.stockpile.quantityOf(entry.key) < entry.value) {
+              anySellerNeedsCastIronImprovementInput = true;
+              break;
+            }
+          }
+        }
+      }
+      if (player.treasury >= affluenceThreshold && !isSeller) {
+        affluentNonSellerIds.add(player.id);
+      }
+    }
+    sortedGpIds.sort();
+    affluentNonSellerIds.sort();
+
+    final designatedBuyerId = !anyBrokeGreatPower || affluentNonSellerIds.isEmpty
+        ? ''
+        : affluentNonSellerIds[
+            game.worldState.turnState.turnNumber % affluentNonSellerIds.length];
+
+    return _LockRecoveryGameScan._(
+      sortedGpIds: sortedGpIds,
+      anyBrokeGreatPower: anyBrokeGreatPower,
+      anySellerNeedsRegimentBuildInput: anySellerNeedsRegimentBuildInput,
+      anySellerNeedsCastIronImprovementInput:
+          anySellerNeedsCastIronImprovementInput,
+      isLockRecoverySellerByPlayerId: isLockRecoverySellerByPlayerId,
+      designatedBuyerId: designatedBuyerId,
+    );
+  }
+
+  bool isLockRecoverySeller(String playerId) =>
+      isLockRecoverySellerByPlayerId[playerId] ?? false;
+}
+
 int _treasuryForPlayer(Game game, String playerId) =>
     game.playerById(playerId)?.treasury ?? 0;
 
@@ -62,26 +159,12 @@ bool _isBelowQuotaZeroNwLockRecoverySeller({
 
 /// True when any below-quota zero-NW lock-recovery seller still needs the
 /// H8 regiment build-input bootstrap path (Refs #2847 H8-supply market).
-bool _anyLockRecoverySellerNeedsRegimentBuildInput(Game game) {
-  final threshold = cheapestRegimentBuildTreasuryCost();
-  for (final player in game.players) {
-    if (!_isBelowQuotaZeroNwLockRecoverySeller(
-      game: game,
-      playerId: player.id,
-    )) {
-      continue;
-    }
-    if (player.treasury < threshold) continue;
-    if (regimentCountForPlayer(game, player.id) > 0) continue;
-    for (final entry
-        in RegimentEconomyCatalog.peasantLevies.buildInputs.entries) {
-      if (player.stockpile.quantityOf(entry.key) < entry.value) {
-        return true;
-      }
-    }
-  }
-  return false;
-}
+bool _anyLockRecoverySellerNeedsRegimentBuildInput(
+  Game game, {
+  _LockRecoveryGameScan? scan,
+}) =>
+    (scan ?? _LockRecoveryGameScan.fromGame(game))
+        .anySellerNeedsRegimentBuildInput;
 
 /// Public accessor for the below-quota zero-NW lock-recovery seller predicate
 /// (Refs #2847 H8-supply castIron source). The economy planner uses it to keep
@@ -107,65 +190,21 @@ bool isBelowQuotaZeroNwLockRecoverySeller(
 /// surplus + aligns its offer tier so the locked seller's bid can cross.
 /// Pure function of `(game)` and the static catalogs; returns `false` once no
 /// locked seller still needs the improvement input (self-clearing).
-bool anyLockRecoverySellerNeedsCastIronImprovementInput(Game game) {
-  for (final player in game.players) {
-    if (!_isBelowQuotaZeroNwLockRecoverySeller(
-      game: game,
-      playerId: player.id,
-    )) {
-      continue;
-    }
-    final cost = regimentBuildInputFeedstockImprovementInputCost(
-      game,
-      player.id,
-    );
-    if (cost.isEmpty) continue;
-    for (final entry in cost.entries) {
-      if (!kDomesticProductionImprovementInputIds.contains(entry.key)) {
-        continue;
-      }
-      if (player.stockpile.quantityOf(entry.key) < entry.value) {
-        return true;
-      }
-    }
-  }
-  return false;
-}
-
-/// Sorted Great Power ids for deterministic per-turn buyer rotation.
-List<String> _sortedGreatPowerIds(Game game) {
-  final ids = <String>[
-    for (final player in game.players) player.id,
-  ]..sort();
-  return ids;
-}
-
-/// True iff at least one Great Power has `player.treasury <
-/// cheapestRegimentBuildTreasuryCost()`. The lock-recovery liquidity bid is
-/// only useful when at least one broke GP needs buy-side demand for its
-/// urgent offers. Refs #2924 F12.
-bool _anyBrokeGreatPower(Game game) {
-  final threshold = cheapestRegimentBuildTreasuryCost();
-  for (final player in game.players) {
-    if (player.treasury < threshold) return true;
-  }
-  return false;
-}
+bool anyLockRecoverySellerNeedsCastIronImprovementInput(
+  Game game, {
+  _LockRecoveryGameScan? scan,
+}) =>
+    (scan ?? _LockRecoveryGameScan.fromGame(game))
+        .anySellerNeedsCastIronImprovementInput;
 
 bool _isAffluentDesignatedLockRecoveryBuyer({
   required Game game,
   required String playerId,
+  _LockRecoveryGameScan? scan,
 }) {
-  if (!_anyBrokeGreatPower(game)) return false;
-  final gpIds = _sortedGreatPowerIds(game);
-  final affluent = <String>[
-    for (final id in gpIds)
-      if (_treasuryForPlayer(game, id) >= treasuryAffluenceThreshold() &&
-          !_isBelowQuotaZeroNwLockRecoverySeller(game: game, playerId: id))
-        id,
-  ];
-  if (affluent.isEmpty) return false;
-  final designated = lockRecoveryDesignatedBuyerId(game);
+  final resolved = scan ?? _LockRecoveryGameScan.fromGame(game);
+  if (!resolved.anyBrokeGreatPower) return false;
+  final designated = resolved.designatedBuyerId;
   return designated.isNotEmpty && playerId == designated;
 }
 
@@ -176,8 +215,10 @@ bool isLockRecoveryLiquidityBuyer({
   required String playerId,
   required int treasuryBudgetForBids,
   required int treasuryForecast,
+  _LockRecoveryGameScan? scan,
 }) {
-  if (!_anyBrokeGreatPower(game)) return false;
+  final resolved = scan ?? _LockRecoveryGameScan.fromGame(game);
+  if (!resolved.anyBrokeGreatPower) return false;
   final liquidity = _lockRecoveryLiquidityCommodity(game.worldMarketState);
   final pricePerUnit = game.worldMarketState.prices[liquidity] ?? 0;
   if (pricePerUnit <= 0 || treasuryBudgetForBids < pricePerUnit) {
@@ -189,16 +230,8 @@ bool isLockRecoveryLiquidityBuyer({
   if (rawTreasury < threshold && treasuryForecast >= threshold) {
     return false;
   }
-  final gpIds = _sortedGreatPowerIds(game);
-  final affluent = <String>[
-    for (final id in gpIds)
-      if (_treasuryForPlayer(game, id) >= treasuryAffluenceThreshold() &&
-          !_isBelowQuotaZeroNwLockRecoverySeller(game: game, playerId: id))
-        id,
-  ];
-  if (affluent.isNotEmpty) {
-    final designated = lockRecoveryDesignatedBuyerId(game);
-    return designated.isNotEmpty && playerId == designated;
+  if (resolved.designatedBuyerId.isNotEmpty) {
+    return playerId == resolved.designatedBuyerId;
   }
   // F15: when no GP is affluent, logic-phase minor auto-bids (`world_market_phase`
   // / `computeLockRecoveryMinorAutoBids`) fund liquidity-food purchases. GP buyers
@@ -214,8 +247,12 @@ const List<String> kLockRecoveryPreferredBuyerIds = ['gp1', 'gp2'];
 /// Buyer when no GP meets [treasuryAffluenceThreshold]: rotate among
 /// [kLockRecoveryPreferredBuyerIds] present in the game, else the two
 /// richest-by-treasury GPs.
-String lockRecoveryFallbackBuyerId(Game game) {
-  final gpIds = _sortedGreatPowerIds(game);
+String lockRecoveryFallbackBuyerId(
+  Game game, {
+  _LockRecoveryGameScan? scan,
+}) {
+  final resolved = scan ?? _LockRecoveryGameScan.fromGame(game);
+  final gpIds = resolved.sortedGpIds;
   if (gpIds.isEmpty) return '';
   final preferred = <String>[
     for (final id in kLockRecoveryPreferredBuyerIds)
@@ -223,15 +260,18 @@ String lockRecoveryFallbackBuyerId(Game game) {
   ];
   final buyerPool = preferred.length >= 2
       ? preferred
-      : _twoRichestGreatPowerIdsByTreasury(game);
+      : _twoRichestGreatPowerIdsByTreasury(game, scan: resolved);
   if (buyerPool.isEmpty) return '';
   if (buyerPool.length == 1) return buyerPool.first;
   final turn = game.worldState.turnState.turnNumber;
   return buyerPool[turn % buyerPool.length];
 }
 
-List<String> _twoRichestGreatPowerIdsByTreasury(Game game) {
-  final gpIds = _sortedGreatPowerIds(game);
+List<String> _twoRichestGreatPowerIdsByTreasury(
+  Game game, {
+  _LockRecoveryGameScan? scan,
+}) {
+  final gpIds = (scan ?? _LockRecoveryGameScan.fromGame(game)).sortedGpIds;
   if (gpIds.isEmpty) return const [];
   final ranked = [...gpIds]
     ..sort((a, b) {
@@ -257,21 +297,11 @@ List<String> _twoRichestGreatPowerIdsByTreasury(Game game) {
 /// Returns the empty string when no Great Power is broke — every GP is
 /// already at or above the regiment threshold and the F1–F5 / F10 paths
 /// handle the steady state without a synthetic grain bid. Refs #2924 F12.
-String lockRecoveryDesignatedBuyerId(Game game) {
-  if (!_anyBrokeGreatPower(game)) return '';
-  final gpIds = _sortedGreatPowerIds(game);
-  if (gpIds.isEmpty) return '';
-  final threshold = treasuryAffluenceThreshold();
-  final affluent = <String>[
-    for (final id in gpIds)
-      if (_treasuryForPlayer(game, id) >= threshold &&
-          !_isBelowQuotaZeroNwLockRecoverySeller(game: game, playerId: id))
-        id,
-  ];
-  if (affluent.isEmpty) return '';
-  final turn = game.worldState.turnState.turnNumber;
-  return affluent[turn % affluent.length];
-}
+String lockRecoveryDesignatedBuyerId(
+  Game game, {
+  _LockRecoveryGameScan? scan,
+}) =>
+    (scan ?? _LockRecoveryGameScan.fromGame(game)).designatedBuyerId;
 
 /// Designated buyer bids [commodityId] and does not offer it this turn.
 ///

--- a/packages/colonizethis_ai/lib/src/planning/treasury_lock_recovery.dart
+++ b/packages/colonizethis_ai/lib/src/planning/treasury_lock_recovery.dart
@@ -51,30 +51,15 @@ final class _LockRecoveryGameScan {
       );
       isLockRecoverySellerByPlayerId[player.id] = isSeller;
       if (isSeller) {
-        if (player.treasury >= regimentThreshold &&
-            regimentCountForPlayer(game, player.id) == 0) {
-          for (final entry
-              in RegimentEconomyCatalog.peasantLevies.buildInputs.entries) {
-            if (player.stockpile.quantityOf(entry.key) < entry.value) {
-              anySellerNeedsRegimentBuildInput = true;
-              break;
-            }
-          }
-        }
-        final cost = regimentBuildInputFeedstockImprovementInputCost(
+        if (_lockRecoverySellerNeedsRegimentBuildInput(
           game,
-          player.id,
-        );
-        if (cost.isNotEmpty) {
-          for (final entry in cost.entries) {
-            if (!kDomesticProductionImprovementInputIds.contains(entry.key)) {
-              continue;
-            }
-            if (player.stockpile.quantityOf(entry.key) < entry.value) {
-              anySellerNeedsCastIronImprovementInput = true;
-              break;
-            }
-          }
+          player,
+          regimentThreshold: regimentThreshold,
+        )) {
+          anySellerNeedsRegimentBuildInput = true;
+        }
+        if (_lockRecoverySellerNeedsCastIronImprovementInput(game, player)) {
+          anySellerNeedsCastIronImprovementInput = true;
         }
       }
       if (player.treasury >= affluenceThreshold && !isSeller) {
@@ -102,6 +87,43 @@ final class _LockRecoveryGameScan {
 
   bool isLockRecoverySeller(String playerId) =>
       isLockRecoverySellerByPlayerId[playerId] ?? false;
+}
+
+bool _lockRecoverySellerNeedsRegimentBuildInput(
+  Game game,
+  Player player, {
+  required int regimentThreshold,
+}) {
+  if (player.treasury < regimentThreshold ||
+      regimentCountForPlayer(game, player.id) != 0) {
+    return false;
+  }
+  for (final entry in RegimentEconomyCatalog.peasantLevies.buildInputs.entries) {
+    if (player.stockpile.quantityOf(entry.key) < entry.value) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool _lockRecoverySellerNeedsCastIronImprovementInput(
+  Game game,
+  Player player,
+) {
+  final cost = regimentBuildInputFeedstockImprovementInputCost(
+    game,
+    player.id,
+  );
+  if (cost.isEmpty) return false;
+  for (final entry in cost.entries) {
+    if (!kDomesticProductionImprovementInputIds.contains(entry.key)) {
+      continue;
+    }
+    if (player.stockpile.quantityOf(entry.key) < entry.value) {
+      return true;
+    }
+  }
+  return false;
 }
 
 int _treasuryForPlayer(Game game, String playerId) =>

--- a/packages/colonizethis_ai/lib/src/planning/treasury_lock_recovery.dart
+++ b/packages/colonizethis_ai/lib/src/planning/treasury_lock_recovery.dart
@@ -10,7 +10,25 @@ part of 'treasury_planner.dart';
 int _treasuryForPlayer(Game game, String playerId) =>
     game.playerById(playerId)?.treasury ?? 0;
 
-int _newWorldProvinceCountOwnedBy(Game game, String playerId) {
+int _oldWorldProvinceCountOwnedBy(
+  Game game,
+  String playerId, {
+  AIWorldSnapshot? snapshot,
+}) {
+  if (snapshot != null && snapshot.playerId == playerId) {
+    return snapshot.conquest.oldWorldProvincesOwned;
+  }
+  return oldWorldProvinceCountOwnedBy(game, playerId);
+}
+
+int _newWorldProvinceCountOwnedBy(
+  Game game,
+  String playerId, {
+  AIWorldSnapshot? snapshot,
+}) {
+  if (snapshot != null && snapshot.playerId == playerId) {
+    return snapshot.colonial.newWorldProvincesOwned;
+  }
   var count = 0;
   for (final province in game.worldState.newWorld.provinces) {
     if (province.ownerId == playerId) count++;
@@ -25,11 +43,18 @@ int _newWorldProvinceCountOwnedBy(Game game, String playerId) {
 bool _isBelowQuotaZeroNwLockRecoverySeller({
   required Game game,
   required String playerId,
+  AIWorldSnapshot? snapshot,
 }) {
-  final ow = oldWorldProvinceCountOwnedBy(game, playerId);
+  final ow = _oldWorldProvinceCountOwnedBy(
+    game,
+    playerId,
+    snapshot: snapshot,
+  );
   if (ow <= 0) return false;
   if (!isBelowObserverConquestQuota(ow)) return false;
-  if (_newWorldProvinceCountOwnedBy(game, playerId) != 0) return false;
+  if (_newWorldProvinceCountOwnedBy(game, playerId, snapshot: snapshot) != 0) {
+    return false;
+  }
   // Mid-below-quota EXPAND band (seed-42 gp3–gp6); excludes minimal
   // single-province test fixtures that are not Path F lock-recovery sellers.
   return ow >= 2;
@@ -62,8 +87,16 @@ bool _anyLockRecoverySellerNeedsRegimentBuildInput(Game game) {
 /// (Refs #2847 H8-supply castIron source). The economy planner uses it to keep
 /// the supplier `castIron` over-production off for a GP that is itself a locked
 /// seller (its own self-path boost already covers it).
-bool isBelowQuotaZeroNwLockRecoverySeller(Game game, String playerId) =>
-    _isBelowQuotaZeroNwLockRecoverySeller(game: game, playerId: playerId);
+bool isBelowQuotaZeroNwLockRecoverySeller(
+  Game game,
+  String playerId, {
+  AIWorldSnapshot? snapshot,
+}) =>
+    _isBelowQuotaZeroNwLockRecoverySeller(
+      game: game,
+      playerId: playerId,
+      snapshot: snapshot,
+    );
 
 /// True when any below-quota zero-NW lock-recovery seller still lacks a
 /// domestically-produced level-0 `build_improvement` input (a

--- a/packages/colonizethis_ai/lib/src/planning/treasury_need_analysis.dart
+++ b/packages/colonizethis_ai/lib/src/planning/treasury_need_analysis.dart
@@ -84,6 +84,49 @@ Map<CommodityId, int> _inputNeedsFromAssignments(
   return needs;
 }
 
+void _populateTreasurySurplusAndNeedMaps({
+  required Iterable<CommodityId> trackedCommodityIds,
+  required Map<CommodityId, int> inputNeeds,
+  required Stockpile projected,
+  required Map<CommodityId, int> carryForwardOffers,
+  required Map<CommodityId, int> carryForwardBids,
+  required Map<CommodityId, int> marketPrices,
+  required bool isLockRecoverySeller,
+  required bool isRegimentBuildInputMarketSupplier,
+  required Map<CommodityId, int> available,
+  required Map<CommodityId, int> need,
+}) {
+  for (final id in trackedCommodityIds) {
+    if (richesCommodityIds.contains(id)) continue;
+    final commodity = CommodityCatalog.byId[id];
+    if (commodity == null) continue;
+    final consumption = _consumptionForecast(
+      commodityId: id,
+      commodity: commodity,
+      inputNeeds: inputNeeds,
+    );
+    final inputs = inputNeeds[id] ?? 0;
+    var safety = commodity.category == CommodityCategory.food
+        ? (isLockRecoverySeller ? 0 : consumption * 2)
+        : consumption;
+    if (isRegimentBuildInputMarketSupplier &&
+        _regimentBuildInputSupplyCommodityIds.contains(id)) {
+      safety = 0;
+    }
+    final reserve = consumption + inputs + safety;
+    final projectedQty = projected.quantityOf(id);
+    final surplus = projectedQty - reserve - (carryForwardOffers[id] ?? 0);
+    if (surplus > 0) {
+      available[id] = surplus;
+    }
+    final deficit =
+        (consumption + inputs) - projectedQty - (carryForwardBids[id] ?? 0);
+    if (deficit > 0 && _marketPriceBelowProductionCost(id, marketPrices)) {
+      need[id] = deficit;
+    }
+  }
+}
+
 /// Returns prior-turn offer-side fill rate (`0.0`–`1.0`) for [commodityId] from
 /// [state.lastTurnActivity]. Returns `1.0` when no activity exists or
 /// `totalOfferQuantity <= 0`, matching the "no prior data → assume fully

--- a/packages/colonizethis_ai/lib/src/planning/treasury_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/treasury_planner.dart
@@ -122,6 +122,10 @@ List<TradeOrder> runTreasuryPlanner({
   final rawTreasury = treasury < 0 ? 0 : treasury;
   final threshold = cheapestRegimentBuildTreasuryCost();
   final brokeForLockRecovery = rawTreasury < threshold;
+  final lockRecoveryScan = _LockRecoveryGameScan.fromGame(
+    game,
+    snapshot: snapshot,
+  );
 
   // Refs #2924 F17: a below-quota zero-NW lock-recovery seller releases its
   // food surplus aggressively so its trade cargo is spent selling the
@@ -133,11 +137,7 @@ List<TradeOrder> runTreasuryPlanner({
   // recovers. Dropping the safety buffer (keeping one consumption-cycle
   // reserve) lets the seller offer down to that floor each turn.
   // SPEC/ai/treasury-planner.md § Lock-recovery seller food-surplus release.
-  final isLockRecoverySeller = _isBelowQuotaZeroNwLockRecoverySeller(
-    game: game,
-    playerId: playerId,
-    snapshot: snapshot,
-  );
+  final isLockRecoverySeller = lockRecoveryScan.isLockRecoverySeller(playerId);
   // Refs #2847 H8-supply (S7-D lumber re-localization): the supplier release
   // also activates when a peer lock-recovery seller is stuck one stage earlier —
   // at the level-0 `build_improvement` gate whose producible inputs the world
@@ -150,7 +150,7 @@ List<TradeOrder> runTreasuryPlanner({
   // (fabric) stage. SPEC/ai/treasury-planner.md § Lock-recovery castIron
   // improvement-input supplier source.
   final regimentBuildInputMarketSupplyActive =
-      _anyLockRecoverySellerNeedsRegimentBuildInput(game) ||
+      lockRecoveryScan.anySellerNeedsRegimentBuildInput ||
           peerLockRecoverySellerNeededProducibleImprovementInputs(
             game,
             excludePlayerId: playerId,
@@ -240,10 +240,12 @@ List<TradeOrder> runTreasuryPlanner({
     playerId: playerId,
     treasuryBudgetForBids: treasuryBudgetForBids,
     treasuryForecast: treasuryForecast,
+    scan: lockRecoveryScan,
   );
   final isAffluentDesignatedBuyer = _isAffluentDesignatedLockRecoveryBuyer(
     game: game,
     playerId: playerId,
+    scan: lockRecoveryScan,
   );
 
   // Refs #2924 F10: affluent GPs spend treasury on inventory ahead of strict

--- a/packages/colonizethis_ai/lib/src/planning/treasury_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/treasury_planner.dart
@@ -172,35 +172,18 @@ List<TradeOrder> runTreasuryPlanner({
   final isRegimentBuildInputMarketSupplier =
       regimentBuildInputMarketSupplyActive && !isLockRecoverySeller;
 
-  for (final id in trackedCommodityIds) {
-    if (richesCommodityIds.contains(id)) continue;
-    final commodity = CommodityCatalog.byId[id];
-    if (commodity == null) continue;
-    final consumption = _consumptionForecast(
-      commodityId: id,
-      commodity: commodity,
-      inputNeeds: inputNeeds,
-    );
-    final inputs = inputNeeds[id] ?? 0;
-    var safety = commodity.category == CommodityCategory.food
-        ? (isLockRecoverySeller ? 0 : consumption * 2)
-        : consumption;
-    if (isRegimentBuildInputMarketSupplier &&
-        _regimentBuildInputSupplyCommodityIds.contains(id)) {
-      safety = 0;
-    }
-    final reserve = consumption + inputs + safety;
-    final projectedQty = projected.quantityOf(id);
-    final surplus = projectedQty - reserve - (carryForwardOffers[id] ?? 0);
-    if (surplus > 0) {
-      available[id] = surplus;
-    }
-    final deficit =
-        (consumption + inputs) - projectedQty - (carryForwardBids[id] ?? 0);
-    if (deficit > 0 && _marketPriceBelowProductionCost(id, marketPrices)) {
-      need[id] = deficit;
-    }
-  }
+  _populateTreasurySurplusAndNeedMaps(
+    trackedCommodityIds: trackedCommodityIds,
+    inputNeeds: inputNeeds,
+    projected: projected,
+    carryForwardOffers: carryForwardOffers,
+    carryForwardBids: carryForwardBids,
+    marketPrices: marketPrices,
+    isLockRecoverySeller: isLockRecoverySeller,
+    isRegimentBuildInputMarketSupplier: isRegimentBuildInputMarketSupplier,
+    available: available,
+    need: need,
+  );
 
   // Refs #3122: treasury budget that bounds total bid notional this turn.
   // Mirrors the matcher-side per-buyer clamp introduced by #3115 so the

--- a/packages/colonizethis_ai/lib/src/planning/treasury_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/treasury_planner.dart
@@ -17,6 +17,7 @@ import 'package:colonizethis_logic/order_suggestion_api.dart'
     show TradeOrderSuggester, TradeSuggestionContext;
 import 'package:colonizethis_models/colonizethis_models.dart';
 
+import '../perception/perception_snapshot.dart';
 import 'army_conquest_prep.dart' show regimentCountForPlayer;
 import 'recipe_scoring.dart' show kShortageThreshold;
 
@@ -75,6 +76,7 @@ List<TradeOrder> runTreasuryPlanner({
   required Stockpile stockpile,
   required List<AssignedRecipe> productionAssignments,
   required int treasury,
+  AIWorldSnapshot? snapshot,
   Map<String, TileMapResult>? tileMapByRegion,
   MapTopology? topology,
   Orders currentOrders = const Orders(),
@@ -131,8 +133,11 @@ List<TradeOrder> runTreasuryPlanner({
   // recovers. Dropping the safety buffer (keeping one consumption-cycle
   // reserve) lets the seller offer down to that floor each turn.
   // SPEC/ai/treasury-planner.md § Lock-recovery seller food-surplus release.
-  final isLockRecoverySeller =
-      _isBelowQuotaZeroNwLockRecoverySeller(game: game, playerId: playerId);
+  final isLockRecoverySeller = _isBelowQuotaZeroNwLockRecoverySeller(
+    game: game,
+    playerId: playerId,
+    snapshot: snapshot,
+  );
   // Refs #2847 H8-supply (S7-D lumber re-localization): the supplier release
   // also activates when a peer lock-recovery seller is stuck one stage earlier —
   // at the level-0 `build_improvement` gate whose producible inputs the world

--- a/packages/colonizethis_ai/test/planning/treasury_planner_test.dart
+++ b/packages/colonizethis_ai/test/planning/treasury_planner_test.dart
@@ -5,6 +5,7 @@
 /// line repo-lint ceiling).
 library;
 
+import 'package:colonizethis_ai/src/perception/perception_snapshot.dart';
 import 'package:colonizethis_ai/src/planning/treasury_planner.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
@@ -681,5 +682,38 @@ void main() {
       );
       expect(a, b);
     });
+
+    test(
+      'snapshot province counts match world-state scans (Refs #3288)',
+      () {
+        final stockpile = const Stockpile().applyDelta('grain', 20);
+        final game = _lockRecoverySellerGame(stockpile: stockpile, treasury: 0);
+        const snapshot = AIWorldSnapshot(
+          playerId: 'gp1',
+          threats: ThreatSummary(),
+          opportunities: OpportunitySummary(),
+          conquest: ConquestSummary(oldWorldProvincesOwned: 3),
+          colonial: ColonialSummary(newWorldProvincesOwned: 0),
+          economy: EconomySummary(treasury: 0),
+          relations: {},
+        );
+        final withoutSnapshot = runTreasuryPlanner(
+          game: game,
+          playerId: 'gp1',
+          stockpile: stockpile,
+          productionAssignments: const [],
+          treasury: 0,
+        );
+        final withSnapshot = runTreasuryPlanner(
+          game: game,
+          playerId: 'gp1',
+          stockpile: stockpile,
+          productionAssignments: const [],
+          treasury: 0,
+          snapshot: snapshot,
+        );
+        expect(withSnapshot, withoutSnapshot);
+      },
+    );
   });
 }

--- a/test/check_disallowed_ast_patterns_ai_recipe_catalog_test.dart
+++ b/test/check_disallowed_ast_patterns_ai_recipe_catalog_test.dart
@@ -1,0 +1,105 @@
+import 'package:test/test.dart';
+
+import '../tool/check_disallowed_ast_patterns.dart';
+import 'disallowed_ast_patterns_test_yaml_fixture.dart';
+
+void main() {
+  late List<DisallowedPatternRule> rules;
+
+  setUp(() {
+    rules = loadDisallowedAstRulesForTest(disallowedAstPatternsTestYaml);
+  });
+
+  Iterable<DisallowedAstViolation> recipeScanViolations(
+    String path,
+    String src,
+  ) =>
+      findDisallowedAstViolations(path, src, rules)
+          .where((e) => e.ruleId == 'ai_full_recipe_catalog_scan');
+
+  group('ai_full_recipe_catalog_scan', () {
+    test('flags ProductionRecipesCatalog.all under colonizethis_ai/lib', () {
+      const src = r'''
+List<Object> bad() {
+  final recipes = ProductionRecipesCatalog.all;
+  return recipes;
+}
+''';
+      expect(
+        recipeScanViolations(
+          'packages/colonizethis_ai/lib/src/planning/economy_planner.dart',
+          src,
+        ),
+        isNotEmpty,
+      );
+    });
+
+    test('flags ProductionRecipesCatalog.all inside a spread literal', () {
+      const src = r'''
+List<Object> bad() {
+  final sorted = [...ProductionRecipesCatalog.all];
+  return sorted;
+}
+''';
+      expect(
+        recipeScanViolations(
+          'packages/colonizethis_ai/lib/src/planning/treasury_planner.dart',
+          src,
+        ),
+        isNotEmpty,
+      );
+    });
+
+    test('ignores producing()/byId index lookups', () {
+      const src = r'''
+Object? ok(String commodityId, String recipeId) {
+  for (final recipe in ProductionRecipesCatalog.producing(commodityId)) {
+    return recipe;
+  }
+  return ProductionRecipesCatalog.byId[recipeId];
+}
+''';
+      expect(
+        recipeScanViolations(
+          'packages/colonizethis_ai/lib/src/planning/economy_planner.dart',
+          src,
+        ),
+        isEmpty,
+      );
+    });
+
+    test('ignores ProductionRecipesCatalog.all outside colonizethis_ai/lib',
+        () {
+      const src = r'''
+List<Object> still() {
+  final recipes = ProductionRecipesCatalog.all;
+  return recipes;
+}
+''';
+      expect(
+        recipeScanViolations(
+          'packages/colonizethis_data/lib/src/catalog.dart',
+          src,
+        ),
+        isEmpty,
+      );
+    });
+
+    test('respects same-line ignore for ai_full_recipe_catalog_scan', () {
+      const src = r'''
+List<Object> suppressed() {
+  // ignore: disallowed_ast_ai_full_recipe_catalog_scan
+  final recipes = ProductionRecipesCatalog.all;
+  return recipes;
+}
+''';
+      expect(
+        recipeScanViolations(
+          'packages/colonizethis_ai/lib/src/planning/economy_planner.dart',
+          src,
+        ),
+        isEmpty,
+      );
+    });
+  });
+}

--- a/test/disallowed_ast_patterns_test_yaml_fixture.dart
+++ b/test/disallowed_ast_patterns_test_yaml_fixture.dart
@@ -121,4 +121,13 @@ rules:
       kind: nested_world_state_copywith
       relative_path_prefix: packages/colonizethis_logic/lib/
       outer_argument_name: worldState
+  - id: ai_full_recipe_catalog_scan
+    message: >-
+      Do not scan ProductionRecipesCatalog.all under
+      packages/colonizethis_ai/lib/. Use producing(commodityId) or byId index.
+    match:
+      kind: static_member_access
+      type_name: ProductionRecipesCatalog
+      member_name: all
+      relative_path_prefix: packages/colonizethis_ai/lib/
 ''';

--- a/tool/check_disallowed_ast_patterns.dart
+++ b/tool/check_disallowed_ast_patterns.dart
@@ -573,6 +573,24 @@ bool _isSimpleReceiverRemoveAtZeroPattern(
   return arg0.value == 0;
 }
 
+bool _isStaticMemberAccessPattern(
+  PrefixedIdentifier node,
+  DisallowedPatternRule rule,
+  String relativePath,
+) {
+  final typeName = rule.staticMemberTypeName;
+  final memberName = rule.staticMemberName;
+  final prefix = rule.staticMemberPathPrefix;
+  if (typeName == null || memberName == null || prefix == null) {
+    return false;
+  }
+  final slashPath = relativePath.replaceAll('\\', '/');
+  if (!slashPath.startsWith(prefix)) {
+    return false;
+  }
+  return node.prefix.name == typeName && node.identifier.name == memberName;
+}
+
 bool _isUnprefixedProvinceIdStringLiteralInvocation(
   MethodInvocation node,
   DisallowedPatternRule rule,
@@ -716,6 +734,19 @@ class _DisallowedAstVisitor extends RecursiveAstVisitor<void> {
       }
     }
     super.visitMethodInvocation(node);
+  }
+
+  @override
+  void visitPrefixedIdentifier(PrefixedIdentifier node) {
+    for (final rule in rules) {
+      if (rule.kind != DisallowedAstMatchKind.staticMemberAccess) {
+        continue;
+      }
+      if (_isStaticMemberAccessPattern(node, rule, path)) {
+        _recordIfAllowed(node, rule);
+      }
+    }
+    super.visitPrefixedIdentifier(node);
   }
 
   @override

--- a/tool/disallowed_ast_pattern_rules.dart
+++ b/tool/disallowed_ast_pattern_rules.dart
@@ -17,6 +17,7 @@ enum DisallowedAstMatchKind {
   incrementalValidatorForPlayerInLoop,
   redundantWhereToListWhereChain,
   nestedWorldStateCopyWith,
+  staticMemberAccess,
 }
 
 class DisallowedPatternRule {
@@ -41,6 +42,9 @@ class DisallowedPatternRule {
     this.linearCollectionNames = const {},
     this.linearCollectionPathPrefix,
     this.nestedCopyWithOuterArgumentName,
+    this.staticMemberTypeName,
+    this.staticMemberName,
+    this.staticMemberPathPrefix,
   });
 
   final String id;
@@ -83,6 +87,20 @@ class DisallowedPatternRule {
   /// (defaults to `worldState`). Only chains whose outermost `copyWith` passes
   /// that named argument are scanned for deeper nesting.
   final String? nestedCopyWithOuterArgumentName;
+
+  /// When [kind] is [DisallowedAstMatchKind.staticMemberAccess]: the simple
+  /// type-name prefix of the disallowed static access (for example
+  /// `ProductionRecipesCatalog` in `ProductionRecipesCatalog.all`).
+  final String? staticMemberTypeName;
+
+  /// When [kind] is [DisallowedAstMatchKind.staticMemberAccess]: the accessed
+  /// member name (for example `all`).
+  final String? staticMemberName;
+
+  /// When [kind] is [DisallowedAstMatchKind.staticMemberAccess]: path prefix
+  /// (POSIX slashes) limiting matches, for example
+  /// `packages/colonizethis_ai/lib/`.
+  final String? staticMemberPathPrefix;
 }
 
 class DisallowedAstViolation {
@@ -514,6 +532,41 @@ List<DisallowedPatternRule> parseDisallowedAstRulesFromYaml(Object? yamlRoot) {
               outerArgumentName != null && outerArgumentName.isNotEmpty
                   ? outerArgumentName
                   : 'worldState',
+        ),
+      );
+    } else if (kind == 'static_member_access') {
+      final typeName = match['type_name']?.toString();
+      final memberName = match['member_name']?.toString();
+      final prefix =
+          match['relative_path_prefix']?.toString().replaceAll('\\', '/');
+      if (typeName == null ||
+          typeName.isEmpty ||
+          memberName == null ||
+          memberName.isEmpty ||
+          prefix == null ||
+          prefix.isEmpty) {
+        continue;
+      }
+      out.add(
+        DisallowedPatternRule(
+          id: id,
+          message: message,
+          kind: DisallowedAstMatchKind.staticMemberAccess,
+          cascadedMethodNames: const {},
+          commentSubstring: null,
+          rawNamedTypeNames: const {},
+          functionName: null,
+          maxBodyLineSpan: null,
+          requireWidgetClassExtends: false,
+          argumentIndex: null,
+          invocationMethodNames: const {},
+          allowedRelativePaths: const {},
+          scopedRelativePathPrefixes: const {},
+          packageName: null,
+          allowedPackageImports: const {},
+          staticMemberTypeName: typeName,
+          staticMemberName: memberName,
+          staticMemberPathPrefix: prefix,
         ),
       );
     } else if (kind == 'scoped_package_import_contract') {

--- a/tool/disallowed_ast_patterns.yaml
+++ b/tool/disallowed_ast_patterns.yaml
@@ -173,6 +173,21 @@ rules:
       SPEC/program/disallowed-ast-patterns.md.
     match:
       kind: redundant_where_to_list_where_chain
+  - id: ai_full_recipe_catalog_scan
+    message: >-
+      Do not scan the full production recipe catalog via
+      `ProductionRecipesCatalog.all` inside `packages/colonizethis_ai/lib/`.
+      Use the O(1) output index `ProductionRecipesCatalog.producing(commodityId)`
+      or the id index `ProductionRecipesCatalog.byId[recipeId]` so per-turn AI
+      planning stays off the 15s next-turn budget hot path (Refs #3288,
+      SPEC/program/disallowed-ast-patterns.md). A genuine
+      all-recipes-must-be-considered loop may suppress with an inline
+      `// ignore: disallowed_ast_ai_full_recipe_catalog_scan` and a rationale.
+    match:
+      kind: static_member_access
+      type_name: ProductionRecipesCatalog
+      member_name: all
+      relative_path_prefix: packages/colonizethis_ai/lib/
   - id: nested_world_state_copywith
     message: >-
       Do not chain `Game.copyWith(worldState: ...copyWith(...copyWith(...)))`


### PR DESCRIPTION
## Summary

Aggressive `colonizethis_ai` hot-path performance work for the 15 000 ms turn-1 budget (Refs #3288). Consolidates the remaining implementation slices and the CI recipe-catalog lint guard (formerly PR #3312).

**Done (this PR)**
- Recipe-by-output index via `ProductionRecipesCatalog.producing` in treasury planner
- O(1) `game.playerById` treasury lookups
- Mutable `OrdersBuilder` in domain-planner orchestrator (single freeze; merged via #3307)
- Treasury planner file split + `repo.ai_no_repeated_*` regression guards
- Optional `AIWorldSnapshot` threaded into `runTreasuryPlanner` for active-GP province counts
- Single-pass `_LockRecoveryGameScan` per treasury invocation (replaces repeated `game.players` scans in lock-recovery helpers)
- Hot-path log guards in conquest, move, and diplomacy planners (`debugEnabled` / `infoEnabled`)
- `ai_full_recipe_catalog_scan` disallowed-AST rule under `packages/colonizethis_ai/lib/` (with documented economy-planner labour-allocation suppression)
- SPEC updates in `SPEC/ai/treasury-planner.md` § Internal lookup indices and `SPEC/program/disallowed-ast-patterns.md`
- Repo lint compliance: control-flow nesting + function-size gates for lock-recovery refactor

**Deferred**
- None material for #3288 ACs; issue ready for verification after merge

## Test plan

- [x] `dart test test/planning/treasury_planner_test.dart`
- [x] `dart test test/planning/treasury_planner_treasury_budget_test.dart`
- [x] `dart test test/orders_builder_test.dart test/planner_context_test.dart`
- [x] `dart test test/perf/` (15s budget gates)
- [x] `dart test test/check_disallowed_ast_patterns_ai_recipe_catalog_test.dart`
- [x] `dart run tool/ct_repo_lint.dart` (all 72 rules)
- [x] `riverpod` removed from runtime `dependencies` (dev/test only)

Refs #3288