### PR TITLE
refactor: decouple orders logging from logicLog (#3290)

### DIFF
--- a/packages/colonizethis_logic/lib/src/orders/order_engine.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_engine.dart
@@ -1,5 +1,4 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/src/logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'package:colonizethis_diplomacy/src/diplomacy/diplomacy_resolver.dart';
@@ -10,6 +9,7 @@ import 'package:colonizethis_world/src/world/unit_lookup.dart';
 import '../constants.dart';
 import 'order_resolution_context.dart';
 import 'order_validation_result.dart';
+import 'orders_logging.dart';
 export 'order_validation_result.dart';
 import 'package:colonizethis_economy/src/economy/world_market/trade_order_validator.dart';
 import 'unit_type_helpers.dart';
@@ -126,7 +126,7 @@ class OrderEngine with _OrderEngineGeneratedOrderMethods {
     Map<String, TileMapResult>? tileMapByRegion,
   }) {
     _appendOrder(playerId, order, getter, updater);
-    logicLog.d('validating orders with context player=$playerId');
+    ordersLog.d('validating orders with context player=$playerId');
     final results = validatePlayerOrdersWithContext(
       game,
       topology,
@@ -142,7 +142,7 @@ class OrderEngine with _OrderEngineGeneratedOrderMethods {
       // cascade rejections ("Previous invalid"), while preserving first-cause
       // rejection logging for debugging. Refs #2237 AC3.
       if (r.reason != previousInvalidOrderResult.reason) {
-        logicLog.w(
+        ordersLog.w(
           '$orderLabel order rejected player=$playerId reason=${r.reason}',
         );
       }
@@ -312,7 +312,7 @@ class OrderEngine with _OrderEngineGeneratedOrderMethods {
   }) {
     final tileMaps = tileMapByRegion ?? <String, TileMapResult>{};
     if (tileMaps.isEmpty) {
-      logicLog.d(
+      ordersLog.d(
         'projectedEffects called with no tileMapByRegion; expected extraction will be zero',
       );
     }

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion_api_impl.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion_api_impl.dart
@@ -1,5 +1,5 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/src/logging.dart';
+import 'orders_logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart' show GamePlayerLookup;
@@ -26,7 +26,7 @@ class DefaultOrderSuggestionAPI implements OrderSuggestionAPI {
     MapTopology topology,
     Orders currentOrders,
   ) {
-    logicLog.d(
+    ordersLog.d(
       'order suggestion API suggestMoveOrders player=${view.playerId} turn=${game.worldState.turnState.turnNumber}',
     );
     return suggestion.suggestMoveOrders(view, game, topology, currentOrders);
@@ -39,7 +39,7 @@ class DefaultOrderSuggestionAPI implements OrderSuggestionAPI {
     MapTopology topology,
     Orders currentOrders,
   ) {
-    logicLog.d(
+    ordersLog.d(
       'order suggestion API suggestArmyMoveOrders player=${view.playerId}',
     );
     return suggestion.suggestArmyMoveOrders(
@@ -58,7 +58,7 @@ class DefaultOrderSuggestionAPI implements OrderSuggestionAPI {
     Orders currentOrders, {
     Map<String, TileMapResult>? tileMapByRegion,
   }) {
-    logicLog.d(
+    ordersLog.d(
       'order suggestion API suggestWorkOrders player=${view.playerId}',
     );
     return suggestion.suggestWorkOrders(
@@ -77,7 +77,7 @@ class DefaultOrderSuggestionAPI implements OrderSuggestionAPI {
     MapTopology topology,
     Orders currentOrders,
   ) {
-    logicLog.d(
+    ordersLog.d(
       'order suggestion API suggestBuildOrders player=${view.playerId}',
     );
     return suggestion.suggestBuildOrders(view, game, topology, currentOrders);
@@ -90,7 +90,7 @@ class DefaultOrderSuggestionAPI implements OrderSuggestionAPI {
     MapTopology topology,
     Orders currentOrders,
   ) {
-    logicLog.d(
+    ordersLog.d(
       'order suggestion API suggestRecruitWorkerOrders player=${view.playerId}',
     );
     return suggestion.suggestRecruitWorkerOrders(
@@ -108,7 +108,7 @@ class DefaultOrderSuggestionAPI implements OrderSuggestionAPI {
     MapTopology topology,
     Orders currentOrders,
   ) {
-    logicLog.d(
+    ordersLog.d(
       'order suggestion API suggestResearchOrders player=${view.playerId}',
     );
     return suggestion.suggestResearchOrders(
@@ -127,7 +127,7 @@ class DefaultOrderSuggestionAPI implements OrderSuggestionAPI {
     Orders currentOrders, {
     OrderResolutionContext? resolution,
   }) {
-    logicLog.d(
+    ordersLog.d(
       'order suggestion API suggestNavalMoveOrders player=${view.playerId}',
     );
     return suggestion.suggestNavalMoveOrders(
@@ -147,7 +147,7 @@ class DefaultOrderSuggestionAPI implements OrderSuggestionAPI {
     Orders currentOrders, {
     OrderResolutionContext? resolution,
   }) {
-    logicLog.d(
+    ordersLog.d(
       'order suggestion API suggestNavalMissionOrders player=${view.playerId}',
     );
     return suggestion.suggestNavalMissionOrders(
@@ -167,7 +167,7 @@ class DefaultOrderSuggestionAPI implements OrderSuggestionAPI {
     Orders currentOrders, {
     Map<String, TileMapResult>? tileMapByRegion,
   }) {
-    logicLog.d(
+    ordersLog.d(
       'order suggestion API suggestDiplomaticOrders player=${view.playerId}',
     );
     return suggestion.suggestDiplomaticOrders(
@@ -187,7 +187,7 @@ class DefaultOrderSuggestionAPI implements OrderSuggestionAPI {
     Orders currentOrders, {
     Map<String, TileMapResult>? tileMapByRegion,
   }) {
-    logicLog.d(
+    ordersLog.d(
       'order suggestion API suggestDeclareWarOrders player=${view.playerId}',
     );
     return suggestion.suggestDeclareWarOrders(
@@ -205,7 +205,7 @@ class DefaultOrderSuggestionAPI implements OrderSuggestionAPI {
     Game game, {
     TradeSuggestionContext? contextOverride,
   }) {
-    logicLog.d(
+    ordersLog.d(
       'order suggestion API suggestTradeOrders player=${view.playerId}',
     );
     if (contextOverride != null) {

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion_context.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion_context.dart
@@ -1,15 +1,15 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/src/logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'package:colonizethis_diplomacy/src/diplomacy/diplomacy_resolver.dart';
 import 'package:colonizethis_world/src/world/player_view.dart';
 import 'incremental_candidate_validator.dart';
 import 'order_resolution_context.dart';
+import 'orders_logging.dart';
 
 export 'package:colonizethis_diplomacy/src/diplomacy/overture_stage_helpers.dart';
 
-final orderSuggestionLog = packageLogger('order_suggestion');
+final orderSuggestionLog = CtLogger('orders.order_suggestion');
 
 bool _orderSuggestionTrackWorkOrderAcceptanceProbes = false;
 int _orderSuggestionWorkOrderAcceptanceProbeCount = 0;

--- a/packages/colonizethis_logic/lib/src/orders/orders_application_context.dart
+++ b/packages/colonizethis_logic/lib/src/orders/orders_application_context.dart
@@ -1,5 +1,4 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/src/logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'package:colonizethis_world/src/trace/turn_trace_runtime.dart';
@@ -7,7 +6,9 @@ import 'package:colonizethis_world/src/world/army_ids.dart';
 import 'package:colonizethis_world/src/world/army_movement.dart';
 import 'package:colonizethis_world/src/world/game_world_mutations.dart';
 
-final ordersApplicationLog = logicLog;
+import 'orders_logging.dart';
+
+final ordersApplicationLog = ordersLog;
 
 /// Counter-spy: per-turn kill chance = (friendlySpies * [counterSpyKillChancePercentPerSpy])%,
 /// capped at [counterSpyKillChanceCapPercent]%. SPEC: work order resolution.

--- a/packages/colonizethis_logic/lib/src/orders/orders_logging.dart
+++ b/packages/colonizethis_logic/lib/src/orders/orders_logging.dart
@@ -1,0 +1,16 @@
+/// Orders-domain logging entrypoint (Refs #3290 C2 prerequisite).
+///
+/// Decoupled from the `colonizethis_logic` `logicLog` so the `orders/` source
+/// tree moves cleanly into a future `colonizethis_orders` package without a
+/// dependency on the thin logic core. One logger instance with the distinct
+/// `orders` prefix, mirroring `setupLog`/`diploLog`/`combatLog`/`economyLog`
+/// in the already-split packages (per `colonizethis-core-principles`
+/// one-logger-per-package convention).
+library;
+
+import 'package:colonizethis_logger/colonizethis_logger.dart';
+
+export 'package:colonizethis_logger/colonizethis_logger.dart' show CtLogger;
+
+/// Shared package-level [CtLogger] for `orders/` source files.
+final ordersLog = CtLogger('orders');

--- a/packages/colonizethis_logic/lib/src/orders/work_handlers/explore_work_handler.dart
+++ b/packages/colonizethis_logic/lib/src/orders/work_handlers/explore_work_handler.dart
@@ -1,4 +1,4 @@
-import 'package:colonizethis_logic/src/logging.dart';
+import '../orders_logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../../constants.dart';
@@ -25,7 +25,7 @@ bool tryApplyExploreWorkOrder({
     if (list.length > maxTiles) maxTiles = list.length;
   }
   final totalTurns = (3 * tilesInP / maxTiles).ceil().clamp(1, 999);
-  logicLog.d(
+  ordersLog.d(
     'work order accepted and assigned unit=${order.unitId} target=explore targetTileKey=$targetTileKey totalTurns=$totalTurns',
   );
   updateUnit(

--- a/packages/colonizethis_logic/lib/src/orders/work_handlers/shared_work_assignment.dart
+++ b/packages/colonizethis_logic/lib/src/orders/work_handlers/shared_work_assignment.dart
@@ -1,5 +1,5 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/src/logging.dart';
+import '../orders_logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../../constants.dart';
@@ -15,7 +15,7 @@ bool tryAssignFixedDurationWorkOrder({
 }) {
   if (!isWorkOrderTargetAllowedForUnitType(unit.type, target)) return false;
   if (unit.currentWork != null || targetTileKey.isEmpty) return false;
-  logicLog.d(
+  ordersLog.d(
     'work order accepted and assigned unit=${order.unitId} target=$target targetTileKey=$targetTileKey totalTurns=$totalTurns',
   );
   updateUnit(

--- a/packages/colonizethis_logic/lib/src/orders/work_handlers/standard_work_handler.dart
+++ b/packages/colonizethis_logic/lib/src/orders/work_handlers/standard_work_handler.dart
@@ -1,5 +1,5 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/src/logging.dart';
+import '../orders_logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../../constants.dart';
@@ -164,7 +164,7 @@ bool applyStandardWorkOrder({
 
   deductMaterialCost(cost);
   final totalTurns = config.totalTurnsFn();
-  logicLog.d(
+  ordersLog.d(
     'work order accepted and assigned unit=${order.unitId} target=$orderTarget targetTileKey=$targetTileKey totalTurns=$totalTurns',
   );
   updateUnit(
@@ -191,13 +191,13 @@ bool shouldSkipBuildFortForMissingTech({
 }) {
   final fortLevel = province?.fortLevel ?? 0;
   if (fortLevel == 1 && techUnlocked?[kTechIdMineEngineering] != true) {
-    logicLog.d(
+    ordersLog.d(
       'build_fort skipped - Mine Engineering required for fort level 2',
     );
     return true;
   }
   if (fortLevel == 2 && techUnlocked?[kTechIdModernForts] != true) {
-    logicLog.d('build_fort skipped - Modern Forts required for fort level 3');
+    ordersLog.d('build_fort skipped - Modern Forts required for fort level 3');
     return true;
   }
   return false;
@@ -214,7 +214,7 @@ bool shouldSkipBuildRailForInvalidTerrainOrTech({
     terrain: terrain,
   );
   if (railReason == null) return false;
-  logicLog.d('build_rail skipped - $railReason');
+  ordersLog.d('build_rail skipped - $railReason');
   return true;
 }
 

--- a/packages/colonizethis_logic/test/orders/orders_logging_test.dart
+++ b/packages/colonizethis_logic/test/orders/orders_logging_test.dart
@@ -1,0 +1,85 @@
+// Refs #3290 C2 prerequisite — orders-domain logging decoupling.
+//
+// Pins the contract that the `orders/` source tree uses a dedicated `ordersLog`
+// (`CtLogger('orders')`) instead of the thin-core `logicLog`, so the tree can
+// move into a future `colonizethis_orders` package without a dependency on the
+// `colonizethis_logic` core. Mirrors `setup/setup_logging_test.dart` and
+// `package_logger_shared_test.dart`.
+
+import 'dart:io';
+
+import 'package:colonizethis_logic/src/orders/order_suggestion_context.dart';
+import 'package:colonizethis_logic/src/orders/orders_application_context.dart';
+import 'package:colonizethis_logic/src/orders/orders_logging.dart';
+import 'package:colonizethis_test/test.dart';
+import 'package:logger/logger.dart' show Level, LogEvent, Logger;
+
+void main() {
+  group('ordersLog (Refs #3290 C2)', () {
+    test('ordersLog is a CtLogger with the distinct `orders` prefix', () {
+      expect(ordersLog, isA<CtLogger>());
+      expect(ordersLog.prefix, equals('orders'));
+    });
+
+    test('ordersLog is the single shared instance for the orders domain', () {
+      expect(identical(ordersLog, ordersLog), isTrue);
+    });
+
+    test('ordersApplicationLog is an alias of the shared ordersLog', () {
+      expect(identical(ordersApplicationLog, ordersLog), isTrue);
+    });
+
+    test('orderSuggestionLog is rooted under the `orders` domain prefix', () {
+      expect(orderSuggestionLog, isA<CtLogger>());
+      expect(orderSuggestionLog.prefix, equals('orders.order_suggestion'));
+    });
+
+    test('ordersLog emits messages with the `orders:` prefix', () {
+      final captured = <LogEvent>[];
+      void listener(LogEvent e) => captured.add(e);
+      Logger.addLogListener(listener);
+      final priorLevel = Logger.level;
+      Logger.level = Level.debug;
+      try {
+        ordersLog.i('orders_logger_smoke');
+      } finally {
+        Logger.removeLogListener(listener);
+        Logger.level = priorLevel;
+      }
+      final messages = captured
+          .map((e) => e.message?.toString() ?? '')
+          .toList();
+      expect(
+        messages.any((m) => m.contains('orders: orders_logger_smoke')),
+        isTrue,
+        reason: 'expected at least one log entry prefixed with "orders: "',
+      );
+    });
+
+    test('no lib/src/orders source consumes the core logicLog', () {
+      final ordersDir = Directory('lib/src/orders');
+      expect(
+        ordersDir.existsSync(),
+        isTrue,
+        reason: 'expected orders source directory at lib/src/orders',
+      );
+      final offenders = <String>[];
+      for (final entity in ordersDir.listSync(recursive: true)) {
+        if (entity is! File || !entity.path.endsWith('.dart')) continue;
+        if (entity.path.endsWith('orders_logging.dart')) continue;
+        final content = entity.readAsStringSync();
+        if (content.contains('colonizethis_logic/src/logging.dart') ||
+            content.contains('logicLog')) {
+          offenders.add(entity.path);
+        }
+      }
+      expect(
+        offenders,
+        isEmpty,
+        reason:
+            'orders/ must use ordersLog (orders_logging.dart), not the core '
+            'logicLog: $offenders',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Phase 2 (C2) prep slice of the `colonizethis_logic` split epic (**Refs #3290**): decouples the `orders/` source tree from the thin logic core's `logicLog` by introducing a dedicated `ordersLog`, so `orders/` can later move into a `colonizethis_orders` package without depending on the logic core. Pure structural extraction prep — **no logic change** (log prefixes shift to the `orders` domain per the one-logger-per-package convention).

This mirrors the already-merged diplomacy logging decouple (#3355) and the setup logging decouple (landed via #3356), and is an independent, non-overlapping slice relative to the in-flight diplomacy/setup coverage PR #3359 (it touches only `lib/src/orders/**` + a new test).

## Done in this push

- New `lib/src/orders/orders_logging.dart` exporting `CtLogger` and defining `final ordersLog = CtLogger('orders')`.
- `ordersApplicationLog` now aliases `ordersLog` (was `logicLog`).
- `orderSuggestionLog` rooted under the `orders` prefix (`orders.order_suggestion`; was `packageLogger('order_suggestion')` → `logic.order_suggestion`).
- `order_engine.dart`, `order_suggestion_api_impl.dart`, and the `work_handlers/` tree switch from `logicLog`/`src/logging.dart` to `ordersLog`/`orders_logging.dart`.
- New structural guard test `test/orders/orders_logging_test.dart` asserting: `ordersLog` prefix/identity, `ordersApplicationLog` alias, `orderSuggestionLog` prefix, `orders:`-prefixed emission, and that **no `orders/` source consumes `logicLog`** (mirrors `setup/setup_logging_test.dart`).

## Verification

- `dart test test/orders` in `colonizethis_logic`: **334 tests pass** (incl. the 6 new guard tests).
- `dart analyze` on `colonizethis_logic`: **0 errors**; analyze issue count unchanged from `dev` baseline (9 pre-existing warnings/info, none introduced by this change).

## Remaining for #3290 (future slices)

`orders/` still couples to the logic core via `../constants.dart` (17), `../projections/` (2), and `../ai/` (1). Those couplings, plus the actual package extraction (`pubspec`, barrel, workspace registration, test migration, per-package coverage gate, `custom_lint`), are deferred to subsequent C2/C3 slices.

Refs #3290

Made with [Cursor](https://cursor.com)