### PR TITLE
refactor(logic): eliminate economy->diplomacy import edge (Refs #3290)

### DIFF
--- a/SPEC/program/logic-package-split-phase0.md
+++ b/SPEC/program/logic-package-split-phase0.md
@@ -27,6 +27,7 @@ Phase 0 deliverables (child issue C0):
 | `world` | `dossier` | **Eliminated** — `naval_resolution` (dossier/dialogue side-effects) relocated from `world/` to `turn/` |
 | `economy` | `orders` | **Eliminated** — `OrderValidationResult` moved to `lib/src/validation/`; `projectOrderEffects` import removed by inverting `tradeOrderValidationContextFromGame` (caller-computed `projectedTreasuryDelta`) |
 | `orders` | `economy` | Allowed |
+| `economy` | `diplomacy` | **Eliminated** — `worldMarketBidTypeCap` / `kWorldMarketBaselineBidTypeCap` moved to `economy/world_market/bid_type_cap.dart`; `DiplomacyFactionMembership` and `enemiesOf` retargeted to their `world/` source files |
 | `turn` | `orders` | Allowed |
 | `orders` | `turn` | **Eliminated** — trace runtime hoisted to `lib/src/trace/`; `projectOrderEffects` dry-run hoisted to `lib/src/projections/` |
 | `turn` | `world` | Allowed |
@@ -69,6 +70,18 @@ Phase 0 deliverables (child issue C0):
 |--------|---------|-------------|--------|
 | `orders/order_validation_result.dart` | `OrderValidationResult`, `OrderValidationStatus` | `lib/src/validation/order_validation_result.dart` | Fixed |
 | `orders/order_projections.dart` | `projectOrderEffects` | Inverted — the order engine computes `projectOrderEffects(...).treasuryDelta` and passes it as `tradeOrderValidationContextFromGame`'s `projectedTreasuryDelta`; the economy builder adds back `stagedBidTotalSpendByPlayer`. | Fixed |
+
+### `economy → diplomacy`
+
+**Wrong:** `economy` → `diplomacy` (eliminated)
+
+| Source file | Import | Symbols | Destination | Status |
+|-------------|--------|---------|-------------|--------|
+| `economy/world_market/trade_order_validator.dart` | `diplomacy/diplomacy_subsidies_relations_resolver.dart` | `worldMarketBidTypeCap` | `economy/world_market/bid_type_cap.dart` (pure world-market helper relocated into the economy domain; `tradeSlotsForGp` stays in diplomacy) | Fixed |
+| `economy/world_market/purchased_tile_index.dart` | `diplomacy/diplomacy_resolver.dart` | `DiplomacyFactionMembership` | `package:colonizethis_world/src/world/faction_membership.dart` (the class already lived in `colonizethis_world`; diplomacy only re-exported it) | Fixed |
+| `economy/sea_transport.dart` | `diplomacy/diplomacy_relation_lookup.dart` | `enemiesOf` | `package:colonizethis_world/src/world/diplomatic_relation_lookup.dart` (already a `colonizethis_world` symbol) | Fixed |
+
+`ai_api.dart` and the `colonizethis_logic` barrel now expose `worldMarketBidTypeCap` / `kWorldMarketBaselineBidTypeCap` from the economy file, preserving the public surface for AI/order/UI consumers. The edge is enforced by `repo.logic_domain_import_dag` (`economy->diplomacy` forbidden pair, no grandfather entry).
 
 ### `orders ↔ turn`
 

--- a/SPEC/program/world-market-resolution.md
+++ b/SPEC/program/world-market-resolution.md
@@ -348,7 +348,7 @@ Rules 1–2 are intrinsic to the order. Rules 3–4 are computed from the submit
 
 ### Bid type cap helper
 
-`worldMarketBidTypeCap(Game game, String playerId)` lives in `packages/colonizethis_logic/lib/src/diplomacy/diplomacy_subsidies_relations_resolver.dart` next to `tradeSlotsForGp` ([diplomacy-resolution.md](diplomacy-resolution.md)):
+`worldMarketBidTypeCap(Game game, String playerId)` lives in `packages/colonizethis_logic/lib/src/economy/world_market/bid_type_cap.dart` (a pure world-market helper with no diplomacy-domain dependency, Refs #3290). Per-target trade-agreement slots remain governed by `tradeSlotsForGp` in `diplomacy_subsidies_relations_resolver.dart` ([diplomacy-resolution.md](diplomacy-resolution.md)):
 
 - `0` only when [playerId] is not a known player (`Game.playerById` returns `null`).
 - `kWorldMarketBaselineBidTypeCap` (= **1**) when the player exists and has no embassy (`OvertureStage.embassy` or stronger) with **any** target faction. This baseline keeps the global market liquid for every Great Power — including EXPAND-phase GPs that are structurally blocked from emitting NW-only `establishOverture` orders (`SPEC/ai/phase-planner-architecture.md` § EXPAND planner suppressions) — so treasury can still redistribute through legitimate trade per [world-market.md](../game/world-market.md) § Bid type cap.

--- a/packages/colonizethis_logic/lib/ai_api.dart
+++ b/packages/colonizethis_logic/lib/ai_api.dart
@@ -62,7 +62,7 @@ export 'src/orders/incremental_candidate_validator.dart'
 export 'src/orders/order_suggestion_move_army.dart'
     show armyMoveCandidateDestinationProvinceIds;
 export 'package:colonizethis_world/src/world/movement.dart' show neighborProvinceIdsInRegion;
-export 'src/diplomacy/diplomacy_subsidies_relations_resolver.dart'
+export 'src/economy/world_market/bid_type_cap.dart'
     show kWorldMarketBaselineBidTypeCap, worldMarketBidTypeCap;
 export 'src/economy/economy_riches_to_treasury.dart'
     show pendingRichesTreasuryDelta;

--- a/packages/colonizethis_logic/lib/colonizethis_logic.dart
+++ b/packages/colonizethis_logic/lib/colonizethis_logic.dart
@@ -54,6 +54,7 @@ export 'src/economy/resource_extractor.dart';
 export 'src/economy/sea_transport.dart';
 export 'src/economy/worker_action_cost.dart';
 export 'src/economy/worker_economy.dart';
+export 'src/economy/world_market/bid_type_cap.dart';
 export 'src/economy/world_market/deal_matcher.dart';
 export 'src/economy/world_market/first_right_credits.dart';
 export 'src/economy/world_market/first_right_profit.dart';

--- a/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_resolver.dart
@@ -23,8 +23,7 @@ import 'overture_resolver.dart';
 import 'war_resolver.dart';
 
 export 'diplomacy_relation_lookup.dart';
-export 'diplomacy_subsidies_relations_resolver.dart'
-    show kWorldMarketBaselineBidTypeCap, tradeSlotsForGp, worldMarketBidTypeCap;
+export 'diplomacy_subsidies_relations_resolver.dart' show tradeSlotsForGp;
 export 'ftp_resolver.dart'
     show aiGpAcceptsFtp, breakFtpOnEmbassyLoss, breakFtpOnWar;
 export 'diplomacy_relation_lookup.dart'

--- a/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_subsidies_relations_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_subsidies_relations_resolver.dart
@@ -366,38 +366,3 @@ int tradeSlotsForGp(Game game, String gpId, String targetFactionId) {
   final u = p.techUnlocked ?? const <String, bool>{};
   return u[kTechIdTradeFairs] == true ? 6 : 3;
 }
-
-/// World-market bid-type cap (distinct bid commodities per turn).
-///
-/// Semantics aggregate across **all** of the player's embassies because the
-/// market is global, not per-target. Returns:
-///
-/// - `0` when the player has no embassy-tier overture
-///   ([OvertureState.hasEmbassy]) with any target.
-/// - `3` when the player has at least one embassy-tier overture and has not
-///   unlocked [kTechIdTradeFairs].
-/// - `6` when the player has at least one embassy-tier overture and has
-///   unlocked [kTechIdTradeFairs].
-///
-/// Source of truth: SPEC/program/world-market-resolution.md § Bid type cap
-/// helper. Per-target trade-agreement slots remain governed by
-/// [tradeSlotsForGp]. Refs #2989 A5.
-/// Baseline distinct-commodity bid cap for a known player with no embassy.
-///
-/// Authorizes basic participation in the single global world market for every
-/// Great Power, including EXPAND-phase GPs that are structurally blocked from
-/// emitting `establishOverture` orders. Refs #2924; SPEC/game/world-market.md
-/// § Bid type cap and SPEC/program/world-market-resolution.md § Bid type cap
-/// helper.
-const int kWorldMarketBaselineBidTypeCap = 1;
-
-int worldMarketBidTypeCap(Game game, String playerId) {
-  final p = game.playerById(playerId);
-  if (p == null) return 0;
-  final hasAnyEmbassy = game.overtureStates.any(
-    (o) => o.gpId == playerId && o.hasEmbassy,
-  );
-  if (!hasAnyEmbassy) return kWorldMarketBaselineBidTypeCap;
-  final u = p.techUnlocked ?? const <String, bool>{};
-  return u[kTechIdTradeFairs] == true ? 6 : 3;
-}

--- a/packages/colonizethis_logic/lib/src/economy/sea_transport.dart
+++ b/packages/colonizethis_logic/lib/src/economy/sea_transport.dart
@@ -3,7 +3,8 @@ import 'package:colonizethis_logic/src/logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:logger/logger.dart';
 
-import '../diplomacy/diplomacy_relation_lookup.dart';
+import 'package:colonizethis_world/src/world/diplomatic_relation_lookup.dart'
+    show enemiesOf;
 import 'package:colonizethis_world/src/world/naval.dart';
 
 /// Sea transport: allocate overseas extraction to stockpile by priority. SPEC/program/auto-transport.

--- a/packages/colonizethis_logic/lib/src/economy/world_market/bid_type_cap.dart
+++ b/packages/colonizethis_logic/lib/src/economy/world_market/bid_type_cap.dart
@@ -1,0 +1,50 @@
+/// World-market bid-type cap helpers.
+///
+/// These are **pure** world-market economy helpers (deterministic for fixed
+/// inputs, silent — no logger calls) used by trade-order validation,
+/// suggestion, and AI bid planning. They depend only on `colonizethis_models`,
+/// `colonizethis_data`, and the `colonizethis_logic` core `GamePlayerLookup`
+/// extension, so they carry no dependency on the diplomacy domain (Refs #3290
+/// — break the economy -> diplomacy import edge; the helpers were previously
+/// co-located in `diplomacy_subsidies_relations_resolver.dart`).
+library;
+
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import '../../constants.dart' show GamePlayerLookup;
+
+/// Baseline distinct-commodity bid cap for a known player with no embassy.
+///
+/// Authorizes basic participation in the single global world market for every
+/// Great Power, including EXPAND-phase GPs that are structurally blocked from
+/// emitting `establishOverture` orders. Refs #2924; SPEC/game/world-market.md
+/// § Bid type cap and SPEC/program/world-market-resolution.md § Bid type cap
+/// helper.
+const int kWorldMarketBaselineBidTypeCap = 1;
+
+/// World-market bid-type cap (distinct bid commodities per turn).
+///
+/// Semantics aggregate across **all** of the player's embassies because the
+/// market is global, not per-target. Returns:
+///
+/// - [kWorldMarketBaselineBidTypeCap] (1) when the player has no embassy-tier
+///   overture ([OvertureState.hasEmbassy]) with any target.
+/// - `3` when the player has at least one embassy-tier overture and has not
+///   unlocked [kTechIdTradeFairs].
+/// - `6` when the player has at least one embassy-tier overture and has
+///   unlocked [kTechIdTradeFairs].
+///
+/// Source of truth: SPEC/program/world-market-resolution.md § Bid type cap
+/// helper. Per-target trade-agreement slots remain governed by `tradeSlotsForGp`
+/// in `diplomacy_subsidies_relations_resolver.dart`. Refs #2989 A5.
+int worldMarketBidTypeCap(Game game, String playerId) {
+  final p = game.playerById(playerId);
+  if (p == null) return 0;
+  final hasAnyEmbassy = game.overtureStates.any(
+    (o) => o.gpId == playerId && o.hasEmbassy,
+  );
+  if (!hasAnyEmbassy) return kWorldMarketBaselineBidTypeCap;
+  final u = p.techUnlocked ?? const <String, bool>{};
+  return u[kTechIdTradeFairs] == true ? 6 : 3;
+}

--- a/packages/colonizethis_logic/lib/src/economy/world_market/purchased_tile_index.dart
+++ b/packages/colonizethis_logic/lib/src/economy/world_market/purchased_tile_index.dart
@@ -29,7 +29,7 @@ library;
 
 import 'package:colonizethis_models/colonizethis_models.dart' show Game;
 
-import '../../diplomacy/diplomacy_resolver.dart'
+import 'package:colonizethis_world/src/world/faction_membership.dart'
     show DiplomacyFactionMembership;
 import 'package:colonizethis_world/src/world/province_lookup.dart' show WorldStateProvinceLookup;
 

--- a/packages/colonizethis_logic/lib/src/economy/world_market/trade_order_suggester.dart
+++ b/packages/colonizethis_logic/lib/src/economy/world_market/trade_order_suggester.dart
@@ -56,7 +56,7 @@ class TradeSuggestionContext {
 
   /// `0 / 3 / 6` cap on distinct bid commodities for this player this turn.
   /// Pre-computed via `worldMarketBidTypeCap` in
-  /// `packages/colonizethis_logic/lib/src/diplomacy/diplomacy_subsidies_relations_resolver.dart`.
+  /// `packages/colonizethis_logic/lib/src/economy/world_market/bid_type_cap.dart`.
   final int bidTypeCap;
 
   /// Cross-commodity cargo budget for this player's bids this turn (units).

--- a/packages/colonizethis_logic/lib/src/economy/world_market/trade_order_validator.dart
+++ b/packages/colonizethis_logic/lib/src/economy/world_market/trade_order_validator.dart
@@ -13,8 +13,7 @@ library;
 import 'package:colonizethis_data/colonizethis_data.dart' as data;
 import 'package:colonizethis_models/colonizethis_models.dart';
 
-import '../../diplomacy/diplomacy_subsidies_relations_resolver.dart'
-    show worldMarketBidTypeCap;
+import 'bid_type_cap.dart' show worldMarketBidTypeCap;
 import '../../economy/sea_transport.dart' show cargoHoldsForHomeFleet;
 import '../../validation/order_validation_result.dart';
 import 'sellable_quantity.dart' show offerCapByCommodityId;
@@ -83,7 +82,7 @@ class TradeOrderValidationContext {
 
   /// `0 / 3 / 6` cap on distinct bid commodities for this player this turn.
   /// Pre-computed via `worldMarketBidTypeCap` in
-  /// `packages/colonizethis_logic/lib/src/diplomacy/diplomacy_subsidies_relations_resolver.dart`.
+  /// `packages/colonizethis_logic/lib/src/economy/world_market/bid_type_cap.dart`.
   final int bidTypeCap;
 
   /// Cross-commodity cargo budget for this player's bids this turn (units).

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion_api_impl.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion_api_impl.dart
@@ -3,8 +3,8 @@ import 'package:colonizethis_logic/src/logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart' show GamePlayerLookup;
-import '../diplomacy/diplomacy_resolver.dart' show worldMarketBidTypeCap;
 import '../economy/sea_transport.dart' show cargoHoldsForHomeFleet;
+import '../economy/world_market/bid_type_cap.dart' show worldMarketBidTypeCap;
 import '../economy/world_market/trade_order_suggester.dart';
 import '../economy/world_market/treasury_bid_budget.dart'
     show treasuryAvailableForBidsByPlayer;

--- a/test/check_logic_domain_import_dag_test.dart
+++ b/test/check_logic_domain_import_dag_test.dart
@@ -202,6 +202,39 @@ void noop() {}
     expect(code, 1);
   });
 
+  test('economy->diplomacy edge is enforced and fully eliminated (Refs #3290)',
+      () {
+    final forbidden = logicDomainImportForbiddenEdgesForTests();
+    expect(forbidden, contains('economy->diplomacy'));
+
+    final allowlist = logicDomainImportDagGrandfatherAllowlistForTests();
+    expect(
+      allowlist.where((e) => e.startsWith('economy->diplomacy:')),
+      isEmpty,
+    );
+  });
+
+  test('fails when a new forbidden economy->diplomacy import appears', () {
+    final temp = Directory.systemTemp.createTempSync('logic_dag_econ_dipl_');
+    addTearDown(() => temp.deleteSync(recursive: true));
+
+    File(
+      '${temp.path}/packages/colonizethis_logic/lib/src/economy/bad_diplomacy.dart',
+    )
+      ..createSync(recursive: true)
+      ..writeAsStringSync("""
+import '../diplomacy/diplomacy_resolver.dart';
+void noop() {}
+""");
+
+    final code = runCheckLogicDomainImportDag(
+      temp.path,
+      info: (_) {},
+      err: (_) {},
+    );
+    expect(code, 1);
+  });
+
   test('diplomacy->ai edge is enforced and fully eliminated (Refs #3290)', () {
     final forbidden = logicDomainImportForbiddenEdgesForTests();
     expect(forbidden, contains('diplomacy->ai'));

--- a/tool/check_logic_domain_import_dag.dart
+++ b/tool/check_logic_domain_import_dag.dart
@@ -48,6 +48,15 @@ const _forbiddenEdges = <(String, String)>{
   ('world', 'dossier'),
   ('combat', 'diplomacy'),
   ('economy', 'orders'),
+  // `economy` and `diplomacy` are leaf peers above `world`: `economy` depends
+  // on `world` only, while `diplomacy` depends on `world`/`combat`. An
+  // `economy -> diplomacy` import would push `economy` above the diplomacy
+  // layer and block its leaf extraction. The sole crossing symbol
+  // (`worldMarketBidTypeCap` / `kWorldMarketBaselineBidTypeCap`) now lives in
+  // `economy/world_market/bid_type_cap.dart`; `DiplomacyFactionMembership` and
+  // `enemiesOf` were already `colonizethis_world` symbols re-exported by
+  // diplomacy, so this edge is eliminated and forbidden (Refs #3290 Phase 1).
+  ('economy', 'diplomacy'),
   ('orders', 'turn'),
   ('ai', 'diplomacy'),
   // `diplomacy` is a mid-layer domain; the `turn` orchestrator sits above it.


### PR DESCRIPTION
## Summary

Phase 1 prerequisite for the `colonizethis_economy` leaf extraction (#3290 C1). The economy domain is supposed to depend only on `world`/`models`/`data`, but three `economy/` (incl. `world_market/`) files imported `diplomacy/`. This PR eliminates that `economy -> diplomacy` edge — a behavior-preserving relocation/redirect mirroring the merged edge-elimination PRs (#3333 `economy->orders`, #3332 `ai->diplomacy`).

## Done in this PR

**Relocate the misplaced world-market helper (real edge)**
- Moved `worldMarketBidTypeCap` and `kWorldMarketBaselineBidTypeCap` from `diplomacy/diplomacy_subsidies_relations_resolver.dart` into a new pure-economy file `economy/world_market/bid_type_cap.dart` (function body byte-identical; depends only on `models`/`data`/core `GamePlayerLookup`). `tradeSlotsForGp` (genuinely per-target diplomacy) stays in diplomacy.
- `trade_order_validator.dart` and `order_suggestion_api_impl.dart` now import the helper from the economy file.
- The `colonizethis_logic` barrel and `ai_api.dart` re-export the helper from the economy file, so the public surface for AI/order/UI/test consumers is unchanged.
- Removed the now-stale re-export from `diplomacy_resolver.dart` (keeps `tradeSlotsForGp`).

**Redirect two false edges to their real `colonizethis_world` source**
- `sea_transport.dart`: `enemiesOf` imported directly from `colonizethis_world/.../diplomatic_relation_lookup.dart` (it was always a world symbol re-exported by diplomacy).
- `purchased_tile_index.dart`: `DiplomacyFactionMembership` imported directly from `colonizethis_world/.../faction_membership.dart` (the class lives in world; diplomacy only re-exported it).

**Lock in the boundary (CI enforcement)**
- Added `('economy','diplomacy')` to `repo.logic_domain_import_dag` forbidden edges with positive + negative tests in `test/check_logic_domain_import_dag_test.dart`.

**SPEC**
- `SPEC/program/logic-package-split-phase0.md`: edge table row + per-edge enumeration section.
- `SPEC/program/world-market-resolution.md`: bid-type-cap helper now cited at its economy location.

## ACs covered
- economy `lib/` no longer imports any `diplomacy/` symbol; the edge is forbidden by `repo.logic_domain_import_dag` with no grandfather entry.
- World-market bid-type-cap behavior unchanged (same `0/1/3/6` semantics).
- Public symbol surface (`worldMarketBidTypeCap`, `kWorldMarketBaselineBidTypeCap`) preserved via barrel + `ai_api`.

## Tests
- `test/check_logic_domain_import_dag_test.dart` — +2 (enforced + negative); all 18 pass, including the real-tree pass.
- Logic: `diplomacy_resolver_trade_and_labels_test`, `order_engine_validate_trade_test`, `order_suggestion_api_impl_trade_test`, `world_market_trade_order_validator_*`, `world_market_trade_order_suggester_test` — all green.
- `dart analyze` on touched logic/ai files introduces no new issues.

## Deferred
- The full `colonizethis_economy` leaf extraction (own package + barrel + coverage gate) remains follow-up work on #3290; it additionally requires breaking economy's logic-core deps (`constants`, `validation`). This PR only removes the diplomacy edge.

Refs #3290

Made with [Cursor](https://cursor.com)