### PR TITLE
fix(ai): peasant-recruit fabric bid + offerable-fabric localization (#2847)

### DIFF
--- a/packages/colonizethis_ai/lib/src/planning/treasury_lock_recovery.dart
+++ b/packages/colonizethis_ai/lib/src/planning/treasury_lock_recovery.dart
@@ -69,10 +69,11 @@ final class _LockRecoveryGameScan {
     sortedGpIds.sort();
     affluentNonSellerIds.sort();
 
-    final designatedBuyerId = !anyBrokeGreatPower || affluentNonSellerIds.isEmpty
+    final designatedBuyerId =
+        !anyBrokeGreatPower || affluentNonSellerIds.isEmpty
         ? ''
-        : affluentNonSellerIds[
-            game.worldState.turnState.turnNumber % affluentNonSellerIds.length];
+        : affluentNonSellerIds[game.worldState.turnState.turnNumber %
+              affluentNonSellerIds.length];
 
     return _LockRecoveryGameScan._(
       sortedGpIds: sortedGpIds,
@@ -98,7 +99,8 @@ bool _lockRecoverySellerNeedsRegimentBuildInput(
       regimentCountForPlayer(game, player.id) != 0) {
     return false;
   }
-  for (final entry in RegimentEconomyCatalog.peasantLevies.buildInputs.entries) {
+  for (final entry
+      in RegimentEconomyCatalog.peasantLevies.buildInputs.entries) {
     if (player.stockpile.quantityOf(entry.key) < entry.value) {
       return true;
     }
@@ -110,10 +112,7 @@ bool _lockRecoverySellerNeedsCastIronImprovementInput(
   Game game,
   Player player,
 ) {
-  final cost = regimentBuildInputFeedstockImprovementInputCost(
-    game,
-    player.id,
-  );
+  final cost = regimentBuildInputFeedstockImprovementInputCost(game, player.id);
   if (cost.isEmpty) return false;
   for (final entry in cost.entries) {
     if (!kDomesticProductionImprovementInputIds.contains(entry.key)) {
@@ -164,11 +163,7 @@ bool _isBelowQuotaZeroNwLockRecoverySeller({
   required String playerId,
   AIWorldSnapshot? snapshot,
 }) {
-  final ow = _oldWorldProvinceCountOwnedBy(
-    game,
-    playerId,
-    snapshot: snapshot,
-  );
+  final ow = _oldWorldProvinceCountOwnedBy(game, playerId, snapshot: snapshot);
   if (ow <= 0) return false;
   if (!isBelowObserverConquestQuota(ow)) return false;
   if (_newWorldProvinceCountOwnedBy(game, playerId, snapshot: snapshot) != 0) {
@@ -184,9 +179,8 @@ bool _isBelowQuotaZeroNwLockRecoverySeller({
 bool _anyLockRecoverySellerNeedsRegimentBuildInput(
   Game game, {
   _LockRecoveryGameScan? scan,
-}) =>
-    (scan ?? _LockRecoveryGameScan.fromGame(game))
-        .anySellerNeedsRegimentBuildInput;
+}) => (scan ?? _LockRecoveryGameScan.fromGame(game))
+    .anySellerNeedsRegimentBuildInput;
 
 /// Public accessor for the below-quota zero-NW lock-recovery seller predicate
 /// (Refs #2847 H8-supply castIron source). The economy planner uses it to keep
@@ -196,12 +190,60 @@ bool isBelowQuotaZeroNwLockRecoverySeller(
   Game game,
   String playerId, {
   AIWorldSnapshot? snapshot,
-}) =>
-    _isBelowQuotaZeroNwLockRecoverySeller(
-      game: game,
-      playerId: playerId,
-      snapshot: snapshot,
-    );
+}) => _isBelowQuotaZeroNwLockRecoverySeller(
+  game: game,
+  playerId: playerId,
+  snapshot: snapshot,
+);
+
+/// True when [playerId]'s `fabric` (the cheapest regiment's build input) is
+/// withheld from the world-market offer set this turn by the regiment-rebuild
+/// offer-retention carve-out in [_applyLockRecoverySellerRegimentRebuildBids]:
+/// a below-quota zero-NW lock-recovery seller ([isBelowQuotaZeroNwLockRecoverySeller])
+/// holding **zero regiments**.
+///
+/// While the carve-out is active every `peasant_levies` build input — `fabric`
+/// among them — is removed from the offer set so it banks toward the regiment
+/// build cost instead of being sold back as surplus. A holder for which this is
+/// true therefore contributes its `fabric` to gross holdings
+/// ([otherGreatPowerFabricHeld]) yet offers none of it to the market. Pure
+/// read-only over `(game, playerId)`; mirrors the carve-out scope exactly
+/// (`isLockRecoverySeller && regimentCountForPlayer == 0`). Refs #2847 § S7-D
+/// market-fabric offer/acquisition localization.
+bool isFabricOfferRetainingLockRecoverySeller(Game game, String playerId) {
+  if (!_isBelowQuotaZeroNwLockRecoverySeller(game: game, playerId: playerId)) {
+    return false;
+  }
+  return regimentCountForPlayer(game, playerId) == 0;
+}
+
+/// Total `fabric` held by great powers other than [playerId] that is actually
+/// **offerable** to the world market this turn — the offer-side refinement of
+/// [otherGreatPowerFabricHeld]. It excludes holders whose `fabric` is withheld
+/// by the regiment-rebuild offer-retention carve-out
+/// ([isFabricOfferRetainingLockRecoverySeller]).
+///
+/// [otherGreatPowerFabricHeld] is a gross-holdings proxy — it counts `fabric`
+/// even when every holder retains it, so a positive holdings total does not
+/// imply any counterparty actually offers `fabric` a fabric-starved seller could
+/// buy. This function closes that gap: when holdings are positive
+/// ([otherGreatPowerFabricHeld] > 0) yet this offerable total is 0, the closed
+/// market door is localized to the **offer/retention layer** (every holder is
+/// itself a retaining lock-recovery seller) rather than to buyer-side
+/// acquisition; a positive offerable total instead re-points the residual to the
+/// fabric-starved seller's own buy/bid path. It remains a planner-scope offer
+/// proxy, not a full world-market offer/match simulation. Pure read-only over
+/// `game.players`; no game-state mutation. Refs #2847 § S7-D market-fabric
+/// offer/acquisition localization.
+int otherGreatPowerOfferableFabricHeld(Game game, String playerId) {
+  var total = 0;
+  for (final player in game.players) {
+    if (player.id == playerId) continue;
+    if (isFabricOfferRetainingLockRecoverySeller(game, player.id)) continue;
+    total += player.stockpile.quantityOf(CommodityCatalog.fabric.id);
+  }
+  return total;
+}
 
 /// True when any below-quota zero-NW lock-recovery seller still lacks a
 /// domestically-produced level-0 `build_improvement` input (a
@@ -215,9 +257,8 @@ bool isBelowQuotaZeroNwLockRecoverySeller(
 bool anyLockRecoverySellerNeedsCastIronImprovementInput(
   Game game, {
   _LockRecoveryGameScan? scan,
-}) =>
-    (scan ?? _LockRecoveryGameScan.fromGame(game))
-        .anySellerNeedsCastIronImprovementInput;
+}) => (scan ?? _LockRecoveryGameScan.fromGame(game))
+    .anySellerNeedsCastIronImprovementInput;
 
 bool _isAffluentDesignatedLockRecoveryBuyer({
   required Game game,
@@ -269,10 +310,7 @@ const List<String> kLockRecoveryPreferredBuyerIds = ['gp1', 'gp2'];
 /// Buyer when no GP meets [treasuryAffluenceThreshold]: rotate among
 /// [kLockRecoveryPreferredBuyerIds] present in the game, else the two
 /// richest-by-treasury GPs.
-String lockRecoveryFallbackBuyerId(
-  Game game, {
-  _LockRecoveryGameScan? scan,
-}) {
+String lockRecoveryFallbackBuyerId(Game game, {_LockRecoveryGameScan? scan}) {
   final resolved = scan ?? _LockRecoveryGameScan.fromGame(game);
   final gpIds = resolved.sortedGpIds;
   if (gpIds.isEmpty) return '';
@@ -322,8 +360,7 @@ List<String> _twoRichestGreatPowerIdsByTreasury(
 String lockRecoveryDesignatedBuyerId(
   Game game, {
   _LockRecoveryGameScan? scan,
-}) =>
-    (scan ?? _LockRecoveryGameScan.fromGame(game)).designatedBuyerId;
+}) => (scan ?? _LockRecoveryGameScan.fromGame(game)).designatedBuyerId;
 
 /// Designated buyer bids [commodityId] and does not offer it this turn.
 ///
@@ -347,8 +384,7 @@ void _applyLockRecoveryLiquidityBid({
   if (!addSyntheticBid) return;
   final pricePerUnit = game.worldMarketState.prices[commodityId] ?? 0;
   if (pricePerUnit <= 0) return;
-  final budget =
-      treasuryBudgetForBids < 0 ? 0 : treasuryBudgetForBids;
+  final budget = treasuryBudgetForBids < 0 ? 0 : treasuryBudgetForBids;
   final affordableQty = budget ~/ pricePerUnit;
   // Refs #2924 F14: lock-recovery liquidity bids use the full per-turn
   // treasury budget (after pending costs and carry-forward notional), not

--- a/packages/colonizethis_ai/test/planning/treasury_planner_offerable_fabric_test.dart
+++ b/packages/colonizethis_ai/test/planning/treasury_planner_offerable_fabric_test.dart
@@ -1,0 +1,148 @@
+/// Offer-side market-fabric localization predicates
+/// (Refs #2847 § S7-D market-fabric offer/acquisition).
+///
+/// `otherGreatPowerFabricHeld` (cast_iron_labour_gate.dart) is a gross-holdings
+/// proxy: it counts `fabric` even when every holder withholds it via the
+/// regiment-rebuild offer-retention carve-out, so a positive holdings total does
+/// not prove any counterparty actually offers `fabric`. These tests pin the
+/// offer-side refinement — `otherGreatPowerOfferableFabricHeld` excludes holders
+/// that are themselves below-quota zero-NW zero-regiment lock-recovery sellers
+/// (their `fabric` is staged toward the regiment build cost, not offered), and
+/// `isFabricOfferRetainingLockRecoverySeller` mirrors that carve-out scope.
+library;
+
+import 'package:colonizethis_ai/src/planning/treasury_planner.dart'
+    show
+        isFabricOfferRetainingLockRecoverySeller,
+        otherGreatPowerOfferableFabricHeld;
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+const _ow = 'oldWorld';
+
+/// One great power for the fixture: [ow] owned Old World provinces, [fabric]
+/// units held, and whether it fields a [regiment] (lifts it out of the
+/// zero-regiment retention carve-out).
+typedef _Gp = ({String id, int ow, int fabric, bool regiment});
+
+Game _game(List<_Gp> gps) {
+  final provinces = <Province>[];
+  final armies = <Army>[];
+  for (final gp in gps) {
+    for (var i = 0; i < gp.ow; i++) {
+      provinces.add(
+        Province(id: '$_ow|${gp.id}_$i', regionId: _ow, ownerId: gp.id),
+      );
+    }
+    if (gp.regiment) {
+      armies.add(
+        Army(
+          id: 'army-${gp.id}',
+          ownerId: gp.id,
+          regionId: _ow,
+          stationedProvinceId: '$_ow|${gp.id}_0',
+          regimentUnitIds: ['reg-${gp.id}'],
+        ),
+      );
+    }
+  }
+  return Game(
+    id: 'g-offerable-fabric',
+    worldState: WorldState(
+      turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 50),
+      oldWorld: RegionData(provinces: provinces),
+      newWorld: const RegionData(provinces: []),
+      armies: armies,
+    ),
+    players: [
+      for (final gp in gps)
+        Player(
+          id: gp.id,
+          displayName: gp.id,
+          isHuman: false,
+          stockpile: gp.fabric > 0
+              ? Stockpile.empty.applyDelta(
+                  CommodityCatalog.fabric.id,
+                  gp.fabric,
+                )
+              : Stockpile.empty,
+        ),
+    ],
+  );
+}
+
+void main() {
+  group('isFabricOfferRetainingLockRecoverySeller (Refs #2847)', () {
+    test('positive: below-quota zero-NW seller holding zero regiments', () {
+      final game = _game([(id: 'gp5', ow: 3, fabric: 5, regiment: false)]);
+      expect(isFabricOfferRetainingLockRecoverySeller(game, 'gp5'), isTrue);
+    });
+
+    test('negative: a held regiment lifts the carve-out (seller offers)', () {
+      final game = _game([(id: 'gp5', ow: 3, fabric: 5, regiment: true)]);
+      expect(
+        isFabricOfferRetainingLockRecoverySeller(game, 'gp5'),
+        isFalse,
+        reason: 'The retention targets the zero-regiment rebuild gap only.',
+      );
+    });
+
+    test('negative: quota-met GP is not a lock-recovery seller', () {
+      final game = _game([(id: 'gp5', ow: 12, fabric: 5, regiment: false)]);
+      expect(
+        isFabricOfferRetainingLockRecoverySeller(game, 'gp5'),
+        isFalse,
+        reason: 'The retention is scoped to below-quota zero-NW sellers.',
+      );
+    });
+
+    test('negative: a GP owning no Old World province is not a seller', () {
+      final game = _game([(id: 'gp5', ow: 0, fabric: 5, regiment: false)]);
+      expect(isFabricOfferRetainingLockRecoverySeller(game, 'gp5'), isFalse);
+    });
+  });
+
+  group('otherGreatPowerOfferableFabricHeld (Refs #2847)', () {
+    test('positive: sums fabric across non-retaining offerable holders', () {
+      // gp2 holds a regiment, gp3 is quota-met — both offer their fabric.
+      final game = _game([
+        (id: 'gp5', ow: 3, fabric: 0, regiment: false),
+        (id: 'gp2', ow: 3, fabric: 4, regiment: true),
+        (id: 'gp3', ow: 12, fabric: 6, regiment: false),
+      ]);
+      expect(otherGreatPowerOfferableFabricHeld(game, 'gp5'), 10);
+    });
+
+    test(
+      'excludes retaining lock-recovery sellers (door closed at offer layer)',
+      () {
+        // gp1 holds fabric but is a below-quota zero-NW zero-regiment seller, so
+        // it withholds every unit — gross holdings are positive yet none is
+        // offerable.
+        final game = _game([
+          (id: 'gp5', ow: 3, fabric: 0, regiment: false),
+          (id: 'gp1', ow: 3, fabric: 5, regiment: false),
+        ]);
+        expect(otherGreatPowerOfferableFabricHeld(game, 'gp5'), 0);
+      },
+    );
+
+    test('mixed holders: only the offerable share is counted', () {
+      final game = _game([
+        (id: 'gp5', ow: 3, fabric: 0, regiment: false),
+        (id: 'gp1', ow: 3, fabric: 5, regiment: false), // retained
+        (id: 'gp2', ow: 3, fabric: 4, regiment: true), // offerable
+      ]);
+      expect(otherGreatPowerOfferableFabricHeld(game, 'gp5'), 4);
+    });
+
+    test('excludes the queried seller\'s own fabric holdings', () {
+      final game = _game([
+        (id: 'gp5', ow: 3, fabric: 9, regiment: true),
+        (id: 'gp1', ow: 3, fabric: 5, regiment: false), // retained
+      ]);
+      expect(otherGreatPowerOfferableFabricHeld(game, 'gp5'), 0);
+    });
+  });
+}

--- a/packages/colonizethis_ai/test/seed42_observer_conquest_s7d_diagnostic_test.dart
+++ b/packages/colonizethis_ai/test/seed42_observer_conquest_s7d_diagnostic_test.dart
@@ -10,7 +10,7 @@ import 'package:colonizethis_ai/src/planning/expand_phase_planner.dart'
         cheapestRegimentBuildTreasuryCost,
         expandSellerFeedstockTileAcquisitionTarget;
 import 'package:colonizethis_ai/src/planning/treasury_planner.dart'
-    show kTreasuryOfferPriorityUrgent;
+    show kTreasuryOfferPriorityUrgent, otherGreatPowerOfferableFabricHeld;
 import 'package:colonizethis_data/colonizethis_data.dart'
     hide cheapestRegimentBuildTreasuryCost;
 import 'package:colonizethis_logger/colonizethis_logger.dart';
@@ -2080,6 +2080,19 @@ void main() {
       // freely as later slices land.
       final castIronLabourPeasantRecruitMarketFabricStarvedTurns =
           <String, int>{for (final gpId in gpIds) gpId: 0};
+      // Refs #2847 § S7-D market-fabric offer/acquisition localization: the
+      // complementary subset of the fabric-starved turns where other great
+      // powers DO hold `fabric` (so this is not market-starved) yet none of it
+      // is offerable — every holder is itself a below-quota zero-NW zero-
+      // regiment lock-recovery seller withholding its `fabric` by the regiment-
+      // rebuild offer-retention carve-out (`otherGreatPowerOfferableFabricHeld
+      // <= 0` while `otherGreatPowerFabricHeld > 0`). A high count here forks
+      // the residual onto the offer/retention layer (no counterparty offers
+      // `fabric`); a low count with holdings present instead re-points it to the
+      // starved seller's own buy/bid path. Read-only; counts move freely as
+      // later slices land.
+      final castIronLabourPeasantRecruitMarketFabricUnofferedTurns =
+          <String, int>{for (final gpId in gpIds) gpId: 0};
       // Minimum `labourPerOutput` across the castIron recipes — the cheapest
       // single run's effective-labour requirement, used as the food-starved /
       // population-bound fork threshold above.
@@ -2526,6 +2539,15 @@ void main() {
                     castIronLabourPeasantRecruitMarketFabricStarvedTurns,
                     gpId,
                   );
+                } else if (otherGreatPowerOfferableFabricHeld(game, gpId) <=
+                    0) {
+                  // Holders exist but every one withholds its `fabric` via the
+                  // regiment-rebuild offer-retention carve-out — the market door
+                  // is closed at the offer/retention layer, not at holdings.
+                  bumpCounter(
+                    castIronLabourPeasantRecruitMarketFabricUnofferedTurns,
+                    gpId,
+                  );
                 }
               }
             }
@@ -2884,6 +2906,8 @@ void main() {
             castIronLabourPeasantRecruitFabricStarvedTurns,
         'gpCastIronLabourPeasantRecruitMarketFabricStarvedTurns':
             castIronLabourPeasantRecruitMarketFabricStarvedTurns,
+        'gpCastIronLabourPeasantRecruitMarketFabricUnofferedTurns':
+            castIronLabourPeasantRecruitMarketFabricUnofferedTurns,
         'castIronMinLabourPerOutput': castIronMinLabourPerOutput,
         'gpTurn99Snapshot': lastSnapshotFields,
       };
@@ -2980,6 +3004,8 @@ void main() {
             castIronLabourPeasantRecruitFabricStarvedTurns,
         castIronLabourPeasantRecruitMarketFabricStarvedTurns:
             castIronLabourPeasantRecruitMarketFabricStarvedTurns,
+        castIronLabourPeasantRecruitMarketFabricUnofferedTurns:
+            castIronLabourPeasantRecruitMarketFabricUnofferedTurns,
         fabricRecipeFeasibleTurns: fabricRecipeFeasibleTurns,
         fabricRecipeLabourFeasibleTurns: fabricRecipeLabourFeasibleTurns,
       );

--- a/packages/colonizethis_ai/test/support/seed42_s7d_feedstock_helpers.dart
+++ b/packages/colonizethis_ai/test/support/seed42_s7d_feedstock_helpers.dart
@@ -420,7 +420,11 @@ seed42S7dCastIronLabourTurnMeasure({
   // the cheaper material check already failed.
   final fabricRecipeLabourFeasible =
       fabricRecipeFeasible &&
-      stockpileAndLabourAffordAnyProductionRecipe(game, playerId, fabricRecipes);
+      stockpileAndLabourAffordAnyProductionRecipe(
+        game,
+        playerId,
+        fabricRecipes,
+      );
   final castIronMaterialFeasible = stockpileAffordsAnyProductionRecipe(
     player.stockpile,
     castIronRecipes,
@@ -600,7 +604,10 @@ void assertSeed42S7dStructuralInvariants({
   required Map<String, int> castIronLabourPeasantRecruitGateTurns,
   required Map<String, int> castIronLabourPeasantRecruitAffordableTurns,
   required Map<String, int> castIronLabourPeasantRecruitFabricStarvedTurns,
-  required Map<String, int> castIronLabourPeasantRecruitMarketFabricStarvedTurns,
+  required Map<String, int>
+  castIronLabourPeasantRecruitMarketFabricStarvedTurns,
+  required Map<String, int>
+  castIronLabourPeasantRecruitMarketFabricUnofferedTurns,
   required Map<String, int> fabricRecipeFeasibleTurns,
   required Map<String, int> fabricRecipeLabourFeasibleTurns,
 }) {
@@ -742,6 +749,30 @@ void assertSeed42S7dStructuralInvariants({
       reason:
           '$gpId peasant-recruit market-fabric-starved turns cannot exceed '
           'the fabric-starved turns (market-starved requires fabric-starved)',
+    );
+    // Refs #2847 § S7-D market-fabric offer/acquisition localization: the
+    // market-fabric-unoffered counter is also a subset of the fabric-starved
+    // turns (gate active AND recruit unpayable AND holders present yet none
+    // offerable), AND it is mutually exclusive with the market-fabric-starved
+    // counter (one requires `otherGreatPowerFabricHeld <= 0`, the other
+    // `> 0`), so the two offer-side subsets together cannot exceed the
+    // fabric-starved total. Guards the instrumentation gating itself without
+    // pinning the (freely tunable) per-GP counts.
+    expect(
+      castIronLabourPeasantRecruitMarketFabricUnofferedTurns[gpId]!,
+      lessThanOrEqualTo(castIronLabourPeasantRecruitFabricStarvedTurns[gpId]!),
+      reason:
+          '$gpId peasant-recruit market-fabric-unoffered turns cannot exceed '
+          'the fabric-starved turns (unoffered requires fabric-starved)',
+    );
+    expect(
+      castIronLabourPeasantRecruitMarketFabricStarvedTurns[gpId]! +
+          castIronLabourPeasantRecruitMarketFabricUnofferedTurns[gpId]!,
+      lessThanOrEqualTo(castIronLabourPeasantRecruitFabricStarvedTurns[gpId]!),
+      reason:
+          '$gpId market-fabric-starved and market-fabric-unoffered turns are '
+          'disjoint fabric-starved subsets, so their sum cannot exceed the '
+          'fabric-starved total',
     );
     // Refs #2847 § S7-D fabric circular-labour localization: a fabric run is
     // labour-feasible only when it is also materially feasible


### PR DESCRIPTION
## Summary

Two stacked #2847 S7-D slices on the castIron-labour peasant-recruit fabric path.

Refs #2847 (does not close it).

## Done

- Offer-side localization: offerable-fabric predicates + MarketFabricUnoffered counter
- Buyer-side fix: peasant-recruit fabric direct bid sizes to 2-fabric recruit cost when staging active
- SPEC ACs, unit tests, S7-D buyer-side bid/deal counters

## Deferred

Turn-100 OW gate still open; seed-42 S7-D long diagnostic re-run deferred.

Refs #2847