### PR TITLE
refactor: consolidate diplomacy evidence/dialogue guards + split overture handler (#3419)

### DIFF
--- a/packages/colonizethis_diplomacy/lib/src/diplomacy/overture_resolver.dart
+++ b/packages/colonizethis_diplomacy/lib/src/diplomacy/overture_resolver.dart
@@ -142,165 +142,92 @@ int? _overtureCostForStage(OvertureStage stage) {
   return (accepted: _aiGpAccepts(state, gpId, targetId), pending: null);
 }
 
-({
+/// Result of processing one establish-overture order: the (possibly updated)
+/// rolling state, or an [earlyExit] when the phase must suspend for human input.
+typedef _OvertureOrderStep = ({
   List<Player> players,
   List<OvertureState> overtures,
   Game state,
   Player player,
   OverturePaymentsResult? earlyExit,
-})
-_processEstablishOvertureOrderIfApplicable({
+});
+
+/// Validated, applicable establish-overture order: the resolved stage, target
+/// classification, and stage cost. Null when the order is not applicable (no
+/// state change), letting [_processEstablishOvertureOrderIfApplicable] skip it.
+typedef _ValidatedOverture = ({
+  OvertureStage stage,
+  bool targetIsMinorOrTribe,
+  bool targetIsGp,
+  int cost,
+});
+
+/// Validates an establish-overture [order] against stage progression, target
+/// membership, war state, tech prerequisites, and affordability.
+///
+/// Returns null when the order should be skipped without changing state;
+/// otherwise the resolved stage/target/cost for acceptance resolution.
+_ValidatedOverture? _validateEstablishOvertureOrder({
   required Game state,
-  required List<Player> players,
-  required List<OvertureState> overtures,
-  required int playerIdx,
   required Player player,
   required String gpId,
   required DiplomaticOrder order,
-  required int turn,
+  required List<OvertureState> overtures,
   required DiplomacyFactionMembership factionMembership,
-  List<OvertureDecision>? overtureDecisions,
-  IntraTurnEventTally? eventTally,
 }) {
-  if (order.type != DiplomaticOrderType.establishOverture) {
-    return (
-      players: players,
-      overtures: overtures,
-      state: state,
-      player: player,
-      earlyExit: null,
-    );
-  }
+  if (order.type != DiplomaticOrderType.establishOverture) return null;
   final stage = order.overtureStage;
-  if (stage == null || stage == OvertureStage.none) {
-    return (
-      players: players,
-      overtures: overtures,
-      state: state,
-      player: player,
-      earlyExit: null,
-    );
-  }
+  if (stage == null || stage == OvertureStage.none) return null;
 
   final targetId = order.targetFactionId;
   final targetIsMinorOrTribe = factionMembership.isMinorOrTribe(targetId);
   final targetIsGp = factionMembership.isGreatPower(targetId);
-  if (!targetIsMinorOrTribe && !targetIsGp) {
-    return (
-      players: players,
-      overtures: overtures,
-      state: state,
-      player: player,
-      earlyExit: null,
-    );
-  }
+  if (!targetIsMinorOrTribe && !targetIsGp) return null;
 
   final rel = getRelation(state, gpId, targetId);
-  if (rel != null && rel.atWar) {
-    return (
-      players: players,
-      overtures: overtures,
-      state: state,
-      player: player,
-      earlyExit: null,
-    );
-  }
+  if (rel != null && rel.atWar) return null;
 
   final existing = _findOvertureForGpTarget(overtures, gpId, targetId);
   final prevStage = stage.previous;
   final atPrevStage =
       (existing == null && prevStage == OvertureStage.none) ||
       (existing != null && existing.stage == prevStage);
-  if (!atPrevStage) {
-    return (
-      players: players,
-      overtures: overtures,
-      state: state,
-      player: player,
-      earlyExit: null,
-    );
-  }
+  if (!atPrevStage) return null;
 
   if (targetIsMinorOrTribe &&
       (stage == OvertureStage.tradeConsulate ||
           stage == OvertureStage.embassy ||
           stage == OvertureStage.nap) &&
       player.techUnlocked?[kTechIdDiplomaticExpertise] != true) {
-    return (
-      players: players,
-      overtures: overtures,
-      state: state,
-      player: player,
-      earlyExit: null,
-    );
+    return null;
   }
 
   final cost = _overtureCostForStage(stage);
-  if (cost == null) {
-    return (
-      players: players,
-      overtures: overtures,
-      state: state,
-      player: player,
-      earlyExit: null,
-    );
-  }
+  if (cost == null) return null;
+  if (player.treasury < cost && cost > 0) return null;
 
-  if (player.treasury < cost && cost > 0) {
-    return (
-      players: players,
-      overtures: overtures,
-      state: state,
-      player: player,
-      earlyExit: null,
-    );
-  }
-
-  final resolution = _resolveOvertureAcceptance(
-    state: state,
-    gpId: gpId,
-    targetId: targetId,
+  return (
     stage: stage,
     targetIsMinorOrTribe: targetIsMinorOrTribe,
-    players: players,
-    overtures: overtures,
-    overtureDecisions: overtureDecisions,
+    targetIsGp: targetIsGp,
+    cost: cost,
   );
-  if (resolution.pending != null) {
-    return (
-      players: players,
-      overtures: overtures,
-      state: state,
-      player: player,
-      earlyExit: resolution.pending,
-    );
-  }
-  final accepted = resolution.accepted;
+}
 
-  if (!accepted) {
-    var nextState = state;
-    if (targetIsGp) {
-      nextState = appendDiplomaticEvent(
-        nextState,
-        turn,
-        DiplomaticEventType.overtureRejected,
-        {gpId, targetId},
-        fromFactionId: gpId,
-        toFactionId: targetId,
-        overtureStage: stage,
-        wasAiInitiator: isAiControlledForEvidence(nextState, gpId),
-        eventTally: eventTally,
-      );
-    }
-    return (
-      players: players,
-      overtures: overtures,
-      state: nextState,
-      player: player,
-      earlyExit: null,
-    );
-  }
-
+/// Applies an accepted overture: debits the offerer, upserts the overture stage,
+/// records the acceptance event, and returns the advanced step.
+_OvertureOrderStep _applyAcceptedOverture({
+  required Game state,
+  required List<Player> players,
+  required List<OvertureState> overtures,
+  required int playerIdx,
+  required String gpId,
+  required String targetId,
+  required OvertureStage stage,
+  required int cost,
+  required int turn,
+  IntraTurnEventTally? eventTally,
+}) {
   final nextPlayers = debitPlayerTreasury(players, playerIdx, cost);
   final nextPlayer = nextPlayers[playerIdx];
 
@@ -347,6 +274,94 @@ _processEstablishOvertureOrderIfApplicable({
     state: nextState,
     player: nextPlayer,
     earlyExit: null,
+  );
+}
+
+_OvertureOrderStep _processEstablishOvertureOrderIfApplicable({
+  required Game state,
+  required List<Player> players,
+  required List<OvertureState> overtures,
+  required int playerIdx,
+  required Player player,
+  required String gpId,
+  required DiplomaticOrder order,
+  required int turn,
+  required DiplomacyFactionMembership factionMembership,
+  List<OvertureDecision>? overtureDecisions,
+  IntraTurnEventTally? eventTally,
+}) {
+  final unchanged = (
+    players: players,
+    overtures: overtures,
+    state: state,
+    player: player,
+    earlyExit: null,
+  );
+
+  final validated = _validateEstablishOvertureOrder(
+    state: state,
+    player: player,
+    gpId: gpId,
+    order: order,
+    overtures: overtures,
+    factionMembership: factionMembership,
+  );
+  if (validated == null) return unchanged;
+
+  final targetId = order.targetFactionId;
+  final resolution = _resolveOvertureAcceptance(
+    state: state,
+    gpId: gpId,
+    targetId: targetId,
+    stage: validated.stage,
+    targetIsMinorOrTribe: validated.targetIsMinorOrTribe,
+    players: players,
+    overtures: overtures,
+    overtureDecisions: overtureDecisions,
+  );
+  if (resolution.pending != null) {
+    return (
+      players: players,
+      overtures: overtures,
+      state: state,
+      player: player,
+      earlyExit: resolution.pending,
+    );
+  }
+
+  if (!resolution.accepted) {
+    if (!validated.targetIsGp) return unchanged;
+    final nextState = appendDiplomaticEvent(
+      state,
+      turn,
+      DiplomaticEventType.overtureRejected,
+      {gpId, targetId},
+      fromFactionId: gpId,
+      toFactionId: targetId,
+      overtureStage: validated.stage,
+      wasAiInitiator: isAiControlledForEvidence(state, gpId),
+      eventTally: eventTally,
+    );
+    return (
+      players: players,
+      overtures: overtures,
+      state: nextState,
+      player: player,
+      earlyExit: null,
+    );
+  }
+
+  return _applyAcceptedOverture(
+    state: state,
+    players: players,
+    overtures: overtures,
+    playerIdx: playerIdx,
+    gpId: gpId,
+    targetId: targetId,
+    stage: validated.stage,
+    cost: validated.cost,
+    turn: turn,
+    eventTally: eventTally,
   );
 }
 

--- a/packages/colonizethis_diplomacy/lib/src/dossier/event_dialogue.dart
+++ b/packages/colonizethis_diplomacy/lib/src/dossier/event_dialogue.dart
@@ -61,9 +61,7 @@ List<DialogueEvent> dialogueEventsForLandBattleResult(
   int seed,
 ) {
   final events = <DialogueEvent>[];
-  final mapping = game.turnTimeMapping ?? TurnTimeMapping.gdd01;
-  final year = mapping.yearAtTurn(turnNumber);
-  final era = eraFromYear(year);
+  final era = _eraForTurn(game, turnNumber);
   if (isAiControlledForEvidence(game, victorId)) {
     events.add(
       DialogueEvent(
@@ -99,9 +97,7 @@ List<DialogueEvent> dialogueEventsForNavalBattleResult(
   int seed,
 ) {
   final events = <DialogueEvent>[];
-  final mapping = game.turnTimeMapping ?? TurnTimeMapping.gdd01;
-  final year = mapping.yearAtTurn(turnNumber);
-  final era = eraFromYear(year);
+  final era = _eraForTurn(game, turnNumber);
   if (isAiControlledForEvidence(game, victorId)) {
     events.add(
       DialogueEvent(
@@ -154,9 +150,7 @@ List<DialogueEvent> dialogueEventsForReactiveFortsOnBorder(
     regionId,
     localId,
   );
-  final mapping = game.turnTimeMapping ?? TurnTimeMapping.gdd01;
-  final year = mapping.yearAtTurn(game.worldState.turnState.turnNumber);
-  final era = eraFromYear(year);
+  final era = _eraForTurn(game, game.worldState.turnState.turnNumber);
   final events = <DialogueEvent>[];
   final seenAi = <String>{};
   for (final neighborLocal in neighborLocalIds) {

--- a/packages/colonizethis_diplomacy/lib/src/dossier/evidence_rules.dart
+++ b/packages/colonizethis_diplomacy/lib/src/dossier/evidence_rules.dart
@@ -13,6 +13,19 @@ List<String> _humanObserverIds(Game game) {
   return game.players.where((p) => p.isHuman).map((p) => p.id).toList();
 }
 
+/// Returns the human observer ids for which evidence about [subjectId] should
+/// be recorded, or null when no evidence applies.
+///
+/// Consolidates the AI-subject + at-least-one-human-observer guard repeated at
+/// the top of every `evidenceFor*` rule (Refs #3419): evidence is recorded only
+/// when [subjectId] is AI-controlled and at least one human observer exists.
+List<String>? _evidenceObservers(Game game, String subjectId) {
+  if (!isAiControlledForEvidence(game, subjectId)) return null;
+  final observers = _humanObserverIds(game);
+  if (observers.isEmpty) return null;
+  return observers;
+}
+
 /// True if [playerId] is AI-controlled (evidence/dialogue only for AI subjects).
 /// Named to avoid export clash with ai_planner.isAiControlled.
 bool isAiControlledForEvidence(Game game, String playerId) {
@@ -60,9 +73,8 @@ List<DossierEvidenceEntry> evidenceForDeclareWar(
   String targetFactionId,
   int turnNumber,
 ) {
-  if (!isAiControlledForEvidence(game, actorGpId)) return [];
-  final observers = _humanObserverIds(game);
-  if (observers.isEmpty) return [];
+  final observers = _evidenceObservers(game, actorGpId);
+  if (observers == null) return [];
 
   final rel = getRelation(game, actorGpId, targetFactionId);
   final wasAllied = rel != null && rel.level == RelationLevel.allied;
@@ -131,9 +143,8 @@ List<DossierEvidenceEntry> evidenceForOfferPeace(
   String targetFactionId,
   int turnNumber,
 ) {
-  if (!isAiControlledForEvidence(game, actorGpId)) return [];
-  final observers = _humanObserverIds(game);
-  if (observers.isEmpty) return [];
+  final observers = _evidenceObservers(game, actorGpId);
+  if (observers == null) return [];
 
   final entries = <DossierEvidenceEntry>[];
   for (final observerId in observers) {
@@ -162,9 +173,8 @@ List<DossierEvidenceEntry> evidenceForLandBattleVictory(
   String defenderFactionId,
   int turnNumber,
 ) {
-  if (!isAiControlledForEvidence(game, victorGpId)) return [];
-  final observers = _humanObserverIds(game);
-  if (observers.isEmpty) return [];
+  final observers = _evidenceObservers(game, victorGpId);
+  if (observers == null) return [];
 
   final targetIsGp = game.playerById(defenderFactionId) != null;
   final weaker = targetIsGp && _isWeakerGp(game, victorGpId, defenderFactionId);
@@ -200,9 +210,8 @@ List<DossierEvidenceEntry> evidenceForNavalBattleVictory(
   String loserOwnerId,
   int turnNumber,
 ) {
-  if (!isAiControlledForEvidence(game, victorOwnerId)) return [];
-  final observers = _humanObserverIds(game);
-  if (observers.isEmpty) return [];
+  final observers = _evidenceObservers(game, victorOwnerId);
+  if (observers == null) return [];
 
   final entries = <DossierEvidenceEntry>[];
   for (final observerId in observers) {
@@ -233,13 +242,8 @@ List<DossierEvidenceEntry> evidenceForIsolationistCallToArmsRefuse(
   String defenderGpId,
   int turnNumber,
 ) {
-  if (!isAiControlledForEvidence(game, allyGpId)) {
-    return [];
-  }
-  final observers = _humanObserverIds(game);
-  if (observers.isEmpty) {
-    return [];
-  }
+  final observers = _evidenceObservers(game, allyGpId);
+  if (observers == null) return [];
   final rel = getRelation(game, allyGpId, defenderGpId);
   if (rel == null || !rel.atPeace) {
     return [];
@@ -297,9 +301,8 @@ List<DossierEvidenceEntry> evidenceForEnvyResearchMirror(
   int turnNumber,
   List<DossierEvidenceEntry> pendingSameTurn,
 ) {
-  if (!isAiControlledForEvidence(game, aiGpId)) return [];
-  final observers = _humanObserverIds(game);
-  if (observers.isEmpty) return [];
+  final observers = _evidenceObservers(game, aiGpId);
+  if (observers == null) return [];
 
   final refCat = game.lastHumanCompletedResearchCategory;
   final refTurn = game.lastHumanResearchCategoryCompletionTurn;
@@ -346,13 +349,8 @@ List<DossierEvidenceEntry> evidenceForAiStealTechResolved(
   int turnNumber, {
   required bool success,
 }) {
-  if (!isAiControlledForEvidence(game, aiSpyOwnerGpId)) {
-    return [];
-  }
-  final observers = _humanObserverIds(game);
-  if (observers.isEmpty) {
-    return [];
-  }
+  final observers = _evidenceObservers(game, aiSpyOwnerGpId);
+  if (observers == null) return [];
   final scoreDelta = success ? 3 : 1;
   final entries = <DossierEvidenceEntry>[];
   for (final observerId in observers) {


### PR DESCRIPTION
## Summary

Follow-up to the merged #3420, completing the deferred maintainability steps for #3419 in `packages/colonizethis_diplomacy`. Behaviour-preserving structural refactors only — no SPEC behaviour changes, no new features.

`Refs #3419`

## Done on this PR (issue steps 10-12)

### Step 10 — evidence guard consolidation (`evidence_rules.dart`)
- Extracted `_evidenceObservers(game, subjectId)`: returns the human observer ids when the subject is AI-controlled and at least one human observer exists, else `null`.
- Replaced the repeated `isAiControlledForEvidence(...) + _humanObserverIds(...) + isEmpty` guard across all 7 `evidenceFor*` rules (`declareWar`, `offerPeace`, `landBattleVictory`, `navalBattleVictory`, `isolationistCallToArmsRefuse`, `envyResearchMirror`, `aiStealTechResolved`).

### Step 11 — dialogue era consolidation (`event_dialogue.dart`)
- Routed the three inline `turnTimeMapping.yearAtTurn(...) -> eraFromYear(...)` computations (`dialogueEventsForLandBattleResult`, `dialogueEventsForNavalBattleResult`, `dialogueEventsForReactiveFortsOnBorder`) through the existing `_eraForTurn` helper, so era derivation lives in one place.

### Step 12 — split `_processEstablishOvertureOrderIfApplicable` (`overture_resolver.dart`)
- Extracted `_validateEstablishOvertureOrder` (stage/membership/war/stage-progression/tech/affordability gates → `null` when not applicable).
- Extracted `_applyAcceptedOverture` (treasury debit + overture upsert + accepted event).
- Added a `_OvertureOrderStep` typedef and removed the ~10 repeated pass-through record literals; the main handler is now a short validate → resolve → (pending | reject | accept) flow.

## Tests
- Full package suite green: **214 tests passed** (`dart test`).
- `dart analyze lib` clean for the changed files (the one remaining `unnecessary_import` note on `overture_resolver.dart:4` is pre-existing on `dev`, unrelated to this change).
- Refactors are behaviour-preserving and fully exercised by existing positive/negative tests:
  - Evidence guard: `test/dossier/evidence_rules_test.dart`, `evidence_rules_isolationist_test.dart`, `evidence_rules_war_peace_test.dart` (incl. non-AI subject and no-human-observer → `[]`).
  - Dialogue era: `test/event_dialogue_test.dart` (era from turn-time mapping; human victor/loser suppression).
  - Overture handler: `test/diplomacy/diplomacy_resolver_phase_*` and overture suites.

## ACs covered now (quality-gate ACs for steps 9-12)
- [x] All existing tests pass with zero changes (214 passing).
- [x] No new `dynamic` types; no `print` calls introduced.
- [x] Evidence/dialogue guard patterns consolidated; overture handler split.

## Deferred (optional, issue step 9)
- Splitting `diplomacy_phase_result.dart` into one file per value type is explicitly optional in the issue (the file is ~252 lines, well under the 1000-line gate). Not done in this PR to keep scope tight.

Issue stays open until step 9 is decided.

Made with [Cursor](https://cursor.com)