### PR TITLE
feat(ai): growth-stage production prioritization behind flag (#3371)

### DIFF
--- a/SPEC/ai/economy-planner.md
+++ b/SPEC/ai/economy-planner.md
@@ -8,6 +8,8 @@
 
 The economy planner chooses **production assignments** (which recipes receive how much labour) and a **cargo preference** (whether to favour more cargo capacity this turn). It runs once per AI-controlled Great Power per turn, before or as part of domain planning. Output feeds turn resolution (production phase) and optionally the naval planner (join home fleet vs missions).
 
+**Growth-stage prioritization (Refs #3371):** When `growthStagePlannerEnabled` is true, recipe ranking uses the dampen-and-bias model in [growth-stage-planner.md](growth-stage-planner.md) and the H8 reactive boost sections below are disabled. When false (default), legacy H8 behaviour applies unchanged.
+
 ---
 
 ## Inputs

--- a/SPEC/ai/growth-stage-planner.md
+++ b/SPEC/ai/growth-stage-planner.md
@@ -1,0 +1,103 @@
+# Growth-stage planner
+
+Refs #3371. Replaces reactive H8 production boosts with proactive, state-derived priority weights when `growthStagePlannerEnabled` is true.
+
+## Purpose
+
+The economy planner scores every feasible recipe each turn. Without growth-stage awareness, shortage-dominated static weights cause bootstrap Great Powers to allocate labour to military inputs before fabric and castIron infrastructure. The growth-stage planner computes a **priority vector** from game state each turn and modulates recipe scores, recruitment, build suppression, and (follow-up) civilian work routing.
+
+## Priority vector
+
+```dart
+class GrowthStage {
+  final double workerGrowthPriority;       // 0..1
+  final double infrastructurePriority;   // 0..1
+  final double resourceProductionPriority; // 0..1
+  final double militaryPriority;           // 0..1
+}
+```
+
+Pure function: `GrowthStage.compute(game, playerId, {snapshot})`. No hidden state, no RNG.
+
+### Worker growth
+
+`workerGrowthPriority = max(0, 1 - effectiveLabour / targetLabourForMaturity)`. Halved when `fabric >= kReserveTarget`.
+
+### Infrastructure
+
+`infrastructurePriority = max(0, 1 - prospectedImprovedFeedstockTileCount / targetFeedstockTileCount)`. Halved when `castIron >= kReserveTarget` **and** `lumber >= kReserveTarget`.
+
+Feedstock tiles: owned tiles hosting `wool`, `cotton`, `timber`, `iron`, or `coal` with `improvementLevel >= 1`; mineral tiles must also be prospected.
+
+### Resource production
+
+```
+maturityFactor = min(1, effectiveLabour / targetLabourForMaturity)
+reserveShortfall(r) = max(0, 1 - stockpile[r] / kReserveTarget)  for r in {fabric, lumber, castIron}
+reserveShortfall = max over r
+resourceProductionPriority = maturityFactor × reserveShortfall
+```
+
+### Military
+
+```
+computed = clamp((effectiveLabour - minLabourForMilitary) / labourRangeForMilitary, 0, 1)
+militaryPriority = isAtWar ? max(kAtWarMilitaryFloor, computed) : computed
+```
+
+`isAtWar`: active diplomacy war **or** invadable Old World frontier (`ThreatSummary.atWarWith` non-empty or `invadableProvinceIdsSorted` non-empty when snapshot supplied; else `Game.diplomacyRelations`).
+
+## Recipe scoring (dampen-and-bias)
+
+```
+categoryPriority = mapped priority for output commodity, floored at kMinCategoryFloor
+stageScaledScore = categoryPriority × (scoreRecipe(...) + kStagePriorityBias)
+```
+
+| Output | categoryPriority |
+|--------|------------------|
+| `fabric` | `max(workerGrowthPriority, resourceProductionPriority)` |
+| `castIron`, `lumber` | `max(infrastructurePriority, resourceProductionPriority)` |
+| `steel`, `bronze` | `militaryPriority` |
+| `refinedSugar`, `cigars`, `furHats` | `militaryPriority` |
+| other | `max(workerGrowth, infrastructure, resourceProduction, military)` |
+
+When `growthStagePlannerEnabled == true`, `_allocateLabour` ranks by `stageScaledScore` and **disables** all H8 reactive boosts (`kRegimentBuildInputProductionScoreBoost`, supplier release, castIron-labour fabric pre-pass).
+
+## Recruitment modulation
+
+Peasant-recruit scaling: `max(kRecruitmentFloor, workerGrowthPriority)`. Exported as `peasantRecruitScoreScale(stage)` for tests.
+
+## Build suppression
+
+When `militaryPriority < kMilitaryBuildSuppressionThreshold`, `runRecruitmentPlanner` rejects all regiment and naval build candidates. At-war floor (0.3) keeps at-war GPs above the threshold.
+
+## Coexistence flag
+
+`growthStagePlannerEnabled` (default **false**). When false, legacy H8 behaviour in `economy-planner.md` is unchanged. When true, growth-stage scoring replaces H8 boosts; H8 code removal is AC9 after AC7 calibration.
+
+## Tunable constants
+
+| Constant | Default |
+|----------|---------|
+| `targetLabourForMaturity` | 12 |
+| `targetFeedstockTileCount` | 6 |
+| `minLabourForMilitary` | 6 |
+| `labourRangeForMilitary` | 6 |
+| `kReserveTarget` | 20 |
+| `kAtWarMilitaryFloor` | 0.3 |
+| `kStagePriorityBias` | 16.0 |
+| `kMinCategoryFloor` | 0.1 |
+| `kRecruitmentFloor` | 0.25 |
+| `kMilitaryBuildSuppressionThreshold` | 0.2 |
+
+## Integration
+
+- `economy_planner.dart` — `_allocateLabour`, optional `growthStagePlannerEnabled` parameter.
+- `recruitment_planner.dart` — build suppression, peasant scale helper.
+- `recipe_scoring.dart` — `stageScaledRecipeScore`.
+- Civilian work priority modulation: follow-up slice (not in initial flag-off default path).
+
+## Acceptance criteria (issue #3371)
+
+AC1–AC6, AC10–AC12: unit tests in `growth_stage_planner_test.dart`. AC7 seed-42 regression and AC9 H8 removal: follow-up after calibration with flag default on.

--- a/packages/colonizethis_ai/lib/colonizethis_ai.dart
+++ b/packages/colonizethis_ai/lib/colonizethis_ai.dart
@@ -16,6 +16,20 @@ export 'src/perception/perception_snapshot.dart';
 export 'src/planning/domain_planner_orchestrator.dart';
 export 'src/planning/diplomacy_planner.dart';
 export 'src/planning/economy_planner.dart';
+export 'src/planning/growth_stage.dart'
+    show
+        GrowthStage,
+        categoryPriorityForOutput,
+        kAtWarMilitaryFloor,
+        kGrowthStagePlannerEnabled,
+        kMilitaryBuildSuppressionThreshold,
+        kRecruitmentFloor,
+        kReserveTarget,
+        kStagePriorityBias,
+        kTargetLabourForMaturity,
+        peasantRecruitScoreScale,
+        prospectedImprovedFeedstockTileCount;
+export 'src/planning/recipe_scoring.dart' show stageScaledRecipeScore;
 export 'src/planning/full_ai_planner.dart';
 export 'src/planning/goal_manager.dart';
 export 'src/planning/observer_goal_phase.dart' show ObserverGoalPhase;
@@ -34,6 +48,7 @@ export 'src/planning/recruitment_planner.dart'
         RecruitmentPlan,
         RejectedRecruitmentSuggestion,
         kRecruitmentRejectInsufficientWorkers,
+        kRecruitmentRejectMilitaryBuildSuppressed,
         kRecruitmentRejectSoftLuxuryCap,
         runRecruitmentPlanner;
 export 'src/social/hidden_agenda.dart';

--- a/packages/colonizethis_ai/lib/src/planning/economy_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/economy_planner.dart
@@ -7,6 +7,7 @@ import 'cast_iron_labour_gate.dart'
         isCastIronLabourPeasantRecruitFabricShort,
         isCastIronLabourPopulationBoundForLockRecoverySeller;
 import 'expand_phase_planner.dart' hide cheapestRegimentBuildTreasuryCost;
+import 'growth_stage.dart';
 import 'phase_planner_dispatch.dart';
 import 'phase_planner_economy_filter.dart';
 import 'phase_planner_expand_economy.dart';
@@ -64,6 +65,7 @@ EconomyPlan runEconomyPlanner({
   Map<String, TileMapResult>? tileMapByRegion,
   MapTopology? topology,
   bool skipTradeOrderGeneration = false,
+  bool growthStagePlannerEnabled = kGrowthStagePlannerEnabled,
 }) {
   final player = game.playerById(view.playerId);
   if (player == null) {
@@ -278,6 +280,14 @@ EconomyPlan runEconomyPlanner({
     ...supplierReleaseImprovementInputs,
   };
 
+  final growthStage = growthStagePlannerEnabled
+      ? GrowthStage.compute(
+          game,
+          view.playerId,
+          snapshot: snapshot,
+        )
+      : null;
+
   final assignments = _allocateLabour(
     stockpile: stockpile,
     workers: workers,
@@ -285,12 +295,22 @@ EconomyPlan runEconomyPlanner({
     config: config,
     seeds: seeds,
     militaryRebuildCrisis: militaryRebuildCrisis,
-    regimentBuildInputProductionBoost: regimentBuildInputProductionBoost,
-    missingRegimentBuildInputIds: boostedBuildInputOutputs,
-    supplierReleaseImprovementInputIds: supplierReleaseImprovementInputs,
-    feedstockReserveOutputIds: feedstockReserveOutputIds,
-    castIronLabourPeasantRecruitFabricBoost:
-        castIronLabourPeasantRecruitFabricBoost,
+    regimentBuildInputProductionBoost: growthStagePlannerEnabled
+        ? false
+        : regimentBuildInputProductionBoost,
+    missingRegimentBuildInputIds: growthStagePlannerEnabled
+        ? const <String>{}
+        : boostedBuildInputOutputs,
+    supplierReleaseImprovementInputIds: growthStagePlannerEnabled
+        ? const <String>{}
+        : supplierReleaseImprovementInputs,
+    feedstockReserveOutputIds: growthStagePlannerEnabled
+        ? const <String>{}
+        : feedstockReserveOutputIds,
+    castIronLabourPeasantRecruitFabricBoost: growthStagePlannerEnabled
+        ? false
+        : castIronLabourPeasantRecruitFabricBoost,
+    growthStage: growthStage,
   );
 
   final cargoPref = _cargoPreference(
@@ -397,6 +417,7 @@ List<AssignedRecipe> _allocateLabour({
   Set<String> supplierReleaseImprovementInputIds = const {},
   Set<String> feedstockReserveOutputIds = const {},
   bool castIronLabourPeasantRecruitFabricBoost = false,
+  GrowthStage? growthStage,
 }) {
   // Labour allocation scores every feasible recipe to pick the best runs, so
   // this is an intrinsic full-catalog pass, not an output-keyed lookup that the
@@ -453,22 +474,37 @@ List<AssignedRecipe> _allocateLabour({
     );
     if (runs <= 0) continue;
 
-    var score = scoreRecipe(
-      recipe: recipe,
-      stockpile: virtual,
-      workers: workers,
-      agendaId: agendaId,
-    );
-    if (militaryRebuildCrisis && _isMilitaryInputRecipe(recipe)) {
-      score += 40;
-    }
-    if (regimentBuildInputProductionBoost &&
-        missingRegimentBuildInputIds.contains(recipe.outputCommodityId)) {
-      score += kRegimentBuildInputProductionScoreBoost;
-    }
-    if (supplierReleaseImprovementInputIds.contains(recipe.outputCommodityId)) {
-      score += kSupplierBuildInputReleaseProductionScoreBoost;
-    }
+    final score = growthStage != null
+        ? stageScaledRecipeScore(
+            recipe: recipe,
+            stockpile: virtual,
+            workers: workers,
+            agendaId: agendaId,
+            stage: growthStage,
+          )
+        : () {
+            var legacy = scoreRecipe(
+              recipe: recipe,
+              stockpile: virtual,
+              workers: workers,
+              agendaId: agendaId,
+            );
+            if (militaryRebuildCrisis && _isMilitaryInputRecipe(recipe)) {
+              legacy += 40;
+            }
+            if (regimentBuildInputProductionBoost &&
+                missingRegimentBuildInputIds.contains(
+                  recipe.outputCommodityId,
+                )) {
+              legacy += kRegimentBuildInputProductionScoreBoost;
+            }
+            if (supplierReleaseImprovementInputIds.contains(
+              recipe.outputCommodityId,
+            )) {
+              legacy += kSupplierBuildInputReleaseProductionScoreBoost;
+            }
+            return legacy;
+          }();
     candidates.add(ScoredRecipe(recipe: recipe, score: score));
   }
 

--- a/packages/colonizethis_ai/lib/src/planning/growth_stage.dart
+++ b/packages/colonizethis_ai/lib/src/planning/growth_stage.dart
@@ -1,0 +1,248 @@
+// Growth-stage priority vector for economy planning. SPEC/ai/growth-stage-planner.md.
+
+import '../perception/perception_snapshot.dart';
+import 'planning_imports.dart';
+
+/// When true, growth-stage scoring replaces H8 reactive boosts in the economy
+/// planner. Default off until AC7 calibration (Refs #3371).
+const bool kGrowthStagePlannerEnabled = false;
+
+/// Effective labour at which worker growth priority reaches ~0.
+const int kTargetLabourForMaturity = 12;
+
+/// Improved feedstock tiles at which infrastructure priority reaches ~0.
+const int kTargetFeedstockTileCount = 6;
+
+/// Effective labour below which computed military priority is 0.
+const int kMinLabourForMilitary = 6;
+
+/// Labour span over which military priority ramps 0→1.
+const int kLabourRangeForMilitary = 6;
+
+/// Per-commodity reserve target for stockpile damping.
+const int kReserveTarget = 20;
+
+/// Minimum military priority for an at-war GP.
+const double kAtWarMilitaryFloor = 0.3;
+
+/// Additive bias (≈ max shortage) so in-stage low-shortage recipes can win.
+const double kStagePriorityBias = 16.0;
+
+/// Minimum category priority so a critically short off-stage recipe is not zeroed.
+const double kMinCategoryFloor = 0.1;
+
+/// Minimum peasant-recruit score scaling for mature GPs.
+const double kRecruitmentFloor = 0.25;
+
+/// Military priority below which regiment/ship builds are suppressed.
+const double kMilitaryBuildSuppressionThreshold = 0.2;
+
+const Set<String> _kCriticalFeedstockResourceIds = {
+  'wool',
+  'cotton',
+  'timber',
+  'iron',
+  'coal',
+};
+
+/// Persistent growth-stage priorities derived each turn from game state.
+class GrowthStage {
+  const GrowthStage({
+    required this.workerGrowthPriority,
+    required this.infrastructurePriority,
+    required this.resourceProductionPriority,
+    required this.militaryPriority,
+  });
+
+  final double workerGrowthPriority;
+  final double infrastructurePriority;
+  final double resourceProductionPriority;
+  final double militaryPriority;
+
+  /// Pure, deterministic priority vector for one GP (Refs #3371 AC10).
+  static GrowthStage compute(
+    Game game,
+    String playerId, {
+    AIWorldSnapshot? snapshot,
+  }) {
+    final player = game.playerById(playerId);
+    if (player == null) {
+      return const GrowthStage(
+        workerGrowthPriority: 0,
+        infrastructurePriority: 0,
+        resourceProductionPriority: 0,
+        militaryPriority: 0,
+      );
+    }
+
+    final regimentCounts = regimentTypeCountsForPlayer(
+      game.worldState,
+      playerId,
+    );
+    final shipCounts = shipTypeCountsForPlayer(game.worldState, playerId);
+    final effectiveLabour = effectiveLabourForWorkers(
+      workers: player.workerPool,
+      stockpile: player.stockpile,
+      regimentCountsById: regimentCounts,
+      shipCountsById: shipCounts,
+    );
+    final stockpile = player.stockpile;
+
+    var workerGrowth = _clamp01(
+      1.0 - effectiveLabour / kTargetLabourForMaturity,
+    );
+    if (stockpile.quantityOf(CommodityCatalog.fabric.id) >= kReserveTarget) {
+      workerGrowth *= 0.5;
+    }
+
+    var infrastructure = _clamp01(
+      1.0 -
+          prospectedImprovedFeedstockTileCount(game, playerId) /
+              kTargetFeedstockTileCount,
+    );
+    if (stockpile.quantityOf(CommodityCatalog.castIron.id) >= kReserveTarget &&
+        stockpile.quantityOf(CommodityCatalog.lumber.id) >= kReserveTarget) {
+      infrastructure *= 0.5;
+    }
+
+    final maturityFactor = _clamp01(
+      effectiveLabour / kTargetLabourForMaturity,
+    );
+    final reserveShortfall = _maxReserveShortfall(stockpile);
+    final resourceProduction = maturityFactor * reserveShortfall;
+
+    final computedMilitary = _clamp01(
+      (effectiveLabour - kMinLabourForMilitary) / kLabourRangeForMilitary,
+    );
+    final atWar = _isAtWar(game, playerId, snapshot: snapshot);
+    final military = atWar
+        ? computedMilitary < kAtWarMilitaryFloor
+              ? kAtWarMilitaryFloor
+              : computedMilitary
+        : computedMilitary;
+
+    return GrowthStage(
+      workerGrowthPriority: workerGrowth,
+      infrastructurePriority: infrastructure,
+      resourceProductionPriority: resourceProduction,
+      militaryPriority: military,
+    );
+  }
+}
+
+/// Peasant-recruit action score scale (Refs #3371 AC12).
+double peasantRecruitScoreScale(GrowthStage stage) {
+  final scaled = stage.workerGrowthPriority;
+  return scaled < kRecruitmentFloor ? kRecruitmentFloor : scaled;
+}
+
+/// Category priority for a recipe output under [stage].
+double categoryPriorityForOutput(String outputId, GrowthStage stage) {
+  final fabricId = CommodityCatalog.fabric.id;
+  final castIronId = CommodityCatalog.castIron.id;
+  final lumberId = CommodityCatalog.lumber.id;
+
+  double priority;
+  if (outputId == fabricId) {
+    priority = stage.workerGrowthPriority > stage.resourceProductionPriority
+        ? stage.workerGrowthPriority
+        : stage.resourceProductionPriority;
+  } else if (outputId == castIronId || outputId == lumberId) {
+    priority = stage.infrastructurePriority > stage.resourceProductionPriority
+        ? stage.infrastructurePriority
+        : stage.resourceProductionPriority;
+  } else if (_isMilitaryOutput(outputId) || _isLuxuryOutput(outputId)) {
+    priority = stage.militaryPriority;
+  } else {
+    priority = _maxOfFour(
+      stage.workerGrowthPriority,
+      stage.infrastructurePriority,
+      stage.resourceProductionPriority,
+      stage.militaryPriority,
+    );
+  }
+  return priority < kMinCategoryFloor ? kMinCategoryFloor : priority;
+}
+
+int prospectedImprovedFeedstockTileCount(Game game, String playerId) {
+  final ws = game.worldState;
+  final ownerByProvince = getProvinceOwnerMap(game);
+  final prospected = ws.playerProspectedTiles[playerId] ?? const <String>{};
+  var count = 0;
+  for (final entry in ws.resourceByTileKey.entries) {
+    final resourceId = entry.value;
+    if (!_kCriticalFeedstockResourceIds.contains(resourceId)) continue;
+    final provinceId = Unit.provinceIdFromTileKey(entry.key);
+    if (ownerByProvince[provinceId] != playerId) continue;
+    if (ws.tileState.improvementLevel(entry.key) < 1) continue;
+    if (kMineralResourceIds.contains(resourceId) &&
+        !prospected.contains(entry.key)) {
+      continue;
+    }
+    count++;
+  }
+  return count;
+}
+
+bool _isAtWar(
+  Game game,
+  String playerId, {
+  AIWorldSnapshot? snapshot,
+}) {
+  if (snapshot != null) {
+    if (snapshot.threats.atWarWith.isNotEmpty) return true;
+    if (snapshot.conquest.invadableProvinceIdsSorted.isNotEmpty) return true;
+    return false;
+  }
+  for (final rel in game.diplomacyRelations) {
+    if (!rel.atWar) continue;
+    if (rel.involvesNation(playerId)) return true;
+  }
+  return false;
+}
+
+double _maxReserveShortfall(Stockpile stockpile) {
+  final fabricId = CommodityCatalog.fabric.id;
+  final lumberId = CommodityCatalog.lumber.id;
+  final castIronId = CommodityCatalog.castIron.id;
+  final fabric = _reserveShortfall(
+    stockpile.quantityOf(fabricId),
+  );
+  final lumber = _reserveShortfall(stockpile.quantityOf(lumberId));
+  final castIron = _reserveShortfall(stockpile.quantityOf(castIronId));
+  return fabric > lumber
+      ? (fabric > castIron ? fabric : castIron)
+      : (lumber > castIron ? lumber : castIron);
+}
+
+double _reserveShortfall(int quantity) {
+  if (kReserveTarget <= 0) return 0;
+  final ratio = quantity / kReserveTarget;
+  final shortfall = 1.0 - ratio;
+  return shortfall < 0 ? 0 : shortfall;
+}
+
+bool _isMilitaryOutput(String outputId) {
+  return outputId == CommodityCatalog.steel.id ||
+      outputId == CommodityCatalog.bronze.id;
+}
+
+bool _isLuxuryOutput(String outputId) {
+  return outputId == CommodityCatalog.refinedSugar.id ||
+      outputId == CommodityCatalog.cigars.id ||
+      outputId == CommodityCatalog.furHats.id;
+}
+
+double _clamp01(double value) {
+  if (value < 0) return 0;
+  if (value > 1) return 1;
+  return value;
+}
+
+double _maxOfFour(double a, double b, double c, double d) {
+  var max = a;
+  if (b > max) max = b;
+  if (c > max) max = c;
+  if (d > max) max = d;
+  return max;
+}

--- a/packages/colonizethis_ai/lib/src/planning/recipe_scoring.dart
+++ b/packages/colonizethis_ai/lib/src/planning/recipe_scoring.dart
@@ -3,6 +3,9 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
+import 'growth_stage.dart'
+    show GrowthStage, categoryPriorityForOutput, kStagePriorityBias;
+
 /// Shortage target below which we consider a commodity "needed".
 const int kShortageThreshold = 8;
 
@@ -64,6 +67,27 @@ double scoreRecipe({
   final agenda = _recipeAgendaScore(agendaId, outputId);
 
   return shortage * kShortageWeight + chain * kChainWeight + agenda * kAgendaWeight;
+}
+
+/// Growth-stage dampen-and-bias score. SPEC/ai/growth-stage-planner.md.
+double stageScaledRecipeScore({
+  required ProductionRecipe recipe,
+  required Stockpile stockpile,
+  required WorkerPool workers,
+  required String agendaId,
+  required GrowthStage stage,
+}) {
+  final base = scoreRecipe(
+    recipe: recipe,
+    stockpile: stockpile,
+    workers: workers,
+    agendaId: agendaId,
+  );
+  final categoryPriority = categoryPriorityForOutput(
+    recipe.outputCommodityId,
+    stage,
+  );
+  return categoryPriority * (base + kStagePriorityBias);
 }
 
 /// Chain value: outputs that feed other recipes or are luxuries.

--- a/packages/colonizethis_ai/lib/src/planning/recruitment_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/recruitment_planner.dart
@@ -4,6 +4,8 @@
 
 import 'package:colonizethis_logic/order_suggestion_api.dart';
 
+import '../perception/perception_snapshot.dart';
+import 'growth_stage.dart';
 import 'observer_goal_phase.dart';
 import 'planning_imports.dart';
 
@@ -49,6 +51,11 @@ const String kRecruitmentRejectInsufficientWorkers = 'Insufficient workers';
 /// above the (deficit-aware) soft luxury cap defined in
 /// `SPEC/game/workers-and-population.md` Requirement #10.
 const String kRecruitmentRejectSoftLuxuryCap = 'Soft luxury cap exceeded';
+
+/// Stable rejection reason: growth-stage military priority is below the build
+/// suppression threshold (Refs #3371).
+const String kRecruitmentRejectMilitaryBuildSuppressed =
+    'Military build suppressed';
 
 /// One dropped candidate from [runRecruitmentPlanner]. Refs #2692 S8.
 class RejectedRecruitmentSuggestion {
@@ -110,9 +117,11 @@ RecruitmentPlan runRecruitmentPlanner({
   required AIConfig config,
   required AISeedBundle seeds,
   required ObserverGoalPhase goalPhase,
-  required OrderSuggestionAPI suggestionApi,
+  required   OrderSuggestionAPI suggestionApi,
   MapTopology? topology,
   EconomyPlan? economyPlanHint,
+  bool growthStagePlannerEnabled = kGrowthStagePlannerEnabled,
+  AIWorldSnapshot? snapshot,
 }) {
   final playerId = view.playerId;
   final player = game.playerById(playerId);
@@ -122,6 +131,12 @@ RecruitmentPlan runRecruitmentPlanner({
   }
 
   final mapTopology = topology ?? const MapTopology(nodes: [], edges: []);
+
+  final growthStage = growthStagePlannerEnabled
+      ? GrowthStage.compute(game, playerId, snapshot: snapshot)
+      : null;
+  final suppressMilitaryBuilds = growthStage != null &&
+      growthStage.militaryPriority < kMilitaryBuildSuppressionThreshold;
 
   final recruitCandidates = suggestionApi.suggestRecruitWorkerOrders(
     view,
@@ -181,6 +196,15 @@ RecruitmentPlan runRecruitmentPlanner({
 
   void processBuilds() {
     for (final candidate in buildCandidates) {
+      if (suppressMilitaryBuilds && _buildConsumesPeasant(candidate)) {
+        rejected.add(
+          RejectedRecruitmentSuggestion(
+            reason: kRecruitmentRejectMilitaryBuildSuppressed,
+            targetTier: candidate.unitType,
+          ),
+        );
+        continue;
+      }
       final outcome = _evaluateBuildCandidate(candidate, state);
       switch (outcome) {
         case _CandidateOutcome.accepted:

--- a/packages/colonizethis_ai/test/growth_stage_planner_test.dart
+++ b/packages/colonizethis_ai/test/growth_stage_planner_test.dart
@@ -1,0 +1,409 @@
+// Growth-stage planner (Refs #3371). SPEC/ai/growth-stage-planner.md.
+
+import 'package:colonizethis_ai/colonizethis_ai.dart';
+import 'package:colonizethis_ai/src/perception/perception_snapshot.dart';
+import 'package:colonizethis_ai/src/perception/summary_models.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_logic/order_suggestion_api.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+import 'domain_planner_test_fake_api.dart';
+
+const _topology = MapTopology(nodes: [], edges: []);
+const _config = AIConfig(
+  leaderId: 'victoria',
+  personalityId: 'victoria',
+  hiddenAgendaId: 'peacemaker',
+);
+final _seeds = AISeedBundle.fromTurnSeed(3371);
+
+Game _gameWith(Player player) => Game(
+  id: 'g1',
+  worldState: WorldState(
+    turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+    oldWorld: const RegionData(provinces: [], units: []),
+    newWorld: const RegionData(provinces: [], units: []),
+  ),
+  players: [player],
+);
+
+OrderSuggestionAPI _fakeApi({
+  List<RecruitWorkerOrder> recruit = const [],
+  List<BuildUnitOrder> build = const [],
+}) {
+  return FakeOrderSuggestionAPIForDomainPlannerTests(
+    work: const [],
+    build: build,
+    move: const [],
+    research: const [],
+    navalMove: const [],
+    navalMission: const [],
+    recruitWorker: recruit,
+  );
+}
+
+int _labourForRecipe(EconomyPlan plan, String recipeId) {
+  for (final a in plan.productionAssignments) {
+    if (a.recipeId == recipeId) return a.assignedLabour;
+  }
+  return 0;
+}
+
+Game _bootstrapFabricGame() {
+  const ow = 'oldWorld';
+  return Game(
+    id: 'g-3371-ac1',
+    worldState: WorldState(
+      turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+      oldWorld: const RegionData(
+        provinces: [
+          Province(id: '$ow|p0', regionId: ow, ownerId: 'gp1'),
+        ],
+      ),
+      newWorld: const RegionData(),
+      resourceByTileKey: const {'$ow|p0|1|0': 'wool'},
+    ),
+    players: [
+      Player(
+        id: 'gp1',
+        displayName: 'GP1',
+        isHuman: false,
+        capitalProvinceId: '$ow|p0',
+        stockpile: const Stockpile()
+            .applyDelta(CommodityCatalog.grain.id, 40)
+            .applyDelta(CommodityCatalog.wool.id, 10),
+        workerPool: const WorkerPool(peasants: 4),
+      ),
+    ],
+  );
+}
+
+Game _matureCastIronGame({int castIronHeld = 0}) {
+  const ow = 'oldWorld';
+  return Game(
+    id: 'g-3371-ac2',
+    worldState: WorldState(
+      turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+      oldWorld: const RegionData(
+        provinces: [
+          Province(id: '$ow|p0', regionId: ow, ownerId: 'gp1'),
+          Province(id: '$ow|p1', regionId: ow, ownerId: 'gp1'),
+        ],
+      ),
+      newWorld: const RegionData(),
+      resourceByTileKey: const {
+        '$ow|p0|1|0': 'timber',
+        '$ow|p1|1|0': 'iron',
+      },
+      tileState: const TileMapState(
+        improvementByTile: {
+          '$ow|p0|1|0': 1,
+          '$ow|p1|1|0': 1,
+        },
+      ),
+      playerProspectedTiles: const {
+        'gp1': {'$ow|p1|1|0'},
+      },
+    ),
+    players: [
+      Player(
+        id: 'gp1',
+        displayName: 'GP1',
+        isHuman: false,
+        capitalProvinceId: '$ow|p0',
+        stockpile: Stockpile()
+            .applyDelta(CommodityCatalog.grain.id, 80)
+            .applyDelta(CommodityCatalog.timber.id, 30)
+            .applyDelta(CommodityCatalog.iron.id, 10)
+            .applyDelta(CommodityCatalog.castIron.id, castIronHeld),
+        workerPool: const WorkerPool(peasants: 12),
+      ),
+    ],
+  );
+}
+
+AIWorldSnapshot _atWarSnapshot(String playerId) {
+  return AIWorldSnapshot(
+    playerId: playerId,
+    threats: const ThreatSummary(
+      atWarWith: ['gp2'],
+      neighborProvincesHostile: 1,
+      capitalThreatened: false,
+    ),
+    opportunities: const OpportunitySummary(),
+    conquest: const ConquestSummary(
+      oldWorldProvincesOwned: 2,
+      provincesToVictory: 29,
+      invadableProvinceIdsSorted: ['oldWorld|enemy'],
+    ),
+    economy: const EconomySummary(
+      workerCount: 4,
+      treasury: 100,
+      ownProvinceCount: 2,
+    ),
+    relations: const {},
+  );
+}
+
+void main() {
+  group('GrowthStage.compute — AC10 determinism', () {
+    test('identical inputs yield identical priorities', () {
+      final game = _bootstrapFabricGame();
+      final a = GrowthStage.compute(game, 'gp1');
+      final b = GrowthStage.compute(game, 'gp1');
+      expect(a.workerGrowthPriority, b.workerGrowthPriority);
+      expect(a.infrastructurePriority, b.infrastructurePriority);
+      expect(a.resourceProductionPriority, b.resourceProductionPriority);
+      expect(a.militaryPriority, b.militaryPriority);
+    });
+  });
+
+  group('runEconomyPlanner growth-stage — AC1 bootstrap worker growth', () {
+    test('fabric recipe receives the most labour', () {
+      final game = _bootstrapFabricGame();
+      final view = buildPlayerView(game, _topology, 'gp1');
+      final plan = runEconomyPlanner(
+        game: game,
+        view: view,
+        config: _config,
+        seeds: _seeds,
+        growthStagePlannerEnabled: true,
+      );
+
+      final fabricLabour = _labourForRecipe(
+        plan,
+        ProductionRecipesCatalog.fabricFromWool.id,
+      );
+      expect(fabricLabour, greaterThan(0));
+      for (final assignment in plan.productionAssignments) {
+        if (assignment.recipeId ==
+            ProductionRecipesCatalog.fabricFromWool.id) {
+          continue;
+        }
+        expect(
+          fabricLabour,
+          greaterThan(assignment.assignedLabour),
+          reason:
+              'fabric should receive more labour than ${assignment.recipeId}',
+        );
+      }
+    });
+  });
+
+  group('runEconomyPlanner growth-stage — AC2 infrastructure', () {
+    test('assigns labour to castIron when mature and inputs on hand', () {
+      final game = _matureCastIronGame();
+      final view = buildPlayerView(game, _topology, 'gp1');
+      final plan = runEconomyPlanner(
+        game: game,
+        view: view,
+        config: _config,
+        seeds: _seeds,
+        growthStagePlannerEnabled: true,
+      );
+
+      expect(
+        _labourForRecipe(
+          plan,
+          ProductionRecipesCatalog.castIronFromTimberIronCoal.id,
+        ),
+        greaterThan(0),
+      );
+    });
+  });
+
+  group('stageScaledRecipeScore — AC5 stockpile damping', () {
+    test('high castIron stockpile dampens castIron recipe score', () {
+      const workers = WorkerPool(peasants: 12);
+      const agenda = 'peacemaker';
+      final matureStage = GrowthStage.compute(_matureCastIronGame(), 'gp1');
+      final stockLow = const Stockpile()
+          .applyDelta(CommodityCatalog.grain.id, 80)
+          .applyDelta(CommodityCatalog.timber.id, 30)
+          .applyDelta(CommodityCatalog.iron.id, 10);
+      final stockHigh = stockLow.applyDelta(CommodityCatalog.castIron.id, 25);
+
+      final scoreLow = stageScaledRecipeScore(
+        recipe: ProductionRecipesCatalog.castIronFromTimberIronCoal,
+        stockpile: stockLow,
+        workers: workers,
+        agendaId: agenda,
+        stage: matureStage,
+      );
+      final scoreHigh = stageScaledRecipeScore(
+        recipe: ProductionRecipesCatalog.castIronFromTimberIronCoal,
+        stockpile: stockHigh,
+        workers: workers,
+        agendaId: agenda,
+        stage: matureStage,
+      );
+      expect(scoreHigh, lessThan(scoreLow));
+    });
+  });
+
+  group('GrowthStage — AC6 at-war military floor', () {
+    test('at-war GP with 4 labour has militaryPriority 0.3', () {
+      final game = _bootstrapFabricGame();
+      final stage = GrowthStage.compute(
+        game,
+        'gp1',
+        snapshot: _atWarSnapshot('gp1'),
+      );
+      expect(stage.militaryPriority, kAtWarMilitaryFloor);
+    });
+
+    test('military-input recipe receives labour under at-war floor', () {
+      final game = Game(
+        id: 'g-3371-ac6',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: const RegionData(
+            provinces: [
+              Province(id: 'oldWorld|p0', regionId: 'oldWorld', ownerId: 'gp1'),
+            ],
+          ),
+          newWorld: const RegionData(),
+        ),
+        players: [
+          Player(
+            id: 'gp1',
+            displayName: 'GP1',
+            isHuman: false,
+            capitalProvinceId: 'oldWorld|p0',
+            stockpile: const Stockpile()
+                .applyDelta(CommodityCatalog.grain.id, 40)
+                .applyDelta(CommodityCatalog.copper.id, 5)
+                .applyDelta(CommodityCatalog.tin.id, 5),
+            workerPool: const WorkerPool(peasants: 4),
+          ),
+        ],
+      );
+      final view = buildPlayerView(game, _topology, 'gp1');
+      final plan = runEconomyPlanner(
+        game: game,
+        view: view,
+        config: _config,
+        seeds: _seeds,
+        snapshot: _atWarSnapshot('gp1'),
+        growthStagePlannerEnabled: true,
+      );
+
+      final bronzeLabour = _labourForRecipe(
+        plan,
+        ProductionRecipesCatalog.bronzeFromCopperTin.id,
+      );
+      expect(bronzeLabour, greaterThan(0));
+    });
+  });
+
+  group('stageScaledRecipeScore — AC11 shortage dominance', () {
+    test('fabric stageScaledScore beats military input in bootstrap', () {
+      final game = Game(
+        id: 'g-3371-ac11',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: const RegionData(
+            provinces: [
+              Province(id: 'oldWorld|p0', regionId: 'oldWorld', ownerId: 'gp1'),
+            ],
+          ),
+          newWorld: const RegionData(),
+          resourceByTileKey: const {'oldWorld|p0|1|0': 'wool'},
+        ),
+        players: [
+          Player(
+            id: 'gp1',
+            displayName: 'GP1',
+            isHuman: false,
+            capitalProvinceId: 'oldWorld|p0',
+            stockpile: const Stockpile()
+                .applyDelta(CommodityCatalog.grain.id, 40)
+                .applyDelta(CommodityCatalog.wool.id, 10)
+                .applyDelta(CommodityCatalog.copper.id, 5)
+                .applyDelta(CommodityCatalog.tin.id, 5),
+            workerPool: const WorkerPool(peasants: 2),
+          ),
+        ],
+      );
+      final stage = GrowthStage.compute(game, 'gp1');
+      expect(stage.workerGrowthPriority, greaterThan(0.8));
+
+      const workers = WorkerPool(peasants: 2);
+      final stockpile = game.players.first.stockpile;
+
+      final fabricScore = stageScaledRecipeScore(
+        recipe: ProductionRecipesCatalog.fabricFromWool,
+        stockpile: stockpile,
+        workers: workers,
+        agendaId: 'peacemaker',
+        stage: stage,
+      );
+      final militaryScore = stageScaledRecipeScore(
+        recipe: ProductionRecipesCatalog.bronzeFromCopperTin,
+        stockpile: stockpile,
+        workers: workers,
+        agendaId: 'peacemaker',
+        stage: stage,
+      );
+      expect(fabricScore, greaterThan(militaryScore));
+    });
+  });
+
+  group('runRecruitmentPlanner growth-stage — AC4 bootstrap build suppression',
+      () {
+    test('suppresses regiment builds when military priority is low', () {
+      final game = _gameWith(
+        Player(
+          id: 'gp1',
+          displayName: 'A',
+          isHuman: false,
+          workerPool: const WorkerPool(peasants: 3),
+          stockpile: const Stockpile().applyDelta(CommodityCatalog.grain.id, 30),
+        ),
+      );
+      final view = buildPlayerView(game, _topology, 'gp1');
+      final api = _fakeApi(
+        build: const [
+          BuildUnitOrder(
+            unitType: 'peasant_levies',
+            isMilitary: true,
+            spawnProvinceId: 'oldWorld|P1',
+          ),
+        ],
+      );
+
+      final plan = runRecruitmentPlanner(
+        game: game,
+        view: view,
+        currentOrders: const Orders(),
+        config: _config,
+        seeds: _seeds,
+        goalPhase: ObserverGoalPhase.expand,
+        suggestionApi: api,
+        growthStagePlannerEnabled: true,
+      );
+
+      expect(plan.buildUnitOrders, isEmpty);
+      expect(plan.rejected, hasLength(1));
+      expect(
+        plan.rejected.first.reason,
+        kRecruitmentRejectMilitaryBuildSuppressed,
+      );
+    });
+  });
+
+  group('peasantRecruitScoreScale — AC12 recruitment modulation', () {
+    test('bootstrap scale exceeds mature scale; mature respects floor', () {
+      final bootstrap = GrowthStage.compute(_bootstrapFabricGame(), 'gp1');
+      final mature = GrowthStage.compute(_matureCastIronGame(), 'gp1');
+
+      final bootstrapScale = peasantRecruitScoreScale(bootstrap);
+      final matureScale = peasantRecruitScoreScale(mature);
+
+      expect(bootstrapScale, greaterThan(matureScale));
+      expect(matureScale, greaterThanOrEqualTo(kRecruitmentFloor));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Adds `GrowthStage.compute` and dampen-and-bias `stageScaledRecipeScore` per `SPEC/ai/growth-stage-planner.md`.
- Wires growth-stage scoring into `runEconomyPlanner` and build suppression / peasant-recruit scaling into `runRecruitmentPlanner` behind `growthStagePlannerEnabled` (default **off**).
- When the flag is on, H8 reactive boosts are short-circuited; when off, behaviour is unchanged.

Refs #3371

## Done in this PR

- New spec: `SPEC/ai/growth-stage-planner.md`; cross-reference in `economy-planner.md`.
- Implementation: `growth_stage.dart`, `stageScaledRecipeScore`, economy + recruitment integration.
- Tests mapping AC1, AC2, AC4, AC5, AC6, AC10, AC11, AC12 (`growth_stage_planner_test.dart`).

## Deferred (same issue, follow-up)

- **AC3** — mature military-input + build-pass integration (needs orchestrator wiring).
- **AC7** — seed-42 observer regression with flag on (calibration pass).
- **AC8** — full H8 section removal from `economy-planner.md` (after AC7).
- **AC9** — delete H8 reactive code paths (after default flag flip).
- Civilian work priority modulation (`full_ai_civilian_work_selection`).

## Test plan

- [x] `packages/colonizethis_ai/test/growth_stage_planner_test.dart`
- [x] `packages/colonizethis_ai/test/economy_planner_regiment_build_input_production_test.dart` (flag off — no regression)
- [x] `packages/colonizethis_ai/test/recruitment_planner_test.dart`


Made with [Cursor](https://cursor.com)