### PR TITLE
refactor(logic): eliminate diplomacy->orders import edge (Refs #3290)

### DIFF
--- a/SPEC/program/logic-package-split-phase0.md
+++ b/SPEC/program/logic-package-split-phase0.md
@@ -36,6 +36,8 @@ Phase 0 deliverables (child issue C0):
 | `ai` | `diplomacy` | **Eliminated** — `DiplomacyFactionMembership` / `isMinorOrTribe` consumed from `world/faction_membership.dart` |
 | `turn` | `diplomacy` | Allowed — orchestrator `TurnResolutionResult` variants consume diplomacy phase value types |
 | `diplomacy` | `turn` | **Eliminated** — overture/FTP/intervention/call-to-arms offer + decision types and `DiplomacyPhaseResult` moved to `diplomacy/diplomacy_phase_result.dart`; `turn/turn_resolution_result.dart` imports + re-exports them |
+| `orders` | `diplomacy` | Allowed — order suggesters consume diplomacy relation/visibility helpers |
+| `diplomacy` | `orders` | **Eliminated** — `knownDiplomaticTargetFactionIds` (diplomacy-domain visibility helper) moved from `orders/order_suggestion_helpers.dart` to `diplomacy/known_diplomatic_targets.dart` |
 
 ## Edge pair enumerations (wrong-direction symbols)
 
@@ -82,6 +84,18 @@ Phase 0 deliverables (child issue C0):
 | `economy/sea_transport.dart` | `diplomacy/diplomacy_relation_lookup.dart` | `enemiesOf` | `package:colonizethis_world/src/world/diplomatic_relation_lookup.dart` (already a `colonizethis_world` symbol) | Fixed |
 
 `ai_api.dart` and the `colonizethis_logic` barrel now expose `worldMarketBidTypeCap` / `kWorldMarketBaselineBidTypeCap` from the economy file, preserving the public surface for AI/order/UI consumers. The edge is enforced by `repo.logic_domain_import_dag` (`economy->diplomacy` forbidden pair, no grandfather entry).
+
+### `diplomacy → orders`
+
+**Wrong:** `diplomacy` → `orders` (1 file, eliminated)
+
+`orders` sits above `diplomacy` in the target DAG (the `colonizethis_orders` package depends on `colonizethis_diplomacy`), so a `diplomacy → orders` import would push `diplomacy` above the orders layer and block the `colonizethis_diplomacy` extraction. The sole crossing symbol was `knownDiplomaticTargetFactionIds`, a diplomacy-domain visibility helper (it derives targetable faction ids from relations, tile visibility, and sea-reachable New World provinces) that happened to live in the orders helpers file. It depends only on `world/`/`models`/`data`/`constants`, so it relocates cleanly into the diplomacy domain.
+
+| Source file | Import | Symbols | Destination | Status |
+|-------------|--------|---------|-------------|--------|
+| `diplomacy/gp_tribe_first_contact.dart` | `orders/order_suggestion_helpers.dart` | `knownDiplomaticTargetFactionIds` | `diplomacy/known_diplomatic_targets.dart` | Fixed |
+
+**Correct:** `orders` → `diplomacy` — `orders/order_suggestion_naval_diplomatic.dart` (the diplomatic order suggesters) imports `knownDiplomaticTargetFactionIds` one-way from `diplomacy/known_diplomatic_targets.dart`. `order_suggestion_api.dart` and `ai_api.dart` re-export the symbol from the diplomacy path, so the public surface for AI/order/UI consumers is unchanged.
 
 ### `orders ↔ turn`
 
@@ -204,4 +218,5 @@ Future per-package rules (`repo.world_dead_files`, `repo.world_no_logic_deps`, e
 - **Given** `economy/world_market/trade_order_validator.dart`, **when** the graph is scanned, **then** the file imports no `orders/` symbol and `repo.logic_domain_import_dag` carries no `economy->orders` grandfather entry.
 - **Given** the four diplomacy resolvers (`overture_resolver.dart`, `intervention_resolver.dart`, `diplomacy_resolver.dart`, `ftp_resolver.dart`), **when** `repo.logic_domain_import_dag` runs, **then** no `diplomacy` file imports `turn/`, `diplomacy->turn` is a forbidden edge, and `repo.logic_domain_import_dag` carries no `diplomacy->turn` grandfather entry.
 - **Given** the `diplomacy/` source files, **when** `repo.logic_domain_import_dag` runs, **then** no `diplomacy` file imports `ai/`, `diplomacy->ai` is a forbidden edge, and `repo.logic_domain_import_dag` carries no `diplomacy->ai` grandfather entry.
+- **Given** the `diplomacy/` source files, **when** `repo.logic_domain_import_dag` runs, **then** no `diplomacy` file imports `orders/`, `diplomacy->orders` is a forbidden edge, and `repo.logic_domain_import_dag` carries no `diplomacy->orders` grandfather entry.
 - **Given** a `Game` with `Player.treasury == 175`, empty staged orders (no bids) and `projectedTreasuryDelta == -50`, **when** `tradeOrderValidationContextFromGame(game, playerId, stagedOrders: <empty>, projectedTreasuryDelta: -50)` builds the context, **then** `TradeOrderValidationContext.treasuryBudgetForBids == 125` (`max(0, 175 − max(0, 50))`).

--- a/packages/colonizethis_logic/lib/ai_api.dart
+++ b/packages/colonizethis_logic/lib/ai_api.dart
@@ -76,12 +76,13 @@ export 'src/economy/worker_economy.dart' show effectiveLabourForWorkers;
 export 'src/economy/worker_action_cost.dart' show canAffordRecruitWorker;
 export 'src/orders/draft_orders_mutations.dart'
     show applyArmyMoveOrderForPlayer;
+export 'src/diplomacy/known_diplomatic_targets.dart'
+    show knownDiplomaticTargetFactionIds;
 export 'src/orders/order_suggestion_helpers.dart'
     show
         filterArmyMoveOrdersByDiplomacy,
         filterMoveOrdersByDiplomacy,
-        getProvinceOwnerMap,
-        knownDiplomaticTargetFactionIds;
+        getProvinceOwnerMap;
 export 'package:colonizethis_world/src/trace/turn_trace_contracts.dart' show TurnTraceAiSection;
 export 'package:colonizethis_world/src/world/army_commands.dart' show applyArmySplit;
 export 'package:colonizethis_world/src/world/army_ids.dart' show homeArmyIdFor;

--- a/packages/colonizethis_logic/lib/order_suggestion_api.dart
+++ b/packages/colonizethis_logic/lib/order_suggestion_api.dart
@@ -17,7 +17,7 @@ export 'src/orders/diplomatic_panel_actions.dart'
         diplomaticPanelActionCandidates,
         enumerateDiplomaticPanelActionsForTarget,
         kDiplomaticPanelOvertureStages;
-export 'src/orders/order_suggestion_helpers.dart'
+export 'src/diplomacy/known_diplomatic_targets.dart'
     show knownDiplomaticTargetFactionIds;
 export 'src/diplomacy/gp_tribe_first_contact.dart'
     show GpTribeFirstContactResult, applyGpTribeFirstContactRelations;

--- a/packages/colonizethis_logic/lib/src/diplomacy/gp_tribe_first_contact.dart
+++ b/packages/colonizethis_logic/lib/src/diplomacy/gp_tribe_first_contact.dart
@@ -2,9 +2,9 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_world/src/world/player_view.dart';
 
-import '../orders/order_suggestion_helpers.dart';
 import 'diplomacy_relation_lookup.dart';
 import 'diplomacy_relation_updates.dart';
+import 'known_diplomatic_targets.dart';
 
 /// Outcome of applying GP–Tribe first-contact relations for one human GP.
 /// SPEC/game/diplomacy.md § GP–Tribe first contact (issue #3341).

--- a/packages/colonizethis_logic/lib/src/diplomacy/known_diplomatic_targets.dart
+++ b/packages/colonizethis_logic/lib/src/diplomacy/known_diplomatic_targets.dart
@@ -1,0 +1,72 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_world/src/world/player_view.dart';
+import 'package:colonizethis_world/src/world/sea_reachable_provinces.dart';
+import 'package:colonizethis_world/src/world/tile_key_coordinates.dart';
+
+import '../constants.dart';
+
+/// Faction ids the player may target with diplomatic suggestions.
+///
+/// Diplomacy-domain visibility helper: derives the targetable faction set from
+/// existing relations, tile visibility, and sea-reachable New World provinces.
+/// Relocated from `orders/order_suggestion_helpers.dart` so the diplomacy
+/// domain owns its own targeting logic and never imports `orders/`
+/// (one-way `orders -> diplomacy` edge, Refs #3290 Phase 2).
+///
+/// SPEC/program/order-suggestions.md § Diplomatic orders (visibility).
+Set<String> knownDiplomaticTargetFactionIds({
+  required PlayerView view,
+  required Game game,
+  required MapTopology topology,
+}) {
+  final knownFactionIds = <String>{};
+  final playerId = view.playerId;
+
+  for (final rel in game.diplomacyRelations) {
+    if (rel.factionId1 == playerId) {
+      knownFactionIds.add(rel.factionId2);
+    } else if (rel.factionId2 == playerId) {
+      knownFactionIds.add(rel.factionId1);
+    }
+  }
+
+  for (final entry in view.visibilityByTile.entries) {
+    if (entry.value == VisibilityLevel.unknown) continue;
+    final parsed = parseTileKeyCoordinates(entry.key);
+    if (parsed == null) continue;
+    final regionId = parsed.regionId;
+    final provinceLocalId = parsed.provinceLocalId;
+    final provinceId = ProvinceId.full(regionId, provinceLocalId);
+    final province = view.provinceByRegionAndId(regionId, provinceId);
+    final ownerId = province?.ownerId;
+    if (ownerId != null && ownerId != playerId) {
+      knownFactionIds.add(ownerId);
+    }
+  }
+
+  final anchorProvinces = <String>{};
+  for (final p in view.provincesById.entries) {
+    if (p.value.ownerId == playerId) anchorProvinces.add(p.key);
+  }
+  for (final u in view.ownUnits) {
+    if (u.locationProvinceId.isNotEmpty) {
+      anchorProvinces.add(u.locationProvinceId);
+    }
+  }
+  final seaReachableNw = reachableNonOwnedProvinceIdsViaSeas(
+    topology,
+    anchorProvinces,
+    view,
+    regionIdFilter: kRegionNewWorld,
+  );
+  for (final provId in seaReachableNw) {
+    final ownerId = view.provincesById[provId]?.ownerId;
+    if (ownerId == null || ownerId == playerId) continue;
+    if (game.tribes.any((t) => t.id == ownerId)) {
+      knownFactionIds.add(ownerId);
+    }
+  }
+
+  return knownFactionIds;
+}

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion_helpers.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion_helpers.dart
@@ -6,68 +6,9 @@ import '../diplomacy/diplomacy_resolver.dart';
 import 'package:colonizethis_world/src/world/player_view.dart';
 import 'package:colonizethis_world/src/world/province_lookup.dart';
 import 'package:colonizethis_world/src/world/sea_reachable_provinces.dart';
-import 'package:colonizethis_world/src/world/tile_key_coordinates.dart';
 
 /// Shared helpers for order suggestion. SPEC/ai/ai-architecture.md.
 /// Used by order_suggestion and AI planners.
-
-/// Faction ids the player may target with diplomatic suggestions.
-/// SPEC/program/order-suggestions.md § Diplomatic orders (visibility).
-Set<String> knownDiplomaticTargetFactionIds({
-  required PlayerView view,
-  required Game game,
-  required MapTopology topology,
-}) {
-  final knownFactionIds = <String>{};
-  final playerId = view.playerId;
-
-  for (final rel in game.diplomacyRelations) {
-    if (rel.factionId1 == playerId) {
-      knownFactionIds.add(rel.factionId2);
-    } else if (rel.factionId2 == playerId) {
-      knownFactionIds.add(rel.factionId1);
-    }
-  }
-
-  for (final entry in view.visibilityByTile.entries) {
-    if (entry.value == VisibilityLevel.unknown) continue;
-    final parsed = parseTileKeyCoordinates(entry.key);
-    if (parsed == null) continue;
-    final regionId = parsed.regionId;
-    final provinceLocalId = parsed.provinceLocalId;
-    final provinceId = ProvinceId.full(regionId, provinceLocalId);
-    final province = view.provinceByRegionAndId(regionId, provinceId);
-    final ownerId = province?.ownerId;
-    if (ownerId != null && ownerId != playerId) {
-      knownFactionIds.add(ownerId);
-    }
-  }
-
-  final anchorProvinces = <String>{};
-  for (final p in view.provincesById.entries) {
-    if (p.value.ownerId == playerId) anchorProvinces.add(p.key);
-  }
-  for (final u in view.ownUnits) {
-    if (u.locationProvinceId.isNotEmpty) {
-      anchorProvinces.add(u.locationProvinceId);
-    }
-  }
-  final seaReachableNw = reachableNonOwnedProvinceIdsViaSeas(
-    topology,
-    anchorProvinces,
-    view,
-    regionIdFilter: kRegionNewWorld,
-  );
-  for (final provId in seaReachableNw) {
-    final ownerId = view.provincesById[provId]?.ownerId;
-    if (ownerId == null || ownerId == playerId) continue;
-    if (game.tribes.any((t) => t.id == ownerId)) {
-      knownFactionIds.add(ownerId);
-    }
-  }
-
-  return knownFactionIds;
-}
 
 /// Sea-reachable unowned New World provinces for colonial explore targeting.
 /// SPEC/program/order-suggestions.md § GP↔Tribe colonial intel (Refs #2509).

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion_naval_diplomatic.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion_naval_diplomatic.dart
@@ -3,6 +3,7 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';
 import '../diplomacy/diplomacy_resolver.dart';
+import '../diplomacy/known_diplomatic_targets.dart';
 import 'package:colonizethis_world/src/world/naval.dart';
 import 'package:colonizethis_world/src/world/player_view.dart';
 import 'package:colonizethis_world/src/world/province_lookup.dart';
@@ -10,7 +11,6 @@ import 'package:colonizethis_world/src/world/topology_helpers.dart';
 import 'incremental_candidate_validator.dart';
 import 'order_resolution_context.dart';
 import 'order_suggestion_context.dart';
-import 'order_suggestion_helpers.dart';
 
 // Naval and diplomatic order-suggestion families share this library's imports
 // and the private [_effectiveOrderResolutionContext] helper below. The naval

--- a/test/check_logic_domain_import_dag_test.dart
+++ b/test/check_logic_domain_import_dag_test.dart
@@ -243,6 +243,36 @@ void noop() {}
     expect(allowlist.where((e) => e.startsWith('diplomacy->ai:')), isEmpty);
   });
 
+  test('diplomacy->orders edge is enforced and fully eliminated (Refs #3290)',
+      () {
+    final forbidden = logicDomainImportForbiddenEdgesForTests();
+    expect(forbidden, contains('diplomacy->orders'));
+
+    final allowlist = logicDomainImportDagGrandfatherAllowlistForTests();
+    expect(allowlist.where((e) => e.startsWith('diplomacy->orders:')), isEmpty);
+  });
+
+  test('fails when a new forbidden diplomacy->orders import appears', () {
+    final temp = Directory.systemTemp.createTempSync('logic_dag_dipl_orders_');
+    addTearDown(() => temp.deleteSync(recursive: true));
+
+    File(
+      '${temp.path}/packages/colonizethis_logic/lib/src/diplomacy/bad_orders.dart',
+    )
+      ..createSync(recursive: true)
+      ..writeAsStringSync("""
+import '../orders/order_suggestion_helpers.dart';
+void noop() {}
+""");
+
+    final code = runCheckLogicDomainImportDag(
+      temp.path,
+      info: (_) {},
+      err: (_) {},
+    );
+    expect(code, 1);
+  });
+
   test('fails when a new forbidden diplomacy->ai import appears', () {
     final temp = Directory.systemTemp.createTempSync('logic_dag_dipl_ai_');
     addTearDown(() => temp.deleteSync(recursive: true));

--- a/tool/check_logic_domain_import_dag.dart
+++ b/tool/check_logic_domain_import_dag.dart
@@ -64,6 +64,15 @@ const _forbiddenEdges = <(String, String)>{
   // `diplomacy/diplomacy_phase_result.dart`, so `turn` depends on `diplomacy`
   // one-way and `diplomacy` must not import `turn/` (Refs #3290 Phase 0).
   ('diplomacy', 'turn'),
+  // `orders` sits above `diplomacy` (the `colonizethis_orders` package depends
+  // on `colonizethis_diplomacy`), so `diplomacy` must not import `orders/`. The
+  // sole crossing symbol (`knownDiplomaticTargetFactionIds`, used by
+  // `diplomacy/gp_tribe_first_contact.dart`) is a diplomacy-domain visibility
+  // helper; it now lives in `diplomacy/known_diplomatic_targets.dart` and is
+  // re-exported by `order_suggestion_api.dart` / `ai_api.dart`, so the public
+  // surface is preserved and this edge is eliminated and forbidden
+  // (Refs #3290 Phase 2 prerequisite for the colonizethis_diplomacy extraction).
+  ('diplomacy', 'orders'),
   // `ai` (the `colonizethis_ai_contracts` file set) sits above `diplomacy`:
   // after Phase 4 `ai_contracts` depends on `orders`, which depends on
   // `diplomacy`. A `diplomacy -> ai` import would therefore close the cycle

--- a/tool/logic_all_provinces_sanctions.yaml
+++ b/tool/logic_all_provinces_sanctions.yaml
@@ -47,7 +47,7 @@ sanctions:
     issue: https://github.com/waigore/colonizethisv3/issues/2394
 
   - path: packages/colonizethis_logic/lib/src/orders/order_suggestion_helpers.dart
-    line: 139
+    line: 80
     rationale: getProvinceOwnerMap walks all provinces once per diplomacy filter pass.
     spec: SPEC/program/logic-dual-region-province-access.md
     issue: https://github.com/waigore/colonizethisv3/issues/2509


### PR DESCRIPTION
## Summary

Phase 2 prerequisite for the `colonizethis_diplomacy` extraction (epic #3290). `orders` sits above `diplomacy` in the target one-way DAG (`colonizethis_orders` depends on `colonizethis_diplomacy`), so the diplomacy domain must not import `orders/`. This was the **last remaining wrong-direction edge among the seven tracked pairs** that blocks the diplomacy leaf-mid extraction.

The sole crossing symbol was `knownDiplomaticTargetFactionIds` — a diplomacy-domain visibility helper (it derives targetable faction ids from relations, tile visibility, and sea-reachable New World provinces) that happened to live in the orders helpers file. It depends only on `world/`/`models`/`data`/`constants`, so it relocates cleanly into the diplomacy domain.

## Done in this push

- Relocate `knownDiplomaticTargetFactionIds` (behavior-identical) into new `diplomacy/known_diplomatic_targets.dart`.
- Repoint consumers: `diplomacy/gp_tribe_first_contact.dart` imports it intra-domain; `orders/order_suggestion_naval_diplomatic.dart` imports it one-way (`orders -> diplomacy`) and drops its now-unused helpers import.
- Preserve the public surface: `order_suggestion_api.dart` and `ai_api.dart` re-export the symbol from the diplomacy path (the broad `colonizethis_logic` barrel still exposes it transitively). `colonizethis_ai` is unchanged.
- Enforce the boundary: add `('diplomacy','orders')` to `repo.logic_domain_import_dag` forbidden edges with positive + negative tests; document the elimination + AC in `SPEC/program/logic-package-split-phase0.md`.

## Scope / deferred

- Pure structural extraction; **no behavior change**, no new config constants.
- The `colonizethis_diplomacy` package extraction itself (pubspec, workspace member, CI gates, test migration) remains follow-up Phase 2 work.

## Tests

- `dart run tool/check_logic_domain_import_dag.dart` -> no violations.
- `dart test test/check_logic_domain_import_dag_test.dart` -> 20 passed (incl. 2 new `diplomacy->orders` positive/negative tests).
- `dart test` (logic) on `order_suggestion_declare_war_colonial_discovery_test`, `order_suggestion_declare_war_intervention_risk_test`, `order_suggestion_colonial_acquisition_join_empire_or_war_test`, `diplomacy/gp_tribe_first_contact_test` -> all passed (exercise the moved symbol via the public barrel/`ai_api`).
- `dart analyze` of all touched files -> no issues.

## Note on epic PRs

Epic #3290 is delivered as sequential single-slice PRs (each `Refs #3290`). PR #3347 (economy extraction) is currently open and merge-ready; this is an independent edge-break slice that touches disjoint files.

Refs #3290

Made with [Cursor](https://cursor.com)