### PR TITLE
test(ai): localize seed-42 castIron build_improvement market-supply wall (Refs #2847)

### DIFF
--- a/packages/colonizethis_ai/test/seed42_observer_conquest_s7d_diagnostic_test.dart
+++ b/packages/colonizethis_ai/test/seed42_observer_conquest_s7d_diagnostic_test.dart
@@ -2104,6 +2104,19 @@ void main() {
           <String, int>{for (final gpId in gpIds) gpId: 0};
       final castIronLabourPeasantRecruitFabricDealAsBuyerTurns =
           <String, int>{for (final gpId in gpIds) gpId: 0};
+      // Refs #2847 § castIron market-supply wall: on feedstock-extraction
+      // gate-active turns, whether any *other* faction offered `castIron` (the
+      // manufactured level-0 `build_improvement` input) on the world market —
+      // i.e. whether the seller's direct-acquisition branch had any supply to
+      // bid against. A flat-zero present count across the run proves the
+      // direct castIron purchase path is permanently closed (every GP consumes
+      // its castIron for Old World military builds), leaving only the
+      // labour-walled domestic run. Read-only; counts move freely as later
+      // supply slices land.
+      final castIronMarketOfferPresentTurns =
+          <String, int>{for (final gpId in gpIds) gpId: 0};
+      final castIronMarketOfferAbsentTurns =
+          <String, int>{for (final gpId in gpIds) gpId: 0};
       // Minimum `labourPerOutput` across the castIron recipes — the cheapest
       // single run's effective-labour requirement, used as the food-starved /
       // population-bound fork threshold above.
@@ -2242,6 +2255,10 @@ void main() {
 
       for (var t = 0; t < 100; t++) {
         final fabricStarvedThisTurn = <String>{};
+        // Refs #2847 § castIron market-supply wall: GPs whose feedstock-
+        // extraction gate is active this turn, scanned post-merge for castIron
+        // market-offer presence/absence.
+        final feedstockGateActiveThisTurn = <String>{};
         // Refs #2847 H8: per-turn rebuild-readiness + cheapest-regiment input
         // availability, populated in the pre-resolution GP loop and reconciled
         // against the emitted military builds after the merge below.
@@ -2333,6 +2350,7 @@ void main() {
                 gpId,
               ).isNotEmpty;
           if (feedstockGateActive) {
+            feedstockGateActiveThisTurn.add(gpId);
             feedstockExtractionGateActiveTurns[gpId] =
                 (feedstockExtractionGateActiveTurns[gpId] ?? 0) + 1;
             // Refs #2847 H8-extraction execution-gap disambiguation: split the
@@ -2697,6 +2715,18 @@ void main() {
           absentTurns: castIronLabourPeasantRecruitFabricBidAbsentTurns,
         );
 
+        // Refs #2847 § castIron market-supply wall: on the feedstock-extraction
+        // gate-active turns, record whether any other faction offered castIron
+        // (the manufactured level-0 build_improvement input) this turn.
+        recordSeed42S7dCastIronMarketOfferCounters(
+          feedstockGateActiveThisTurn: feedstockGateActiveThisTurn,
+          tradeOrdersByPlayerId: merged.tradeOrdersByPlayerId,
+          castIronCommodityId:
+              castIronProductionRecipe?.outputCommodityId ?? 'castIron',
+          presentTurns: castIronMarketOfferPresentTurns,
+          absentTurns: castIronMarketOfferAbsentTurns,
+        );
+
         final assignments = fullAi.economyPlansByPlayerId.map(
           (pid, plan) => MapEntry(pid, plan.productionAssignments),
         );
@@ -2925,6 +2955,8 @@ void main() {
             castIronLabourPeasantRecruitFabricBidAbsentTurns,
         'gpCastIronLabourPeasantRecruitFabricDealAsBuyerTurns':
             castIronLabourPeasantRecruitFabricDealAsBuyerTurns,
+        'gpCastIronMarketOfferPresentTurns': castIronMarketOfferPresentTurns,
+        'gpCastIronMarketOfferAbsentTurns': castIronMarketOfferAbsentTurns,
         'castIronMinLabourPerOutput': castIronMinLabourPerOutput,
         'gpTurn99Snapshot': lastSnapshotFields,
       };
@@ -3031,6 +3063,8 @@ void main() {
             castIronLabourPeasantRecruitFabricDealAsBuyerTurns,
         fabricRecipeFeasibleTurns: fabricRecipeFeasibleTurns,
         fabricRecipeLabourFeasibleTurns: fabricRecipeLabourFeasibleTurns,
+        castIronMarketOfferPresentTurns: castIronMarketOfferPresentTurns,
+        castIronMarketOfferAbsentTurns: castIronMarketOfferAbsentTurns,
       );
     },
     skip:

--- a/packages/colonizethis_ai/test/seed42_observer_conquest_s7d_diagnostic_test.dart
+++ b/packages/colonizethis_ai/test/seed42_observer_conquest_s7d_diagnostic_test.dart
@@ -1574,6 +1574,7 @@ void main() {
       final tileMap = init.tileMapByRegion;
 
       final gpIds = [for (var i = 1; i <= 6; i++) 'gp$i'];
+      Map<String, int> zeroPerGp() => {for (final gpId in gpIds) gpId: 0};
       final owStart = <String, int>{
         for (final gpId in gpIds)
           gpId: game.worldState.oldWorld.provinces
@@ -1607,9 +1608,7 @@ void main() {
       final atWarTurnsByPeer = <String, Map<String, int>>{
         for (final gpId in gpIds) gpId: <String, int>{},
       };
-      final treasuryUnderCheapestTurns = <String, int>{
-        for (final gpId in gpIds) gpId: 0,
-      };
+      final treasuryUnderCheapestTurns = zeroPerGp();
       final lastSnapshotFields = <String, Map<String, Object?>>{};
 
       // Refs #2847 regiment-accumulation surface (post-#2924 / World
@@ -1623,15 +1622,9 @@ void main() {
       // apart "the build order is never emitted/accepted" from "regiments
       // are built but immediately lost in the peer-war zero-sum churn".
       final regimentPeak = <String, int>{for (final gpId in gpIds) gpId: 0};
-      final regimentTurnsAtZero = <String, int>{
-        for (final gpId in gpIds) gpId: 0,
-      };
-      final treasuryAtOrAboveCheapestTurns = <String, int>{
-        for (final gpId in gpIds) gpId: 0,
-      };
-      final militaryBuildOrdersEmitted = <String, int>{
-        for (final gpId in gpIds) gpId: 0,
-      };
+      final regimentTurnsAtZero = zeroPerGp();
+      final treasuryAtOrAboveCheapestTurns = zeroPerGp();
+      final militaryBuildOrdersEmitted = zeroPerGp();
 
       // Refs #2847 H8 conversion-gap isolation. The headline H8 finding is
       // that `forceCheapestRegimentBuild` fires 85-100 turns while
@@ -1649,21 +1642,11 @@ void main() {
       // unit of fabric, so fabric availability is the proximate input gate.
       final cheapestRegimentInputs =
           RegimentEconomyCatalog.peasantLevies.buildInputs;
-      final fabricInStockpileTurns = <String, int>{
-        for (final gpId in gpIds) gpId: 0,
-      };
-      final rebuildReadyTurns = <String, int>{
-        for (final gpId in gpIds) gpId: 0,
-      };
-      final rebuildReadyNoBuildTurns = <String, int>{
-        for (final gpId in gpIds) gpId: 0,
-      };
-      final rebuildReadyNoBuildMissingInputTurns = <String, int>{
-        for (final gpId in gpIds) gpId: 0,
-      };
-      final rebuildReadyNoBuildInputsPresentTurns = <String, int>{
-        for (final gpId in gpIds) gpId: 0,
-      };
+      final fabricInStockpileTurns = zeroPerGp();
+      final rebuildReadyTurns = zeroPerGp();
+      final rebuildReadyNoBuildTurns = zeroPerGp();
+      final rebuildReadyNoBuildMissingInputTurns = zeroPerGp();
+      final rebuildReadyNoBuildInputsPresentTurns = zeroPerGp();
       // Cheapest-regiment input commodity ids (e.g. fabric) and the bid /
       // fill counters that prove whether the #3226 lock-recovery build-input
       // bid carve-out actually secures the input from the world market. A
@@ -1671,12 +1654,8 @@ void main() {
       // world-market *supply* (no seller / no production feedstock) rather
       // than the planner failing to bid.
       final regimentInputCommodityIds = cheapestRegimentInputs.keys.toSet();
-      final regimentInputBidsEmitted = <String, int>{
-        for (final gpId in gpIds) gpId: 0,
-      };
-      final regimentInputDealsAsBuyer = <String, int>{
-        for (final gpId in gpIds) gpId: 0,
-      };
+      final regimentInputBidsEmitted = zeroPerGp();
+      final regimentInputDealsAsBuyer = zeroPerGp();
 
       // Refs #2847 H8-extraction supply-side localization. The level-0
       // `build_improvement` material (lumber + cast iron) is the prerequisite a

--- a/packages/colonizethis_ai/test/seed42_s7d_feedstock_helpers_test.dart
+++ b/packages/colonizethis_ai/test/seed42_s7d_feedstock_helpers_test.dart
@@ -502,4 +502,83 @@ void main() {
       },
     );
   });
+
+  group('recordSeed42S7dCastIronMarketOfferCounters', () {
+    final castIronId = CommodityCatalog.castIron.id;
+
+    TradeOrder offer(String id) => TradeOrder(
+      commodityId: id,
+      type: TradeOrderType.offer,
+      quantity: 1,
+      priority: 1,
+    );
+    TradeOrder bid(String id) => TradeOrder(
+      commodityId: id,
+      type: TradeOrderType.bid,
+      quantity: 1,
+      priority: 1,
+    );
+
+    test(
+      'positive: another faction offers castIron => present bumped, absent not',
+      () {
+        final present = <String, int>{'gp3': 0};
+        final absent = <String, int>{'gp3': 0};
+        recordSeed42S7dCastIronMarketOfferCounters(
+          feedstockGateActiveThisTurn: {'gp3'},
+          tradeOrdersByPlayerId: {
+            'gp1': [offer(castIronId)],
+            'gp3': [bid(castIronId)],
+          },
+          castIronCommodityId: castIronId,
+          presentTurns: present,
+          absentTurns: absent,
+        );
+        expect(present['gp3'], 1);
+        expect(absent['gp3'], 0);
+      },
+    );
+
+    test(
+      'negative: no other faction offers castIron (only own offer + others\' '
+      'bids / unrelated offers) => absent bumped, present not',
+      () {
+        final present = <String, int>{'gp3': 0};
+        final absent = <String, int>{'gp3': 0};
+        recordSeed42S7dCastIronMarketOfferCounters(
+          feedstockGateActiveThisTurn: {'gp3'},
+          tradeOrdersByPlayerId: {
+            // The seller's own castIron offer must not count as supply.
+            'gp3': [offer(castIronId)],
+            // Other GPs bid castIron (demand, not supply) or offer a
+            // different commodity — neither is releasable castIron supply.
+            'gp1': [bid(castIronId), offer(timberId)],
+            'gp2': [offer(ironId)],
+          },
+          castIronCommodityId: castIronId,
+          presentTurns: present,
+          absentTurns: absent,
+        );
+        expect(present['gp3'], 0);
+        expect(absent['gp3'], 1);
+      },
+    );
+
+    test('gates strictly on the active set — inactive GPs are untouched', () {
+      final present = <String, int>{'gp3': 0, 'gp4': 0};
+      final absent = <String, int>{'gp3': 0, 'gp4': 0};
+      recordSeed42S7dCastIronMarketOfferCounters(
+        feedstockGateActiveThisTurn: {'gp3'},
+        tradeOrdersByPlayerId: {
+          'gp1': [offer(castIronId)],
+        },
+        castIronCommodityId: castIronId,
+        presentTurns: present,
+        absentTurns: absent,
+      );
+      expect(present['gp3'], 1);
+      expect(present['gp4'], 0);
+      expect(absent['gp4'], 0);
+    });
+  });
 }

--- a/packages/colonizethis_ai/test/support/seed42_s7d_feedstock_helpers.dart
+++ b/packages/colonizethis_ai/test/support/seed42_s7d_feedstock_helpers.dart
@@ -615,6 +615,8 @@ void assertSeed42S7dStructuralInvariants({
   required Map<String, int> castIronLabourPeasantRecruitFabricDealAsBuyerTurns,
   required Map<String, int> fabricRecipeFeasibleTurns,
   required Map<String, int> fabricRecipeLabourFeasibleTurns,
+  required Map<String, int> castIronMarketOfferPresentTurns,
+  required Map<String, int> castIronMarketOfferAbsentTurns,
 }) {
   for (final gpId in gpIds) {
     expect(
@@ -826,6 +828,19 @@ void assertSeed42S7dStructuralInvariants({
           '$gpId fabric labour-feasible turns cannot exceed the fabric '
           'material-feasible turns (labour-feasible requires material-feasible)',
     );
+    // Refs #2847 § castIron market-supply wall: every feedstock-extraction
+    // gate-active turn is classified as exactly one of castIron-offer-present
+    // or castIron-offer-absent, so the two partition the gate-active total.
+    // Guards the instrumentation gating itself without pinning the (freely
+    // tunable) per-GP counts.
+    expect(
+      castIronMarketOfferPresentTurns[gpId]! +
+          castIronMarketOfferAbsentTurns[gpId]!,
+      feedstockExtractionGateActiveTurns[gpId],
+      reason:
+          '$gpId castIron market-offer present + absent turns must partition '
+          'the feedstock-extraction-gate-active turns',
+    );
   }
 }
 
@@ -951,6 +966,60 @@ void recordSeed42S7dFabricBidCounters({
         );
     if (emittedFabricBid) {
       bumpCounter(emittedTurns, gpId);
+    } else {
+      bumpCounter(absentTurns, gpId);
+    }
+  }
+}
+
+/// Records castIron market-offer presence/absence for the S7-D
+/// feedstock-extraction localization (Refs #2847 § castIron market-supply
+/// wall). On each gp whose regiment-build-input feedstock-extraction gate is
+/// active this turn ([feedstockGateActiveThisTurn]), scans
+/// [tradeOrdersByPlayerId] for any *other* faction emitting a
+/// [castIronCommodityId] offer this turn and bumps [presentTurns] when one
+/// exists, else [absentTurns].
+///
+/// The level-0 `build_improvement` cost a locked seller must clear to extract
+/// its fabric feedstock requires one unit of the manufactured `castIron`
+/// (`work_order_costs.dart` § `workOrderCostBuildImprovement`). The treasury
+/// planner's direct-acquisition branch
+/// (`treasury_regiment_bootstrap.dart` Pass 1 → `_marketHasStandingOfferSupplyFromOthers`)
+/// only bids `castIron` directly when some other Great Power offers it;
+/// otherwise it falls back to bidding the production feedstock (`timber` +
+/// `iron`) for a domestic run. A flat-zero [presentTurns] across the run proves
+/// the direct-acquisition branch is permanently closed — every Great Power
+/// consumes its `castIron` for Old World military builds and never offers a
+/// surplus (corroborated by `gpCastIronHeldAtTurn99 == 0` for every GP) — so
+/// the only remaining path to the improvement input is the domestic castIron
+/// run, which the labour-aware `gpCastIronRecipeLabourFeasibleTurns == 0`
+/// counter shows is itself labour-walled (`castIron` `labourPerOutput` exceeds
+/// a lock-recovery seller's effective labour). Read-only over the supplied maps
+/// except the counter bumps; extracted to keep the diagnostic test file at or
+/// below the repo non-comment line limit.
+void recordSeed42S7dCastIronMarketOfferCounters({
+  required Set<String> feedstockGateActiveThisTurn,
+  required Map<String, List<TradeOrder>> tradeOrdersByPlayerId,
+  required String castIronCommodityId,
+  required Map<String, int> presentTurns,
+  required Map<String, int> absentTurns,
+}) {
+  for (final gpId in feedstockGateActiveThisTurn) {
+    var offeredByOther = false;
+    for (final entry in tradeOrdersByPlayerId.entries) {
+      if (entry.key == gpId) continue;
+      final offeredCastIron = entry.value.any(
+        (order) =>
+            order.type == TradeOrderType.offer &&
+            order.commodityId == castIronCommodityId,
+      );
+      if (offeredCastIron) {
+        offeredByOther = true;
+        break;
+      }
+    }
+    if (offeredByOther) {
+      bumpCounter(presentTurns, gpId);
     } else {
       bumpCounter(absentTurns, gpId);
     }


### PR DESCRIPTION
## Summary

Backlog-implement run on #2847 (foundational soft-phase OW-conquest issue; #2848/#2852 depend on it). Follow-up to merged #3323, whose deferred note left the post-fix S7-D re-run unmeasured and re-pointed the residual to "bid affordability / market match / downstream castIron-labour effects."

This slice re-ran the S7-D diagnostic on current `dev` (post-#3323) and ships the next **read-only** localization counter. The decisive finding **supersedes the gp5 fabric/peasant-recruit chase**: gp5 is peer-war-eliminated this seed (0 OW provinces at turn 99, OW gain −7), so the stable failures are gp3 (+2) and gp4 (+1), and their binding blocker is the **castIron requirement in the level-0 `build_improvement` cost**, which is unobtainable by *both* acquisition paths.

`Refs #2847` (does not close it).

## What the re-run measured (seed 42, turn 100, post-#3323 `dev`)

OW conquest gate — **+6 baseline preserved**:

| GP | gp1 | gp2 | gp3 | gp4 | gp5 | gp6 |
|----|----|----|----|----|----|----|
| OW gain | +6 ✅ | +6 ✅ | +2 ❌ | +1 ❌ | −7 (peer-war) | +10 (peer-war) |

#3323's `fabric` peasant-recruit direct bid still does not fire on seed 42: gp5 `gpCastIronLabourPeasantRecruitFabricBidEmittedTurns` = 0 (absent = 8), and `gpRegimentInputBidsEmitted` = 0 for every GP — the bid never reaches emission because the single `bidTypeCap` slot is consumed upstream, and gp5 itself is now cornered at 0 OW.

gp3 (cleanest stable failure): treasury ≥ 2000 on 39 turns, rebuild-ready 29 turns, **missing the fabric build input on all 29** (`gpRebuildReadyNoBuildMissingInputTurns` = 29), and its feedstock-extraction chain dead-ends at castIron affordability (`gpFeedstockGateImprovementCastIronAffordableTurns` = 0 for every GP; lumber affordable 14).

## The decisive new counter

`gpCastIronMarketOfferPresentTurns` / `gpCastIronMarketOfferAbsentTurns` split the feedstock-extraction gate-active turns by whether any **other** faction offers `castIron` on the world market that turn:

| Counter | gp3 | gp5 | gp6 |
|---|---:|---:|---:|
| `gpFeedstockExtractionGateActiveTurns` | 32 | 13 | 19 |
| `gpCastIronMarketOfferPresentTurns` | **0** | **0** | **0** |
| `gpCastIronMarketOfferAbsentTurns` | 32 | 13 | 19 |

- **Present = 0 across the whole run** — castIron is *never* offered by any faction. Every Great Power consumes its castIron for Old World military builds (corroborated: `gpCastIronHeldAtTurn99` = 0 for **all** GPs). So the treasury planner's direct castIron-acquisition branch (`treasury_regiment_bootstrap.dart` Pass 1 → `_marketHasStandingOfferSupplyFromOthers`) has nothing to bid against.
- The other path — domestic production — is labour-walled: `gpCastIronRecipeLabourFeasibleTurns` = 0 everywhere (`castIron` `labourPerOutput` = 5 ≫ a lock-recovery seller's effective labour of 1–2).

**Both castIron acquisition paths are conclusively closed**, so the level-0 `build_improvement` castIron requirement is the terminal wall for the failing GPs' fabric-feedstock-extraction → regiment-rebuild chain.

## Re-pointed next slice (supersedes the gp5 fabric/peasant-recruit pointer)

The lever is **not** more fabric staging or buyer-side fabric bids. It must create castIron availability for a below-quota zero-NW lock-recovery seller, e.g. either (a) a castIron market-supply lever — make an affluent supplier over-produce + offer a castIron surplus (so the existing direct-bid branch can cross; note this would also require feedstock-tier offer alignment, since the supplier's `timber`/`iron` surplus offers are *not* in `_regimentBuildInputSupplyCommodityIds`, leaving gp3's 14 castIron-feedstock bids at 0 deals), or (b) a castIron-independent level-0 improvement path for the locked seller. Both are out of scope for this read-only localization slice.

## Done in this PR

- **`test/support/seed42_s7d_feedstock_helpers.dart`** — new pure helper `recordSeed42S7dCastIronMarketOfferCounters`; new partition structural invariant (`present + absent == feedstock-extraction-gate-active turns`).
- **`test/seed42_observer_conquest_s7d_diagnostic_test.dart`** — wires the per-turn active set, the post-merge counter, and the JSON rollup fields.
- **`test/seed42_s7d_feedstock_helpers_test.dart`** — positive (other faction offers castIron → present), negative (own offer / others' bids / unrelated offers → absent), and active-set gating tests.

## Scope / deferred

- **No production behaviour change** — purely read-only diagnostic instrumentation, so the +6 OW baseline for gp1/gp2 is unchanged (verified by the re-run). No SPEC behaviour change required.
- Behaviour fixes for the castIron wall (market-supply lever and/or feedstock-tier offer alignment) are deferred to a follow-up slice.

## Tests

- `dart test test/seed42_s7d_feedstock_helpers_test.dart` — 35 passed (3 new).
- `dart test test/seed42_observer_conquest_s7d_diagnostic_test.dart --run-skipped` — passes; partition invariant holds; counters captured above.
- `dart analyze` on the three touched test files — clean.

Refs #2847

Made with [Cursor](https://cursor.com)