### PR TITLE
docs: document post-split DI provider aggregation (#3290)

### DIFF
--- a/SPEC/program/dependency-injection.md
+++ b/SPEC/program/dependency-injection.md
@@ -14,11 +14,11 @@
 
 ## Canonical providers
 
-| Provider | Package | Default |
-|----------|---------|---------|
-| `orderSuggestionApiProvider` | `colonizethis_logic` | `DefaultOrderSuggestionAPI` |
-| `gameEventBusProvider` | `colonizethis_logic` | `DefaultGameEventBus` |
-| `tileMapRegionGeneratorProvider` | `colonizethis_map` | `defaultTileMapRegionGenerator` |
+| Provider | Declared in | Default | Default impl source |
+|----------|-------------|---------|---------------------|
+| `orderSuggestionApiProvider` | `colonizethis_logic` | `DefaultOrderSuggestionAPI` | `colonizethis_orders` |
+| `gameEventBusProvider` | `colonizethis_logic` | `DefaultGameEventBus` | `colonizethis_world` (event bus) |
+| `tileMapRegionGeneratorProvider` | `colonizethis_map` | `defaultTileMapRegionGenerator` | `colonizethis_map` |
 
 Import DI from secondary libraries (avoid pulling Riverpod into consumers that do not need it):
 
@@ -27,6 +27,17 @@ Import DI from secondary libraries (avoid pulling Riverpod into consumers that d
 - `package:colonizethis_ai/di.dart` (re-exports logic providers used by AI tests)
 
 The main package barrels (`colonizethis_logic.dart`, `colonizethis_map.dart`) do **not** export these providers.
+
+---
+
+## Post-split provider aggregation (Refs #3290)
+
+After the `colonizethis_logic` domain split, `colonizethis_logic` is a thin core whose `src/di/logic_providers.dart` acts as the **cross-package provider aggregator**: the provider declarations stay in `colonizethis_logic`, but their concrete defaults are imported from the split domain packages.
+
+- `orderSuggestionApiProvider` → `DefaultOrderSuggestionAPI` from `colonizethis_orders`.
+- `gameEventBusProvider` → `DefaultGameEventBus` from `colonizethis_world` (the `event_bus/` domain is folded into `colonizethis_world`; there is no standalone `colonizethis_event_bus` package).
+
+Consumer import paths are unchanged by the split (F6): `app/`, `colonizethis_ai`, and tooling continue to read these providers via `package:colonizethis_logic/di.dart`. The thin core remains the single aggregation point, so providers spanning the split packages are **not** distributed into the individual domain packages.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes a **Required** SPEC follow-up for the `colonizethis_logic` domain-split epic. After the split, the canonical Riverpod providers (`orderSuggestionApiProvider`, `gameEventBusProvider`) remain declared in the thin `colonizethis_logic` core as a cross-package aggregator (resolved decision **F6**), but their concrete defaults are now imported from the split domain packages — `DefaultOrderSuggestionAPI` from `colonizethis_orders` and `DefaultGameEventBus` from `colonizethis_world`. `SPEC/program/dependency-injection.md` still described the pre-split world.

## Done in this push

- Canonical-providers table now records **Declared in** vs **Default impl source** so the aggregation is explicit.
- New **Post-split provider aggregation (Refs #3290)** section documents:
  - providers stay declared in the thin core (not distributed to domain packages);
  - default impls come from `colonizethis_orders` / `colonizethis_world` (event_bus folded into world; no standalone `colonizethis_event_bus` package);
  - consumer import path `package:colonizethis_logic/di.dart` is unchanged (F6).

## Scope / coverage

- Addresses the epic's *SPEC follow-up → Required: Update `SPEC/program/dependency-injection.md` (Riverpod providers spanning packages)* deliverable. The companion `repo-and-packages.md` update landed earlier (#3379).
- SPEC-only change; no behavior change, no code touched. Doc stays within the 1000-word per-document budget (460 words).

## Verification

- Confirmed `DefaultGameEventBus` lives in `colonizethis_world` and `DefaultOrderSuggestionAPI` in `colonizethis_orders`, matching `logic_providers.dart` imports and the public `colonizethis_logic/lib/di.dart` re-export.
- Dependency-direction gates pass (`check_{world,combat,economy,diplomacy,setup,orders,turn,ai_contracts}_no_logic_deps.dart`, `check_logic_domain_import_dag.dart`).

## Deferred

- Remaining epic items (full per-package test/coverage verification, optional per-package SPEC files) are out of scope for this slice. Issue stays at `backlog:implementation`.

Refs #3290

Made with [Cursor](https://cursor.com)