### PR TITLE
fix(ai): bid peasant-recruit fabric deficit in lock-recovery bootstrap (#2847)

### DIFF
--- a/SPEC/ai/treasury-planner.md
+++ b/SPEC/ai/treasury-planner.md
@@ -442,6 +442,42 @@ zero-regiment population-bound seller cohort as
 economy-planner.md § Fabric staging ahead of castIron-labour peasant recruit;
 healthy regiment-holding GPs are unaffected.
 
+##### Peasant-recruit fabric direct bid (Refs #2847)
+
+The build-input bootstrap direct bid (§ Build-input bootstrap bid) sizes each
+missing `peasant_levies` build input to `entry.value - held`. When
+`isCastIronLabourPopulationBoundForLockRecoverySeller(game, playerId)` is
+`true` and `isCastIronLabourPeasantRecruitFabricShort(projected)` holds, the
+direct bid instead targets the peasant recruit material cost
+(`WorkerActionEconomyCatalog.peasant`, **2** `fabric`) for `fabric` — the
+regiment build input requires only **1**, so a seller holding exactly one
+unit clears the regiment missing-input check yet still cannot pay the recruit
+(S7-D: `gpCastIronLabourPeasantRecruitFabricStarvedTurns`). The bid quantity
+becomes `max(peasantFabricCost, peasantLevies.buildInputs[fabric]) - held`
+(typically `2 - held`). Scoped to the same below-quota zero-NW zero-regiment
+lock-recovery seller bootstrap gate as the regiment build-input bid; treasury,
+`bidTypeCap`, and cargo clamps are unchanged.
+
+#### Acceptance criteria (peasant-recruit fabric direct bid)
+
+- Given a below-quota zero-NW lock-recovery seller with
+  `player.treasury >= cheapestRegimentBuildTreasuryCost()`,
+  `regimentCountForPlayer(game, playerId) == 0`,
+  `isCastIronLabourPopulationBoundForLockRecoverySeller(game, playerId) == true`,
+  a projected stockpile holding exactly **1** `fabric` and enough `wool` for one
+  `fabric_from_wool` run, when `runTreasuryPlanner` runs, then it emits at least
+  one `TradeOrderType.bid` for `fabric` with `quantity >= 1`.
+- Given an otherwise identical seller holding **0** `fabric` and enough `wool`
+  for one `fabric_from_wool` run, when `runTreasuryPlanner` runs, then it emits
+  at least one `TradeOrderType.bid` for `fabric` with `quantity >= 2`.
+- Given an otherwise identical seller holding at least **2** `fabric`, when
+  `runTreasuryPlanner` runs, then it emits **no** `fabric` bid (negative control
+  — recruit cost is already met).
+- Given an otherwise identical seller that is **not**
+  population-bound for castIron labour, holding exactly **1** `fabric`, when
+  `runTreasuryPlanner` runs, then it emits **no** `fabric` bid (negative control
+  — peasant-recruit staging is inactive).
+
 The reservation never weakens a healthy GP: it is gated to the below-quota
 zero-NW seller band (gp1 / gp2 are above quota) and to the zero-regiment rebuild
 case (a seller already holding regiments keeps selling feedstock). Only the

--- a/packages/colonizethis_ai/lib/src/planning/treasury_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/treasury_planner.dart
@@ -505,6 +505,7 @@ void _applyLockRecoverySellerRegimentRebuildBids({
       projected: projected,
       carryForwardBids: carryForwardBids,
       need: need,
+      peasantRecruitFabricStaging: peasantRecruitFabricStaging,
     );
   }
 }

--- a/packages/colonizethis_ai/lib/src/planning/treasury_regiment_bootstrap.dart
+++ b/packages/colonizethis_ai/lib/src/planning/treasury_regiment_bootstrap.dart
@@ -211,16 +211,32 @@ ProductionRecipe? _lowestIdRecipeProducing(CommodityId commodityId) {
 
 /// Adds direct bids for any missing `peasant_levies` build input when no
 /// feedstock bootstrap bid is pending.
+///
+/// When [peasantRecruitFabricStaging] is true the castIron-labour peasant
+/// recruit row costs **2** `fabric` while the regiment build input requires
+/// only **1**, so a seller holding one unit is not short for the regiment yet
+/// still cannot pay the recruit — bid to the peasant material cost instead.
+/// Refs #2847 § castIron-labour peasant-recruit fabric direct bid.
 void _addRegimentBuildInputDirectNeed({
   required Stockpile projected,
   required Map<CommodityId, int> carryForwardBids,
   required Map<CommodityId, int> need,
+  bool peasantRecruitFabricStaging = false,
 }) {
   for (final input in RegimentEconomyCatalog.peasantLevies.buildInputs.entries) {
+    var targetQty = input.value;
+    if (peasantRecruitFabricStaging &&
+        input.key == CommodityCatalog.fabric.id) {
+      final peasantFabricCost =
+          WorkerActionEconomyCatalog.peasant.materialCosts[input.key] ?? 0;
+      if (peasantFabricCost > targetQty) {
+        targetQty = peasantFabricCost;
+      }
+    }
     final held =
         projected.quantityOf(input.key) + (carryForwardBids[input.key] ?? 0);
-    if (held < input.value) {
-      need[input.key] = input.value - held;
+    if (held < targetQty) {
+      need[input.key] = targetQty - held;
     }
   }
 }

--- a/packages/colonizethis_ai/test/planning/treasury_planner_regiment_input_feedstock_test.dart
+++ b/packages/colonizethis_ai/test/planning/treasury_planner_regiment_input_feedstock_test.dart
@@ -309,6 +309,71 @@ void main() {
           );
         },
       );
+
+      test(
+        'emits a fabric bid for the remaining unit when fabric meets regiment '
+        'cost but not peasant recruit',
+        () {
+          final game = _populationBoundSellerGame(fabricHeld: 1, woolHeld: 20);
+          final fabricBids = _run(game)
+              .where(
+                (o) =>
+                    o.type == TradeOrderType.bid && o.commodityId == _fabricId,
+              )
+              .toList();
+          expect(
+            fabricBids,
+            isNotEmpty,
+            reason:
+                'One fabric satisfies the regiment build input but not the '
+                '2-fabric peasant recruit; the bootstrap must bid for the '
+                'remaining unit.',
+          );
+          expect(
+            fabricBids.first.quantity,
+            greaterThanOrEqualTo(1),
+          );
+        },
+      );
+
+      test(
+        'emits a fabric bid sized to the peasant recruit cost when fabric is '
+        'zero and feedstock is on hand',
+        () {
+          final game = _populationBoundSellerGame(fabricHeld: 0, woolHeld: 20);
+          final fabricBids = _run(game)
+              .where(
+                (o) =>
+                    o.type == TradeOrderType.bid && o.commodityId == _fabricId,
+              )
+              .toList();
+          expect(
+            fabricBids,
+            isNotEmpty,
+            reason:
+                'Population-bound peasant-recruit staging must bid for fabric '
+                'once feedstock is on hand.',
+          );
+          expect(
+            fabricBids.first.quantity,
+            greaterThanOrEqualTo(peasantFabricCost),
+          );
+        },
+      );
+
+      test(
+        'emits no fabric bid once peasant recruit fabric cost is met',
+        () {
+          final game = _populationBoundSellerGame(fabricHeld: 2, woolHeld: 20);
+          final fabricBids = _run(game)
+              .where(
+                (o) =>
+                    o.type == TradeOrderType.bid && o.commodityId == _fabricId,
+              )
+              .toList();
+          expect(fabricBids, isEmpty);
+        },
+      );
     },
   );
 }

--- a/packages/colonizethis_ai/test/seed42_observer_conquest_s7d_diagnostic_test.dart
+++ b/packages/colonizethis_ai/test/seed42_observer_conquest_s7d_diagnostic_test.dart
@@ -2093,6 +2093,17 @@ void main() {
       // later slices land.
       final castIronLabourPeasantRecruitMarketFabricUnofferedTurns =
           <String, int>{for (final gpId in gpIds) gpId: 0};
+      // Refs #2847 § S7-D buyer-side fabric acquisition localization: on
+      // fabric-starved peasant-recruit turns where offerable `fabric` exists
+      // (`otherGreatPowerOfferableFabricHeld > 0`), whether the starved seller
+      // emits a `fabric` bid and whether a deal fills as buyer. Read-only;
+      // counts move freely as later slices land.
+      final castIronLabourPeasantRecruitFabricBidEmittedTurns =
+          <String, int>{for (final gpId in gpIds) gpId: 0};
+      final castIronLabourPeasantRecruitFabricBidAbsentTurns =
+          <String, int>{for (final gpId in gpIds) gpId: 0};
+      final castIronLabourPeasantRecruitFabricDealAsBuyerTurns =
+          <String, int>{for (final gpId in gpIds) gpId: 0};
       // Minimum `labourPerOutput` across the castIron recipes — the cheapest
       // single run's effective-labour requirement, used as the food-starved /
       // population-bound fork threshold above.
@@ -2230,6 +2241,7 @@ void main() {
       };
 
       for (var t = 0; t < 100; t++) {
+        final fabricStarvedThisTurn = <String>{};
         // Refs #2847 H8: per-turn rebuild-readiness + cheapest-regiment input
         // availability, populated in the pre-resolution GP loop and reconciled
         // against the emitted military builds after the merge below.
@@ -2530,6 +2542,7 @@ void main() {
                   castIronLabourPeasantRecruitFabricStarvedTurns,
                   gpId,
                 );
+                fabricStarvedThisTurn.add(gpId);
                 // Refs #2847 § S7-D market-fabric localization: of those
                 // fabric-starved turns, the ones where no other great power
                 // holds any `fabric` to sell, so the recruit `fabric` can be
@@ -2693,6 +2706,26 @@ void main() {
           }
         }
 
+        // Refs #2847 § S7-D buyer-side fabric acquisition: on fabric-starved
+        // peasant-recruit turns with offerable counterparty supply, record
+        // whether the seller emitted a `fabric` bid this turn.
+        const fabricCommodityId = 'fabric';
+        for (final gpId in fabricStarvedThisTurn) {
+          if (otherGreatPowerOfferableFabricHeld(game, gpId) <= 0) continue;
+          final tradeOrders = merged.tradeOrdersByPlayerId[gpId];
+          final emittedFabricBid = tradeOrders != null &&
+              tradeOrders.any(
+                (order) =>
+                    order.type == TradeOrderType.bid &&
+                    order.commodityId == fabricCommodityId,
+              );
+          if (emittedFabricBid) {
+            bumpCounter(castIronLabourPeasantRecruitFabricBidEmittedTurns, gpId);
+          } else {
+            bumpCounter(castIronLabourPeasantRecruitFabricBidAbsentTurns, gpId);
+          }
+        }
+
         final assignments = fullAi.economyPlansByPlayerId.map(
           (pid, plan) => MapEntry(pid, plan.productionAssignments),
         );
@@ -2738,6 +2771,13 @@ void main() {
               if (castIronFeedstockIds.contains(deal.commodityId)) {
                 castIronFeedstockDealsAsBuyer[buyer] =
                     (castIronFeedstockDealsAsBuyer[buyer] ?? 0) + 1;
+              }
+              if (fabricStarvedThisTurn.contains(buyer) &&
+                  deal.commodityId == fabricCommodityId) {
+                bumpCounter(
+                  castIronLabourPeasantRecruitFabricDealAsBuyerTurns,
+                  buyer,
+                );
               }
             }
           }
@@ -2908,6 +2948,12 @@ void main() {
             castIronLabourPeasantRecruitMarketFabricStarvedTurns,
         'gpCastIronLabourPeasantRecruitMarketFabricUnofferedTurns':
             castIronLabourPeasantRecruitMarketFabricUnofferedTurns,
+        'gpCastIronLabourPeasantRecruitFabricBidEmittedTurns':
+            castIronLabourPeasantRecruitFabricBidEmittedTurns,
+        'gpCastIronLabourPeasantRecruitFabricBidAbsentTurns':
+            castIronLabourPeasantRecruitFabricBidAbsentTurns,
+        'gpCastIronLabourPeasantRecruitFabricDealAsBuyerTurns':
+            castIronLabourPeasantRecruitFabricDealAsBuyerTurns,
         'castIronMinLabourPerOutput': castIronMinLabourPerOutput,
         'gpTurn99Snapshot': lastSnapshotFields,
       };
@@ -3006,6 +3052,12 @@ void main() {
             castIronLabourPeasantRecruitMarketFabricStarvedTurns,
         castIronLabourPeasantRecruitMarketFabricUnofferedTurns:
             castIronLabourPeasantRecruitMarketFabricUnofferedTurns,
+        castIronLabourPeasantRecruitFabricBidEmittedTurns:
+            castIronLabourPeasantRecruitFabricBidEmittedTurns,
+        castIronLabourPeasantRecruitFabricBidAbsentTurns:
+            castIronLabourPeasantRecruitFabricBidAbsentTurns,
+        castIronLabourPeasantRecruitFabricDealAsBuyerTurns:
+            castIronLabourPeasantRecruitFabricDealAsBuyerTurns,
         fabricRecipeFeasibleTurns: fabricRecipeFeasibleTurns,
         fabricRecipeLabourFeasibleTurns: fabricRecipeLabourFeasibleTurns,
       );

--- a/packages/colonizethis_ai/test/seed42_observer_conquest_s7d_diagnostic_test.dart
+++ b/packages/colonizethis_ai/test/seed42_observer_conquest_s7d_diagnostic_test.dart
@@ -10,7 +10,7 @@ import 'package:colonizethis_ai/src/planning/expand_phase_planner.dart'
         cheapestRegimentBuildTreasuryCost,
         expandSellerFeedstockTileAcquisitionTarget;
 import 'package:colonizethis_ai/src/planning/treasury_planner.dart'
-    show kTreasuryOfferPriorityUrgent, otherGreatPowerOfferableFabricHeld;
+    show otherGreatPowerOfferableFabricHeld;
 import 'package:colonizethis_data/colonizethis_data.dart'
     hide cheapestRegimentBuildTreasuryCost;
 import 'package:colonizethis_logger/colonizethis_logger.dart';
@@ -2670,61 +2670,32 @@ void main() {
         // Carry-forward bids/offers re-injected by the world-market
         // phase are not counted here; this metric reflects what the
         // AI actively emits each turn.
-        for (final gpId in gpIds) {
-          final tradeOrders = merged.tradeOrdersByPlayerId[gpId];
-          if (tradeOrders == null) continue;
-          for (final order in tradeOrders) {
-            if (order.type == TradeOrderType.offer) {
-              tradeOfferCount[gpId] = (tradeOfferCount[gpId] ?? 0) + 1;
-              if (order.priority >= kTreasuryOfferPriorityUrgent) {
-                tradeUrgentOfferCount[gpId] =
-                    (tradeUrgentOfferCount[gpId] ?? 0) + 1;
-              }
-              if (improvementInputCommodityIds.contains(order.commodityId)) {
-                improvementInputOffersEmitted[gpId] =
-                    (improvementInputOffersEmitted[gpId] ?? 0) + 1;
-              }
-              if (castIronFeedstockIds.contains(order.commodityId)) {
-                castIronFeedstockOffersEmitted[gpId] =
-                    (castIronFeedstockOffersEmitted[gpId] ?? 0) + 1;
-              }
-            } else if (order.type == TradeOrderType.bid) {
-              tradeBidCount[gpId] = (tradeBidCount[gpId] ?? 0) + 1;
-              if (regimentInputCommodityIds.contains(order.commodityId)) {
-                regimentInputBidsEmitted[gpId] =
-                    (regimentInputBidsEmitted[gpId] ?? 0) + 1;
-              }
-              if (improvementInputCommodityIds.contains(order.commodityId)) {
-                improvementInputBidsEmitted[gpId] =
-                    (improvementInputBidsEmitted[gpId] ?? 0) + 1;
-              }
-              if (castIronFeedstockIds.contains(order.commodityId)) {
-                castIronFeedstockBidsEmitted[gpId] =
-                    (castIronFeedstockBidsEmitted[gpId] ?? 0) + 1;
-              }
-            }
-          }
-        }
+        recordSeed42S7dTradeOrderCounters(
+          gpIds: gpIds,
+          tradeOrdersByPlayerId: merged.tradeOrdersByPlayerId,
+          regimentInputCommodityIds: regimentInputCommodityIds,
+          improvementInputCommodityIds: improvementInputCommodityIds,
+          castIronFeedstockIds: castIronFeedstockIds,
+          tradeOfferCount: tradeOfferCount,
+          tradeUrgentOfferCount: tradeUrgentOfferCount,
+          tradeBidCount: tradeBidCount,
+          improvementInputOffersEmitted: improvementInputOffersEmitted,
+          castIronFeedstockOffersEmitted: castIronFeedstockOffersEmitted,
+          regimentInputBidsEmitted: regimentInputBidsEmitted,
+          improvementInputBidsEmitted: improvementInputBidsEmitted,
+          castIronFeedstockBidsEmitted: castIronFeedstockBidsEmitted,
+        );
 
         // Refs #2847 § S7-D buyer-side fabric acquisition: on fabric-starved
         // peasant-recruit turns with offerable counterparty supply, record
         // whether the seller emitted a `fabric` bid this turn.
-        const fabricCommodityId = 'fabric';
-        for (final gpId in fabricStarvedThisTurn) {
-          if (otherGreatPowerOfferableFabricHeld(game, gpId) <= 0) continue;
-          final tradeOrders = merged.tradeOrdersByPlayerId[gpId];
-          final emittedFabricBid = tradeOrders != null &&
-              tradeOrders.any(
-                (order) =>
-                    order.type == TradeOrderType.bid &&
-                    order.commodityId == fabricCommodityId,
-              );
-          if (emittedFabricBid) {
-            bumpCounter(castIronLabourPeasantRecruitFabricBidEmittedTurns, gpId);
-          } else {
-            bumpCounter(castIronLabourPeasantRecruitFabricBidAbsentTurns, gpId);
-          }
-        }
+        recordSeed42S7dFabricBidCounters(
+          game: game,
+          fabricStarvedThisTurn: fabricStarvedThisTurn,
+          tradeOrdersByPlayerId: merged.tradeOrdersByPlayerId,
+          emittedTurns: castIronLabourPeasantRecruitFabricBidEmittedTurns,
+          absentTurns: castIronLabourPeasantRecruitFabricBidAbsentTurns,
+        );
 
         final assignments = fullAi.economyPlansByPlayerId.map(
           (pid, plan) => MapEntry(pid, plan.productionAssignments),
@@ -2773,7 +2744,7 @@ void main() {
                     (castIronFeedstockDealsAsBuyer[buyer] ?? 0) + 1;
               }
               if (fabricStarvedThisTurn.contains(buyer) &&
-                  deal.commodityId == fabricCommodityId) {
+                  deal.commodityId == 'fabric') {
                 bumpCounter(
                   castIronLabourPeasantRecruitFabricDealAsBuyerTurns,
                   buyer,

--- a/packages/colonizethis_ai/test/support/seed42_s7d_feedstock_helpers.dart
+++ b/packages/colonizethis_ai/test/support/seed42_s7d_feedstock_helpers.dart
@@ -859,30 +859,68 @@ void recordSeed42S7dTradeOrderCounters({
     final tradeOrders = tradeOrdersByPlayerId[gpId];
     if (tradeOrders == null) continue;
     for (final order in tradeOrders) {
-      if (order.type == TradeOrderType.offer) {
-        bumpCounter(tradeOfferCount, gpId);
-        if (order.priority >= kTreasuryOfferPriorityUrgent) {
-          bumpCounter(tradeUrgentOfferCount, gpId);
-        }
-        if (improvementInputCommodityIds.contains(order.commodityId)) {
-          bumpCounter(improvementInputOffersEmitted, gpId);
-        }
-        if (castIronFeedstockIds.contains(order.commodityId)) {
-          bumpCounter(castIronFeedstockOffersEmitted, gpId);
-        }
-      } else if (order.type == TradeOrderType.bid) {
-        bumpCounter(tradeBidCount, gpId);
-        if (regimentInputCommodityIds.contains(order.commodityId)) {
-          bumpCounter(regimentInputBidsEmitted, gpId);
-        }
-        if (improvementInputCommodityIds.contains(order.commodityId)) {
-          bumpCounter(improvementInputBidsEmitted, gpId);
-        }
-        if (castIronFeedstockIds.contains(order.commodityId)) {
-          bumpCounter(castIronFeedstockBidsEmitted, gpId);
-        }
-      }
+      _recordSeed42S7dTradeOrderCounter(
+        gpId: gpId,
+        order: order,
+        regimentInputCommodityIds: regimentInputCommodityIds,
+        improvementInputCommodityIds: improvementInputCommodityIds,
+        castIronFeedstockIds: castIronFeedstockIds,
+        tradeOfferCount: tradeOfferCount,
+        tradeUrgentOfferCount: tradeUrgentOfferCount,
+        tradeBidCount: tradeBidCount,
+        improvementInputOffersEmitted: improvementInputOffersEmitted,
+        castIronFeedstockOffersEmitted: castIronFeedstockOffersEmitted,
+        regimentInputBidsEmitted: regimentInputBidsEmitted,
+        improvementInputBidsEmitted: improvementInputBidsEmitted,
+        castIronFeedstockBidsEmitted: castIronFeedstockBidsEmitted,
+      );
     }
+  }
+}
+
+/// Records the per-GP counter bumps for a single merged [order] (Refs #2924
+/// Step 0). Extracted from [recordSeed42S7dTradeOrderCounters] so the scan loop
+/// stays within the repo control-flow nesting-depth limit; behavior is
+/// identical to the inline offer/bid handling it replaced. Read-only over the
+/// supplied sets except for the counter bumps.
+void _recordSeed42S7dTradeOrderCounter({
+  required String gpId,
+  required TradeOrder order,
+  required Set<String> regimentInputCommodityIds,
+  required Set<String> improvementInputCommodityIds,
+  required Set<String> castIronFeedstockIds,
+  required Map<String, int> tradeOfferCount,
+  required Map<String, int> tradeUrgentOfferCount,
+  required Map<String, int> tradeBidCount,
+  required Map<String, int> improvementInputOffersEmitted,
+  required Map<String, int> castIronFeedstockOffersEmitted,
+  required Map<String, int> regimentInputBidsEmitted,
+  required Map<String, int> improvementInputBidsEmitted,
+  required Map<String, int> castIronFeedstockBidsEmitted,
+}) {
+  if (order.type == TradeOrderType.offer) {
+    bumpCounter(tradeOfferCount, gpId);
+    if (order.priority >= kTreasuryOfferPriorityUrgent) {
+      bumpCounter(tradeUrgentOfferCount, gpId);
+    }
+    if (improvementInputCommodityIds.contains(order.commodityId)) {
+      bumpCounter(improvementInputOffersEmitted, gpId);
+    }
+    if (castIronFeedstockIds.contains(order.commodityId)) {
+      bumpCounter(castIronFeedstockOffersEmitted, gpId);
+    }
+    return;
+  }
+  if (order.type != TradeOrderType.bid) return;
+  bumpCounter(tradeBidCount, gpId);
+  if (regimentInputCommodityIds.contains(order.commodityId)) {
+    bumpCounter(regimentInputBidsEmitted, gpId);
+  }
+  if (improvementInputCommodityIds.contains(order.commodityId)) {
+    bumpCounter(improvementInputBidsEmitted, gpId);
+  }
+  if (castIronFeedstockIds.contains(order.commodityId)) {
+    bumpCounter(castIronFeedstockBidsEmitted, gpId);
   }
 }
 

--- a/packages/colonizethis_ai/test/support/seed42_s7d_feedstock_helpers.dart
+++ b/packages/colonizethis_ai/test/support/seed42_s7d_feedstock_helpers.dart
@@ -16,6 +16,8 @@ import 'package:colonizethis_ai/src/planning/expand_phase_planner.dart'
     show cheapestRegimentBuildTreasuryCost;
 import 'package:colonizethis_ai/src/planning/recipe_scoring.dart'
     show feasibleRuns;
+import 'package:colonizethis_ai/src/planning/treasury_planner.dart'
+    show kTreasuryOfferPriorityUrgent, otherGreatPowerOfferableFabricHeld;
 import 'package:colonizethis_data/colonizethis_data.dart'
     hide cheapestRegimentBuildTreasuryCost;
 import 'package:colonizethis_logic/colonizethis_logic.dart';
@@ -824,6 +826,96 @@ void assertSeed42S7dStructuralInvariants({
           '$gpId fabric labour-feasible turns cannot exceed the fabric '
           'material-feasible turns (labour-feasible requires material-feasible)',
     );
+  }
+}
+
+/// Tallies the per-GP submitted trade-order counters for one turn from the
+/// merged order list the resolver will apply (Refs #2924 Step 0). Mirrors the
+/// inline scan it replaced: each offer bumps [tradeOfferCount] (plus
+/// [tradeUrgentOfferCount] / [improvementInputOffersEmitted] /
+/// [castIronFeedstockOffersEmitted] where the order qualifies); each bid bumps
+/// [tradeBidCount] (plus the regiment- / improvement-input and castIron-
+/// feedstock bid counters where the commodity matches). Carry-forward
+/// world-market re-injections are excluded by construction — the caller passes
+/// only the AI-emitted merged orders. Read-only over the supplied maps except
+/// for the counter bumps. Extracted to keep the diagnostic test file at or
+/// below the repo non-comment line limit.
+void recordSeed42S7dTradeOrderCounters({
+  required List<String> gpIds,
+  required Map<String, List<TradeOrder>> tradeOrdersByPlayerId,
+  required Set<String> regimentInputCommodityIds,
+  required Set<String> improvementInputCommodityIds,
+  required Set<String> castIronFeedstockIds,
+  required Map<String, int> tradeOfferCount,
+  required Map<String, int> tradeUrgentOfferCount,
+  required Map<String, int> tradeBidCount,
+  required Map<String, int> improvementInputOffersEmitted,
+  required Map<String, int> castIronFeedstockOffersEmitted,
+  required Map<String, int> regimentInputBidsEmitted,
+  required Map<String, int> improvementInputBidsEmitted,
+  required Map<String, int> castIronFeedstockBidsEmitted,
+}) {
+  for (final gpId in gpIds) {
+    final tradeOrders = tradeOrdersByPlayerId[gpId];
+    if (tradeOrders == null) continue;
+    for (final order in tradeOrders) {
+      if (order.type == TradeOrderType.offer) {
+        bumpCounter(tradeOfferCount, gpId);
+        if (order.priority >= kTreasuryOfferPriorityUrgent) {
+          bumpCounter(tradeUrgentOfferCount, gpId);
+        }
+        if (improvementInputCommodityIds.contains(order.commodityId)) {
+          bumpCounter(improvementInputOffersEmitted, gpId);
+        }
+        if (castIronFeedstockIds.contains(order.commodityId)) {
+          bumpCounter(castIronFeedstockOffersEmitted, gpId);
+        }
+      } else if (order.type == TradeOrderType.bid) {
+        bumpCounter(tradeBidCount, gpId);
+        if (regimentInputCommodityIds.contains(order.commodityId)) {
+          bumpCounter(regimentInputBidsEmitted, gpId);
+        }
+        if (improvementInputCommodityIds.contains(order.commodityId)) {
+          bumpCounter(improvementInputBidsEmitted, gpId);
+        }
+        if (castIronFeedstockIds.contains(order.commodityId)) {
+          bumpCounter(castIronFeedstockBidsEmitted, gpId);
+        }
+      }
+    }
+  }
+}
+
+/// Records buyer-side `fabric` bid emission for the S7-D peasant-recruit
+/// localization (Refs #2847 § buyer-side fabric acquisition). On each
+/// fabric-starved gp this turn with offerable counterparty fabric supply
+/// (`otherGreatPowerOfferableFabricHeld > 0`), bumps [emittedTurns] when the gp
+/// emitted a `fabric` bid in [tradeOrdersByPlayerId], else [absentTurns].
+/// Read-only over `(game, tradeOrdersByPlayerId)` except the counter bumps;
+/// extracted to keep the diagnostic test file at or below the repo non-comment
+/// line limit.
+void recordSeed42S7dFabricBidCounters({
+  required Game game,
+  required Set<String> fabricStarvedThisTurn,
+  required Map<String, List<TradeOrder>> tradeOrdersByPlayerId,
+  required Map<String, int> emittedTurns,
+  required Map<String, int> absentTurns,
+}) {
+  const fabricCommodityId = 'fabric';
+  for (final gpId in fabricStarvedThisTurn) {
+    if (otherGreatPowerOfferableFabricHeld(game, gpId) <= 0) continue;
+    final tradeOrders = tradeOrdersByPlayerId[gpId];
+    final emittedFabricBid = tradeOrders != null &&
+        tradeOrders.any(
+          (order) =>
+              order.type == TradeOrderType.bid &&
+              order.commodityId == fabricCommodityId,
+        );
+    if (emittedFabricBid) {
+      bumpCounter(emittedTurns, gpId);
+    } else {
+      bumpCounter(absentTurns, gpId);
+    }
   }
 }
 

--- a/packages/colonizethis_ai/test/support/seed42_s7d_feedstock_helpers.dart
+++ b/packages/colonizethis_ai/test/support/seed42_s7d_feedstock_helpers.dart
@@ -608,6 +608,9 @@ void assertSeed42S7dStructuralInvariants({
   castIronLabourPeasantRecruitMarketFabricStarvedTurns,
   required Map<String, int>
   castIronLabourPeasantRecruitMarketFabricUnofferedTurns,
+  required Map<String, int> castIronLabourPeasantRecruitFabricBidEmittedTurns,
+  required Map<String, int> castIronLabourPeasantRecruitFabricBidAbsentTurns,
+  required Map<String, int> castIronLabourPeasantRecruitFabricDealAsBuyerTurns,
   required Map<String, int> fabricRecipeFeasibleTurns,
   required Map<String, int> fabricRecipeLabourFeasibleTurns,
 }) {
@@ -773,6 +776,41 @@ void assertSeed42S7dStructuralInvariants({
           '$gpId market-fabric-starved and market-fabric-unoffered turns are '
           'disjoint fabric-starved subsets, so their sum cannot exceed the '
           'fabric-starved total',
+    );
+    // Refs #2847 § S7-D buyer-side fabric acquisition: bid-emitted and
+    // bid-absent counters are each measured only on fabric-starved turns with
+    // offerable counterparty supply, so neither can exceed the fabric-starved
+    // total; deals-as-buyer cannot exceed bid-emitted turns on the same axis.
+    expect(
+      castIronLabourPeasantRecruitFabricBidEmittedTurns[gpId]!,
+      lessThanOrEqualTo(castIronLabourPeasantRecruitFabricStarvedTurns[gpId]!),
+      reason:
+          '$gpId peasant-recruit fabric-bid-emitted turns cannot exceed the '
+          'fabric-starved turns',
+    );
+    expect(
+      castIronLabourPeasantRecruitFabricBidAbsentTurns[gpId]!,
+      lessThanOrEqualTo(castIronLabourPeasantRecruitFabricStarvedTurns[gpId]!),
+      reason:
+          '$gpId peasant-recruit fabric-bid-absent turns cannot exceed the '
+          'fabric-starved turns',
+    );
+    expect(
+      castIronLabourPeasantRecruitFabricBidEmittedTurns[gpId]! +
+          castIronLabourPeasantRecruitFabricBidAbsentTurns[gpId]!,
+      lessThanOrEqualTo(castIronLabourPeasantRecruitFabricStarvedTurns[gpId]!),
+      reason:
+          '$gpId fabric-bid-emitted and fabric-bid-absent turns are disjoint '
+          'buyer-side subsets of offerable-supply fabric-starved turns',
+    );
+    expect(
+      castIronLabourPeasantRecruitFabricDealAsBuyerTurns[gpId]!,
+      lessThanOrEqualTo(
+        castIronLabourPeasantRecruitFabricBidEmittedTurns[gpId]!,
+      ),
+      reason:
+          '$gpId peasant-recruit fabric deals-as-buyer turns cannot exceed '
+          'fabric-bid-emitted turns on the same axis',
     );
     // Refs #2847 § S7-D fabric circular-labour localization: a fabric run is
     // labour-feasible only when it is also materially feasible


### PR DESCRIPTION
## Summary

Follow-up to merged #3322 (offerable-fabric localization). PR #3322 cleared the offer/retention layer on seed-42 gp5 fabric-starved peasant-recruit turns and re-pointed the residual to **buyer-side acquisition**. This slice closes the bid-sizing gap: the H8 regiment build-input direct bid sized `fabric` to the `peasant_levies` build input (1 unit), so a population-bound seller holding exactly one `fabric` cleared the regiment missing-input check yet never bid for the second unit the 2-`fabric` peasant recruit requires.

`Refs #2847` (does not close it).

## Done in this PR

### Behaviour fix — `treasury_regiment_bootstrap.dart`

- **`_addRegimentBuildInputDirectNeed`** targets `WorkerActionEconomyCatalog.peasant` material cost (2 `fabric`) when castIron-labour peasant-recruit fabric staging is active, instead of stopping at the regiment build input (1).

### SPEC — `SPEC/ai/treasury-planner.md`

- New § **Peasant-recruit fabric direct bid** with positive/negative ACs.

### Unit tests — `treasury_planner_regiment_input_feedstock_test.dart`

- fabric=1 + population-bound → fabric bid qty ≥ 1
- fabric=0 + wool on hand → fabric bid qty ≥ 2
- fabric=2 → no fabric bid (negative control)

### S7-D buyer-side diagnostics — `seed42_observer_conquest_s7d_diagnostic_test.dart`

- **`gpCastIronLabourPeasantRecruitFabricBidEmittedTurns`**
- **`gpCastIronLabourPeasantRecruitFabricBidAbsentTurns`**
- **`gpCastIronLabourPeasantRecruitFabricDealAsBuyerTurns`**
- Structural invariants in `seed42_s7d_feedstock_helpers.dart`

## Deferred

- Turn-100 OW conquest gate still open for gp3/gp4/gp5/gp6 — bid affordability / market match / downstream castIron-labour effects may need further slices.
- Seed-42 S7-D long diagnostic re-run (`dart test --run-skipped test/seed42_observer_conquest_s7d_diagnostic_test.dart`) not executed in-agent (~5 min).

## Tests

- `dart test test/planning/treasury_planner_regiment_input_feedstock_test.dart` — 21 passed
- `dart test test/planning/treasury_planner_offerable_fabric_test.dart` — 8 passed
- `dart analyze` on touched treasury planner files — clean

Refs #2847

Made with [Cursor](https://cursor.com)