### PR TITLE
test(ai): split fabric recipe feasibility by labour in S7-D diagnostic (#2847)

### DIFF
--- a/packages/colonizethis_ai/test/seed42_observer_conquest_s7d_diagnostic_test.dart
+++ b/packages/colonizethis_ai/test/seed42_observer_conquest_s7d_diagnostic_test.dart
@@ -1923,6 +1923,27 @@ void main() {
       final fabricRecipeFeasibleTurns = <String, int>{
         for (final gpId in gpIds) gpId: 0,
       };
+      // Refs #2847 § S7-D fabric circular-labour localization (read-only). The
+      // #3303/#3315 castIron-labour peasant-recruit boost stages domestic
+      // `fabric` so a lock-recovery seller can pay the 2-`fabric` peasant
+      // recruit that would grow its castIron labour. The post-#3315 refresh
+      // shows the recruit gate fires for gp5 (8 turns) yet is fabric-starved on
+      // every one (`gpCastIronLabourPeasantRecruitAffordableTurns == 0`), while
+      // `gpFabricRecipeFeasibleTurns` (material-only) is high (gp5 47) but
+      // `gpFabricProductionAssignedTurns` is ~2. This counter splits the
+      // material-feasible fabric turns by the planner's own labour gate
+      // (`feasibleRuns(...) > 0` against full `effectiveLabourForWorkers`,
+      // mirroring `gpCastIronRecipeLabourFeasibleTurns`). A near-zero count
+      // while the material count is high localizes the unbuilt recruit-fabric
+      // to **labour starvation of the fabric recipe itself** (`fabric_from_*`
+      // carries `labourPerOutput == 2`, above the seller's effective labour of
+      // 1), i.e. the recruit boost is a circular deadlock — the next lever must
+      // grow raw population by a non-`fabric` path, not stage more domestic
+      // fabric. Read-only; the (freely tunable) counts can move as later slices
+      // land.
+      final fabricRecipeLabourFeasibleTurns = <String, int>{
+        for (final gpId in gpIds) gpId: 0,
+      };
       // Refs #2847 H8 castIron production-assignment localization (read-only).
       // The castIron recipe `castIron_from_timber_iron_coal` consumes only
       // `timber` + `iron` (no coal in `inputQuantities`), so it is materially
@@ -2464,6 +2485,9 @@ void main() {
             }
             if (ci.fabricRecipeFeasible) {
               bumpCounter(fabricRecipeFeasibleTurns, gpId);
+              if (ci.fabricRecipeLabourFeasible) {
+                bumpCounter(fabricRecipeLabourFeasibleTurns, gpId);
+              }
             }
             if (ci.castIronMaterialFeasible) {
               bumpCounter(castIronRecipeFeasibleTurns, gpId);
@@ -2794,6 +2818,7 @@ void main() {
             feedstockAcquisitionTargetWithFieldArmyTurns,
         'gpFeedstockInStockpileTurns': feedstockInStockpileTurns,
         'gpFabricRecipeFeasibleTurns': fabricRecipeFeasibleTurns,
+        'gpFabricRecipeLabourFeasibleTurns': fabricRecipeLabourFeasibleTurns,
         'gpCastIronRecipeFeasibleTurns': castIronRecipeFeasibleTurns,
         'gpCastIronRecipeLabourFeasibleTurns':
             castIronRecipeLabourFeasibleTurns,
@@ -2902,6 +2927,8 @@ void main() {
             castIronLabourPeasantRecruitAffordableTurns,
         castIronLabourPeasantRecruitFabricStarvedTurns:
             castIronLabourPeasantRecruitFabricStarvedTurns,
+        fabricRecipeFeasibleTurns: fabricRecipeFeasibleTurns,
+        fabricRecipeLabourFeasibleTurns: fabricRecipeLabourFeasibleTurns,
       );
     },
     skip:

--- a/packages/colonizethis_ai/test/seed42_s7d_feedstock_helpers_test.dart
+++ b/packages/colonizethis_ai/test/seed42_s7d_feedstock_helpers_test.dart
@@ -57,8 +57,10 @@ Game _game({
 void main() {
   final castIron = ProductionRecipesCatalog.castIronFromTimberIronCoal;
   final lumber = ProductionRecipesCatalog.lumberFromTimber;
+  final fabricFromWool = ProductionRecipesCatalog.fabricFromWool;
   final timberId = CommodityCatalog.timber.id;
   final ironId = CommodityCatalog.iron.id;
+  final woolId = CommodityCatalog.wool.id;
   final grainId = CommodityCatalog.grain.id;
   final meatId = CommodityCatalog.meat.id;
 
@@ -211,6 +213,52 @@ void main() {
         isFalse,
       );
     });
+
+    test(
+      'positive (fabric): material on hand and effective labour covers one '
+      'fabric run (labourPerOutput 2)',
+      () {
+        // 2 peasants fed by 2 grain -> 2 effective labour; fabric_from_wool
+        // needs 2 labour and 2 wool, so feasibleRuns >= 1.
+        final game = _game(
+          workers: const WorkerPool(peasants: 2),
+          stockpile: Stockpile(quantities: {grainId: 2, woolId: 2}),
+        );
+        expect(
+          stockpileAndLabourAffordAnyProductionRecipe(game, _playerId, [
+            fabricFromWool,
+          ]),
+          isTrue,
+        );
+      },
+    );
+
+    test(
+      'negative (fabric labour-starved): wool on hand but a single effective '
+      'labour is below the fabric run (the gp5 circular-fabric case)',
+      () {
+        // 1 peasant fed by 1 grain -> 1 effective labour < fabric_from_wool's
+        // labourPerOutput 2. The recruit boost that would grow castIron labour
+        // needs 2 fabric, but fabric itself cannot be produced at 1 labour:
+        // the Refs #2847 S7-D circular deadlock the new counter localizes.
+        final stockpile = Stockpile(quantities: {grainId: 1, woolId: 2});
+        final game = _game(
+          workers: const WorkerPool(peasants: 1),
+          stockpile: stockpile,
+        );
+        expect(
+          stockpileAffordsAnyProductionRecipe(stockpile, [fabricFromWool]),
+          isTrue,
+          reason: 'control: the same turn is material-feasible',
+        );
+        expect(
+          stockpileAndLabourAffordAnyProductionRecipe(game, _playerId, [
+            fabricFromWool,
+          ]),
+          isFalse,
+        );
+      },
+    );
   });
 
   group('ownsFeedstockResourceTileAnyLevel', () {
@@ -388,5 +436,70 @@ void main() {
       );
       expect(playerFoodOnHand(game, 'no_such_player', foodIds), 0);
     });
+  });
+
+  group('seed42S7dCastIronLabourTurnMeasure.fabricRecipeLabourFeasible', () {
+    ({
+      bool peasantRecruitGate,
+      bool peasantRecruitAffordable,
+      bool holdsFabricFeedstock,
+      bool fabricRecipeFeasible,
+      bool fabricRecipeLabourFeasible,
+      bool castIronMaterialFeasible,
+      bool castIronLabourFeasible,
+      bool castIronLabourFoodStarved,
+      bool castIronLabourPopulationBound,
+      bool castIronOwnsFeedstockTile,
+    })
+    measure(Game game) => seed42S7dCastIronLabourTurnMeasure(
+      game: game,
+      playerId: _playerId,
+      fabricFeedstockIds: {woolId},
+      fabricRecipes: [fabricFromWool],
+      castIronRecipes: [castIron],
+      castIronFeedstockIds: {timberId, ironId},
+      castIronMinLabourPerOutput: 5,
+    );
+
+    test('positive: fabric material- and labour-feasible at 2 labour', () {
+      final ci = measure(
+        _game(
+          workers: const WorkerPool(peasants: 2),
+          stockpile: Stockpile(quantities: {grainId: 2, woolId: 2}),
+        ),
+      );
+      expect(ci.fabricRecipeFeasible, isTrue);
+      expect(ci.fabricRecipeLabourFeasible, isTrue);
+    });
+
+    test(
+      'negative (circular deadlock): fabric material-feasible yet labour-'
+      'starved at a single effective labour',
+      () {
+        final ci = measure(
+          _game(
+            workers: const WorkerPool(peasants: 1),
+            stockpile: Stockpile(quantities: {grainId: 1, woolId: 2}),
+          ),
+        );
+        expect(ci.fabricRecipeFeasible, isTrue);
+        expect(ci.fabricRecipeLabourFeasible, isFalse);
+      },
+    );
+
+    test(
+      'subset invariant: labour-feasible is false whenever material-feasible '
+      'is false (no wool on hand)',
+      () {
+        final ci = measure(
+          _game(
+            workers: const WorkerPool(peasants: 10),
+            stockpile: Stockpile(quantities: {grainId: 10}),
+          ),
+        );
+        expect(ci.fabricRecipeFeasible, isFalse);
+        expect(ci.fabricRecipeLabourFeasible, isFalse);
+      },
+    );
   });
 }

--- a/packages/colonizethis_ai/test/support/seed42_s7d_feedstock_helpers.dart
+++ b/packages/colonizethis_ai/test/support/seed42_s7d_feedstock_helpers.dart
@@ -344,6 +344,18 @@ void bumpCounter(Map<String, int> counter, String key) =>
 ///     [castIronLabourPeasantRecruitProbe] (the #3303 boost localization).
 ///   * `holdsFabricFeedstock` — any [fabricFeedstockIds] held in the stockpile.
 ///   * `fabricRecipeFeasible` — any [fabricRecipes] materially runnable.
+///   * `fabricRecipeLabourFeasible` — any [fabricRecipes] runnable against the
+///     seller's full effective labour too
+///     ([stockpileAndLabourAffordAnyProductionRecipe]). Always a subset of
+///     `fabricRecipeFeasible`. A near-zero count here while
+///     `fabricRecipeFeasible` is high localizes the unbuilt peasant-recruit
+///     `fabric` to **labour starvation of the fabric recipe itself**
+///     (`fabric_from_*` carries `labourPerOutput == 2`, above a lock-recovery
+///     seller's effective labour of 1), i.e. the #3303/#3315 peasant-recruit
+///     boost is a circular deadlock: growing castIron labour needs a peasant,
+///     the peasant needs `fabric`, and `fabric` itself needs labour the seller
+///     does not have — so the lever cannot be domestic `fabric` and must grow
+///     raw population by a non-`fabric` path.
 ///   * `castIronMaterialFeasible` — any [castIronRecipes] materially runnable
 ///     ([stockpileAffordsAnyProductionRecipe]); the labour / food / tile flags
 ///     below are only meaningful (non-false) when this holds.
@@ -363,6 +375,7 @@ void bumpCounter(Map<String, int> counter, String key) =>
   bool peasantRecruitAffordable,
   bool holdsFabricFeedstock,
   bool fabricRecipeFeasible,
+  bool fabricRecipeLabourFeasible,
   bool castIronMaterialFeasible,
   bool castIronLabourFeasible,
   bool castIronLabourFoodStarved,
@@ -383,6 +396,7 @@ seed42S7dCastIronLabourTurnMeasure({
     peasantRecruitAffordable: false,
     holdsFabricFeedstock: false,
     fabricRecipeFeasible: false,
+    fabricRecipeLabourFeasible: false,
     castIronMaterialFeasible: false,
     castIronLabourFeasible: false,
     castIronLabourFoodStarved: false,
@@ -400,6 +414,13 @@ seed42S7dCastIronLabourTurnMeasure({
       (e) => player.stockpile.quantityOf(e.key) >= e.value,
     ),
   );
+  // Labour-aware fabric feasibility (Refs #2847 § S7-D fabric circular-labour
+  // localization). A subset of `fabricRecipeFeasible`: a fabric run needs both
+  // its feedstock on hand AND `labourPerOutput` effective labour. Skipped when
+  // the cheaper material check already failed.
+  final fabricRecipeLabourFeasible =
+      fabricRecipeFeasible &&
+      stockpileAndLabourAffordAnyProductionRecipe(game, playerId, fabricRecipes);
   final castIronMaterialFeasible = stockpileAffordsAnyProductionRecipe(
     player.stockpile,
     castIronRecipes,
@@ -432,6 +453,7 @@ seed42S7dCastIronLabourTurnMeasure({
     peasantRecruitAffordable: recruit.affordable,
     holdsFabricFeedstock: holdsFabricFeedstock,
     fabricRecipeFeasible: fabricRecipeFeasible,
+    fabricRecipeLabourFeasible: fabricRecipeLabourFeasible,
     castIronMaterialFeasible: castIronMaterialFeasible,
     castIronLabourFeasible: castIronLabourFeasible,
     castIronLabourFoodStarved: foodStarved,
@@ -578,6 +600,8 @@ void assertSeed42S7dStructuralInvariants({
   required Map<String, int> castIronLabourPeasantRecruitGateTurns,
   required Map<String, int> castIronLabourPeasantRecruitAffordableTurns,
   required Map<String, int> castIronLabourPeasantRecruitFabricStarvedTurns,
+  required Map<String, int> fabricRecipeFeasibleTurns,
+  required Map<String, int> fabricRecipeLabourFeasibleTurns,
 }) {
   for (final gpId in gpIds) {
     expect(
@@ -705,6 +729,18 @@ void assertSeed42S7dStructuralInvariants({
       reason:
           '$gpId peasant-recruit gate-active turns cannot exceed the '
           '100-turn run length',
+    );
+    // Refs #2847 § S7-D fabric circular-labour localization: a fabric run is
+    // labour-feasible only when it is also materially feasible
+    // (`feasibleRuns` incorporates the input check), so the labour-feasible
+    // count can never exceed the material-feasible count. Guards the
+    // instrumentation without pinning the (freely tunable) per-GP counts.
+    expect(
+      fabricRecipeLabourFeasibleTurns[gpId]!,
+      lessThanOrEqualTo(fabricRecipeFeasibleTurns[gpId]!),
+      reason:
+          '$gpId fabric labour-feasible turns cannot exceed the fabric '
+          'material-feasible turns (labour-feasible requires material-feasible)',
     );
   }
 }


### PR DESCRIPTION
## Summary

Refs #2847 S7-D. **Read-only diagnostic instrumentation; no behaviour change, no config constants, no gate-threshold changes.** The +6 OW baseline (gp1/gp2) is unaffected by construction.

The post-#3315 seed-42 turn-100 refresh shows the castIron-labour peasant-recruit boost (#3303/#3309/#3315) now *fires* for gp5 (`gpCastIronLabourPeasantRecruitGateTurns` = 8) yet is fabric-starved on **every** one (`gpCastIronLabourPeasantRecruitAffordableTurns` = 0, `...FabricStarvedTurns` = 8). Meanwhile `gpFabricRecipeFeasibleTurns` (material-only) is high (gp5 47, gp6 43) but `gpFabricProductionAssignedTurns` is ~2. The open fork was *why* the recruit-fabric is never produced despite ample material feasibility.

This slice adds a labour-aware fabric feasibility counter `gpFabricRecipeLabourFeasibleTurns` (reusing the already-tested `stockpileAndLabourAffordAnyProductionRecipe` helper, mirroring `gpCastIronRecipeLabourFeasibleTurns`) to split the material-feasible fabric turns by the planner's own labour gate.

## Re-localization result (seed 42, turn 100, this branch)

| GP | `gpFabricRecipeFeasibleTurns` (material) | `gpFabricRecipeLabourFeasibleTurns` (new) |
|----|------:|------:|
| gp1 | 1 | 1 |
| gp2 | 1 | 1 |
| gp5 | **47** | **2** |
| gp6 | **43** | **4** |

**Decisive:** fabric is materially feasible ~47 turns for gp5 but **labour-feasible only 2**. `fabric_from_*` carries `labourPerOutput == 2`, above a lock-recovery seller's effective labour of 1, so the seller can essentially never produce the 2 `fabric` the peasant recruit costs. The #3303/#3315 recruit boost is therefore a **circular labour deadlock**: growing castIron labour needs a peasant, the peasant needs `fabric`, and `fabric` itself needs labour the seller does not have. The next behaviour lever must grow raw population by a **non-`fabric`** path, not stage more domestic fabric.

OW conquest gate this run: gp1 +6, gp2 +6 (baseline held); gp3 +2, gp4 +1; gp5 +10 / gp6 -7 reflects the gp5↔gp6 peer-war swing (read-only change, no behaviour effect).

## What changed

- `seed42S7dCastIronLabourTurnMeasure` gains a `fabricRecipeLabourFeasible` flag (a strict subset of `fabricRecipeFeasible`).
- New `gpFabricRecipeLabourFeasibleTurns` counter + JSON field in the S7-D diagnostic.
- Structural invariant: labour-feasible turns ≤ material-feasible turns (`assertSeed42S7dStructuralInvariants`).
- Positive/negative unit tests for the helper (fabric `labourPerOutput 2` starvation) and the measure field (`packages/colonizethis_ai/test/seed42_s7d_feedstock_helpers_test.dart`).

## Tests

- `dart test test/seed42_s7d_feedstock_helpers_test.dart` → 32/32 pass (5 new).
- `dart analyze` on all three touched files → no issues.
- `dart test test/seed42_observer_conquest_s7d_diagnostic_test.dart --run-skipped` → passes (new structural invariant holds on real data; numbers above).

## Scope / deferred

- This is the localization slice only. The behaviour lever (a non-`fabric` raw-population growth path for a below-quota zero-NW lock-recovery seller, or sourcing the peasant-recruit `fabric` off-chain) is **deferred** to a follow-up slice once this counter is on `dev`.
- The turn-100 OW conquest gate remains red for gp3/gp4/gp6 → issue stays in `backlog:implementation`.

Refs #2847

Made with [Cursor](https://cursor.com)