### PR TITLE
refactor(logic): decouple diplomacy/dossier logging from logicLog (Refs #3290)

### DIFF
--- a/SPEC/program/logic-package-split-phase0.md
+++ b/SPEC/program/logic-package-split-phase0.md
@@ -224,6 +224,20 @@ The monolith `constants.dart` re-exports `GamePlayerLookup` and region ids from 
 
 `dossier/` folds into `colonizethis_diplomacy` at extraction; decoupling from `constants.dart` is a Phase 2 prerequisite so the new package depends only on `colonizethis_world`, `colonizethis_combat`, `colonizethis_models`, `colonizethis_data`, and `colonizethis_logger`. Enforced by `test/check_logic_domain_import_dag_test.dart` (no `../constants.dart` under `diplomacy/` or `dossier/`).
 
+### `diplomacy` / `dossier` logging decoupling from `logicLog`
+
+**Wrong:** `diplomacy` / `dossier` → `colonizethis_logic` core logging (3 files, eliminated)
+
+Three files logged via the `colonizethis_logic` core `logicLog` (`CtLogger('logic')`), which would force the future `colonizethis_diplomacy` package to depend on the thin logic core just for logging. The fix introduces a single diplomacy-domain logger `diploLog` (`CtLogger('diplomacy')`) in `diplomacy/diplomacy_logging.dart`, mirroring the one-logger-per-package convention already used by `combatLog` (`combat:`) and `economyLog` (`economy:`). Diplomacy/dossier log lines now carry the `diplomacy:` prefix instead of `logic:`; this is the same prefix migration combat performed at extraction and is the only behavioural change (structural logging move, no logic change).
+
+| Source file | Symbol | Before | After |
+|-------------|--------|--------|-------|
+| `diplomacy/diplomacy_resolver.dart` | `diploLog` | `final diploLog = logicLog;` (imports `src/logging.dart`) | imports + re-exports `diplomacy/diplomacy_logging.dart` (`diploLog`) |
+| `diplomacy/ftp_resolver.dart` | `logicLog.i` | imports `../logging.dart` | `diploLog.i` from `diplomacy_logging.dart` (redundant inline `logic:` prefix dropped) |
+| `dossier/evidence_rules.dart` | `logicLog.d` | imports `src/logging.dart` | `diploLog.d` from `../diplomacy/diplomacy_logging.dart` |
+
+All other diplomacy files (`alliance_resolver.dart`, `overture_resolver.dart`, `war_resolver.dart`, `intervention_resolver_call_to_arms.dart`, `diplomacy_subsidies_relations_resolver.dart`) already consumed `diploLog` via `diplomacy_resolver.dart`; the re-export keeps them unchanged. Enforced by `test/check_logic_domain_import_dag_test.dart` (no `src/logging.dart`, `package_logger.dart`, `../logging.dart`, `../package_logger.dart`, or the `colonizethis_logic` barrel under `diplomacy/` or `dossier/`).
+
 ## Phase 1 slice — `colonizethis_combat` (Refs #3290 C1)
 
 **Given** the `colonizethis_world` leaf on `dev`, **when** the `colonizethis_combat` package is extracted, **then**:

--- a/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_logging.dart
+++ b/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_logging.dart
@@ -1,0 +1,16 @@
+/// Diplomacy-domain logging entrypoint (Refs #3290 C2 prerequisite).
+///
+/// Decoupled from the `colonizethis_logic` `logicLog` so the `diplomacy/` and
+/// `dossier/` source trees move cleanly into `colonizethis_diplomacy` without a
+/// dependency on the thin logic core. One logger instance with the distinct
+/// `diplomacy` prefix, mirroring `combatLog`/`economyLog` in the already-split
+/// leaf packages (per `colonizethis-core-principles` one-logger-per-package
+/// convention).
+library;
+
+import 'package:colonizethis_logger/colonizethis_logger.dart';
+
+export 'package:colonizethis_logger/colonizethis_logger.dart' show CtLogger;
+
+/// Shared package-level [CtLogger] for `diplomacy/` and `dossier/` source files.
+final diploLog = CtLogger('diplomacy');

--- a/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_resolver.dart
@@ -5,10 +5,10 @@
 /// relation modifiers, score update.
 library;
 
-import 'package:colonizethis_logic/src/logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'package:colonizethis_world/src/game_player_lookup.dart';
+import 'diplomacy_logging.dart';
 import 'diplomacy_phase_result.dart';
 import 'package:colonizethis_world/src/world/faction_membership.dart';
 import 'package:colonizethis_world/src/world/province_lookup.dart';
@@ -32,8 +32,7 @@ export 'diplomacy_relation_lookup.dart'
     show ftpPairKeysFromGame, hasEmbassyOverture, hasFtpPartnership;
 export 'intervention_resolver.dart'
     show applyInterventionChoice, needsInterventionChoice;
-
-final diploLog = logicLog;
+export 'diplomacy_logging.dart' show diploLog;
 
 /// Target GP is "nearly defeated" for Join Empire: ≤3 provinces and does not hold its original capital tile province. SPEC/game/diplomacy.md.
 bool isGreatPowerNearlyDefeatedForJoinEmpire(

--- a/packages/colonizethis_logic/lib/src/diplomacy/ftp_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/diplomacy/ftp_resolver.dart
@@ -2,7 +2,7 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'package:colonizethis_world/src/game_player_lookup.dart';
 import '../dossier/evidence_rules.dart';
-import '../logging.dart';
+import 'diplomacy_logging.dart';
 import 'diplomacy_phase_result.dart';
 import 'diplomacy_relation_lookup.dart';
 import 'diplomacy_resolver.dart' show DiplomacyFactionMembership;
@@ -78,7 +78,7 @@ Game _addFtpPartnership(
     toFactionId: targetGpId,
     wasAiInitiator: isAiControlledForEvidence(next, proposerGpId),
   );
-  logicLog.i('logic: diplomacy ftp formed $proposerGpId-$targetGpId');
+  diploLog.i('diplomacy ftp formed $proposerGpId-$targetGpId');
   return next;
 }
 
@@ -110,8 +110,8 @@ Game clearFtpPartnerships(
       reason: reason,
     );
   }
-  logicLog.i(
-    'logic: diplomacy ftp cleared count=${keysToRemove.length} reason=$reason',
+  diploLog.i(
+    'diplomacy ftp cleared count=${keysToRemove.length} reason=$reason',
   );
   return next;
 }

--- a/packages/colonizethis_logic/lib/src/dossier/evidence_rules.dart
+++ b/packages/colonizethis_logic/lib/src/dossier/evidence_rules.dart
@@ -2,10 +2,10 @@
 // When diplomatic (or other) actions are applied, evidence rules add suspicion points per agenda type.
 // Evidence is stored per (observer, subject, agenda type); only human observers receive entries.
 
-import 'package:colonizethis_logic/src/logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'package:colonizethis_world/src/game_player_lookup.dart';
+import '../diplomacy/diplomacy_logging.dart';
 import '../diplomacy/diplomacy_relation_lookup.dart';
 
 /// Human Great Power ids (observers for whom we store evidence).
@@ -117,7 +117,7 @@ List<DossierEvidenceEntry> evidenceForDeclareWar(
     }
   }
   if (entries.isNotEmpty) {
-    logicLog.d(
+    diploLog.d(
       'evidence for declareWar actor=$actorGpId target=$targetFactionId entries=${entries.length}',
     );
   }
@@ -148,7 +148,7 @@ List<DossierEvidenceEntry> evidenceForOfferPeace(
       ),
     );
   }
-  logicLog.d(
+  diploLog.d(
     'evidence for offerPeace actor=$actorGpId target=$targetFactionId entries=${entries.length}',
   );
   return entries;
@@ -186,7 +186,7 @@ List<DossierEvidenceEntry> evidenceForLandBattleVictory(
     );
   }
   if (entries.isNotEmpty) {
-    logicLog.d(
+    diploLog.d(
       'evidence for land battle victory victor=$victorGpId defender=$defenderFactionId entries=${entries.length}',
     );
   }
@@ -218,7 +218,7 @@ List<DossierEvidenceEntry> evidenceForNavalBattleVictory(
     );
   }
   if (entries.isNotEmpty) {
-    logicLog.d(
+    diploLog.d(
       'evidence for naval battle victory victor=$victorOwnerId loser=$loserOwnerId entries=${entries.length}',
     );
   }
@@ -330,7 +330,7 @@ List<DossierEvidenceEntry> evidenceForEnvyResearchMirror(
     );
   }
   if (entries.isNotEmpty) {
-    logicLog.d(
+    diploLog.d(
       'evidence envy mirror ai=$aiGpId category=$completedCategory turn=$turnNumber',
     );
   }

--- a/test/check_logic_domain_import_dag_test.dart
+++ b/test/check_logic_domain_import_dag_test.dart
@@ -320,4 +320,45 @@ void noop() {}
       );
     },
   );
+
+  test(
+    'diplomacy and dossier do not import logic core logging (Refs #3290 Phase 2)',
+    () {
+      // The diplomacy/dossier trees fold into colonizethis_diplomacy, which must
+      // depend only on world/combat/models/data/logger — not on the thin
+      // colonizethis_logic core. Logging therefore goes through the
+      // diplomacy-domain logger (diploLog), not the logic-core logicLog.
+      const forbiddenLoggingImports = <String>[
+        "import 'package:colonizethis_logic/src/logging.dart';",
+        "import 'package:colonizethis_logic/package_logger.dart';",
+        "import '../logging.dart';",
+        "import '../package_logger.dart';",
+        "import 'package:colonizethis_logic/colonizethis_logic.dart';",
+      ];
+      final violations = <String>[];
+      for (final domain in ['diplomacy', 'dossier']) {
+        final domainDir = Directory(
+          'packages/colonizethis_logic/lib/src/$domain',
+        );
+        if (!domainDir.existsSync()) continue;
+        for (final entity in domainDir.listSync(recursive: true)) {
+          if (entity is! File || !entity.path.endsWith('.dart')) continue;
+          final content = entity.readAsStringSync();
+          for (final bad in forbiddenLoggingImports) {
+            if (content.contains(bad)) {
+              violations.add('${entity.path}: $bad');
+            }
+          }
+        }
+      }
+      expect(
+        violations,
+        isEmpty,
+        reason:
+            'diplomacy/dossier must log via the diplomacy-domain logger '
+            '(diploLog in diplomacy/diplomacy_logging.dart), not the '
+            'colonizethis_logic core logicLog',
+      );
+    },
+  );
 }


### PR DESCRIPTION
## Summary

Phase 2 prerequisite for the `colonizethis_diplomacy` extraction (Refs #3290 C2). Three `diplomacy/`/`dossier/` files logged via the `colonizethis_logic` core `logicLog` (`CtLogger('logic')`), which would force the future `colonizethis_diplomacy` package to depend on the thin logic core just for logging.

This slice introduces a single diplomacy-domain logger `diploLog` (`CtLogger('diplomacy')`) in `diplomacy/diplomacy_logging.dart`, mirroring the one-logger-per-package convention already used by `combatLog` (`combat:`) and `economyLog` (`economy:`).

## Done in this push

- **New `diplomacy/diplomacy_logging.dart`** — one `diploLog` instance, distinct `diplomacy` prefix, imports `colonizethis_logger` directly (no logic-core dependency).
- **`diplomacy_resolver.dart`** — drops `final diploLog = logicLog;` and the `src/logging.dart` import; imports + re-exports `diploLog` from `diplomacy_logging.dart`, so the five sibling files that consume `diploLog` via `diplomacy_resolver.dart` are unchanged.
- **`ftp_resolver.dart`** — `logicLog.i` → `diploLog.i`; redundant inline `logic:` message prefix dropped.
- **`dossier/evidence_rules.dart`** — `logicLog.d` → `diploLog.d` (5 call sites) via `../diplomacy/diplomacy_logging.dart` (an existing, allowed `dossier → diplomacy` edge).
- **DAG-test guard** in `test/check_logic_domain_import_dag_test.dart` forbidding `src/logging.dart`, `package_logger.dart`, `../logging.dart`, `../package_logger.dart`, and the logic barrel under `diplomacy/`/`dossier/`.
- **SPEC** `SPEC/program/logic-package-split-phase0.md` documents the eliminated edge.

## Behavioural note

Diplomacy/dossier log lines now carry the `diplomacy:` prefix instead of `logic:`. This is the same prefix migration combat performed at extraction (SPEC § combat slice) and is the only behavioural change — a structural logging move, no game logic change.

## Deferred (follow-up PRs on same issue)

- Full `colonizethis_diplomacy` package extraction (move source files, relocate tests, add `repo.diplomacy_no_logic_deps` gate, wire CI test-plan).

## Tests

- [x] `dart test test/check_logic_domain_import_dag_test.dart` — 22/22 pass (incl. new logging guard)
- [x] `dart test test/diplomacy test/dossier` (in `colonizethis_logic`) — 37/37 pass; output confirms `diplomacy:` prefix
- [x] `dart analyze packages/colonizethis_logic/lib/src/diplomacy lib/src/dossier` — clean (no new issues)

Refs #3290 (does not close — incremental Phase 2 prerequisite slice).

Made with [Cursor](https://cursor.com)