### PR TITLE
refactor(logic): break orders->ai feedstock-bootstrap cost edge (Refs #3290)

### DIFF
--- a/packages/colonizethis_logic/lib/ai_api.dart
+++ b/packages/colonizethis_logic/lib/ai_api.dart
@@ -15,7 +15,7 @@ export 'src/ai/full_ai_civilian_work_ow_feedstock_localization.dart'
         ownsIdleExplorerColocatedWithUnprospectedOldWorldMineralFeedstockTile,
         ownsProspectedOldWorldMineralFeedstockTile,
         suggestsProspectForColocatedMineralEligibleUnprospectedOldWorldFeedstockTile;
-export 'src/ai/full_ai_civilian_work_feedstock_bootstrap.dart'
+export 'src/orders/feedstock_bootstrap_cost.dart'
     show
         feedstockBootstrapBuildImprovementCastIronWaived,
         feedstockBootstrapBuildImprovementEffectiveCost,

--- a/packages/colonizethis_logic/lib/src/orders/feedstock_bootstrap_cost.dart
+++ b/packages/colonizethis_logic/lib/src/orders/feedstock_bootstrap_cost.dart
@@ -1,7 +1,15 @@
+/// Work-order material-cost waivers for the H8 feedstock bootstrap.
+///
+/// Lives in `orders/` because these helpers compute effective `build_improvement`
+/// material cost (consumed by `WorkOrderCostCalculator`); they consume
+/// `feedstock_extraction_targets.dart` from the same domain. Relocated out of
+/// `src/ai/` to keep the orders -> ai import edge one-way. Refs #3290; #2847 § H8.
+library;
+
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
-import '../orders/feedstock_extraction_targets.dart';
+import 'feedstock_extraction_targets.dart';
 
 bool _isFeedstockBootstrapTarget(
   Game game,

--- a/packages/colonizethis_logic/lib/src/orders/validators/work_order_cost_calculator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/validators/work_order_cost_calculator.dart
@@ -1,8 +1,8 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
-import '../../ai/full_ai_civilian_work_feedstock_bootstrap.dart';
 import '../../constants.dart';
+import '../feedstock_bootstrap_cost.dart';
 import 'package:colonizethis_world/src/world/province_lookup.dart';
 
 /// Calculates work order material costs. Reduces duplication between validation and projection.


### PR DESCRIPTION
## Summary

Refs #3290 (Phase-0 bidirectional-edge break, prerequisite for the Phase-2 `colonizethis_orders` extraction).

Eliminates the last `orders -> ai` import edge inside `colonizethis_logic` by relocating the H8 feedstock-bootstrap **cost** helpers from `src/ai/` into the `orders` domain where they belong.

## Done in this push

- `git mv src/ai/full_ai_civilian_work_feedstock_bootstrap.dart -> src/orders/feedstock_bootstrap_cost.dart`. The helpers (`feedstockBootstrapBuildImprovementCastIronWaived`, `…LumberWaived`, `…EffectiveCost`) compute effective `build_improvement` work-order material cost, are consumed by `WorkOrderCostCalculator`, and depend on `orders/feedstock_extraction_targets.dart` — a pure orders concern.
- Updated the moved file's intra-domain import (`../orders/…` -> sibling) and added a file-header note explaining the relocation.
- `orders/validators/work_order_cost_calculator.dart` now imports the sibling `../feedstock_bootstrap_cost.dart` instead of `../../ai/…`.
- `ai_api.dart` re-exports the same three `feedstockBootstrap*` symbols from the new path, so the narrow AI contract surface is byte-for-byte equivalent for `colonizethis_ai` and all tests.

Result: zero `orders -> ai` imports remain; the `ai -> orders` direction is now one-way per the #3290 D1 package-split DAG.

## Scope / behavior

- **Pure structural move**, behavior-preserving (no logic changed). No SPEC change required — the #3290 epic authorizes in-place extraction; the import-graph one-way DAG is an epic AC.
- Deferred (remainder of #3290): Phase-2 `colonizethis_orders` package extraction, Phase-3 `colonizethis_turn`, Phase-4 `colonizethis_ai_contracts` + thin core. Issue stays `backlog:implementation`.

## Verification

| Command | Result |
|---------|--------|
| `git grep '\.\./ai/' under lib/src/orders/**` | no matches (edge eliminated) |
| `dart analyze` (3 changed files) | No issues found |
| `dart test test/orders/validators/work_order_cost_calculator_feedstock_bootstrap_test.dart test/orders/order_suggestion_work_feedstock_priority_test.dart` | 12/12 pass |

Refs #3290

Made with [Cursor](https://cursor.com)