### PR TITLE
refactor: collapse completed-work handlers into CompletedWorkContext (#3404)

### DIFF
--- a/packages/colonizethis_orders/lib/src/orders/orders_application_completed_work.dart
+++ b/packages/colonizethis_orders/lib/src/orders/orders_application_completed_work.dart
@@ -88,16 +88,22 @@ TileMapState propagateRoadToAdjacentCapitalOrPort({
   return current;
 }
 
-typedef _CompletedWorkHandler =
-    BuildWorkState Function(
-      BuildWorkState s,
-      Unit u,
+/// Bundles the six values every completed-work handler needs so each handler is
+/// a single-argument `(CompletedWorkContext) -> BuildWorkState` closure instead
+/// of repeating the wide positional signature in every function (Refs #3404).
+typedef CompletedWorkContext =
+    ({
+      BuildWorkState state,
+      Unit unit,
       CurrentWork cw,
       List<Province> Function() getProvinces,
       WorkOrderState Function(WorkOrderState, List<Province>) replaceProvinces,
       BuildWorkState Function(BuildWorkState, Unit, String)
       applyExploreCompletion,
-    );
+    });
+
+typedef _CompletedWorkHandler =
+    BuildWorkState Function(CompletedWorkContext ctx);
 
 BuildWorkState dispatchCompletedWorkTarget(
   BuildWorkState s,
@@ -112,24 +118,20 @@ BuildWorkState dispatchCompletedWorkTarget(
   );
   final handler = _completedWorkTargetHandlers[cw.workTarget];
   if (handler == null) return s;
-  return handler(
-    s,
-    u,
-    cw,
-    getProvinces,
-    replaceProvinces,
-    applyExploreCompletion,
-  );
+  return handler((
+    state: s,
+    unit: u,
+    cw: cw,
+    getProvinces: getProvinces,
+    replaceProvinces: replaceProvinces,
+    applyExploreCompletion: applyExploreCompletion,
+  ));
 }
 
-BuildWorkState _completedWorkBuildImprovement(
-  BuildWorkState s,
-  Unit u,
-  CurrentWork cw,
-  List<Province> Function() getProvinces,
-  WorkOrderState Function(WorkOrderState, List<Province>) replaceProvinces,
-  BuildWorkState Function(BuildWorkState, Unit, String) applyExploreCompletion,
-) {
+BuildWorkState _completedWorkBuildImprovement(CompletedWorkContext ctx) {
+  final s = ctx.state;
+  final u = ctx.unit;
+  final cw = ctx.cw;
   final level = s.work.tileState.improvementLevel(cw.tileKey);
   var work = s.work.copyWith(
     tileState: s.work.tileState.setImprovement(
@@ -170,14 +172,11 @@ BuildWorkState _completedWorkBuildImprovement(
   return s.copyWith(game: game, work: work);
 }
 
-BuildWorkState _completedWorkUpgradeTown(
-  BuildWorkState s,
-  Unit u,
-  CurrentWork cw,
-  List<Province> Function() getProvinces,
-  WorkOrderState Function(WorkOrderState, List<Province>) replaceProvinces,
-  BuildWorkState Function(BuildWorkState, Unit, String) applyExploreCompletion,
-) {
+BuildWorkState _completedWorkUpgradeTown(CompletedWorkContext ctx) {
+  final s = ctx.state;
+  final u = ctx.unit;
+  final getProvinces = ctx.getProvinces;
+  final replaceProvinces = ctx.replaceProvinces;
   final provinces = getProvinces();
   var replaced = false;
   final next = provinces.map((p) {
@@ -193,29 +192,19 @@ BuildWorkState _completedWorkUpgradeTown(
   return s.copyWith(work: replaceProvinces(s.work, next));
 }
 
-BuildWorkState _completedWorkExplore(
-  BuildWorkState s,
-  Unit u,
-  CurrentWork cw,
-  List<Province> Function() getProvinces,
-  WorkOrderState Function(WorkOrderState, List<Province>) replaceProvinces,
-  BuildWorkState Function(BuildWorkState, Unit, String) applyExploreCompletion,
-) {
-  return applyExploreCompletion(
-    s,
+BuildWorkState _completedWorkExplore(CompletedWorkContext ctx) {
+  final u = ctx.unit;
+  return ctx.applyExploreCompletion(
+    ctx.state,
     u,
     ProvinceId.regionIdFrom(u.locationProvinceId),
   );
 }
 
-BuildWorkState _completedWorkBuildRoad(
-  BuildWorkState s,
-  Unit u,
-  CurrentWork cw,
-  List<Province> Function() getProvinces,
-  WorkOrderState Function(WorkOrderState, List<Province>) replaceProvinces,
-  BuildWorkState Function(BuildWorkState, Unit, String) applyExploreCompletion,
-) {
+BuildWorkState _completedWorkBuildRoad(CompletedWorkContext ctx) {
+  final s = ctx.state;
+  final u = ctx.unit;
+  final cw = ctx.cw;
   final roadLevel = s.work.tileState.roadLevel(cw.tileKey);
   final player = s.game.playerById(u.ownerId);
   final hasRoadConstruction =
@@ -237,14 +226,10 @@ BuildWorkState _completedWorkBuildRoad(
   return s.copyWith(work: s.work.copyWith(tileState: tileState));
 }
 
-BuildWorkState _completedWorkBuildPort(
-  BuildWorkState s,
-  Unit u,
-  CurrentWork cw,
-  List<Province> Function() getProvinces,
-  WorkOrderState Function(WorkOrderState, List<Province>) replaceProvinces,
-  BuildWorkState Function(BuildWorkState, Unit, String) applyExploreCompletion,
-) {
+BuildWorkState _completedWorkBuildPort(CompletedWorkContext ctx) {
+  final s = ctx.state;
+  final u = ctx.unit;
+  final cw = ctx.cw;
   if (s.topology == null) {
     return s;
   }
@@ -269,14 +254,11 @@ BuildWorkState _completedWorkBuildPort(
   );
 }
 
-BuildWorkState _completedWorkBuildFort(
-  BuildWorkState s,
-  Unit u,
-  CurrentWork cw,
-  List<Province> Function() getProvinces,
-  WorkOrderState Function(WorkOrderState, List<Province>) replaceProvinces,
-  BuildWorkState Function(BuildWorkState, Unit, String) applyExploreCompletion,
-) {
+BuildWorkState _completedWorkBuildFort(CompletedWorkContext ctx) {
+  final s = ctx.state;
+  final u = ctx.unit;
+  final getProvinces = ctx.getProvinces;
+  final replaceProvinces = ctx.replaceProvinces;
   final provinces = getProvinces();
   var replaced = false;
   final nextProvinces = provinces.map((p) {
@@ -310,14 +292,10 @@ BuildWorkState _completedWorkBuildFort(
   return s.copyWith(work: work);
 }
 
-BuildWorkState _completedWorkBuildRail(
-  BuildWorkState s,
-  Unit u,
-  CurrentWork cw,
-  List<Province> Function() getProvinces,
-  WorkOrderState Function(WorkOrderState, List<Province>) replaceProvinces,
-  BuildWorkState Function(BuildWorkState, Unit, String) applyExploreCompletion,
-) {
+BuildWorkState _completedWorkBuildRail(CompletedWorkContext ctx) {
+  final s = ctx.state;
+  final u = ctx.unit;
+  final cw = ctx.cw;
   final player = s.game.playerById(u.ownerId);
   final roadLevel = s.work.tileState.roadLevel(cw.tileKey);
   final terrain = terrainTypeForTileKey(s.tileMapByRegion, cw.tileKey);
@@ -339,23 +317,12 @@ BuildWorkState _completedWorkBuildRail(
   return s;
 }
 
-BuildWorkState _completedWorkNoop(
-  BuildWorkState s,
-  Unit u,
-  CurrentWork cw,
-  List<Province> Function() getProvinces,
-  WorkOrderState Function(WorkOrderState, List<Province>) replaceProvinces,
-  BuildWorkState Function(BuildWorkState, Unit, String) applyExploreCompletion,
-) => s;
+BuildWorkState _completedWorkNoop(CompletedWorkContext ctx) => ctx.state;
 
-BuildWorkState _completedWorkProspect(
-  BuildWorkState s,
-  Unit u,
-  CurrentWork cw,
-  List<Province> Function() getProvinces,
-  WorkOrderState Function(WorkOrderState, List<Province>) replaceProvinces,
-  BuildWorkState Function(BuildWorkState, Unit, String) applyExploreCompletion,
-) {
+BuildWorkState _completedWorkProspect(CompletedWorkContext ctx) {
+  final s = ctx.state;
+  final u = ctx.unit;
+  final cw = ctx.cw;
   if (!isMineralEligibleTile(s.game, s.tileMapByRegion, cw.tileKey)) {
     return s;
   }
@@ -374,14 +341,10 @@ BuildWorkState _completedWorkProspect(
   return s.copyWith(game: s.game.withWorldState(ws));
 }
 
-BuildWorkState _completedWorkPurchaseLand(
-  BuildWorkState s,
-  Unit u,
-  CurrentWork cw,
-  List<Province> Function() getProvinces,
-  WorkOrderState Function(WorkOrderState, List<Province>) replaceProvinces,
-  BuildWorkState Function(BuildWorkState, Unit, String) applyExploreCompletion,
-) {
+BuildWorkState _completedWorkPurchaseLand(CompletedWorkContext ctx) {
+  final s = ctx.state;
+  final u = ctx.unit;
+  final cw = ctx.cw;
   final player = s.game.playerById(u.ownerId);
   if (player == null) {
     return s;

--- a/packages/colonizethis_orders/test/orders_application_completed_work_dispatch_test.dart
+++ b/packages/colonizethis_orders/test/orders_application_completed_work_dispatch_test.dart
@@ -161,5 +161,128 @@ void main() {
 
       expect(next.work.tileState.roadLevel(tileKey), 0);
     });
+
+    test('upgrade_town threads getProvinces/replaceProvinces through the '
+        'CompletedWorkContext record', () {
+      final unit = Unit(
+        id: 'u1',
+        type: kUnitTypeBuilder,
+        ownerId: 'p1',
+        locationProvinceId: provinceId,
+        tileKey: tileKey,
+        status: UnitStatus.working,
+      );
+      const province = Province(
+        id: provinceId,
+        regionId: ow,
+        ownerId: 'p1',
+        townDevelopmentLevel: 0,
+      );
+      final game = Game(
+        id: 'g',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: RegionData(provinces: const [province], units: [unit]),
+          newWorld: const RegionData(),
+          tileState: TileMapState(),
+        ),
+        players: const [Player(id: 'p1', displayName: 'P1', isHuman: true)],
+      );
+      final work = WorkOrderState(
+        oldUnitsById: {unit.id: unit},
+        newUnitsById: const {},
+        tileState: TileMapState(),
+        visibilityByTile: const {},
+        portsByProvinceSeaboard: const {},
+        purchasedTilesByTileKey: const {},
+        oldProvinces: const [province],
+        newProvinces: const [],
+      );
+      final state = BuildWorkState(
+        game: game,
+        buildOrders: const {},
+        workOrders: const {},
+        tileMapByRegion: const {},
+        work: work,
+      );
+      const cw = CurrentWork(
+        workTarget: kWorkTargetUpgradeTown,
+        tileKey: tileKey,
+        totalTurns: 1,
+        remainingTurns: 0,
+      );
+
+      final next = dispatchCompletedWorkTarget(
+        state,
+        unit,
+        cw,
+        () => game.worldState.oldWorld.provinces,
+        (w, p) => w.copyWith(oldProvinces: p),
+        (s, u, regionId) => s,
+      );
+
+      expect(next.work.oldProvinces.single.townDevelopmentLevel, 1);
+    });
+
+    test('explore invokes the applyExploreCompletion closure with the unit '
+        'region via the CompletedWorkContext record', () {
+      final unit = Unit(
+        id: 'u1',
+        type: kUnitTypeExplorer,
+        ownerId: 'p1',
+        locationProvinceId: provinceId,
+        tileKey: tileKey,
+        status: UnitStatus.working,
+      );
+      final game = Game(
+        id: 'g',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: RegionData(units: [unit]),
+          newWorld: const RegionData(),
+          tileState: TileMapState(),
+        ),
+        players: const [Player(id: 'p1', displayName: 'P1', isHuman: true)],
+      );
+      final work = WorkOrderState(
+        oldUnitsById: {unit.id: unit},
+        newUnitsById: const {},
+        tileState: TileMapState(),
+        visibilityByTile: const {},
+        portsByProvinceSeaboard: const {},
+        purchasedTilesByTileKey: const {},
+        oldProvinces: const [],
+        newProvinces: const [],
+      );
+      final state = BuildWorkState(
+        game: game,
+        buildOrders: const {},
+        workOrders: const {},
+        tileMapByRegion: const {},
+        work: work,
+      );
+      const cw = CurrentWork(
+        workTarget: kWorkTargetExplore,
+        tileKey: tileKey,
+        totalTurns: 1,
+        remainingTurns: 0,
+      );
+
+      String? capturedRegionId;
+      final next = dispatchCompletedWorkTarget(
+        state,
+        unit,
+        cw,
+        () => game.worldState.oldWorld.provinces,
+        (w, p) => w.copyWith(oldProvinces: p),
+        (s, u, regionId) {
+          capturedRegionId = regionId;
+          return s;
+        },
+      );
+
+      expect(capturedRegionId, ow);
+      expect(identical(next, state), isTrue);
+    });
   });
 }


### PR DESCRIPTION
## Summary

Follow-up slice of #3404 (orders-package dedup), continuing after the merged first slice (#3406, order-merge unification + stockpile clone dedup). Behaviour-preserving, logic-only, scoped to `packages/colonizethis_orders/`.

Maps to issue AC:
- **"`_CompletedWorkHandler` typedef replaced with `CompletedWorkContext` record; each of the 10 handlers is a single-argument closure."**

## Done in this push

### `CompletedWorkContext` record (`orders_application_completed_work.dart`)
- Replaced the repeated six-parameter `_CompletedWorkHandler` typedef with a single `CompletedWorkContext` record: `(BuildWorkState state, Unit unit, CurrentWork cw, List<Province> Function() getProvinces, WorkOrderState Function(WorkOrderState, List<Province>) replaceProvinces, BuildWorkState Function(BuildWorkState, Unit, String) applyExploreCompletion)`.
- Rewrote all **10** completed-work handlers (`build_improvement`, `upgrade_town`, `explore`, `build_road`, `build_port`, `build_fort`, `build_rail`, `noop`, `prospect`, `purchase_land`) as single-argument `(CompletedWorkContext) -> BuildWorkState` closures; each destructures only the fields it uses (no unused locals).
- `dispatchCompletedWorkTarget` keeps its public positional signature and builds the record once before dispatching, so the caller (`orders_application.dart`) and existing tests are unchanged. The 11-entry dispatch map is untouched.
- Behaviour preserved: every handler body is otherwise identical to before.

### Tests
- Added two positive dispatch tests exercising the record's closure fields end-to-end:
  - `upgrade_town` threads `getProvinces` / `replaceProvinces` (asserts `townDevelopmentLevel` increments through `replaceProvinces`).
  - `explore` invokes the `applyExploreCompletion` closure with the unit's region id (asserts captured region + identity return).

## Deferred (remaining for #3404, future PRs)
- Old/new world `({old, new})` record refactor (eliminate `isOldWorld` ternaries in `orders_application.dart`).
- `repo.orders_file_size` gate for `orders_application.dart` / `orders_application_completed_work.dart`.
- The `Map<String, Unit>.from(...)` arm of `repo.orders_dedup_map_clones` (lands with the old/new record slice).

## SPEC
- None. The issue scopes this as behaviour-preserving with no spec changes.

## Test plan
- [x] `dart test` `colonizethis_orders` full suite — 671 green (was 669; +2 new dispatch tests).
- [x] `dart test test/orders_application_completed_work_dispatch_test.dart` — 4 green.
- [x] `dart analyze` clean on both touched files (`orders_application_completed_work.dart`, dispatch test).

Refs #3404

Made with [Cursor](https://cursor.com)