### PR TITLE
refactor: thread TurnResolverConfig through turn resume entry points + param-budget gate (#3416)

### DIFF
--- a/SPEC/program/turn-defensive-copy-audit.md
+++ b/SPEC/program/turn-defensive-copy-audit.md
@@ -1,0 +1,40 @@
+# Turn package — defensive collection-copy audit (#3416)
+
+**SPEC/program** — documents which `Map.from` / `List.from` copies remain in
+`packages/colonizethis_turn/lib/` after the #3416 hot-path audit and why.
+
+## Motivation
+
+Several turn-phase handlers previously shallow-copied collections on every
+invocation even when the copy was not required for mutation safety or
+immutability contracts. Unnecessary copies add allocator pressure on the
+15-second next-turn budget path (`colonizethis-turn-resolution-budget.mdc`).
+
+## Removals (this audit)
+
+| Location | Change | Rationale |
+|----------|--------|-----------|
+| `turn_order_acceptance.dart` | Pass through `researchOrdersByPlayerId`, `navalMoveOrdersByPlayerId`, and `navalMissionOrdersByPlayerId` without `Map.from` | These order families are not filtered in this function; outer-map copies did not isolate inner lists |
+| `world_market_phase_carry_forward.dart` | Assign carry-forward `orders` lists directly when stockpile/capacity is absent | Lists are read-only in the pass-through branch |
+| `turn_resolution_events.dart` | Sort player ids instead of cloning `Player` lists | Deterministic iteration without duplicating player records |
+| `production_phase.dart` | Store `result.productionByRecipe` directly | `resolveProduction` returns a fresh map per player invocation |
+
+## Retained copies (required)
+
+| Location | Copy | Rationale |
+|----------|------|-----------|
+| `movement_phase.dart` | Lazy `Map<String, int>.from` for spy timers | Mutates nested province timers only when a spy leaves a province |
+| `movement_phase.dart` | `Map<String, Unit>.from(allUnitsById)` | Updates `unitById` as bundled work moves units within the phase |
+| `naval_resolution.dart` | `List<Fleet>.from`, nested visibility maps | Fleets and visibility are mutated during naval move application |
+| `consumption_phase.dart` | Feeding and idle-labour maps | Phase writes per-player coverage into local maps before `copyWith` |
+| `turn_pipeline_state.dart` | Constructor `Map.from` for carry-over fields | Value-type immutability for pipeline state between phases |
+| `research_resolver.dart` | Tech-unlock and progress maps | Mutable working state while applying research orders |
+| `turn_resolution_events.dart` | `List<DiplomaticOrder>.from(diplo)` in order acceptance | Preserves list identity when assembling filtered diplomatic orders per player |
+
+## Acceptance criteria
+
+- Given `filterAcceptedOrdersForAllPlayers` runs with research, naval, and mission orders present, when the function returns, then the returned `Orders` object references the same outer maps for those three families as the source `OrderEngine.orders` (no redundant `Map.from` on the outer map).
+- Given carry-forward offers exist for a faction with no stockpile entry at validation time, when `validateCarryForwards` runs, then the surviving offers list is the same list instance as the input carry-forward list (no `List.from` in the pass-through branch).
+- Given `emitPlayerDiscoveryEvents` runs for a game with N players, when events are emitted, then player iteration order is deterministic by sorted player id and no `List<Player>.from` clone of `stateAfter.players` is constructed.
+- Given `runProductionPipelinePhase` records non-empty production for a player, when the production callback map is populated, then each player's entry references the `productionByRecipe` map returned by `resolveProduction` for that player (no redundant `Map.from`).
+- Given naval move orders are applied, when `applyNavalMovesAndShipReveal` mutates fleet or visibility state, then the implementation still clones `game.worldState.fleets` and `playerVisibilityByTile` before mutation (retained defensive copies).

--- a/SPEC/program/turn-resume-config-dispatch.md
+++ b/SPEC/program/turn-resume-config-dispatch.md
@@ -1,0 +1,104 @@
+# Turn resume entry points — config-based dispatch (repo lint)
+
+**SPEC/program** — defines the parameter contract for the Diplomacy-phase
+resume entry points in `packages/colonizethis_turn` and the repository lint
+gate (`repo.turn_resume_param_budget`) that keeps them slim.
+
+## Motivation
+
+Turn resolution can pause at the Diplomacy phase for blocking human input
+(`SPEC/program/turn-resolution-phases.md` § Blocking human input). The app
+collects decisions and resumes via one of four entry points:
+
+- `resumeTurnResolutionWithOvertureDecisions`
+- `resumeTurnResolutionWithFtpDecisions`
+- `resumeTurnResolutionWithInterventionDecisions`
+- `resumeTurnResolutionWithCallToArmsDecisions`
+
+These functions re-enter resolution at `TurnPhase.diplomacy` with identical
+parameter forwarding, differing only in which decision list they carry.
+Previously each wrapper re-declared the full resolver parameter list (~14
+parameters) and forwarded them one by one through a shared private dispatch.
+Adding a resolver parameter required editing every wrapper, and the duplicated
+signatures were a maintenance hazard (Refs #3416).
+
+The resolver already bundles its inputs in `TurnResolverConfig`
+(consumed by `resolveTurnForGameWithConfig`). The resume entry points therefore
+take a single `TurnResolverConfig config` plus only the resume-specific
+arguments (`game`, the decision list, and `pendingOvertures` for the overture
+variant). The shared private dispatch overrides `startFromPhase` and the one
+decision list via `TurnResolverConfig.copyWith`. A new resolver parameter is
+added to `TurnResolverConfig` once and flows through automatically.
+
+## Contract
+
+- Each public `resumeTurnResolutionWith*Decisions` entry point accepts a
+  required `TurnResolverConfig config` and forwards it unchanged except for the
+  `startFromPhase` and decision-list overrides applied by the shared dispatch.
+- The supplied `config` must match the configuration used for the original
+  `resolveTurnForGameWithConfig` / `resolveTurnForGame` call (orders, topology,
+  tile maps, default assignments, callbacks).
+- The shared dispatch always re-enters at `TurnPhase.diplomacy` and sets exactly
+  the decision list belonging to the calling wrapper; other decision lists
+  remain as carried by `config` (normally unset on resume).
+- Behaviour is unchanged versus the previous individually-threaded parameters:
+  identical `config` inputs and decisions produce identical results.
+
+## Lint gate
+
+A `resumeTurnResolution*` declaration (public wrappers and the private shared
+dispatch) must declare at most `turnResumeMaxNamedParams` (**6**) named
+parameters. The public overture wrapper carries 4 (`game`, `pendingOvertures`,
+`decisions`, `config`); the widest legitimate declaration is the private shared
+dispatch `_resumeTurnResolutionWithDiplomacyDecisions` with 6 (`game`, `config`,
+and the four optional decision lists). Re-introducing an individually threaded
+parameter list (~14) pushes a declaration well over budget and fails the gate.
+
+### Source of truth
+
+| Artifact | Role |
+|----------|------|
+| `tool/check_turn_resume_param_budget.dart` | Checker and CLI entrypoint |
+| `tool/ct_repo_lint_manifest.yaml` (`repo.turn_resume_param_budget`) | Rule registration |
+
+### Scan scope
+
+The checker scans files returned by `collectRepoLintDomainDartFiles` and
+evaluates only those whose repo-relative path begins with
+`packages/colonizethis_turn/lib/`. Generated and test files stay excluded by the
+shared repo-lint scan contract.
+
+### Declaration detection and counting
+
+A declaration is recognised by the function name `resumeTurnResolution<...>`
+immediately followed by a named-parameter block opener `({`. Call sites pass
+named arguments (`(\n game: ...`) and never match the `({` form, so only
+declarations are evaluated. The parameter count is the number of top-level
+named parameters; commas nested in generic arguments (`<...>`), function-type
+parameter lists (`(...)`), collection literals (`[...]`), or nested record
+groups (`{...}`) are ignored, and a trailing comma does not inflate the count.
+
+## Acceptance criteria
+
+- Given the file `packages/colonizethis_turn/lib/src/turn/turn_resolver.dart`
+  with all `resumeTurnResolution*` declarations forwarding a single
+  `TurnResolverConfig` (≤ 6 named parameters each), when the checker runs, then
+  the checker passes with exit code 0.
+- Given a Dart file under `packages/colonizethis_turn/lib/` declaring a
+  function `resumeTurnResolutionWithXDecisions` with 14 named parameters, when
+  the checker runs, then the checker fails with exit code 1 and the violation
+  text names that file's repo-relative path, the 1-based line of the
+  declaration, the function name, and its parameter count.
+- Given a Dart file under `packages/colonizethis_turn/lib/` that contains a
+  call `resumeTurnResolutionWithOvertureDecisions(game: g, decisions: d,
+  config: c)` (a call, not a declaration), when the checker runs, then the
+  checker does not treat the call as a declaration and does not fail because of
+  it.
+- Given a `resumeTurnResolution*` declaration whose only function-type
+  parameter is `void Function(int, int)? cb` (commas nested inside the
+  function-type parameter list), when the checker runs, then the checker counts
+  that parameter once and does not count the nested commas.
+- Given a Dart file outside `packages/colonizethis_turn/lib/` declaring a
+  `resumeTurnResolutionWithXDecisions` function with 20 named parameters, when
+  the checker runs, then the checker does not evaluate that file for this rule
+  and does not fail because of it.

--- a/packages/colonizethis_turn/lib/src/turn/phases/production_phase.dart
+++ b/packages/colonizethis_turn/lib/src/turn/phases/production_phase.dart
@@ -28,9 +28,7 @@ TurnPipelineState runProductionPipelinePhase(
       assignments: assignments,
     );
     if (result.productionByRecipe.isNotEmpty) {
-      productionByRecipeByPlayerId[player.id] = Map<String, int>.from(
-        result.productionByRecipe,
-      );
+      productionByRecipeByPlayerId[player.id] = result.productionByRecipe;
     }
     return player.copyWith(
       stockpile: result.stockpile,

--- a/packages/colonizethis_turn/lib/src/turn/phases/world_market_phase_carry_forward.dart
+++ b/packages/colonizethis_turn/lib/src/turn/phases/world_market_phase_carry_forward.dart
@@ -60,7 +60,7 @@ CarryForwardValidationResult validateCarryForwards({
     if (orders.isEmpty) continue;
     final stockpile = stockpileByFactionId[factionId];
     if (stockpile == null) {
-      validOffers[factionId] = List<TradeOrder>.from(orders);
+      validOffers[factionId] = orders;
       continue;
     }
     final cumulativeByCommodity = <CommodityId, int>{};
@@ -92,7 +92,7 @@ CarryForwardValidationResult validateCarryForwards({
     if (orders.isEmpty) continue;
     final capacity = tradeCapacityByFactionId[factionId];
     if (capacity == null) {
-      validBids[factionId] = List<TradeOrder>.from(orders);
+      validBids[factionId] = orders;
       continue;
     }
     int cumulative = 0;

--- a/packages/colonizethis_turn/lib/src/turn/turn_order_acceptance.dart
+++ b/packages/colonizethis_turn/lib/src/turn/turn_order_acceptance.dart
@@ -128,17 +128,11 @@ Orders filterAcceptedOrdersForAllPlayers({
     }
   }
 
-  final researchByPlayer = Map<String, List<ResearchOrder>>.from(
-    original.researchOrdersByPlayerId,
-  );
-
-  final navalByPlayer = Map<String, List<NavalMoveOrder>>.from(
-    original.navalMoveOrdersByPlayerId,
-  );
-
-  final missionByPlayer = Map<String, List<NavalMissionOrder>>.from(
-    original.navalMissionOrdersByPlayerId,
-  );
+  // Research, naval, and mission orders are not filtered here; shallow-copying
+  // the outer map would not isolate inner lists anyway. Pass through references.
+  final researchByPlayer = original.researchOrdersByPlayerId;
+  final navalByPlayer = original.navalMoveOrdersByPlayerId;
+  final missionByPlayer = original.navalMissionOrdersByPlayerId;
 
   return Orders(
     moveOrdersByPlayerId: moveByPlayer,

--- a/packages/colonizethis_turn/lib/src/turn/turn_resolution_events.dart
+++ b/packages/colonizethis_turn/lib/src/turn/turn_resolution_events.dart
@@ -63,9 +63,11 @@ void emitResearchCompleteEvents(
 ) {
   final hadTechBefore = _techKeysUnlockedBefore(stateBefore);
   final firstDiscoveriesThisTurn = <String>{};
-  final sortedPlayers = List<Player>.from(stateAfter.players)
-    ..sort((a, b) => a.id.compareTo(b.id));
-  for (final player in sortedPlayers) {
+  final sortedPlayerIds = stateAfter.players.map((p) => p.id).toList()
+    ..sort();
+  for (final playerId in sortedPlayerIds) {
+    final player = stateAfter.playerById(playerId);
+    if (player == null) continue;
     final unlocked = player.techUnlocked ?? {};
     final current = unlocked.entries
         .where((e) => e.value)
@@ -271,24 +273,24 @@ void emitPlayerDiscoveryEvents(
       beforeIndex ?? buildProvinceVisibilityIndex(stateBefore);
   final resolvedAfterIndex =
       afterIndex ?? buildProvinceVisibilityIndex(stateAfter);
-  final sortedPlayers = List<Player>.from(stateAfter.players)
-    ..sort((a, b) => a.id.compareTo(b.id));
-  for (final player in sortedPlayers) {
+  final sortedPlayerIds = stateAfter.players.map((p) => p.id).toList()
+    ..sort();
+  for (final playerId in sortedPlayerIds) {
     _emitPlayerProvinceDiscoveryEvents(
       stateAfter: stateAfter,
-      playerId: player.id,
+      playerId: playerId,
       turn: turn,
       beforeIndex: resolvedBeforeIndex,
       afterIndex: resolvedAfterIndex,
       eventBus: eventBus,
       onGameEvent: onGameEvent,
     );
-    final beforeSea = _seaZonesAtSeaForPlayer(stateBefore, player.id);
-    final afterSea = _seaZonesAtSeaForPlayer(stateAfter, player.id);
+    final beforeSea = _seaZonesAtSeaForPlayer(stateBefore, playerId);
+    final afterSea = _seaZonesAtSeaForPlayer(stateAfter, playerId);
     final newlyDiscovered = afterSea.difference(beforeSea).toList()..sort();
     for (final seaZoneId in newlyDiscovered) {
       final event = PlayerSeaZoneDiscoveredEvent(
-        playerId: player.id,
+        playerId: playerId,
         seaZoneId: seaZoneId,
         turnNumber: turn,
       );

--- a/packages/colonizethis_turn/lib/src/turn/turn_resolver.dart
+++ b/packages/colonizethis_turn/lib/src/turn/turn_resolver.dart
@@ -313,186 +313,95 @@ String _pendingTurnResolutionMessage(TurnResolutionResult result) {
   };
 }
 
-/// Resumes turn resolution after the app has collected overture accept/reject decisions
-/// from the human target(s). Call with the [game] and [pendingOvertures] from
-/// [TurnResolutionPendingOvertures], and the [decisions] from the user. Other parameters
-/// must match those used for the original resolveTurnForGame call (orders, topology, etc.).
+/// Resumes turn resolution after the app has collected overture accept/reject
+/// decisions from the human target(s). Call with the [game] and
+/// [pendingOvertures] from [TurnResolutionPendingOvertures], the [decisions]
+/// from the user, and the [config] that matches the original
+/// [resolveTurnForGameWithConfig] call (orders, topology, etc.). The resume
+/// entry points re-enter resolution at [TurnPhase.diplomacy] (Refs #3416,
+/// `SPEC/program/turn-resume-config-dispatch.md`).
 TurnResolutionResult resumeTurnResolutionWithOvertureDecisions({
   required Game game,
   required List<OvertureOffer> pendingOvertures,
   required List<OvertureDecision> decisions,
-  required MapTopology topology,
-  required Orders orders,
-  Map<String, TileMapResult>? tileMapByRegion,
-  Map<String, MapTopology>? topologyByRegion,
-  Map<String, Map<CommodityId, int>> extractedByPlayerId = const {},
-  List<AssignedRecipe> defaultAssignments = const [],
-  Map<String, List<AssignedRecipe>>? defaultAssignmentsByPlayerId,
-  GameEventBus? eventBus,
-  void Function(DialogueEvent)? onDialogue,
-  void Function(GameEvent)? onGameEvent,
-  void Function(Map<String, Map<String, int>> productionByRecipeByPlayerId)?
-  onProductionComplete,
+  required TurnResolverConfig config,
 }) {
   return _resumeTurnResolutionWithDiplomacyDecisions(
     game: game,
-    topology: topology,
-    orders: orders,
-    tileMapByRegion: tileMapByRegion,
-    topologyByRegion: topologyByRegion,
-    extractedByPlayerId: extractedByPlayerId,
-    defaultAssignments: defaultAssignments,
-    defaultAssignmentsByPlayerId: defaultAssignmentsByPlayerId,
-    eventBus: eventBus,
-    onDialogue: onDialogue,
-    onGameEvent: onGameEvent,
-    onProductionComplete: onProductionComplete,
+    config: config,
     overtureDecisions: decisions,
   );
 }
 
-/// Resumes turn resolution after human FTP accept/reject decisions (Diplomacy phase).
+/// Resumes turn resolution after human FTP accept/reject decisions (Diplomacy
+/// phase). [config] must match the original resolve call. See
+/// [resumeTurnResolutionWithOvertureDecisions].
 TurnResolutionResult resumeTurnResolutionWithFtpDecisions({
   required Game game,
   required List<FtpDecision> decisions,
-  required MapTopology topology,
-  required Orders orders,
-  Map<String, TileMapResult>? tileMapByRegion,
-  Map<String, MapTopology>? topologyByRegion,
-  Map<String, Map<CommodityId, int>> extractedByPlayerId = const {},
-  List<AssignedRecipe> defaultAssignments = const [],
-  Map<String, List<AssignedRecipe>>? defaultAssignmentsByPlayerId,
-  GameEventBus? eventBus,
-  void Function(DialogueEvent)? onDialogue,
-  void Function(GameEvent)? onGameEvent,
-  void Function(Map<String, Map<String, int>> productionByRecipeByPlayerId)?
-  onProductionComplete,
+  required TurnResolverConfig config,
 }) {
   return _resumeTurnResolutionWithDiplomacyDecisions(
     game: game,
-    topology: topology,
-    orders: orders,
-    tileMapByRegion: tileMapByRegion,
-    topologyByRegion: topologyByRegion,
-    extractedByPlayerId: extractedByPlayerId,
-    defaultAssignments: defaultAssignments,
-    defaultAssignmentsByPlayerId: defaultAssignmentsByPlayerId,
-    eventBus: eventBus,
-    onDialogue: onDialogue,
-    onGameEvent: onGameEvent,
-    onProductionComplete: onProductionComplete,
+    config: config,
     ftpDecisions: decisions,
   );
 }
 
 /// Resumes turn resolution after human intervention choices (Diplomacy phase).
+/// [config] must match the original resolve call. See
+/// [resumeTurnResolutionWithOvertureDecisions].
 TurnResolutionResult resumeTurnResolutionWithInterventionDecisions({
   required Game game,
   required List<InterventionDecision> decisions,
-  required MapTopology topology,
-  required Orders orders,
-  Map<String, TileMapResult>? tileMapByRegion,
-  Map<String, MapTopology>? topologyByRegion,
-  Map<String, Map<CommodityId, int>> extractedByPlayerId = const {},
-  List<AssignedRecipe> defaultAssignments = const [],
-  Map<String, List<AssignedRecipe>>? defaultAssignmentsByPlayerId,
-  GameEventBus? eventBus,
-  void Function(DialogueEvent)? onDialogue,
-  void Function(GameEvent)? onGameEvent,
-  void Function(Map<String, Map<String, int>> productionByRecipeByPlayerId)?
-  onProductionComplete,
+  required TurnResolverConfig config,
 }) {
   return _resumeTurnResolutionWithDiplomacyDecisions(
     game: game,
-    topology: topology,
-    orders: orders,
-    tileMapByRegion: tileMapByRegion,
-    topologyByRegion: topologyByRegion,
-    extractedByPlayerId: extractedByPlayerId,
-    defaultAssignments: defaultAssignments,
-    defaultAssignmentsByPlayerId: defaultAssignmentsByPlayerId,
-    eventBus: eventBus,
-    onDialogue: onDialogue,
-    onGameEvent: onGameEvent,
-    onProductionComplete: onProductionComplete,
+    config: config,
     interventionDecisions: decisions,
   );
 }
 
 /// Resumes turn resolution after human ally(ies) responded to call to arms.
+/// [config] must match the original resolve call. See
+/// [resumeTurnResolutionWithOvertureDecisions].
 TurnResolutionResult resumeTurnResolutionWithCallToArmsDecisions({
   required Game game,
   required List<CallToArmsDecision> decisions,
-  required MapTopology topology,
-  required Orders orders,
-  Map<String, TileMapResult>? tileMapByRegion,
-  Map<String, MapTopology>? topologyByRegion,
-  Map<String, Map<CommodityId, int>> extractedByPlayerId = const {},
-  List<AssignedRecipe> defaultAssignments = const [],
-  Map<String, List<AssignedRecipe>>? defaultAssignmentsByPlayerId,
-  GameEventBus? eventBus,
-  void Function(DialogueEvent)? onDialogue,
-  void Function(GameEvent)? onGameEvent,
-  void Function(Map<String, Map<String, int>> productionByRecipeByPlayerId)?
-  onProductionComplete,
+  required TurnResolverConfig config,
 }) {
   return _resumeTurnResolutionWithDiplomacyDecisions(
     game: game,
-    topology: topology,
-    orders: orders,
-    tileMapByRegion: tileMapByRegion,
-    topologyByRegion: topologyByRegion,
-    extractedByPlayerId: extractedByPlayerId,
-    defaultAssignments: defaultAssignments,
-    defaultAssignmentsByPlayerId: defaultAssignmentsByPlayerId,
-    eventBus: eventBus,
-    onDialogue: onDialogue,
-    onGameEvent: onGameEvent,
-    onProductionComplete: onProductionComplete,
+    config: config,
     callToArmsDecisions: decisions,
   );
 }
 
 /// Shared dispatch for the Diplomacy-phase resume entry points. All re-enter
-/// [resolveTurnForGame] at [TurnPhase.diplomacy] with identical parameter
-/// forwarding, differing only in which decision list they carry, so a new
-/// [resolveTurnForGame] parameter is threaded through once here.
+/// [resolveTurnForGameWithConfig] at [TurnPhase.diplomacy] using the supplied
+/// [config], overriding only [TurnResolverConfig.startFromPhase] and the one
+/// decision list each wrapper carries. Threading a single [TurnResolverConfig]
+/// (instead of every individual resolver parameter) keeps the resume entry
+/// points free of duplicated parameter lists: a new resolver parameter is added
+/// to [TurnResolverConfig] once and flows through here automatically (Refs
+/// #3416, `SPEC/program/turn-resume-config-dispatch.md`).
 TurnResolutionResult _resumeTurnResolutionWithDiplomacyDecisions({
   required Game game,
-  required MapTopology topology,
-  required Orders orders,
-  Map<String, TileMapResult>? tileMapByRegion,
-  Map<String, MapTopology>? topologyByRegion,
-  Map<String, Map<CommodityId, int>> extractedByPlayerId = const {},
-  List<AssignedRecipe> defaultAssignments = const [],
-  Map<String, List<AssignedRecipe>>? defaultAssignmentsByPlayerId,
-  GameEventBus? eventBus,
-  void Function(DialogueEvent)? onDialogue,
-  void Function(GameEvent)? onGameEvent,
-  void Function(Map<String, Map<String, int>> productionByRecipeByPlayerId)?
-  onProductionComplete,
+  required TurnResolverConfig config,
   List<OvertureDecision>? overtureDecisions,
   List<FtpDecision>? ftpDecisions,
   List<InterventionDecision>? interventionDecisions,
   List<CallToArmsDecision>? callToArmsDecisions,
 }) {
-  return resolveTurnForGame(
+  return resolveTurnForGameWithConfig(
     game: game,
-    topology: topology,
-    orders: orders,
-    tileMapByRegion: tileMapByRegion,
-    topologyByRegion: topologyByRegion,
-    extractedByPlayerId: extractedByPlayerId,
-    defaultAssignments: defaultAssignments,
-    defaultAssignmentsByPlayerId: defaultAssignmentsByPlayerId,
-    eventBus: eventBus,
-    onDialogue: onDialogue,
-    onGameEvent: onGameEvent,
-    onProductionComplete: onProductionComplete,
-    startFromPhase: TurnPhase.diplomacy,
-    overtureDecisions: overtureDecisions,
-    ftpDecisions: ftpDecisions,
-    interventionDecisions: interventionDecisions,
-    callToArmsDecisions: callToArmsDecisions,
+    config: config.copyWith(
+      startFromPhase: TurnPhase.diplomacy,
+      overtureDecisions: overtureDecisions,
+      ftpDecisions: ftpDecisions,
+      interventionDecisions: interventionDecisions,
+      callToArmsDecisions: callToArmsDecisions,
+    ),
   );
 }

--- a/packages/colonizethis_turn/lib/src/turn/turn_resolver_config.dart
+++ b/packages/colonizethis_turn/lib/src/turn/turn_resolver_config.dart
@@ -79,4 +79,63 @@ class TurnResolverConfig {
   /// When non-null with [onTurnTracePhase], collects order-level events (for
   /// example civilian move apply/ignore) for the active phase.
   final TurnTraceRuntime? turnTraceRuntime;
+
+  /// Returns a copy with the given overrides applied. A `null` argument leaves
+  /// the existing value unchanged.
+  ///
+  /// Used by the Diplomacy-phase resume entry points so each resume wrapper can
+  /// forward a single [TurnResolverConfig] and only override [startFromPhase]
+  /// and the one decision list it carries, instead of re-threading every
+  /// resolver parameter individually (Refs #3416,
+  /// `SPEC/program/turn-resume-config-dispatch.md`).
+  TurnResolverConfig copyWith({
+    MapTopology? topology,
+    Orders? orders,
+    Map<String, TileMapResult>? tileMapByRegion,
+    Map<String, MapTopology>? topologyByRegion,
+    Map<String, Map<CommodityId, int>>? extractedByPlayerId,
+    List<AssignedRecipe>? defaultAssignments,
+    Map<String, List<AssignedRecipe>>? defaultAssignmentsByPlayerId,
+    GameEventBus? eventBus,
+    void Function(DialogueEvent)? onDialogue,
+    void Function(GameEvent)? onGameEvent,
+    void Function(Map<String, Map<String, int>> productionByRecipeByPlayerId)?
+    onProductionComplete,
+    TurnPhase? startFromPhase,
+    List<OvertureDecision>? overtureDecisions,
+    List<FtpDecision>? ftpDecisions,
+    List<InterventionDecision>? interventionDecisions,
+    List<CallToArmsDecision>? callToArmsDecisions,
+    Map<TurnPhase, TurnPhaseHandler>? phaseHandlerOverrides,
+    void Function(TurnPhase phase, TurnPhaseProgressMarker marker)?
+    onPhaseProgress,
+    void Function(TurnTracePhaseTrace phaseTrace)? onTurnTracePhase,
+    TurnTraceRuntime? turnTraceRuntime,
+  }) {
+    return TurnResolverConfig(
+      topology: topology ?? this.topology,
+      orders: orders ?? this.orders,
+      tileMapByRegion: tileMapByRegion ?? this.tileMapByRegion,
+      topologyByRegion: topologyByRegion ?? this.topologyByRegion,
+      extractedByPlayerId: extractedByPlayerId ?? this.extractedByPlayerId,
+      defaultAssignments: defaultAssignments ?? this.defaultAssignments,
+      defaultAssignmentsByPlayerId:
+          defaultAssignmentsByPlayerId ?? this.defaultAssignmentsByPlayerId,
+      eventBus: eventBus ?? this.eventBus,
+      onDialogue: onDialogue ?? this.onDialogue,
+      onGameEvent: onGameEvent ?? this.onGameEvent,
+      onProductionComplete: onProductionComplete ?? this.onProductionComplete,
+      startFromPhase: startFromPhase ?? this.startFromPhase,
+      overtureDecisions: overtureDecisions ?? this.overtureDecisions,
+      ftpDecisions: ftpDecisions ?? this.ftpDecisions,
+      interventionDecisions:
+          interventionDecisions ?? this.interventionDecisions,
+      callToArmsDecisions: callToArmsDecisions ?? this.callToArmsDecisions,
+      phaseHandlerOverrides:
+          phaseHandlerOverrides ?? this.phaseHandlerOverrides,
+      onPhaseProgress: onPhaseProgress ?? this.onPhaseProgress,
+      onTurnTracePhase: onTurnTracePhase ?? this.onTurnTracePhase,
+      turnTraceRuntime: turnTraceRuntime ?? this.turnTraceRuntime,
+    );
+  }
 }

--- a/packages/colonizethis_turn/test/diplomacy_intervention_diplomacy_phase_test.dart
+++ b/packages/colonizethis_turn/test/diplomacy_intervention_diplomacy_phase_test.dart
@@ -277,8 +277,10 @@ void main() {
             choice: InterventionChoice.protest,
           ),
         ],
-        topology: const MapTopology(),
-        orders: orders,
+        config: TurnResolverConfig(
+          topology: const MapTopology(),
+          orders: orders,
+        ),
       );
       expect(complete, isA<TurnResolutionComplete>());
       final rel = getRelation((complete as TurnResolutionComplete).game, 'gp1', 'gp2');

--- a/packages/colonizethis_turn/test/turn_defensive_copy_audit_test.dart
+++ b/packages/colonizethis_turn/test/turn_defensive_copy_audit_test.dart
@@ -1,0 +1,119 @@
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_turn/src/turn/phases/world_market_phase_carry_forward.dart';
+import 'package:colonizethis_test/test.dart';
+
+/// Guards the turn-package defensive-copy audit (#3416,
+/// SPEC/program/turn-defensive-copy-audit.md). The pass-through branches of
+/// [validateCarryForwards] must NOT re-introduce a `List.from` clone, while the
+/// constraint-filtering branches must still allocate a fresh kept list.
+void main() {
+  group('validateCarryForwards defensive-copy audit (#3416)', () {
+    TradeOrder offer(String commodity, int qty, int priority) => TradeOrder(
+      commodityId: commodity,
+      type: TradeOrderType.offer,
+      quantity: qty,
+      priority: priority,
+    );
+
+    TradeOrder bid(String commodity, int qty, int priority) => TradeOrder(
+      commodityId: commodity,
+      type: TradeOrderType.bid,
+      quantity: qty,
+      priority: priority,
+    );
+
+    test(
+      'offers pass through the same list instance when the faction has no '
+      'stockpile entry (SPEC AC: no List.from in pass-through branch)',
+      () {
+        final orders = <TradeOrder>[offer('grain', 5, 1), offer('iron', 3, 2)];
+        final result = validateCarryForwards(
+          carryForwardOffersByFactionId: {'f1': orders},
+          carryForwardBidsByFactionId: const {},
+          stockpileByFactionId: const {},
+          tradeCapacityByFactionId: const {},
+        );
+
+        expect(
+          identical(result.validOffersByFactionId['f1'], orders),
+          isTrue,
+          reason: 'pass-through must reference the input list, not a copy',
+        );
+        expect(result.dropNotesByCommodity, isEmpty);
+      },
+    );
+
+    test(
+      'bids pass through the same list instance when the faction has no trade '
+      'capacity entry (SPEC AC: no List.from in pass-through branch)',
+      () {
+        final orders = <TradeOrder>[bid('grain', 5, 1)];
+        final result = validateCarryForwards(
+          carryForwardOffersByFactionId: const {},
+          carryForwardBidsByFactionId: {'f1': orders},
+          stockpileByFactionId: const {},
+          tradeCapacityByFactionId: const {},
+        );
+
+        expect(
+          identical(result.validBidsByFactionId['f1'], orders),
+          isTrue,
+          reason: 'pass-through must reference the input list, not a copy',
+        );
+        expect(result.dropNotesByCommodity, isEmpty);
+      },
+    );
+
+    test(
+      'offers filtered against a stockpile produce a fresh kept list (not the '
+      'input) and record drop notes for the dropped order',
+      () {
+        final orders = <TradeOrder>[offer('grain', 8, 1), offer('grain', 5, 2)];
+        final result = validateCarryForwards(
+          carryForwardOffersByFactionId: {'f1': orders},
+          carryForwardBidsByFactionId: const {},
+          stockpileByFactionId: const {
+            'f1': Stockpile(quantities: {'grain': 10}),
+          },
+          tradeCapacityByFactionId: const {},
+        );
+
+        final kept = result.validOffersByFactionId['f1'];
+        expect(kept, isNotNull);
+        expect(
+          identical(kept, orders),
+          isFalse,
+          reason: 'filtering branch must build a new kept list',
+        );
+        expect(kept, hasLength(1));
+        expect(kept!.single.quantity, 8);
+        expect(result.dropNotesByCommodity['grain'], hasLength(1));
+      },
+    );
+
+    test(
+      'bids filtered against trade capacity produce a fresh kept list (not the '
+      'input) and record drop notes for the dropped order',
+      () {
+        final orders = <TradeOrder>[bid('grain', 6, 1), bid('iron', 6, 2)];
+        final result = validateCarryForwards(
+          carryForwardOffersByFactionId: const {},
+          carryForwardBidsByFactionId: {'f1': orders},
+          stockpileByFactionId: const {},
+          tradeCapacityByFactionId: const {'f1': 6},
+        );
+
+        final kept = result.validBidsByFactionId['f1'];
+        expect(kept, isNotNull);
+        expect(
+          identical(kept, orders),
+          isFalse,
+          reason: 'filtering branch must build a new kept list',
+        );
+        expect(kept, hasLength(1));
+        expect(kept!.single.commodityId, 'grain');
+        expect(result.dropNotesByCommodity['iron'], hasLength(1));
+      },
+    );
+  });
+}

--- a/test/check_turn_resume_param_budget_test.dart
+++ b/test/check_turn_resume_param_budget_test.dart
@@ -1,0 +1,171 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+import '../tool/check_turn_resume_param_budget.dart';
+
+const _wideResumeDeclaration = '''
+import 'turn_resolver_config.dart';
+
+TurnResolutionResult resumeTurnResolutionWithOvertureDecisions({
+  required Game game,
+  required List<OvertureOffer> pendingOvertures,
+  required List<OvertureDecision> decisions,
+  required MapTopology topology,
+  required Orders orders,
+  Map<String, TileMapResult>? tileMapByRegion,
+  Map<String, MapTopology>? topologyByRegion,
+  Map<String, Map<CommodityId, int>> extractedByPlayerId = const {},
+  List<AssignedRecipe> defaultAssignments = const [],
+  Map<String, List<AssignedRecipe>>? defaultAssignmentsByPlayerId,
+  GameEventBus? eventBus,
+  void Function(DialogueEvent)? onDialogue,
+  void Function(GameEvent)? onGameEvent,
+  void Function(Map<String, Map<String, int>> byRecipe)? onProductionComplete,
+}) {
+  return _dispatch();
+}
+''';
+
+const _configResumeDeclaration = '''
+import 'turn_resolver_config.dart';
+
+TurnResolutionResult resumeTurnResolutionWithOvertureDecisions({
+  required Game game,
+  required List<OvertureOffer> pendingOvertures,
+  required List<OvertureDecision> decisions,
+  required TurnResolverConfig config,
+}) {
+  return _dispatch(game: game, config: config, overtureDecisions: decisions);
+}
+
+TurnResolutionResult resumeTurnResolutionWithFtpDecisions({
+  required Game game,
+  required List<FtpDecision> decisions,
+  required TurnResolverConfig config,
+}) {
+  return _dispatch(game: game, config: config, ftpDecisions: decisions);
+}
+''';
+
+void main() {
+  group('runCheckTurnResumeParamBudget', () {
+    test('fails for a wide resume declaration in turn lib', () {
+      final temp = Directory.systemTemp.createTempSync('turn-resume-wide-');
+      try {
+        _writeTurnLibFile(temp, 'turn_resolver.dart', _wideResumeDeclaration);
+
+        final errors = <String>[];
+        final exitCode = runCheckTurnResumeParamBudget(
+          temp.path,
+          info: (_) {},
+          err: errors.add,
+        );
+        expect(exitCode, 1);
+        final joined = errors.join('\n');
+        expect(joined, contains('turn_resolver.dart:3'));
+        expect(joined, contains('resumeTurnResolutionWithOvertureDecisions'));
+        expect(joined, contains('14'));
+      } finally {
+        temp.deleteSync(recursive: true);
+      }
+    });
+
+    test('passes for config-based resume declarations in turn lib', () {
+      final temp = Directory.systemTemp.createTempSync('turn-resume-ok-');
+      try {
+        _writeTurnLibFile(temp, 'turn_resolver.dart', _configResumeDeclaration);
+
+        final exitCode = runCheckTurnResumeParamBudget(
+          temp.path,
+          info: (_) {},
+          err: (_) {},
+        );
+        expect(exitCode, 0);
+      } finally {
+        temp.deleteSync(recursive: true);
+      }
+    });
+
+    test('ignores a wide resume declaration outside the turn lib', () {
+      final temp = Directory.systemTemp.createTempSync('turn-resume-other-');
+      try {
+        final otherLib = Directory(
+          p.join(temp.path, 'packages', 'colonizethis_logic', 'lib', 'src'),
+        )..createSync(recursive: true);
+        _writeDartFile(
+          p.join(otherLib.path, 'turn_resolver.dart'),
+          _wideResumeDeclaration,
+        );
+
+        final exitCode = runCheckTurnResumeParamBudget(
+          temp.path,
+          info: (_) {},
+          err: (_) {},
+        );
+        expect(exitCode, 0);
+      } finally {
+        temp.deleteSync(recursive: true);
+      }
+    });
+  });
+
+  group('turnResumeCountNamedParams', () {
+    test('counts top-level named parameters', () {
+      const sig = '({required Game game, required TurnResolverConfig config})';
+      expect(turnResumeCountNamedParams(sig, sig.indexOf('{')), 2);
+    });
+
+    test('ignores commas nested in a function-type parameter', () {
+      const sig =
+          '({required Game game, void Function(int, int)? cb, int? x})';
+      expect(turnResumeCountNamedParams(sig, sig.indexOf('{')), 3);
+    });
+
+    test('ignores commas nested in generic type arguments', () {
+      const sig = '({Map<String, int>? a, List<int>? b, int? c})';
+      expect(turnResumeCountNamedParams(sig, sig.indexOf('{')), 3);
+    });
+
+    test('does not inflate the count for a trailing comma', () {
+      const sig = '({required Game game, required TurnResolverConfig config,})';
+      expect(turnResumeCountNamedParams(sig, sig.indexOf('{')), 2);
+    });
+
+    test('returns 0 for an empty parameter block', () {
+      const sig = '({})';
+      expect(turnResumeCountNamedParams(sig, sig.indexOf('{')), 0);
+    });
+  });
+
+  group('turnResumeParamBudgetPathInScope', () {
+    test('matches turn package lib paths only', () {
+      expect(
+        turnResumeParamBudgetPathInScope(
+          'packages/colonizethis_turn/lib/src/turn/turn_resolver.dart',
+        ),
+        isTrue,
+      );
+      expect(
+        turnResumeParamBudgetPathInScope(
+          'packages/colonizethis_logic/lib/src/x.dart',
+        ),
+        isFalse,
+      );
+    });
+  });
+}
+
+void _writeTurnLibFile(Directory temp, String name, String content) {
+  final turnLib = Directory(
+    p.join(temp.path, 'packages', 'colonizethis_turn', 'lib', 'src', 'turn'),
+  )..createSync(recursive: true);
+  _writeDartFile(p.join(turnLib.path, name), content);
+}
+
+void _writeDartFile(String path, String content) {
+  File(path)
+    ..createSync(recursive: true)
+    ..writeAsStringSync(content);
+}

--- a/tool/check_turn_resume_param_budget.dart
+++ b/tool/check_turn_resume_param_budget.dart
@@ -1,0 +1,204 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+import 'ct_repo_lint_scan_contract.dart';
+
+/// Repo-relative path prefix whose `lib/` Dart sources host the Diplomacy-phase
+/// resume entry points (`resumeTurnResolutionWith*Decisions`). Refs #3416.
+const String _turnLibPathPrefix = 'packages/colonizethis_turn/lib/';
+
+/// Maximum number of named parameters a `resumeTurnResolution*` entry point or
+/// its shared dispatch may declare. The resume wrappers must forward a single
+/// [TurnResolverConfig] (plus the resume-specific `game`, decision list, and
+/// `pendingOvertures`) instead of re-threading every resolver parameter
+/// individually. The widest legitimate declaration is the private shared
+/// dispatch `_resumeTurnResolutionWithDiplomacyDecisions`, which carries `game`,
+/// `config`, and the four optional decision lists (6). Re-threading the full
+/// individual resolver parameter list (~14) stays well above this budget.
+/// Raising this budget requires a SPEC update in
+/// `SPEC/program/turn-resume-config-dispatch.md` and a maintainer-reviewed PR.
+const int turnResumeMaxNamedParams = 6;
+
+/// Matches the opening of a `resumeTurnResolution*` declaration whose named
+/// parameter block (`({`) follows the function name. Call sites pass named
+/// arguments (`(\n game: ...`) and therefore never match this `(` + `{` form,
+/// so only declarations are evaluated. The leading `_` of the private dispatch
+/// is outside the captured name but still produces a match.
+final RegExp _resumeDeclPattern = RegExp(
+  r'(resumeTurnResolution\w*)\s*\(\s*\{',
+);
+
+/// True when the repo-relative [slashPath] is under the turn package `lib/`.
+bool turnResumeParamBudgetPathInScope(String slashPath) {
+  final normalized = slashPath.replaceAll('\\', '/');
+  return normalized.startsWith(_turnLibPathPrefix);
+}
+
+/// Counts the top-level named parameters declared in the parameter block that
+/// begins at [openBraceIndex] (the `{` of a `({ ... })` named parameter list).
+///
+/// Commas nested inside generic type arguments (`<...>`), function-type
+/// parameter lists (`(...)`), collection literals (`[...]`), or nested record
+/// `{...}` groups are ignored; only separators at the block's top level are
+/// counted. A trailing comma does not inflate the count.
+int turnResumeCountNamedParams(String source, int openBraceIndex) {
+  var braceDepth = 0;
+  var parenDepth = 0;
+  var bracketDepth = 0;
+  var angleDepth = 0;
+  var topLevelCommas = 0;
+  final buffer = StringBuffer();
+  var closed = false;
+  for (var i = openBraceIndex; i < source.length; i++) {
+    final c = source[i];
+    if (c == '{') {
+      braceDepth++;
+      continue;
+    }
+    if (c == '}') {
+      braceDepth--;
+      if (braceDepth == 0) {
+        closed = true;
+        break;
+      }
+      buffer.write(c);
+      continue;
+    }
+    if (c == '(') {
+      parenDepth++;
+      buffer.write(c);
+      continue;
+    }
+    if (c == ')') {
+      parenDepth--;
+      buffer.write(c);
+      continue;
+    }
+    if (c == '[') {
+      bracketDepth++;
+      buffer.write(c);
+      continue;
+    }
+    if (c == ']') {
+      bracketDepth--;
+      buffer.write(c);
+      continue;
+    }
+    if (c == '<') {
+      angleDepth++;
+      buffer.write(c);
+      continue;
+    }
+    if (c == '>') {
+      if (angleDepth > 0) angleDepth--;
+      buffer.write(c);
+      continue;
+    }
+    final atTopLevel =
+        braceDepth == 1 &&
+        parenDepth == 0 &&
+        bracketDepth == 0 &&
+        angleDepth == 0;
+    if (c == ',' && atTopLevel) {
+      topLevelCommas++;
+    }
+    buffer.write(c);
+  }
+  if (!closed) {
+    return -1;
+  }
+  final content = buffer.toString().trim();
+  if (content.isEmpty) {
+    return 0;
+  }
+  final trailingComma = content.endsWith(',');
+  return topLevelCommas + (trailingComma ? 0 : 1);
+}
+
+/// Returns the violations in [content]: each `resumeTurnResolution*` declaration
+/// whose named-parameter count exceeds [turnResumeMaxNamedParams].
+List<TurnResumeParamHit> turnResumeParamBudgetViolations(
+  String relPath,
+  String content,
+) {
+  final hits = <TurnResumeParamHit>[];
+  for (final match in _resumeDeclPattern.allMatches(content)) {
+    final braceIndex = content.indexOf('{', match.start);
+    if (braceIndex < 0) continue;
+    final count = turnResumeCountNamedParams(content, braceIndex);
+    if (count <= turnResumeMaxNamedParams) {
+      continue;
+    }
+    final line = '\n'.allMatches(content.substring(0, match.start)).length + 1;
+    hits.add(
+      TurnResumeParamHit(
+        path: relPath,
+        line: line,
+        functionName: match.group(1)!,
+        paramCount: count,
+      ),
+    );
+  }
+  return hits;
+}
+
+int runCheckTurnResumeParamBudget(
+  String repoRoot, {
+  void Function(String line)? info,
+  void Function(String line)? err,
+}) {
+  final logI = info ?? stdout.writeln;
+  final logE = err ?? stderr.writeln;
+
+  final violations = <TurnResumeParamHit>[];
+  for (final file in collectRepoLintDomainDartFiles(repoRoot)) {
+    final rel = p.relative(file.path, from: repoRoot).replaceAll('\\', '/');
+    if (!turnResumeParamBudgetPathInScope(rel)) {
+      continue;
+    }
+    violations.addAll(
+      turnResumeParamBudgetViolations(rel, file.readAsStringSync()),
+    );
+  }
+
+  if (violations.isEmpty) {
+    logI(
+      'check_turn_resume_param_budget: no resume entry point exceeds '
+      '$turnResumeMaxNamedParams named parameters.',
+    );
+    return 0;
+  }
+  logE(
+    'check_turn_resume_param_budget: ${violations.length} resume entry '
+    'point(s) exceed the $turnResumeMaxNamedParams named-parameter budget. '
+    'Forward a single TurnResolverConfig instead of re-threading individual '
+    'resolver parameters (Refs #3416; '
+    'SPEC/program/turn-resume-config-dispatch.md):',
+  );
+  for (final v in violations) {
+    logE(
+      ' - ${v.path}:${v.line}: ${v.functionName} declares ${v.paramCount} '
+      'named parameters (> $turnResumeMaxNamedParams)',
+    );
+  }
+  return 1;
+}
+
+void main() {
+  exit(runCheckTurnResumeParamBudget(Directory.current.path));
+}
+
+final class TurnResumeParamHit {
+  const TurnResumeParamHit({
+    required this.path,
+    required this.line,
+    required this.functionName,
+    required this.paramCount,
+  });
+
+  final String path;
+  final int line;
+  final String functionName;
+  final int paramCount;
+}

--- a/tool/ct_repo_lint_lib.dart
+++ b/tool/ct_repo_lint_lib.dart
@@ -61,6 +61,7 @@ import 'check_screen_registry_active_paths.dart';
 import 'check_subscription_tracker.dart';
 import 'check_tech_id_constants.dart';
 import 'check_turn_no_part_directives.dart';
+import 'check_turn_resume_param_budget.dart';
 import 'check_work_target_constants.dart';
 import 'check_workspace_outdated_latest_direct.dart';
 import 'check_workspace_outdated_resolvable.dart';
@@ -806,6 +807,8 @@ int? _tryRunDartRuleInProcess({
       return runCheckPartUnitSize(repoRoot);
     case 'repo.turn_no_part_directives':
       return runCheckTurnNoPartDirectives(repoRoot);
+    case 'repo.turn_resume_param_budget':
+      return runCheckTurnResumeParamBudget(repoRoot);
     case 'repo.no_flame_in_widgets':
       return runCheckNoFlameInWidgets(repoRoot);
     case 'repo.no_screen_in_game_widgets':

--- a/tool/ct_repo_lint_manifest.yaml
+++ b/tool/ct_repo_lint_manifest.yaml
@@ -270,6 +270,13 @@ rules:
     runner: dart
     script: tool/check_turn_no_part_directives.dart
 
+  - rule_id: repo.turn_resume_param_budget
+    group: structure
+    title: colonizethis_turn resume entry points must forward TurnResolverConfig (param budget, Refs #3416)
+    spec: SPEC/program/turn-resume-config-dispatch.md
+    runner: dart
+    script: tool/check_turn_resume_param_budget.dart
+
   - rule_id: repo.no_flame_in_widgets
     group: structure
     title: app/lib/widgets must not import package:flame directly

--- a/tool/logic_all_provinces_sanctions.yaml
+++ b/tool/logic_all_provinces_sanctions.yaml
@@ -22,13 +22,13 @@ sanctions:
     issue: https://github.com/waigore/colonizethisv3/issues/3416
 
   - path: packages/colonizethis_turn/lib/src/turn/turn_resolution_events.dart
-    line: 136
+    line: 138
     rationale: Province-captured events scan all provinces for owner handovers (unified dual-region iteration, Refs #3416).
     spec: SPEC/program/logic-dual-region-province-access.md
     issue: https://github.com/waigore/colonizethisv3/issues/3416
 
   - path: packages/colonizethis_turn/lib/src/turn/turn_resolution_events.dart
-    line: 309
+    line: 311
     rationale: Per-player province discovery events scan all provinces (unified dual-region iteration, Refs #3416).
     spec: SPEC/program/logic-dual-region-province-access.md
     issue: https://github.com/waigore/colonizethisv3/issues/3416

--- a/tool/sim_scenarios/lib/scenario_runner.dart
+++ b/tool/sim_scenarios/lib/scenario_runner.dart
@@ -629,6 +629,13 @@ class ScenarioRunner {
       defaultAssignments: defaultAssignments,
     );
 
+    final resumeConfig = TurnResolverConfig(
+      topology: topology,
+      orders: orderEngine.orders,
+      tileMapByRegion: context.tileMapByRegion,
+      defaultAssignments: defaultAssignments,
+    );
+
     while (true) {
       if (result is TurnResolutionComplete) {
         return result.game;
@@ -659,10 +666,7 @@ class ScenarioRunner {
           game: result.game,
           pendingOvertures: result.pendingOvertures,
           decisions: logicDecisions,
-          topology: topology,
-          orders: orderEngine.orders,
-          tileMapByRegion: context.tileMapByRegion,
-          defaultAssignments: defaultAssignments,
+          config: resumeConfig,
         );
         continue;
       }
@@ -687,10 +691,7 @@ class ScenarioRunner {
         result = resumeTurnResolutionWithCallToArmsDecisions(
           game: result.game,
           decisions: logicDecisions,
-          topology: topology,
-          orders: orderEngine.orders,
-          tileMapByRegion: context.tileMapByRegion,
-          defaultAssignments: defaultAssignments,
+          config: resumeConfig,
         );
         continue;
       }


### PR DESCRIPTION
## Summary

Closes the remaining open work on the turn-package refactor (#3416). Prior merged PRs (#3417, #3418) already delivered the resume-dispatch consolidation, part-of removal + ban gate, conditional `toJson` tracing, visibility-index memoization, unified province iteration, and the research-allocation context type. This PR completes the **config-based resume dispatch** (Expected behavior #1) and the **parameter-budget enforcement** half of AC #6, and lands the **defensive-copy audit** (Expected behavior #6).

- The four Diplomacy-phase resume entry points (`resumeTurnResolutionWith{Overture,Ftp,Intervention,CallToArms}Decisions`) previously re-declared the full ~14-parameter resolver list and forwarded each one individually. They now accept a single `TurnResolverConfig` plus only the resume-specific args (`game`, the decision list, and `pendingOvertures` for the overture variant).
- Added `TurnResolverConfig.copyWith` so the shared private dispatch overrides only `startFromPhase` and the relevant decision list.
- Added repo lint rule `repo.turn_resume_param_budget` (`tool/check_turn_resume_param_budget.dart` + manifest + in-process wiring + SPEC + test) enforcing that `resumeTurnResolution*` declarations stay at/under **6** named parameters, preventing regression of the parameter explosion.
- **Defensive-copy audit (Expected behavior #6):** removed unnecessary `Map.from` / `List.from` on hot paths where the underlying collection is read-only or freshly allocated (`turn_order_acceptance.dart`, `world_market_phase_carry_forward.dart`, `production_phase.dart`, `turn_resolution_events.dart`). Each removal and each retained-copy justification is documented with Given/When/Then ACs in `SPEC/program/turn-defensive-copy-audit.md`.

## Done in this push

- Config-based resume dispatch + `TurnResolverConfig.copyWith`.
- `repo.turn_resume_param_budget` lint gate + SPEC + test.
- Defensive-copy audit code + `SPEC/program/turn-defensive-copy-audit.md`.
- New `test/turn_defensive_copy_audit_test.dart`: positive identity tests proving the carry-forward pass-through branches reference the input list (no `List.from`), plus negative/regression tests proving the stockpile/capacity filtering branches still allocate a fresh kept list and record drop notes.

## Scope

- **Done in this PR:** Expected behavior #1 (config-based resume) + AC #6 parameter-budget enforcement gate (`SPEC/program/turn-resume-config-dispatch.md`) + Expected behavior #6 defensive-copy audit (`SPEC/program/turn-defensive-copy-audit.md`) with tests.
- **Already on `dev` (not this PR):** ACs #1 (dispatch consolidation), #2 (part-of removal + ban gate), #3 (conditional `toJson`), #4 (visibility index once), #5 (unified province iteration), and Expected behavior #7 (`_ResearchAllocationContext`) — landed via #3417/#3418.
- **Deferred:** none for this slice. A generic ">12 parameter" check over all turn entry points was intentionally not added, because legitimate public convenience wrappers (e.g. `resolveTurnForGame`) exceed that count by design; the issue scopes the parameter concern to "the resume wrappers", which this gate targets precisely.

## SPEC

- Added `SPEC/program/turn-resume-config-dispatch.md` (config-based resume + lint gate, Given/When/Then ACs).
- Added `SPEC/program/turn-defensive-copy-audit.md` (removed vs retained copies, Given/When/Then ACs).

## Tests

- New `test/check_turn_resume_param_budget_test.dart` (9 cases).
- New `test/turn_defensive_copy_audit_test.dart` (4 cases: carry-forward pass-through identity + filtering allocates fresh kept list).
- `dart analyze` clean on the turn package, tool, and sim_scenarios changes.

Refs #3416

Made with [Cursor](https://cursor.com)