### PR TITLE
chore: add repo.domain_package_dead_files gate for split domain packages (#3290)

### DIFF
--- a/SPEC/program/repo-lint.md
+++ b/SPEC/program/repo-lint.md
@@ -66,6 +66,7 @@
 | `tool/check_land_province_bucket_keys.dart` | For guarded explore/fog/news paths, disallow local-only land-province tile-bucket lookups (`tileKeysByRegionAndProvince[region]?[localId]`); require canonical full-id buckets only; rule `repo.land_province_bucket_keys` |
 | `tool/check_logic_dual_region_province_field_access.dart` | Caps direct `oldWorld/newWorld` `provinces` / `units` references in `packages/colonizethis_world/lib/src/**` outside canonical lookup files (`province_lookup.dart`, `unit_lookup.dart`) (GitHub #2071; post-split scan root Refs #3290); rule `repo.logic_dual_region_province_field_access` — see `SPEC/program/logic-dual-region-province-access.md` |
 | `tool/check_logic_dead_files.dart` | Unreferenced `lib/src` scan for `colonizethis_logic`; rule `repo.logic_dead_files` — see subsection below |
+| `tool/check_domain_package_dead_files.dart` | Workspace-wide unreferenced `lib/src` scan for the eight split logic-domain packages (`world`, `combat`, `economy`, `diplomacy`, `setup`, `orders`, `turn`, `ai_contracts`); rule `repo.domain_package_dead_files` (Refs #3290) — see subsection below |
 | `tool/check_logic_dedup_logger.dart` | Forbid private `final _log = packageLogger();` declarations under `packages/colonizethis_logic/lib/src/**` (Refs #2391, Pattern 1); files MUST consume the shared `logicLog` from `package:colonizethis_logic/package_logger.dart`; rule `repo.logic_dedup_logger` |
 | `tool/check_ai_dedup_gp_wars_filter.dart` | Forbid inline GP-wars filter comprehensions (`for (final … in <expr>.atWarWith) … playerById(…) != null`) under `packages/colonizethis_ai/lib/**` outside the canonical helper file `src/planning/planning_helpers.dart`; planner/filter code MUST call the shared `gpFactionIdsAtWarWith(game, snapshot)` helper (Refs #3278); rule `repo.ai_dedup_gp_wars_filter` |
 | `tool/check_ai_dedup_weight_scale_clamp.dart` | Forbid the inline weight-scale clamp idiom (`<= 0.0) { return 0; }` guard + `final clamped = X > 1.0 ? 1.0 : X;` + `return (Y * clamped).round();`) under `packages/colonizethis_ai/lib/**` outside the canonical helper file `src/planning/planning_helpers.dart`; filter/scoring code MUST call the shared `scaleWeightedBonus(weight, baseConstant)` helper (Refs #3278); rule `repo.ai_dedup_weight_scale_clamp` |
@@ -105,6 +106,25 @@
 **Deferred paths:** `lib/src/ai/ai_planner.dart` and `lib/src/ai/sim_game_ai.dart` are temporarily exempt in `tool/check_logic_dead_files.dart` until product wiring or deletion is decided (issue #2201); the checker still lists them in the pass message when they are the only findings.
 
 **Consumer note:** The root barrel may export setup/dossier/world modules that are not referenced by `app/` or `colonizethis_ai/` today; that keeps tests on a single `package:colonizethis_logic/colonizethis_logic.dart` import. Narrowing those exports is optional maintenance, not required for the dead-file rule.
+
+### `repo.domain_package_dead_files` (split domain-package `lib/src` orphans)
+
+**Goal (Refs #3290):** Extend dead-file detection to the eight extracted logic-domain packages (`colonizethis_world`, `colonizethis_combat`, `colonizethis_economy`, `colonizethis_diplomacy`, `colonizethis_setup`, `colonizethis_orders`, `colonizethis_turn`, `colonizethis_ai_contracts`) so an orphaned `lib/src` file in any of them fails CI, the same way `repo.logic_dead_files` protects the thin `colonizethis_logic` core.
+
+**Why workspace-wide (vs. the intra-package `repo.logic_dead_files` model):** After the split, a domain `lib/src` file is frequently consumed by a *different* package — for example `colonizethis_turn` re-exporting `package:colonizethis_world/src/world/...`, the thin `colonizethis_logic` barrel re-exporting domain src through `ai_api.dart` / `order_suggestion_api.dart` / `colonizethis_logic.dart`, or `app/lib` importing a domain src path directly. Intra-package reachability alone would mislabel these public files as dead, so liveness is resolved across the whole workspace.
+
+**Predicate:** `tool/check_domain_package_dead_files.dart` collects every non-test `.dart` file under the consumer roots (`packages/*/lib`, `app/lib`, `ctdev/lib`, `tool`). Every such file that lives **outside** the eight domain `lib/src` trees is an **anchor root**. Reachability follows parsed `import` / `export` / `part` directives (resolving workspace `package:<pkg>/...` URIs to `packages/<pkg>/lib/...` and relative paths) transitively. A domain `lib/src` file is **dead** when no anchor root reaches it through that directive graph.
+
+**Test imports:** Files under any `test/` or `integration_test/` directory are excluded from the consumer roots, so a domain `lib/src` file used only by tests is still treated as dead (mirrors `repo.logic_dead_files`).
+
+**Missing-tree guard:** If any of the eight `packages/colonizethis_<domain>/lib/src` trees is absent, the checker exits `1` (the split is incomplete or a package was misnamed).
+
+**Acceptance criteria:**
+
+- **Given** the post-split domain packages on `dev`, **when** `repo.domain_package_dead_files` scans every `packages/colonizethis_<domain>/lib/src` tree, **then** every `lib/src` file is reachable from at least one non-test anchor root and the rule exits `0`.
+- **Given** a `packages/colonizethis_world/lib/src` file that no non-test consumer imports, exports, or includes via `part`, **when** `repo.domain_package_dead_files` runs, **then** the rule lists that file under `packages/colonizethis_world/lib/src` and exits `1`.
+- **Given** a domain `lib/src` file consumed only through a cross-package re-export (for example `colonizethis_turn` `export 'package:colonizethis_world/src/world/...'`), **when** `repo.domain_package_dead_files` runs, **then** that file is treated as live and the rule exits `0`.
+- **Given** a workspace where one of the eight `packages/colonizethis_<domain>/lib/src` trees is missing, **when** `repo.domain_package_dead_files` runs, **then** the rule reports `Missing domain src tree` and exits `1`.
 
 ## Rule IDs and groups
 

--- a/test/check_domain_package_dead_files_test.dart
+++ b/test/check_domain_package_dead_files_test.dart
@@ -1,0 +1,134 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+import '../tool/check_domain_package_dead_files.dart';
+
+void _makeDomainSrcDirs(String root, {Iterable<String>? only}) {
+  final domains = only ?? domainPackageDeadFilesDomainsForTests;
+  for (final domain in domains) {
+    Directory(p.join(root, 'packages', 'colonizethis_$domain', 'lib', 'src'))
+        .createSync(recursive: true);
+  }
+}
+
+void main() {
+  test('passes on real repo workspace', () {
+    final repoRoot = Directory.current.path;
+    final logs = <String>[];
+    final code = runCheckDomainPackageDeadFiles(
+      repoRoot,
+      info: logs.add,
+      err: logs.add,
+    );
+    expect(code, 0, reason: logs.join('\n'));
+    expect(
+      logs.join('\n'),
+      contains('Domain-package dead-file check passed'),
+    );
+  });
+
+  test('audits the eight extracted domain packages', () {
+    expect(
+      domainPackageDeadFilesDomainsForTests,
+      containsAll(<String>[
+        'world',
+        'combat',
+        'economy',
+        'diplomacy',
+        'setup',
+        'orders',
+        'turn',
+        'ai_contracts',
+      ]),
+    );
+    expect(domainPackageDeadFilesDomainsForTests.length, 8);
+  });
+
+  test('fails when a domain src file is unreachable from any consumer', () {
+    final temp =
+        Directory.systemTemp.createTempSync('domain_dead_files_fail_');
+    addTearDown(() => temp.deleteSync(recursive: true));
+
+    _makeDomainSrcDirs(temp.path);
+
+    final worldSrc = Directory(
+      p.join(temp.path, 'packages/colonizethis_world/lib/src/world'),
+    )..createSync(recursive: true);
+    File(p.join(worldSrc.path, 'used.dart'))
+        .writeAsStringSync('class Used {}\n');
+    File(p.join(worldSrc.path, 'orphan.dart'))
+        .writeAsStringSync('class Orphan {}\n');
+
+    // An anchor consumer outside the domain src trees references `used.dart`
+    // (directly via the package src path) but never `orphan.dart`.
+    final appLib = Directory(p.join(temp.path, 'app/lib'))
+      ..createSync(recursive: true);
+    File(p.join(appLib.path, 'anchor.dart')).writeAsStringSync(
+      "import 'package:colonizethis_world/src/world/used.dart';\n"
+      'void useIt() => Used();\n',
+    );
+
+    final err = <String>[];
+    final code = runCheckDomainPackageDeadFiles(
+      temp.path,
+      info: (_) {},
+      err: err.add,
+    );
+
+    expect(code, 1);
+    expect(err.join('\n'), contains('orphan.dart'));
+    expect(err.join('\n'), isNot(contains('used.dart')));
+  });
+
+  test('keeps a domain file reachable through a cross-package re-export', () {
+    final temp =
+        Directory.systemTemp.createTempSync('domain_dead_files_reexport_');
+    addTearDown(() => temp.deleteSync(recursive: true));
+
+    _makeDomainSrcDirs(temp.path);
+
+    // world src file consumed only via a re-export from another package's lib.
+    final worldSrc = Directory(
+      p.join(temp.path, 'packages/colonizethis_world/lib/src/world'),
+    )..createSync(recursive: true);
+    File(p.join(worldSrc.path, 'naval.dart'))
+        .writeAsStringSync('class Naval {}\n');
+
+    // turn (a non-domain-src anchor file) re-exports the world src file.
+    final turnLib = Directory(p.join(temp.path, 'packages/colonizethis_turn/lib'))
+      ..createSync(recursive: true);
+    File(p.join(turnLib.path, 'colonizethis_turn.dart')).writeAsStringSync(
+      "export 'package:colonizethis_world/src/world/naval.dart';\n",
+    );
+
+    final logs = <String>[];
+    final code = runCheckDomainPackageDeadFiles(
+      temp.path,
+      info: logs.add,
+      err: logs.add,
+    );
+
+    expect(code, 0, reason: logs.join('\n'));
+  });
+
+  test('fails when a domain src tree is missing', () {
+    final temp =
+        Directory.systemTemp.createTempSync('domain_dead_files_missing_');
+    addTearDown(() => temp.deleteSync(recursive: true));
+
+    // Only create a subset of the required domain src trees.
+    _makeDomainSrcDirs(temp.path, only: const ['world', 'combat']);
+
+    final err = <String>[];
+    final code = runCheckDomainPackageDeadFiles(
+      temp.path,
+      info: (_) {},
+      err: err.add,
+    );
+
+    expect(code, 1);
+    expect(err.join('\n'), contains('Missing domain src tree'));
+  });
+}

--- a/tool/check_domain_package_dead_files.dart
+++ b/tool/check_domain_package_dead_files.dart
@@ -1,0 +1,269 @@
+// Dead-file detection for the eight split logic-domain packages (Refs #3290).
+//
+// Mirrors the intent of `repo.logic_dead_files`
+// (`tool/check_logic_dead_files.dart`) for the extracted domain packages, but
+// resolves liveness across the whole workspace. After the split, a domain
+// `lib/src` file is frequently consumed by a *different* package (for example
+// `colonizethis_turn` re-exporting `package:colonizethis_world/src/...`, or the
+// thin `colonizethis_logic` barrel re-exporting domain src), so intra-package
+// reachability alone would mislabel public files as dead.
+//
+// Liveness model: every non-test `.dart` file under the scanned consumer roots
+// (`packages/*/lib`, `app/lib`, `ctdev/lib`, `tool`) that lives OUTSIDE the
+// eight domain `lib/src` trees is an anchor root. Reachability follows
+// `import` / `export` / `part` directives (resolving workspace `package:`
+// URIs and relative paths) transitively. A domain `lib/src` file is dead when
+// no anchor root reaches it through that directive graph.
+import 'dart:collection';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+/// Split domain packages whose `lib/src` trees must stay free of orphans.
+const List<String> domainPackageDeadFilesDomainsForTests = [
+  'world',
+  'combat',
+  'economy',
+  'diplomacy',
+  'setup',
+  'orders',
+  'turn',
+  'ai_contracts',
+];
+
+final RegExp _directivePattern = RegExp(
+  "^\\s*(import|export|part)\\s+['\\\"]([^'\\\"]+)['\\\"]",
+  multiLine: true,
+);
+
+void main() {
+  exit(runCheckDomainPackageDeadFiles(Directory.current.path));
+}
+
+/// Runs the workspace-wide dead-file scan for every split domain package,
+/// returning `0` when all domain `lib/src` files are reachable and `1` when a
+/// domain `lib/src` tree is missing or contains an unreferenced file.
+int runCheckDomainPackageDeadFiles(
+  String repoRoot, {
+  void Function(String line)? info,
+  void Function(String line)? err,
+}) {
+  final void Function(String line) logI = info ?? stdout.writeln;
+  final void Function(String line) logE = err ?? stderr.writeln;
+
+  final root = p.normalize(repoRoot);
+
+  // Domain src directories (the trees we audit for orphans).
+  final domainSrcDirs = <String, String>{};
+  for (final domain in domainPackageDeadFilesDomainsForTests) {
+    final srcRelative = p.join('packages', 'colonizethis_$domain', 'lib', 'src');
+    final srcDir = Directory(p.join(root, srcRelative));
+    if (!srcDir.existsSync()) {
+      logE('ERROR: Missing domain src tree: $srcRelative');
+      return 1;
+    }
+    domainSrcDirs['colonizethis_$domain'] = srcRelative;
+  }
+
+  // Collect every non-test consumer `.dart` file under the scan roots.
+  final scanRoots = <String>[
+    ...Directory(p.join(root, 'packages'))
+        .listSync(followLinks: false)
+        .whereType<Directory>()
+        .map((dir) => p.join(dir.path, 'lib'))
+        .where((libPath) => Directory(libPath).existsSync()),
+    p.join(root, 'app', 'lib'),
+    p.join(root, 'ctdev', 'lib'),
+    p.join(root, 'tool'),
+  ];
+
+  final allFiles = <String>{};
+  for (final scanRoot in scanRoots) {
+    final dir = Directory(scanRoot);
+    if (!dir.existsSync()) {
+      continue;
+    }
+    for (final filePath in _listDartFiles(dir.path)) {
+      if (_isUnderTestDir(filePath)) {
+        continue;
+      }
+      allFiles.add(p.normalize(filePath));
+    }
+  }
+
+  // Build the directive graph and identify domain src files.
+  final edges = <String, Set<String>>{};
+  final domainSrcFiles = <String>{};
+  for (final domainSrc in domainSrcDirs.values) {
+    final absDomainSrc = p.join(root, domainSrc);
+    for (final filePath in _listDartFiles(absDomainSrc)) {
+      final normalized = p.normalize(filePath);
+      domainSrcFiles.add(normalized);
+      allFiles.add(normalized);
+    }
+  }
+
+  for (final filePath in allFiles) {
+    final targets = <String>{};
+    for (final directive in _parseDirectives(filePath)) {
+      final targetPath = _resolveTargetPath(
+        sourcePath: filePath,
+        target: directive.target,
+        repoRoot: root,
+      );
+      if (targetPath == null || !targetPath.endsWith('.dart')) {
+        continue;
+      }
+      if (!allFiles.contains(targetPath) && !File(targetPath).existsSync()) {
+        continue;
+      }
+      targets.add(targetPath);
+    }
+    if (targets.isNotEmpty) {
+      edges[filePath] = targets;
+    }
+  }
+
+  // Anchor roots: every consumer file outside the domain src trees.
+  final roots = allFiles.difference(domainSrcFiles);
+  final reachable = _collectReachable(roots, edges);
+
+  final deadByPackage = <String, List<String>>{};
+  for (final srcFile in domainSrcFiles) {
+    if (reachable.contains(srcFile)) {
+      continue;
+    }
+    final relative = _relativeToRoot(srcFile, root);
+    final pkg = _owningPackage(relative);
+    deadByPackage.putIfAbsent(pkg, () => <String>[]).add(relative);
+  }
+
+  if (deadByPackage.isEmpty) {
+    logI('Domain-package dead-file check passed for all split packages.');
+    return 0;
+  }
+
+  final packages = deadByPackage.keys.toList()..sort();
+  for (final pkg in packages) {
+    final files = deadByPackage[pkg]!..sort();
+    logE(
+      'ERROR: Found ${files.length} dead file(s) under packages/$pkg/lib/src.\n'
+      'A file is dead when it is not reachable (via import/export/part '
+      'directives) from any non-test consumer outside the eight domain '
+      'lib/src trees.',
+    );
+    for (final file in files) {
+      logE('  $file');
+    }
+  }
+  return 1;
+}
+
+Set<String> _collectReachable(
+  Set<String> roots,
+  Map<String, Set<String>> edges,
+) {
+  final visited = <String>{};
+  final queue = Queue<String>()..addAll(roots);
+  while (queue.isNotEmpty) {
+    final current = queue.removeFirst();
+    if (!visited.add(current)) {
+      continue;
+    }
+    final targets = edges[current];
+    if (targets == null) {
+      continue;
+    }
+    for (final target in targets) {
+      if (!visited.contains(target)) {
+        queue.add(target);
+      }
+    }
+  }
+  return visited;
+}
+
+bool _isUnderTestDir(String filePath) {
+  final segments = p.split(filePath);
+  return segments.contains('test') || segments.contains('integration_test');
+}
+
+String _owningPackage(String relativePath) {
+  final segments = p.split(relativePath);
+  // relativePath looks like packages/<pkg>/lib/src/...
+  if (segments.length >= 2 && segments.first == 'packages') {
+    return segments[1];
+  }
+  return relativePath;
+}
+
+List<String> _listDartFiles(String dirPath) {
+  final dir = Directory(dirPath);
+  if (!dir.existsSync()) {
+    return const [];
+  }
+  return dir
+      .listSync(recursive: true, followLinks: false)
+      .whereType<File>()
+      .map((file) => p.normalize(file.path))
+      .where((filePath) => filePath.endsWith('.dart'))
+      .toList();
+}
+
+String _relativeToRoot(String filePath, String repoRoot) {
+  return p.normalize(p.relative(filePath, from: repoRoot));
+}
+
+List<_Directive> _parseDirectives(String filePath) {
+  final file = File(filePath);
+  if (!file.existsSync()) {
+    return const [];
+  }
+  final content = file.readAsStringSync();
+  final directives = <_Directive>[];
+  for (final match in _directivePattern.allMatches(content)) {
+    final kindText = match.group(1);
+    final target = match.group(2);
+    if (kindText == null || target == null) {
+      continue;
+    }
+    directives.add(_Directive(target: target));
+  }
+  return directives;
+}
+
+String? _resolveTargetPath({
+  required String sourcePath,
+  required String target,
+  required String repoRoot,
+}) {
+  if (target.startsWith('dart:')) {
+    return null;
+  }
+  if (target.startsWith('package:')) {
+    const prefix = 'package:';
+    final withoutScheme = target.substring(prefix.length);
+    final slash = withoutScheme.indexOf('/');
+    if (slash <= 0) {
+      return null;
+    }
+    final packageName = withoutScheme.substring(0, slash);
+    final packageRelative = withoutScheme.substring(slash + 1);
+    final packageLib = Directory(
+      p.join(repoRoot, 'packages', packageName, 'lib'),
+    );
+    if (!packageLib.existsSync()) {
+      return null;
+    }
+    return p.normalize(p.join(packageLib.path, packageRelative));
+  }
+
+  final sourceDir = p.dirname(sourcePath);
+  return p.normalize(p.join(sourceDir, target));
+}
+
+final class _Directive {
+  const _Directive({required this.target});
+
+  final String target;
+}

--- a/tool/ct_repo_lint_manifest.yaml
+++ b/tool/ct_repo_lint_manifest.yaml
@@ -406,6 +406,13 @@ rules:
     runner: dart
     script: tool/check_domain_package_test_file_size.dart
 
+  - rule_id: repo.domain_package_dead_files
+    group: architecture
+    title: split domain packages must have no unreferenced lib/src files (Refs #3290)
+    spec: SPEC/program/repo-lint.md
+    runner: dart
+    script: tool/check_domain_package_dead_files.dart
+
   - rule_id: repo.dart_file_non_comment_line_size
     group: structure
     title: Dart files must stay at or below 1000 non-comment lines


### PR DESCRIPTION
## Summary

Extends repository dead-file detection to the eight extracted logic-domain
packages, completing a piece of the #3290 CI/enforcement roadmap
(`SPEC/program/logic-package-split-phase0.md` line: "Future per-package rules
(`repo.world_dead_files`, ...) are added when packages are created"). Today
only `repo.logic_dead_files` protects the thin `colonizethis_logic` core; the
split domain packages (`world`, `combat`, `economy`, `diplomacy`, `setup`,
`orders`, `turn`, `ai_contracts`) had no orphan-file gate.

`Refs #3290`

## Done in this push

- **New tool** `tool/check_domain_package_dead_files.dart` — single
  consolidated checker over all eight domain packages, following the
  established `repo.domain_package_test_file_size` / `repo.domain_package_import_dag`
  consolidated pattern rather than 8 separate rules.
- **New rule** `repo.domain_package_dead_files` in `tool/ct_repo_lint_manifest.yaml`
  (group `architecture`, runs via the orchestrator's `dart run` fallback like
  its domain-package peers).
- **SPEC** `SPEC/program/repo-lint.md` — tool-table row + dedicated subsection
  with four Given/When/Then acceptance criteria.
- **Tests** `test/check_domain_package_dead_files_test.dart` — real-repo green
  pass, negative orphan detection, cross-package re-export liveness, and the
  missing-domain-src-tree guard.

## Design note (workspace-wide liveness)

Unlike the intra-package `repo.logic_dead_files` model, a domain `lib/src` file
is frequently consumed by a *different* package post-split (e.g.
`colonizethis_turn` re-exporting `package:colonizethis_world/src/...`, or the
`colonizethis_logic` barrel re-exporting domain src). Intra-package
reachability alone would mislabel public files as dead, so the checker treats
every non-test `.dart` under `packages/*/lib`, `app/lib`, `ctdev/lib`, and
`tool` that lives outside the eight domain `lib/src` trees as an anchor root,
then follows `import`/`export`/`part` directives transitively. A domain
`lib/src` file is dead only when no anchor reaches it. Test directories are
excluded (a file used only by tests is still dead), matching
`repo.logic_dead_files`.

## Scope / non-goals

- Pure CI-gate addition + SPEC; no production behavior change.
- Consolidated rule over all eight packages (matches existing post-split
  domain-package rule precedent) rather than per-package rule ids.

## Test plan

- [x] `dart test test/check_domain_package_dead_files_test.dart` — 5 tests pass
- [x] `dart test test/ct_repo_lint_test.dart` — manifest still loads
- [x] `dart run tool/ct_repo_lint.dart --rule repo.domain_package_dead_files` — exits 0 on `dev`
- [x] `dart analyze` on new tool + test — no issues

Made with [Cursor](https://cursor.com)