### PR TITLE
feat(ai): wire growth-stage planner through full AI path (Refs #3371)

### DIFF
--- a/SPEC/ai/growth-stage-planner.md
+++ b/SPEC/ai/growth-stage-planner.md
@@ -96,8 +96,10 @@ When `militaryPriority < kMilitaryBuildSuppressionThreshold`, `runRecruitmentPla
 - `economy_planner.dart` — `_allocateLabour`, optional `growthStagePlannerEnabled` parameter.
 - `recruitment_planner.dart` — build suppression, peasant scale helper.
 - `recipe_scoring.dart` — `stageScaledRecipeScore`.
+- `strategic_ai.dart` / `full_ai_planner.dart` — thread `growthStagePlannerEnabled` into economy and domain planners for end-to-end simulation (AC7).
+- `domain_planner_orchestrator.dart` — growth-stage military build suppression in `_appendEconomyBuildOrders`; H8 castIron-labour peasant recruit skipped when the flag is on.
 - Civilian work priority modulation: follow-up slice (not in initial flag-off default path).
 
 ## Acceptance criteria (issue #3371)
 
-AC1–AC6, AC10–AC12: unit tests in `growth_stage_planner_test.dart`. AC7 seed-42 regression and AC9 H8 removal: follow-up after calibration with flag default on.
+AC1–AC6, AC10–AC12: unit tests in `growth_stage_planner_test.dart`. AC7: `seed42_growth_stage_conquest_regression_test.dart` (skipped until calibration). AC9 H8 removal: follow-up after AC7 passes with flag default on.

--- a/packages/colonizethis_ai/lib/colonizethis_ai.dart
+++ b/packages/colonizethis_ai/lib/colonizethis_ai.dart
@@ -21,6 +21,7 @@ export 'src/planning/growth_stage.dart'
         GrowthStage,
         categoryPriorityForOutput,
         kAtWarMilitaryFloor,
+        growthStageSuppressesMilitaryBuilds,
         kGrowthStagePlannerEnabled,
         kMilitaryBuildSuppressionThreshold,
         kRecruitmentFloor,

--- a/packages/colonizethis_ai/lib/src/planning/domain_planner_orchestrator.dart
+++ b/packages/colonizethis_ai/lib/src/planning/domain_planner_orchestrator.dart
@@ -1,5 +1,7 @@
 import 'dart:math' as math;
 
+import 'package:colonizethis_data/colonizethis_data.dart'
+    show BuildUnitCategory, buildUnitCategoryForUnitType;
 import 'package:colonizethis_logic/ai_api.dart' show canAffordRecruitWorker;
 import 'package:colonizethis_logic/order_suggestion_api.dart';
 
@@ -17,6 +19,7 @@ import '../perception/perception_snapshot.dart';
 import '../util/orders_builder.dart';
 import '../util/orders_extensions.dart';
 import 'build_planner.dart';
+import 'growth_stage.dart';
 import 'conquest_planner.dart';
 import 'diplomacy_planner.dart';
 import 'domain_planner_outcome.dart';
@@ -97,6 +100,7 @@ DomainPlannerOutcome runDomainPlannersWithOutcome({
   Orders? sameTurnPriorDiplomaticOrders,
   PhasePlanOutcome? phasePlan,
   bool recomputeTradeOrdersWithPendingCosts = false,
+  bool growthStagePlannerEnabled = kGrowthStagePlannerEnabled,
 }) {
   void emit(String phaseId) => onStagedPlannerProgress?.call(phaseId);
 
@@ -128,6 +132,7 @@ DomainPlannerOutcome runDomainPlannersWithOutcome({
     economyPlan: economyPlan,
     tileMapByRegion: tileMapByRegion,
     emit: emit,
+    growthStagePlannerEnabled: growthStagePlannerEnabled,
   );
   ctx = economyResult.ctx;
   final economyGate = economyResult.gate;
@@ -332,6 +337,7 @@ _EconomyDomainPlannersResult _runEconomyDomainPlanners({
   required EconomyPlan economyPlan,
   Map<String, TileMapResult>? tileMapByRegion,
   required void Function(String phaseId) emit,
+  bool growthStagePlannerEnabled = kGrowthStagePlannerEnabled,
 }) {
   // Refs #3288: accumulate the orchestrator-emitted economy families (work,
   // recruit, build) into a single mutable [OrdersBuilder] and freeze once,
@@ -479,7 +485,8 @@ _EconomyDomainPlannersResult _runEconomyDomainPlanners({
   emit('aiStageA');
 
   final expandEconomy = expandEconomyPlanFromPhasePlan(phasePlan);
-  if (expandEconomy.boostCastIronLabourPeasantRecruitment) {
+  if (!growthStagePlannerEnabled &&
+      expandEconomy.boostCastIronLabourPeasantRecruitment) {
     final recruitCandidates = ctx.suggestionAPI.suggestRecruitWorkerOrders(
       ctx.view,
       ctx.game,
@@ -527,6 +534,7 @@ _EconomyDomainPlannersResult _runEconomyDomainPlanners({
     colonialPressure: colonialPressure,
     buildCandidates: buildCandidates,
     domainEconomyWeight: domainWeights.economy,
+    growthStagePlannerEnabled: growthStagePlannerEnabled,
   );
   emit('aiStageB');
   return _EconomyDomainPlannersResult(
@@ -562,6 +570,7 @@ _BuildPassResult _appendEconomyBuildOrders({
   required bool colonialPressure,
   required List<BuildUnitOrder> buildCandidates,
   required int domainEconomyWeight,
+  bool growthStagePlannerEnabled = kGrowthStagePlannerEnabled,
 }) {
   // Refs #2509 S5: derive below-quota OW build-pass routing from the
   // dispatched phase plan instead of recomputing
@@ -718,9 +727,31 @@ _BuildPassResult _appendEconomyBuildOrders({
     'buildCandidatesCount=${buildCandidates.length} '
     'regimentCount=$regimentCount forceRegimentRebuild=$forceRegimentRebuild',
   );
-  if (buildCandidates.isEmpty ||
+  var candidatesForGate = buildCandidates;
+  if (growthStagePlannerEnabled) {
+    final stage = GrowthStage.compute(
+      ctx.game,
+      ctx.nationId,
+      snapshot: snapshot,
+    );
+    if (growthStageSuppressesMilitaryBuilds(stage)) {
+      candidatesForGate = buildCandidates
+          .where((order) {
+            final category = buildUnitCategoryForUnitType(order.unitType);
+            return category != BuildUnitCategory.military &&
+                category != BuildUnitCategory.naval;
+          })
+          .toList();
+      _log.d(
+        'growth_stage military build suppressed nationId=${ctx.nationId} '
+        'militaryPriority=${stage.militaryPriority}',
+      );
+    }
+  }
+
+  if (candidatesForGate.isEmpty ||
       (domainEconomyWeight < buildThreshold && !forceRegimentRebuild)) {
-    if (buildCandidates.isNotEmpty) {
+    if (candidatesForGate.isNotEmpty) {
       _log.d('build skipped nationId=${ctx.nationId} weight below threshold');
     }
     return _BuildPassResult(
@@ -728,7 +759,7 @@ _BuildPassResult _appendEconomyBuildOrders({
       buildThreshold: buildThreshold,
     );
   }
-  var candidatesForBuild = buildCandidates;
+  var candidatesForBuild = candidatesForGate;
   if (forceRegimentRebuild && !firstNavalTransportBootstrap) {
     final regimentsOnly = buildCandidates
         .where((o) => RegimentEconomyCatalog.byId.containsKey(o.unitType))

--- a/packages/colonizethis_ai/lib/src/planning/full_ai_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/full_ai_planner.dart
@@ -5,6 +5,7 @@ import 'package:colonizethis_logic/order_suggestion_api.dart';
 import 'diplomacy_planner.dart';
 import 'observer_goal_phase.dart';
 import 'planning_imports.dart';
+import 'growth_stage.dart' show kGrowthStagePlannerEnabled;
 import 'strategic_ai.dart';
 
 final _log = packageLogger();
@@ -44,6 +45,7 @@ StrategicOrderTraceResult generateOrdersForPlayerFullAIWithTrace(
   void Function(PortraitMoodEvent)? onMood,
   void Function(String phaseId)? onStagedPlannerProgress,
   Orders? sameTurnPriorDiplomaticOrders,
+  bool growthStagePlannerEnabled = kGrowthStagePlannerEnabled,
 }) {
   final player = game.playerById(playerId);
   if (player == null || !isAiControlled(game, player.id)) {
@@ -88,6 +90,7 @@ StrategicOrderTraceResult generateOrdersForPlayerFullAIWithTrace(
     onMood: onMood,
     onStagedPlannerProgress: onStagedPlannerProgress,
     sameTurnPriorDiplomaticOrders: sameTurnPriorDiplomaticOrders,
+    growthStagePlannerEnabled: growthStagePlannerEnabled,
   );
   return traced;
 }
@@ -116,6 +119,7 @@ FullAIResult generateOrdersForGameFullAI(
   void Function(DialogueEvent)? onDialogue,
   void Function(PortraitMoodEvent)? onMood,
   void Function(String phaseId)? onStagedPlannerProgress,
+  bool growthStagePlannerEnabled = kGrowthStagePlannerEnabled,
 }) {
   final totalStopwatch = Stopwatch()..start();
   var planningGame = game;
@@ -159,6 +163,7 @@ FullAIResult generateOrdersForGameFullAI(
       onMood: onMood,
       onStagedPlannerProgress: onStagedPlannerProgress,
       sameTurnPriorDiplomaticOrders: sameTurnPriorDiplomaticOrders,
+      growthStagePlannerEnabled: growthStagePlannerEnabled,
     );
     _log.i(
       'full_ai player_complete gameId=${game.id} playerId=$playerId '

--- a/packages/colonizethis_ai/lib/src/planning/growth_stage.dart
+++ b/packages/colonizethis_ai/lib/src/planning/growth_stage.dart
@@ -130,6 +130,12 @@ class GrowthStage {
   }
 }
 
+/// True when growth-stage military priority is below the build-suppression
+/// threshold (Refs #3371 AC4).
+bool growthStageSuppressesMilitaryBuilds(GrowthStage stage) {
+  return stage.militaryPriority < kMilitaryBuildSuppressionThreshold;
+}
+
 /// Peasant-recruit action score scale (Refs #3371 AC12).
 double peasantRecruitScoreScale(GrowthStage stage) {
   final scaled = stage.workerGrowthPriority;

--- a/packages/colonizethis_ai/lib/src/planning/strategic_ai.dart
+++ b/packages/colonizethis_ai/lib/src/planning/strategic_ai.dart
@@ -8,6 +8,7 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import 'army_conquest_prep.dart';
 import 'domain_planner_orchestrator.dart';
 import 'economy_planner.dart';
+import 'growth_stage.dart' show kGrowthStagePlannerEnabled;
 import 'goal_manager.dart';
 import 'observer_goal_phase.dart';
 import 'phase_planner_dispatch.dart';
@@ -77,6 +78,7 @@ StrategicOrderTraceResult generateStrategicOrdersWithTrace({
   void Function(PortraitMoodEvent)? onMood,
   void Function(String phaseId)? onStagedPlannerProgress,
   Orders? sameTurnPriorDiplomaticOrders,
+  bool growthStagePlannerEnabled = kGrowthStagePlannerEnabled,
 }) {
   final turn = game.worldState.turnState.turnNumber;
   _log.i('generateStrategicOrders nationId=$nationId turn=$turn');
@@ -174,6 +176,7 @@ StrategicOrderTraceResult generateStrategicOrdersWithTrace({
     tileMapByRegion: tileMapByRegion,
     topology: topology,
     skipTradeOrderGeneration: true,
+    growthStagePlannerEnabled: growthStagePlannerEnabled,
   );
   final plannerOutcome = runDomainPlannersWithOutcome(
     game: planningGame,
@@ -191,6 +194,7 @@ StrategicOrderTraceResult generateStrategicOrdersWithTrace({
     sameTurnPriorDiplomaticOrders: sameTurnPriorDiplomaticOrders,
     phasePlan: phasePlan,
     recomputeTradeOrdersWithPendingCosts: true,
+    growthStagePlannerEnabled: growthStagePlannerEnabled,
   );
   // Trade orders are merged into [Orders.tradeOrdersByPlayerId] inside the
   // domain orchestrator (Refs #2994 F7) so all orchestrator callers see the

--- a/packages/colonizethis_ai/test/growth_stage_planner_test.dart
+++ b/packages/colonizethis_ai/test/growth_stage_planner_test.dart
@@ -394,6 +394,96 @@ void main() {
     });
   });
 
+  group('runEconomyPlanner growth-stage — AC3 military unlocks at maturity', () {
+    test('assigns military-input labour and does not suppress builds', () {
+      const ow = 'oldWorld';
+      final game = Game(
+        id: 'g-3371-ac3',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: const RegionData(
+            provinces: [
+              Province(id: '$ow|p0', regionId: ow, ownerId: 'gp1'),
+            ],
+          ),
+          newWorld: const RegionData(),
+          resourceByTileKey: const {
+            '$ow|p0|1|0': 'timber',
+            '$ow|p0|2|0': 'iron',
+          },
+          tileState: const TileMapState(
+            improvementByTile: {
+              '$ow|p0|1|0': 1,
+              '$ow|p0|2|0': 1,
+            },
+          ),
+          playerProspectedTiles: const {
+            'gp1': {'$ow|p0|2|0'},
+          },
+        ),
+        players: [
+          Player(
+            id: 'gp1',
+            displayName: 'GP1',
+            isHuman: false,
+            capitalProvinceId: '$ow|p0',
+            treasury: 2500,
+            stockpile: const Stockpile()
+                .applyDelta(CommodityCatalog.grain.id, 80)
+                .applyDelta(CommodityCatalog.fabric.id, 6)
+                .applyDelta(CommodityCatalog.castIron.id, 6)
+                .applyDelta(CommodityCatalog.copper.id, 10)
+                .applyDelta(CommodityCatalog.tin.id, 10),
+            workerPool: const WorkerPool(peasants: 12),
+          ),
+        ],
+      );
+      final snapshot = _atWarSnapshot('gp1');
+      final stage = GrowthStage.compute(game, 'gp1', snapshot: snapshot);
+      expect(growthStageSuppressesMilitaryBuilds(stage), isFalse);
+
+      final view = buildPlayerView(game, _topology, 'gp1');
+      final plan = runEconomyPlanner(
+        game: game,
+        view: view,
+        config: _config,
+        seeds: _seeds,
+        snapshot: snapshot,
+        growthStagePlannerEnabled: true,
+      );
+
+      expect(
+        _labourForRecipe(
+          plan,
+          ProductionRecipesCatalog.bronzeFromCopperTin.id,
+        ),
+        greaterThan(0),
+        reason: 'mature at-war GP should assign military-input labour',
+      );
+
+      final recruitPlan = runRecruitmentPlanner(
+        game: game,
+        view: view,
+        currentOrders: const Orders(),
+        config: _config,
+        seeds: _seeds,
+        goalPhase: ObserverGoalPhase.expand,
+        suggestionApi: _fakeApi(
+          build: const [
+            BuildUnitOrder(
+              unitType: 'peasant_levies',
+              isMilitary: true,
+              spawnProvinceId: '$ow|p0',
+            ),
+          ],
+        ),
+        growthStagePlannerEnabled: true,
+        snapshot: snapshot,
+      );
+      expect(recruitPlan.buildUnitOrders, isNotEmpty);
+    });
+  });
+
   group('peasantRecruitScoreScale — AC12 recruitment modulation', () {
     test('bootstrap scale exceeds mature scale; mature respects floor', () {
       final bootstrap = GrowthStage.compute(_bootstrapFabricGame(), 'gp1');

--- a/packages/colonizethis_ai/test/seed42_growth_stage_conquest_regression_test.dart
+++ b/packages/colonizethis_ai/test/seed42_growth_stage_conquest_regression_test.dart
@@ -1,0 +1,97 @@
+import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_test/test.dart';
+import 'package:colonizethis_ai/colonizethis_ai.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:logger/logger.dart';
+
+import 'support/faithful_full_ai_test_handoff.dart';
+
+/// Growth-stage planner seed-42 conquest gate (Refs #3371 AC7).
+///
+/// Runs with `growthStagePlannerEnabled: true` (H8 reactive boosts off).
+void main() {
+  setUpAll(() {
+    CtLogger.level = Level.off;
+  });
+
+  test(
+    'seed 42 turn 100 with growth-stage planner: per-GP OW conquest baselines',
+    () {
+      final init = runInitGame(
+        config: GameSetupConfig(seed: 42),
+        options: const InitGameOptions(
+          cellSize: 24,
+          renderPng: false,
+          skipFillLakes: false,
+        ),
+      );
+      var game = applyFaithfulFullAiTestHandoff(init.game);
+      final topo = init.combinedTopology;
+      final tileMap = init.tileMapByRegion;
+      final owStart = <String, int>{};
+      for (var i = 1; i <= 6; i++) {
+        final gpId = 'gp$i';
+        owStart[gpId] = game.worldState.oldWorld.provinces
+            .where((p) => p.ownerId == gpId)
+            .length;
+      }
+      for (var t = 0; t < 100; t++) {
+        final fullAi = generateOrdersForGameFullAI(
+          game,
+          topo,
+          tileMapByRegion: tileMap,
+          growthStagePlannerEnabled: true,
+        );
+        final merged = mergeOrderLists(
+          humanOrders: const Orders(),
+          aiOrders: fullAi.orders,
+        );
+        final assignments = fullAi.economyPlansByPlayerId.map(
+          (pid, plan) => MapEntry(pid, plan.productionAssignments),
+        );
+        final result = validateOrdersAndResolveTurnFromTrustedOrders(
+          game: fullAi.game,
+          topology: topo,
+          orders: merged,
+          tileMapByRegion: tileMap,
+          defaultAssignmentsByPlayerId: assignments,
+        );
+        expect(result, isA<TurnResolutionComplete>());
+        game = (result as TurnResolutionComplete).game;
+      }
+      final gains = <String, int>{};
+      for (var i = 1; i <= 6; i++) {
+        final gpId = 'gp$i';
+        final end = game.worldState.oldWorld.provinces
+            .where((p) => p.ownerId == gpId)
+            .length;
+        gains[gpId] = end - owStart[gpId]!;
+      }
+
+      const baselines = <String, int>{
+        'gp1': 6,
+        'gp2': 6,
+        'gp4': 3,
+        'gp6': 10,
+        'gp3': 3,
+        'gp5': 3,
+      };
+      for (final entry in baselines.entries) {
+        expect(
+          gains[entry.key],
+          greaterThanOrEqualTo(entry.value),
+          reason:
+              '${entry.key} OW gain=${gains[entry.key]} '
+              'required>=${entry.value} allGains=$gains',
+        );
+      }
+    },
+    skip:
+        'Refs #3371 AC7: growth-stage calibration pending — run with '
+        'growthStagePlannerEnabled=true after constant tuning. H8 boosts are '
+        'disabled in this path; baseline parity vs legacy seed-42 is not yet '
+        'verified on dev HEAD.',
+  );
+}


### PR DESCRIPTION
## Summary

- Threads `growthStagePlannerEnabled` from `generateOrdersForGameFullAI` through strategic AI into `runEconomyPlanner` and the domain orchestrator build pass.
- When the flag is on, disables H8 castIron-labour peasant recruit and applies growth-stage military build suppression in `_appendEconomyBuildOrders`.
- Adds AC3 unit test (mature GP military-input production + build not suppressed) and a skipped seed-42 AC7 calibration regression test.

## Deferred (same issue)

- **AC7:** Un-skip `seed42_growth_stage_conquest_regression_test.dart` after constant tuning proves baseline parity with flag on.
- **AC9:** Remove H8 reactive boost code paths after AC7 passes; flip `kGrowthStagePlannerEnabled` default to `true`.
- Civilian work priority modulation under growth-stage scoring.

## Test plan

- [x] `packages/colonizethis_ai/test/growth_stage_planner_test.dart` (AC1–AC6, AC10–AC12 + new AC3)
- [x] `packages/colonizethis_ai/test/seed42_growth_stage_conquest_regression_test.dart` (skipped AC7 harness)

Refs #3371

Made with [Cursor](https://cursor.com)