### PR TITLE
test(ai): localize fabric trade-order offer presence on peasant-recruit path (Refs #2847)

### DIFF
--- a/packages/colonizethis_ai/test/seed42_observer_conquest_s7d_diagnostic_test.dart
+++ b/packages/colonizethis_ai/test/seed42_observer_conquest_s7d_diagnostic_test.dart
@@ -1724,18 +1724,10 @@ void main() {
       final improvementInputCommodityIds = workOrderCostBuildImprovement(
         0,
       ).keys.toSet();
-      final improvementInputOffersEmitted = <String, int>{
-        for (final gpId in gpIds) gpId: 0,
-      };
-      final improvementInputBidsEmitted = <String, int>{
-        for (final gpId in gpIds) gpId: 0,
-      };
-      final improvementInputDealsAsBuyer = <String, int>{
-        for (final gpId in gpIds) gpId: 0,
-      };
-      final improvementInputHeldAtTurn99 = <String, int>{
-        for (final gpId in gpIds) gpId: 0,
-      };
+      final improvementInputOffersEmitted = zeroPerGpCounter(gpIds);
+      final improvementInputBidsEmitted = zeroPerGpCounter(gpIds);
+      final improvementInputDealsAsBuyer = zeroPerGpCounter(gpIds);
+      final improvementInputHeldAtTurn99 = zeroPerGpCounter(gpIds);
 
       // Refs #2847 H8-extraction castIron residual localization (post-#3241).
       // The level-0 `build_improvement` material is `lumber + castIron`. #3241
@@ -1777,27 +1769,13 @@ void main() {
         ProductionRecipesCatalog.fabricFromWool.id,
         ProductionRecipesCatalog.fabricFromCotton.id,
       };
-      final fabricProductionAssignedTurns = <String, int>{
-        for (final gpId in gpIds) gpId: 0,
-      };
-      final castIronFeedstockBidsEmitted = <String, int>{
-        for (final gpId in gpIds) gpId: 0,
-      };
-      final castIronFeedstockOffersEmitted = <String, int>{
-        for (final gpId in gpIds) gpId: 0,
-      };
-      final castIronFeedstockDealsAsBuyer = <String, int>{
-        for (final gpId in gpIds) gpId: 0,
-      };
-      final castIronProductionAssignedTurns = <String, int>{
-        for (final gpId in gpIds) gpId: 0,
-      };
-      final lumberHeldAtTurn99 = <String, int>{
-        for (final gpId in gpIds) gpId: 0,
-      };
-      final castIronHeldAtTurn99 = <String, int>{
-        for (final gpId in gpIds) gpId: 0,
-      };
+      final fabricProductionAssignedTurns = zeroPerGpCounter(gpIds);
+      final castIronFeedstockBidsEmitted = zeroPerGpCounter(gpIds);
+      final castIronFeedstockOffersEmitted = zeroPerGpCounter(gpIds);
+      final castIronFeedstockDealsAsBuyer = zeroPerGpCounter(gpIds);
+      final castIronProductionAssignedTurns = zeroPerGpCounter(gpIds);
+      final lumberHeldAtTurn99 = zeroPerGpCounter(gpIds);
+      final castIronHeldAtTurn99 = zeroPerGpCounter(gpIds);
       // Refs #2847 H8-extraction supplier feedstock: per-GP count of turns the
       // supplier-side castIron feedstock extraction gate is active
       // (`supplierImprovementInputFeedstockExtractionResourceIds` non-empty) —

--- a/packages/colonizethis_ai/test/seed42_observer_conquest_s7d_diagnostic_test.dart
+++ b/packages/colonizethis_ai/test/seed42_observer_conquest_s7d_diagnostic_test.dart
@@ -3,6 +3,8 @@ import 'dart:convert';
 import 'package:colonizethis_ai/colonizethis_ai.dart';
 import 'package:colonizethis_ai/src/planning/army_conquest_prep.dart'
     show regimentCountForPlayer;
+import 'package:colonizethis_ai/src/planning/cast_iron_labour_gate.dart'
+    show isCastIronLabourPeasantRecruitFabricMarketPathActive;
 import 'package:colonizethis_ai/src/planning/expand_phase_planner.dart'
     show
         cheapestRegimentBuildTreasuryCost,
@@ -2168,6 +2170,16 @@ void main() {
       final castIronMarketOfferAbsentTurns = <String, int>{
         for (final gpId in gpIds) gpId: 0,
       };
+      // Refs #2847 § fabric offer-side split: on peasant-recruit fabric market
+      // path-active turns, whether any *other* faction emitted a `fabric` sell
+      // offer in trade orders (the trade-order emission layer between
+      // offerable-holdings proxy and buyer-side bid/deal counters).
+      final fabricMarketOfferPresentTurns = <String, int>{
+        for (final gpId in gpIds) gpId: 0,
+      };
+      final fabricMarketOfferAbsentTurns = <String, int>{
+        for (final gpId in gpIds) gpId: 0,
+      };
       // Minimum `labourPerOutput` across the castIron recipes — the cheapest
       // single run's effective-labour requirement, used as the food-starved /
       // population-bound fork threshold above.
@@ -2306,6 +2318,9 @@ void main() {
 
       for (var t = 0; t < 100; t++) {
         final fabricStarvedThisTurn = <String>{};
+        // Refs #2847 § fabric offer-side split: GPs whose castIron-labour
+        // peasant-recruit fabric market path is active this turn.
+        final fabricMarketPathActiveThisTurn = <String>{};
         // Refs #2847 § castIron market-supply wall: GPs whose feedstock-
         // extraction gate is active this turn, scanned post-merge for castIron
         // market-offer presence/absence.
@@ -2616,6 +2631,13 @@ void main() {
               castIronFeedstockIds: castIronFeedstockIds,
               castIronMinLabourPerOutput: castIronMinLabourPerOutput,
             );
+            if (isCastIronLabourPeasantRecruitFabricMarketPathActive(
+              game: game,
+              playerId: gpId,
+              projected: player.stockpile,
+            )) {
+              fabricMarketPathActiveThisTurn.add(gpId);
+            }
             recordSeed42S7dCastIronLabourCounters(
               game: game,
               gpId: gpId,
@@ -2750,6 +2772,16 @@ void main() {
           tradeOrdersByPlayerId: merged.tradeOrdersByPlayerId,
           emittedTurns: castIronLabourPeasantRecruitFabricBidEmittedTurns,
           absentTurns: castIronLabourPeasantRecruitFabricBidAbsentTurns,
+        );
+
+        // Refs #2847 § fabric offer-side split: on peasant-recruit fabric
+        // market-path-active turns, record whether any other faction offered
+        // `fabric` in trade orders this turn.
+        recordSeed42S7dFabricMarketOfferCounters(
+          fabricMarketPathActiveThisTurn: fabricMarketPathActiveThisTurn,
+          tradeOrdersByPlayerId: merged.tradeOrdersByPlayerId,
+          presentTurns: fabricMarketOfferPresentTurns,
+          absentTurns: fabricMarketOfferAbsentTurns,
         );
 
         // Refs #2847 § castIron market-supply wall: on the feedstock-extraction
@@ -2994,6 +3026,8 @@ void main() {
             castIronLabourPeasantRecruitFabricDealAsBuyerTurns,
         'gpCastIronMarketOfferPresentTurns': castIronMarketOfferPresentTurns,
         'gpCastIronMarketOfferAbsentTurns': castIronMarketOfferAbsentTurns,
+        'gpFabricMarketOfferPresentTurns': fabricMarketOfferPresentTurns,
+        'gpFabricMarketOfferAbsentTurns': fabricMarketOfferAbsentTurns,
         'gpCastIronFeedstockExtractionLabourFutileTurns':
             castIronFeedstockExtractionLabourFutileTurns,
         'castIronMinLabourPerOutput': castIronMinLabourPerOutput,

--- a/packages/colonizethis_ai/test/seed42_s7d_feedstock_helpers_test.dart
+++ b/packages/colonizethis_ai/test/seed42_s7d_feedstock_helpers_test.dart
@@ -666,4 +666,76 @@ void main() {
       expect(absent['gp4'], 0);
     });
   });
+
+  group('recordSeed42S7dFabricMarketOfferCounters (Refs #2847)', () {
+    final fabricId = CommodityCatalog.fabric.id;
+
+    TradeOrder offer(String id) => TradeOrder(
+      commodityId: id,
+      type: TradeOrderType.offer,
+      quantity: 1,
+      priority: 1,
+    );
+    TradeOrder bid(String id) => TradeOrder(
+      commodityId: id,
+      type: TradeOrderType.bid,
+      quantity: 1,
+      priority: 1,
+    );
+
+    test(
+      'positive: another faction offers fabric => present bumped, absent not',
+      () {
+        final present = <String, int>{'gp3': 0};
+        final absent = <String, int>{'gp3': 0};
+        recordSeed42S7dFabricMarketOfferCounters(
+          fabricMarketPathActiveThisTurn: {'gp3'},
+          tradeOrdersByPlayerId: {
+            'gp1': [offer(fabricId)],
+            'gp3': [bid(fabricId)],
+          },
+          presentTurns: present,
+          absentTurns: absent,
+        );
+        expect(present['gp3'], 1);
+        expect(absent['gp3'], 0);
+      },
+    );
+
+    test(
+      'negative: no other faction offers fabric => absent bumped, present not',
+      () {
+        final present = <String, int>{'gp3': 0};
+        final absent = <String, int>{'gp3': 0};
+        recordSeed42S7dFabricMarketOfferCounters(
+          fabricMarketPathActiveThisTurn: {'gp3'},
+          tradeOrdersByPlayerId: {
+            'gp3': [offer(fabricId)],
+            'gp1': [bid(fabricId)],
+            'gp2': [offer(CommodityCatalog.timber.id)],
+          },
+          presentTurns: present,
+          absentTurns: absent,
+        );
+        expect(present['gp3'], 0);
+        expect(absent['gp3'], 1);
+      },
+    );
+
+    test('gates strictly on the active set — inactive GPs are untouched', () {
+      final present = <String, int>{'gp3': 0, 'gp5': 0};
+      final absent = <String, int>{'gp3': 0, 'gp5': 0};
+      recordSeed42S7dFabricMarketOfferCounters(
+        fabricMarketPathActiveThisTurn: {'gp3'},
+        tradeOrdersByPlayerId: {
+          'gp2': [offer(fabricId)],
+        },
+        presentTurns: present,
+        absentTurns: absent,
+      );
+      expect(present['gp3'], 1);
+      expect(present['gp5'], 0);
+      expect(absent['gp5'], 0);
+    });
+  });
 }

--- a/packages/colonizethis_ai/test/support/seed42_s7d_feedstock_helpers.dart
+++ b/packages/colonizethis_ai/test/support/seed42_s7d_feedstock_helpers.dart
@@ -1076,6 +1076,51 @@ void recordSeed42S7dCastIronMarketOfferCounters({
   }
 }
 
+/// Records `fabric` market-offer presence/absence for the S7-D peasant-recruit
+/// fabric localization (Refs #2847 § fabric offer-side split).
+///
+/// On each gp whose castIron-labour peasant-recruit fabric market path is
+/// active this turn ([fabricMarketPathActiveThisTurn]), scans
+/// [tradeOrdersByPlayerId] for any *other* faction emitting a `fabric` offer
+/// and bumps [presentTurns] when one exists, else [absentTurns].
+///
+/// Complements [otherGreatPowerFabricHeld] (gross holdings) and
+/// [otherGreatPowerOfferableFabricHeld] (planner-scope offerable proxy): a
+/// positive holdings / offerable total with a flat-zero [presentTurns] across
+/// the run localizes the closed market door to the **trade-order emission**
+/// layer (holders retain `fabric` in stockpile but never emit a sell offer)
+/// rather than to buyer-side bid/match. Read-only over the supplied maps except
+/// the counter bumps; extracted to keep the diagnostic test file at or below
+/// the repo non-comment line limit.
+void recordSeed42S7dFabricMarketOfferCounters({
+  required Set<String> fabricMarketPathActiveThisTurn,
+  required Map<String, List<TradeOrder>> tradeOrdersByPlayerId,
+  required Map<String, int> presentTurns,
+  required Map<String, int> absentTurns,
+}) {
+  const fabricCommodityId = 'fabric';
+  for (final gpId in fabricMarketPathActiveThisTurn) {
+    var offeredByOther = false;
+    for (final entry in tradeOrdersByPlayerId.entries) {
+      if (entry.key == gpId) continue;
+      final offeredFabric = entry.value.any(
+        (order) =>
+            order.type == TradeOrderType.offer &&
+            order.commodityId == fabricCommodityId,
+      );
+      if (offeredFabric) {
+        offeredByOther = true;
+        break;
+      }
+    }
+    if (offeredByOther) {
+      bumpCounter(presentTurns, gpId);
+    } else {
+      bumpCounter(absentTurns, gpId);
+    }
+  }
+}
+
 /// True iff [playerId] owns at least one idle Builder for which the work-order
 /// engine **accepts** a `build_improvement` on an owned unimproved feedstock
 /// tile (a member of [feedstockIds]) — i.e. `getValidWorkOrderTileKeys` (the

--- a/packages/colonizethis_ai/test/support/seed42_s7d_feedstock_helpers.dart
+++ b/packages/colonizethis_ai/test/support/seed42_s7d_feedstock_helpers.dart
@@ -373,6 +373,16 @@ bool castIronFeedstockExtractionLabourFutile(
 void bumpCounter(Map<String, int> counter, String key) =>
     counter[key] = (counter[key] ?? 0) + 1;
 
+/// Builds a fresh zero-initialised per-GP `<String, int>` diagnostic counter
+/// map keyed by every id in [gpIds]. Shared by the S7-D diagnostic to keep its
+/// many counter declarations to a single line each (the inline
+/// `{for (final gpId in gpIds) gpId: 0}` literal otherwise wraps to three
+/// physical lines per counter, pushing the test file over the repo non-comment
+/// line limit).
+Map<String, int> zeroPerGpCounter(List<String> gpIds) => {
+  for (final gpId in gpIds) gpId: 0,
+};
+
 /// Per-turn castIron-labour stage-localization measurement for one GP (Refs
 /// #2847). Pure read-only over `(game, playerId)`: bundles the boolean flags
 /// the S7-D diagnostic increments each turn so the caller only applies counter


### PR DESCRIPTION
## Summary

- **Fabric offer-side localization (Refs #2847):** Adds `gpFabricMarketOfferPresentTurns` / `gpFabricMarketOfferAbsentTurns` counters to the S7-D diagnostic, gated on `isCastIronLabourPeasantRecruitFabricMarketPathActive` turns. Completes the offer-side split chain: gross holdings (`otherGreatPowerFabricHeld`) → offerable proxy (`otherGreatPowerOfferableFabricHeld`) → **trade-order emission** (this slice) → buyer bid/deal counters.
- **H7 peace slice attempted and rejected:** `criticalWeakGpSurvivalPeaceTargetsForProduction` was prototyped but regressed the gp6 +10 baseline to +4 (gp5 improved -7→-1 at gp6's expense). Not included in this PR.

## Deferred

- Behaviour lever for gp3/gp5 still blocked on rules-level raw-labour bootstrap or world-market fabric-purchase path (documented in regression-test skip reason).
- Full S7-D diagnostic re-run with new counters not executed in this run (instrumentation only; no behaviour change).

## Test plan

- [x] `dart test test/seed42_s7d_feedstock_helpers_test.dart` — 43/43 pass (3 new fabric-offer counter tests: positive, negative, gate boundary)
- [x] Baseline gate unchanged: `{gp1: 6, gp2: 6, gp3: 0, gp4: 3, gp5: -7, gp6: 10}` (read-only slice; no behaviour change)

Refs #2847 (does not close — diagnostic instrumentation slice)

Made with [Cursor](https://cursor.com)