### PR TITLE
refactor(logic): eliminate ai->diplomacy import edge (Refs #3290)

### DIFF
--- a/SPEC/program/logic-package-split-phase0.md
+++ b/SPEC/program/logic-package-split-phase0.md
@@ -32,7 +32,7 @@ Phase 0 deliverables (child issue C0):
 | `turn` | `world` | Allowed |
 | `world` | `turn` | **Eliminated** — `turn_resolution_seeds.dart` and `trace/` hoisted to `lib/src/` |
 | `diplomacy` | `ai` | Allowed (becomes `diplomacy` → `ai_contracts` after Phase 4) |
-| `ai` | `diplomacy` | Deferred — 2 files |
+| `ai` | `diplomacy` | **Eliminated** — `DiplomacyFactionMembership` / `isMinorOrTribe` consumed from `world/faction_membership.dart` |
 
 ## Edge pair enumerations (wrong-direction symbols)
 
@@ -70,13 +70,13 @@ Phase 0 deliverables (child issue C0):
 
 ### `orders ↔ turn`
 
-**Wrong:** `orders` → `turn` (3 files)
+**Wrong:** `orders` → `turn` (1 file remaining; 2 trace consumers fixed)
 
-| Source | Import | Symbols | Proposed destination |
-|--------|--------|---------|---------------------|
-| `orders/orders_application.dart` | `turn/trace/turn_trace_runtime.dart` | `TurnTraceRuntime` | `lib/src/trace/` (hoisted; import path updated) |
-| `orders/orders_application_context.dart` | same | same | same |
-| `orders/order_projections.dart` | `turn/turn_resolver.dart` | `resolveTurnForGame`, `requireTurnResolutionComplete` | Invert: callback injection or move projections to `turn/` |
+| Source | Import | Symbols | Destination | Status |
+|--------|--------|---------|-------------|--------|
+| `orders/orders_application.dart` | `lib/src/trace/turn_trace_runtime.dart` | `TurnTraceRuntime` | `lib/src/trace/` (hoisted; now imported directly) | Fixed |
+| `orders/orders_application_context.dart` | same | same | same | Fixed |
+| `orders/order_projections.dart` | `turn/turn_resolver.dart` | `resolveTurnForGame`, `requireTurnResolutionComplete` | Invert: callback injection or move projections to `turn/` | Deferred (grandfathered) |
 
 ### `world ↔ diplomacy`
 
@@ -120,12 +120,14 @@ Phase 0 deliverables (child issue C0):
 
 ### `diplomacy ↔ ai`
 
-**Wrong:** `ai` → `diplomacy` (2 files); **allowed:** `diplomacy/intervention_resolver.dart` → `ai/ai_control.dart`
+**Wrong:** `ai` → `diplomacy` (2 files, fixed in Phase 0 slice); **allowed:** `diplomacy/intervention_resolver.dart` → `ai/ai_control.dart`
 
-| Source | Import | Proposed fix |
-|--------|--------|--------------|
-| `ai/full_ai_civilian_work_selection.dart` | `diplomacy_resolver.dart` | Inject legality predicate from `ai_contracts` consumer |
-| `ai/simple_ai_heuristics.dart` | `diplomacy_resolver.dart` | same |
+Both AI files consumed only `DiplomacyFactionMembership` (and the top-level `isMinorOrTribe` helper), which already live in the leaf module `world/faction_membership.dart` (`diplomacy_resolver.dart` merely re-exports them). Retargeting the imports to the world module removes the wrong-direction edge with no behavior change.
+
+| Source | Import | Symbols used | Destination |
+|--------|--------|--------------|-------------|
+| `ai/full_ai_civilian_work_selection.dart` | `diplomacy_resolver.dart` | `DiplomacyFactionMembership`, `isMinorOrTribe` | `world/faction_membership.dart` |
+| `ai/simple_ai_heuristics.dart` | `diplomacy_resolver.dart` | `DiplomacyFactionMembership` | `world/faction_membership.dart` |
 
 ## AI contracts file set (Phase 0 planning, D1)
 

--- a/packages/colonizethis_logic/lib/src/ai/full_ai_civilian_work_selection.dart
+++ b/packages/colonizethis_logic/lib/src/ai/full_ai_civilian_work_selection.dart
@@ -4,8 +4,8 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';
-import '../diplomacy/diplomacy_resolver.dart';
 import '../orders/build_rail_work_rules.dart';
+import '../world/faction_membership.dart';
 import '../world/player_view.dart';
 import '../world/province_lookup.dart';
 import '../world/unit_lookup.dart';

--- a/packages/colonizethis_logic/lib/src/ai/simple_ai_heuristics.dart
+++ b/packages/colonizethis_logic/lib/src/ai/simple_ai_heuristics.dart
@@ -9,12 +9,12 @@ import 'package:colonizethis_logic/src/logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';
-import '../diplomacy/diplomacy_resolver.dart';
 import '../orders/draft_orders_mutations.dart';
 import '../orders/order_suggestion.dart';
 import '../orders/order_resolution_context.dart';
 import '../orders/order_suggestion_context.dart';
 import '../world/army_migration.dart';
+import '../world/faction_membership.dart';
 import '../world/player_view.dart';
 import '../world/unit_lookup.dart';
 

--- a/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_relation_lookup.dart
+++ b/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_relation_lookup.dart
@@ -13,6 +13,7 @@ import '../world/diplomatic_relation_lookup.dart';
 import '../world/province_lookup.dart';
 
 export '../world/diplomatic_relation_lookup.dart';
+export '../world/province_lookup.dart' show oldWorldProvinceCountOwnedBy;
 
 /// Overture costs per diplomacy-resolution. Consulate £500, Embassy £1000.
 const int overtureConsulateCost = 500;
@@ -43,14 +44,6 @@ Map<String, int> _provinceCountsByOwner(Game game) =>
 /// Returns the number of provinces owned by [factionId] (Minor or Tribe) in [game].
 int provinceCountOwnedBy(Game game, String factionId) {
   return _provinceCountsByOwner(game)[factionId] ?? 0;
-}
-
-/// Old World provinces owned by [factionId] (observer conquest / survival peace).
-int oldWorldProvinceCountOwnedBy(Game game, String factionId) {
-  return game.worldState
-      .provincesForRegion(kRegionOldWorld)
-      .where((p) => p.ownerId == factionId)
-      .length;
 }
 
 /// Default weights for Great Power power score. SPEC/game/diplomacy.md § Great Power power score.

--- a/packages/colonizethis_logic/lib/src/world/province_lookup.dart
+++ b/packages/colonizethis_logic/lib/src/world/province_lookup.dart
@@ -1,7 +1,7 @@
 import 'dart:collection' show UnmodifiableMapView;
 
 import 'package:colonizethis_models/colonizethis_models.dart'
-    show Province, ProvinceId, RegionData, Unit, WorldState;
+    show Game, Province, ProvinceId, RegionData, Unit, WorldState;
 
 import '../constants.dart';
 import '../utils/expando_index.dart';
@@ -421,4 +421,16 @@ extension WorldStateProvinceLookup on WorldState {
       kRegionNewWorld: List<Province>.from(newWorld.provinces),
     };
   }
+}
+
+/// Old World provinces owned by [factionId] (observer conquest / survival peace).
+///
+/// Pure world/province lookup with no diplomacy dependency; lives in `world/`
+/// so leaf-layer consumers (and `colonizethis_world` after extraction) do not
+/// import the diplomacy domain (Refs #3290 Phase 0 — `ai → diplomacy` edge).
+int oldWorldProvinceCountOwnedBy(Game game, String factionId) {
+  return game.worldState
+      .provincesForRegion(kRegionOldWorld)
+      .where((p) => p.ownerId == factionId)
+      .length;
 }

--- a/test/check_logic_domain_import_dag_test.dart
+++ b/test/check_logic_domain_import_dag_test.dart
@@ -37,34 +37,75 @@ void noop() {}
   test('documents grandfather allowlist entries for deferred C0 edges', () {
     final allowlist = logicDomainImportDagGrandfatherAllowlistForTests();
     expect(allowlist, contains('orders->turn:orders/order_projections.dart'));
-    expect(allowlist, contains('ai->diplomacy:ai/simple_ai_heuristics.dart'));
-  });
-
-  test('combat->diplomacy edge is fully eliminated (no grandfather entries)', () {
-    final allowlist = logicDomainImportDagGrandfatherAllowlistForTests();
     expect(
-      allowlist.where((e) => e.startsWith('combat->diplomacy:')),
-      isEmpty,
+      allowlist,
+      contains(
+        'economy->orders:economy/world_market/trade_order_validator.dart',
+      ),
     );
   });
 
-  test('world->combat and world->dossier leaf edges are enforced + eliminated', () {
-    final forbidden = logicDomainImportForbiddenEdgesForTests();
-    expect(forbidden, contains('world->combat'));
-    expect(forbidden, contains('world->dossier'));
+  test(
+    'combat->diplomacy edge is fully eliminated (no grandfather entries)',
+    () {
+      final allowlist = logicDomainImportDagGrandfatherAllowlistForTests();
+      expect(
+        allowlist.where((e) => e.startsWith('combat->diplomacy:')),
+        isEmpty,
+      );
+    },
+  );
 
-    final allowlist = logicDomainImportDagGrandfatherAllowlistForTests();
-    expect(allowlist.where((e) => e.startsWith('world->combat:')), isEmpty);
-    expect(allowlist.where((e) => e.startsWith('world->dossier:')), isEmpty);
+  test(
+    'ai->diplomacy edge is enforced + fully eliminated (no grandfather entries)',
+    () {
+      final forbidden = logicDomainImportForbiddenEdgesForTests();
+      expect(forbidden, contains('ai->diplomacy'));
+
+      final allowlist = logicDomainImportDagGrandfatherAllowlistForTests();
+      expect(allowlist.where((e) => e.startsWith('ai->diplomacy:')), isEmpty);
+    },
+  );
+
+  test('fails when a new forbidden ai->diplomacy import appears', () {
+    final temp = Directory.systemTemp.createTempSync('logic_dag_ai_dipl_fail_');
+    addTearDown(() => temp.deleteSync(recursive: true));
+
+    File('${temp.path}/packages/colonizethis_logic/lib/src/ai/bad_ai.dart')
+      ..createSync(recursive: true)
+      ..writeAsStringSync("""
+import '../diplomacy/diplomacy_resolver.dart';
+void noop() {}
+""");
+
+    final code = runCheckLogicDomainImportDag(
+      temp.path,
+      info: (_) {},
+      err: (_) {},
+    );
+    expect(code, 1);
   });
+
+  test(
+    'world->combat and world->dossier leaf edges are enforced + eliminated',
+    () {
+      final forbidden = logicDomainImportForbiddenEdgesForTests();
+      expect(forbidden, contains('world->combat'));
+      expect(forbidden, contains('world->dossier'));
+
+      final allowlist = logicDomainImportDagGrandfatherAllowlistForTests();
+      expect(allowlist.where((e) => e.startsWith('world->combat:')), isEmpty);
+      expect(allowlist.where((e) => e.startsWith('world->dossier:')), isEmpty);
+    },
+  );
 
   test('fails when a new forbidden world->combat import appears', () {
     final temp = Directory.systemTemp.createTempSync('logic_dag_combat_fail_');
     addTearDown(() => temp.deleteSync(recursive: true));
 
     File(
-      '${temp.path}/packages/colonizethis_logic/lib/src/world/bad_combat.dart',
-    )
+        '${temp.path}/packages/colonizethis_logic/lib/src/world/bad_combat.dart',
+      )
       ..createSync(recursive: true)
       ..writeAsStringSync("""
 import '../combat/naval_combat_resolver.dart';

--- a/tool/check_logic_domain_import_dag.dart
+++ b/tool/check_logic_domain_import_dag.dart
@@ -57,10 +57,6 @@ const _forbiddenEdges = <(String, String)>{
 const _grandfatherAllowlist = <String>{
   'economy->orders:economy/world_market/trade_order_validator.dart',
   'orders->turn:orders/order_projections.dart',
-  'orders->turn:orders/orders_application.dart',
-  'orders->turn:orders/orders_application_context.dart',
-  'ai->diplomacy:ai/full_ai_civilian_work_selection.dart',
-  'ai->diplomacy:ai/simple_ai_heuristics.dart',
 };
 
 void main() {
@@ -130,7 +126,9 @@ String? _domainForSrcRelativePath(String relativePath) {
 
 String? _resolveImportTargetDomain(String fromRelativeFile, String importPath) {
   if (importPath.startsWith('package:colonizethis_logic/src/')) {
-    final remainder = importPath.substring('package:colonizethis_logic/src/'.length);
+    final remainder = importPath.substring(
+      'package:colonizethis_logic/src/'.length,
+    );
     return _domainFromResolvedPath(remainder);
   }
   if (!importPath.startsWith('../') && !importPath.startsWith('./')) {

--- a/tool/logic_all_provinces_sanctions.yaml
+++ b/tool/logic_all_provinces_sanctions.yaml
@@ -10,7 +10,7 @@ sanctions:
     issue: https://github.com/waigore/colonizethisv3/issues/2278
 
   - path: packages/colonizethis_logic/lib/src/diplomacy/diplomacy_relation_lookup.dart
-    line: 32
+    line: 33
     rationale: Diplomatic relation scoring inspects province ownership globally.
     spec: SPEC/program/logic-dual-region-province-access.md
     issue: https://github.com/waigore/colonizethisv3/issues/2278


### PR DESCRIPTION
## Summary

Phase 0 (C0) boundary slice for epic #3290 — eliminates the last `ai -> diplomacy` wrong-direction import edge inside `colonizethis_logic`, advancing the one-way domain DAG ahead of package extraction. Behavior-preserving (pure structural relocation + import retargeting).

`Refs #3290`

## Done in this push

- **Relocate `oldWorldProvinceCountOwnedBy`** from `lib/src/diplomacy/diplomacy_relation_lookup.dart` to `lib/src/world/province_lookup.dart`. It is a pure world/province lookup (only `worldState.provincesForRegion(kRegionOldWorld)` + ownership), so it belongs in the `world` leaf layer. `diplomacy_relation_lookup.dart` now re-exports it (`export '../world/province_lookup.dart' show oldWorldProvinceCountOwnedBy;`), so `war_resolver.dart`, the diplomacy barrel, the survival-peace test, and `ai_api.dart` consumers (incl. the `colonizethis_ai` package) keep importing it unchanged.
- **Retarget the two `src/ai/` files** (`full_ai_civilian_work_selection.dart`, `simple_ai_heuristics.dart`) to import `DiplomacyFactionMembership` / `isMinorOrTribe` from `world/faction_membership.dart` and the OW-count helper from `world/province_lookup.dart` (already imported). Neither file imports the diplomacy domain anymore.
- **DAG allowlist hygiene** (`tool/check_logic_domain_import_dag.dart`): drop both `ai->diplomacy:*` grandfather entries, and drop the two stale `orders->turn:*` entries for `orders_application.dart` / `orders_application_context.dart` (they already import the hoisted `lib/src/trace/turn_trace_runtime.dart`, so they no longer violate). Only `orders->turn:order_projections.dart` and `economy->orders:trade_order_validator.dart` remain grandfathered.
- **Tests** (`test/check_logic_domain_import_dag_test.dart`): replace the now-stale `ai->diplomacy` allowlist assertion with an `economy->orders` one; add a positive "edge enforced + fully eliminated (no grandfather entries)" test and a negative "fails when a new forbidden ai->diplomacy import appears" test.
- **SPEC** (`SPEC/program/logic-package-split-phase0.md`): mark `ai -> diplomacy` **Eliminated** in the target DAG table and the edge-pair enumeration; update the `orders <-> turn` table to reflect the two fixed trace consumers (only `order_projections` deferred).

## ACs covered (Phase 0 / C0)

- Domain import DAG: zero `ai->diplomacy` imports; the edge is enforced with no grandfather entries.
- Edge-pair enumeration for `diplomacy <-> ai` updated with chosen destinations.

## Deferred (remaining C0 grandfathered edges, not in this PR)

- `orders -> turn` via `order_projections.dart` (`projectOrderEffects` dry-run resolution; needs callback inversion or relocation).
- `economy -> orders` via `trade_order_validator.dart` (`projectOrderEffects`).

## Verification

- `dart run tool/check_logic_domain_import_dag.dart` -> no violations outside allowlist.
- `dart test test/check_logic_domain_import_dag_test.dart` -> 8/8 pass.
- `dart test` (logic): `simple_ai_heuristics_additional_generation_test`, `full_ai_civilian_work_supplier_feedstock_mineral_prospecting_test`, `diplomacy_faction_membership_test`, `diplomacy_resolver_survival_peace_test` -> all pass.
- `dart analyze` on touched files + `ai_api.dart` -> no new issues (only 2 pre-existing unrelated warnings in `simple_ai_heuristics.dart`).

Made with [Cursor](https://cursor.com)