### PR TITLE
refactor: dedup setup package, add perturbSeed util, CI coverage (#3428)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -103,6 +103,8 @@ jobs:
               - 'packages/colonizethis_economy/**'
             pkg_diplomacy:
               - 'packages/colonizethis_diplomacy/**'
+            pkg_setup:
+              - 'packages/colonizethis_setup/**'
             pkg_turn:
               - 'packages/colonizethis_turn/**'
             pkg_ai_contracts:
@@ -125,6 +127,7 @@ jobs:
             --changed-combat="${{ steps.filter.outputs.pkg_combat }}" \
             --changed-economy="${{ steps.filter.outputs.pkg_economy }}" \
             --changed-diplomacy="${{ steps.filter.outputs.pkg_diplomacy }}" \
+            --changed-setup="${{ steps.filter.outputs.pkg_setup }}" \
             --changed-turn="${{ steps.filter.outputs.pkg_turn }}" \
             --changed-ai_contracts="${{ steps.filter.outputs.pkg_ai_contracts }}" \
             --changed-logic="${{ steps.filter.outputs.pkg_logic }}" \

--- a/packages/colonizethis_data/lib/src/locked_partition_topology_gates.dart
+++ b/packages/colonizethis_data/lib/src/locked_partition_topology_gates.dart
@@ -23,7 +23,8 @@ Map<String, Set<String>> provincePpNeighbours(MapTopology topology) {
   return neighbours;
 }
 
-void _pushUnvisitedPpNeighbors(
+/// Pushes the not-yet-[visited] P–P neighbours of [u] onto [stack].
+void pushUnvisitedPpNeighbors(
   String u,
   Map<String, Set<String>> neighbours,
   Set<String> visited,
@@ -49,7 +50,7 @@ List<int> ppLandComponentSizesSorted(MapTopology topology) {
       final u = stack.removeLast();
       if (!visited.add(u)) continue;
       size++;
-      _pushUnvisitedPpNeighbors(u, neighbours, visited, stack);
+      pushUnvisitedPpNeighbors(u, neighbours, visited, stack);
     }
     sizes.add(size);
   }
@@ -85,15 +86,17 @@ bool newWorldPartitionMatchesLockedProfile(MapTopology topology) {
   ]);
 }
 
-typedef _LandmassInfo = ({
+/// Connected-component (landmass) summary over P–P province adjacency.
+typedef LandmassInfo = ({
   int size,
   String minProvinceId,
   Set<String> provinces,
 });
 
-List<_LandmassInfo> _landmassesSortedDesc(Map<String, Set<String>> neighbours) {
+/// P–P connected components as [LandmassInfo], sorted by size desc then min id.
+List<LandmassInfo> landmassesSortedDesc(Map<String, Set<String>> neighbours) {
   final visited = <String>{};
-  final out = <_LandmassInfo>[];
+  final out = <LandmassInfo>[];
   for (final start in neighbours.keys.toList()..sort()) {
     if (visited.contains(start)) continue;
     final comp = <String>{};
@@ -102,7 +105,7 @@ List<_LandmassInfo> _landmassesSortedDesc(Map<String, Set<String>> neighbours) {
       final u = stack.removeLast();
       if (!visited.add(u)) continue;
       comp.add(u);
-      _pushUnvisitedPpNeighbors(u, neighbours, visited, stack);
+      pushUnvisitedPpNeighbors(u, neighbours, visited, stack);
     }
     final minId = comp.reduce((a, b) => a.compareTo(b) < 0 ? a : b);
     out.add((size: comp.length, minProvinceId: minId, provinces: comp));
@@ -120,7 +123,7 @@ bool lockedOldWorldRoleFeasibilityHolds({
   required MapTopology topology,
   required Map<String, Set<String>> neighbours,
 }) {
-  final landmasses = _landmassesSortedDesc(neighbours);
+  final landmasses = landmassesSortedDesc(neighbours);
   if (landmasses.length != 4) return false;
   for (final lm in landmasses) {
     var sea = 0;
@@ -141,7 +144,7 @@ bool lockedNewWorldRoleFeasibilityHolds({
   required MapTopology topology,
   required Map<String, Set<String>> neighbours,
 }) {
-  final landmasses = _landmassesSortedDesc(neighbours);
+  final landmasses = landmassesSortedDesc(neighbours);
   if (landmasses.length != 4) return false;
   for (final lm in landmasses) {
     if (lm.size != 9 && lm.size != 6) return false;

--- a/packages/colonizethis_data/test/locked_topology_gates_test.dart
+++ b/packages/colonizethis_data/test/locked_topology_gates_test.dart
@@ -70,6 +70,34 @@ void main() {
       expect(provincePpNeighbours(topo), {'p1': <String>{}});
     });
 
+    test('landmassesSortedDesc orders by size desc then min province id', () {
+      final topo = _mergeTopologies([
+        _pathLandmass(prefix: 'B', size: 2, seaBoundProvinceCount: 1),
+        _pathLandmass(prefix: 'A', size: 3, seaBoundProvinceCount: 1),
+        _pathLandmass(prefix: 'C', size: 2, seaBoundProvinceCount: 1),
+      ]);
+      final nbr = provincePpNeighbours(topo);
+      final landmasses = landmassesSortedDesc(nbr);
+      expect(landmasses.map((lm) => lm.size).toList(), [3, 2, 2]);
+      // Equal-size landmasses break ties on the lexicographically-min id.
+      expect(
+        landmasses[1].minProvinceId.compareTo(landmasses[2].minProvinceId) < 0,
+        true,
+      );
+    });
+
+    test('pushUnvisitedPpNeighbors skips visited and pushes the rest', () {
+      final neighbours = <String, Set<String>>{
+        'a': {'b', 'c'},
+        'b': {'a'},
+        'c': {'a'},
+      };
+      final stack = <String>[];
+      // Negative: a visited neighbour must not be re-pushed.
+      pushUnvisitedPpNeighbors('a', neighbours, {'b'}, stack);
+      expect(stack, ['c']);
+    });
+
     test('ppLandComponentSizesSorted returns sorted multiset', () {
       final topo = MapTopology(
         nodes: const [

--- a/packages/colonizethis_setup/lib/src/setup/game_setup_helpers_bootstrap.dart
+++ b/packages/colonizethis_setup/lib/src/setup/game_setup_helpers_bootstrap.dart
@@ -244,42 +244,22 @@ String startingShipTypeForPlayer(Player _) {
   return ShipEconomyCatalog.carrack.shipTypeId;
 }
 
-void _pushUnvisitedPpNeighborsDiag(
-  String u,
-  Map<String, Set<String>> neighbours,
-  Set<String> visited,
-  List<String> stack,
+/// Formats per-landmass diagnostic parts shared by the OW/NW failure dumps.
+List<String> _formatLandmassDiagnosticParts(
+  MapTopology topology,
+  Map<String, Set<String>> ppNbr,
 ) {
-  for (final v in neighbours[u] ?? const <String>{}) {
-    if (visited.contains(v)) continue;
-    stack.add(v);
-  }
-}
-
-typedef _LmDiag = ({int size, String minProvinceId, Set<String> provinces});
-
-List<_LmDiag> _landmassesSortedDescDiag(Map<String, Set<String>> neighbours) {
-  final visited = <String>{};
-  final out = <_LmDiag>[];
-  for (final start in neighbours.keys.toList()..sort()) {
-    if (visited.contains(start)) continue;
-    final comp = <String>{};
-    final stack = <String>[start];
-    while (stack.isNotEmpty) {
-      final u = stack.removeLast();
-      if (!visited.add(u)) continue;
-      comp.add(u);
-      _pushUnvisitedPpNeighborsDiag(u, neighbours, visited, stack);
+  final lms = landmassesSortedDesc(ppNbr);
+  final lmParts = <String>[];
+  for (var i = 0; i < lms.length; i++) {
+    final lm = lms[i];
+    var sea = 0;
+    for (final p in lm.provinces) {
+      if (isProvinceSeaBound(topology, p)) sea++;
     }
-    final minId = comp.reduce((a, b) => a.compareTo(b) < 0 ? a : b);
-    out.add((size: comp.length, minProvinceId: minId, provinces: comp));
+    lmParts.add('i=$i|sz=${lm.size}|sea=$sea|min=${lm.minProvinceId}');
   }
-  out.sort((a, b) {
-    final c = b.size.compareTo(a.size);
-    if (c != 0) return c;
-    return a.minProvinceId.compareTo(b.minProvinceId);
-  });
-  return out;
+  return lmParts;
 }
 
 String lockedOwAssignFailureDiagnostics({
@@ -294,16 +274,7 @@ String lockedOwAssignFailureDiagnostics({
     topology: topology,
     neighbours: ppNbr,
   );
-  final lms = _landmassesSortedDescDiag(ppNbr);
-  final lmParts = <String>[];
-  for (var i = 0; i < lms.length; i++) {
-    final lm = lms[i];
-    var sea = 0;
-    for (final p in lm.provinces) {
-      if (isProvinceSeaBound(topology, p)) sea++;
-    }
-    lmParts.add('i=$i|sz=${lm.size}|sea=$sea|min=${lm.minProvinceId}');
-  }
+  final lmParts = _formatLandmassDiagnosticParts(topology, ppNbr);
   var degMin = 1 << 30;
   var degMax = 0;
   var degSum = 0;
@@ -338,16 +309,7 @@ String lockedNwAssignFailureDiagnostics({
     topology: topology,
     neighbours: ppNbr,
   );
-  final lms = _landmassesSortedDescDiag(ppNbr);
-  final lmParts = <String>[];
-  for (var i = 0; i < lms.length; i++) {
-    final lm = lms[i];
-    var sea = 0;
-    for (final p in lm.provinces) {
-      if (isProvinceSeaBound(topology, p)) sea++;
-    }
-    lmParts.add('i=$i|sz=${lm.size}|sea=$sea|min=${lm.minProvinceId}');
-  }
+  final lmParts = _formatLandmassDiagnosticParts(topology, ppNbr);
   return 'lockedNW_diag seed=${config.seed} nodes=${topology.nodes.length} '
       'edges=${topology.edges.length} nProv=${ppNbr.length} ppSizes=$sizes '
       'partitionOk=$partitionOk feasibilityOk=$feasibilityOk '

--- a/packages/colonizethis_setup/lib/src/setup/gp_old_world_resource_redistribution.dart
+++ b/packages/colonizethis_setup/lib/src/setup/gp_old_world_resource_redistribution.dart
@@ -7,6 +7,7 @@ import 'setup_logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'package:colonizethis_world/colonizethis_world.dart';
+import 'seed_perturbation.dart';
 import 'setup_exceptions.dart';
 import 'town_capital_occupancy.dart';
 

--- a/packages/colonizethis_setup/lib/src/setup/gp_old_world_resource_redistribution_quota_placement.dart
+++ b/packages/colonizethis_setup/lib/src/setup/gp_old_world_resource_redistribution_quota_placement.dart
@@ -177,7 +177,11 @@ void _distributeQuotaPool({
   var resMap = Map<String, String>.from(resMapIn);
   final g = gpIdsSorted.length;
   final rnd = Random(
-    Object.hash(setupSeedBase, kGpOwResourceRedistributionSalt, r.index),
+    perturbSeed(
+      setupSeedBase,
+      kGpOwResourceRedistributionSalt,
+      args: [r.index],
+    ),
   );
   final shuffled = List<String>.from(gpIdsSorted)..shuffle(rnd);
 

--- a/packages/colonizethis_setup/lib/src/setup/gp_old_world_terrain_redistribution.dart
+++ b/packages/colonizethis_setup/lib/src/setup/gp_old_world_terrain_redistribution.dart
@@ -5,6 +5,7 @@ import 'setup_logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'package:colonizethis_world/colonizethis_world.dart';
+import 'seed_perturbation.dart';
 import 'town_capital_occupancy.dart';
 
 /// Salt for deterministic tie-breaks when assigning Hamilton +1 remainders.
@@ -129,19 +130,15 @@ Map<String, int> _hamiltonTargetsForType({
       final rb = remainder[b] ?? 0;
       final c = rb.compareTo(ra);
       if (c != 0) return c;
-      final ha = Object.hash(
+      final ha = perturbSeed(
         setupSeedBase,
         kGpOwTerrainRedistributionSalt,
-        tieTerrainIndex,
-        nT,
-        a,
+        args: [tieTerrainIndex, nT, a],
       );
-      final hb = Object.hash(
+      final hb = perturbSeed(
         setupSeedBase,
         kGpOwTerrainRedistributionSalt,
-        tieTerrainIndex,
-        nT,
-        b,
+        args: [tieTerrainIndex, nT, b],
       );
       final hc = ha.compareTo(hb);
       if (hc != 0) return hc;

--- a/packages/colonizethis_setup/lib/src/setup/seed_perturbation.dart
+++ b/packages/colonizethis_setup/lib/src/setup/seed_perturbation.dart
@@ -1,0 +1,14 @@
+// SPEC/program/game-setup-pipeline.md — deterministic seed perturbation helper.
+
+/// Derives a deterministic perturbed seed from a [base] seed, a call-site
+/// [salt], and optional extra [args].
+///
+/// Package-internal (Refs #3428): shared by the GP Old World redistribution
+/// passes so each call site need not inline `Object.hash(...)`. This is
+/// identity-preserving with the previous inline form because
+/// `Object.hashAll(<Object?>[base, salt, ...args])` produces the same value as
+/// `Object.hash(base, salt, ...args)` for the same arguments in the same order,
+/// keeping golden-seed redistribution outputs unchanged. [args] is typed
+/// `Object?` so heterogeneous keys (for example a `String` GP id) are accepted.
+int perturbSeed(int base, int salt, {List<Object?> args = const <Object?>[]}) =>
+    Object.hashAll(<Object?>[base, salt, ...args]);

--- a/packages/colonizethis_setup/test/setup/seed_perturbation_test.dart
+++ b/packages/colonizethis_setup/test/setup/seed_perturbation_test.dart
@@ -1,0 +1,51 @@
+import 'package:colonizethis_setup/src/setup/seed_perturbation.dart';
+import 'package:colonizethis_test/test.dart';
+
+/// Identity-preservation contract for `perturbSeed` (Refs #3428): it must
+/// reproduce the previously-inlined `Object.hash(base, salt, ...args)` values
+/// so deterministic GP Old World redistribution outputs do not regress.
+void main() {
+  group('perturbSeed', () {
+    const base = 0x1234;
+    const salt = 0x5452524e; // ASCII "TRRN" terrain salt.
+
+    test('positive: equals Object.hash for a single int arg', () {
+      expect(
+        perturbSeed(base, salt, args: const [7]),
+        Object.hash(base, salt, 7),
+      );
+    });
+
+    test('positive: equals Object.hash for heterogeneous (int+String) args', () {
+      expect(
+        perturbSeed(base, salt, args: const [3, 9, 'gp_blue']),
+        Object.hash(base, salt, 3, 9, 'gp_blue'),
+      );
+    });
+
+    test('positive: equals Object.hash with no extra args', () {
+      expect(perturbSeed(base, salt), Object.hash(base, salt));
+    });
+
+    test('positive: deterministic for identical inputs', () {
+      expect(
+        perturbSeed(base, salt, args: const [1, 2]),
+        perturbSeed(base, salt, args: const [1, 2]),
+      );
+    });
+
+    test('negative: differing args generally yield different seeds', () {
+      expect(
+        perturbSeed(base, salt, args: const ['gp_red']),
+        isNot(perturbSeed(base, salt, args: const ['gp_blue'])),
+      );
+    });
+
+    test('negative: differing salt generally yields different seeds', () {
+      expect(
+        perturbSeed(base, salt, args: const [1]),
+        isNot(perturbSeed(base, 0x5245444f, args: const [1])),
+      );
+    });
+  });
+}

--- a/tool/compute_package_test_plan.py
+++ b/tool/compute_package_test_plan.py
@@ -124,6 +124,7 @@ SHORT_TO_FULL: dict[str, str] = {
     "combat": "colonizethis_combat",
     "economy": "colonizethis_economy",
     "diplomacy": "colonizethis_diplomacy",
+    "setup": "colonizethis_setup",
     "turn": "colonizethis_turn",
     "ai_contracts": "colonizethis_ai_contracts",
     "logic": "colonizethis_logic",


### PR DESCRIPTION
## Summary

Reduces duplication, unifies seed-perturbation, and closes a CI coverage gap in `packages/colonizethis_setup`. Tracked by #3428.

`Refs #3428`

## Done in this push

1. **Single-owned diagnostic landmass helpers.** Promoted `_pushUnvisitedPpNeighbors` → `pushUnvisitedPpNeighbors`, `_landmassesSortedDesc` → `landmassesSortedDesc`, and `_LandmassInfo` → `LandmassInfo` to public in `colonizethis_data`; removed the verbatim `*Diag` clones + `_LmDiag` typedef from `game_setup_helpers_bootstrap.dart` and pointed call sites at the public data-package versions.
2. **Shared failure-diagnostics helper.** Extracted private `_formatLandmassDiagnosticParts(topology, ppNbr)` consumed by both `lockedOwAssignFailureDiagnostics` and `lockedNwAssignFailureDiagnostics`, removing the duplicated landmass-iteration block. Output strings are unchanged.
3. **`perturbSeed` utility.** Added package-internal `int perturbSeed(int base, int salt, {List<Object?> args})` in `colonizethis_setup` (`lib/src/setup/seed_perturbation.dart`, **not** exported, **not** in `colonizethis_data`'s public API) implemented via `Object.hashAll`, which is identity-preserving with the prior `Object.hash(...)` calls. Both GP Old World redistribution files now call it. The naming subsystem's additive `rowSalt + kSalt` pattern is **left unchanged** (out of scope).
4. **CI detects setup changes.** Added a `pkg_setup:` change-detection filter to `.github/workflows/quality.yml`, wired `--changed-setup` into the test-plan invocation, and added `"setup": "colonizethis_setup"` to `SHORT_TO_FULL` in `tool/compute_package_test_plan.py`.

## ACs covered

- [x] Diag clones (`_pushUnvisitedPpNeighborsDiag`, `_landmassesSortedDescDiag`, `_LmDiag`) removed; call sites use public data-package versions.
- [x] OW/NW failure diagnostics share landmass-iteration code via a common private helper.
- [x] Package-internal `perturbSeed` exists (not exported / not in data public API); both redistribution files call it; existing redistribution tests pass unchanged.
- [x] Naming subsystem additive salt-offset left unchanged.
- [x] Setup-only PRs trigger `package_tests` and include `colonizethis_setup` in the plan (verified: `compute_package_test_plan.py --changed-setup=true` → includes `colonizethis_setup`).
- [x] All existing setup-package tests pass (`dart test` from `packages/colonizethis_setup/`).
- [x] `dart analyze` reports no new issues in the touched packages.

## SPEC

None required — diagnostics are speculative/non-normative; `perturbSeed` is identity-preserving so golden-seed outputs are unchanged.

## Tests

- Added `seed_perturbation_test.dart` (positive: matches `Object.hash` for int/heterogeneous/no-arg cases + deterministic; negative: differing args/salt diverge).
- Extended `locked_topology_gates_test.dart` with positive (`landmassesSortedDesc` ordering) and negative (`pushUnvisitedPpNeighbors` skips visited) coverage for the newly-public helpers.
- Ran full `colonizethis_setup` `dart test` suite (all pass) and `colonizethis_data` topology-gates test (pass). `dart analyze` clean on both packages (one pre-existing unrelated warning in `tech_extraction.dart`).

## Deferred

None for this issue.

Made with [Cursor](https://cursor.com)