### PR TITLE
refactor: economy phase 1–2 quick wins and extraction pipeline (#3427)

### DIFF
--- a/packages/colonizethis_economy/lib/colonizethis_economy.dart
+++ b/packages/colonizethis_economy/lib/colonizethis_economy.dart
@@ -24,6 +24,7 @@ export 'src/economy/world_market/purchased_tile_index.dart';
 export 'src/economy/world_market/purchased_tile_riches.dart';
 export 'src/economy/world_market/sellable_quantity.dart';
 export 'src/economy/world_market/trade_order_suggester.dart';
+export 'src/economy/world_market/trade_order_validation_context.dart';
 export 'src/economy/world_market/trade_order_validator.dart';
 export 'src/economy/world_market/treasury_bid_budget.dart';
 export 'src/validation/order_validation_result.dart';

--- a/packages/colonizethis_economy/lib/src/economy/non_gp_extraction.dart
+++ b/packages/colonizethis_economy/lib/src/economy/non_gp_extraction.dart
@@ -3,10 +3,10 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'economy_resource_constants.dart';
 import 'game_lookup_helpers.dart';
+import 'tile_extraction_pipeline.dart';
 import 'tile_extraction_yield.dart';
 import 'package:colonizethis_economy/src/logging.dart';
 import 'package:colonizethis_world/colonizethis_world.dart';
-import 'package:colonizethis_world/src/world/tile_key_coordinates.dart';
 
 /// Per-faction extraction for non-Great-Power factions (Minor Nations and
 /// Tribes). Mirrors the per-tile formula in
@@ -311,37 +311,26 @@ _NonGpTileContribution? _computeNonGpTileContribution({
   if (!connectedTileKeys.contains(tileKey)) {
     return null;
   }
-  final coords = parseTileKeyCoordinates(tileKey);
-  if (coords == null) return null;
-  if (coords.x < 0 || coords.y < 0) return null;
 
-  final map = tileMapByRegion[coords.regionId];
-  if (map == null) return null;
+  final tileContext = resolveTileKeyExtractionContext(
+    tileKey: tileKey,
+    tileMapByRegion: tileMapByRegion,
+    provincesByFullId: provincesByFullId,
+    logContext: 'non_gp_extraction',
+  );
+  if (tileContext == null) {
+    return null;
+  }
 
-  final resource = map.resourceAt(coords.x, coords.y);
-  if (resource == null) return null;
-
-  // Resource enum name is the canonical commodity id; matches the existing
-  // GP-side `_resourceToCommodityId` switch (see resource_extractor.dart) and
-  // `kMineralResourceIds` membership check in constants.dart.
-  final CommodityId commodityId = resource.name;
-
+  final commodityId = tileContext.commodityId;
   if (kMineralResourceIds.contains(commodityId)) {
     // Non-GP factions never prospect — exclude minerals unconditionally per
     // SPEC/game/extraction-and-improvements.md § Non-Great-Power extraction.
     return null;
   }
 
-  final provinceId = '${coords.regionId}|${coords.provinceLocalId}';
-  final province = provincesByFullId[provinceId];
-  if (province == null) {
-    final msg =
-        'non_gp_extraction province missing tileKey=$tileKey '
-        'provinceId=$provinceId (region-scoped lookup failed; '
-        'SPEC/game/world-model-identity.md)';
-    economyLog.e(msg, error: StateError(msg), stackTrace: StackTrace.current);
-    return null;
-  }
+  final province = tileContext.province;
+  final provinceId = tileContext.provinceId;
 
   final townDevelopmentCap = province.townDevelopmentLevel;
   final townTileKey = province.townTileKey;
@@ -371,19 +360,23 @@ _NonGpTileContribution? _computeNonGpTileContribution({
   // The faction-capital-region check is preserved for parity with the GP
   // helper; in current SPEC every owned non-GP tile is same-region, so this
   // branch is informational only — non-GP output is always land-only.
-  final isLandRelativeToCapital = coords.regionId == factionCapitalRegionId;
+  final isLandRelativeToCapital =
+      tileContext.regionId == factionCapitalRegionId;
   if (!isLandRelativeToCapital) {
     // Non-GP factions cannot own tiles outside their capital region under
     // current SPEC; emit a debug log and skip so this stays observable if a
     // future ruleset changes that invariant.
     economyLog.d(
       'non_gp_extraction skip overseas tile factionCapitalRegionId='
-      '$factionCapitalRegionId tileRegionId=${coords.regionId} '
+      '$factionCapitalRegionId tileRegionId=${tileContext.regionId} '
       'tileKey=$tileKey',
     );
     return null;
   }
-  return _NonGpTileContribution(commodityId: commodityId, units: effective);
+  return _NonGpTileContribution(
+    commodityId: tileContext.commodityId,
+    units: effective,
+  );
 }
 
 class _NonGpTileContribution {

--- a/packages/colonizethis_economy/lib/src/economy/resource_extractor.dart
+++ b/packages/colonizethis_economy/lib/src/economy/resource_extractor.dart
@@ -4,9 +4,9 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'economy_resource_constants.dart';
 import 'game_lookup_helpers.dart';
+import 'tile_extraction_pipeline.dart';
 import 'tile_extraction_yield.dart';
 import 'package:colonizethis_world/colonizethis_world.dart';
-import 'package:colonizethis_world/src/world/tile_key_coordinates.dart';
 
 /// Per-player extraction totals: land (same region as capital) vs overseas.
 class ExtractionTotals {
@@ -156,25 +156,19 @@ TileExtractionContribution? computeTileExtractionContributionForPlayer({
   if (!connectedTileKeys.contains(tileKey)) {
     return null;
   }
-  final coords = parseTileKeyCoordinates(tileKey);
-  if (coords == null) {
-    return null;
-  }
-  if (coords.x < 0 || coords.y < 0) {
+
+  final tileContext = resolveTileKeyExtractionContext(
+    tileKey: tileKey,
+    tileMapByRegion: tileMapByRegion,
+    provincesByFullId: provincesByFullId,
+    game: game,
+    logContext: 'extraction',
+  );
+  if (tileContext == null) {
     return null;
   }
 
-  final map = tileMapByRegion[coords.regionId];
-  if (map == null) {
-    return null;
-  }
-
-  final resource = map.resourceAt(coords.x, coords.y);
-  if (resource == null) {
-    return null;
-  }
-
-  final CommodityId commodityId = resource.name;
+  final commodityId = tileContext.commodityId;
   final techCap =
       techCapForPlayerAndResource?.call(player.id, commodityId) ??
       techCapForPlayer(player.id);
@@ -183,18 +177,8 @@ TileExtractionContribution? computeTileExtractionContributionForPlayer({
     return null;
   }
 
-  // Province lookup must be region-scoped. SPEC/game/world-model-identity.md.
-  final provinceId = '${coords.regionId}|${coords.provinceLocalId}';
-  final province = provincesByFullId != null
-      ? provincesByFullId[provinceId]
-      : game.worldState.tryGetProvince(provinceId);
-  if (province == null) {
-    final msg =
-        'extraction province missing tileKey=$tileKey provinceId=$provinceId '
-        '(region-scoped lookup failed; SPEC/game/world-model-identity.md)';
-    economyLog.e(msg, error: StateError(msg), stackTrace: StackTrace.current);
-    return null;
-  }
+  final province = tileContext.province;
+  final provinceId = tileContext.provinceId;
   final townDevelopmentCap = province.townDevelopmentLevel;
   final townTileKey = province.townTileKey;
   final townTileIsPort =
@@ -221,7 +205,7 @@ TileExtractionContribution? computeTileExtractionContributionForPlayer({
     tileKey: tileKey,
     commodityId: commodityId,
     units: effectiveCapped,
-    isLandRelativeToCapital: coords.regionId == capitalRegionId,
+    isLandRelativeToCapital: tileContext.regionId == capitalRegionId,
   );
 }
 

--- a/packages/colonizethis_economy/lib/src/economy/resource_extractor.dart
+++ b/packages/colonizethis_economy/lib/src/economy/resource_extractor.dart
@@ -174,7 +174,7 @@ TileExtractionContribution? computeTileExtractionContributionForPlayer({
     return null;
   }
 
-  final commodityId = _resourceToCommodityId(resource);
+  final CommodityId commodityId = resource.name;
   final techCap =
       techCapForPlayerAndResource?.call(player.id, commodityId) ??
       techCapForPlayer(player.id);
@@ -226,44 +226,3 @@ TileExtractionContribution? computeTileExtractionContributionForPlayer({
 }
 
 int _defaultTechCap(String playerId) => defaultExtractionCap;
-
-CommodityId _resourceToCommodityId(Resource resource) {
-  switch (resource) {
-    case Resource.grain:
-      return 'grain';
-    case Resource.meat:
-      return 'meat';
-    case Resource.wool:
-      return 'wool';
-    case Resource.horses:
-      return 'horses';
-    case Resource.timber:
-      return 'timber';
-    case Resource.iron:
-      return 'iron';
-    case Resource.copper:
-      return 'copper';
-    case Resource.tin:
-      return 'tin';
-    case Resource.coal:
-      return 'coal';
-    case Resource.sugarCane:
-      return 'sugarCane';
-    case Resource.tobacco:
-      return 'tobacco';
-    case Resource.cotton:
-      return 'cotton';
-    case Resource.furs:
-      return 'furs';
-    case Resource.spices:
-      return 'spices';
-    case Resource.silver:
-      return 'silver';
-    case Resource.gold:
-      return 'gold';
-    case Resource.gems:
-      return 'gems';
-    case Resource.diamonds:
-      return 'diamonds';
-  }
-}

--- a/packages/colonizethis_economy/lib/src/economy/tile_extraction_pipeline.dart
+++ b/packages/colonizethis_economy/lib/src/economy/tile_extraction_pipeline.dart
@@ -1,0 +1,134 @@
+/// Shared tile-key → map → resource → province resolution for extraction paths.
+///
+/// Great-Power extraction ([computeTileExtractionContributionForPlayer] in
+/// `resource_extractor.dart`), non-GP extraction (`_computeNonGpTileContribution`
+/// in `non_gp_extraction.dart`), and purchased-tile riches
+/// ([computePurchasedTileRichesCredits] in `purchased_tile_riches.dart`) all
+/// performed the same parse → coordinates → map → resource → commodity-id steps
+/// independently. This module holds that shared pipeline; callers supply the
+/// documented per-path gates (prospecting, mineral exclusion, riches filter) and
+/// yield math via [computeEffectiveTileYield].
+library;
+
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_economy/src/logging.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_world/colonizethis_world.dart';
+import 'package:colonizethis_world/src/world/tile_key_coordinates.dart';
+
+/// Tile key resolved through map lookup to a [Resource] and [CommodityId].
+class TileKeyResourceContext {
+  const TileKeyResourceContext({
+    required this.tileKey,
+    required this.regionId,
+    required this.provinceLocalId,
+    required this.x,
+    required this.y,
+    required this.resource,
+    required this.commodityId,
+  });
+
+  final String tileKey;
+  final String regionId;
+  final String provinceLocalId;
+  final int x;
+  final int y;
+  final Resource resource;
+  final CommodityId commodityId;
+
+  /// Region-scoped province id per `SPEC/game/world-model-identity.md`.
+  String get provinceId => '$regionId|$provinceLocalId';
+}
+
+/// [TileKeyResourceContext] extended with a resolved [Province] row.
+class TileKeyExtractionContext {
+  const TileKeyExtractionContext({
+    required this.resourceContext,
+    required this.province,
+  });
+
+  final TileKeyResourceContext resourceContext;
+  final Province province;
+
+  String get tileKey => resourceContext.tileKey;
+  CommodityId get commodityId => resourceContext.commodityId;
+  String get provinceId => resourceContext.provinceId;
+  String get regionId => resourceContext.regionId;
+}
+
+/// Parses [tileKey], resolves the region map, and returns the tile [Resource].
+///
+/// Returns null when the key is invalid, coordinates are negative, the region
+/// map is missing, or the tile has no resource. [commodityId] is always
+/// [Resource.name] — the canonical mapping shared across all extraction paths.
+TileKeyResourceContext? resolveTileKeyResourceContext({
+  required String tileKey,
+  required Map<String, TileMapResult> tileMapByRegion,
+}) {
+  final coords = parseTileKeyCoordinates(tileKey);
+  if (coords == null) {
+    return null;
+  }
+  if (coords.x < 0 || coords.y < 0) {
+    return null;
+  }
+
+  final map = tileMapByRegion[coords.regionId];
+  if (map == null) {
+    return null;
+  }
+
+  final resource = map.resourceAt(coords.x, coords.y);
+  if (resource == null) {
+    return null;
+  }
+
+  return TileKeyResourceContext(
+    tileKey: tileKey,
+    regionId: coords.regionId,
+    provinceLocalId: coords.provinceLocalId,
+    x: coords.x,
+    y: coords.y,
+    resource: resource,
+    commodityId: resource.name,
+  );
+}
+
+/// Resolves [resolveTileKeyResourceContext] and looks up the owning [Province].
+///
+/// [provincesByFullId] is preferred when supplied (built once per extraction
+/// pass). When absent or missing the row, [game] is consulted via
+/// [WorldState.tryGetProvince]. Returns null and logs when the province row
+/// cannot be resolved.
+TileKeyExtractionContext? resolveTileKeyExtractionContext({
+  required String tileKey,
+  required Map<String, TileMapResult> tileMapByRegion,
+  Map<String, Province>? provincesByFullId,
+  Game? game,
+  required String logContext,
+}) {
+  final resourceContext = resolveTileKeyResourceContext(
+    tileKey: tileKey,
+    tileMapByRegion: tileMapByRegion,
+  );
+  if (resourceContext == null) {
+    return null;
+  }
+
+  final provinceId = resourceContext.provinceId;
+  final province =
+      provincesByFullId?[provinceId] ??
+      game?.worldState.tryGetProvince(provinceId);
+  if (province == null) {
+    final msg =
+        '$logContext province missing tileKey=$tileKey provinceId=$provinceId '
+        '(region-scoped lookup failed; SPEC/game/world-model-identity.md)';
+    economyLog.e(msg, error: StateError(msg), stackTrace: StackTrace.current);
+    return null;
+  }
+
+  return TileKeyExtractionContext(
+    resourceContext: resourceContext,
+    province: province,
+  );
+}

--- a/packages/colonizethis_economy/lib/src/economy/world_market/purchased_tile_riches.dart
+++ b/packages/colonizethis_economy/lib/src/economy/world_market/purchased_tile_riches.dart
@@ -35,7 +35,7 @@ library;
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
-import 'package:colonizethis_world/src/world/tile_key_coordinates.dart';
+import '../tile_extraction_pipeline.dart';
 import '../tile_extraction_yield.dart';
 import 'purchased_tile_index.dart';
 
@@ -190,17 +190,13 @@ PurchasedTileRichesResult computePurchasedTileRichesCredits({
 
   for (final attribution in attributions) {
     final tileKey = attribution.tileKey;
-    final coords = parseTileKeyCoordinates(tileKey);
-    if (coords == null) continue;
-    if (coords.x < 0 || coords.y < 0) continue;
+    final resourceContext = resolveTileKeyResourceContext(
+      tileKey: tileKey,
+      tileMapByRegion: tileMapByRegion,
+    );
+    if (resourceContext == null) continue;
 
-    final map = tileMapByRegion[coords.regionId];
-    if (map == null) continue;
-
-    final resource = map.resourceAt(coords.x, coords.y);
-    if (resource == null) continue;
-
-    final CommodityId commodityId = resource.name;
+    final commodityId = resourceContext.commodityId;
     if (!richesCommodityIds.contains(commodityId)) continue;
 
     final basePrice = richesBasePrice(commodityId);

--- a/packages/colonizethis_economy/lib/src/economy/world_market/purchased_tile_riches.dart
+++ b/packages/colonizethis_economy/lib/src/economy/world_market/purchased_tile_riches.dart
@@ -36,7 +36,15 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'package:colonizethis_world/src/world/tile_key_coordinates.dart';
+import '../tile_extraction_yield.dart';
 import 'purchased_tile_index.dart';
+
+/// Sentinel town-development cap passed to [computeEffectiveTileYield] from the
+/// purchased-tile riches path. The town-cap branches are never entered here
+/// (not a capital province, no road-rule/port-town path), so this value is
+/// never applied; it stays at the maximum tile yield so any future change that
+/// enters a town-cap branch cannot silently clamp purchased-tile riches.
+const int _townDevelopmentCapDisabled = 4;
 
 /// Per-tile riches credit produced by [computePurchasedTileRichesCredits].
 ///
@@ -198,19 +206,23 @@ PurchasedTileRichesResult computePurchasedTileRichesCredits({
     final basePrice = richesBasePrice(commodityId);
     if (basePrice <= 0) continue;
 
-    final improvementLevel = tileState.improvementLevel(tileKey).clamp(0, 4);
-    if (improvementLevel <= 0) continue;
-
-    final roadLevel = tileState.roadLevel(tileKey);
-    final isPort = portTileKeys.contains(tileKey);
-    final tileTransportLevel = isPort ? 4 : (roadLevel > 0 ? roadLevel : 0);
-
-    const techCap = defaultExtractionCap;
-    final production = (improvementLevel < techCap ? improvementLevel : techCap)
-        .clamp(0, 4);
-    final effective =
-        (production < tileTransportLevel ? production : tileTransportLevel)
-            .clamp(0, 4);
+    // Purchased-tile riches deliberately skip the town-development cap: the
+    // owning GP's purchase authorizes the yield independent of the source
+    // province's town development (see SPEC § Riches handoff). The shared
+    // [computeEffectiveTileYield] math is reused with the town-cap branches
+    // disabled (not capital, no road-rule/port-town path) and an empty
+    // `pathTransportCap` so the per-tile transport level governs the cap.
+    final effective = computeEffectiveTileYield(
+      tileState: tileState,
+      tileKey: tileKey,
+      techCap: defaultExtractionCap,
+      townDevelopmentCap: _townDevelopmentCapDisabled,
+      townTileIsPort: false,
+      isCapitalProvince: false,
+      usesRoadRule: false,
+      portTileKeys: portTileKeys,
+      pathTransportCap: const <String, int>{},
+    );
     if (effective <= 0) continue;
 
     final treasuryDelta = (effective * basePrice * richesCashMultiplier)

--- a/packages/colonizethis_economy/lib/src/economy/world_market/trade_order_validation_context.dart
+++ b/packages/colonizethis_economy/lib/src/economy/world_market/trade_order_validation_context.dart
@@ -1,0 +1,138 @@
+/// Trade-order validation context and rejection-reason codes for the world
+/// market.
+///
+/// SPEC/game/world-market.md § Trade orders,
+/// SPEC/program/world-market-resolution.md § Trade order validation.
+///
+/// This file carries the *context-building* concern: the stable rejection
+/// reason codes, the pre-computed [TradeOrderValidationContext] inputs, and
+/// the [tradeOrderValidationContextFromGame] factory. Rule evaluation lives in
+/// `trade_order_validator.dart`. Both are re-exported from the same
+/// `colonizethis_economy` barrel, so callers are unaffected by the split.
+///
+library;
+
+import 'package:colonizethis_data/colonizethis_data.dart' as data;
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import 'bid_type_cap.dart' show worldMarketBidTypeCap;
+import '../sea_transport.dart' show cargoHoldsForHomeFleet;
+import 'sellable_quantity.dart' show offerCapByCommodityId;
+import 'world_market_context_base.dart';
+import 'treasury_bid_budget.dart'
+    show stagedBidTotalSpendByPlayer, treasuryAvailableForBidsByPlayer;
+
+/// Stable rejection-reason codes returned by `TradeOrderValidator.validate`.
+///
+/// UI, suggestion code, and tests should branch on these constants rather
+/// than parsing the free-text `OrderValidationResult.reason`. Codes line up
+/// 1:1 with the rules table in
+/// `SPEC/program/world-market-resolution.md § Validation rules`.
+abstract final class TradeOrderRejectionReasons {
+  /// Rule 1 — `TradeOrder.quantity > 0`.
+  static const String invalidQuantity = 'trade_order_invalid_quantity';
+
+  /// Rule 2 — Commodity is in `richesCommodityIds` and may not trade on the
+  /// world market.
+  static const String richesNotTradeable = 'trade_order_riches_not_tradeable';
+
+  /// Rule 3 — The same commodity appears as both a bid and an offer in the
+  /// submitted set. Both sides are rejected.
+  static const String mutualExclusion = 'trade_order_mutual_exclusion';
+
+  /// Rule 4 — Distinct bid commodity count exceeds the player's
+  /// `worldMarketBidTypeCap`.
+  static const String bidTypeCapExceeded = 'trade_order_bid_type_cap_exceeded';
+
+  /// Rule 5 — Cross-commodity bid spend would exceed `treasuryBudgetForBids`.
+  static const String bidExceedsTreasuryBudget =
+      'trade_order_bid_exceeds_treasury_budget';
+
+  /// Rule 6 — Per-commodity bid quantity exceeds `tradeCargoCapacity`.
+  static const String bidExceedsCargoCapacity =
+      'trade_order_bid_exceeds_cargo_capacity';
+
+  /// Rule 7 — Per-commodity offer quantity exceeds
+  /// `availableStockpileByCommodityId[commodityId] ?? 0`.
+  static const String offerExceedsStockpile =
+      'trade_order_offer_exceeds_stockpile';
+}
+
+/// Inputs for one `TradeOrderValidator.validate` pass.
+///
+/// All fields are pre-computed by the caller. The validator never touches
+/// the `Game` directly — keeping it pure makes it trivially reusable from
+/// the order engine, AI planner, and tests without mocking.
+class TradeOrderValidationContext extends WorldMarketContextBase {
+  TradeOrderValidationContext({
+    required super.playerId,
+    required super.bidTypeCap,
+    required super.tradeCargoCapacity,
+    required super.availableStockpileByCommodityId,
+    required this.treasuryBudgetForBids,
+    this.worldMarketState = const WorldMarketState(),
+    data.ResourceRules? resourceRules,
+  }) : resourceRules = resourceRules ?? data.ResourceRules.defaultRules;
+
+  /// Maximum `Σ (quantity × effectiveMarketPrice)` across admitted bids this
+  /// turn (`SPEC/game/world-market.md` § Treasury budget for bids).
+  final int treasuryBudgetForBids;
+
+  /// Market prices used to price bid spend (integer treasury units).
+  final WorldMarketState worldMarketState;
+
+  /// Catalog fallback prices when [worldMarketState.prices] lacks an entry.
+  final data.ResourceRules resourceRules;
+}
+
+/// Builds a [TradeOrderValidationContext] from live [Game] state for order
+/// submission and [OrderEngine] validation.
+///
+/// When [stagedOrders] and [projectedTreasuryDelta] are supplied, the treasury
+/// bid budget subtracts projected non-bid deficits (same composition as the
+/// Trade UI per `SPEC/ui/trade-screen.md` § treasury bid cap). The caller
+/// supplies [projectedTreasuryDelta] — the signed net treasury change for the
+/// turn under the staged orders (the `projectOrderEffects(...).treasuryDelta`
+/// dry-run, which is a `turn`-layer operation and so is computed by the order
+/// engine / UI rather than here, keeping `colonizethis_economy` free of any
+/// `orders`/`turn` dependency per `SPEC/program/logic-package-split-phase0.md`
+/// § economy ↔ orders). The non-bid contribution is reconstructed by adding
+/// this player's running bid spend back to [projectedTreasuryDelta]. When
+/// either argument is omitted the budget is raw treasury only.
+TradeOrderValidationContext tradeOrderValidationContextFromGame(
+  Game game,
+  String playerId, {
+  Orders? stagedOrders,
+  int? projectedTreasuryDelta,
+}) {
+  final rules = data.ResourceRules.defaultRules;
+  var treasuryBudget = treasuryAvailableForBidsByPlayer(
+    game: game,
+    playerId: playerId,
+  );
+  if (stagedOrders != null && projectedTreasuryDelta != null) {
+    final int bidSpend = stagedBidTotalSpendByPlayer(
+      orders: stagedOrders,
+      playerId: playerId,
+      game: game,
+      resourceRules: rules,
+    );
+    treasuryBudget = treasuryAvailableForBidsByPlayer(
+      game: game,
+      playerId: playerId,
+      projectedNonBidTreasuryDelta: projectedTreasuryDelta + bidSpend,
+    );
+  }
+  return TradeOrderValidationContext(
+    playerId: playerId,
+    bidTypeCap: worldMarketBidTypeCap(game, playerId),
+    tradeCargoCapacity: cargoHoldsForHomeFleet(game, playerId),
+    availableStockpileByCommodityId: offerCapByCommodityId(
+      game: game,
+      playerId: playerId,
+    ),
+    treasuryBudgetForBids: treasuryBudget,
+    worldMarketState: game.worldMarketState,
+    resourceRules: rules,
+  );
+}

--- a/packages/colonizethis_economy/lib/src/economy/world_market/trade_order_validator.dart
+++ b/packages/colonizethis_economy/lib/src/economy/world_market/trade_order_validator.dart
@@ -1,4 +1,4 @@
-/// Trade-order validation for the world market.
+/// Trade-order validation rules for the world market.
 ///
 /// SPEC/game/world-market.md § Trade orders,
 /// SPEC/program/world-market-resolution.md § Trade order validation.
@@ -8,136 +8,19 @@
 /// resolver-prep paths under the 15-second turn-resolution budget per
 /// `.cursor/rules/colonizethis-turn-resolution-budget.mdc`.
 ///
+/// The context-building concern ([TradeOrderValidationContext], the
+/// [TradeOrderRejectionReasons] codes, and `tradeOrderValidationContextFromGame`)
+/// lives in `trade_order_validation_context.dart`; both files are re-exported
+/// from the `colonizethis_economy` barrel so callers import from one path.
+///
 library;
 
 import 'package:colonizethis_data/colonizethis_data.dart' as data;
 import 'package:colonizethis_models/colonizethis_models.dart';
 
-import 'bid_type_cap.dart' show worldMarketBidTypeCap;
-import '../sea_transport.dart' show cargoHoldsForHomeFleet;
 import 'package:colonizethis_economy/src/validation/order_validation_result.dart';
-import 'sellable_quantity.dart' show offerCapByCommodityId;
-import 'world_market_context_base.dart';
-import 'treasury_bid_budget.dart'
-    show
-        effectiveMarketPriceForCommodityId,
-        stagedBidTotalSpendByPlayer,
-        treasuryAvailableForBidsByPlayer;
-
-/// Stable rejection-reason codes returned by [TradeOrderValidator.validate].
-///
-/// UI, suggestion code, and tests should branch on these constants rather
-/// than parsing the free-text [OrderValidationResult.reason]. Codes line up
-/// 1:1 with the rules table in
-/// `SPEC/program/world-market-resolution.md § Validation rules`.
-abstract final class TradeOrderRejectionReasons {
-  /// Rule 1 — `TradeOrder.quantity > 0`.
-  static const String invalidQuantity = 'trade_order_invalid_quantity';
-
-  /// Rule 2 — Commodity is in `richesCommodityIds` and may not trade on the
-  /// world market.
-  static const String richesNotTradeable = 'trade_order_riches_not_tradeable';
-
-  /// Rule 3 — The same commodity appears as both a bid and an offer in the
-  /// submitted set. Both sides are rejected.
-  static const String mutualExclusion = 'trade_order_mutual_exclusion';
-
-  /// Rule 4 — Distinct bid commodity count exceeds the player's
-  /// `worldMarketBidTypeCap`.
-  static const String bidTypeCapExceeded = 'trade_order_bid_type_cap_exceeded';
-
-  /// Rule 5 — Cross-commodity bid spend would exceed `treasuryBudgetForBids`.
-  static const String bidExceedsTreasuryBudget =
-      'trade_order_bid_exceeds_treasury_budget';
-
-  /// Rule 6 — Per-commodity bid quantity exceeds `tradeCargoCapacity`.
-  static const String bidExceedsCargoCapacity =
-      'trade_order_bid_exceeds_cargo_capacity';
-
-  /// Rule 7 — Per-commodity offer quantity exceeds
-  /// `availableStockpileByCommodityId[commodityId] ?? 0`.
-  static const String offerExceedsStockpile =
-      'trade_order_offer_exceeds_stockpile';
-}
-
-/// Inputs for one [TradeOrderValidator.validate] pass.
-///
-/// All fields are pre-computed by the caller. The validator never touches
-/// the `Game` directly — keeping it pure makes it trivially reusable from
-/// the order engine, AI planner, and tests without mocking.
-class TradeOrderValidationContext extends WorldMarketContextBase {
-  TradeOrderValidationContext({
-    required super.playerId,
-    required super.bidTypeCap,
-    required super.tradeCargoCapacity,
-    required super.availableStockpileByCommodityId,
-    required this.treasuryBudgetForBids,
-    this.worldMarketState = const WorldMarketState(),
-    data.ResourceRules? resourceRules,
-  }) : resourceRules = resourceRules ?? data.ResourceRules.defaultRules;
-
-  /// Maximum `Σ (quantity × effectiveMarketPrice)` across admitted bids this
-  /// turn (`SPEC/game/world-market.md` § Treasury budget for bids).
-  final int treasuryBudgetForBids;
-
-  /// Market prices used to price bid spend (integer treasury units).
-  final WorldMarketState worldMarketState;
-
-  /// Catalog fallback prices when [worldMarketState.prices] lacks an entry.
-  final data.ResourceRules resourceRules;
-}
-
-/// Builds a [TradeOrderValidationContext] from live [Game] state for order
-/// submission and [OrderEngine] validation.
-///
-/// When [stagedOrders] and [projectedTreasuryDelta] are supplied, the treasury
-/// bid budget subtracts projected non-bid deficits (same composition as the
-/// Trade UI per `SPEC/ui/trade-screen.md` § treasury bid cap). The caller
-/// supplies [projectedTreasuryDelta] — the signed net treasury change for the
-/// turn under the staged orders (the `projectOrderEffects(...).treasuryDelta`
-/// dry-run, which is a `turn`-layer operation and so is computed by the order
-/// engine / UI rather than here, keeping `colonizethis_economy` free of any
-/// `orders`/`turn` dependency per `SPEC/program/logic-package-split-phase0.md`
-/// § economy ↔ orders). The non-bid contribution is reconstructed by adding
-/// this player's running bid spend back to [projectedTreasuryDelta]. When
-/// either argument is omitted the budget is raw treasury only.
-TradeOrderValidationContext tradeOrderValidationContextFromGame(
-  Game game,
-  String playerId, {
-  Orders? stagedOrders,
-  int? projectedTreasuryDelta,
-}) {
-  final rules = data.ResourceRules.defaultRules;
-  var treasuryBudget = treasuryAvailableForBidsByPlayer(
-    game: game,
-    playerId: playerId,
-  );
-  if (stagedOrders != null && projectedTreasuryDelta != null) {
-    final int bidSpend = stagedBidTotalSpendByPlayer(
-      orders: stagedOrders,
-      playerId: playerId,
-      game: game,
-      resourceRules: rules,
-    );
-    treasuryBudget = treasuryAvailableForBidsByPlayer(
-      game: game,
-      playerId: playerId,
-      projectedNonBidTreasuryDelta: projectedTreasuryDelta + bidSpend,
-    );
-  }
-  return TradeOrderValidationContext(
-    playerId: playerId,
-    bidTypeCap: worldMarketBidTypeCap(game, playerId),
-    tradeCargoCapacity: cargoHoldsForHomeFleet(game, playerId),
-    availableStockpileByCommodityId: offerCapByCommodityId(
-      game: game,
-      playerId: playerId,
-    ),
-    treasuryBudgetForBids: treasuryBudget,
-    worldMarketState: game.worldMarketState,
-    resourceRules: rules,
-  );
-}
+import 'trade_order_validation_context.dart';
+import 'treasury_bid_budget.dart' show effectiveMarketPriceForCommodityId;
 
 /// Validates a single player's full set of [TradeOrder] entries for the turn.
 class TradeOrderValidator {

--- a/packages/colonizethis_economy/lib/src/economy/world_market/treasury_bid_budget.dart
+++ b/packages/colonizethis_economy/lib/src/economy/world_market/treasury_bid_budget.dart
@@ -81,10 +81,30 @@ int stagedBidTotalSpendByPlayer({
   required Game game,
   required data.ResourceRules resourceRules,
 }) {
-  final List<TradeOrder>? list = orders.tradeOrdersByPlayerId[playerId];
-  if (list == null || list.isEmpty) return 0;
+  return _sumBidSpend(
+    orders: orders.tradeOrdersByPlayerId[playerId],
+    game: game,
+    resourceRules: resourceRules,
+  );
+}
+
+/// Sum of `quantity × effectiveMarketPrice` over the bid orders in [orders].
+///
+/// Shared core for [stagedBidTotalSpendByPlayer] (staged orders) and
+/// [carryForwardBidNotionalByPlayer] (carry-forward bids): the only
+/// difference between the two callers is the source iterable. Offers,
+/// non-positive quantities, and bids on commodities with no effective
+/// price are skipped so the total stays defensive against out-of-band
+/// orders injected by AI or save state. Returns `0` for a `null` or
+/// empty [orders].
+int _sumBidSpend({
+  required List<TradeOrder>? orders,
+  required Game game,
+  required data.ResourceRules resourceRules,
+}) {
+  if (orders == null || orders.isEmpty) return 0;
   int total = 0;
-  for (final TradeOrder o in list) {
+  for (final TradeOrder o in orders) {
     if (o.type != TradeOrderType.bid) continue;
     if (o.quantity <= 0) continue;
     final int? price = effectiveMarketPriceForCommodityId(
@@ -119,22 +139,11 @@ int carryForwardBidNotionalByPlayer({
   required String playerId,
   required data.ResourceRules resourceRules,
 }) {
-  final List<TradeOrder>? list =
-      game.worldMarketState.carryForwardBidsByFactionId[playerId];
-  if (list == null || list.isEmpty) return 0;
-  int total = 0;
-  for (final TradeOrder o in list) {
-    if (o.type != TradeOrderType.bid) continue;
-    if (o.quantity <= 0) continue;
-    final int? price = effectiveMarketPriceForCommodityId(
-      commodityId: o.commodityId,
-      worldMarket: game.worldMarketState,
-      resourceRules: resourceRules,
-    );
-    if (price == null) continue;
-    total += o.quantity * price;
-  }
-  return total;
+  return _sumBidSpend(
+    orders: game.worldMarketState.carryForwardBidsByFactionId[playerId],
+    game: game,
+    resourceRules: resourceRules,
+  );
 }
 
 /// Treasury budget [playerId] may commit to bids this turn.

--- a/packages/colonizethis_economy/lib/src/economy/world_market/world_market_context_base.dart
+++ b/packages/colonizethis_economy/lib/src/economy/world_market/world_market_context_base.dart
@@ -1,6 +1,6 @@
 /// Shared base for the world-market pure-context inputs.
 ///
-/// `TradeOrderValidationContext` (`trade_order_validator.dart`) and
+/// `TradeOrderValidationContext` (`trade_order_validation_context.dart`) and
 /// `TradeSuggestionContext` (`trade_order_suggester.dart`) both carry the same
 /// four numeric/identity fields (`playerId`, `bidTypeCap`,
 /// `tradeCargoCapacity`, `availableStockpileByCommodityId`). This base holds

--- a/packages/colonizethis_economy/test/resource_commodity_id_mapping_test.dart
+++ b/packages/colonizethis_economy/test/resource_commodity_id_mapping_test.dart
@@ -1,0 +1,47 @@
+// Guard tests for the `Resource` enum → `CommodityId` mapping (Refs #3427).
+//
+// `resource_extractor.dart` (and the other extraction call sites) map a tile
+// `Resource` to its `CommodityId` via `resource.name`, replacing the former
+// 18-case `switch`. These tests pin the invariant the switch removal relies on:
+// every `Resource` enum variant name is a valid catalog commodity id, so a
+// future enum/`CommodityId` divergence fails fast here instead of silently
+// dropping extraction yield on the hot path.
+
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+void main() {
+  group('Resource → CommodityId mapping (Refs #3427)', () {
+    test('every Resource.name resolves to a catalog commodity id', () {
+      for (final Resource resource in Resource.values) {
+        final CommodityId commodityId = resource.name;
+        expect(
+          CommodityCatalog.byId.containsKey(commodityId),
+          isTrue,
+          reason:
+              'Resource.${resource.name} maps to commodity id "$commodityId" '
+              'which is not present in CommodityCatalog. Resource enum names '
+              'must stay aligned with CommodityId strings (resource.name) — '
+              'see resource_extractor.dart.',
+        );
+      }
+    });
+
+    test('the mapping is total over all Resource values', () {
+      expect(
+        Resource.values.every((r) => CommodityCatalog.byId.containsKey(r.name)),
+        isTrue,
+      );
+    });
+
+    test('mapped commodity ids are unique per resource (no collisions)', () {
+      final names = Resource.values.map((r) => r.name).toSet();
+      expect(
+        names.length,
+        Resource.values.length,
+        reason: 'each Resource must map to a distinct CommodityId',
+      );
+    });
+  });
+}

--- a/packages/colonizethis_economy/test/tile_extraction_pipeline_test.dart
+++ b/packages/colonizethis_economy/test/tile_extraction_pipeline_test.dart
@@ -1,7 +1,7 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_economy/src/economy/tile_extraction_pipeline.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
-import 'package:test/test.dart';
+import 'package:colonizethis_test/test.dart';
 
 import 'non_gp_extraction_test_support.dart';
 

--- a/packages/colonizethis_economy/test/tile_extraction_pipeline_test.dart
+++ b/packages/colonizethis_economy/test/tile_extraction_pipeline_test.dart
@@ -1,0 +1,117 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_economy/src/economy/tile_extraction_pipeline.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:test/test.dart';
+
+import 'non_gp_extraction_test_support.dart';
+
+void main() {
+  group('resolveTileKeyResourceContext', () {
+    final tileMap = tileMapAllInProvinceForNonGpExtractionTest(
+      provinceId: 'oldWorld|p1',
+      width: 2,
+      height: 1,
+      resources: [
+        [Resource.grain, Resource.iron],
+      ],
+    );
+
+    test('returns resource context for valid tile key', () {
+      final ctx = resolveTileKeyResourceContext(
+        tileKey: 'oldWorld|p1|0|0',
+        tileMapByRegion: {'oldWorld': tileMap},
+      );
+
+      expect(ctx, isNotNull);
+      expect(ctx!.commodityId, CommodityCatalog.grain.id);
+      expect(ctx.provinceId, 'oldWorld|p1');
+      expect(ctx.resource, Resource.grain);
+    });
+
+    test('maps commodity id via resource.name consistently', () {
+      final ctx = resolveTileKeyResourceContext(
+        tileKey: 'oldWorld|p1|1|0',
+        tileMapByRegion: {'oldWorld': tileMap},
+      );
+
+      expect(ctx!.commodityId, Resource.iron.name);
+      expect(ctx.commodityId, CommodityCatalog.iron.id);
+    });
+
+    test('returns null for invalid or out-of-range keys', () {
+      expect(
+        resolveTileKeyResourceContext(
+          tileKey: 'bad-key',
+          tileMapByRegion: {'oldWorld': tileMap},
+        ),
+        isNull,
+      );
+      expect(
+        resolveTileKeyResourceContext(
+          tileKey: 'oldWorld|p1|-1|0',
+          tileMapByRegion: {'oldWorld': tileMap},
+        ),
+        isNull,
+      );
+      expect(
+        resolveTileKeyResourceContext(
+          tileKey: 'newWorld|p1|0|0',
+          tileMapByRegion: {'oldWorld': tileMap},
+        ),
+        isNull,
+      );
+    });
+  });
+
+  group('resolveTileKeyExtractionContext', () {
+    const provinceId = 'oldWorld|p1';
+    final province = capitalProvinceForNonGpExtractionTest(
+      provinceId: provinceId,
+    );
+    final tileMap = tileMapAllInProvinceForNonGpExtractionTest(
+      provinceId: provinceId,
+      width: 1,
+      height: 1,
+      resources: [
+        [Resource.grain],
+      ],
+    );
+    final tileMapByRegion = {'oldWorld': tileMap};
+
+    test('resolves province from provincesByFullId index', () {
+      final ctx = resolveTileKeyExtractionContext(
+        tileKey: '$provinceId|0|0',
+        tileMapByRegion: tileMapByRegion,
+        provincesByFullId: {provinceId: province},
+        logContext: 'test',
+      );
+
+      expect(ctx, isNotNull);
+      expect(ctx!.province.id, provinceId);
+      expect(ctx.commodityId, CommodityCatalog.grain.id);
+    });
+
+    test('falls back to game.worldState when index misses', () {
+      final game = gameForNonGpExtractionTest(provinces: [province]);
+      final ctx = resolveTileKeyExtractionContext(
+        tileKey: '$provinceId|0|0',
+        tileMapByRegion: tileMapByRegion,
+        game: game,
+        logContext: 'test',
+      );
+
+      expect(ctx!.province.id, provinceId);
+    });
+
+    test('returns null when province row is missing', () {
+      final ctx = resolveTileKeyExtractionContext(
+        tileKey: '$provinceId|0|0',
+        tileMapByRegion: tileMapByRegion,
+        provincesByFullId: const {},
+        logContext: 'test',
+      );
+
+      expect(ctx, isNull);
+    });
+  });
+}

--- a/packages/colonizethis_economy/test/world_market_bid_spend_shared_helper_test.dart
+++ b/packages/colonizethis_economy/test/world_market_bid_spend_shared_helper_test.dart
@@ -1,0 +1,125 @@
+// Parity tests for the shared bid-spend summation helper (Refs #3427).
+//
+// `stagedBidTotalSpendByPlayer` (staged orders) and
+// `carryForwardBidNotionalByPlayer` (carry-forward bids) now delegate to one
+// private `_sumBidSpend` core whose only varying input is the source iterable.
+// These tests pin that the two public entry points compute identical totals for
+// identical bid lists and apply the same defensive skips (offers, non-positive
+// quantities, unpriced commodities), guarding against future drift between the
+// two call sites.
+
+import 'package:colonizethis_data/colonizethis_data.dart' as data;
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+const String _gp = 'gp_h';
+
+Game _gameWith(List<TradeOrder> bids, {required Map<CommodityId, int> prices}) {
+  return Game(
+    id: 'g_bid_spend_parity',
+    worldState: WorldState(
+      turnState: TurnState(phase: TurnPhase.orders, turnNumber: 1),
+      oldWorld: const RegionData(),
+      newWorld: const RegionData(),
+    ),
+    players: [
+      Player(id: _gp, displayName: 'England', isHuman: true, treasury: 10000),
+    ],
+    worldMarketState: WorldMarketState(
+      prices: prices,
+      carryForwardBidsByFactionId: {_gp: bids},
+    ),
+  );
+}
+
+TradeOrder _bid(String commodityId, int qty) => TradeOrder(
+  commodityId: commodityId,
+  type: TradeOrderType.bid,
+  quantity: qty,
+  priority: 1,
+);
+
+TradeOrder _offer(String commodityId, int qty) => TradeOrder(
+  commodityId: commodityId,
+  type: TradeOrderType.offer,
+  quantity: qty,
+  priority: 1,
+);
+
+void main() {
+  final data.ResourceRules rules = data.ResourceRules.defaultRules;
+
+  group('shared bid-spend helper parity (Refs #3427)', () {
+    test('staged and carry-forward totals match for an identical bid list', () {
+      final bids = [_bid('timber', 4), _bid('iron', 2)];
+      final game = _gameWith(bids, prices: const {'timber': 30, 'iron': 80});
+      final staged = stagedBidTotalSpendByPlayer(
+        orders: Orders(tradeOrdersByPlayerId: {_gp: bids}),
+        playerId: _gp,
+        game: game,
+        resourceRules: rules,
+      );
+      final carryForward = carryForwardBidNotionalByPlayer(
+        game: game,
+        playerId: _gp,
+        resourceRules: rules,
+      );
+      expect(staged, 4 * 30 + 2 * 80);
+      expect(
+        carryForward,
+        staged,
+        reason: 'both entry points must delegate to the same summation core',
+      );
+    });
+
+    test('both apply identical defensive skips '
+        '(offers, zero qty, unpriced ids)', () {
+      final list = [
+        _offer('timber', 9),
+        _bid('timber', 0),
+        _bid('not_a_commodity', 5),
+        _bid('iron', 3),
+      ];
+      final game = _gameWith(list, prices: const {'timber': 30, 'iron': 80});
+      final staged = stagedBidTotalSpendByPlayer(
+        orders: Orders(tradeOrdersByPlayerId: {_gp: list}),
+        playerId: _gp,
+        game: game,
+        resourceRules: rules,
+      );
+      final carryForward = carryForwardBidNotionalByPlayer(
+        game: game,
+        playerId: _gp,
+        resourceRules: rules,
+      );
+      expect(
+        staged,
+        3 * 80,
+        reason: 'only the priced positive iron bid counts',
+      );
+      expect(carryForward, staged);
+    });
+
+    test('both return 0 for an empty bid list', () {
+      final game = _gameWith(const [], prices: const {'timber': 30});
+      expect(
+        stagedBidTotalSpendByPlayer(
+          orders: const Orders(),
+          playerId: _gp,
+          game: game,
+          resourceRules: rules,
+        ),
+        0,
+      );
+      expect(
+        carryForwardBidNotionalByPlayer(
+          game: game,
+          playerId: _gp,
+          resourceRules: rules,
+        ),
+        0,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Slices of #3427 (`Refactor colonizethis_economy: deduplicate, build abstractions, split large files`). Behavior-preserving refactors on economy hot paths. Phases 3–5 (large-file decomposition, deep-import/barrel resolution, test consolidation) remain deferred.

`Refs #3427`

## Done in this push

### Phase 1 — Quick wins
- **(step 1)** Replaced the 18-case `_resourceToCommodityId` switch in `resource_extractor.dart` with `resource.name`.
- **(step 2)** Extracted shared `_sumBidSpend` in `treasury_bid_budget.dart`; staged and carry-forward bid spend both delegate.
- **(step 4)** Wired `purchased_tile_riches.dart` to `computeEffectiveTileYield` instead of inline yield math.

### Phase 2 — Extraction pipeline dedup
- **(steps 5, 6)** Added `tile_extraction_pipeline.dart` with `resolveTileKeyResourceContext` and `resolveTileKeyExtractionContext`. GP extraction, non-GP extraction, and purchased-tile riches now compose through the shared pipeline; commodity-id mapping is consistently `resource.name` across all three.

## Tests

- `test/resource_commodity_id_mapping_test.dart` — Resource ↔ CommodityId guard (step 1 AC).
- `test/world_market_bid_spend_shared_helper_test.dart` — staged/carry-forward bid-spend parity (step 2 AC).
- `test/tile_extraction_pipeline_test.dart` — shared pipeline resolution and `resource.name` mapping (steps 5–6 AC).
- Step 4 covered by existing `purchased_tile_riches_test.dart`.
- `dart test` in `packages/colonizethis_economy` → **387 tests pass**.

## ACs covered now

- [x] step 1 — `resource_extractor.dart` uses `resource.name`; mapping guard test
- [x] step 2 — shared `_sumBidSpend`; treasury-bid tests pass
- [x] step 4 — `purchased_tile_riches.dart` calls `computeEffectiveTileYield`
- [x] steps 5, 6 — shared tile-extraction pipeline; consistent `resource.name` across GP, non-GP, purchased-tile paths
- [x] step 11 — `trade_order_validator.dart` ≤ 300 lines (324 → 208); `TradeOrderValidationContext` + factory + rejection-reason codes moved to `trade_order_validation_context.dart`; both remain importable from the `colonizethis_economy` barrel; existing validation tests pass unchanged

## CI fix in this push

- `test/tile_extraction_pipeline_test.dart` now imports `package:colonizethis_test/test.dart` (was `package:test/test.dart`), clearing the `repo.test_imports` ct_repo_lint gate that was failing the Quality check.

## Deferred for #3427 (follow-up commits)

- Phase 1 step 3 (shared logger guard — sequenced after Phase 3 `sea_transport.dart` split)
- Phase 3 remaining (steps 7–10: `sea_transport.dart`, `non_gp_extraction.dart`, `economy_consumption.dart`, `build_cost.dart` decomposition)
- Phase 4 (deep-import / barrel resolution)
- Phase 5 (test consolidation + direct tests for untested logic files)

## Test plan

- [x] `cd packages/colonizethis_economy && dart test`
- [ ] CI `quality` gates on changed files