### PR TITLE
feat: record per-turn turn-processing wall-clock budget in run_observer_game (#3393)

### DIFF
--- a/SPEC/program/run_observer_game-tool.md
+++ b/SPEC/program/run_observer_game-tool.md
@@ -77,6 +77,13 @@ HTML is a render-only wrapper: the `<pre>` body uses the **same** pretty-printed
 
 ## Turn processing wall-clock budget (Refs #2507)
 
+### Per-turn measurement, logging, and summary (Refs #3393 Phase 6c)
+
+A single `Stopwatch` wraps the budget segment per resolved turn in **both** full-trace and minimal-trace modes; it starts immediately before `generateOrdersForGameFullAI` and stops immediately after `validateOrdersAndResolveTurnFromTrustedOrders` returns, **before** any trace export, snapshot/HTML write, or `run-summary.json` I/O.
+
+- **Logging signal (`session` sub-prefix):** Each resolved turn emits exactly one timing line. At or under budget → **info** `observer:turn_processing turn=<n> ms=<int> budgetMs=15000 overBudget=false`. Over budget (`ms > kTurnProcessingWallClockBudgetMs`) → **warning** `observer:turn_processing_over_budget turn=<n> ms=<int> budgetMs=15000`. These are grep-stable tokens for budget-regression triage and complement the per-phase `logic` logs in [logging/turn-resolution.md](logging/turn-resolution.md).
+- **`run-summary.json` fields (`runSummarySchemaVersion: 2`):** the summary additionally carries `turn_processing_wall_clock_budget_ms` (the `15000` ceiling), `turn_processing_wall_clock_ms_by_turn` (one entry per resolved turn, in resolution order), `max_turn_processing_wall_clock_ms`, `turns_over_wall_clock_budget` (count), and `over_wall_clock_budget_turn_numbers` (post-resolution turn numbers that breached the ceiling). For a zero-turn run (`--max-turns 0`) the list is empty and `max_turn_processing_wall_clock_ms` is `0`.
+
 Each **resolved turn** in the session loop measures the same segment as the app next-turn worker: **`generateOrdersForGameFullAI`** through **`validateOrdersAndResolveTurnFromTrustedOrders`** returning **`TurnResolutionComplete`**. That segment shares the **15 000 ms** ceiling **`kTurnProcessingWallClockBudgetMs`** ([turn-resolution.md](turn-resolution.md) § Turn processing wall-clock budget). **Excluded:** `runInitGame`, trace export, snapshot/HTML writes, and `run-summary.json` I/O. Nightly observer runs are integration targets; the **quality** gate enforces the budget via `colonizethis_ai` perf test on **turn 1** of **`GameSetupConfig.defaultConfig`**.
 
 ## Relationship to app / ctdev
@@ -114,3 +121,6 @@ CI: **≥ 80% line coverage on `tool/run_observer_game/lib/`** (`quality` workfl
 
 - Given `melos run run_observer_game -- --help`, when the command completes, then exit code is **0** and stdout describes options and artifact layout at a high level.
 - Given a successful multi-turn run (**S4+**), when outputs are written, then layout matches § Artifact layout and summary matches **#2498** ACs.
+- Given a successful run that resolves **N ≥ 1** turns, when `run-summary.json` is written, then `runSummarySchemaVersion` is `2`, `turn_processing_wall_clock_ms_by_turn` is a list of exactly **N** non-negative integers, `turn_processing_wall_clock_budget_ms` equals `kTurnProcessingWallClockBudgetMs` (`15000`), and `max_turn_processing_wall_clock_ms` equals the maximum of that list.
+- Given a run with `--max-turns 0`, when `run-summary.json` is written, then `turn_processing_wall_clock_ms_by_turn` is an empty list, `max_turn_processing_wall_clock_ms` is `0`, and `turns_over_wall_clock_budget` is `0`.
+- Given a resolved turn whose measured segment is at or under `15000` ms, when the turn completes, then the `session` logger emits exactly one **info** line containing `observer:turn_processing turn=<n>` with `overBudget=false`; given a resolved turn whose segment exceeds `15000` ms, then the `session` logger instead emits a **warning** line containing `observer:turn_processing_over_budget turn=<n>` and the turn number is appended to `over_wall_clock_budget_turn_numbers` in `run-summary.json`.

--- a/tool/run_observer_game/lib/observer_session_runner.dart
+++ b/tool/run_observer_game/lib/observer_session_runner.dart
@@ -71,6 +71,14 @@ Future<int> runObserverSession({
   var resolvedCount = 0;
   var terminationReason = 'unknown';
 
+  // Per-resolved-turn wall-clock for the turn-processing segment
+  // (`generateOrdersForGameFullAI` through `validateOrdersAndResolveTurnFrom
+  // TrustedOrders` returning `TurnResolutionComplete`). Trace export, snapshot/
+  // HTML writes, and `run-summary.json` I/O are excluded per
+  // SPEC/program/run_observer_game-tool.md § Turn processing wall-clock budget.
+  final turnProcessingMsByTurn = <int>[];
+  final overBudgetTurnNumbers = <int>[];
+
   Future<void> writeTraceArtifact(
     String gameId,
     String relativeName,
@@ -114,6 +122,10 @@ Future<int> runObserverSession({
 
       final before = game;
 
+      // Measures the same segment as the app next-turn worker; excludes trace
+      // export and artifact I/O (stopped before any write below).
+      final turnProcessingStopwatch = Stopwatch()..start();
+
       final fullAi = generateOrdersForGameFullAI(
         before,
         init.combinedTopology,
@@ -149,6 +161,7 @@ Future<int> runObserverSession({
           defaultAssignmentsByPlayerId: defaultAssignmentsByPlayerId,
           onProductionComplete: captureProductionComplete,
         );
+        turnProcessingStopwatch.stop();
       } else {
         final phaseTraces = <TurnTracePhaseTrace>[];
         final traceStartedAt = DateTime.now().toUtc();
@@ -164,6 +177,7 @@ Future<int> runObserverSession({
           onTurnTracePhase: phaseTraces.add,
           turnTraceRuntime: traceRuntime,
         );
+        turnProcessingStopwatch.stop();
 
         if (result is TurnResolutionComplete) {
           final nowUtc = DateTime.now().toUtc();
@@ -199,6 +213,22 @@ Future<int> runObserverSession({
 
       final postTurn = game.worldState.turnState.turnNumber;
       final turnLabel = postTurn.toString().padLeft(6, '0');
+
+      final turnProcessingMs = turnProcessingStopwatch.elapsedMilliseconds;
+      final overBudget = turnProcessingMs > kTurnProcessingWallClockBudgetMs;
+      turnProcessingMsByTurn.add(turnProcessingMs);
+      if (overBudget) {
+        overBudgetTurnNumbers.add(postTurn);
+        _sessionLog.w(
+          'observer:turn_processing_over_budget turn=$postTurn '
+          'ms=$turnProcessingMs budgetMs=$kTurnProcessingWallClockBudgetMs',
+        );
+      } else {
+        _sessionLog.i(
+          'observer:turn_processing turn=$postTurn ms=$turnProcessingMs '
+          'budgetMs=$kTurnProcessingWallClockBudgetMs overBudget=false',
+        );
+      }
 
       final writeSnapshot = requiredSnapshotTurns == null ||
           requiredSnapshotTurns.contains(postTurn);
@@ -249,8 +279,12 @@ Future<int> runObserverSession({
       ? game.victory!.winnerPlayerId
       : pickUniqueGreatPowerLeaderByPowerScore(game);
 
+  final maxTurnProcessingMs = turnProcessingMsByTurn.isEmpty
+      ? 0
+      : turnProcessingMsByTurn.reduce((a, b) => a > b ? a : b);
+
   final summary = <String, Object?>{
-    'runSummarySchemaVersion': 1,
+    'runSummarySchemaVersion': 2,
     'termination_reason': terminationReason,
     'declared_winner_player_id': winnerId,
     'final_turn_number': game.worldState.turnState.turnNumber,
@@ -258,6 +292,13 @@ Future<int> runObserverSession({
     'seed': setupConfig.seed,
     'game_id': game.id,
     'observer_traces_relative': 'observer-traces/${game.id}',
+    'turn_processing_wall_clock_budget_ms': kTurnProcessingWallClockBudgetMs,
+    'turn_processing_wall_clock_ms_by_turn':
+        List<int>.unmodifiable(turnProcessingMsByTurn),
+    'max_turn_processing_wall_clock_ms': maxTurnProcessingMs,
+    'turns_over_wall_clock_budget': overBudgetTurnNumbers.length,
+    'over_wall_clock_budget_turn_numbers':
+        List<int>.unmodifiable(overBudgetTurnNumbers),
     if (minimalTraceMode) 'minimal_trace_mode': true,
   };
 

--- a/tool/run_observer_game/test/run_observer_game_cli_test.dart
+++ b/tool/run_observer_game/test/run_observer_game_cli_test.dart
@@ -300,7 +300,8 @@ void main() {
           kTurnProcessingWallClockBudgetMs,
         );
         final byTurn =
-            (sum['turn_processing_wall_clock_ms_by_turn'] as List).cast<int>();
+            (sum['turn_processing_wall_clock_ms_by_turn'] as List<Object?>)
+                .cast<int>();
         expect(byTurn, hasLength(1));
         expect(byTurn.single, greaterThanOrEqualTo(0));
         expect(sum['max_turn_processing_wall_clock_ms'], byTurn.single);
@@ -377,7 +378,7 @@ void main() {
         // Minimal-trace mode still measures the per-turn budget segment.
         expect(summary['runSummarySchemaVersion'], 2);
         expect(
-          (summary['turn_processing_wall_clock_ms_by_turn'] as List),
+          summary['turn_processing_wall_clock_ms_by_turn'] as List<Object?>,
           hasLength(1),
         );
 

--- a/tool/run_observer_game/test/run_observer_game_cli_test.dart
+++ b/tool/run_observer_game/test/run_observer_game_cli_test.dart
@@ -223,6 +223,18 @@ void main() {
 
         expect(decoded['termination_reason'], 'max_turns_override');
         expect(decoded['resolved_full_turns'], 0);
+
+        // Schema v2 turn-processing wall-clock fields are present even for a
+        // zero-turn run (empty list, zero max, zero over-budget).
+        expect(decoded['runSummarySchemaVersion'], 2);
+        expect(
+          decoded['turn_processing_wall_clock_budget_ms'],
+          kTurnProcessingWallClockBudgetMs,
+        );
+        expect(decoded['turn_processing_wall_clock_ms_by_turn'], isEmpty);
+        expect(decoded['max_turn_processing_wall_clock_ms'], 0);
+        expect(decoded['turns_over_wall_clock_budget'], 0);
+        expect(decoded['over_wall_clock_budget_turn_numbers'], isEmpty);
       },
       timeout: const Timeout(Duration(minutes: 15)),
     );
@@ -279,6 +291,19 @@ void main() {
             jsonDecode(summaryFile.readAsStringSync()) as Map<String, Object?>;
         expect(sum['termination_reason'], 'max_turns_override');
         expect(sum['resolved_full_turns'], 1);
+
+        // One resolved turn => exactly one wall-clock sample; the budget field
+        // mirrors the shared ceiling and the max equals the single sample.
+        expect(sum['runSummarySchemaVersion'], 2);
+        expect(
+          sum['turn_processing_wall_clock_budget_ms'],
+          kTurnProcessingWallClockBudgetMs,
+        );
+        final byTurn =
+            (sum['turn_processing_wall_clock_ms_by_turn'] as List).cast<int>();
+        expect(byTurn, hasLength(1));
+        expect(byTurn.single, greaterThanOrEqualTo(0));
+        expect(sum['max_turn_processing_wall_clock_ms'], byTurn.single);
 
         final snapshotPath = names.firstWhere(
           (n) => n.endsWith('.snapshot.json'),
@@ -348,6 +373,13 @@ void main() {
             jsonDecode(File('${gameDir.path}/run-summary.json').readAsStringSync())
                 as Map<String, Object?>;
         expect(summary['minimal_trace_mode'], isTrue);
+
+        // Minimal-trace mode still measures the per-turn budget segment.
+        expect(summary['runSummarySchemaVersion'], 2);
+        expect(
+          (summary['turn_processing_wall_clock_ms_by_turn'] as List),
+          hasLength(1),
+        );
 
         var totalBytes = 0;
         for (final f in gameDir.listSync().whereType<File>()) {


### PR DESCRIPTION
## Summary

Advances **#3393 Phase 6c** (WorldState projection profiling). The umbrella's
six phases are merged, but the sole open AC — *"`run_observer_game` benchmark
profiling shows no regression of the end-to-end next-turn budget (≤15 s), with
phase-level timing slices recorded"* — was unverifiable because the observer
tool never measured the per-turn budget segment that
`SPEC/program/run_observer_game-tool.md` § *Turn processing wall-clock budget*
already describes. This PR adds that measurement so Phase 6c can be profiled.

## Done in this push

- **Per-turn measurement:** `observer_session_runner.dart` now wraps the
  `generateOrdersForGameFullAI` → `validateOrdersAndResolveTurnFromTrustedOrders`
  segment in a single `Stopwatch` per resolved turn, in **both** full-trace and
  minimal-trace modes. The stopwatch stops **before** any trace export,
  snapshot/HTML write, or `run-summary.json` I/O, matching the SPEC-excluded set
  and the app next-turn worker segment (shared `kTurnProcessingWallClockBudgetMs`
  = 15 000 ms).
- **Logging:** each resolved turn emits one grep-stable `session` line —
  **info** `observer:turn_processing turn=<n> ms=<int> budgetMs=15000 overBudget=false`
  or **warning** `observer:turn_processing_over_budget turn=<n> ms=<int> budgetMs=15000`.
- **`run-summary.json` (schema v2):** adds `turn_processing_wall_clock_budget_ms`,
  `turn_processing_wall_clock_ms_by_turn`, `max_turn_processing_wall_clock_ms`,
  `turns_over_wall_clock_budget`, and `over_wall_clock_budget_turn_numbers`.

## SPEC

- `SPEC/program/run_observer_game-tool.md` — documented the logging signal, the
  schema-v2 run-summary fields, and added tool-specific ACs (multi-turn, zero-turn,
  and over-budget paths).

## Tests

- Extended `tool/run_observer_game/test/run_observer_game_cli_test.dart` smoke
  tests to assert the schema-v2 timing fields for: zero-turn (`--max-turns 0`,
  empty list + zero max), one-turn full-trace (single sample == max), and
  minimal-trace (single sample) runs.
- `dart test tool/run_observer_game/test/run_observer_game_cli_test.dart` → all 15 pass.
- `dart analyze tool/run_observer_game` → clean (one pre-existing unrelated info in
  another test file).

## Scope notes / deferred

- This PR provides the **measurement/reporting capability** for Phase 6c. The
  actual benchmark *run* (seed 42, ≥150 turns) and the no-regression sign-off
  remain a verification-lane activity, now backed by concrete per-turn evidence.
- The over-budget warning branch is reporting-only; it does not change exit codes
  (the `quality` perf test on turn 1 remains the enforcement gate).

Behavior-preserving for turn resolution; no game-logic or UI changes.

Refs #3393.

Made with [Cursor](https://cursor.com)