### PR TITLE
feat(ai): growth-stage military fabric reservation (#3371)

### DIFF
--- a/SPEC/ai/growth-stage-planner.md
+++ b/SPEC/ai/growth-stage-planner.md
@@ -127,6 +127,30 @@ Peasant-recruit scaling: `max(kRecruitmentFloor, workerGrowthPriority)`. Exporte
 
 When `militaryPriority < kMilitaryBuildSuppressionThreshold`, `runRecruitmentPlanner` rejects all regiment and naval build candidates. At-war floor (0.3) keeps at-war GPs above the threshold.
 
+## Military fabric reservation (AC13)
+
+A below-quota GP that is military-relevant but **fabric-scarce** must not drain
+its scarce `fabric` on the peasant-recruit worker action
+(`WorkerActionEconomyCatalog.peasant`, `materialCosts: {fabric: 2}`) when that
+same fabric is the lone missing input for a regiment build. This targets the
+seed-42 gp3 failure mode (treasury ≥ cheapest regiment cost, an invadable
+frontier, 0 regiments, "missing only the lone fabric build input it can never
+source").
+
+`growthStageReservesFabricForMilitary(stage, treasury, fabricHeld, cheapestRegimentTreasuryCost)`
+returns true when **all** hold:
+
+- `stage.militaryPriority >= kMilitaryBuildSuppressionThreshold` (builds are not suppressed);
+- `treasury >= cheapestRegimentTreasuryCost` (a regiment is already affordable); and
+- `fabricHeld < kReserveTarget` (fabric is scarce — a mature GP with full reserves keeps recruiting).
+
+When the reservation is active **and** at least one fabric-consuming
+military/naval build candidate is on offer this turn, `runRecruitmentPlanner`
+rejects every fabric-costing recruit candidate (only the peasant tier carries a
+fabric cost) with reason `kRecruitmentRejectMilitaryFabricReservation`, so the
+GP's scarce fabric is preserved to fund the regiment build pass (which runs
+first in EXPAND/COLONIAL). Flag-off behaviour is unchanged.
+
 ## Coexistence flag
 
 `growthStagePlannerEnabled` (default **false**). When false, legacy H8 behaviour in `economy-planner.md` is unchanged. When true, growth-stage scoring replaces H8 boosts; H8 code removal is AC9 after AC7 calibration.
@@ -161,4 +185,7 @@ When `militaryPriority < kMilitaryBuildSuppressionThreshold`, `runRecruitmentPla
 
 ## Acceptance criteria (issue #3371)
 
-AC1–AC6, AC10–AC12: unit tests in `growth_stage_planner_test.dart`. AC7: `seed42_growth_stage_conquest_regression_test.dart` (skipped until calibration). AC9 H8 removal: follow-up after AC7 passes with flag default on.
+AC1–AC6, AC10–AC13: unit tests in `growth_stage_planner_test.dart`. AC7: `seed42_growth_stage_conquest_regression_test.dart` (skipped until calibration). AC9 H8 removal: follow-up after AC7 passes with flag default on.
+
+- **AC13 (positive — military fabric reservation):** Given a GP with `militaryPriority >= kMilitaryBuildSuppressionThreshold`, treasury ≥ the cheapest regiment build cost, fabric held `< kReserveTarget`, and a fabric-consuming military build candidate on offer, when `runRecruitmentPlanner` runs under the growth-stage system, then every peasant-tier (fabric-costing) recruit candidate is rejected with reason `kRecruitmentRejectMilitaryFabricReservation` and no peasant recruit order is emitted.
+- **AC13 (negative — no reservation when fabric is abundant):** Given the same GP but holding `fabric >= kReserveTarget`, when `runRecruitmentPlanner` runs, then peasant-tier recruit candidates are not reservation-rejected (worker growth continues).

--- a/packages/colonizethis_ai/lib/colonizethis_ai.dart
+++ b/packages/colonizethis_ai/lib/colonizethis_ai.dart
@@ -50,6 +50,7 @@ export 'src/planning/recruitment_planner.dart'
         RejectedRecruitmentSuggestion,
         kRecruitmentRejectInsufficientWorkers,
         kRecruitmentRejectMilitaryBuildSuppressed,
+        kRecruitmentRejectMilitaryFabricReservation,
         kRecruitmentRejectSoftLuxuryCap,
         runRecruitmentPlanner;
 export 'src/social/hidden_agenda.dart';

--- a/packages/colonizethis_ai/lib/src/planning/growth_stage.dart
+++ b/packages/colonizethis_ai/lib/src/planning/growth_stage.dart
@@ -142,6 +142,37 @@ double peasantRecruitScoreScale(GrowthStage stage) {
   return scaled < kRecruitmentFloor ? kRecruitmentFloor : scaled;
 }
 
+/// True when a GP should reserve its scarce `fabric` to fund a regiment build
+/// instead of spending it on the fabric-costing peasant-recruit worker action
+/// (Refs #3371 AC13).
+///
+/// Targets the seed-42 gp3 failure mode: a below-quota GP at war with treasury
+/// at or above the cheapest regiment cost and an invadable frontier holds the
+/// treasury to rebuild but never sources the lone `fabric` build input because
+/// the peasant-recruit action (`materialCosts: {fabric: 2}`) drains the same
+/// scarce fabric first. Reservation is active only when:
+///
+/// - military builds are **not** suppressed (`militaryPriority >=
+///   kMilitaryBuildSuppressionThreshold`), so a pure bootstrap GP keeps growing
+///   workers;
+/// - the GP can already afford the cheapest regiment
+///   (`treasury >= cheapestRegimentTreasuryCost`); and
+/// - `fabric` is scarce (`fabricHeld < kReserveTarget`) — a mature GP with full
+///   fabric reserves keeps recruiting peasants.
+///
+/// Pure and deterministic given its inputs.
+bool growthStageReservesFabricForMilitary({
+  required GrowthStage stage,
+  required int treasury,
+  required int fabricHeld,
+  required int cheapestRegimentTreasuryCost,
+}) {
+  if (stage.militaryPriority < kMilitaryBuildSuppressionThreshold) return false;
+  if (treasury < cheapestRegimentTreasuryCost) return false;
+  if (fabricHeld >= kReserveTarget) return false;
+  return true;
+}
+
 /// Category priority for a recipe output under [stage].
 double categoryPriorityForOutput(String outputId, GrowthStage stage) {
   final fabricId = CommodityCatalog.fabric.id;

--- a/packages/colonizethis_ai/lib/src/planning/recruitment_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/recruitment_planner.dart
@@ -57,6 +57,12 @@ const String kRecruitmentRejectSoftLuxuryCap = 'Soft luxury cap exceeded';
 const String kRecruitmentRejectMilitaryBuildSuppressed =
     'Military build suppressed';
 
+/// Stable rejection reason: a fabric-costing peasant-recruit candidate is
+/// dropped so the GP's scarce fabric is reserved to fund a regiment build
+/// (Refs #3371 AC13 — growth-stage military fabric reservation).
+const String kRecruitmentRejectMilitaryFabricReservation =
+    'Military fabric reservation';
+
 /// One dropped candidate from [runRecruitmentPlanner]. Refs #2692 S8.
 class RejectedRecruitmentSuggestion {
   const RejectedRecruitmentSuggestion({
@@ -151,6 +157,20 @@ RecruitmentPlan runRecruitmentPlanner({
     currentOrders,
   );
 
+  // Refs #3371 AC13: a military-ready GP reserves its scarce fabric for the
+  // regiment build instead of draining it on the fabric-costing peasant-recruit
+  // action. Only meaningful when a fabric-consuming military/naval build is
+  // actually on offer this turn.
+  final reserveFabricForMilitary = growthStage != null &&
+      !suppressMilitaryBuilds &&
+      buildCandidates.any(_buildConsumesPeasant) &&
+      growthStageReservesFabricForMilitary(
+        stage: growthStage,
+        treasury: player.treasury,
+        fabricHeld: player.stockpile.quantityOf(CommodityCatalog.fabric.id),
+        cheapestRegimentTreasuryCost: cheapestRegimentBuildTreasuryCost(),
+      );
+
   final state = _PlanState(
     workerPool: player.workerPool,
     stockpile: player.stockpile,
@@ -171,6 +191,15 @@ RecruitmentPlan runRecruitmentPlanner({
 
   void processRecruit() {
     for (final candidate in recruitCandidates) {
+      if (reserveFabricForMilitary && _recruitConsumesFabric(candidate)) {
+        rejected.add(
+          RejectedRecruitmentSuggestion(
+            reason: kRecruitmentRejectMilitaryFabricReservation,
+            targetTier: candidate.targetTier.name,
+          ),
+        );
+        continue;
+      }
       final outcome = _evaluateRecruitCandidate(candidate, state);
       switch (outcome) {
         case _CandidateOutcome.accepted:
@@ -436,6 +465,14 @@ bool _buildConsumesPeasant(BuildUnitOrder order) {
   final category = buildUnitCategoryForUnitType(order.unitType);
   return category == BuildUnitCategory.military ||
       category == BuildUnitCategory.naval;
+}
+
+/// True when the recruit/train action for [order]'s tier costs `fabric`.
+/// Only the peasant-recruit row carries a fabric material cost (Refs #3371
+/// AC13); trained tiers cost `paper`.
+bool _recruitConsumesFabric(RecruitWorkerOrder order) {
+  final row = WorkerActionEconomyCatalog.forTier(order.targetTier);
+  return (row.materialCosts[CommodityCatalog.fabric.id] ?? 0) > 0;
 }
 
 int _currentTierCount(WorkerPool pool, WorkerTier tier) {

--- a/packages/colonizethis_ai/test/growth_stage_planner_test.dart
+++ b/packages/colonizethis_ai/test/growth_stage_planner_test.dart
@@ -809,4 +809,119 @@ void main() {
       expect(matureScale, greaterThanOrEqualTo(kRecruitmentFloor));
     });
   });
+
+  group('runRecruitmentPlanner growth-stage — AC13 military fabric reservation',
+      () {
+    Game militaryReadyGame({required int fabricHeld}) {
+      const ow = 'oldWorld';
+      return Game(
+        id: 'g-3371-ac13',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: const RegionData(
+            provinces: [
+              Province(id: '$ow|p0', regionId: ow, ownerId: 'gp1'),
+            ],
+          ),
+          newWorld: const RegionData(),
+        ),
+        players: [
+          Player(
+            id: 'gp1',
+            displayName: 'GP1',
+            isHuman: false,
+            capitalProvinceId: '$ow|p0',
+            treasury: 2500,
+            stockpile: Stockpile()
+                .applyDelta(CommodityCatalog.grain.id, 40)
+                .applyDelta(CommodityCatalog.fabric.id, fabricHeld),
+            workerPool: const WorkerPool(peasants: 4),
+          ),
+        ],
+      );
+    }
+
+    OrderSuggestionAPI api() => _fakeApi(
+      recruit: const [RecruitWorkerOrder(targetTier: WorkerTier.peasant)],
+      build: const [
+        BuildUnitOrder(
+          unitType: 'peasant_levies',
+          isMilitary: true,
+          spawnProvinceId: 'oldWorld|p0',
+        ),
+      ],
+    );
+
+    test('reserves scarce fabric: peasant recruit dropped, regiment kept', () {
+      final game = militaryReadyGame(fabricHeld: 1);
+      final view = buildPlayerView(game, _topology, 'gp1');
+      final snapshot = _atWarSnapshot('gp1');
+
+      final plan = runRecruitmentPlanner(
+        game: game,
+        view: view,
+        currentOrders: const Orders(),
+        config: _config,
+        seeds: _seeds,
+        goalPhase: ObserverGoalPhase.expand,
+        suggestionApi: api(),
+        growthStagePlannerEnabled: true,
+        snapshot: snapshot,
+      );
+
+      expect(plan.recruitOrders, isEmpty);
+      expect(plan.buildUnitOrders, isNotEmpty);
+      expect(
+        plan.rejected.map((r) => r.reason),
+        contains(kRecruitmentRejectMilitaryFabricReservation),
+      );
+    });
+
+    test('abundant fabric: peasant recruit not reservation-rejected', () {
+      final game = militaryReadyGame(fabricHeld: kReserveTarget);
+      final view = buildPlayerView(game, _topology, 'gp1');
+      final snapshot = _atWarSnapshot('gp1');
+
+      final plan = runRecruitmentPlanner(
+        game: game,
+        view: view,
+        currentOrders: const Orders(),
+        config: _config,
+        seeds: _seeds,
+        goalPhase: ObserverGoalPhase.expand,
+        suggestionApi: api(),
+        growthStagePlannerEnabled: true,
+        snapshot: snapshot,
+      );
+
+      expect(plan.recruitOrders, isNotEmpty);
+      expect(
+        plan.rejected.map((r) => r.reason),
+        isNot(contains(kRecruitmentRejectMilitaryFabricReservation)),
+      );
+    });
+
+    test('flag off: no reservation rejection', () {
+      final game = militaryReadyGame(fabricHeld: 1);
+      final view = buildPlayerView(game, _topology, 'gp1');
+      final snapshot = _atWarSnapshot('gp1');
+
+      final plan = runRecruitmentPlanner(
+        game: game,
+        view: view,
+        currentOrders: const Orders(),
+        config: _config,
+        seeds: _seeds,
+        goalPhase: ObserverGoalPhase.expand,
+        suggestionApi: api(),
+        growthStagePlannerEnabled: false,
+        snapshot: snapshot,
+      );
+
+      expect(
+        plan.rejected.map((r) => r.reason),
+        isNot(contains(kRecruitmentRejectMilitaryFabricReservation)),
+      );
+    });
+  });
 }


### PR DESCRIPTION
## Summary

Follow-up slice for #3371 after #3377 merged. Adds **AC13 — growth-stage military fabric reservation**: a military-ready, fabric-scarce Great Power reserves its scarce `fabric` to fund a regiment build instead of draining it on the fabric-costing peasant-recruit worker action (`WorkerActionEconomyCatalog.peasant`, `materialCosts: {fabric: 2}`).

- New pure helper `growthStageReservesFabricForMilitary(stage, treasury, fabricHeld, cheapestRegimentTreasuryCost)` in `growth_stage.dart`.
- `runRecruitmentPlanner` drops fabric-costing peasant-recruit candidates (reason `kRecruitmentRejectMilitaryFabricReservation`) when: growth-stage is enabled, military builds are not suppressed, `treasury >= cheapestRegimentBuildTreasuryCost()`, a fabric-consuming military build is on offer, and `fabric < kReserveTarget`.
- `SPEC/ai/growth-stage-planner.md` amended with the reservation contract + positive/negative ACs.

## Done in this PR

- AC13 reservation lever (3 new unit tests: scarce-fabric reservation, abundant-fabric no-op, flag-off no-op).
- All 21 `growth_stage_planner_test.dart` tests pass; existing `recruitment_planner_test.dart` unaffected (flag-off path byte-identical).

## Flag safety

Fully gated by `kGrowthStagePlannerEnabled` (default **false**). The flag-off / production path is byte-identical; only the seed-42 growth-stage path (flag on) is affected.

## Scope / honesty — does NOT close AC7

Measured seed-42 turn-100 with the planner enabled: `{gp1:6, gp2:6, gp3:0, gp4:3, gp5:-7, gp6:10}` — **identical** to the legacy baseline (gp1/gp2/gp4/gp6 baselines hold; this slice is non-regressive). gp3 still gains 0 and gp5 still collapses to -7.

Root-cause finding from this run: gp3's binding wall is fabric **production**, not fabric **allocation**. gp3 cannot source fabric beyond its starting wool because the only `castIron` recipe is labour-walled (`labourPerOutput == 5` vs raw labour ≤ 3), so the level-0 `build_improvement` (needs castIron) can't extract more wool. The reservation lever is therefore non-binding for gp3 this run, but is a correct, defensive behavior aligned with the issue's proactive-input-sequencing intent and will matter once the upstream production wall is addressed.

## Deferred (same issue #3371)

- **AC7** — seed-42 regression still skipped/failing (gp3=0, gp5=-7). Next lever should target fabric **production** (bootstrap wool-extraction via starting improvement slots) and the gp5 peer-war attrition collapse, not recruitment allocation.
- **AC9** — H8 boost removal + flag default flip, gated on AC7.

## Test plan

- [x] `dart test packages/colonizethis_ai/test/growth_stage_planner_test.dart` (21 pass)
- [x] `dart test packages/colonizethis_ai/test/recruitment_planner_test.dart` (14 pass)
- [x] `dart test packages/colonizethis_ai/test/seed42_growth_stage_conquest_regression_test.dart --run-skipped` (still fails gp3/gp5 — documented; baselines unchanged)

Refs #3371

Made with [Cursor](https://cursor.com)