### PR TITLE
ci(lint): forbid ProductionRecipesCatalog.all scans in colonizethis_ai (#3288)

### DIFF
--- a/SPEC/program/disallowed-ast-patterns.md
+++ b/SPEC/program/disallowed-ast-patterns.md
@@ -295,6 +295,28 @@ Rule id: `nested_world_state_copywith` (`match.kind`:
 `packages/colonizethis_logic/lib/`, `match.outer_argument_name`:
 `worldState`).
 
+### Full production-recipe-catalog scans in `colonizethis_ai`
+
+In `packages/colonizethis_ai/lib/**`, accessing the static member
+**`ProductionRecipesCatalog.all`** is disallowed. AI planning must resolve
+recipes through the O(1) indexes **`ProductionRecipesCatalog.producing(commodityId)`**
+(output index) or **`ProductionRecipesCatalog.byId[recipeId]`** (id index)
+instead of iterating the whole catalog per commodity / per turn.
+
+Rationale: per-turn AI planning runs inside the 15-second next-turn-resolution
+budget. A full `ProductionRecipesCatalog.all` scan is `O(recipes)` per lookup
+and, in hot feedstock/market loops, easily becomes `O(recipes × commodities)`
+per player per turn. The index conversions in Refs #3288 removed every
+output-keyed full scan from the economy and treasury planners; this rule
+prevents silent regression. A genuine all-recipes loop (for example labour
+allocation that must score every feasible recipe, not look one up by output)
+may suppress with an inline `// ignore: disallowed_ast_ai_full_recipe_catalog_scan`
+and a rationale comment.
+
+Rule id: `ai_full_recipe_catalog_scan` (`match.kind`: `static_member_access`,
+`match.type_name`: `ProductionRecipesCatalog`, `match.member_name`: `all`,
+`match.relative_path_prefix`: `packages/colonizethis_ai/lib/`).
+
 ### Coverage
 
 Enforcement walks the same domain trees via `tool/ct_repo_lint_scan_contract.dart` (`collectRepoLintDomainDartFiles`), aligned with `SPEC/program/exception-enforcement.md` coverage:
@@ -529,3 +551,25 @@ Generated files (`*.g.dart`, `*.freezed.dart`, `*.mocks.dart`) and tests (`**/te
   `// ignore_for_file: disallowed_ast_nested_world_state_copywith` marker,
   **when** the disallowed AST checker runs, **then** it does not report
   that violation for `nested_world_state_copywith`.
+
+- **Given** runtime Dart source under `packages/colonizethis_ai/lib/`
+  that accesses `ProductionRecipesCatalog.all`, **when** the disallowed AST
+  checker runs, **then** it reports at least one violation for
+  `ai_full_recipe_catalog_scan` with the correct file and line.
+
+- **Given** runtime Dart source under `packages/colonizethis_ai/lib/`
+  that resolves recipes via `ProductionRecipesCatalog.producing(commodityId)`
+  or `ProductionRecipesCatalog.byId[recipeId]` instead of `.all`, **when** the
+  disallowed AST checker runs, **then** it does not report an
+  `ai_full_recipe_catalog_scan` violation for that access.
+
+- **Given** runtime Dart source outside `packages/colonizethis_ai/lib/`
+  that accesses `ProductionRecipesCatalog.all`, **when** the disallowed AST
+  checker runs, **then** it does not report an `ai_full_recipe_catalog_scan`
+  violation for that access.
+
+- **Given** runtime Dart source under `packages/colonizethis_ai/lib/`
+  that accesses `ProductionRecipesCatalog.all` with
+  `// ignore: disallowed_ast_ai_full_recipe_catalog_scan` on the violating
+  line or the line above, **when** the disallowed AST checker runs, **then**
+  it does not report that violation for `ai_full_recipe_catalog_scan`.

--- a/packages/colonizethis_ai/lib/src/planning/economy_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/economy_planner.dart
@@ -367,6 +367,10 @@ List<AssignedRecipe> _allocateLabour({
   Set<String> supplierReleaseImprovementInputIds = const {},
   Set<String> feedstockReserveOutputIds = const {},
 }) {
+  // Labour allocation scores every feasible recipe to pick the best runs, so
+  // this is an intrinsic full-catalog pass, not an output-keyed lookup that the
+  // producing()/byId index could replace (Refs #3288).
+  // ignore: disallowed_ast_ai_full_recipe_catalog_scan
   final recipes = ProductionRecipesCatalog.all;
   final agendaId = config.hiddenAgendaId;
   Stockpile virtual = stockpile;

--- a/test/check_disallowed_ast_patterns_ai_recipe_catalog_test.dart
+++ b/test/check_disallowed_ast_patterns_ai_recipe_catalog_test.dart
@@ -1,0 +1,105 @@
+import 'package:test/test.dart';
+
+import '../tool/check_disallowed_ast_patterns.dart';
+import 'disallowed_ast_patterns_test_yaml_fixture.dart';
+
+void main() {
+  late List<DisallowedPatternRule> rules;
+
+  setUp(() {
+    rules = loadDisallowedAstRulesForTest(disallowedAstPatternsTestYaml);
+  });
+
+  Iterable<DisallowedAstViolation> recipeScanViolations(
+    String path,
+    String src,
+  ) =>
+      findDisallowedAstViolations(path, src, rules)
+          .where((e) => e.ruleId == 'ai_full_recipe_catalog_scan');
+
+  group('ai_full_recipe_catalog_scan', () {
+    test('flags ProductionRecipesCatalog.all under colonizethis_ai/lib', () {
+      const src = r'''
+List<Object> bad() {
+  final recipes = ProductionRecipesCatalog.all;
+  return recipes;
+}
+''';
+      expect(
+        recipeScanViolations(
+          'packages/colonizethis_ai/lib/src/planning/economy_planner.dart',
+          src,
+        ),
+        isNotEmpty,
+      );
+    });
+
+    test('flags ProductionRecipesCatalog.all inside a spread literal', () {
+      const src = r'''
+List<Object> bad() {
+  final sorted = [...ProductionRecipesCatalog.all];
+  return sorted;
+}
+''';
+      expect(
+        recipeScanViolations(
+          'packages/colonizethis_ai/lib/src/planning/treasury_planner.dart',
+          src,
+        ),
+        isNotEmpty,
+      );
+    });
+
+    test('ignores producing()/byId index lookups', () {
+      const src = r'''
+Object? ok(String commodityId, String recipeId) {
+  for (final recipe in ProductionRecipesCatalog.producing(commodityId)) {
+    return recipe;
+  }
+  return ProductionRecipesCatalog.byId[recipeId];
+}
+''';
+      expect(
+        recipeScanViolations(
+          'packages/colonizethis_ai/lib/src/planning/economy_planner.dart',
+          src,
+        ),
+        isEmpty,
+      );
+    });
+
+    test('ignores ProductionRecipesCatalog.all outside colonizethis_ai/lib',
+        () {
+      const src = r'''
+List<Object> still() {
+  final recipes = ProductionRecipesCatalog.all;
+  return recipes;
+}
+''';
+      expect(
+        recipeScanViolations(
+          'packages/colonizethis_data/lib/src/catalog.dart',
+          src,
+        ),
+        isEmpty,
+      );
+    });
+
+    test('respects same-line ignore for ai_full_recipe_catalog_scan', () {
+      const src = r'''
+List<Object> suppressed() {
+  // ignore: disallowed_ast_ai_full_recipe_catalog_scan
+  final recipes = ProductionRecipesCatalog.all;
+  return recipes;
+}
+''';
+      expect(
+        recipeScanViolations(
+          'packages/colonizethis_ai/lib/src/planning/economy_planner.dart',
+          src,
+        ),
+        isEmpty,
+      );
+    });
+  });
+}

--- a/test/disallowed_ast_patterns_test_yaml_fixture.dart
+++ b/test/disallowed_ast_patterns_test_yaml_fixture.dart
@@ -121,4 +121,13 @@ rules:
       kind: nested_world_state_copywith
       relative_path_prefix: packages/colonizethis_logic/lib/
       outer_argument_name: worldState
+  - id: ai_full_recipe_catalog_scan
+    message: >-
+      Do not scan ProductionRecipesCatalog.all under
+      packages/colonizethis_ai/lib/. Use producing(commodityId) or byId index.
+    match:
+      kind: static_member_access
+      type_name: ProductionRecipesCatalog
+      member_name: all
+      relative_path_prefix: packages/colonizethis_ai/lib/
 ''';

--- a/tool/check_disallowed_ast_patterns.dart
+++ b/tool/check_disallowed_ast_patterns.dart
@@ -573,6 +573,24 @@ bool _isSimpleReceiverRemoveAtZeroPattern(
   return arg0.value == 0;
 }
 
+bool _isStaticMemberAccessPattern(
+  PrefixedIdentifier node,
+  DisallowedPatternRule rule,
+  String relativePath,
+) {
+  final typeName = rule.staticMemberTypeName;
+  final memberName = rule.staticMemberName;
+  final prefix = rule.staticMemberPathPrefix;
+  if (typeName == null || memberName == null || prefix == null) {
+    return false;
+  }
+  final slashPath = relativePath.replaceAll('\\', '/');
+  if (!slashPath.startsWith(prefix)) {
+    return false;
+  }
+  return node.prefix.name == typeName && node.identifier.name == memberName;
+}
+
 bool _isUnprefixedProvinceIdStringLiteralInvocation(
   MethodInvocation node,
   DisallowedPatternRule rule,
@@ -716,6 +734,19 @@ class _DisallowedAstVisitor extends RecursiveAstVisitor<void> {
       }
     }
     super.visitMethodInvocation(node);
+  }
+
+  @override
+  void visitPrefixedIdentifier(PrefixedIdentifier node) {
+    for (final rule in rules) {
+      if (rule.kind != DisallowedAstMatchKind.staticMemberAccess) {
+        continue;
+      }
+      if (_isStaticMemberAccessPattern(node, rule, path)) {
+        _recordIfAllowed(node, rule);
+      }
+    }
+    super.visitPrefixedIdentifier(node);
   }
 
   @override

--- a/tool/disallowed_ast_pattern_rules.dart
+++ b/tool/disallowed_ast_pattern_rules.dart
@@ -17,6 +17,7 @@ enum DisallowedAstMatchKind {
   incrementalValidatorForPlayerInLoop,
   redundantWhereToListWhereChain,
   nestedWorldStateCopyWith,
+  staticMemberAccess,
 }
 
 class DisallowedPatternRule {
@@ -41,6 +42,9 @@ class DisallowedPatternRule {
     this.linearCollectionNames = const {},
     this.linearCollectionPathPrefix,
     this.nestedCopyWithOuterArgumentName,
+    this.staticMemberTypeName,
+    this.staticMemberName,
+    this.staticMemberPathPrefix,
   });
 
   final String id;
@@ -83,6 +87,20 @@ class DisallowedPatternRule {
   /// (defaults to `worldState`). Only chains whose outermost `copyWith` passes
   /// that named argument are scanned for deeper nesting.
   final String? nestedCopyWithOuterArgumentName;
+
+  /// When [kind] is [DisallowedAstMatchKind.staticMemberAccess]: the simple
+  /// type-name prefix of the disallowed static access (for example
+  /// `ProductionRecipesCatalog` in `ProductionRecipesCatalog.all`).
+  final String? staticMemberTypeName;
+
+  /// When [kind] is [DisallowedAstMatchKind.staticMemberAccess]: the accessed
+  /// member name (for example `all`).
+  final String? staticMemberName;
+
+  /// When [kind] is [DisallowedAstMatchKind.staticMemberAccess]: path prefix
+  /// (POSIX slashes) limiting matches, for example
+  /// `packages/colonizethis_ai/lib/`.
+  final String? staticMemberPathPrefix;
 }
 
 class DisallowedAstViolation {
@@ -514,6 +532,41 @@ List<DisallowedPatternRule> parseDisallowedAstRulesFromYaml(Object? yamlRoot) {
               outerArgumentName != null && outerArgumentName.isNotEmpty
                   ? outerArgumentName
                   : 'worldState',
+        ),
+      );
+    } else if (kind == 'static_member_access') {
+      final typeName = match['type_name']?.toString();
+      final memberName = match['member_name']?.toString();
+      final prefix =
+          match['relative_path_prefix']?.toString().replaceAll('\\', '/');
+      if (typeName == null ||
+          typeName.isEmpty ||
+          memberName == null ||
+          memberName.isEmpty ||
+          prefix == null ||
+          prefix.isEmpty) {
+        continue;
+      }
+      out.add(
+        DisallowedPatternRule(
+          id: id,
+          message: message,
+          kind: DisallowedAstMatchKind.staticMemberAccess,
+          cascadedMethodNames: const {},
+          commentSubstring: null,
+          rawNamedTypeNames: const {},
+          functionName: null,
+          maxBodyLineSpan: null,
+          requireWidgetClassExtends: false,
+          argumentIndex: null,
+          invocationMethodNames: const {},
+          allowedRelativePaths: const {},
+          scopedRelativePathPrefixes: const {},
+          packageName: null,
+          allowedPackageImports: const {},
+          staticMemberTypeName: typeName,
+          staticMemberName: memberName,
+          staticMemberPathPrefix: prefix,
         ),
       );
     } else if (kind == 'scoped_package_import_contract') {

--- a/tool/disallowed_ast_patterns.yaml
+++ b/tool/disallowed_ast_patterns.yaml
@@ -173,6 +173,21 @@ rules:
       SPEC/program/disallowed-ast-patterns.md.
     match:
       kind: redundant_where_to_list_where_chain
+  - id: ai_full_recipe_catalog_scan
+    message: >-
+      Do not scan the full production recipe catalog via
+      `ProductionRecipesCatalog.all` inside `packages/colonizethis_ai/lib/`.
+      Use the O(1) output index `ProductionRecipesCatalog.producing(commodityId)`
+      or the id index `ProductionRecipesCatalog.byId[recipeId]` so per-turn AI
+      planning stays off the 15s next-turn budget hot path (Refs #3288,
+      SPEC/program/disallowed-ast-patterns.md). A genuine
+      all-recipes-must-be-considered loop may suppress with an inline
+      `// ignore: disallowed_ast_ai_full_recipe_catalog_scan` and a rationale.
+    match:
+      kind: static_member_access
+      type_name: ProductionRecipesCatalog
+      member_name: all
+      relative_path_prefix: packages/colonizethis_ai/lib/
   - id: nested_world_state_copywith
     message: >-
       Do not chain `Game.copyWith(worldState: ...copyWith(...copyWith(...)))`


### PR DESCRIPTION
## Summary

Locks in the AI planning recipe-index perf work for #3288 with a CI regression guard, completing the issue's **CI / enforcement** acceptance criterion.

- Adds a manifest-driven `static_member_access` match kind to the disallowed-AST checker (`tool/check_disallowed_ast_patterns.dart`, `tool/disallowed_ast_pattern_rules.dart`).
- Adds rule `ai_full_recipe_catalog_scan`: forbids `ProductionRecipesCatalog.all` under `packages/colonizethis_ai/lib/`. AI planning must use the O(1) `ProductionRecipesCatalog.producing(commodityId)` output index or `ProductionRecipesCatalog.byId[recipeId]` id index instead of an `O(recipes)` per-commodity scan on the 15s next-turn budget hot path.
- The one intrinsic full-catalog pass (labour allocation scoring every feasible recipe in `economy_planner.dart`) carries a documented inline `// ignore: disallowed_ast_ai_full_recipe_catalog_scan` since it is not an output-keyed lookup the index could replace.

## Context

The prior slice for this issue (PR #3308 — `producing()` index for economy-planner feedstock lookups) **merged** into `dev` during this run. Per the one-open-PR-per-issue policy, this is a follow-up PR from current `dev` for the remaining enforcement work.

## SPEC

- `SPEC/program/disallowed-ast-patterns.md`: new policy section + Given/When/Then ACs for `ai_full_recipe_catalog_scan`.

## Done in this push

- New AST match kind + rule + production/test-fixture YAML entries.
- SPEC policy + ACs.
- Documented suppression on the legitimate labour-allocation scan.

## Remaining for #3288 (deferred, follow-up)

- Optional: hot-path `_log` level guards (`debugEnabled`/`infoEnabled`) on the remaining per-GP planner log sites (AC #6). The catalog-index (AC #5) and file-split (AC #8) work already landed via earlier merged PRs; the turn-1 wall-clock budget test currently passes.

## Tests

- `test/check_disallowed_ast_patterns_ai_recipe_catalog_test.dart` (new): positive (flags `.all` in AI lib + spread form), negative (indexed `producing()`/`byId`, out-of-scope path, inline ignore).
- Commands run: `dart test test/check_disallowed_ast_patterns_ai_recipe_catalog_test.dart` (+ existing checker suites) → pass; `dart run tool/check_disallowed_ast_patterns.dart` repo-wide → no violations; `dart analyze` on touched files → clean.

Refs #3288

Made with [Cursor](https://cursor.com)