### PR TITLE
test(ai): localize seed-42 castIron-feedstock order-matching off critical path (Refs #2847)

### DIFF
--- a/packages/colonizethis_ai/test/seed42_observer_conquest_s7d_diagnostic_test.dart
+++ b/packages/colonizethis_ai/test/seed42_observer_conquest_s7d_diagnostic_test.dart
@@ -3,14 +3,10 @@ import 'dart:convert';
 import 'package:colonizethis_ai/colonizethis_ai.dart';
 import 'package:colonizethis_ai/src/planning/army_conquest_prep.dart'
     show regimentCountForPlayer;
-import 'package:colonizethis_ai/src/planning/cast_iron_labour_gate.dart'
-    show otherGreatPowerFabricHeld;
 import 'package:colonizethis_ai/src/planning/expand_phase_planner.dart'
     show
         cheapestRegimentBuildTreasuryCost,
         expandSellerFeedstockTileAcquisitionTarget;
-import 'package:colonizethis_ai/src/planning/treasury_planner.dart'
-    show otherGreatPowerOfferableFabricHeld;
 import 'package:colonizethis_data/colonizethis_data.dart'
     hide cheapestRegimentBuildTreasuryCost;
 import 'package:colonizethis_logger/colonizethis_logger.dart';
@@ -2148,12 +2144,15 @@ void main() {
       // (`otherGreatPowerOfferableFabricHeld > 0`), whether the starved seller
       // emits a `fabric` bid and whether a deal fills as buyer. Read-only;
       // counts move freely as later slices land.
-      final castIronLabourPeasantRecruitFabricBidEmittedTurns =
-          <String, int>{for (final gpId in gpIds) gpId: 0};
-      final castIronLabourPeasantRecruitFabricBidAbsentTurns =
-          <String, int>{for (final gpId in gpIds) gpId: 0};
-      final castIronLabourPeasantRecruitFabricDealAsBuyerTurns =
-          <String, int>{for (final gpId in gpIds) gpId: 0};
+      final castIronLabourPeasantRecruitFabricBidEmittedTurns = <String, int>{
+        for (final gpId in gpIds) gpId: 0,
+      };
+      final castIronLabourPeasantRecruitFabricBidAbsentTurns = <String, int>{
+        for (final gpId in gpIds) gpId: 0,
+      };
+      final castIronLabourPeasantRecruitFabricDealAsBuyerTurns = <String, int>{
+        for (final gpId in gpIds) gpId: 0,
+      };
       // Refs #2847 § castIron market-supply wall: on feedstock-extraction
       // gate-active turns, whether any *other* faction offered `castIron` (the
       // manufactured level-0 `build_improvement` input) on the world market —
@@ -2163,10 +2162,12 @@ void main() {
       // its castIron for Old World military builds), leaving only the
       // labour-walled domestic run. Read-only; counts move freely as later
       // supply slices land.
-      final castIronMarketOfferPresentTurns =
-          <String, int>{for (final gpId in gpIds) gpId: 0};
-      final castIronMarketOfferAbsentTurns =
-          <String, int>{for (final gpId in gpIds) gpId: 0};
+      final castIronMarketOfferPresentTurns = <String, int>{
+        for (final gpId in gpIds) gpId: 0,
+      };
+      final castIronMarketOfferAbsentTurns = <String, int>{
+        for (final gpId in gpIds) gpId: 0,
+      };
       // Minimum `labourPerOutput` across the castIron recipes — the cheapest
       // single run's effective-labour requirement, used as the food-starved /
       // population-bound fork threshold above.
@@ -2615,61 +2616,33 @@ void main() {
               castIronFeedstockIds: castIronFeedstockIds,
               castIronMinLabourPerOutput: castIronMinLabourPerOutput,
             );
-            if (ci.peasantRecruitGate) {
-              bumpCounter(castIronLabourPeasantRecruitGateTurns, gpId);
-              if (ci.peasantRecruitAffordable) {
-                bumpCounter(castIronLabourPeasantRecruitAffordableTurns, gpId);
-              } else {
-                bumpCounter(
+            recordSeed42S7dCastIronLabourCounters(
+              game: game,
+              gpId: gpId,
+              ci: ci,
+              fabricStarvedThisTurn: fabricStarvedThisTurn,
+              castIronLabourPeasantRecruitGateTurns:
+                  castIronLabourPeasantRecruitGateTurns,
+              castIronLabourPeasantRecruitAffordableTurns:
+                  castIronLabourPeasantRecruitAffordableTurns,
+              castIronLabourPeasantRecruitFabricStarvedTurns:
                   castIronLabourPeasantRecruitFabricStarvedTurns,
-                  gpId,
-                );
-                fabricStarvedThisTurn.add(gpId);
-                // Refs #2847 § S7-D market-fabric localization: of those
-                // fabric-starved turns, the ones where no other great power
-                // holds any `fabric` to sell, so the recruit `fabric` can be
-                // neither produced nor bought.
-                if (otherGreatPowerFabricHeld(game, gpId) <= 0) {
-                  bumpCounter(
-                    castIronLabourPeasantRecruitMarketFabricStarvedTurns,
-                    gpId,
-                  );
-                } else if (otherGreatPowerOfferableFabricHeld(game, gpId) <=
-                    0) {
-                  // Holders exist but every one withholds its `fabric` via the
-                  // regiment-rebuild offer-retention carve-out — the market door
-                  // is closed at the offer/retention layer, not at holdings.
-                  bumpCounter(
-                    castIronLabourPeasantRecruitMarketFabricUnofferedTurns,
-                    gpId,
-                  );
-                }
-              }
-            }
-            if (ci.holdsFabricFeedstock) {
-              bumpCounter(feedstockInStockpileTurns, gpId);
-            }
-            if (ci.fabricRecipeFeasible) {
-              bumpCounter(fabricRecipeFeasibleTurns, gpId);
-              if (ci.fabricRecipeLabourFeasible) {
-                bumpCounter(fabricRecipeLabourFeasibleTurns, gpId);
-              }
-            }
-            if (ci.castIronMaterialFeasible) {
-              bumpCounter(castIronRecipeFeasibleTurns, gpId);
-              // Split the material-feasible turns by the planner's labour gate
-              // and by the staging gate's tile-ownership precondition.
-              if (ci.castIronLabourFeasible) {
-                bumpCounter(castIronRecipeLabourFeasibleTurns, gpId);
-              } else if (ci.castIronLabourFoodStarved) {
-                bumpCounter(castIronLabourFoodStarvedTurns, gpId);
-              } else if (ci.castIronLabourPopulationBound) {
-                bumpCounter(castIronLabourPopulationBoundTurns, gpId);
-              }
-              if (ci.castIronOwnsFeedstockTile) {
-                bumpCounter(castIronFeasibleOwnsFeedstockTileTurns, gpId);
-              }
-            }
+              castIronLabourPeasantRecruitMarketFabricStarvedTurns:
+                  castIronLabourPeasantRecruitMarketFabricStarvedTurns,
+              castIronLabourPeasantRecruitMarketFabricUnofferedTurns:
+                  castIronLabourPeasantRecruitMarketFabricUnofferedTurns,
+              feedstockInStockpileTurns: feedstockInStockpileTurns,
+              fabricRecipeFeasibleTurns: fabricRecipeFeasibleTurns,
+              fabricRecipeLabourFeasibleTurns: fabricRecipeLabourFeasibleTurns,
+              castIronRecipeFeasibleTurns: castIronRecipeFeasibleTurns,
+              castIronRecipeLabourFeasibleTurns:
+                  castIronRecipeLabourFeasibleTurns,
+              castIronLabourFoodStarvedTurns: castIronLabourFoodStarvedTurns,
+              castIronLabourPopulationBoundTurns:
+                  castIronLabourPopulationBoundTurns,
+              castIronFeasibleOwnsFeedstockTileTurns:
+                  castIronFeasibleOwnsFeedstockTileTurns,
+            );
           }
           // Cache the turn-99 snapshot fields for the final rollup.
           if (t == 99) {

--- a/packages/colonizethis_ai/test/seed42_observer_conquest_s7d_diagnostic_test.dart
+++ b/packages/colonizethis_ai/test/seed42_observer_conquest_s7d_diagnostic_test.dart
@@ -1536,6 +1536,56 @@ import 'support/seed42_s7d_feedstock_helpers.dart';
 /// a strict refinement of the fabric-starved turns under a structural-invariant
 /// assertion).
 ///
+/// ## S7-D refresh (captured 2026-06-07 on current `dev` HEAD — castIron-feedstock
+///     order-matching gap surfaced but localized OFF the critical path; this
+///     slice, Refs #2847)
+///
+/// Re-running the diagnostic on the merged `dev` HEAD surfaces a **new** market
+/// state the prior refreshes did not have, and resolves where it sits on the
+/// chain. OW gain: gp1 = +6, gp2 = +6 (PASS); gp3 = +1, gp4 = +2, gp5 = −7,
+/// gp6 = +10 (FAIL) — gp5/gp6 are the peer-war-variance pair (gp5 cornered this
+/// run); gp3/gp4 are the stable below-quota failures. The +6 baseline holds.
+///
+///   * **Suppliers now OFFER the castIron feedstock.**
+///     `gpCastIronFeedstockOffersEmitted` = **gp1 89 / gp2 24 / gp5 46 / gp6 33**
+///     (`timber` / `iron`) — the supplier feedstock-extraction routing landed,
+///     so the historical "no holder has a `timber` / `iron` surplus to release"
+///     finding is now **stale**. gp1 ends the run holding `timber` 133 / `iron`
+///     118; gp5 `timber` 27 / `iron` 35.
+///   * **Yet the locked seller's feedstock bids fill nothing.**
+///     `gpCastIronFeedstockBidsEmitted` = gp3 14 / gp6 2, but
+///     `gpCastIronFeedstockDealsAsBuyer` = **0 for every GP**. With offers now
+///     present, the residual is a `timber` / `iron` offer/bid **priority-tier
+///     mismatch** (the same class `_alignBuildInputSupplyOfferTiers` already
+///     fixes for the `lumber` / `castIron` improvement inputs, which DO cross —
+///     gp3's improvement-input bids fill 15/15).
+///   * **But that order-matching gap is OFF the critical path.** New counter
+///     `gpCastIronFeedstockExtractionLabourFutileTurns` records the
+///     feedstock-extraction-gate-active turns whose fully-fed raw labour ceiling
+///     is below the castIron `labourPerOutput` (5). For gp3 this equals the full
+///     gate-active total (raw labour ceiling 2): on **every** such turn, even a
+///     fully-filled `timber` / `iron` bid could not yield a labour-feasible
+///     castIron run. So aligning the feedstock offer tier (or any further
+///     supplier-release work) would only let gp3 **hoard unusable feedstock** —
+///     it cannot move the OW gate while the seller stays population-bound.
+///
+/// **Re-pointed next slice (supersedes the castIron market-supply / offer-tier
+/// candidates):** the feedstock supply and order-matching levers are now
+/// confirmed dead ends for the stable failures — `timber` / `iron` are offered,
+/// and even filling the bids leaves the castIron recipe labour-infeasible. The
+/// binding constraint remains the lock-recovery seller's **worker population**
+/// (raw labour ceiling 1-2 vs castIron's 5 / fabric's 2), consistent with the
+/// population-bound conclusion above; the only raw-population-growth action
+/// (peasant recruit) is `fabric`-gated and the seller's `fabric` is itself
+/// labour-walled (the circular deadlock). The next *behaviour* lever must grow
+/// the seller's labour pool without consuming the scarce end-of-chain `fabric`,
+/// under the same self-clearing lock-recovery-seller gate that keeps the +6
+/// baseline GPs out. This slice is read-only diagnostic instrumentation (no
+/// behaviour change, no config constants, no gate-threshold changes; a positive
+/// + negative + boundary unit test for the helper
+/// `castIronFeedstockExtractionLabourFutile` and a structural-invariant
+/// assertion bounding the counter by the gate-active total).
+///
 /// ## Refs #2924 Step 0 — world-market lock-recovery metrics
 ///
 /// The same run now also emits a separate
@@ -1914,6 +1964,27 @@ void main() {
         for (final recipe in fabricRecipes) ...recipe.inputQuantities.keys,
       };
       final feedstockExtractionGateActiveTurns = <String, int>{
+        for (final gpId in gpIds) gpId: 0,
+      };
+      // Refs #2847 § S7-D castIron-feedstock order-matching off-critical path
+      // (read-only). Affluent suppliers now *offer* `timber` / `iron`
+      // (`gpCastIronFeedstockOffersEmitted` non-zero — supplier feedstock
+      // extraction landed), yet a below-quota zero-NW lock-recovery seller's
+      // castIron-feedstock bids still fill 0 deals
+      // (`gpCastIronFeedstockDealsAsBuyer == 0`, a `timber` / `iron` offer-tier
+      // mismatch). This counter records the feedstock-extraction-gate-active
+      // turns on which the seller's fully-fed raw labour ceiling is below the
+      // castIron `labourPerOutput`, so even a *fully filled* feedstock bid could
+      // not yield a labour-feasible domestic castIron run. A count equal to
+      // `gpFeedstockExtractionGateActiveTurns` proves the order-matching gap is
+      // **off the critical path** — closing it (offer-tier alignment / supplier
+      // release) cannot move the gate while the seller stays population-bound —
+      // and re-points the next behaviour lever to worker-population growth.
+      // Generalises `gpCastIronLabourPopulationBoundTurns` (measured only on
+      // castIron material-feasible turns, which gp3 never reaches) to the gate
+      // turns where the seller is still bidding the feedstock. Read-only; the
+      // (freely tunable) counts can move as later slices land.
+      final castIronFeedstockExtractionLabourFutileTurns = <String, int>{
         for (final gpId in gpIds) gpId: 0,
       };
       final unimprovedFeedstockTileOwnedTurns = <String, int>{
@@ -2388,6 +2459,20 @@ void main() {
               feedstockGateImprovementCastIronAffordableTurns[gpId] =
                   (feedstockGateImprovementCastIronAffordableTurns[gpId] ?? 0) +
                   1;
+            }
+            // Refs #2847 § S7-D castIron-feedstock order-matching off-critical
+            // path: on a gate-active turn whose fully-fed raw labour ceiling is
+            // below the castIron `labourPerOutput`, even a fully-filled
+            // `timber` / `iron` feedstock bid could not yield a labour-feasible
+            // domestic castIron run, so the order-matching gap is not on the
+            // critical path — the binding constraint stays worker population.
+            if (castIronFeedstockExtractionLabourFutile(
+              game,
+              gpId,
+              castIronMinLabourPerOutput,
+            )) {
+              castIronFeedstockExtractionLabourFutileTurns[gpId] =
+                  (castIronFeedstockExtractionLabourFutileTurns[gpId] ?? 0) + 1;
             }
           }
           if (ownsUnimprovedFeedstockResourceTile(
@@ -2936,6 +3021,8 @@ void main() {
             castIronLabourPeasantRecruitFabricDealAsBuyerTurns,
         'gpCastIronMarketOfferPresentTurns': castIronMarketOfferPresentTurns,
         'gpCastIronMarketOfferAbsentTurns': castIronMarketOfferAbsentTurns,
+        'gpCastIronFeedstockExtractionLabourFutileTurns':
+            castIronFeedstockExtractionLabourFutileTurns,
         'castIronMinLabourPerOutput': castIronMinLabourPerOutput,
         'gpTurn99Snapshot': lastSnapshotFields,
       };
@@ -3044,6 +3131,8 @@ void main() {
         fabricRecipeLabourFeasibleTurns: fabricRecipeLabourFeasibleTurns,
         castIronMarketOfferPresentTurns: castIronMarketOfferPresentTurns,
         castIronMarketOfferAbsentTurns: castIronMarketOfferAbsentTurns,
+        castIronFeedstockExtractionLabourFutileTurns:
+            castIronFeedstockExtractionLabourFutileTurns,
       );
     },
     skip:

--- a/packages/colonizethis_ai/test/seed42_s7d_feedstock_helpers_test.dart
+++ b/packages/colonizethis_ai/test/seed42_s7d_feedstock_helpers_test.dart
@@ -503,6 +503,91 @@ void main() {
     );
   });
 
+  group('castIronFeedstockExtractionLabourFutile', () {
+    // castIron's labourPerOutput is 5; a lock-recovery seller's raw labour
+    // ceiling sits at 1-2 on seed 42, so the helper localizes the
+    // castIron-feedstock order-matching gap off the critical path.
+    const castIronMinLabour = 5;
+
+    test(
+      'positive: raw labour ceiling below the castIron labourPerOutput is '
+      'futile (a filled feedstock bid still cannot run the recipe)',
+      () {
+        // 2 peasants -> raw ceiling 2 < 5, regardless of food on hand: even a
+        // fully-fed seller cannot fund one castIron run.
+        final game = _game(workers: const WorkerPool(peasants: 2));
+        expect(playerRawLabourSupply(game, _playerId), 2);
+        expect(
+          castIronFeedstockExtractionLabourFutile(
+            game,
+            _playerId,
+            castIronMinLabour,
+          ),
+          isTrue,
+        );
+      },
+    );
+
+    test(
+      'negative: raw labour ceiling at or above the castIron labourPerOutput is '
+      'not futile (the feedstock bid would matter)',
+      () {
+        // 1 journeyman -> raw ceiling 6 >= 5: a filled timber/iron bid could
+        // yield a labour-feasible castIron run, so feedstock supply is on-path.
+        final game = _game(workers: const WorkerPool(journeymen: 1));
+        expect(playerRawLabourSupply(game, _playerId), 6);
+        expect(
+          castIronFeedstockExtractionLabourFutile(
+            game,
+            _playerId,
+            castIronMinLabour,
+          ),
+          isFalse,
+        );
+      },
+    );
+
+    test('boundary: raw ceiling exactly equal to labourPerOutput is not futile', () {
+      // 5 peasants -> raw ceiling 5 == 5: one run is exactly fundable.
+      final game = _game(workers: const WorkerPool(peasants: 5));
+      expect(playerRawLabourSupply(game, _playerId), 5);
+      expect(
+        castIronFeedstockExtractionLabourFutile(
+          game,
+          _playerId,
+          castIronMinLabour,
+        ),
+        isFalse,
+      );
+    });
+
+    test('negative: a non-positive min labourPerOutput is never futile', () {
+      // No castIron recipe (min == 0) means the labour ceiling is trivially
+      // sufficient; the helper must not report futility.
+      final game = _game(workers: const WorkerPool());
+      expect(
+        castIronFeedstockExtractionLabourFutile(game, _playerId, 0),
+        isFalse,
+      );
+    });
+
+    test(
+      'unknown player: zero raw labour is below the positive threshold => '
+      'futile',
+      () {
+        final game = _game(workers: const WorkerPool(peasants: 10));
+        expect(
+          castIronFeedstockExtractionLabourFutile(
+            game,
+            'no_such_player',
+            castIronMinLabour,
+          ),
+          isTrue,
+        );
+      },
+    );
+  });
+
   group('recordSeed42S7dCastIronMarketOfferCounters', () {
     final castIronId = CommodityCatalog.castIron.id;
 

--- a/packages/colonizethis_ai/test/support/seed42_s7d_feedstock_helpers.dart
+++ b/packages/colonizethis_ai/test/support/seed42_s7d_feedstock_helpers.dart
@@ -331,6 +331,40 @@ int playerFoodOnHand(Game game, String playerId, Set<String> foodCommodityIds) {
   return total;
 }
 
+/// True iff [playerId]'s fully-fed raw labour ceiling ([playerRawLabourSupply])
+/// is **below** [castIronMinLabourPerOutput] — i.e. even if the locked seller
+/// won every `timber` / `iron` deal its castIron-feedstock bids chase (or
+/// extracted that feedstock outright), the only `castIron` recipe still could
+/// not run a single output against its labour ceiling.
+///
+/// The S7-D castIron-feedstock order-matching counters
+/// (`gpCastIronFeedstockBidsEmitted` high, `gpCastIronFeedstockDealsAsBuyer`
+/// zero) show a below-quota zero-NW lock-recovery seller bidding `timber` /
+/// `iron` for a domestic `castIron` run whose bids never cross, now that
+/// affluent suppliers finally *offer* the feedstock
+/// (`gpCastIronFeedstockOffersEmitted` non-zero — the historical "no surplus to
+/// release" finding is stale once the supplier feedstock-extraction routing
+/// landed). This helper backs the counter that proves that order-matching gap is
+/// **off the critical path**: with a raw labour ceiling below `castIron`'s
+/// `labourPerOutput` (5), filling the feedstock bids could never yield a
+/// labour-feasible `castIron` run, so the binding constraint remains the
+/// seller's worker population — not feedstock supply or offer-tier alignment. It
+/// generalises `gpCastIronLabourPopulationBoundTurns` (measured only on castIron
+/// *material*-feasible turns, which a seller that never holds both feedstocks —
+/// e.g. gp3 — never reaches) to the feedstock-extraction-gate-active turns where
+/// the seller is still *bidding* the feedstock. Returns `false` when
+/// [castIronMinLabourPerOutput] is not positive (no recipe means the labour
+/// ceiling is trivially sufficient). Pure read-only over `(game, playerId)`; no
+/// game-state mutation.
+bool castIronFeedstockExtractionLabourFutile(
+  Game game,
+  String playerId,
+  int castIronMinLabourPerOutput,
+) {
+  if (castIronMinLabourPerOutput <= 0) return false;
+  return playerRawLabourSupply(game, playerId) < castIronMinLabourPerOutput;
+}
+
 /// Increments the per-GP [key] entry of a `<String, int>` diagnostic [counter]
 /// by one, treating an absent entry as zero. Shared by the S7-D diagnostic to
 /// keep its many per-turn counter bumps to a single line each.
@@ -617,6 +651,7 @@ void assertSeed42S7dStructuralInvariants({
   required Map<String, int> fabricRecipeLabourFeasibleTurns,
   required Map<String, int> castIronMarketOfferPresentTurns,
   required Map<String, int> castIronMarketOfferAbsentTurns,
+  required Map<String, int> castIronFeedstockExtractionLabourFutileTurns,
 }) {
   for (final gpId in gpIds) {
     expect(
@@ -840,6 +875,18 @@ void assertSeed42S7dStructuralInvariants({
       reason:
           '$gpId castIron market-offer present + absent turns must partition '
           'the feedstock-extraction-gate-active turns',
+    );
+    // Refs #2847 § S7-D castIron-feedstock order-matching off-critical path:
+    // the labour-futile counter is measured only on a feedstock-extraction-
+    // gate-active turn (raw labour ceiling below the castIron labourPerOutput),
+    // so it can never exceed the gate-active total. Guards the instrumentation
+    // gating itself without pinning the (freely tunable) per-GP counts.
+    expect(
+      castIronFeedstockExtractionLabourFutileTurns[gpId]!,
+      lessThanOrEqualTo(feedstockExtractionGateActiveTurns[gpId]!),
+      reason:
+          '$gpId castIron-feedstock-extraction labour-futile turns cannot '
+          'exceed the feedstock-extraction-gate-active turns',
     );
   }
 }

--- a/packages/colonizethis_ai/test/support/seed42_s7d_feedstock_helpers.dart
+++ b/packages/colonizethis_ai/test/support/seed42_s7d_feedstock_helpers.dart
@@ -11,7 +11,9 @@ import 'package:colonizethis_ai/src/planning/army_conquest_prep.dart'
 import 'package:colonizethis_ai/src/planning/observer_goal_phase.dart'
     show ObserverGoalPhase;
 import 'package:colonizethis_ai/src/planning/cast_iron_labour_gate.dart'
-    show isCastIronLabourPopulationBoundForLockRecoverySeller;
+    show
+        isCastIronLabourPopulationBoundForLockRecoverySeller,
+        otherGreatPowerFabricHeld;
 import 'package:colonizethis_ai/src/planning/expand_phase_planner.dart'
     show cheapestRegimentBuildTreasuryCost;
 import 'package:colonizethis_ai/src/planning/recipe_scoring.dart'
@@ -1005,7 +1007,8 @@ void recordSeed42S7dFabricBidCounters({
   for (final gpId in fabricStarvedThisTurn) {
     if (otherGreatPowerOfferableFabricHeld(game, gpId) <= 0) continue;
     final tradeOrders = tradeOrdersByPlayerId[gpId];
-    final emittedFabricBid = tradeOrders != null &&
+    final emittedFabricBid =
+        tradeOrders != null &&
         tradeOrders.any(
           (order) =>
               order.type == TradeOrderType.bid &&
@@ -1118,4 +1121,98 @@ bool hasValidBuildImprovementOnUnimprovedFeedstockTile(
     }
   }
   return false;
+}
+
+/// Applies the per-turn castIron-labour stage-localization counter bumps for one
+/// GP from a [seed42S7dCastIronLabourTurnMeasure] result [ci] (Refs #2847).
+///
+/// Mirrors the inline counter cascade it replaced exactly: the #3303
+/// peasant-recruit gate / affordability split (adding fabric-starved GPs to
+/// [fabricStarvedThisTurn] and forking the market-fabric-starved vs
+/// market-fabric-unoffered sub-causes off `game`), the fabric feedstock /
+/// recipe feasibility counters, and the castIron material / labour-fork /
+/// owns-feedstock-tile counters. Extracted to keep the diagnostic test file at
+/// or below the repo non-comment line limit
+/// (`repo.dart_file_non_comment_line_size`); read-only over `game` except the
+/// supplied counter-map / set bumps.
+void recordSeed42S7dCastIronLabourCounters({
+  required Game game,
+  required String gpId,
+  required ({
+    bool peasantRecruitGate,
+    bool peasantRecruitAffordable,
+    bool holdsFabricFeedstock,
+    bool fabricRecipeFeasible,
+    bool fabricRecipeLabourFeasible,
+    bool castIronMaterialFeasible,
+    bool castIronLabourFeasible,
+    bool castIronLabourFoodStarved,
+    bool castIronLabourPopulationBound,
+    bool castIronOwnsFeedstockTile,
+  })
+  ci,
+  required Set<String> fabricStarvedThisTurn,
+  required Map<String, int> castIronLabourPeasantRecruitGateTurns,
+  required Map<String, int> castIronLabourPeasantRecruitAffordableTurns,
+  required Map<String, int> castIronLabourPeasantRecruitFabricStarvedTurns,
+  required Map<String, int>
+  castIronLabourPeasantRecruitMarketFabricStarvedTurns,
+  required Map<String, int>
+  castIronLabourPeasantRecruitMarketFabricUnofferedTurns,
+  required Map<String, int> feedstockInStockpileTurns,
+  required Map<String, int> fabricRecipeFeasibleTurns,
+  required Map<String, int> fabricRecipeLabourFeasibleTurns,
+  required Map<String, int> castIronRecipeFeasibleTurns,
+  required Map<String, int> castIronRecipeLabourFeasibleTurns,
+  required Map<String, int> castIronLabourFoodStarvedTurns,
+  required Map<String, int> castIronLabourPopulationBoundTurns,
+  required Map<String, int> castIronFeasibleOwnsFeedstockTileTurns,
+}) {
+  if (ci.peasantRecruitGate) {
+    bumpCounter(castIronLabourPeasantRecruitGateTurns, gpId);
+    if (ci.peasantRecruitAffordable) {
+      bumpCounter(castIronLabourPeasantRecruitAffordableTurns, gpId);
+    } else {
+      bumpCounter(castIronLabourPeasantRecruitFabricStarvedTurns, gpId);
+      fabricStarvedThisTurn.add(gpId);
+      // Refs #2847 § S7-D market-fabric localization: of those fabric-starved
+      // turns, the ones where no other great power holds any `fabric` to sell,
+      // so the recruit `fabric` can be neither produced nor bought.
+      if (otherGreatPowerFabricHeld(game, gpId) <= 0) {
+        bumpCounter(castIronLabourPeasantRecruitMarketFabricStarvedTurns, gpId);
+      } else if (otherGreatPowerOfferableFabricHeld(game, gpId) <= 0) {
+        // Holders exist but every one withholds its `fabric` via the
+        // regiment-rebuild offer-retention carve-out — the market door is
+        // closed at the offer/retention layer, not at holdings.
+        bumpCounter(
+          castIronLabourPeasantRecruitMarketFabricUnofferedTurns,
+          gpId,
+        );
+      }
+    }
+  }
+  if (ci.holdsFabricFeedstock) {
+    bumpCounter(feedstockInStockpileTurns, gpId);
+  }
+  if (ci.fabricRecipeFeasible) {
+    bumpCounter(fabricRecipeFeasibleTurns, gpId);
+    if (ci.fabricRecipeLabourFeasible) {
+      bumpCounter(fabricRecipeLabourFeasibleTurns, gpId);
+    }
+  }
+  if (ci.castIronMaterialFeasible) {
+    bumpCounter(castIronRecipeFeasibleTurns, gpId);
+    // Split the material-feasible turns by the planner's labour gate and by the
+    // staging gate's tile-ownership precondition.
+    if (ci.castIronLabourFeasible) {
+      bumpCounter(castIronRecipeLabourFeasibleTurns, gpId);
+    } else if (ci.castIronLabourFoodStarved) {
+      bumpCounter(castIronLabourFoodStarvedTurns, gpId);
+    } else if (ci.castIronLabourPopulationBound) {
+      bumpCounter(castIronLabourPopulationBoundTurns, gpId);
+    }
+    if (ci.castIronOwnsFeedstockTile) {
+      bumpCounter(castIronFeasibleOwnsFeedstockTileTurns, gpId);
+    }
+  }
 }

--- a/packages/colonizethis_ai/test/support/seed42_s7d_feedstock_helpers.dart
+++ b/packages/colonizethis_ai/test/support/seed42_s7d_feedstock_helpers.dart
@@ -1175,20 +1175,14 @@ void recordSeed42S7dCastIronLabourCounters({
     } else {
       bumpCounter(castIronLabourPeasantRecruitFabricStarvedTurns, gpId);
       fabricStarvedThisTurn.add(gpId);
-      // Refs #2847 § S7-D market-fabric localization: of those fabric-starved
-      // turns, the ones where no other great power holds any `fabric` to sell,
-      // so the recruit `fabric` can be neither produced nor bought.
-      if (otherGreatPowerFabricHeld(game, gpId) <= 0) {
-        bumpCounter(castIronLabourPeasantRecruitMarketFabricStarvedTurns, gpId);
-      } else if (otherGreatPowerOfferableFabricHeld(game, gpId) <= 0) {
-        // Holders exist but every one withholds its `fabric` via the
-        // regiment-rebuild offer-retention carve-out — the market door is
-        // closed at the offer/retention layer, not at holdings.
-        bumpCounter(
-          castIronLabourPeasantRecruitMarketFabricUnofferedTurns,
-          gpId,
-        );
-      }
+      recordSeed42S7dPeasantRecruitFabricMarketSubCause(
+        game: game,
+        gpId: gpId,
+        marketFabricStarvedTurns:
+            castIronLabourPeasantRecruitMarketFabricStarvedTurns,
+        marketFabricUnofferedTurns:
+            castIronLabourPeasantRecruitMarketFabricUnofferedTurns,
+      );
     }
   }
   if (ci.holdsFabricFeedstock) {
@@ -1204,15 +1198,70 @@ void recordSeed42S7dCastIronLabourCounters({
     bumpCounter(castIronRecipeFeasibleTurns, gpId);
     // Split the material-feasible turns by the planner's labour gate and by the
     // staging gate's tile-ownership precondition.
-    if (ci.castIronLabourFeasible) {
-      bumpCounter(castIronRecipeLabourFeasibleTurns, gpId);
-    } else if (ci.castIronLabourFoodStarved) {
-      bumpCounter(castIronLabourFoodStarvedTurns, gpId);
-    } else if (ci.castIronLabourPopulationBound) {
-      bumpCounter(castIronLabourPopulationBoundTurns, gpId);
-    }
+    recordSeed42S7dCastIronLabourFork(
+      gpId: gpId,
+      castIronLabourFeasible: ci.castIronLabourFeasible,
+      castIronLabourFoodStarved: ci.castIronLabourFoodStarved,
+      castIronLabourPopulationBound: ci.castIronLabourPopulationBound,
+      castIronRecipeLabourFeasibleTurns: castIronRecipeLabourFeasibleTurns,
+      castIronLabourFoodStarvedTurns: castIronLabourFoodStarvedTurns,
+      castIronLabourPopulationBoundTurns: castIronLabourPopulationBoundTurns,
+    );
     if (ci.castIronOwnsFeedstockTile) {
       bumpCounter(castIronFeasibleOwnsFeedstockTileTurns, gpId);
     }
+  }
+}
+
+/// Records the peasant-recruit fabric-starved market sub-cause split for [gpId]
+/// (Refs #2847 § S7-D market-fabric localization).
+///
+/// Of the fabric-starved recruit turns, bumps [marketFabricStarvedTurns] when no
+/// other great power holds any `fabric` to sell (the recruit `fabric` can be
+/// neither produced nor bought), else bumps [marketFabricUnofferedTurns] when
+/// holders exist but every one withholds its `fabric` via the regiment-rebuild
+/// offer-retention carve-out (the market door is closed at the offer/retention
+/// layer, not at holdings). Read-only over `game` except the counter bumps.
+void recordSeed42S7dPeasantRecruitFabricMarketSubCause({
+  required Game game,
+  required String gpId,
+  required Map<String, int> marketFabricStarvedTurns,
+  required Map<String, int> marketFabricUnofferedTurns,
+}) {
+  if (otherGreatPowerFabricHeld(game, gpId) <= 0) {
+    bumpCounter(marketFabricStarvedTurns, gpId);
+    return;
+  }
+  if (otherGreatPowerOfferableFabricHeld(game, gpId) <= 0) {
+    bumpCounter(marketFabricUnofferedTurns, gpId);
+  }
+}
+
+/// Records the castIron material-feasible labour fork for [gpId] (Refs #2847
+/// § S7-D).
+///
+/// On a material-feasible turn, bumps exactly one of the three labour-stage
+/// counters following the planner's labour-gate precedence: labour-feasible,
+/// else food-starved, else population-bound. A material-feasible turn that is
+/// none of these (e.g. another labour gate) bumps no labour-stage counter.
+void recordSeed42S7dCastIronLabourFork({
+  required String gpId,
+  required bool castIronLabourFeasible,
+  required bool castIronLabourFoodStarved,
+  required bool castIronLabourPopulationBound,
+  required Map<String, int> castIronRecipeLabourFeasibleTurns,
+  required Map<String, int> castIronLabourFoodStarvedTurns,
+  required Map<String, int> castIronLabourPopulationBoundTurns,
+}) {
+  if (castIronLabourFeasible) {
+    bumpCounter(castIronRecipeLabourFeasibleTurns, gpId);
+    return;
+  }
+  if (castIronLabourFoodStarved) {
+    bumpCounter(castIronLabourFoodStarvedTurns, gpId);
+    return;
+  }
+  if (castIronLabourPopulationBound) {
+    bumpCounter(castIronLabourPopulationBoundTurns, gpId);
   }
 }


### PR DESCRIPTION
## Summary

Read-only S7-D diagnostic slice for the seed-42 turn-100 observer conquest gate. Re-running the diagnostic on current `dev` surfaces a **new** market state and pins where it sits on the lock-recovery chain.

- **Suppliers now offer the castIron feedstock.** `gpCastIronFeedstockOffersEmitted` = gp1 89 / gp2 24 / gp5 46 / gp6 33 (`timber` / `iron`) — the supplier feedstock-extraction routing landed, so the historical "no holder has a `timber` / `iron` surplus to release" finding is **stale**.
- **Yet the locked seller's feedstock bids fill nothing.** `gpCastIronFeedstockBidsEmitted` = gp3 14 / gp6 2 but `gpCastIronFeedstockDealsAsBuyer` = **0** — a `timber` / `iron` offer/bid priority-tier mismatch (the class `_alignBuildInputSupplyOfferTiers` already fixes for `lumber` / `castIron`, which DO cross: gp3 fills 15/15).
- **But that gap is OFF the critical path.** New counter `gpCastIronFeedstockExtractionLabourFutileTurns` = gp3 **32** / gp5 **13** / gp6 **19** — **exactly equal** to `gpFeedstockExtractionGateActiveTurns`. On every gate-active turn the seller's fully-fed raw labour ceiling (1-2) is below castIron's `labourPerOutput` (5), so even a fully-filled feedstock bid could not run the recipe. Aligning the feedstock offer tier would only let the seller hoard unusable feedstock.

**Conclusion / re-point:** feedstock supply and order-matching are confirmed dead ends for the stable failures; the binding constraint stays the lock-recovery seller's **worker population**. The next behaviour lever must grow labour without consuming the scarce end-of-chain `fabric` (the peasant-recruit circular deadlock), under the self-clearing lock-recovery-seller gate that keeps the +6 baseline GPs out.

## Scope

- **Done in this push:** new pure helper `castIronFeedstockExtractionLabourFutile` + diagnostic counter + JSON field + structural-invariant assertion (counter ≤ gate-active turns); doc-comment refresh section.
- **Deferred:** the worker-population behaviour lever (separate slice).
- Read-only instrumentation only: **no behaviour change, no config constants, no gate-threshold changes**. The +6 baseline (gp1/gp2) is preserved; OW gain unchanged in kind.

## Tests

- `packages/colonizethis_ai/test/seed42_s7d_feedstock_helpers_test.dart`: added positive / negative / boundary / non-positive-min / unknown-player cases for the helper (40 pass).
- `dart analyze` clean on all three touched files.
- Full `seed42_observer_conquest_s7d_diagnostic_test.dart --run-skipped` passes (structural invariant holds; counter equals gate-active total for gp3/gp5/gp6).

Refs #2847 (does not close).

Made with [Cursor](https://cursor.com)