### PR TITLE
refactor: cache topology graph index + unify sea-reachability BFS (#3403)

### DIFF
--- a/packages/colonizethis_world/lib/src/utils/graph_traversal.dart
+++ b/packages/colonizethis_world/lib/src/utils/graph_traversal.dart
@@ -1,9 +1,13 @@
 import 'dart:collection';
 
+import 'package:colonizethis_data/colonizethis_data.dart';
+
 /// Shared graph traversals. Refactor slice for waigore/colonizethis#2071.
 ///
 /// Includes [propagateConnectivityBottleneckQueue] for capital connectivity
-/// (per-edge transport caps; not the same as [breadthFirstReachableInSubgraph]).
+/// (per-edge transport caps; not the same as [breadthFirstReachableInSubgraph])
+/// and [bfsTopologyGraph], the canonical topology-graph BFS shared by the
+/// sea-reachability planners (Refs #3403 Phase 2).
 
 /// Connected components of the subgraph induced by [subset].
 ///
@@ -81,6 +85,109 @@ Set<T> breadthFirstReachableInSubgraph<T>(
     }
   }
   return reachable;
+}
+
+/// Canonical breadth-first traversal over a `MapTopology` graph, shared by the
+/// sea-reachability planners (Refs #3403 Phase 2). The traversal owns frontier
+/// expansion; callers pass the **cached** node-type and adjacency indexes
+/// (`topologyNodeTypeById` / `topologyAdjacency` in `topology_helpers.dart`) so
+/// no per-call `topology.nodes`/`topology.edges` rebuild happens on hot paths.
+///
+/// Expansion rules mirror the colonial sea-reachability contract
+/// (SPEC/ai/ai-architecture.md § Colonial expansion):
+///
+///   * Every node in [sourceIds] is seeded at distance 0 and expanded.
+///   * A province node is expanded (its neighbours enqueued) only when
+///     [isExpandableProvince] returns true (owned anchors / owned territory).
+///   * A sea-zone node is always expanded once, the first time it is reached.
+///   * A province node for which [isForeignProvince] returns true is **collected
+///     but not expanded** — it terminates that branch.
+///
+/// Each edge counts as distance 1. Neighbour iteration follows the insertion
+/// order of the cached [adjacency] sets (built from `topology.edges` order), so
+/// results are deterministic for fixed inputs (Refs #2509 Must-have #7).
+///
+/// Visitor callbacks are **observation-only** and cannot abort traversal:
+///   * [onProvinceVisited] — fires once when an *expandable* province is first
+///     enqueued, with its BFS distance.
+///   * [onSeaVisited] — fires once when a sea zone is first enqueued.
+///   * [onForeignProvinceDiscovered] — fires once, on the **first** time a
+///     foreign province is reached. Because this is a uniform-weight FIFO BFS,
+///     first discovery is also the shortest-distance discovery.
+void bfsTopologyGraph({
+  required Iterable<String> sourceIds,
+  required Map<String, TopologyNodeType> nodeType,
+  required Map<String, Set<String>> adjacency,
+  required bool Function(String provinceId) isExpandableProvince,
+  required bool Function(String provinceId) isForeignProvince,
+  void Function(String provinceId, int distance)? onProvinceVisited,
+  void Function(String seaZoneId, int distance)? onSeaVisited,
+  void Function(String provinceId, int distance)? onForeignProvinceDiscovered,
+}) {
+  final visited = <String>{...sourceIds};
+  final discoveredForeign = <String>{};
+  final queue = Queue<_TopologyProbe>.from(
+    sourceIds.map((id) => _TopologyProbe(id, 0)),
+  );
+  while (queue.isNotEmpty) {
+    final cur = queue.removeFirst();
+    final nextDistance = cur.distance + 1;
+    for (final nb in adjacency[cur.id] ?? const <String>{}) {
+      _visitTopologyNeighbor(
+        nb: nb,
+        distance: nextDistance,
+        nodeType: nodeType,
+        isExpandableProvince: isExpandableProvince,
+        isForeignProvince: isForeignProvince,
+        visited: visited,
+        discoveredForeign: discoveredForeign,
+        queue: queue,
+        onProvinceVisited: onProvinceVisited,
+        onSeaVisited: onSeaVisited,
+        onForeignProvinceDiscovered: onForeignProvinceDiscovered,
+      );
+    }
+  }
+}
+
+void _visitTopologyNeighbor({
+  required String nb,
+  required int distance,
+  required Map<String, TopologyNodeType> nodeType,
+  required bool Function(String provinceId) isExpandableProvince,
+  required bool Function(String provinceId) isForeignProvince,
+  required Set<String> visited,
+  required Set<String> discoveredForeign,
+  required Queue<_TopologyProbe> queue,
+  required void Function(String provinceId, int distance)? onProvinceVisited,
+  required void Function(String seaZoneId, int distance)? onSeaVisited,
+  required void Function(String provinceId, int distance)?
+  onForeignProvinceDiscovered,
+}) {
+  final nbType = nodeType[nb];
+  if (nbType == null) return;
+
+  if (nbType == TopologyNodeType.province) {
+    if (isForeignProvince(nb) && discoveredForeign.add(nb)) {
+      onForeignProvinceDiscovered?.call(nb, distance);
+    }
+    if (isExpandableProvince(nb) && visited.add(nb)) {
+      onProvinceVisited?.call(nb, distance);
+      queue.add(_TopologyProbe(nb, distance));
+    }
+    return;
+  }
+  if (nbType == TopologyNodeType.seaZone && visited.add(nb)) {
+    onSeaVisited?.call(nb, distance);
+    queue.add(_TopologyProbe(nb, distance));
+  }
+}
+
+class _TopologyProbe {
+  const _TopologyProbe(this.id, this.distance);
+
+  final String id;
+  final int distance;
 }
 
 /// Propagates tile connectivity using [queue], updating [pathCap] bottleneck

--- a/packages/colonizethis_world/lib/src/world/sea_reachable_provinces.dart
+++ b/packages/colonizethis_world/lib/src/world/sea_reachable_provinces.dart
@@ -1,90 +1,29 @@
-import 'dart:collection';
-
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
+import 'package:colonizethis_world/src/utils/graph_traversal.dart';
+
 import 'player_view.dart';
+import 'topology_helpers.dart';
 
 /// Non-owned provinces reachable from GP-owned anchors through owned provinces
 /// and sea zones (including warp S–S links). Foreign provinces are collected but
 /// not expanded through. SPEC/ai/ai-architecture.md § Colonial expansion.
+///
+/// Expressed in terms of [reachableNonOwnedProvinceDistancesViaSeas]: the
+/// distance map's keys are exactly the reachable non-owned province ids
+/// (Refs #3403 Phase 2).
 Set<String> reachableNonOwnedProvinceIdsViaSeas(
   MapTopology topology,
   Set<String> anchorProvinceIds,
   PlayerView view, {
   String? regionIdFilter,
-}) {
-  final nodeType = <String, TopologyNodeType>{
-    for (final n in topology.nodes) n.id: n.type,
-  };
-  final adj = <String, Set<String>>{};
-  for (final e in topology.edges) {
-    adj.putIfAbsent(e.id1, () => <String>{}).add(e.id2);
-    adj.putIfAbsent(e.id2, () => <String>{}).add(e.id1);
-  }
-
-  final owned = <String>{};
-  for (final id in anchorProvinceIds) {
-    if (view.provincesById[id]?.ownerId == view.playerId) {
-      owned.add(id);
-    }
-  }
-
-  final queue = Queue<String>.from(owned);
-  final visited = Set<String>.from(owned);
-  final invadable = <String>{};
-
-  while (queue.isNotEmpty) {
-    final cur = queue.removeFirst();
-    for (final nb in adj[cur] ?? const <String>{}) {
-      _visitSeaReachableNeighbor(
-        nb: nb,
-        nodeType: nodeType,
-        view: view,
-        regionIdFilter: regionIdFilter,
-        visited: visited,
-        queue: queue,
-        invadable: invadable,
-      );
-    }
-  }
-  return invadable;
-}
-
-void _visitSeaReachableNeighbor({
-  required String nb,
-  required Map<String, TopologyNodeType> nodeType,
-  required PlayerView view,
-  required String? regionIdFilter,
-  required Set<String> visited,
-  required Queue<String> queue,
-  required Set<String> invadable,
-}) {
-  if (visited.contains(nb)) return;
-  final nbType = nodeType[nb];
-  if (nbType == null) return;
-
-  if (nbType == TopologyNodeType.province) {
-    final ownerId = view.provincesById[nb]?.ownerId;
-    final isOwn = ownerId == view.playerId;
-    if (!isOwn &&
-        ownerId != null &&
-        ownerId.isNotEmpty &&
-        (regionIdFilter == null ||
-            ProvinceId.regionIdFrom(nb) == regionIdFilter)) {
-      invadable.add(nb);
-    }
-    if (isOwn) {
-      visited.add(nb);
-      queue.add(nb);
-    }
-    return;
-  }
-  if (nbType == TopologyNodeType.seaZone) {
-    visited.add(nb);
-    queue.add(nb);
-  }
-}
+}) => reachableNonOwnedProvinceDistancesViaSeas(
+  topology,
+  anchorProvinceIds,
+  view,
+  regionIdFilter: regionIdFilter,
+).keys.toSet();
 
 /// Non-owned provinces reachable from GP-owned anchors through owned provinces
 /// and sea zones (including warp S-S links), keyed by their BFS topology
@@ -117,89 +56,30 @@ Map<String, int> reachableNonOwnedProvinceDistancesViaSeas(
   PlayerView view, {
   String? regionIdFilter,
 }) {
-  final nodeType = <String, TopologyNodeType>{
-    for (final n in topology.nodes) n.id: n.type,
+  final owned = <String>{
+    for (final id in anchorProvinceIds)
+      if (view.provincesById[id]?.ownerId == view.playerId) id,
   };
-  final adj = <String, Set<String>>{};
-  for (final e in topology.edges) {
-    adj.putIfAbsent(e.id1, () => <String>{}).add(e.id2);
-    adj.putIfAbsent(e.id2, () => <String>{}).add(e.id1);
+
+  bool isOwnProvince(String id) =>
+      view.provincesById[id]?.ownerId == view.playerId;
+
+  bool isForeignProvince(String id) {
+    final ownerId = view.provincesById[id]?.ownerId;
+    if (ownerId == null || ownerId.isEmpty) return false;
+    if (ownerId == view.playerId) return false;
+    return regionIdFilter == null ||
+        ProvinceId.regionIdFrom(id) == regionIdFilter;
   }
 
-  final owned = <String>{};
-  for (final id in anchorProvinceIds) {
-    if (view.provincesById[id]?.ownerId == view.playerId) {
-      owned.add(id);
-    }
-  }
-
-  final queue = Queue<_DistanceProbe>.from(
-    owned.map((id) => _DistanceProbe(id, 0)),
-  );
-  final visited = Set<String>.from(owned);
   final invadable = <String, int>{};
-
-  while (queue.isNotEmpty) {
-    final cur = queue.removeFirst();
-    final nextDistance = cur.distance + 1;
-    for (final nb in adj[cur.id] ?? const <String>{}) {
-      _visitSeaReachableNeighborWithDistance(
-        nb: nb,
-        distance: nextDistance,
-        nodeType: nodeType,
-        view: view,
-        regionIdFilter: regionIdFilter,
-        visited: visited,
-        queue: queue,
-        invadable: invadable,
-      );
-    }
-  }
+  bfsTopologyGraph(
+    sourceIds: owned,
+    nodeType: topologyNodeTypeById(topology),
+    adjacency: topologyAdjacency(topology),
+    isExpandableProvince: isOwnProvince,
+    isForeignProvince: isForeignProvince,
+    onForeignProvinceDiscovered: (id, distance) => invadable[id] = distance,
+  );
   return invadable;
-}
-
-class _DistanceProbe {
-  const _DistanceProbe(this.id, this.distance);
-
-  final String id;
-  final int distance;
-}
-
-void _visitSeaReachableNeighborWithDistance({
-  required String nb,
-  required int distance,
-  required Map<String, TopologyNodeType> nodeType,
-  required PlayerView view,
-  required String? regionIdFilter,
-  required Set<String> visited,
-  required Queue<_DistanceProbe> queue,
-  required Map<String, int> invadable,
-}) {
-  final nbType = nodeType[nb];
-  if (nbType == null) return;
-
-  if (nbType == TopologyNodeType.province) {
-    final ownerId = view.provincesById[nb]?.ownerId;
-    final isOwn = ownerId == view.playerId;
-    if (!isOwn &&
-        ownerId != null &&
-        ownerId.isNotEmpty &&
-        (regionIdFilter == null ||
-            ProvinceId.regionIdFrom(nb) == regionIdFilter)) {
-      final existing = invadable[nb];
-      if (existing == null || distance < existing) {
-        invadable[nb] = distance;
-      }
-    }
-    if (isOwn && !visited.contains(nb)) {
-      visited.add(nb);
-      queue.add(_DistanceProbe(nb, distance));
-    }
-    return;
-  }
-  if (nbType == TopologyNodeType.seaZone) {
-    if (visited.contains(nb)) return;
-    visited.add(nb);
-    queue.add(_DistanceProbe(nb, distance));
-  }
 }

--- a/packages/colonizethis_world/lib/src/world/topology_helpers.dart
+++ b/packages/colonizethis_world/lib/src/world/topology_helpers.dart
@@ -3,6 +3,7 @@ import 'dart:collection';
 import 'package:colonizethis_data/colonizethis_data.dart';
 
 import 'package:colonizethis_world/src/utils/expando_index.dart';
+import 'package:colonizethis_world/src/utils/graph_traversal.dart';
 
 /// Topology helpers shared by movement and connectivity. SPEC/game/map-topology.md.
 ///
@@ -27,6 +28,39 @@ Set<String> _computeSeaZoneNodeIds(MapTopology topology) {
     if (n.type == TopologyNodeType.seaZone) out.add(n.id);
   }
   return UnmodifiableSetView<String>(out);
+}
+
+Map<String, TopologyNodeType> _computeNodeTypeById(MapTopology topology) {
+  final out = <String, TopologyNodeType>{
+    for (final n in topology.nodes) n.id: n.type,
+  };
+  return Map<String, TopologyNodeType>.unmodifiable(out);
+}
+
+Map<String, Set<String>> _computeAdjacency(MapTopology topology) {
+  final mutable = <String, Set<String>>{};
+  for (final e in topology.edges) {
+    mutable.putIfAbsent(e.id1, () => <String>{}).add(e.id2);
+    mutable.putIfAbsent(e.id2, () => <String>{}).add(e.id1);
+  }
+  return Map<String, Set<String>>.unmodifiable({
+    for (final entry in mutable.entries)
+      entry.key: UnmodifiableSetView<String>(entry.value),
+  });
+}
+
+Map<String, Set<String>> _computeSeaZoneAdjacency(MapTopology topology) {
+  final seaZoneIds = seaZoneNodeIds(topology);
+  final mutable = <String, Set<String>>{};
+  for (final e in topology.edges) {
+    if (!seaZoneIds.contains(e.id1) || !seaZoneIds.contains(e.id2)) continue;
+    mutable.putIfAbsent(e.id1, () => <String>{}).add(e.id2);
+    mutable.putIfAbsent(e.id2, () => <String>{}).add(e.id1);
+  }
+  return Map<String, Set<String>>.unmodifiable({
+    for (final entry in mutable.entries)
+      entry.key: UnmodifiableSetView<String>(entry.value),
+  });
 }
 
 Map<String, Set<String>> _computeProvinceNodeIdsByRegion(MapTopology topology) {
@@ -59,6 +93,24 @@ final ExpandoIndex<MapTopology, Set<String>> _seaZoneNodeIdsCache =
       'topology.seaZoneNodeIds',
       _computeSeaZoneNodeIds,
     );
+
+final ExpandoIndex<MapTopology, Map<String, TopologyNodeType>>
+_nodeTypeByIdCache = ExpandoIndex<MapTopology, Map<String, TopologyNodeType>>(
+  'topology.nodeTypeById',
+  _computeNodeTypeById,
+);
+
+final ExpandoIndex<MapTopology, Map<String, Set<String>>> _adjacencyCache =
+    ExpandoIndex<MapTopology, Map<String, Set<String>>>(
+      'topology.adjacency',
+      _computeAdjacency,
+    );
+
+final ExpandoIndex<MapTopology, Map<String, Set<String>>>
+_seaZoneAdjacencyCache = ExpandoIndex<MapTopology, Map<String, Set<String>>>(
+  'topology.seaZoneAdjacency',
+  _computeSeaZoneAdjacency,
+);
 
 final ExpandoIndex<MapTopology, bool> _topologyUsesPrefixedIdsCache =
     ExpandoIndex<MapTopology, bool>(
@@ -99,6 +151,27 @@ bool topologyUsesPrefixedIds(MapTopology topology) =>
 Set<String> seaZoneNodeIds(MapTopology topology) =>
     _seaZoneNodeIdsCache.get(topology);
 
+/// Node id -> [TopologyNodeType] for every node in [topology]. Cached per
+/// topology instance; the returned map is unmodifiable. Shared by topology-graph
+/// BFS so hot paths avoid rebuilding the type index per call (Refs #3403
+/// Phase 2).
+Map<String, TopologyNodeType> topologyNodeTypeById(MapTopology topology) =>
+    _nodeTypeByIdCache.get(topology);
+
+/// Full undirected adjacency (`nodeId -> neighbour ids`) for every edge in
+/// [topology], regardless of node type. Cached per topology instance; the outer
+/// map and each neighbour set are unmodifiable. Neighbour-set iteration follows
+/// `topology.edges` insertion order so BFS over this index stays deterministic
+/// (Refs #3403 Phase 2).
+Map<String, Set<String>> topologyAdjacency(MapTopology topology) =>
+    _adjacencyCache.get(topology);
+
+/// Undirected adjacency restricted to sea-zone-to-sea-zone (S–S) edges. Cached
+/// per topology instance; unmodifiable. Backs [seaZonesReachableBySeaPath]
+/// (Refs #3403 Phase 2).
+Map<String, Set<String>> seaZoneAdjacency(MapTopology topology) =>
+    _seaZoneAdjacencyCache.get(topology);
+
 /// Sea zones reachable from [startSeaZoneIds] by following S–S edges in [topology].
 /// SPEC/game/map-topology.md, capital-and-connectivity § Sea paths.
 ///
@@ -109,28 +182,12 @@ Set<String> seaZonesReachableBySeaPath(
   Set<String> startSeaZoneIds, {
   void Function()? onDequeue,
 }) {
-  final seaZoneIds = seaZoneNodeIds(topology);
-  final neighbours = <String, Set<String>>{};
-  for (final e in topology.edges) {
-    final a = e.id1;
-    final b = e.id2;
-    if (seaZoneIds.contains(a) && seaZoneIds.contains(b)) {
-      neighbours.putIfAbsent(a, () => {}).add(b);
-      neighbours.putIfAbsent(b, () => {}).add(a);
-    }
-  }
-  final reachable = Set<String>.from(startSeaZoneIds);
-  final queue = Queue<String>()..addAll(startSeaZoneIds);
-  while (queue.isNotEmpty) {
-    final z = queue.removeFirst();
-    onDequeue?.call();
-    for (final n in neighbours[z] ?? {}) {
-      if (reachable.contains(n)) continue;
-      reachable.add(n);
-      queue.add(n);
-    }
-  }
-  return reachable;
+  return breadthFirstReachableInSubgraph<String>(
+    startSeaZoneIds,
+    seaZoneAdjacency(topology),
+    seaZoneNodeIds(topology),
+    onDequeue: onDequeue,
+  );
 }
 
 /// Sea zone ids adjacent to province [provinceNodeId] in topology (P–S edges).

--- a/packages/colonizethis_world/test/utils/bfs_topology_graph_test.dart
+++ b/packages/colonizethis_world/test/utils/bfs_topology_graph_test.dart
@@ -1,0 +1,198 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_world/src/utils/graph_traversal.dart';
+import 'package:colonizethis_world/src/world/topology_helpers.dart';
+import 'package:colonizethis_test/test.dart';
+
+/// Phase 2 of #3403: canonical topology-graph BFS shared by the sea-reachability
+/// planners. These tests exercise [bfsTopologyGraph] directly (the visitor
+/// hooks, expansion rules, and determinism) independent of the sea-reachable
+/// wrappers, plus a couple of negative cases.
+TopologyNode _prov(String id, {String regionId = 'oldWorld'}) =>
+    TopologyNode(id: id, regionId: regionId, type: TopologyNodeType.province);
+
+TopologyNode _sea(String id, {String regionId = 'oldWorld'}) =>
+    TopologyNode(id: id, regionId: regionId, type: TopologyNodeType.seaZone);
+
+void main() {
+  group('bfsTopologyGraph (Refs #3403 Phase 2)', () {
+    test('fires onForeignProvinceDiscovered once at shortest distance', () {
+      // enemy reachable directly (1) and via a sea detour (2). FIFO BFS must
+      // discover it first via the direct edge -> distance 1, and only once.
+      final topology = MapTopology(
+        nodes: [_prov('own'), _prov('enemy'), _sea('sea')],
+        edges: const [
+          TopologyEdge(id1: 'own', id2: 'enemy'),
+          TopologyEdge(id1: 'own', id2: 'sea'),
+          TopologyEdge(id1: 'sea', id2: 'enemy'),
+        ],
+      );
+      final foreign = <String, int>{};
+      var foreignCalls = 0;
+      bfsTopologyGraph(
+        sourceIds: const {'own'},
+        nodeType: topologyNodeTypeById(topology),
+        adjacency: topologyAdjacency(topology),
+        isExpandableProvince: (id) => id == 'own',
+        isForeignProvince: (id) => id == 'enemy',
+        onForeignProvinceDiscovered: (id, d) {
+          foreignCalls++;
+          foreign[id] = d;
+        },
+      );
+
+      expect(foreign, {'enemy': 1});
+      expect(foreignCalls, 1, reason: 'discovered exactly once (first reach)');
+    });
+
+    test('does not expand through a foreign province', () {
+      final topology = MapTopology(
+        nodes: [_prov('own'), _prov('enemy'), _prov('beyond')],
+        edges: const [
+          TopologyEdge(id1: 'own', id2: 'enemy'),
+          TopologyEdge(id1: 'enemy', id2: 'beyond'),
+        ],
+      );
+      final foreign = <String>{};
+      bfsTopologyGraph(
+        sourceIds: const {'own'},
+        nodeType: topologyNodeTypeById(topology),
+        adjacency: topologyAdjacency(topology),
+        isExpandableProvince: (id) => id == 'own',
+        isForeignProvince: (id) => id == 'enemy' || id == 'beyond',
+        onForeignProvinceDiscovered: (id, _) => foreign.add(id),
+      );
+      // `beyond` sits behind the foreign `enemy`, which is never expanded.
+      expect(foreign, {'enemy'});
+    });
+
+    test('emits onProvinceVisited/onSeaVisited once per expanded node', () {
+      final topology = MapTopology(
+        nodes: [_prov('own'), _sea('sea'), _prov('ally'), _prov('enemy')],
+        edges: const [
+          TopologyEdge(id1: 'own', id2: 'sea'),
+          TopologyEdge(id1: 'sea', id2: 'ally'),
+          TopologyEdge(id1: 'ally', id2: 'enemy'),
+        ],
+      );
+      final provinceVisits = <String, int>{};
+      final seaVisits = <String, int>{};
+      final foreign = <String, int>{};
+      bfsTopologyGraph(
+        sourceIds: const {'own'},
+        nodeType: topologyNodeTypeById(topology),
+        adjacency: topologyAdjacency(topology),
+        // own + ally are both expandable (owned territory).
+        isExpandableProvince: (id) => id == 'own' || id == 'ally',
+        isForeignProvince: (id) => id == 'enemy',
+        onProvinceVisited: (id, d) => provinceVisits[id] = d,
+        onSeaVisited: (id, d) => seaVisits[id] = d,
+        onForeignProvinceDiscovered: (id, d) => foreign[id] = d,
+      );
+
+      // Seeds are not re-reported via onProvinceVisited.
+      expect(provinceVisits, {'ally': 2});
+      expect(seaVisits, {'sea': 1});
+      expect(foreign, {'enemy': 3});
+    });
+
+    test('ignores unknown neighbour ids missing from the node-type map', () {
+      // Adjacency references a node id absent from the topology node set.
+      const topology = MapTopology(
+        nodes: [
+          TopologyNode(
+            id: 'own',
+            regionId: 'oldWorld',
+            type: TopologyNodeType.province,
+          ),
+        ],
+        edges: [TopologyEdge(id1: 'own', id2: 'ghost')],
+      );
+      final foreign = <String>{};
+      bfsTopologyGraph(
+        sourceIds: const {'own'},
+        nodeType: topologyNodeTypeById(topology),
+        adjacency: topologyAdjacency(topology),
+        isExpandableProvince: (id) => id == 'own',
+        isForeignProvince: (_) => true,
+        onForeignProvinceDiscovered: (id, _) => foreign.add(id),
+      );
+      // `ghost` has no node type -> skipped, never collected.
+      expect(foreign, isEmpty);
+    });
+
+    test('empty source set yields no traversal', () {
+      final topology = MapTopology(
+        nodes: [_prov('own'), _prov('enemy')],
+        edges: const [TopologyEdge(id1: 'own', id2: 'enemy')],
+      );
+      final foreign = <String>{};
+      bfsTopologyGraph(
+        sourceIds: const <String>{},
+        nodeType: topologyNodeTypeById(topology),
+        adjacency: topologyAdjacency(topology),
+        isExpandableProvince: (_) => true,
+        isForeignProvince: (_) => true,
+        onForeignProvinceDiscovered: (id, _) => foreign.add(id),
+      );
+      expect(foreign, isEmpty);
+    });
+  });
+
+  group('topology graph index caches (Refs #3403 Phase 2)', () {
+    final topology = MapTopology(
+      nodes: [_prov('own'), _sea('sea'), _prov('enemy')],
+      edges: const [
+        TopologyEdge(id1: 'own', id2: 'sea'),
+        TopologyEdge(id1: 'sea', id2: 'enemy'),
+      ],
+    );
+
+    test('topologyNodeTypeById returns same unmodifiable instance', () {
+      final first = topologyNodeTypeById(topology);
+      final second = topologyNodeTypeById(topology);
+      expect(identical(first, second), isTrue);
+      expect(first['sea'], TopologyNodeType.seaZone);
+      expect(first['own'], TopologyNodeType.province);
+      expect(
+        () => first['x'] = TopologyNodeType.province,
+        throwsUnsupportedError,
+      );
+    });
+
+    test('topologyAdjacency is cached, unmodifiable, and edge-ordered', () {
+      final first = topologyAdjacency(topology);
+      final second = topologyAdjacency(topology);
+      expect(identical(first, second), isTrue);
+      expect(first['sea'], {'own', 'enemy'});
+      // Insertion order follows topology.edges (own-sea then sea-enemy).
+      expect(first['sea']!.toList(), ['own', 'enemy']);
+      expect(() => first['own']!.add('z'), throwsUnsupportedError);
+      expect(() => first['z'] = {'a'}, throwsUnsupportedError);
+    });
+
+    test('seaZoneAdjacency only contains S–S edges and is cached', () {
+      final withSeaLink = MapTopology(
+        nodes: [_sea('s1'), _sea('s2'), _prov('p1')],
+        edges: const [
+          TopologyEdge(id1: 's1', id2: 's2'),
+          TopologyEdge(id1: 'p1', id2: 's1'),
+        ],
+      );
+      final first = seaZoneAdjacency(withSeaLink);
+      final second = seaZoneAdjacency(withSeaLink);
+      expect(identical(first, second), isTrue);
+      expect(first['s1'], {'s2'});
+      // Province neighbour is excluded from the sea-only adjacency.
+      expect(first['s1']!.contains('p1'), isFalse);
+      expect(first.containsKey('p1'), isFalse);
+    });
+
+    test('separate topology instances do not share cached indexes', () {
+      final other = MapTopology(nodes: [_prov('a')], edges: const []);
+      expect(
+        identical(topologyAdjacency(topology), topologyAdjacency(other)),
+        isFalse,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Phase 2 of #3403 (world-layer dedup/perf, `packages/colonizethis_world/`), landing after the merged Phase 1 (#3405, `landTileKeysForProvinceBucket` dedup). Behaviour-preserving, logic-only.

Targets issue Current Behavior **§B** (divergent BFS/traversal implementations) and **§E** (topology adjacency rebuilt per call in hot paths), and the matching acceptance criteria.

## Done in this push

### Canonical topology-graph BFS (AC: `bfsTopologyGraph` exists + both sea-reachable fns route through it)
- Added `bfsTopologyGraph` to `utils/graph_traversal.dart` with the documented observation-only visitor hooks: `onProvinceVisited(id, distance)`, `onSeaVisited(id, distance)`, `onForeignProvinceDiscovered(id, distance)`. Callbacks cannot abort traversal; the utility owns frontier expansion based on cached adjacency.
- Foreign provinces are collected but not expanded; expandable (owned) provinces and sea zones drive the frontier. Because this is a uniform-weight FIFO BFS, **first discovery == shortest distance**, so `onForeignProvinceDiscovered` fires exactly once per foreign province at its minimum distance.
- Neighbour iteration follows `topology.edges` insertion order (cached adjacency sets are edge-ordered), preserving deterministic results (Refs #2509 Must-have #7).

### Cached topology graph indexes (AC: no `for (final n in topology.nodes)` / `for (final e in topology.edges)` index-building at call time in `sea_reachable_provinces.dart`)
- Added per-`MapTopology` `ExpandoIndex` caches in `topology_helpers.dart`: `topologyNodeTypeById`, `topologyAdjacency` (full undirected, unmodifiable outer map + neighbour sets), and `seaZoneAdjacency` (S–S only).
- `reachableNonOwnedProvinceDistancesViaSeas` now consumes the cached indexes through `bfsTopologyGraph` instead of rebuilding `nodeType` + `adj` on every call.
- `reachableNonOwnedProvinceIdsViaSeas` is now expressed in terms of the distance variant (`...DistancesViaSeas(...).keys.toSet()`), eliminating the second duplicated BFS loop + index build (issue Step 4).
- `seaZonesReachableBySeaPath` routes through the existing shared `breadthFirstReachableInSubgraph` over cached `seaZoneAdjacency`, dropping its own per-call adjacency rebuild.

### Tests
- New `test/utils/bfs_topology_graph_test.dart`: visitor-hook semantics, single shortest-distance foreign discovery, no-expand-through-foreign, per-node visit emission, unknown-neighbour skip (negative), empty-source no-op (negative), and cache identity / unmodifiability / edge-ordering / per-instance isolation.
- Existing `sea_reachable_provinces_test.dart` and `topology_helpers_test.dart` pass unchanged (behaviour preserved).

## Deferred (remaining for #3403)
- **Step 2 / AC:** deprecate the top-level province-lookup wrappers and route internal world-layer callers to the extension methods (touches Phase 1's `province_lookup.dart`).
- **Phase 3 / ACs:** shared `RegionUnitLists` `(ow, nw)` typedef across `movement.dart` + army-migration helpers; reuse a single `canExpandFrom` closure across both connectivity-propagation passes.

## SPEC
None required — behaviour is preserved (issue's own "SPEC follow-up: None required"). `topology_helpers.dart` continues to cite `SPEC/game/map-topology.md`.

## Test plan
- [x] `dart test` full `colonizethis_world` suite — 486 + 10 new green.
- [x] Downstream `colonizethis_logic` sea-reachable distance tests green.
- [x] Downstream `colonizethis_ai` perception-reachability + colonial-acquisition (distance/declare-war) tests green.
- [x] `dart analyze` clean on the three changed lib files + new test (2 remaining warnings are pre-existing in untouched test files).
- [x] `dart format` clean on changed files.

Refs #3403

Made with [Cursor](https://cursor.com)