### PR TITLE
refactor: split diplomacy phase-result value types per file (#3419)

### DIFF
--- a/packages/colonizethis_diplomacy/lib/src/diplomacy/diplomacy_phase_result.dart
+++ b/packages/colonizethis_diplomacy/lib/src/diplomacy/diplomacy_phase_result.dart
@@ -1,227 +1,30 @@
-/// Diplomacy-phase offer/decision value types and the diplomacy phase result.
+/// The Diplomacy phase result plus a single import/export surface for the
+/// per-interaction human-input value types.
 ///
-/// These pure data types describe the human-input prompts the Diplomacy phase
-/// can surface (overtures, FTP proposals, interventions, calls to arms) and the
-/// per-phase [DiplomacyPhaseResult]. They live in the diplomacy domain so the
-/// turn orchestrator's [TurnResolutionResult] (in `turn/turn_resolution_result.dart`)
-/// can depend on them one-way (turn -> diplomacy) without the diplomacy domain
-/// importing `turn/` (Refs #3290 Phase 0, eliminates the diplomacy -> turn edge).
+/// The pure data types describing the human-input prompts the Diplomacy phase
+/// can surface (overtures, FTP proposals, interventions, calls to arms) now
+/// live one-per-file under `phase_types/` (Refs #3419 step 9). This file
+/// retains [DiplomacyPhaseResult] and re-exports those value types so the
+/// existing public surface is preserved: the turn orchestrator's
+/// [TurnResolutionResult] (in `turn/turn_resolution_result.dart`) still depends
+/// on this single file one-way (turn -> diplomacy) without the diplomacy domain
+/// importing `turn/` (Refs #3290 Phase 0), and the package barrel keeps
+/// publishing every value type transitively.
 /// SPEC/program/turn-resolution-phases.md § Blocking human input;
 /// SPEC/game/diplomacy.md § Intervention.
 library;
 
 import 'package:colonizethis_models/colonizethis_models.dart';
 
-/// One overture offer awaiting the target's accept/reject decision.
-class OvertureOffer {
-  const OvertureOffer({
-    required this.offererGpId,
-    required this.targetFactionId,
-    required this.stage,
-  });
+import 'phase_types/call_to_arms_pending.dart';
+import 'phase_types/ftp_offer.dart';
+import 'phase_types/intervention_prompt.dart';
+import 'phase_types/overture_offer.dart';
 
-  final String offererGpId;
-  final String targetFactionId;
-  final OvertureStage stage;
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is OvertureOffer &&
-          offererGpId == other.offererGpId &&
-          targetFactionId == other.targetFactionId &&
-          stage == other.stage;
-
-  @override
-  int get hashCode => Object.hash(offererGpId, targetFactionId, stage);
-}
-
-/// Target's decision for one overture offer.
-class OvertureDecision {
-  const OvertureDecision({
-    required this.offererGpId,
-    required this.targetFactionId,
-    required this.stage,
-    required this.accepted,
-  });
-
-  final String offererGpId;
-  final String targetFactionId;
-  final OvertureStage stage;
-  final bool accepted;
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is OvertureDecision &&
-          offererGpId == other.offererGpId &&
-          targetFactionId == other.targetFactionId &&
-          stage == other.stage &&
-          accepted == other.accepted;
-
-  @override
-  int get hashCode =>
-      Object.hash(offererGpId, targetFactionId, stage, accepted);
-}
-
-/// Human intervention prompt after a GP declares war on a Minor or Tribe.
-/// SPEC/game/diplomacy.md § Intervention.
-class InterventionPrompt {
-  const InterventionPrompt({
-    required this.aggressorGpId,
-    required this.defenderMinorOrTribeId,
-    required this.interveningGpId,
-  });
-
-  final String aggressorGpId;
-  final String defenderMinorOrTribeId;
-  final String interveningGpId;
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is InterventionPrompt &&
-          aggressorGpId == other.aggressorGpId &&
-          defenderMinorOrTribeId == other.defenderMinorOrTribeId &&
-          interveningGpId == other.interveningGpId;
-
-  @override
-  int get hashCode => Object.hash(
-        aggressorGpId,
-        defenderMinorOrTribeId,
-        interveningGpId,
-      );
-}
-
-/// Human ally's decision for one intervention prompt.
-class InterventionDecision {
-  const InterventionDecision({
-    required this.aggressorGpId,
-    required this.defenderMinorOrTribeId,
-    required this.interveningGpId,
-    required this.choice,
-  });
-
-  final String aggressorGpId;
-  final String defenderMinorOrTribeId;
-  final String interveningGpId;
-  final InterventionChoice choice;
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is InterventionDecision &&
-          aggressorGpId == other.aggressorGpId &&
-          defenderMinorOrTribeId == other.defenderMinorOrTribeId &&
-          interveningGpId == other.interveningGpId &&
-          choice == other.choice;
-
-  @override
-  int get hashCode => Object.hash(
-        aggressorGpId,
-        defenderMinorOrTribeId,
-        interveningGpId,
-        choice,
-      );
-}
-
-/// One call-to-arms prompt: ally [allyGpId] must choose to join defender [defenderGpId]
-/// against aggressor [aggressorGpId]. SPEC/game/diplomacy.md mutual defence.
-class CallToArmsPending {
-  const CallToArmsPending({
-    required this.allyGpId,
-    required this.defenderGpId,
-    required this.aggressorGpId,
-  });
-
-  final String allyGpId;
-  final String defenderGpId;
-  final String aggressorGpId;
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is CallToArmsPending &&
-          allyGpId == other.allyGpId &&
-          defenderGpId == other.defenderGpId &&
-          aggressorGpId == other.aggressorGpId;
-
-  @override
-  int get hashCode => Object.hash(allyGpId, defenderGpId, aggressorGpId);
-}
-
-/// One FTP proposal awaiting the target GP's accept/reject decision.
-class FtpOffer {
-  const FtpOffer({
-    required this.proposerGpId,
-    required this.targetGpId,
-  });
-
-  final String proposerGpId;
-  final String targetGpId;
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is FtpOffer &&
-          proposerGpId == other.proposerGpId &&
-          targetGpId == other.targetGpId;
-
-  @override
-  int get hashCode => Object.hash(proposerGpId, targetGpId);
-}
-
-/// Target GP's decision for one [FtpOffer].
-class FtpDecision {
-  const FtpDecision({
-    required this.proposerGpId,
-    required this.targetGpId,
-    required this.accepted,
-  });
-
-  final String proposerGpId;
-  final String targetGpId;
-  final bool accepted;
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is FtpDecision &&
-          proposerGpId == other.proposerGpId &&
-          targetGpId == other.targetGpId &&
-          accepted == other.accepted;
-
-  @override
-  int get hashCode => Object.hash(proposerGpId, targetGpId, accepted);
-}
-
-/// Human ally's decision for one call to arms.
-class CallToArmsDecision {
-  const CallToArmsDecision({
-    required this.allyGpId,
-    required this.defenderGpId,
-    required this.aggressorGpId,
-    required this.accepted,
-  });
-
-  final String allyGpId;
-  final String defenderGpId;
-  final String aggressorGpId;
-  final bool accepted;
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is CallToArmsDecision &&
-          allyGpId == other.allyGpId &&
-          defenderGpId == other.defenderGpId &&
-          aggressorGpId == other.aggressorGpId &&
-          accepted == other.accepted;
-
-  @override
-  int get hashCode =>
-      Object.hash(allyGpId, defenderGpId, aggressorGpId, accepted);
-}
+export 'phase_types/call_to_arms_pending.dart';
+export 'phase_types/ftp_offer.dart';
+export 'phase_types/intervention_prompt.dart';
+export 'phase_types/overture_offer.dart';
 
 /// Result of the Diplomacy phase: complete or pending human input.
 class DiplomacyPhaseResult {

--- a/packages/colonizethis_diplomacy/lib/src/diplomacy/phase_types/call_to_arms_pending.dart
+++ b/packages/colonizethis_diplomacy/lib/src/diplomacy/phase_types/call_to_arms_pending.dart
@@ -1,0 +1,64 @@
+/// Call-to-arms (mutual-defence) human-input value types for the Diplomacy
+/// phase.
+///
+/// [CallToArmsPending] is surfaced when a human-controlled ally must choose to
+/// join a defender against an aggressor; [CallToArmsDecision] carries that
+/// ally's reply. Split out of `diplomacy_phase_result.dart` so each
+/// diplomacy-phase value type lives in its own file (Refs #3419 step 9).
+/// SPEC/game/diplomacy.md § Mutual defence;
+/// SPEC/program/turn-resolution-phases.md § Blocking human input.
+library;
+
+/// One call-to-arms prompt: ally [allyGpId] must choose to join defender
+/// [defenderGpId] against aggressor [aggressorGpId].
+/// SPEC/game/diplomacy.md mutual defence.
+class CallToArmsPending {
+  const CallToArmsPending({
+    required this.allyGpId,
+    required this.defenderGpId,
+    required this.aggressorGpId,
+  });
+
+  final String allyGpId;
+  final String defenderGpId;
+  final String aggressorGpId;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CallToArmsPending &&
+          allyGpId == other.allyGpId &&
+          defenderGpId == other.defenderGpId &&
+          aggressorGpId == other.aggressorGpId;
+
+  @override
+  int get hashCode => Object.hash(allyGpId, defenderGpId, aggressorGpId);
+}
+
+/// Human ally's decision for one call to arms.
+class CallToArmsDecision {
+  const CallToArmsDecision({
+    required this.allyGpId,
+    required this.defenderGpId,
+    required this.aggressorGpId,
+    required this.accepted,
+  });
+
+  final String allyGpId;
+  final String defenderGpId;
+  final String aggressorGpId;
+  final bool accepted;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CallToArmsDecision &&
+          allyGpId == other.allyGpId &&
+          defenderGpId == other.defenderGpId &&
+          aggressorGpId == other.aggressorGpId &&
+          accepted == other.accepted;
+
+  @override
+  int get hashCode =>
+      Object.hash(allyGpId, defenderGpId, aggressorGpId, accepted);
+}

--- a/packages/colonizethis_diplomacy/lib/src/diplomacy/phase_types/ftp_offer.dart
+++ b/packages/colonizethis_diplomacy/lib/src/diplomacy/phase_types/ftp_offer.dart
@@ -1,0 +1,54 @@
+/// Friendship-and-trade-pact (FTP) human-input value types for the Diplomacy
+/// phase.
+///
+/// [FtpOffer] is surfaced when an FTP proposal targets a human GP that must
+/// accept or reject it; [FtpDecision] carries that target GP's reply. Split out
+/// of `diplomacy_phase_result.dart` so each diplomacy-phase value type lives in
+/// its own file (Refs #3419 step 9). SPEC/game/diplomacy.md § Friendship and
+/// trade pacts; SPEC/program/turn-resolution-phases.md § Blocking human input.
+library;
+
+/// One FTP proposal awaiting the target GP's accept/reject decision.
+class FtpOffer {
+  const FtpOffer({
+    required this.proposerGpId,
+    required this.targetGpId,
+  });
+
+  final String proposerGpId;
+  final String targetGpId;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is FtpOffer &&
+          proposerGpId == other.proposerGpId &&
+          targetGpId == other.targetGpId;
+
+  @override
+  int get hashCode => Object.hash(proposerGpId, targetGpId);
+}
+
+/// Target GP's decision for one [FtpOffer].
+class FtpDecision {
+  const FtpDecision({
+    required this.proposerGpId,
+    required this.targetGpId,
+    required this.accepted,
+  });
+
+  final String proposerGpId;
+  final String targetGpId;
+  final bool accepted;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is FtpDecision &&
+          proposerGpId == other.proposerGpId &&
+          targetGpId == other.targetGpId &&
+          accepted == other.accepted;
+
+  @override
+  int get hashCode => Object.hash(proposerGpId, targetGpId, accepted);
+}

--- a/packages/colonizethis_diplomacy/lib/src/diplomacy/phase_types/intervention_prompt.dart
+++ b/packages/colonizethis_diplomacy/lib/src/diplomacy/phase_types/intervention_prompt.dart
@@ -1,0 +1,72 @@
+/// Intervention human-input value types for the Diplomacy phase.
+///
+/// [InterventionPrompt] is surfaced after a GP declares war on a Minor or Tribe
+/// when a human-controlled GP may intervene; [InterventionDecision] carries the
+/// human ally's choice. Split out of `diplomacy_phase_result.dart` so each
+/// diplomacy-phase value type lives in its own file (Refs #3419 step 9).
+/// SPEC/game/diplomacy.md § Intervention;
+/// SPEC/program/turn-resolution-phases.md § Blocking human input.
+library;
+
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+/// Human intervention prompt after a GP declares war on a Minor or Tribe.
+/// SPEC/game/diplomacy.md § Intervention.
+class InterventionPrompt {
+  const InterventionPrompt({
+    required this.aggressorGpId,
+    required this.defenderMinorOrTribeId,
+    required this.interveningGpId,
+  });
+
+  final String aggressorGpId;
+  final String defenderMinorOrTribeId;
+  final String interveningGpId;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is InterventionPrompt &&
+          aggressorGpId == other.aggressorGpId &&
+          defenderMinorOrTribeId == other.defenderMinorOrTribeId &&
+          interveningGpId == other.interveningGpId;
+
+  @override
+  int get hashCode => Object.hash(
+        aggressorGpId,
+        defenderMinorOrTribeId,
+        interveningGpId,
+      );
+}
+
+/// Human ally's decision for one intervention prompt.
+class InterventionDecision {
+  const InterventionDecision({
+    required this.aggressorGpId,
+    required this.defenderMinorOrTribeId,
+    required this.interveningGpId,
+    required this.choice,
+  });
+
+  final String aggressorGpId;
+  final String defenderMinorOrTribeId;
+  final String interveningGpId;
+  final InterventionChoice choice;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is InterventionDecision &&
+          aggressorGpId == other.aggressorGpId &&
+          defenderMinorOrTribeId == other.defenderMinorOrTribeId &&
+          interveningGpId == other.interveningGpId &&
+          choice == other.choice;
+
+  @override
+  int get hashCode => Object.hash(
+        aggressorGpId,
+        defenderMinorOrTribeId,
+        interveningGpId,
+        choice,
+      );
+}

--- a/packages/colonizethis_diplomacy/lib/src/diplomacy/phase_types/overture_offer.dart
+++ b/packages/colonizethis_diplomacy/lib/src/diplomacy/phase_types/overture_offer.dart
@@ -1,0 +1,62 @@
+/// Overture-stage human-input value types for the Diplomacy phase.
+///
+/// [OvertureOffer] is surfaced when a GP's overture targets a human GP that
+/// must accept or reject it; [OvertureDecision] carries that target's reply.
+/// Split out of `diplomacy_phase_result.dart` so each diplomacy-phase value
+/// type lives in its own file (Refs #3419 step 9). SPEC/game/diplomacy.md
+/// § Overtures; SPEC/program/turn-resolution-phases.md § Blocking human input.
+library;
+
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+/// One overture offer awaiting the target's accept/reject decision.
+class OvertureOffer {
+  const OvertureOffer({
+    required this.offererGpId,
+    required this.targetFactionId,
+    required this.stage,
+  });
+
+  final String offererGpId;
+  final String targetFactionId;
+  final OvertureStage stage;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is OvertureOffer &&
+          offererGpId == other.offererGpId &&
+          targetFactionId == other.targetFactionId &&
+          stage == other.stage;
+
+  @override
+  int get hashCode => Object.hash(offererGpId, targetFactionId, stage);
+}
+
+/// Target's decision for one overture offer.
+class OvertureDecision {
+  const OvertureDecision({
+    required this.offererGpId,
+    required this.targetFactionId,
+    required this.stage,
+    required this.accepted,
+  });
+
+  final String offererGpId;
+  final String targetFactionId;
+  final OvertureStage stage;
+  final bool accepted;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is OvertureDecision &&
+          offererGpId == other.offererGpId &&
+          targetFactionId == other.targetFactionId &&
+          stage == other.stage &&
+          accepted == other.accepted;
+
+  @override
+  int get hashCode =>
+      Object.hash(offererGpId, targetFactionId, stage, accepted);
+}

--- a/packages/colonizethis_diplomacy/test/diplomacy_phase_types_split_test.dart
+++ b/packages/colonizethis_diplomacy/test/diplomacy_phase_types_split_test.dart
@@ -1,0 +1,131 @@
+import 'package:colonizethis_test/test.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+// Deep imports of the per-interaction value-type files: each file must be
+// self-contained and constructible without the aggregator
+// `diplomacy_phase_result.dart` (Refs #3419 step 9).
+import 'package:colonizethis_diplomacy/src/diplomacy/phase_types/call_to_arms_pending.dart';
+import 'package:colonizethis_diplomacy/src/diplomacy/phase_types/ftp_offer.dart';
+import 'package:colonizethis_diplomacy/src/diplomacy/phase_types/intervention_prompt.dart';
+import 'package:colonizethis_diplomacy/src/diplomacy/phase_types/overture_offer.dart';
+
+// Aggregator must continue to re-export every value type (preserved public
+// surface for the package barrel and the turn package's narrow re-export).
+import 'package:colonizethis_diplomacy/src/diplomacy/diplomacy_phase_result.dart'
+    as aggregator;
+
+/// Gates that splitting `diplomacy_phase_result.dart` into one file per
+/// interaction family (Refs #3419 step 9) is behaviour-preserving: each new
+/// file is independently importable and the aggregator still exposes the full
+/// symbol surface.
+void main() {
+  group('per-type files are self-contained (deep import)', () {
+    test('positive: each value type is constructible from its own file', () {
+      const overture = OvertureOffer(
+        offererGpId: 'gp1',
+        targetFactionId: 'gp2',
+        stage: OvertureStage.embassy,
+      );
+      const overtureDecision = OvertureDecision(
+        offererGpId: 'gp1',
+        targetFactionId: 'gp2',
+        stage: OvertureStage.embassy,
+        accepted: true,
+      );
+      const ftp = FtpOffer(proposerGpId: 'gp1', targetGpId: 'gp2');
+      const ftpDecision =
+          FtpDecision(proposerGpId: 'gp1', targetGpId: 'gp2', accepted: false);
+      const intervention = InterventionPrompt(
+        aggressorGpId: 'gp1',
+        defenderMinorOrTribeId: 'minor1',
+        interveningGpId: 'gp2',
+      );
+      const interventionDecision = InterventionDecision(
+        aggressorGpId: 'gp1',
+        defenderMinorOrTribeId: 'minor1',
+        interveningGpId: 'gp2',
+        choice: InterventionChoice.intervene,
+      );
+      const callToArms = CallToArmsPending(
+        allyGpId: 'gp1',
+        defenderGpId: 'gp2',
+        aggressorGpId: 'gp3',
+      );
+      const callToArmsDecision = CallToArmsDecision(
+        allyGpId: 'gp1',
+        defenderGpId: 'gp2',
+        aggressorGpId: 'gp3',
+        accepted: true,
+      );
+
+      expect(overture.stage, OvertureStage.embassy);
+      expect(overtureDecision.accepted, isTrue);
+      expect(ftp.targetGpId, 'gp2');
+      expect(ftpDecision.accepted, isFalse);
+      expect(intervention.interveningGpId, 'gp2');
+      expect(interventionDecision.choice, InterventionChoice.intervene);
+      expect(callToArms.aggressorGpId, 'gp3');
+      expect(callToArmsDecision.accepted, isTrue);
+    });
+
+    test('negative: deep-import and aggregator-exported types are identical',
+        () {
+      // The aggregator re-export must resolve to the same class as the deep
+      // import (no shadow/duplicate type introduced by the split).
+      const fromFile = OvertureOffer(
+        offererGpId: 'gp1',
+        targetFactionId: 'gp2',
+        stage: OvertureStage.nap,
+      );
+      const aggregator.OvertureOffer fromAggregator = OvertureOffer(
+        offererGpId: 'gp1',
+        targetFactionId: 'gp2',
+        stage: OvertureStage.nap,
+      );
+      expect(fromFile, equals(fromAggregator));
+      expect(fromFile.runtimeType, fromAggregator.runtimeType);
+    });
+  });
+
+  group('aggregator re-exports preserve the full value-type surface', () {
+    test('positive: DiplomacyPhaseResult builds with each pending list', () {
+      final game = Game(
+        id: 'g',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+        ),
+        players: const [Player(id: 'gp1', displayName: 'A', isHuman: true)],
+      );
+      final result = aggregator.DiplomacyPhaseResult(
+        game,
+        pendingOvertures: const [
+          OvertureOffer(
+            offererGpId: 'gp1',
+            targetFactionId: 'gp2',
+            stage: OvertureStage.embassy,
+          ),
+        ],
+        pendingFtpOffers: const [
+          FtpOffer(proposerGpId: 'gp1', targetGpId: 'gp2'),
+        ],
+        pendingInterventions: const [
+          InterventionPrompt(
+            aggressorGpId: 'gp1',
+            defenderMinorOrTribeId: 'minor1',
+            interveningGpId: 'gp2',
+          ),
+        ],
+        pendingCallToArms: const [
+          CallToArmsPending(
+            allyGpId: 'gp1',
+            defenderGpId: 'gp2',
+            aggressorGpId: 'gp3',
+          ),
+        ],
+      );
+      expect(result.isPending, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Completes the last remaining target-state item for #3419 — **step 9**: split `diplomacy_phase_result.dart` into one file per interaction family. Behaviour-preserving structural refactor; no SPEC behaviour changes, no new features.

`Refs #3419`

## Done in this push

- Moved the per-interaction human-input value types out of `diplomacy_phase_result.dart` into `lib/src/diplomacy/phase_types/`:
  - `overture_offer.dart` — `OvertureOffer`, `OvertureDecision`
  - `ftp_offer.dart` — `FtpOffer`, `FtpDecision`
  - `intervention_prompt.dart` — `InterventionPrompt`, `InterventionDecision`
  - `call_to_arms_pending.dart` — `CallToArmsPending`, `CallToArmsDecision`
- `diplomacy_phase_result.dart` retains `DiplomacyPhaseResult` and `export`s the four new files, so the public symbol surface is unchanged:
  - the `colonizethis_diplomacy` barrel still publishes every value type transitively, and
  - the turn package's deliberate narrow deep `export 'package:colonizethis_diplomacy/src/diplomacy/diplomacy_phase_result.dart'` (`turn -> diplomacy` one-way edge, per `SPEC/program/logic-package-barrel-contracts.md` line 61) still re-exports all value types.

## Scope

- **Done in this push:** target-state step 9 (split per value type) for #3419.
- **Already on `dev` (prior PRs #3420/#3421):** dedup steps 1-4, `part of` removal + CI gate (step 8), `upsertRelation` index-map (step 5), intervention O(1) lookup (step 6), `appendDiplomaticEvent` intra-turn tally (step 7, threaded through all resolvers via `diplomacy_resolver.dart`), evidence/dialogue guard consolidation (steps 10-11), overture-handler split (step 12).
- **Deferred:** none. This was the only outstanding target-state item.

## SPEC

None — structural-only, no behaviour change. The narrow re-export contract this preserves is documented in `SPEC/program/logic-package-barrel-contracts.md`.

## Tests

- New `test/diplomacy_phase_types_split_test.dart`: positive (each new file is self-contained via deep-import construction; aggregator builds `DiplomacyPhaseResult` with each pending list) and negative (deep-import type and aggregator-exported type resolve to the **same** class — no shadow/duplicate type introduced).
- Existing `test/diplomacy_phase_result_value_types_test.dart` (value-equality + `isPending`) continues to pass via the barrel.
- Full package suite green: **217 tests passed** (`dart test`).
- `dart analyze lib test` clean for the changed/added files (the 6 remaining notes are pre-existing on `dev`, e.g. `overture_resolver.dart:4`, unrelated to this change).

Made with [Cursor](https://cursor.com)