### PR TITLE
chore: add repo.logic_reduced_surface thin-core gate (#3290)

### DIFF
--- a/SPEC/program/logic-package-split-phase0.md
+++ b/SPEC/program/logic-package-split-phase0.md
@@ -357,6 +357,16 @@ The `turn_logging.dart` logger is not part of the public barrel and has no exter
 - `colonizethis_ai_contracts` uses exactly one logger with the distinct `ai_contracts` prefix (`aiContractsLog`); AI-contract log lines carry the `ai_contracts:` prefix.
 - AI-contract tests live under `packages/colonizethis_ai_contracts/test/` and reach ≥90% line coverage (enforced by the package coverage gate); `colonizethis_logic` remains a **dev_dependency** of `colonizethis_ai_contracts` for integration fixtures.
 
+## Phase 4 thin-core surface gate (Refs #3290 C4)
+
+After all domain packages are extracted, `colonizethis_logic` is a thin re-export core (constants/logging seams, `turn_to_year.dart`, cross-package DI providers, the public re-export barrel `colonizethis_logic.dart`, and the narrow contract libraries `ai_api.dart`, `order_suggestion_api.dart`, `debug_console_api.dart`, `di.dart`). The epic AC caps this surface at **15 source files** so domain code cannot creep back into the monolith. `repo.logic_reduced_surface` (`tool/check_logic_reduced_surface.dart`) counts non-generated `*.dart` files under `packages/colonizethis_logic/lib/` (recursive) and fails when the count exceeds 15.
+
+### Acceptance criteria (Phase 4 / C4 — thin core surface)
+
+- **Given** the post-split `colonizethis_logic` package on `dev`, **when** `repo.logic_reduced_surface` counts non-generated `*.dart` files under `packages/colonizethis_logic/lib/` (recursive, excluding `*.g.dart` / `*.freezed.dart` / `*.mocks.dart`), **then** the count is at most 15 and the rule exits `0`.
+- **Given** a `colonizethis_logic/lib/` tree containing 16 or more non-generated `*.dart` source files, **when** `runCheckLogicReducedSurface` scans the tree, **then** it returns exit code `1` and lists the offending source files.
+- **Given** the `colonizethis_logic/lib/` tree is missing, **when** `runCheckLogicReducedSurface` runs, **then** it returns exit code `1`.
+
 ## Acceptance criteria (Phase 0 / C0)
 
 - **Given** the monolith on `dev`, **when** `repo.logic_domain_import_dag` runs, **then** zero imports match forbidden pairs outside the documented grandfather allowlist.

--- a/test/check_logic_reduced_surface_test.dart
+++ b/test/check_logic_reduced_surface_test.dart
@@ -1,0 +1,79 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+import '../tool/check_logic_reduced_surface.dart';
+
+void main() {
+  test('thin-core ceiling matches the epic AC (<=15 source files)', () {
+    expect(maxLogicReducedSurfaceFilesForTests(), 15);
+  });
+
+  test('passes for the real post-split colonizethis_logic surface', () {
+    final code = runCheckLogicReducedSurface(
+      Directory.current.path,
+      info: (_) {},
+      err: (_) {},
+    );
+    expect(code, 0);
+  });
+
+  test('fails when lib/ holds more than 15 non-generated source files', () {
+    final temp = Directory.systemTemp.createTempSync('logic_reduced_surface_');
+    addTearDown(() => temp.deleteSync(recursive: true));
+
+    final libDir = Directory(
+      '${temp.path}/packages/colonizethis_logic/lib',
+    )..createSync(recursive: true);
+    for (var i = 0; i < 16; i++) {
+      File('${libDir.path}/file_$i.dart')
+        ..createSync()
+        ..writeAsStringSync('// source $i');
+    }
+
+    final code = runCheckLogicReducedSurface(
+      temp.path,
+      info: (_) {},
+      err: (_) {},
+    );
+    expect(code, 1);
+  });
+
+  test('ignores generated files when counting the surface', () {
+    final temp = Directory.systemTemp.createTempSync('logic_reduced_gen_');
+    addTearDown(() => temp.deleteSync(recursive: true));
+
+    final libDir = Directory(
+      '${temp.path}/packages/colonizethis_logic/lib',
+    )..createSync(recursive: true);
+    for (var i = 0; i < 15; i++) {
+      File('${libDir.path}/file_$i.dart')
+        ..createSync()
+        ..writeAsStringSync('// source $i');
+    }
+    for (var i = 0; i < 5; i++) {
+      File('${libDir.path}/file_$i.g.dart')
+        ..createSync()
+        ..writeAsStringSync('// generated $i');
+    }
+
+    final code = runCheckLogicReducedSurface(
+      temp.path,
+      info: (_) {},
+      err: (_) {},
+    );
+    expect(code, 0);
+  });
+
+  test('fails when the colonizethis_logic lib tree is missing', () {
+    final temp = Directory.systemTemp.createTempSync('logic_reduced_missing_');
+    addTearDown(() => temp.deleteSync(recursive: true));
+
+    final code = runCheckLogicReducedSurface(
+      temp.path,
+      info: (_) {},
+      err: (_) {},
+    );
+    expect(code, 1);
+  });
+}

--- a/tool/check_logic_reduced_surface.dart
+++ b/tool/check_logic_reduced_surface.dart
@@ -1,0 +1,63 @@
+// Guards the thin colonizethis_logic core surface after the domain-package
+// split (Refs #3290 Phase 4). The epic AC requires colonizethis_logic to be
+// reduced to a thin re-export core of <=15 source files (core + contract APIs
+// + re-export barrel). This gate fails if the package's lib/ Dart surface grows
+// back beyond that ceiling, preventing domain code from creeping back into the
+// monolith.
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+const _logicLibRelative = 'packages/colonizethis_logic/lib';
+const _maxSourceFiles = 15;
+
+bool _isGenerated(String path) =>
+    path.endsWith('.g.dart') ||
+    path.endsWith('.freezed.dart') ||
+    path.endsWith('.mocks.dart');
+
+void main() {
+  exit(runCheckLogicReducedSurface(Directory.current.path));
+}
+
+int runCheckLogicReducedSurface(
+  String repoRoot, {
+  void Function(String line)? info,
+  void Function(String line)? err,
+}) {
+  final logI = info ?? stdout.writeln;
+  final logE = err ?? stderr.writeln;
+  final libDir = Directory(p.join(repoRoot, _logicLibRelative));
+  if (!libDir.existsSync()) {
+    logE('check_logic_reduced_surface: missing $_logicLibRelative');
+    return 1;
+  }
+
+  final sourceFiles = <String>[];
+  for (final entity in libDir.listSync(recursive: true, followLinks: false)) {
+    if (entity is! File || !entity.path.endsWith('.dart')) continue;
+    if (_isGenerated(entity.path)) continue;
+    sourceFiles.add(p.relative(entity.path, from: repoRoot));
+  }
+  sourceFiles.sort();
+
+  if (sourceFiles.length <= _maxSourceFiles) {
+    logI(
+      'check_logic_reduced_surface: ${sourceFiles.length} source file(s) '
+      '<= $_maxSourceFiles (thin core preserved).',
+    );
+    return 0;
+  }
+
+  logE(
+    'check_logic_reduced_surface: colonizethis_logic must stay a thin '
+    're-export core of <= $_maxSourceFiles source files, found '
+    '${sourceFiles.length}:',
+  );
+  for (final path in sourceFiles) {
+    logE(' - $path');
+  }
+  return 1;
+}
+
+int maxLogicReducedSurfaceFilesForTests() => _maxSourceFiles;

--- a/tool/ct_repo_lint_manifest.yaml
+++ b/tool/ct_repo_lint_manifest.yaml
@@ -329,6 +329,13 @@ rules:
     runner: dart
     script: tool/check_logic_source_file_size.dart
 
+  - rule_id: repo.logic_reduced_surface
+    group: architecture
+    title: colonizethis_logic must stay a thin re-export core of at most 15 source files (Refs #3290 Phase 4)
+    spec: SPEC/program/logic-package-split-phase0.md
+    runner: dart
+    script: tool/check_logic_reduced_surface.dart
+
   - rule_id: repo.world_no_logic_deps
     group: architecture
     title: colonizethis_world must not depend on colonizethis_logic in lib/ (Refs #3290 Phase 1)


### PR DESCRIPTION
## Summary

Implements the one remaining unimplemented CI deliverable from the `colonizethis_logic` domain-split epic: the **`repo.logic_reduced_surface`** gate. The split itself (all domain packages `colonizethis_world/_combat/_economy/_diplomacy/_setup/_orders/_turn` + `colonizethis_ai_contracts`, thin-core reduction, per-package no-logic-deps gates, import DAG gate) already landed on `dev`. This slice adds the regression guard the epic's "CI / enforcement" section called for but that was never created, so domain code cannot creep back into the monolith.

## Done in this push

- **`tool/check_logic_reduced_surface.dart`** — counts non-generated `*.dart` files under `packages/colonizethis_logic/lib/` (recursive, excluding `*.g.dart` / `*.freezed.dart` / `*.mocks.dart`) and fails when the count exceeds **15** (the epic AC ceiling: "`colonizethis_logic` reduced to ≤15 source files"). Current surface = 10 files, so it passes with headroom.
- **`tool/ct_repo_lint_manifest.yaml`** — registers `repo.logic_reduced_surface` (group `architecture`) next to the other `#3290` split gates.
- **`SPEC/program/logic-package-split-phase0.md`** — adds a "Phase 4 thin-core surface gate" section with three Given–When–Then ACs (passes at ≤15; fails at ≥16 listing offenders; fails on missing tree).
- **`test/check_logic_reduced_surface_test.dart`** — positive (real surface passes; ceiling == 15), negative (>15 files fails; missing tree fails), and an exclusion test (generated files ignored). Runs under the existing CI step `dart test test/check_*_test.dart`.

## Verification

- `dart run tool/check_logic_reduced_surface.dart` → `10 source file(s) <= 15 (thin core preserved)`, exit 0.
- `dart run tool/ct_repo_lint.dart --rule repo.logic_reduced_surface` → passes; rule discovered by the runner.
- `dart test test/check_logic_reduced_surface_test.dart` → 5/5 pass.
- `dart test test/ct_repo_lint*_test.dart` → pass (manifest/CLI rule-list tests still green with the new rule).
- `dart analyze` on both new files → no issues.

## Scope / deferred

- SPEC-authorized, behavior-preserving CI-only change; no production code touched.
- Other remaining epic items (e.g. the in-flight DI-spec slice in #3381, optional per-package SPEC files, full per-package coverage rollups) are out of scope here. Issue stays at `backlog:implementation`.

Refs #3290

Made with [Cursor](https://cursor.com)