### PR TITLE
test(world): lift colonizethis_world coverage to 91% and enable 90% gate (#3290)

### DIFF
--- a/packages/colonizethis_world/test/world/capital_and_gp_fall_reassignment_test.dart
+++ b/packages/colonizethis_world/test/world/capital_and_gp_fall_reassignment_test.dart
@@ -1,0 +1,310 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_world/src/world/capital_and_gp_fall.dart';
+import 'package:colonizethis_world/src/world/capital_reassignment_fatal.dart';
+import 'package:colonizethis_world/src/world/province_lookup.dart';
+import 'package:colonizethis_test/test.dart';
+
+/// Coverage uplift for `colonizethis_world` (Refs #3290 Phase 1 follow-up).
+///
+/// Exercises runtime capital reassignment after combat for Great Powers,
+/// Minor Nations, and Tribes in `lib/src/world/capital_and_gp_fall_reassignment.dart`.
+/// SPEC/game/capital-and-connectivity § Capital loss and reassignment.
+const _emptyTopology = MapTopology();
+
+CapitalTile _tile(String provinceId, int x, int y) => CapitalTile(
+  regionId: ProvinceId.regionIdFrom(provinceId),
+  provinceId: provinceId,
+  x: x,
+  y: y,
+);
+
+Game _gpGame({
+  required List<Province> provinces,
+  String capitalProvinceId = 'oldWorld|cap',
+}) => Game(
+  id: 'g-gp-reassign',
+  worldState: WorldState(
+    turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+    oldWorld: RegionData(provinces: provinces),
+    newWorld: const RegionData(),
+  ),
+  players: [
+    Player(
+      id: 'p1',
+      displayName: 'P1',
+      isHuman: true,
+      capitalProvinceId: capitalProvinceId,
+      capitalTile: _tile(capitalProvinceId, 0, 0),
+    ),
+  ],
+);
+
+void main() {
+  group('applyCapitalReassignmentAfterCombat (Great Power)', () {
+    test('reassigns capital to remaining owned province after loss', () {
+      final game = _gpGame(
+        provinces: const [
+          Province(id: 'oldWorld|cap', regionId: 'oldWorld', ownerId: 'p2'),
+          Province(
+            id: 'oldWorld|alt',
+            regionId: 'oldWorld',
+            ownerId: 'p1',
+            townTileKey: 'oldWorld|alt|3|4',
+          ),
+        ],
+      );
+
+      final result = applyCapitalReassignmentAfterCombat(game, _emptyTopology);
+
+      final p1 = result.players.firstWhere((p) => p.id == 'p1');
+      expect(p1.capitalProvinceId, 'oldWorld|alt');
+      expect(p1.capitalTile?.x, 3);
+      expect(p1.capitalTile?.y, 4);
+      final alt = result.worldState.tryGetProvince('oldWorld|alt');
+      expect(alt?.townDevelopmentLevel, 4);
+    });
+
+    test('clears capital when no owned provinces remain in region', () {
+      final game = _gpGame(
+        provinces: const [
+          Province(id: 'oldWorld|cap', regionId: 'oldWorld', ownerId: 'p2'),
+        ],
+      );
+
+      final result = applyCapitalReassignmentAfterCombat(game, _emptyTopology);
+
+      expect(result.players.single.id, 'p1');
+    });
+
+    test('leaves capital untouched when player still owns it', () {
+      final game = _gpGame(
+        provinces: const [
+          Province(id: 'oldWorld|cap', regionId: 'oldWorld', ownerId: 'p1'),
+        ],
+      );
+
+      final result = applyCapitalReassignmentAfterCombat(game, _emptyTopology);
+
+      expect(
+        result.players.single.capitalProvinceId,
+        'oldWorld|cap',
+      );
+    });
+
+    test('skips players without a capital', () {
+      final game = Game(
+        id: 'g-no-cap',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+        ),
+        players: const [Player(id: 'p1', displayName: 'P1', isHuman: true)],
+      );
+
+      final result = applyCapitalReassignmentAfterCombat(game, _emptyTopology);
+
+      expect(result.players.single.capitalProvinceId, isNull);
+    });
+
+    test('throws fatal error when candidate province has no townTileKey', () {
+      final game = _gpGame(
+        provinces: const [
+          Province(id: 'oldWorld|cap', regionId: 'oldWorld', ownerId: 'p2'),
+          Province(id: 'oldWorld|alt', regionId: 'oldWorld', ownerId: 'p1'),
+        ],
+      );
+
+      expect(
+        () => applyCapitalReassignmentAfterCombat(game, _emptyTopology),
+        throwsA(isA<CapitalReassignmentFatalError>()),
+      );
+    });
+
+    test('throws fatal error when candidate townTileKey is malformed', () {
+      final game = _gpGame(
+        provinces: const [
+          Province(id: 'oldWorld|cap', regionId: 'oldWorld', ownerId: 'p2'),
+          Province(
+            id: 'oldWorld|alt',
+            regionId: 'oldWorld',
+            ownerId: 'p1',
+            townTileKey: 'not-a-valid-key',
+          ),
+        ],
+      );
+
+      expect(
+        () => applyCapitalReassignmentAfterCombat(game, _emptyTopology),
+        throwsA(isA<CapitalReassignmentFatalError>()),
+      );
+    });
+  });
+
+  group('applyFactionCapitalReassignmentAfterCombat (Minor/Tribe)', () {
+    test('reassigns minor nation capital after loss', () {
+      final game = Game(
+        id: 'g-minor',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: const RegionData(
+            provinces: [
+              Province(id: 'oldWorld|mcap', regionId: 'oldWorld', ownerId: 'p2'),
+              Province(
+                id: 'oldWorld|malt',
+                regionId: 'oldWorld',
+                ownerId: 'm1',
+                townTileKey: 'oldWorld|malt|5|6',
+              ),
+            ],
+          ),
+          newWorld: const RegionData(),
+        ),
+        players: const [Player(id: 'p2', displayName: 'P2', isHuman: true)],
+        minorNations: [
+          MinorNation(
+            id: 'm1',
+            capitalProvinceId: 'oldWorld|mcap',
+            capitalTile: _tile('oldWorld|mcap', 0, 0),
+          ),
+        ],
+      );
+
+      final result = applyFactionCapitalReassignmentAfterCombat(
+        game,
+        _emptyTopology,
+      );
+
+      final m1 = result.minorNations.single;
+      expect(m1.capitalProvinceId, 'oldWorld|malt');
+      expect(m1.capitalTile?.x, 5);
+    });
+
+    test('clears minor nation capital when none remain in region', () {
+      final game = Game(
+        id: 'g-minor-clear',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: const RegionData(
+            provinces: [
+              Province(id: 'oldWorld|mcap', regionId: 'oldWorld', ownerId: 'p2'),
+            ],
+          ),
+          newWorld: const RegionData(),
+        ),
+        players: const [Player(id: 'p2', displayName: 'P2', isHuman: true)],
+        minorNations: [
+          MinorNation(
+            id: 'm1',
+            capitalProvinceId: 'oldWorld|mcap',
+            capitalTile: _tile('oldWorld|mcap', 0, 0),
+          ),
+        ],
+      );
+
+      final result = applyFactionCapitalReassignmentAfterCombat(
+        game,
+        _emptyTopology,
+      );
+
+      expect(result.minorNations.single.capitalProvinceId, isNull);
+    });
+
+    test('reassigns tribe capital after loss', () {
+      final game = Game(
+        id: 'g-tribe',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(
+            provinces: [
+              Province(id: 'newWorld|tcap', regionId: 'newWorld', ownerId: 'p2'),
+              Province(
+                id: 'newWorld|talt',
+                regionId: 'newWorld',
+                ownerId: 't1',
+                townTileKey: 'newWorld|talt|7|8',
+              ),
+            ],
+          ),
+        ),
+        players: const [Player(id: 'p2', displayName: 'P2', isHuman: true)],
+        tribes: [
+          Tribe(
+            id: 't1',
+            capitalProvinceId: 'newWorld|tcap',
+            capitalTile: _tile('newWorld|tcap', 0, 0),
+          ),
+        ],
+      );
+
+      final result = applyFactionCapitalReassignmentAfterCombat(
+        game,
+        _emptyTopology,
+      );
+
+      expect(result.tribes.single.capitalProvinceId, 'newWorld|talt');
+    });
+
+    test('clears tribe capital when none remain in region', () {
+      final game = Game(
+        id: 'g-tribe-clear',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(
+            provinces: [
+              Province(id: 'newWorld|tcap', regionId: 'newWorld', ownerId: 'p2'),
+            ],
+          ),
+        ),
+        players: const [Player(id: 'p2', displayName: 'P2', isHuman: true)],
+        tribes: [
+          Tribe(
+            id: 't1',
+            capitalProvinceId: 'newWorld|tcap',
+            capitalTile: _tile('newWorld|tcap', 0, 0),
+          ),
+        ],
+      );
+
+      final result = applyFactionCapitalReassignmentAfterCombat(
+        game,
+        _emptyTopology,
+      );
+
+      expect(result.tribes.single.capitalProvinceId, isNull);
+    });
+
+    test('throws fatal error when minor candidate lacks townTileKey', () {
+      final game = Game(
+        id: 'g-minor-throw',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: const RegionData(
+            provinces: [
+              Province(id: 'oldWorld|mcap', regionId: 'oldWorld', ownerId: 'p2'),
+              Province(id: 'oldWorld|malt', regionId: 'oldWorld', ownerId: 'm1'),
+            ],
+          ),
+          newWorld: const RegionData(),
+        ),
+        players: const [Player(id: 'p2', displayName: 'P2', isHuman: true)],
+        minorNations: [
+          MinorNation(
+            id: 'm1',
+            capitalProvinceId: 'oldWorld|mcap',
+            capitalTile: _tile('oldWorld|mcap', 0, 0),
+          ),
+        ],
+      );
+
+      expect(
+        () =>
+            applyFactionCapitalReassignmentAfterCombat(game, _emptyTopology),
+        throwsA(isA<CapitalReassignmentFatalError>()),
+      );
+    });
+  });
+}

--- a/packages/colonizethis_world/test/world/capital_and_gp_fall_terminal_test.dart
+++ b/packages/colonizethis_world/test/world/capital_and_gp_fall_terminal_test.dart
@@ -1,0 +1,286 @@
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_world/src/world/capital_and_gp_fall.dart';
+import 'package:colonizethis_world/src/world/province_lookup.dart';
+import 'package:colonizethis_test/test.dart';
+
+/// Coverage uplift for `colonizethis_world` (Refs #3290 Phase 1 follow-up).
+///
+/// Exercises terminal fall transfer for Great Powers, Minor Nations, and
+/// Tribes in `lib/src/world/capital_and_gp_fall_terminal.dart`.
+/// SPEC/game/capital-and-connectivity § terminal fall.
+Unit _unit(String id, String ownerId, String provinceId) => Unit(
+  id: id,
+  type: 'grenadiers',
+  ownerId: ownerId,
+  locationProvinceId: provinceId,
+);
+
+Fleet _fleet(String id, String ownerId) =>
+    Fleet(id: id, ownerId: ownerId, seaZoneId: 's1', regionId: 'oldWorld');
+
+void main() {
+  group('applyFactionTerminalFall (Minor)', () {
+    test('transfers provinces and assets to conqueror and removes faction', () {
+      final game = Game(
+        id: 'g-minor-fall',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: RegionData(
+            provinces: const [
+              Province(id: 'oldWorld|mcap', regionId: 'oldWorld', ownerId: 'p2'),
+            ],
+            units: [_unit('u-m', 'm1', 'oldWorld|mcap')],
+          ),
+          newWorld: const RegionData(
+            provinces: [
+              Province(id: 'newWorld|n1', regionId: 'newWorld', ownerId: 'm1'),
+            ],
+          ),
+          fleets: [_fleet('f-m', 'm1')],
+        ),
+        players: const [Player(id: 'p2', displayName: 'P2', isHuman: true)],
+        minorNations: const [MinorNation(id: 'm1')],
+      );
+
+      final result = applyFactionTerminalFall(
+        game,
+        previousCapitalByMinor: const {'m1': 'oldWorld|mcap'},
+        previousCapitalByTribe: const {},
+      );
+
+      expect(result.minorNations, isEmpty);
+      expect(result.worldState.tryGetProvince('newWorld|n1')?.ownerId, 'p2');
+      expect(
+        result.worldState.oldWorld.units.any((u) => u.ownerId == 'm1'),
+        isFalse,
+      );
+      expect(result.worldState.fleets.any((f) => f.ownerId == 'm1'), isFalse);
+    });
+
+    test('does not fall when faction still owns capital province', () {
+      final game = Game(
+        id: 'g-minor-hold',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: const RegionData(
+            provinces: [
+              Province(id: 'oldWorld|mcap', regionId: 'oldWorld', ownerId: 'm1'),
+            ],
+          ),
+          newWorld: const RegionData(),
+        ),
+        players: const [Player(id: 'p2', displayName: 'P2', isHuman: true)],
+        minorNations: const [MinorNation(id: 'm1')],
+      );
+
+      final result = applyFactionTerminalFall(
+        game,
+        previousCapitalByMinor: const {'m1': 'oldWorld|mcap'},
+        previousCapitalByTribe: const {},
+      );
+
+      expect(result.minorNations.single.id, 'm1');
+    });
+
+    test('does not fall when faction still owns a province in the region', () {
+      final game = Game(
+        id: 'g-minor-region',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: const RegionData(
+            provinces: [
+              Province(id: 'oldWorld|mcap', regionId: 'oldWorld', ownerId: 'p2'),
+              Province(id: 'oldWorld|m2', regionId: 'oldWorld', ownerId: 'm1'),
+            ],
+          ),
+          newWorld: const RegionData(),
+        ),
+        players: const [Player(id: 'p2', displayName: 'P2', isHuman: true)],
+        minorNations: const [MinorNation(id: 'm1')],
+      );
+
+      final result = applyFactionTerminalFall(
+        game,
+        previousCapitalByMinor: const {'m1': 'oldWorld|mcap'},
+        previousCapitalByTribe: const {},
+      );
+
+      expect(result.minorNations.single.id, 'm1');
+    });
+
+    test('skips when previous capital province is missing', () {
+      final game = Game(
+        id: 'g-minor-missing',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+        ),
+        players: const [Player(id: 'p2', displayName: 'P2', isHuman: true)],
+        minorNations: const [MinorNation(id: 'm1')],
+      );
+
+      final result = applyFactionTerminalFall(
+        game,
+        previousCapitalByMinor: const {'m1': 'oldWorld|ghost'},
+        previousCapitalByTribe: const {},
+      );
+
+      expect(result.minorNations.single.id, 'm1');
+    });
+
+    test('skips faction not present in the game', () {
+      final game = Game(
+        id: 'g-minor-absent',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+        ),
+        players: const [Player(id: 'p2', displayName: 'P2', isHuman: true)],
+        minorNations: const [],
+      );
+
+      final result = applyFactionTerminalFall(
+        game,
+        previousCapitalByMinor: const {'mX': 'oldWorld|mcap'},
+        previousCapitalByTribe: const {},
+      );
+
+      expect(result.minorNations, isEmpty);
+    });
+  });
+
+  group('applyFactionTerminalFall (Tribe)', () {
+    test('transfers tribe provinces to conqueror and removes tribe', () {
+      final game = Game(
+        id: 'g-tribe-fall',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: const RegionData(
+            provinces: [
+              Province(id: 'oldWorld|t2', regionId: 'oldWorld', ownerId: 't1'),
+            ],
+          ),
+          newWorld: const RegionData(
+            provinces: [
+              Province(id: 'newWorld|tcap', regionId: 'newWorld', ownerId: 'p2'),
+            ],
+          ),
+        ),
+        players: const [Player(id: 'p2', displayName: 'P2', isHuman: true)],
+        tribes: const [Tribe(id: 't1')],
+      );
+
+      final result = applyFactionTerminalFall(
+        game,
+        previousCapitalByMinor: const {},
+        previousCapitalByTribe: const {'t1': 'newWorld|tcap'},
+      );
+
+      expect(result.tribes, isEmpty);
+      expect(result.worldState.tryGetProvince('oldWorld|t2')?.ownerId, 'p2');
+    });
+  });
+
+  group('applyGreatPowerFall', () {
+    test('transfers GP provinces to conqueror when no port province held', () {
+      final game = Game(
+        id: 'g-gp-fall',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: RegionData(
+            provinces: const [
+              Province(id: 'oldWorld|cap', regionId: 'oldWorld', ownerId: 'p2'),
+            ],
+            units: [_unit('u-p1', 'p1', 'oldWorld|cap')],
+          ),
+          newWorld: const RegionData(
+            provinces: [
+              Province(id: 'newWorld|n1', regionId: 'newWorld', ownerId: 'p1'),
+            ],
+          ),
+          fleets: [_fleet('f-p1', 'p1')],
+        ),
+        players: const [
+          Player(id: 'p1', displayName: 'P1', isHuman: true),
+          Player(id: 'p2', displayName: 'P2', isHuman: false),
+        ],
+      );
+
+      final result = applyGreatPowerFall(game, const {'p1': 'oldWorld|cap'});
+
+      expect(result.worldState.tryGetProvince('newWorld|n1')?.ownerId, 'p2');
+      expect(result.worldState.fleets.any((f) => f.ownerId == 'p1'), isFalse);
+      expect(
+        result.worldState.oldWorld.units.any((u) => u.ownerId == 'p1'),
+        isFalse,
+      );
+    });
+
+    test('does not fall when GP still owns a port province', () {
+      final game = Game(
+        id: 'g-gp-port',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: const RegionData(
+            provinces: [
+              Province(id: 'oldWorld|cap', regionId: 'oldWorld', ownerId: 'p2'),
+              Province(id: 'oldWorld|port', regionId: 'oldWorld', ownerId: 'p1'),
+            ],
+          ),
+          newWorld: const RegionData(),
+          portsByProvinceSeaboard: {'oldWorld|port|north': 'oldWorld|port|0|0'},
+        ),
+        players: const [
+          Player(id: 'p1', displayName: 'P1', isHuman: true),
+          Player(id: 'p2', displayName: 'P2', isHuman: false),
+        ],
+      );
+
+      final result = applyGreatPowerFall(game, const {'p1': 'oldWorld|cap'});
+
+      expect(result.worldState.tryGetProvince('oldWorld|port')?.ownerId, 'p1');
+    });
+
+    test('skips when capital still owned by the player', () {
+      final game = Game(
+        id: 'g-gp-hold',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: const RegionData(
+            provinces: [
+              Province(id: 'oldWorld|cap', regionId: 'oldWorld', ownerId: 'p1'),
+            ],
+          ),
+          newWorld: const RegionData(),
+        ),
+        players: const [Player(id: 'p1', displayName: 'P1', isHuman: true)],
+      );
+
+      final result = applyGreatPowerFall(game, const {'p1': 'oldWorld|cap'});
+
+      expect(result.worldState.tryGetProvince('oldWorld|cap')?.ownerId, 'p1');
+    });
+
+    test('skips when capital province has no owner', () {
+      final game = Game(
+        id: 'g-gp-noowner',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: const RegionData(
+            provinces: [
+              Province(id: 'oldWorld|cap', regionId: 'oldWorld'),
+            ],
+          ),
+          newWorld: const RegionData(),
+        ),
+        players: const [Player(id: 'p1', displayName: 'P1', isHuman: true)],
+      );
+
+      final result = applyGreatPowerFall(game, const {'p1': 'oldWorld|cap'});
+
+      expect(result.worldState.tryGetProvince('oldWorld|cap')?.ownerId, isNull);
+    });
+  });
+}

--- a/packages/colonizethis_world/test/world/capital_reassignment_setters_test.dart
+++ b/packages/colonizethis_world/test/world/capital_reassignment_setters_test.dart
@@ -1,0 +1,218 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_world/src/world/capital_reassignment.dart';
+import 'package:colonizethis_world/src/world/capital_reassignment_fatal.dart';
+import 'package:colonizethis_world/src/world/province_lookup.dart';
+import 'package:colonizethis_world/src/logic_validation_exception.dart';
+import 'package:colonizethis_test/test.dart';
+
+import '../test_fixtures.dart';
+
+/// Coverage uplift for `colonizethis_world` (Refs #3290 Phase 1 follow-up).
+///
+/// Exercises the runtime capital setters and the deterministic reassignment
+/// province picker in `lib/src/world/capital_reassignment.dart`.
+/// SPEC/game/capital-and-connectivity § Capital loss and reassignment.
+CapitalTile _tile(String provinceId, {int x = 1, int y = 2}) => CapitalTile(
+  regionId: ProvinceId.regionIdFrom(provinceId),
+  provinceId: provinceId,
+  x: x,
+  y: y,
+);
+
+void main() {
+  group('pickCapitalProvinceIdForReassignment', () {
+    test('throws when no owned provinces are supplied', () {
+      expect(
+        () => pickCapitalProvinceIdForReassignment(
+          const [],
+          const MapTopology(),
+        ),
+        throwsA(isA<LogicValidationException>()),
+      );
+    });
+
+    test('picks first by ascending id when none are sea-bound', () {
+      final picked = pickCapitalProvinceIdForReassignment(
+        const ['oldWorld|b', 'oldWorld|a'],
+        const MapTopology(),
+      );
+      expect(picked, 'oldWorld|a');
+    });
+
+    test('prefers a sea-bound province when one exists', () {
+      const topology = MapTopology(
+        nodes: [
+          TopologyNode(
+            id: 'b',
+            regionId: 'oldWorld',
+            type: TopologyNodeType.province,
+          ),
+          TopologyNode(
+            id: 's1',
+            regionId: 'oldWorld',
+            type: TopologyNodeType.seaZone,
+          ),
+        ],
+        edges: [TopologyEdge(id1: 'b', id2: 's1')],
+      );
+
+      final picked = pickCapitalProvinceIdForReassignment(
+        const ['oldWorld|a', 'oldWorld|b'],
+        topology,
+      );
+      expect(picked, 'oldWorld|b');
+    });
+  });
+
+  group('setCapitalForReassignment', () {
+    test('updates only the targeted player capital fields', () {
+      final game = TestFixtures.minimalGame(
+        players: const [
+          Player(id: 'p1', displayName: 'P1', isHuman: true),
+          Player(id: 'p2', displayName: 'P2', isHuman: false),
+        ],
+      );
+
+      final result = setCapitalForReassignment(
+        game: game,
+        playerId: 'p1',
+        provinceId: 'oldWorld|alt',
+        tile: _tile('oldWorld|alt'),
+      );
+
+      expect(
+        result.players.firstWhere((p) => p.id == 'p1').capitalProvinceId,
+        'oldWorld|alt',
+      );
+      expect(
+        result.players.firstWhere((p) => p.id == 'p2').capitalProvinceId,
+        isNull,
+      );
+    });
+
+    test('throws when tile province does not match target province', () {
+      final game = TestFixtures.minimalGame(
+        players: const [Player(id: 'p1', displayName: 'P1', isHuman: true)],
+      );
+
+      expect(
+        () => setCapitalForReassignment(
+          game: game,
+          playerId: 'p1',
+          provinceId: 'oldWorld|alt',
+          tile: _tile('oldWorld|other'),
+        ),
+        throwsA(isA<CapitalReassignmentFatalError>()),
+      );
+    });
+  });
+
+  group('setCapitalForMinorReassignment', () {
+    test('updates the targeted minor nation capital fields', () {
+      final game = TestFixtures.minimalGame(
+        minorNations: const [MinorNation(id: 'm1')],
+      );
+
+      final result = setCapitalForMinorReassignment(
+        game: game,
+        minorId: 'm1',
+        provinceId: 'oldWorld|malt',
+        tile: _tile('oldWorld|malt'),
+      );
+
+      expect(result.minorNations.single.capitalProvinceId, 'oldWorld|malt');
+    });
+
+    test('throws when tile province does not match', () {
+      final game = TestFixtures.minimalGame(
+        minorNations: const [MinorNation(id: 'm1')],
+      );
+
+      expect(
+        () => setCapitalForMinorReassignment(
+          game: game,
+          minorId: 'm1',
+          provinceId: 'oldWorld|malt',
+          tile: _tile('oldWorld|other'),
+        ),
+        throwsA(isA<CapitalReassignmentFatalError>()),
+      );
+    });
+  });
+
+  group('setCapitalForTribeReassignment', () {
+    test('updates the targeted tribe capital fields', () {
+      final game = TestFixtures.minimalGame(
+        tribes: const [Tribe(id: 't1')],
+      );
+
+      final result = setCapitalForTribeReassignment(
+        game: game,
+        tribeId: 't1',
+        provinceId: 'newWorld|talt',
+        tile: _tile('newWorld|talt'),
+      );
+
+      expect(result.tribes.single.capitalProvinceId, 'newWorld|talt');
+    });
+
+    test('throws when tile province does not match', () {
+      final game = TestFixtures.minimalGame(
+        tribes: const [Tribe(id: 't1')],
+      );
+
+      expect(
+        () => setCapitalForTribeReassignment(
+          game: game,
+          tribeId: 't1',
+          provinceId: 'newWorld|talt',
+          tile: _tile('newWorld|other'),
+        ),
+        throwsA(isA<CapitalReassignmentFatalError>()),
+      );
+    });
+  });
+
+  group('applyGreatPowerCapitalProvinceTownDevelopment', () {
+    test('sets town development level 4 for the matched province', () {
+      final game = TestFixtures.minimalGame(
+        oldWorld: const RegionData(
+          provinces: [
+            Province(id: 'oldWorld|cap', regionId: 'oldWorld', ownerId: 'p1'),
+            Province(id: 'oldWorld|other', regionId: 'oldWorld', ownerId: 'p1'),
+          ],
+        ),
+      );
+
+      final next = applyGreatPowerCapitalProvinceTownDevelopment(
+        game.worldState,
+        'oldWorld',
+        'oldWorld|cap',
+      );
+
+      final cap = next.tryGetProvince('oldWorld|cap');
+      final other = next.tryGetProvince('oldWorld|other');
+      expect(cap?.townDevelopmentLevel, 4);
+      expect(other?.townDevelopmentLevel, 0);
+    });
+
+    test('accepts a bare local capital id', () {
+      final game = TestFixtures.minimalGame(
+        oldWorld: const RegionData(
+          provinces: [
+            Province(id: 'oldWorld|cap', regionId: 'oldWorld', ownerId: 'p1'),
+          ],
+        ),
+      );
+
+      final next = applyGreatPowerCapitalProvinceTownDevelopment(
+        game.worldState,
+        'oldWorld',
+        'cap',
+      );
+
+      expect(next.tryGetProvince('oldWorld|cap')?.townDevelopmentLevel, 4);
+    });
+  });
+}

--- a/packages/colonizethis_world/test/world/naval_topology_test.dart
+++ b/packages/colonizethis_world/test/world/naval_topology_test.dart
@@ -1,0 +1,290 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_world/src/world/naval.dart';
+import 'package:colonizethis_test/test.dart';
+
+/// Coverage uplift for `colonizethis_world` (Refs #3290 Phase 1 follow-up).
+///
+/// Exercises naval topology helpers in `lib/src/world/naval.dart`.
+/// SPEC/program/naval-movement-resolution.md and SPEC/game/ships-and-naval.md.
+///
+/// Two regions: `oldWorld` (province p1 + sea s1) and `newWorld` (province n1 +
+/// sea s2). s1–s2 is a cross-region S–S warp edge.
+MapTopology _topology() => const MapTopology(
+  nodes: [
+    TopologyNode(
+      id: 'oldWorld|p1',
+      regionId: 'oldWorld',
+      type: TopologyNodeType.province,
+    ),
+    TopologyNode(
+      id: 'oldWorld|s1',
+      regionId: 'oldWorld',
+      type: TopologyNodeType.seaZone,
+    ),
+    TopologyNode(
+      id: 'newWorld|n1',
+      regionId: 'newWorld',
+      type: TopologyNodeType.province,
+    ),
+    TopologyNode(
+      id: 'newWorld|s2',
+      regionId: 'newWorld',
+      type: TopologyNodeType.seaZone,
+    ),
+  ],
+  edges: [
+    TopologyEdge(id1: 'oldWorld|p1', id2: 'oldWorld|s1'),
+    TopologyEdge(id1: 'oldWorld|s1', id2: 'newWorld|s2'),
+    TopologyEdge(id1: 'newWorld|n1', id2: 'newWorld|s2'),
+  ],
+);
+
+Game _gameWithCapital(String? capital) => Game(
+  id: 'g-naval',
+  worldState: WorldState(
+    turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+    oldWorld: const RegionData(),
+    newWorld: const RegionData(),
+  ),
+  players: [
+    Player(
+      id: 'p1',
+      displayName: 'P1',
+      isHuman: true,
+      capitalProvinceId: capital,
+    ),
+  ],
+);
+
+void main() {
+  group('dockOrderTargetsPlayerCapital', () {
+    test('matches a prefixed capital', () {
+      final game = _gameWithCapital('oldWorld|p1');
+      expect(dockOrderTargetsPlayerCapital(game, 'p1', 'oldWorld|p1'), isTrue);
+      expect(dockOrderTargetsPlayerCapital(game, 'p1', 'oldWorld|p2'), isFalse);
+    });
+
+    test('matches a legacy local capital against a prefixed dock province', () {
+      final game = _gameWithCapital('p1');
+      expect(dockOrderTargetsPlayerCapital(game, 'p1', 'oldWorld|p1'), isTrue);
+    });
+
+    test('returns false when player or capital is missing', () {
+      expect(
+        dockOrderTargetsPlayerCapital(_gameWithCapital(null), 'p1', 'x|y'),
+        isFalse,
+      );
+      expect(
+        dockOrderTargetsPlayerCapital(_gameWithCapital('oldWorld|p1'), 'zz', 'x|y'),
+        isFalse,
+      );
+    });
+  });
+
+  test('homeFleetIdFor uses the fleet_ convention', () {
+    expect(homeFleetIdFor('p1'), 'fleet_p1');
+  });
+
+  group('regionAndLocalProvinceForFleetInPort', () {
+    test('splits a prefixed in-port province id', () {
+      final rl = regionAndLocalProvinceForFleetInPort('oldWorld|p1', 'newWorld');
+      expect(rl.regionId, 'oldWorld');
+      expect(rl.localId, 'p1');
+    });
+
+    test('falls back to the fleet region for a legacy id', () {
+      final rl = regionAndLocalProvinceForFleetInPort('p1', 'oldWorld');
+      expect(rl.regionId, 'oldWorld');
+      expect(rl.localId, 'p1');
+    });
+  });
+
+  test('indexTopologyNodesByRegion groups nodes by region', () {
+    final byRegion = indexTopologyNodesByRegion(_topology());
+    expect(byRegion.keys, containsAll(['oldWorld', 'newWorld']));
+    expect(byRegion['oldWorld']!.containsKey('oldWorld|p1'), isTrue);
+  });
+
+  group('sea-zone adjacency predicates', () {
+    final topology = _topology();
+
+    test('isAdjacentSeaZone covers edge, same-zone, and non-edge', () {
+      expect(isAdjacentSeaZone(topology, 'oldWorld|s1', 'newWorld|s2'), isTrue);
+      expect(isAdjacentSeaZone(topology, 'oldWorld|s1', 'oldWorld|s1'), isFalse);
+      expect(isAdjacentSeaZone(topology, 'oldWorld|s1', 'oldWorld|p1'), isTrue);
+      expect(isAdjacentSeaZone(topology, 'oldWorld|p1', 'newWorld|s2'), isFalse);
+    });
+
+    test('isAdjacentSeaSeaZone requires both endpoints to be sea zones', () {
+      expect(
+        isAdjacentSeaSeaZone(topology, 'oldWorld|s1', 'newWorld|s2'),
+        isTrue,
+      );
+      expect(
+        isAdjacentSeaSeaZone(topology, 'oldWorld|s1', 'oldWorld|p1'),
+        isFalse,
+      );
+      expect(
+        isAdjacentSeaSeaZone(topology, 'oldWorld|s1', 'oldWorld|s1'),
+        isFalse,
+      );
+    });
+
+    test('adjacentSeaZoneIdsSeaOnly lists S–S neighbors only', () {
+      expect(adjacentSeaZoneIdsSeaOnly(topology, 'oldWorld|s1'), [
+        'newWorld|s2',
+      ]);
+      expect(adjacentSeaZoneIdsSeaOnly(topology, 'oldWorld|p1'), isEmpty);
+    });
+
+    test('isWarpZoneSeaZone detects cross-region S–S edges', () {
+      expect(isWarpZoneSeaZone(topology, 'oldWorld|s1'), isTrue);
+      expect(isWarpZoneSeaZone(topology, 'oldWorld|p1'), isFalse);
+    });
+  });
+
+  group('provinceTopologyNodeId', () {
+    final topology = _topology();
+
+    test('resolves local and prefixed province ids', () {
+      expect(
+        provinceTopologyNodeId(topology, 'p1', 'oldWorld'),
+        'oldWorld|p1',
+      );
+      expect(
+        provinceTopologyNodeId(topology, 'oldWorld|p1', 'oldWorld'),
+        'oldWorld|p1',
+      );
+    });
+
+    test('returns null for sea nodes, missing nodes, and missing regions', () {
+      expect(provinceTopologyNodeId(topology, 's1', 'oldWorld'), isNull);
+      expect(provinceTopologyNodeId(topology, 'ghost', 'oldWorld'), isNull);
+      expect(provinceTopologyNodeId(topology, 'p1', 'zzz'), isNull);
+    });
+  });
+
+  group('navalMoveTopologyPicksForFleet', () {
+    final topology = _topology();
+
+    test('at-sea fleet picks adjacent seas and dockable provinces', () {
+      final picks = navalMoveTopologyPicksForFleet(
+        topology: topology,
+        fleet: Fleet(
+          id: 'f1',
+          ownerId: 'p1',
+          seaZoneId: 'oldWorld|s1',
+          regionId: 'oldWorld',
+        ),
+      );
+      expect(picks.adjacentSeaZoneIds, contains('newWorld|s2'));
+      expect(picks.adjacentProvinceIdsForDock, contains('oldWorld|p1'));
+      expect(picks.totalCount, greaterThan(0));
+    });
+
+    test('in-port fleet picks undock sea zones', () {
+      final picks = navalMoveTopologyPicksForFleet(
+        topology: topology,
+        fleet: Fleet(
+          id: 'f2',
+          ownerId: 'p1',
+          inPortAtProvinceId: 'oldWorld|p1',
+          regionId: 'oldWorld',
+        ),
+      );
+      expect(picks.adjacentSeaZoneIds, contains('oldWorld|s1'));
+      expect(picks.adjacentProvinceIdsForDock, isEmpty);
+    });
+
+    test('in-port fleet with unknown province yields empty picks', () {
+      final picks = navalMoveTopologyPicksForFleet(
+        topology: topology,
+        fleet: Fleet(
+          id: 'f3',
+          ownerId: 'p1',
+          inPortAtProvinceId: 'oldWorld|ghost',
+          regionId: 'oldWorld',
+        ),
+      );
+      expect(picks.totalCount, 0);
+    });
+
+    test('fleet neither at sea nor in port yields empty picks', () {
+      final picks = navalMoveTopologyPicksForFleet(
+        topology: topology,
+        fleet: Fleet(id: 'f4', ownerId: 'p1', regionId: 'oldWorld'),
+      );
+      expect(picks.totalCount, 0);
+    });
+  });
+
+  group('province/sea-zone lookups', () {
+    final topology = _topology();
+
+    test('firstAdjacentSeaZone returns an endpoint or null', () {
+      expect(firstAdjacentSeaZone(topology, 'oldWorld|s1'), isNotNull);
+      expect(firstAdjacentSeaZone(topology, 'oldWorld|orphan'), isNull);
+    });
+
+    test('seaZoneIdForProvince resolves region-scoped and global', () {
+      expect(
+        seaZoneIdForProvince(topology, 'p1', regionId: 'oldWorld'),
+        'oldWorld|s1',
+      );
+      expect(seaZoneIdForProvince(topology, 'oldWorld|p1'), 'oldWorld|s1');
+      expect(
+        seaZoneIdForProvince(topology, 'p1', regionId: 'zzz'),
+        isNull,
+      );
+    });
+
+    test('provinceIdsAdjacentToSeaZone lists coastal provinces', () {
+      expect(
+        provinceIdsAdjacentToSeaZone(topology, 'oldWorld|s1',
+            regionId: 'oldWorld'),
+        contains('oldWorld|p1'),
+      );
+    });
+
+    test('regionIdForSeaZone resolves known and unknown sea zones', () {
+      expect(regionIdForSeaZone(topology, 'oldWorld|s1'), 'oldWorld');
+      expect(regionIdForSeaZone(topology, 'oldWorld|sX'), isNull);
+    });
+
+    test('seaZoneIdsAdjacentToProvince lists P–S neighbors', () {
+      expect(
+        seaZoneIdsAdjacentToProvince(topology, 'oldWorld|p1'),
+        contains('oldWorld|s1'),
+      );
+    });
+  });
+
+  group('fleetsInPortAtProvince', () {
+    test('finds fleets docked at a province (prefixed and legacy)', () {
+      final worldState = WorldState(
+        turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+        oldWorld: const RegionData(),
+        newWorld: const RegionData(),
+        fleets: [
+          Fleet(
+            id: 'f1',
+            ownerId: 'p1',
+            inPortAtProvinceId: 'oldWorld|p1',
+            regionId: 'oldWorld',
+          ),
+          Fleet(
+            id: 'f2',
+            ownerId: 'p1',
+            seaZoneId: 'oldWorld|s1',
+            regionId: 'oldWorld',
+          ),
+        ],
+      );
+
+      expect(fleetsInPortAtProvince(worldState, 'oldWorld|p1').length, 1);
+      expect(fleetsInPortAtProvince(worldState, 'p1').length, 1);
+      expect(fleetsInPortAtProvince(worldState, 'oldWorld|p9'), isEmpty);
+    });
+  });
+}

--- a/tool/run_package_tests.sh
+++ b/tool/run_package_tests.sh
@@ -126,13 +126,13 @@ done
 echo ""
 
 gate_pkgs=()
-for pkg in colonizethis_logic colonizethis_map colonizethis_ai colonizethis_ai_contracts colonizethis_combat colonizethis_economy colonizethis_diplomacy colonizethis_setup colonizethis_orders colonizethis_turn; do
+for pkg in colonizethis_logic colonizethis_map colonizethis_ai colonizethis_ai_contracts colonizethis_world colonizethis_combat colonizethis_economy colonizethis_diplomacy colonizethis_setup colonizethis_orders colonizethis_turn; do
   if printf '%s\n' "${PKGS[@]}" | grep -qxF "$pkg"; then
     gate_pkgs+=("packages/$pkg")
   fi
 done
 if [ ${#gate_pkgs[@]} -gt 0 ]; then
-  echo "=== Coverage gate (logic/map/ai + split domain packages >= 90%; world deferred) ==="
+  echo "=== Coverage gate (logic/map/ai + split domain packages >= 90%) ==="
   "$ROOT/tool/check_coverage_threshold.sh" 90 "${gate_pkgs[@]}"
 fi
 


### PR DESCRIPTION
## Summary

Completes the deferred `colonizethis_world` coverage uplift from PR #3385 (which lifted standalone coverage 66% -> 80% and left world **excluded** from the per-package 90% gate). This PR pushes world to **91.01%** and **enables** the 90% gate for it.

`Refs #3290` (epic: split `colonizethis_logic` into domain packages — Phase 1 coverage follow-up).

## Done in this push

Adds 4 focused unit-test files (all under the 400-line domain-package test cap) covering previously low/zero-covered world modules:

- `capital_and_gp_fall_reassignment.dart` (was 0%) — Great Power / Minor Nation / Tribe runtime capital reassignment after combat: eligible reassignment, ineligible-clear, skip (still owns / no capital), and `CapitalReassignmentFatalError` paths (missing/invalid `townTileKey`).
- `capital_and_gp_fall_terminal.dart` (was 0%) — terminal fall transfer for GP/minor/tribe: province + unit + fleet transfer to conqueror, faction removal, and the no-fall guard branches (still owns capital, owns a province in region, missing capital, absent faction, port-province retention).
- `capital_reassignment.dart` — capital setters (player/minor/tribe, plus province-mismatch throws), the deterministic reassignment province picker (empty throw, sea-bound preference, inland fallback), and GP capital town development.
- `naval.dart` (was 38%) — sea-zone adjacency predicates, warp-zone detection, topology-node resolution, naval move topology picks (at sea / in port / unknown / idle), and in-port fleet lookups.

Standalone `colonizethis_world` line coverage: **79.76% -> 91.01%**.

## Gate change

Removes the **"world deferred"** exclusion in `tool/run_package_tests.sh` so `colonizethis_world` is now enforced at >=90% alongside the other split domain packages.

## Scope / non-goals

- Pure test additions plus a CI-gate wiring change; no production behavior changes (SPEC-aligned with the #3290 non-goal that coverage-restoring test additions are in scope, not new features).

## Test plan

- [x] Full `colonizethis_world` suite — 451 tests pass
- [x] Standalone world line coverage = 91.01% (>= 90%)
- [x] `dart analyze` on the 4 new test files — no issues
- [x] `tool/check_domain_package_test_file_size.dart` — no violations

Made with [Cursor](https://cursor.com)