### PR TITLE
refactor(logic): decouple turn domain logging from logicLog (#3290)

### DIFF
--- a/SPEC/program/logic-package-split-phase0.md
+++ b/SPEC/program/logic-package-split-phase0.md
@@ -296,6 +296,24 @@ Three files logged via the `colonizethis_logic` core `logicLog` (`CtLogger('logi
 
 All other diplomacy files (`alliance_resolver.dart`, `overture_resolver.dart`, `war_resolver.dart`, `intervention_resolver_call_to_arms.dart`, `diplomacy_subsidies_relations_resolver.dart`) already consumed `diploLog` via `diplomacy_resolver.dart`; the re-export keeps them unchanged. Enforced by `test/check_logic_domain_import_dag_test.dart` (no `src/logging.dart`, `package_logger.dart`, `../logging.dart`, `../package_logger.dart`, or the `colonizethis_logic` barrel under `diplomacy/` or `dossier/`).
 
+### `turn` logging decoupling from `logicLog` (Refs #3290 C3 prerequisite)
+
+**Wrong:** `turn` → `colonizethis_logic` core logging (7 files, eliminated)
+
+Seven `turn/` files logged via the `colonizethis_logic` core `logicLog` (`CtLogger('logic')`), which would force the future `colonizethis_turn` package to depend on the thin logic core just for logging. The fix introduces a single turn-domain logger `turnLog` (`CtLogger('turn')`) in `turn/turn_logging.dart`, mirroring the one-logger-per-package convention already used by `ordersLog` (`orders:`), `combatLog` (`combat:`), `economyLog` (`economy:`), and `diploLog` (`diplomacy:`). Turn-orchestrator log lines (including the turn-orchestrated combat-phase lines previously emitted from the core) now carry the `turn:` prefix instead of `logic:`; this is the same prefix migration combat/orders/diplomacy performed at extraction and is the only behavioural change (structural logging move, no logic change).
+
+| Source file | Symbol | Before | After |
+|-------------|--------|--------|-------|
+| `turn/combat_phase_helpers.dart` | `turnLog.i` | imports `src/logging.dart` (`logicLog`) | `turnLog` from `turn_logging.dart` |
+| `turn/end_of_turn_resolver.dart` | `turnLog.i` | imports `src/logging.dart` (`logicLog`) | `turnLog` from `turn_logging.dart` |
+| `turn/naval_resolution.dart` | `turnLog.d` | imports `src/logging.dart` (`logicLog`) | `turnLog` from `turn_logging.dart` |
+| `turn/phases/combat_phase.dart` | `turnLog.i` | imports `src/logging.dart` (`logicLog`) | `turnLog` from `../turn_logging.dart` |
+| `turn/research_resolver.dart` | `turnLog.i` | imports `src/logging.dart` (`logicLog`) | `turnLog` from `turn_logging.dart` |
+| `turn/turn_phase_runner.dart` | `turnLog.i` | imports `src/logging.dart` (`logicLog`) | `turnLog` from `turn_logging.dart` |
+| `turn/turn_resolver.dart` | `turnLog.i` | imports `src/logging.dart` (`logicLog`) | `turnLog` from `turn_logging.dart` |
+
+The `turn_logging.dart` logger is not part of the public barrel and has no external (`app/`, `ctdev/`, AI) consumers, so no re-export shim is needed and the public API surface is unchanged. Enforced by `test/check_logic_domain_import_dag_test.dart` (no `src/logging.dart`, `package_logger.dart`, `../logging.dart`, `../../logging.dart`, `../package_logger.dart`, `../../package_logger.dart`, the `colonizethis_logic` barrel, or any `logicLog` reference under `turn/`) and pinned by `packages/colonizethis_logic/test/turn/turn_logging_test.dart`.
+
 ## Phase 1 slice — `colonizethis_combat` (Refs #3290 C1)
 
 **Given** the `colonizethis_world` leaf on `dev`, **when** the `colonizethis_combat` package is extracted, **then**:
@@ -303,7 +321,7 @@ All other diplomacy files (`alliance_resolver.dart`, `overture_resolver.dart`, `
 - `packages/colonizethis_combat` owns `combat/` (land + naval resolution, conflict detection, quick-battle, general assignment, military strength/attack economy) and depends only on `colonizethis_world`, `colonizethis_models`, `colonizethis_data`, `colonizethis_logger`.
 - `colonizethis_logic` depends on `colonizethis_combat` and re-exports `package:colonizethis_combat/colonizethis_combat.dart` from its barrel for backward compatibility; the `turn/` and `diplomacy/` consumers import combat via `package:colonizethis_combat/...`.
 - `colonizethis_combat/lib/**` imports no `package:colonizethis_logic/**` symbol (`repo.combat_no_logic_deps`).
-- `colonizethis_combat` uses exactly one logger with the distinct `combat` prefix (`combatLog`); land-combat log lines emitted from the package carry the `combat:` prefix, while turn-orchestrated combat-phase lines emitted from `colonizethis_logic` keep the `logic:` prefix.
+- `colonizethis_combat` uses exactly one logger with the distinct `combat` prefix (`combatLog`); land-combat log lines emitted from the package carry the `combat:` prefix, while turn-orchestrated combat-phase lines emitted from the `turn/` domain carry the `turn:` prefix (migrated from `logic:` by the C3 turn logging-decoupling prerequisite).
 - Combat-domain tests live under `packages/colonizethis_combat/test/` and reach ≥90% line coverage (enforced by the package coverage gate); `colonizethis_logic` remains a **dev_dependency** of `colonizethis_combat` for integration fixtures.
 
 ## Acceptance criteria (Phase 0 / C0)
@@ -324,3 +342,5 @@ All other diplomacy files (`alliance_resolver.dart`, `overture_resolver.dart`, `
 - **Given** the `colonizethis_logic` source tree, **when** `logicDomainImportNeutralTopLevelFilesForTests()` is read, **then** the set does not contain `turn_resolution_seeds.dart`, the file exists at `packages/colonizethis_logic/lib/src/turn/turn_resolution_seeds.dart`, and no file remains at `packages/colonizethis_logic/lib/src/turn_resolution_seeds.dart` (the seeds are turn-owned, not a neutral core file).
 - **Given** a synthetic `world/` file that imports `../turn/turn_resolution_seeds.dart`, **when** `runCheckLogicDomainImportDag` scans the tree, **then** it returns exit code `1` because the now turn-owned seeds make this a forbidden `world->turn` edge.
 - **Given** every `*.dart` file under `packages/colonizethis_logic/lib/src/orders/` (recursive), **when** `test/check_logic_domain_import_dag_test.dart` scans their import directives, **then** none imports the neutral core projection module via `import '../projections/order_projections.dart';` or `import '../projections/projected_effects.dart';` (the order engine consumes the dry-run via an injected `OrderEffectsProjector` and the `ProjectedEffects` type from `orders/projected_effects.dart`).
+- **Given** the `turn/` source tree, **when** `turn/turn_logging.dart` is read, **then** it declares a single shared `turnLog` whose `prefix == 'turn'` (`CtLogger('turn')`), and emitting `turnLog.i('m')` produces a log line containing `turn: m`.
+- **Given** every `*.dart` file under `packages/colonizethis_logic/lib/src/turn/` (recursive) except `turn/turn_logging.dart`, **when** `test/check_logic_domain_import_dag_test.dart` scans their content, **then** none imports the core logging (`package:colonizethis_logic/src/logging.dart`, `package:colonizethis_logic/package_logger.dart`, `../logging.dart`, `../../logging.dart`, `../package_logger.dart`, `../../package_logger.dart`, or the `colonizethis_logic` barrel) and none references the symbol `logicLog` (turn logs via the turn-domain `turnLog`).

--- a/packages/colonizethis_logic/lib/src/turn/combat_phase_helpers.dart
+++ b/packages/colonizethis_logic/lib/src/turn/combat_phase_helpers.dart
@@ -1,7 +1,7 @@
 // Helpers for the combat phase: apply one land battle (quick or auto-resolve), evidence, dialogue.
 // SPEC/program/turn-resolution-phase-details.md § Combat. Called from turn_resolver._runCombatPhase.
 
-import 'package:colonizethis_logic/src/logging.dart';
+import 'turn_logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'package:colonizethis_combat/src/combat/battle_general_assignment.dart';
@@ -36,7 +36,7 @@ Game runOneLandBattle(
     0,
     (s, a) => s + a.unitIds.length,
   );
-  logicLog.i(
+  turnLog.i(
     'combat battle_start turn=$turn battleIndex=$battleIndex '
     'regionId=${ctx.regionId} provinceId=${ctx.provinceId} '
     'defenderFactionId=${ctx.defenderFactionId} attackerSides=${ctx.attackers.length} '
@@ -59,7 +59,7 @@ Game runOneLandBattle(
         qbResult.provinceFlips &&
         qbResult.winner == QuickBattleWinner.attacker &&
         ctx.attackers.isNotEmpty;
-    logicLog.i(
+    turnLog.i(
       'combat battle_apply regionId=${ctx.regionId} provinceId=${ctx.provinceId} '
       'mode=quickBattle winner=${qbResult.winner.name} provinceFlipped=$qbFlipped '
       'attCasualties=${qbResult.attackerCasualties.length} '

--- a/packages/colonizethis_logic/lib/src/turn/end_of_turn_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/turn/end_of_turn_resolver.dart
@@ -3,7 +3,7 @@
 // Called from turn_resolver.resolveTurnForGame.
 
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/src/logging.dart';
+import 'turn_logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';
@@ -26,7 +26,7 @@ Game runEndOfTurnPhase(
   final winnerId = findMilitaryVictoryWinner(game);
   if (winnerId != null) {
     final turnNumber = game.worldState.turnState.turnNumber;
-    logicLog.i('military victory set winner=$winnerId turn=$turnNumber');
+    turnLog.i('military victory set winner=$winnerId turn=$turnNumber');
     return game.copyWith(
       victory: VictoryState(
         winnerPlayerId: winnerId,
@@ -73,7 +73,7 @@ Game runEndOfTurnPhase(
   );
 
   if (haltAfterCalendar) {
-    logicLog.i(
+    turnLog.i(
       'calendar campaign halt at turn=$currentTurn '
       '(year ${mapping.yearAtTurn(currentTurn)})',
     );

--- a/packages/colonizethis_logic/lib/src/turn/naval_resolution.dart
+++ b/packages/colonizethis_logic/lib/src/turn/naval_resolution.dart
@@ -1,5 +1,5 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/src/logging.dart';
+import 'turn_logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'package:colonizethis_combat/src/combat/naval_combat_resolver.dart';
@@ -13,7 +13,8 @@ import 'turn_resolution_seeds.dart';
 import 'package:colonizethis_world/src/world/game_world_mutations.dart';
 import 'package:colonizethis_world/src/world/naval.dart';
 import 'package:colonizethis_world/src/world/naval_coastal_visibility.dart';
-import 'package:colonizethis_world/src/world/province_lookup.dart' hide landTileKeysForProvinceBucket;
+import 'package:colonizethis_world/src/world/province_lookup.dart'
+    hide landTileKeysForProvinceBucket;
 import 'package:colonizethis_world/src/world/topology_helpers.dart';
 
 export 'package:colonizethis_world/src/world/naval_coastal_visibility.dart'
@@ -23,7 +24,8 @@ export 'package:colonizethis_world/src/world/naval_coastal_visibility.dart'
         landTileKeysForProvinceBucket,
         revealProvinceTilesForPlayer,
         revealTilesAfterMoveToSeaZone;
-export 'package:colonizethis_world/src/world/naval_mission_orders.dart' show applyNavalMissionOrders;
+export 'package:colonizethis_world/src/world/naval_mission_orders.dart'
+    show applyNavalMissionOrders;
 
 // Naval resolution concern fragments (Refs #3290 Phase-0 file-split). Each
 // `part of` fragment shares this library's imports and library-private scope,
@@ -111,10 +113,8 @@ Game applyNavalMovesAndShipReveal(
   }
 
   return game.updateWorldState(
-    (ws) => ws.copyWith(
-      fleets: fleets,
-      playerVisibilityByTile: visibilityByTile,
-    ),
+    (ws) =>
+        ws.copyWith(fleets: fleets, playerVisibilityByTile: visibilityByTile),
   );
 }
 
@@ -128,7 +128,7 @@ Game runNavalInterceptionCombatPhase(
   GameEventBus? eventBus,
 }) {
   var battles = detectNavalConflicts(game);
-  logicLog.d('naval phase detected battles=${battles.length}');
+  turnLog.d('naval phase detected battles=${battles.length}');
   final movedFleetIds = <String>{
     for (final list in navalMoveOrdersByPlayerId.values)
       for (final order in list) order.fleetId,
@@ -141,7 +141,7 @@ Game runNavalInterceptionCombatPhase(
       (game.globalGameSeed ?? 0) ^
       (game.worldState.turnState.turnNumber * kTurnResolutionSeedMix);
   battles = filterBattlesByInterception(game, battles, movedFleetIds, seed);
-  logicLog.d('naval phase after interception battles=${battles.length}');
+  turnLog.d('naval phase after interception battles=${battles.length}');
   seed =
       (seed * kTurnResolutionLcgMultiplier + kTurnResolutionLcgIncrement) &
       kTurnResolutionLcgMask;
@@ -191,7 +191,7 @@ Game runNavalInterceptionCombatPhase(
       retreatDestinationSide1: retreatZoneSide1,
       retreatDestinationSide2: retreatZoneSide2,
     );
-    logicLog.d(
+    turnLog.d(
       'naval phase battle zone=${battle.seaZoneId} outcome=${result.outcome.name} '
       'side1Retreated=${result.side1Retreated} side2Retreated=${result.side2Retreated}',
     );

--- a/packages/colonizethis_logic/lib/src/turn/phases/combat_phase.dart
+++ b/packages/colonizethis_logic/lib/src/turn/phases/combat_phase.dart
@@ -1,5 +1,5 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/src/logging.dart';
+import '../turn_logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'package:colonizethis_combat/src/combat/battle_general_assignment.dart';
@@ -76,7 +76,7 @@ Game runCombatPhase(
   final preBattleDialogueSeed =
       (game.globalGameSeed ?? 0) ^ (turn * kTurnResolutionSeedMix);
   state = applyUnopposedProvinceCaptures(state, orders);
-  logicLog.i('combat conflict_detection start turn=$turn');
+  turnLog.i('combat conflict_detection start turn=$turn');
   final battles = detectConflicts(state, orders);
   if (onDialogue != null && battles.isNotEmpty) {
     _emitPreBattleDialogueForConflicts(
@@ -87,7 +87,7 @@ Game runCombatPhase(
       onDialogue,
     );
   }
-  logicLog.i(
+  turnLog.i(
     'combat conflict_detection end turn=$turn battleContexts=${battles.length}',
   );
   final combatGeneralLedger = CombatPhaseGeneralLedger();

--- a/packages/colonizethis_logic/lib/src/turn/research_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/turn/research_resolver.dart
@@ -1,5 +1,5 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/src/logging.dart';
+import 'turn_logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';
@@ -119,7 +119,7 @@ void _applyResearchOrderIfValid({
 }) {
   final slots = player.researchSlots ?? defaultResearchSlots;
   if (slots <= 0) {
-    logicLog.i(
+    turnLog.i(
       'research apply turn=$turn playerId=${player.id} '
       'orders=${playerOrders.length} skipped=true reason=no_research_slots',
     );
@@ -204,7 +204,7 @@ void _applyResearchOrderIfValid({
   final nextProgress = progress.isNotEmpty ? progress : const <String, int>{};
 
   final treasuryDelta = treasury - player.treasury;
-  logicLog.i(
+  turnLog.i(
     'research apply turn=$turn playerId=${player.id} '
     'orders=${playerOrders.length} treasuryDelta=$treasuryDelta '
     'completedTechs=${toUnlock.length} inProgressTechs=${nextProgress.length}',
@@ -226,10 +226,10 @@ void _applyResearchOrderIfValid({
 Game resolveResearchPhase(Game game, Orders orders) {
   final turn = game.worldState.turnState.turnNumber;
   final researchByPlayer = orders.researchOrdersByPlayerId;
-  logicLog.i('research phase start turn=$turn');
+  turnLog.i('research phase start turn=$turn');
 
   if (researchByPlayer.isEmpty) {
-    logicLog.i('research phase end turn=$turn playersWithOrders=0');
+    turnLog.i('research phase end turn=$turn playersWithOrders=0');
     return game;
   }
 
@@ -261,7 +261,9 @@ Game resolveResearchPhase(Game game, Orders orders) {
     updatedPlayers.add(resolved.updatedPlayer!);
   }
 
-  logicLog.i('research phase end turn=$turn playersWithOrders=$playersWithOrders');
+  turnLog.i(
+    'research phase end turn=$turn playersWithOrders=$playersWithOrders',
+  );
   return state.copyWith(
     players: updatedPlayers,
     dossierEvidenceEntries: [...state.dossierEvidenceEntries, ...extraEvidence],

--- a/packages/colonizethis_logic/lib/src/turn/turn_logging.dart
+++ b/packages/colonizethis_logic/lib/src/turn/turn_logging.dart
@@ -1,0 +1,16 @@
+/// Turn-domain logging entrypoint (Refs #3290 C3 prerequisite).
+///
+/// Decoupled from the `colonizethis_logic` `logicLog` so the `turn/` source
+/// tree moves cleanly into a future `colonizethis_turn` package without a
+/// dependency on the thin logic core. One logger instance with the distinct
+/// `turn` prefix, mirroring `ordersLog`/`setupLog`/`diploLog`/`combatLog`/
+/// `economyLog` in the already-split packages (per `colonizethis-core-principles`
+/// one-logger-per-package convention).
+library;
+
+import 'package:colonizethis_logger/colonizethis_logger.dart';
+
+export 'package:colonizethis_logger/colonizethis_logger.dart' show CtLogger;
+
+/// Shared package-level [CtLogger] for `turn/` source files.
+final turnLog = CtLogger('turn');

--- a/packages/colonizethis_logic/lib/src/turn/turn_phase_runner.dart
+++ b/packages/colonizethis_logic/lib/src/turn/turn_phase_runner.dart
@@ -1,4 +1,4 @@
-import 'package:colonizethis_logic/src/logging.dart';
+import 'turn_logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'turn_news_digest.dart';
@@ -17,7 +17,7 @@ TurnResolutionResult runTurnResolutionPipeline({
 }) {
   if (gameAtResolutionStart.calendarCampaignHalted) {
     final turn = gameAtResolutionStart.worldState.turnState.turnNumber;
-    logicLog.i('turn $turn resolve skipped (calendar halted)');
+    turnLog.i('turn $turn resolve skipped (calendar halted)');
     emitPlayerDiscoveryEvents(
       gameAtResolutionStart,
       gameAtResolutionStart,
@@ -29,10 +29,7 @@ TurnResolutionResult runTurnResolutionPipeline({
       start: gameAtResolutionStart,
       end: gameAtResolutionStart,
     );
-    return TurnResolutionComplete(
-      news.game,
-      turnNewsDigest: news.digest,
-    );
+    return TurnResolutionComplete(news.game, turnNewsDigest: news.digest);
   }
   var acc = TurnPipelineState(game: gameAtResolutionStart);
   final turn = acc.game.worldState.turnState.turnNumber;
@@ -52,7 +49,7 @@ TurnResolutionResult runTurnResolutionPipeline({
     if (i < phaseIndex) continue;
     config.turnTraceRuntime?.clearPhaseOrderEvents();
     config.onPhaseProgress?.call(phase, TurnPhaseProgressMarker.start);
-    logicLog.i('phase ${phase.name} start');
+    turnLog.i('phase ${phase.name} start');
     final beforeState = config.onTurnTracePhase == null
         ? null
         : acc.game.toJson();
@@ -81,11 +78,11 @@ TurnResolutionResult runTurnResolutionPipeline({
         );
         acc = pipeline;
     }
-    logicLog.i('phase ${phase.name} end');
+    turnLog.i('phase ${phase.name} end');
     config.onPhaseProgress?.call(phase, TurnPhaseProgressMarker.end);
   }
 
-  logicLog.i('turn $turn resolve end');
+  turnLog.i('turn $turn resolve end');
   emitPlayerDiscoveryEvents(
     gameAtResolutionStart,
     acc.game,

--- a/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
@@ -1,5 +1,5 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/src/logging.dart';
+import 'turn_logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'package:colonizethis_world/src/event_bus/game_event_bus.dart';
@@ -282,7 +282,7 @@ TurnResolutionResult resolveTurnForGameWithConfig({
   required TurnResolverConfig config,
 }) {
   final turn = game.worldState.turnState.turnNumber;
-  logicLog.i('turn $turn resolve start');
+  turnLog.i('turn $turn resolve start');
   final state = ensureMilitaryArmiesForGame(game);
   final gameAtResolutionStart = state;
   return runTurnResolutionPipeline(

--- a/packages/colonizethis_logic/test/combat_logging_phase_test.dart
+++ b/packages/colonizethis_logic/test/combat_logging_phase_test.dart
@@ -90,14 +90,14 @@ void main() {
         final combat = capture.combat;
         expect(
           combat.any(
-            (m) => m.contains('logic: combat conflict_detection start'),
+            (m) => m.contains('turn: combat conflict_detection start'),
           ),
           isTrue,
         );
         expect(
           combat.any(
             (m) =>
-                m.contains('logic: combat conflict_detection end') &&
+                m.contains('turn: combat conflict_detection end') &&
                 m.contains('battleContexts=1'),
           ),
           isTrue,
@@ -105,7 +105,7 @@ void main() {
         expect(
           combat.any(
             (m) =>
-                m.contains('logic: combat battle_start') &&
+                m.contains('turn: combat battle_start') &&
                 m.contains('attackerSides=1') &&
                 m.contains('attackerUnitsTotal=1') &&
                 m.contains('mode=autoResolve'),
@@ -128,7 +128,7 @@ void main() {
           capture.events.any(
             (e) =>
                 e.level == Level.info &&
-                e.message.contains('logic: phase combat start'),
+                e.message.contains('turn: phase combat start'),
           ),
           isTrue,
         );
@@ -136,7 +136,7 @@ void main() {
           capture.events.any(
             (e) =>
                 e.level == Level.info &&
-                e.message.contains('logic: phase combat end'),
+                e.message.contains('turn: phase combat end'),
           ),
           isTrue,
         );
@@ -225,7 +225,7 @@ void main() {
         expect(
           combat.any(
             (m) =>
-                m.contains('logic: combat battle_start') &&
+                m.contains('turn: combat battle_start') &&
                 m.contains('mode=quickBattle'),
           ),
           isTrue,
@@ -233,7 +233,7 @@ void main() {
         expect(
           combat.any(
             (m) =>
-                m.contains('logic: combat battle_apply') &&
+                m.contains('turn: combat battle_apply') &&
                 m.contains('mode=quickBattle') &&
                 m.contains('winner='),
           ),
@@ -299,13 +299,13 @@ void main() {
         expect(
           combat.any(
             (m) =>
-                m.contains('logic: combat conflict_detection end') &&
+                m.contains('turn: combat conflict_detection end') &&
                 m.contains('battleContexts=0'),
           ),
           isTrue,
         );
         expect(
-          combat.any((m) => m.contains('logic: combat battle_start')),
+          combat.any((m) => m.contains('turn: combat battle_start')),
           isFalse,
         );
       },

--- a/packages/colonizethis_logic/test/combat_logging_test_support.dart
+++ b/packages/colonizethis_logic/test/combat_logging_test_support.dart
@@ -5,13 +5,15 @@ import 'package:logger/logger.dart';
 ///
 /// After the `colonizethis_combat` package extraction (Refs #3290 Phase 1),
 /// combat-resolution lines emitted from that package carry the `combat:` prefix
-/// (e.g. `combat: combat engagement`), while turn-orchestrated combat-phase
-/// lines emitted from `colonizethis_logic` keep the `logic:` prefix
-/// (e.g. `logic: combat conflict_detection`). This filter matches both so split
-/// test files share one filter rather than duplicate it.
+/// (e.g. `combat: combat engagement`). After the turn-domain logging decouple
+/// (Refs #3290 C3 prerequisite), turn-orchestrated combat-phase lines emitted
+/// from `colonizethis_logic` carry the `turn:` prefix
+/// (e.g. `turn: combat conflict_detection`) instead of the former `logic:`
+/// prefix. This filter matches both so split test files share one filter rather
+/// than duplicate it.
 List<String> combatMessages(List<LogEvent> events) => [
   for (final e in events)
-    if (e.message.contains('logic: combat') ||
+    if (e.message.contains('turn: combat') ||
         e.message.contains('combat: combat'))
       e.message,
 ];

--- a/packages/colonizethis_logic/test/research_logging_test.dart
+++ b/packages/colonizethis_logic/test/research_logging_test.dart
@@ -6,7 +6,7 @@ import 'package:logger/logger.dart';
 import 'package:colonizethis_data/colonizethis_data.dart' show kTechIdCropRotation;
 List<String> _researchMessages(List<LogEvent> events) => [
       for (final e in events)
-        if (e.message.contains('logic: research')) e.message,
+        if (e.message.contains('turn: research')) e.message,
     ];
 
 void main() {
@@ -46,14 +46,14 @@ void main() {
       final lines = _researchMessages(capturedEvents);
       expect(
         lines.any(
-          (m) => m.contains('logic: research phase start') && m.contains('turn=7'),
+          (m) => m.contains('turn: research phase start') && m.contains('turn=7'),
         ),
         isTrue,
       );
       expect(
         lines.any(
           (m) =>
-              m.contains('logic: research phase end') &&
+              m.contains('turn: research phase end') &&
               m.contains('turn=7') &&
               m.contains('playersWithOrders=0'),
         ),
@@ -95,7 +95,7 @@ void main() {
       expect(
         lines.any(
           (m) =>
-              m.contains('logic: research apply') &&
+              m.contains('turn: research apply') &&
               m.contains('turn=3') &&
               m.contains('playerId=p1') &&
               m.contains('orders=1'),
@@ -105,7 +105,7 @@ void main() {
       expect(
         lines.any(
           (m) =>
-              m.contains('logic: research phase end') &&
+              m.contains('turn: research phase end') &&
               m.contains('turn=3') &&
               m.contains('playersWithOrders=1'),
         ),

--- a/packages/colonizethis_logic/test/turn/turn_logging_test.dart
+++ b/packages/colonizethis_logic/test/turn/turn_logging_test.dart
@@ -1,0 +1,74 @@
+// Refs #3290 C3 prerequisite — turn-domain logging decoupling.
+//
+// Pins the contract that the `turn/` source tree uses a dedicated `turnLog`
+// (`CtLogger('turn')`) instead of the thin-core `logicLog`, so the tree can
+// move into a future `colonizethis_turn` package without a dependency on the
+// `colonizethis_logic` core. Mirrors `orders/orders_logging_test.dart` and
+// `package_logger_shared_test.dart`.
+
+import 'dart:io';
+
+import 'package:colonizethis_logic/src/turn/turn_logging.dart';
+import 'package:colonizethis_test/test.dart';
+import 'package:logger/logger.dart' show Level, LogEvent, Logger;
+
+void main() {
+  group('turnLog (Refs #3290 C3)', () {
+    test('turnLog is a CtLogger with the distinct `turn` prefix', () {
+      expect(turnLog, isA<CtLogger>());
+      expect(turnLog.prefix, equals('turn'));
+    });
+
+    test('turnLog is the single shared instance for the turn domain', () {
+      expect(identical(turnLog, turnLog), isTrue);
+    });
+
+    test('turnLog emits messages with the `turn:` prefix', () {
+      final captured = <LogEvent>[];
+      void listener(LogEvent e) => captured.add(e);
+      Logger.addLogListener(listener);
+      final priorLevel = Logger.level;
+      Logger.level = Level.debug;
+      try {
+        turnLog.i('turn_logger_smoke');
+      } finally {
+        Logger.removeLogListener(listener);
+        Logger.level = priorLevel;
+      }
+      final messages = captured
+          .map((e) => e.message?.toString() ?? '')
+          .toList();
+      expect(
+        messages.any((m) => m.contains('turn: turn_logger_smoke')),
+        isTrue,
+        reason: 'expected at least one log entry prefixed with "turn: "',
+      );
+    });
+
+    test('no lib/src/turn source consumes the core logicLog', () {
+      final turnDir = Directory('lib/src/turn');
+      expect(
+        turnDir.existsSync(),
+        isTrue,
+        reason: 'expected turn source directory at lib/src/turn',
+      );
+      final offenders = <String>[];
+      for (final entity in turnDir.listSync(recursive: true)) {
+        if (entity is! File || !entity.path.endsWith('.dart')) continue;
+        if (entity.path.endsWith('turn_logging.dart')) continue;
+        final content = entity.readAsStringSync();
+        if (content.contains('colonizethis_logic/src/logging.dart') ||
+            content.contains('logicLog')) {
+          offenders.add(entity.path);
+        }
+      }
+      expect(
+        offenders,
+        isEmpty,
+        reason:
+            'turn/ must use turnLog (turn_logging.dart), not the core '
+            'logicLog: $offenders',
+      );
+    });
+  });
+}

--- a/test/check_logic_domain_import_dag_test.dart
+++ b/test/check_logic_domain_import_dag_test.dart
@@ -507,4 +507,45 @@ void noop() {}
       );
     },
   );
+
+  test('turn does not import the logic core logging (Refs #3290 C3)', () {
+    // The turn/ tree extracts into colonizethis_turn, which must depend only on
+    // world/combat/economy/diplomacy/orders/models/data/logger — not on the
+    // thin colonizethis_logic core. Logging therefore goes through the
+    // turn-domain logger (turnLog in turn/turn_logging.dart), not the
+    // logic-core logicLog.
+    const forbiddenLoggingImports = <String>[
+      "import 'package:colonizethis_logic/src/logging.dart';",
+      "import 'package:colonizethis_logic/package_logger.dart';",
+      "import '../logging.dart';",
+      "import '../../logging.dart';",
+      "import '../package_logger.dart';",
+      "import '../../package_logger.dart';",
+      "import 'package:colonizethis_logic/colonizethis_logic.dart';",
+    ];
+    final turnDir = Directory('packages/colonizethis_logic/lib/src/turn');
+    final violations = <String>[];
+    if (turnDir.existsSync()) {
+      for (final entity in turnDir.listSync(recursive: true)) {
+        if (entity is! File || !entity.path.endsWith('.dart')) continue;
+        if (entity.path.endsWith('turn_logging.dart')) continue;
+        final content = entity.readAsStringSync();
+        for (final bad in forbiddenLoggingImports) {
+          if (content.contains(bad)) {
+            violations.add('${entity.path}: $bad');
+          }
+        }
+        if (content.contains('logicLog')) {
+          violations.add('${entity.path}: references logicLog');
+        }
+      }
+    }
+    expect(
+      violations,
+      isEmpty,
+      reason:
+          'turn/ must log via the turn-domain logger (turnLog in '
+          'turn/turn_logging.dart), not the colonizethis_logic core logicLog',
+    );
+  });
 }


### PR DESCRIPTION
## Summary

Refs #3290 — **C3 prerequisite** for the `colonizethis_turn` package extraction. Decouples the `turn/` source tree from the thin `colonizethis_logic` core's `logicLog`, so `turn/` can later move into a standalone `colonizethis_turn` package without a logging dependency on the core. Behavior-preserving structural change; mirrors the already-merged `orders`/`diplomacy`/`combat` logging-decoupling prerequisites.

## Done in this push

- **New turn-domain logger.** `packages/colonizethis_logic/lib/src/turn/turn_logging.dart` defines a single shared `turnLog = CtLogger('turn')` (mirrors `orders/orders_logging.dart`, `diplomacy/diplomacy_logging.dart`).
- **Migrated 7 `turn/` files** off `package:colonizethis_logic/src/logging.dart` (`logicLog`) to `turnLog`: `combat_phase_helpers.dart`, `end_of_turn_resolver.dart`, `naval_resolution.dart`, `phases/combat_phase.dart`, `research_resolver.dart`, `turn_phase_runner.dart`, `turn_resolver.dart`. Turn-orchestrator log lines now carry the `turn:` prefix instead of `logic:` (only behavioural change).
- **Enforcement (negative).** New `turn does not import the logic core logging` test in `test/check_logic_domain_import_dag_test.dart` — fails if any `turn/` file (except `turn_logging.dart`) imports core logging or references `logicLog`.
- **Pinning (positive).** New `packages/colonizethis_logic/test/turn/turn_logging_test.dart` — asserts `turnLog` prefix `turn`, single shared instance, `turn:`-prefixed output, and no `turn/` source consumes `logicLog`.

## SPEC

- `SPEC/program/logic-package-split-phase0.md` — added `### turn logging decoupling from logicLog (C3 prerequisite)` section + 2 ACs; updated the combat-extraction note (turn-orchestrated combat-phase lines now carry `turn:`, not `logic:`).

## Tests

- `dart test packages/colonizethis_logic/test/turn/turn_logging_test.dart` — green (output confirms `turn: turn_logger_smoke`).
- `dart test test/check_logic_domain_import_dag_test.dart` — 27 tests green (new turn gate included).
- `dart test packages/colonizethis_logic/test/turn/turn_phase_handler_registry_test.dart test/turn/research_rules_test.dart` — green.
- `dart analyze packages/colonizethis_logic/lib/src/turn` — no issues (pre-existing `orders`/`ai` warnings on `dev` are unrelated and not on this change).

## Deferred (still open on #3290)

- C3 full `colonizethis_turn` package extraction (file move, pubspec, test migration, consumer/CI wiring). The `turn → core constants` decoupling for `kWorkTarget*`-using files is intentionally deferred to that PR because it is entangled with the in-flight `colonizethis_orders` extraction (PR #3369).
- C4 thin core + `colonizethis_ai_contracts`.

Tracked by #3290.

Made with [Cursor](https://cursor.com)