### PR TITLE
refactor: deduplicate, tune, and abstract combat resolution code (#3433)

### DIFF
--- a/packages/colonizethis_combat/lib/colonizethis_combat.dart
+++ b/packages/colonizethis_combat/lib/colonizethis_combat.dart
@@ -2,6 +2,7 @@
 library colonizethis_combat;
 
 export 'src/combat/battle_general_assignment.dart';
+export 'src/combat/combat_effective_strength.dart';
 export 'src/combat/combat_mode_selection.dart';
 export 'src/combat/combat_resolver.dart';
 export 'src/combat/combat_resolver_probabilistic.dart';

--- a/packages/colonizethis_combat/lib/src/combat/combat_effective_strength.dart
+++ b/packages/colonizethis_combat/lib/src/combat/combat_effective_strength.dart
@@ -1,0 +1,95 @@
+// Copyright 2024 Robert W. Guenther
+// SPDX-License-Identifier: Apache-2.0
+
+/// Shared effective-strength pipeline for all combat resolvers.
+///
+/// SPEC/program/combat-resolution.md, SPEC/program/quick-battle-resolution.md.
+///
+/// Auto-resolve ([resolveEngagement]), the probabilistic resolver
+/// ([resolveEngagementProbabilistic]), and Quick Battle each computed the
+/// `rawStrength → terrain × multipliers → fort reduction / emplaced add → wall
+/// HP soak` pipeline independently. This module hosts the single shared
+/// implementation so the three resolvers stay numerically in lockstep.
+///
+/// ## Determinism contract
+///
+/// Floating-point multiplication is commutative but **not** associative, so the
+/// per-side multipliers are applied as an explicit left-associative chain in the
+/// caller-provided order ([factor1] then [factor2] then [factor3], each
+/// defaulting to the identity `1.0`). Multiplying by `1.0` is the IEEE-754
+/// identity, so resolvers that use fewer factors omit the trailing ones without
+/// changing a single bit. Callers MUST pass factors in the same order the
+/// previous inline implementations used.
+library;
+
+import 'package:colonizethis_data/colonizethis_data.dart';
+
+import 'combat_constants.dart';
+
+bool _fortAppliesForCombatModifiers(int fortLevel) =>
+    fortLevel >= kMinFortLevelForCombatModifiers &&
+    fortLevel <= kMaxFortLevelForCombatModifiers;
+
+/// Attacker effective strength: `base × factor1 × factor2 × factor3`, scaled by
+/// the fort damage-reduction factor when [fortLevel] is in the siege range.
+///
+/// Factors are applied left-to-right in the listed order; see the module-level
+/// determinism contract.
+double combatEffectiveAttackerStrength({
+  required double base,
+  required int fortLevel,
+  double factor1 = 1.0,
+  double factor2 = 1.0,
+  double factor3 = 1.0,
+}) {
+  var eff = base * factor1 * factor2 * factor3;
+  if (_fortAppliesForCombatModifiers(fortLevel)) {
+    eff *= (kUnityAttackerStrengthMultiplier - fortDamageReduction[fortLevel]);
+  }
+  return eff;
+}
+
+/// Defender effective strength: `base × factor1 × factor2 × factor3`, plus
+/// [emplacedStrength] when [fortLevel] is in the siege range.
+///
+/// Factors are applied left-to-right in the listed order; see the module-level
+/// determinism contract.
+double combatEffectiveDefenderStrength({
+  required double base,
+  required int fortLevel,
+  double factor1 = 1.0,
+  double factor2 = 1.0,
+  double factor3 = 1.0,
+  double emplacedStrength = 0.0,
+}) {
+  var eff = base * factor1 * factor2 * factor3;
+  if (_fortAppliesForCombatModifiers(fortLevel)) {
+    eff += emplacedStrength;
+  }
+  return eff;
+}
+
+/// Attacker effective strength used for the casualty ratio after wall HP soak.
+///
+/// Outside the siege fort range the value is returned unchanged. Within it, wall
+/// HP is subtracted and the result clamped to
+/// `[clampMin, clampMax]` (defaults match the canonical `[0, ∞)` soak bounds).
+double combatEffectiveAttackForRatio({
+  required double effAtt,
+  required int fortLevel,
+  double clampMin = kEffectiveAttackForRatioClampMin,
+  double clampMax = kEffectiveAttackForRatioClampMax,
+}) {
+  if (!_fortAppliesForCombatModifiers(fortLevel)) return effAtt;
+  final wallHp = wallHpByFortLevel[fortLevel];
+  return (effAtt - wallHp).clamp(clampMin, clampMax);
+}
+
+/// Default lump emplaced-gun strength for a fort level (no per-gun HP tracking).
+///
+/// Returns `0.0` outside the siege fort range. Quick Battle siege resolution
+/// passes its own virtual per-gun alive sum instead of this lump.
+double combatDefaultEmplacedStrength(int fortLevel) {
+  if (!_fortAppliesForCombatModifiers(fortLevel)) return 0.0;
+  return fortGunCount[fortLevel] * fortEmplacedStrength[fortLevel];
+}

--- a/packages/colonizethis_combat/lib/src/combat/combat_engagement.dart
+++ b/packages/colonizethis_combat/lib/src/combat/combat_engagement.dart
@@ -8,6 +8,7 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'combat_constants.dart';
+import 'combat_effective_strength.dart';
 import 'combat_loss_profile.dart';
 import 'combat_types.dart';
 import 'military_strength.dart';
@@ -32,35 +33,27 @@ EngagementOutcome resolveEngagement({
   final terrainMod =
       terrainModifiers[terrain] ??
       (kNeutralTerrainAttackerModifier, kNeutralTerrainDefenderModifier);
-  var effAtt =
-      attStr *
-      terrainMod.$1 *
-      attackerMoraleMultiplier *
-      attackerLeaderMultiplier;
-  var effDef =
-      defStr *
-      terrainMod.$2 *
-      defenderMoraleMultiplier *
-      defenderLeaderMultiplier;
-
-  if (fortLevel >= kMinFortLevelForCombatModifiers &&
-      fortLevel <= kMaxFortLevelForCombatModifiers) {
-    final reduction = fortDamageReduction[fortLevel];
-    effAtt *= (kUnityAttackerStrengthMultiplier - reduction);
-    final emplaced = fortGunCount[fortLevel] * fortEmplacedStrength[fortLevel];
-    effDef += emplaced;
-  }
+  final effAtt = combatEffectiveAttackerStrength(
+    base: attStr,
+    fortLevel: fortLevel,
+    factor1: terrainMod.$1,
+    factor2: attackerMoraleMultiplier,
+    factor3: attackerLeaderMultiplier,
+  );
+  final effDef = combatEffectiveDefenderStrength(
+    base: defStr,
+    fortLevel: fortLevel,
+    factor1: terrainMod.$2,
+    factor2: defenderMoraleMultiplier,
+    factor3: defenderLeaderMultiplier,
+    emplacedStrength: combatDefaultEmplacedStrength(fortLevel),
+  );
 
   // Wall HP soaks damage before it applies to defender casualty ratio. SPEC/game/siege-mechanics.md.
-  var effAttForRatio = effAtt;
-  if (fortLevel >= kMinFortLevelForCombatModifiers &&
-      fortLevel <= kMaxFortLevelForCombatModifiers) {
-    final wallHp = wallHpByFortLevel[fortLevel];
-    effAttForRatio = (effAtt - wallHp).clamp(
-      kEffectiveAttackForRatioClampMin,
-      kEffectiveAttackForRatioClampMax,
-    );
-  }
+  final effAttForRatio = combatEffectiveAttackForRatio(
+    effAtt: effAtt,
+    fortLevel: fortLevel,
+  );
 
   final attackerCasualties = <String>[];
   final defenderCasualties = <String>[];

--- a/packages/colonizethis_combat/lib/src/combat/combat_resolver.dart
+++ b/packages/colonizethis_combat/lib/src/combat/combat_resolver.dart
@@ -98,7 +98,7 @@ Game resolveBattleContext(
 
     final defenderEffectiveLevel = defenderEffectiveLevelByFaction.putIfAbsent(
       defenderFactionId,
-      () => _defenderEffectiveLevel(game, defenderFactionId),
+      () => effectiveEraForFaction(game, defenderFactionId),
     );
     final attackerCoverage =
         feedingCoverageByPlayerId[attacker.side.factionId] ??

--- a/packages/colonizethis_combat/lib/src/combat/combat_resolver_probabilistic.dart
+++ b/packages/colonizethis_combat/lib/src/combat/combat_resolver_probabilistic.dart
@@ -101,8 +101,8 @@ ProbabilisticEngagementOutcome resolveEngagementProbabilistic({
   final allDefenderCasualties = <String>[];
   final roundResults = <ProbabilisticRoundResult>[];
 
-  final initialAttStr = _aggregateStrength(attackerUnits, 4);
-  final initialDefStr = _aggregateStrength(
+  final initialAttStr = aggregateStrength(attackerUnits, 4);
+  final initialDefStr = aggregateStrength(
     defenderUnits,
     defenderEffectiveMilitaryLevel,
   );
@@ -110,8 +110,8 @@ ProbabilisticEngagementOutcome resolveEngagementProbabilistic({
   for (var round = 1; round <= maxCombatRounds; round++) {
     if (attList.isEmpty || defList.isEmpty) break;
 
-    final rawAtt = _aggregateStrength(attList, 4);
-    final rawDef = _aggregateStrength(defList, defenderEffectiveMilitaryLevel);
+    final rawAtt = aggregateStrength(attList, 4);
+    final rawDef = aggregateStrength(defList, defenderEffectiveMilitaryLevel);
 
     final terrainMod = terrainModifiers[terrain] ?? (1.0, 1.0);
     var effAtt = rawAtt * terrainMod.$1 * attackerMoraleMultiplier;
@@ -236,30 +236,25 @@ List<String> _selectCasualtiesWeighted(
     weights.add(1.0 / (s + 0.1));
   }
   final ids = units.map((u) => u.id).toList();
+  final alive = List<bool>.filled(ids.length, true);
   final chosen = <String>[];
 
   for (var i = 0; i < n; i++) {
-    final total = weights.fold(0.0, (a, b) => a + b);
+    var total = 0.0;
+    for (var j = 0; j < weights.length; j++) {
+      if (alive[j]) total += weights[j];
+    }
     if (total <= 0) break;
     var r = rng.nextDouble() * total;
     for (var j = 0; j < weights.length; j++) {
+      if (!alive[j]) continue;
       r -= weights[j];
       if (r <= 0) {
         chosen.add(ids[j]);
-        ids.removeAt(j);
-        weights.removeAt(j);
+        alive[j] = false;
         break;
       }
     }
   }
   return chosen;
-}
-
-/// Aggregates strength for a list of units (probabilistic version with helper).
-double _aggregateStrength(List<Unit> units, int effectiveEra) {
-  var total = 0.0;
-  for (final u in units) {
-    total += unitStrength(u, effectiveEra);
-  }
-  return total;
 }

--- a/packages/colonizethis_combat/lib/src/combat/combat_resolver_probabilistic.dart
+++ b/packages/colonizethis_combat/lib/src/combat/combat_resolver_probabilistic.dart
@@ -9,6 +9,7 @@ import 'dart:math';
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
+import 'combat_effective_strength.dart';
 import 'combat_types.dart';
 import 'military_strength.dart';
 
@@ -114,22 +115,24 @@ ProbabilisticEngagementOutcome resolveEngagementProbabilistic({
     final rawDef = aggregateStrength(defList, defenderEffectiveMilitaryLevel);
 
     final terrainMod = terrainModifiers[terrain] ?? (1.0, 1.0);
-    var effAtt = rawAtt * terrainMod.$1 * attackerMoraleMultiplier;
-    var effDef = rawDef * terrainMod.$2 * defenderMoraleMultiplier;
+    final effAtt = combatEffectiveAttackerStrength(
+      base: rawAtt,
+      fortLevel: fortLevel,
+      factor1: terrainMod.$1,
+      factor2: attackerMoraleMultiplier,
+    );
+    final effDef = combatEffectiveDefenderStrength(
+      base: rawDef,
+      fortLevel: fortLevel,
+      factor1: terrainMod.$2,
+      factor2: defenderMoraleMultiplier,
+      emplacedStrength: combatDefaultEmplacedStrength(fortLevel),
+    );
 
-    if (fortLevel >= 1 && fortLevel <= 3) {
-      final reduction = fortDamageReduction[fortLevel];
-      effAtt *= (1.0 - reduction);
-      final emplaced =
-          fortGunCount[fortLevel] * fortEmplacedStrength[fortLevel];
-      effDef += emplaced;
-    }
-
-    var effAttForRatio = effAtt;
-    if (fortLevel >= 1 && fortLevel <= 3) {
-      final wallHp = wallHpByFortLevel[fortLevel];
-      effAttForRatio = (effAtt - wallHp).clamp(0.0, double.infinity);
-    }
+    final effAttForRatio = combatEffectiveAttackForRatio(
+      effAtt: effAtt,
+      fortLevel: fortLevel,
+    );
 
     final total = effAttForRatio + effDef;
     double pAtt = 0.5;

--- a/packages/colonizethis_combat/lib/src/combat/combat_resolver_support.dart
+++ b/packages/colonizethis_combat/lib/src/combat/combat_resolver_support.dart
@@ -5,25 +5,13 @@ void _sortAttackersByInitiative(
   Map<String, Unit> unitsById,
   Random rng,
 ) {
-  int cavalryCount(AttackingSide side) {
-    var count = 0;
-    for (final id in side.unitIds) {
-      final u = unitsById[id];
-      if (u == null) continue;
-      final stats = regimentStatsById(u.type);
-      if (stats != null && stats.isCavalry) count++;
-    }
-    return count;
-  }
-
   final tieBreakRoll = rng.nextInt(kInitiativeTieBreakRngUpperExclusive);
   int tieRank(String factionId) => Object.hash(factionId, tieBreakRoll);
   final initiativeByAttacker = <_AttackingSideInBattle, double>{};
   for (final attacker in attackers) {
-    final totalUnits = attacker.side.unitIds.length;
-    final cavalryShare = totalUnits > 0
-        ? cavalryCount(attacker.side) / totalUnits
-        : kZeroCavalryShareWhenNoUnits;
+    final cavalryShare = attacker.side.unitIds.isEmpty
+        ? kZeroCavalryShareWhenNoUnits
+        : cavalryFraction(attacker.side.unitIds, unitsById);
     initiativeByAttacker[attacker] =
         cavalryShare * initiativeCavalryShareWeight +
         attacker.side.generalMedals * initiativeGeneralMedalWeight;
@@ -61,16 +49,6 @@ void _incrementGeneralMedals({
       kGeneralMedalsMax,
     ),
   );
-}
-
-int _defenderEffectiveLevel(Game game, String defenderFactionId) {
-  for (final m in game.minorNations) {
-    if (m.id == defenderFactionId) return m.effectiveMilitaryLevel;
-  }
-  for (final t in game.tribes) {
-    if (t.id == defenderFactionId) return t.effectiveMilitaryLevel;
-  }
-  return kDefaultEffectiveMilitaryEra;
 }
 
 /// Max regiments that can participate per side in one engagement.

--- a/packages/colonizethis_combat/lib/src/combat/deterministic_rng.dart
+++ b/packages/colonizethis_combat/lib/src/combat/deterministic_rng.dart
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+/// Deterministic 31-bit LCG RNG (glibc multipliers) for replay-stable rolls.
+class DeterministicRng {
+  DeterministicRng(this._seed);
+
+  int _seed;
+
+  int nextInt(int max) {
+    if (max <= 0) return 0;
+    _seed =
+        (_seed * kDeterministicLcgMultiplierGlibc +
+            kDeterministicLcgIncrementGlibc) &
+        kDeterministicLcg31Mask;
+    return _seed % max;
+  }
+}

--- a/packages/colonizethis_combat/lib/src/combat/military_strength.dart
+++ b/packages/colonizethis_combat/lib/src/combat/military_strength.dart
@@ -47,6 +47,21 @@ double aggregateStrength(List<Unit> units, int effectiveEra) {
   return total;
 }
 
+/// Fraction of [unitIds] that are cavalry regiments (0.0–1.0).
+/// Missing units in [unitsById] are excluded from the numerator but still
+/// count toward the denominator (auto-resolve initiative and Quick Battle).
+double cavalryFraction(List<String> unitIds, Map<String, Unit> unitsById) {
+  if (unitIds.isEmpty) return 0.0;
+  var cavalry = 0;
+  for (final id in unitIds) {
+    final unit = unitsById[id];
+    if (unit == null) continue;
+    final stats = regimentStatsById(unit.type);
+    if (stats != null && stats.isCavalry) cavalry++;
+  }
+  return cavalry / unitIds.length;
+}
+
 /// Morale multiplier from feeding coverage (land or naval). Same breakpoints for
 /// army and fleet upkeep shortfall. SPEC/program/turn-resolution-phase-details.md § Consumption.
 double moraleMultiplierForFeedingCoverage(double coverage) {

--- a/packages/colonizethis_combat/lib/src/combat/naval_combat_resolver.dart
+++ b/packages/colonizethis_combat/lib/src/combat/naval_combat_resolver.dart
@@ -7,6 +7,7 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'package:colonizethis_world/src/world/diplomatic_relation_lookup.dart';
 import 'package:colonizethis_world/colonizethis_world.dart';
+import 'deterministic_rng.dart';
 import 'military_strength.dart';
 
 /// Mission factor for Patrol interception probability.
@@ -183,20 +184,17 @@ List<BattleContextSea> detectNavalConflicts(Game game) {
   return result;
 }
 
-double _fleetInterceptScore(List<String> shipTypeIds) {
-  var total = 0.0;
+(double intercept, double flee) _fleetInterceptAndFleeScores(
+  List<String> shipTypeIds,
+) {
+  var intercept = 0.0;
+  var flee = 0.0;
   for (final id in shipTypeIds) {
-    total += NavalStatsCatalog.get(id).interceptRating;
+    final stats = NavalStatsCatalog.get(id);
+    intercept += stats.interceptRating;
+    flee += stats.fleeRating;
   }
-  return total;
-}
-
-double _fleetFleeScore(List<String> shipTypeIds) {
-  var total = 0.0;
-  for (final id in shipTypeIds) {
-    total += NavalStatsCatalog.get(id).fleeRating;
-  }
-  return total;
+  return (intercept, flee);
 }
 
 /// Interception probability from mission factor × (intercept / (intercept + flee)).
@@ -234,7 +232,7 @@ List<BattleContextSea> filterBattlesByInterception(
   int seed,
 ) {
   if (battles.isEmpty) return battles;
-  final rng = _SeededRng(seed);
+  final rng = DeterministicRng(seed);
 
   // Pre-index moved fleets at sea by (seaZoneId, ownerId) to avoid O(fleets)
   // scan per battle.
@@ -255,10 +253,12 @@ List<BattleContextSea> filterBattlesByInterception(
     final zone = battle.seaZoneId;
     final owner1Moved = ownerMovedInZone(battle.side1.ownerId, zone);
     final owner2Moved = ownerMovedInZone(battle.side2.ownerId, zone);
-    final side1InterceptScore = _fleetInterceptScore(battle.side1.shipTypeIds);
-    final side2InterceptScore = _fleetInterceptScore(battle.side2.shipTypeIds);
-    final side1FleeScore = _fleetFleeScore(battle.side1.shipTypeIds);
-    final side2FleeScore = _fleetFleeScore(battle.side2.shipTypeIds);
+    final (side1InterceptScore, side1FleeScore) = _fleetInterceptAndFleeScores(
+      battle.side1.shipTypeIds,
+    );
+    final (side2InterceptScore, side2FleeScore) = _fleetInterceptAndFleeScores(
+      battle.side2.shipTypeIds,
+    );
     final side2IsInterceptor =
         battle.side2.mission == FleetMission.patrol ||
         battle.side2.mission == FleetMission.blockade;
@@ -334,7 +334,7 @@ NavalBattleResult resolveSeaBattle(
   bool side2CanRetreat = true,
   Map<String, double> navalFeedingCoverageByPlayerId = const {},
 }) {
-  final rng = _SeededRng(seed);
+  final rng = DeterministicRng(seed);
   final cov1 = navalFeedingCoverageByPlayerId[battle.side1.ownerId] ?? 1.0;
   final cov2 = navalFeedingCoverageByPlayerId[battle.side2.ownerId] ?? 1.0;
   final m1 = moraleMultiplierForFeedingCoverage(cov1);
@@ -420,19 +420,6 @@ NavalBattleResult resolveSeaBattle(
     side2Retreated: side2Retreated,
     outcome: outcome,
   );
-}
-
-class _SeededRng {
-  _SeededRng(this._seed);
-  int _seed;
-  int nextInt(int max) {
-    if (max <= 0) return 0;
-    _seed =
-        (_seed * kDeterministicLcgMultiplierGlibc +
-            kDeterministicLcgIncrementGlibc) &
-        kDeterministicLcg31Mask;
-    return _seed % max;
-  }
 }
 
 /// Apply naval battle results to game: replace all fleets of both sides in zone with surviving fleets.

--- a/packages/colonizethis_combat/lib/src/combat/quick_battle_action_modifiers.dart
+++ b/packages/colonizethis_combat/lib/src/combat/quick_battle_action_modifiers.dart
@@ -1,0 +1,93 @@
+/// Per-action combat modifiers for Quick Battle resolution.
+///
+/// SPEC/program/quick-battle-resolution.md.
+///
+/// Action effects (offense, casualties dealt, casualties taken) are expressed as
+/// data ([_actionEffects]) rather than inline switch logic so the modifier table
+/// is discoverable and amenable to future data-driven configuration. The
+/// aggregation semantics (additive deltas from a neutral `1.0` baseline, then a
+/// per-field clamp) are unchanged from the previous inline implementation.
+library;
+
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+/// Aggregated combat modifiers contributed by a round's chosen actions.
+class ActionModifiers {
+  const ActionModifiers({
+    required this.offenseModifier,
+    required this.casualtiesDealtModifier,
+    required this.casualtiesTakenModifier,
+  });
+
+  final double offenseModifier;
+  final double casualtiesDealtModifier;
+  final double casualtiesTakenModifier;
+}
+
+/// Additive deltas a single [QuickBattleAction] contributes to the running
+/// (offense, casualties-dealt, casualties-taken) totals before clamping.
+class _ActionEffect {
+  const _ActionEffect({
+    this.offenseDelta = 0.0,
+    this.dealtDelta = 0.0,
+    this.takenDelta = 0.0,
+  });
+
+  final double offenseDelta;
+  final double dealtDelta;
+  final double takenDelta;
+}
+
+const double _actionModifierBaseline = 1.0;
+const double _actionModifierClampMin = 0.5;
+const double _actionModifierClampMax = 1.5;
+
+/// Canonical per-action effect table. Each entry lists only the non-zero deltas;
+/// omitted fields default to `0.0` (a no-op against the baseline).
+const Map<QuickBattleAction, _ActionEffect> _actionEffects = {
+  QuickBattleAction.volleyFire: _ActionEffect(dealtDelta: 0.15),
+  QuickBattleAction.defendEntrench: _ActionEffect(takenDelta: -0.15),
+  QuickBattleAction.maneuver: _ActionEffect(offenseDelta: 0.05),
+  QuickBattleAction.fallBackRefuseFlank: _ActionEffect(
+    offenseDelta: -0.2,
+    takenDelta: -0.25,
+  ),
+  QuickBattleAction.assaultCharge: _ActionEffect(
+    offenseDelta: 0.25,
+    takenDelta: 0.1,
+  ),
+};
+
+/// Sums the [_actionEffects] deltas for [actions] from the neutral baseline and
+/// clamps each aggregate field to `[0.5, 1.5]`.
+///
+/// Deltas are applied in [actions] order; adding the `0.0` defaults is an
+/// IEEE-754 identity, so the result is bit-identical to the prior switch.
+ActionModifiers aggregateActionModifiers(List<QuickBattleAction> actions) {
+  var offense = _actionModifierBaseline;
+  var dealt = _actionModifierBaseline;
+  var taken = _actionModifierBaseline;
+
+  for (final a in actions) {
+    final effect = _actionEffects[a];
+    if (effect == null) continue;
+    offense += effect.offenseDelta;
+    dealt += effect.dealtDelta;
+    taken += effect.takenDelta;
+  }
+
+  return ActionModifiers(
+    offenseModifier: offense.clamp(
+      _actionModifierClampMin,
+      _actionModifierClampMax,
+    ),
+    casualtiesDealtModifier: dealt.clamp(
+      _actionModifierClampMin,
+      _actionModifierClampMax,
+    ),
+    casualtiesTakenModifier: taken.clamp(
+      _actionModifierClampMin,
+      _actionModifierClampMax,
+    ),
+  );
+}

--- a/packages/colonizethis_combat/lib/src/combat/quick_battle_emplaced_guns.dart
+++ b/packages/colonizethis_combat/lib/src/combat/quick_battle_emplaced_guns.dart
@@ -1,0 +1,86 @@
+/// Virtual emplaced-gun subsystem for Quick Battle siege resolution.
+///
+/// SPEC/program/quick-battle-resolution.md (siege — defender damage split).
+///
+/// Parallels [buildQuickBattleEmplacedGuns] in `quick_battle_emplaced_builder.dart`
+/// (which builds the immutable input guns); this module owns the mutable
+/// in-battle gun state and the round-robin HP damage application used by the
+/// resolver.
+library;
+
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+/// Mutable per-battle state for a virtual emplaced gun. HP is decremented as the
+/// siege progresses; seeded from an immutable [QuickBattleEmplacedGun].
+class MutableEmplacedGun {
+  MutableEmplacedGun({
+    required this.id,
+    required this.maxHp,
+    required this.hp,
+    required this.attackStrength,
+    required this.defenseStrength,
+  });
+
+  /// Creates mutable battle state from an immutable input gun.
+  factory MutableEmplacedGun.fromInput(QuickBattleEmplacedGun g) =>
+      MutableEmplacedGun(
+        id: g.id,
+        maxHp: g.maxHp,
+        hp: g.hp,
+        attackStrength: g.attackStrength,
+        defenseStrength: g.defenseStrength,
+      );
+
+  final String id;
+  final int maxHp;
+  int hp;
+  final double attackStrength;
+  final double defenseStrength;
+}
+
+/// Sum of attack+defense strength over guns still alive (`hp > 0`).
+double aliveGunStrengthSum(List<MutableEmplacedGun> guns) {
+  var s = 0.0;
+  for (final g in guns) {
+    if (g.hp > 0) {
+      s += g.attackStrength + g.defenseStrength;
+    }
+  }
+  return s;
+}
+
+/// Total remaining HP over guns still alive (`hp > 0`).
+int sumAliveGunHp(List<MutableEmplacedGun> guns) {
+  var s = 0;
+  for (final g in guns) {
+    if (g.hp > 0) s += g.hp;
+  }
+  return s;
+}
+
+/// Applies [amount] points of HP damage round-robin across alive guns, sorted
+/// once by [MutableEmplacedGun.id] for determinism.
+///
+/// Dead guns are removed in-place from the working list as they fall instead of
+/// rebuilding it from [guns] on each death.
+void applyRoundRobinGunHpDamage(List<MutableEmplacedGun> guns, int amount) {
+  if (amount <= 0) return;
+  final alive = guns.where((g) => g.hp > 0).toList()
+    ..sort((a, b) => a.id.compareTo(b.id));
+  if (alive.isEmpty) return;
+  var remaining = amount;
+  var idx = 0;
+  while (remaining > 0 && alive.isNotEmpty) {
+    idx = idx % alive.length;
+    final target = alive[idx];
+    target.hp -= 1;
+    remaining--;
+    if (target.hp <= 0) {
+      alive.removeAt(idx);
+      // idx stays the same so the next gun (now shifted into this slot) is
+      // processed next; no need to increment.
+    } else {
+      idx++;
+    }
+  }
+}

--- a/packages/colonizethis_combat/lib/src/combat/quick_battle_input_builder.dart
+++ b/packages/colonizethis_combat/lib/src/combat/quick_battle_input_builder.dart
@@ -5,6 +5,7 @@ import 'package:colonizethis_world/colonizethis_world.dart';
 import 'battle_general_assignment.dart';
 import 'conflict_detection.dart';
 import 'leader_bonus_helpers.dart';
+import 'military_strength.dart';
 import 'quick_battle_emplaced_builder.dart';
 
 /// Builds QuickBattleInput from Game and BattleContext. SPEC/program/quick-battle-resolution.
@@ -60,8 +61,8 @@ QuickBattleInput buildQuickBattleInput(
   );
   final defenderLeaderMult = leaderBonusForFaction(game, ctx.defenderFactionId);
   final emplacedGuns = buildQuickBattleEmplacedGuns(game, ctx);
-  final attackerCavalryShare = _cavalryShare(allAttackerIds, unitsById);
-  final defenderCavalryShare = _cavalryShare(ctx.defenderUnitIds, unitsById);
+  final attackerCavalryShare = cavalryFraction(allAttackerIds, unitsById);
+  final defenderCavalryShare = cavalryFraction(ctx.defenderUnitIds, unitsById);
 
   return QuickBattleInput(
     attackerFactionId: ctx.attackers.first.factionId,
@@ -90,14 +91,3 @@ QuickBattleInput buildQuickBattleInput(
   );
 }
 
-double _cavalryShare(List<String> unitIds, Map<String, Unit> unitsById) {
-  if (unitIds.isEmpty) return 0.0;
-  var cavalry = 0;
-  for (final id in unitIds) {
-    final unit = unitsById[id];
-    if (unit == null) continue;
-    final stats = regimentStatsById(unit.type);
-    if (stats != null && stats.isCavalry) cavalry++;
-  }
-  return cavalry / unitIds.length;
-}

--- a/packages/colonizethis_combat/lib/src/combat/quick_battle_resolver.dart
+++ b/packages/colonizethis_combat/lib/src/combat/quick_battle_resolver.dart
@@ -1,15 +1,14 @@
 import 'dart:math';
 
-import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_combat/src/logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'package:colonizethis_world/colonizethis_world.dart';
-import 'combat_effective_strength.dart';
 import 'conflict_detection.dart';
-
-part 'quick_battle_resolver_engine.dart';
-part 'quick_battle_resolver_outcome.dart';
+import 'quick_battle_action_modifiers.dart';
+import 'quick_battle_emplaced_guns.dart';
+import 'quick_battle_resolver_engine.dart';
+import 'quick_battle_resolver_outcome.dart';
 
 /// Quick Battle resolution pipeline. SPEC/program/quick-battle-resolution.md.
 /// Deterministic for given seed; output feeds same casualty/flip pipeline as auto-resolve.
@@ -24,7 +23,7 @@ part 'quick_battle_resolver_outcome.dart';
 /// - **Gun HP:** `gunHpLoss = min(sumAliveGunHp, max(0, round(defLossFraction * sumAliveGunHp)))`.
 ///   Each point removes 1 HP from virtual guns in **round-robin** over guns sorted by [QuickBattleEmplacedGun.id].
 /// - **Regiments:** `regFrac = regimentCount > 0 ? (defLossFraction * regimentCount / (sumAliveGunHp + regimentCount)).clamp(0, 1) : 0`,
-///   then `_pickCasualties(defGroups, regFrac, rng)`.
+///   then `pickCasualties(defGroups, regFrac, rng)`.
 ///
 /// Determinism: RNG order is unchanged for a given seed (CP rolls and shuffles happen in the same
 /// sequence as before; gun damage uses no extra randomness).
@@ -40,28 +39,25 @@ QuickBattleResult resolveQuickBattle(
     'seed=${input.seed} rounds=${input.maxRounds}',
   );
   final rng = Random(input.seed);
-  var attGroups = _copyGroups(input.attackerDeployment.groups);
-  var defGroups = _copyGroups(input.defenderDeployment.groups);
+  var attGroups = copyGroups(input.attackerDeployment.groups);
+  var defGroups = copyGroups(input.defenderDeployment.groups);
   final attCasualties = <String>[];
   final defCasualties = <String>[];
   final useVirtualEmplaced = input.emplacedGuns.isNotEmpty;
   final mutableGuns = useVirtualEmplaced
-      ? input.emplacedGuns
-            .map(
-              (g) => _MutableEmplacedGun(
-                id: g.id,
-                maxHp: g.maxHp,
-                hp: g.hp,
-                attackStrength: g.attackStrength,
-                defenseStrength: g.defenseStrength,
-              ),
-            )
-            .toList()
-      : <_MutableEmplacedGun>[];
+      ? input.emplacedGuns.map(MutableEmplacedGun.fromInput).toList()
+      : <MutableEmplacedGun>[];
+  final finisher = QuickBattleFinisher(
+    input: input,
+    attackerCasualties: attCasualties,
+    defenderCasualties: defCasualties,
+    mutableGuns: mutableGuns,
+    useVirtualEmplaced: useVirtualEmplaced,
+  );
 
   for (var round = 1; round <= input.maxRounds; round++) {
-    final attCp = _rollCommandPoints(rng);
-    final defCp = _rollCommandPoints(rng);
+    final attCp = rollCommandPoints(rng);
+    final defCp = rollCommandPoints(rng);
 
     final rActions = roundActions != null && round <= roundActions.length
         ? roundActions[round - 1]
@@ -75,22 +71,22 @@ QuickBattleResult resolveQuickBattle(
         rActions?.actions ??
         const [QuickBattleAction.volleyFire];
 
-    final attActs = _limitActionsByCp(rawAttActs, attCp);
-    final defActs = _limitActionsByCp(rawDefActs, defCp);
+    final attActs = limitActionsByCp(rawAttActs, attCp);
+    final defActs = limitActionsByCp(rawDefActs, defCp);
 
-    final attMods = _aggregateActionModifiers(attActs);
-    final defMods = _aggregateActionModifiers(defActs);
+    final attMods = aggregateActionModifiers(attActs);
+    final defMods = aggregateActionModifiers(defActs);
 
-    final attackerActsFirst = _attackerActsFirst(input);
+    final actsFirst = attackerActsFirst(input);
     // Compute round-level effective strengths once. Each strike only mutates
     // one side's state, so the unchanged side's strength stays valid across
     // both strikes within this round.
-    var effAtt = _attackerEffectiveStrength(
+    var effAtt = attackerEffectiveStrength(
       input: input,
       attGroups: attGroups,
       attMods: attMods,
     );
-    var effDef = _defenderEffectiveStrength(
+    var effDef = defenderEffectiveStrength(
       input: input,
       defGroups: defGroups,
       defMods: defMods,
@@ -99,15 +95,15 @@ QuickBattleResult resolveQuickBattle(
     );
     final List<String> defLoss;
     final List<String> attLoss;
-    if (attackerActsFirst) {
-      final defLossFraction = _defenderLossFractionFromAttackerStrike(
+    if (actsFirst) {
+      final defLossFraction = defenderLossFractionFromAttackerStrike(
         input: input,
         effAtt: effAtt,
         effDef: effDef,
         attMods: attMods,
         defMods: defMods,
       );
-      defLoss = _pickDefenderLosses(
+      defLoss = pickDefenderLosses(
         groups: defGroups,
         fraction: defLossFraction,
         rng: rng,
@@ -115,76 +111,66 @@ QuickBattleResult resolveQuickBattle(
         useVirtualEmplaced: useVirtualEmplaced,
       );
       defCasualties.addAll(defLoss);
-      defGroups = _removeCasualties(defGroups, defLoss);
+      defGroups = removeCasualties(defGroups, defLoss);
 
-      if (_totalUnitCount(defGroups) <= 0) {
-        return _finishAndLogQuickBattleResult(
+      if (totalUnitCount(defGroups) <= 0) {
+        return finisher.finish(
           winner: QuickBattleWinner.attacker,
-          attackerCasualties: attCasualties,
-          defenderCasualties: defCasualties,
           provinceFlips: true,
-          input: input,
-          mutableGuns: mutableGuns,
-          useVirtualEmplaced: useVirtualEmplaced,
         );
       }
 
       // Defender state changed (regiments removed, gun HP possibly damaged).
       // Recompute defender strength only; attacker strength is unchanged.
-      effDef = _defenderEffectiveStrength(
+      effDef = defenderEffectiveStrength(
         input: input,
         defGroups: defGroups,
         defMods: defMods,
         mutableGuns: mutableGuns,
         useVirtualEmplaced: useVirtualEmplaced,
       );
-      final attLossFraction = _attackerLossFractionFromDefenderStrike(
+      final attLossFraction = attackerLossFractionFromDefenderStrike(
         effAtt: effAtt,
         effDef: effDef,
         attMods: attMods,
         defMods: defMods,
       );
-      attLoss = _pickCasualties(attGroups, attLossFraction, rng);
+      attLoss = pickCasualties(attGroups, attLossFraction, rng);
       attCasualties.addAll(attLoss);
-      attGroups = _removeCasualties(attGroups, attLoss);
+      attGroups = removeCasualties(attGroups, attLoss);
     } else {
-      final attLossFraction = _attackerLossFractionFromDefenderStrike(
+      final attLossFraction = attackerLossFractionFromDefenderStrike(
         effAtt: effAtt,
         effDef: effDef,
         attMods: attMods,
         defMods: defMods,
       );
-      attLoss = _pickCasualties(attGroups, attLossFraction, rng);
+      attLoss = pickCasualties(attGroups, attLossFraction, rng);
       attCasualties.addAll(attLoss);
-      attGroups = _removeCasualties(attGroups, attLoss);
+      attGroups = removeCasualties(attGroups, attLoss);
 
-      if (_totalUnitCount(attGroups) <= 0) {
-        return _finishAndLogQuickBattleResult(
+      if (totalUnitCount(attGroups) <= 0) {
+        return finisher.finish(
           winner: QuickBattleWinner.defender,
-          attackerCasualties: attCasualties,
-          defenderCasualties: defCasualties,
           provinceFlips: false,
-          input: input,
-          mutableGuns: mutableGuns,
-          useVirtualEmplaced: useVirtualEmplaced,
         );
       }
 
       // Attacker state changed; recompute attacker strength only. Defender
       // groups and gun HP are unchanged so effDef remains valid.
-      effAtt = _attackerEffectiveStrength(
+      effAtt = attackerEffectiveStrength(
         input: input,
         attGroups: attGroups,
         attMods: attMods,
       );
-      final defLossFraction = _defenderLossFractionFromAttackerStrike(
+      final defLossFraction = defenderLossFractionFromAttackerStrike(
         input: input,
         effAtt: effAtt,
         effDef: effDef,
         attMods: attMods,
         defMods: defMods,
       );
-      defLoss = _pickDefenderLosses(
+      defLoss = pickDefenderLosses(
         groups: defGroups,
         fraction: defLossFraction,
         rng: rng,
@@ -192,97 +178,67 @@ QuickBattleResult resolveQuickBattle(
         useVirtualEmplaced: useVirtualEmplaced,
       );
       defCasualties.addAll(defLoss);
-      defGroups = _removeCasualties(defGroups, defLoss);
+      defGroups = removeCasualties(defGroups, defLoss);
     }
 
     if (defLoss.length > attLoss.length && defLoss.isNotEmpty) {
-      defGroups = _degradeCohesion(defGroups);
+      defGroups = degradeCohesion(defGroups);
     } else if (attLoss.length > defLoss.length && attLoss.isNotEmpty) {
-      attGroups = _degradeCohesion(attGroups);
+      attGroups = degradeCohesion(attGroups);
     }
 
-    if (_totalUnitCount(defGroups) <= 0) {
-      return _finishAndLogQuickBattleResult(
+    if (totalUnitCount(defGroups) <= 0) {
+      return finisher.finish(
         winner: QuickBattleWinner.attacker,
-        attackerCasualties: attCasualties,
-        defenderCasualties: defCasualties,
         provinceFlips: true,
-        input: input,
-        mutableGuns: mutableGuns,
-        useVirtualEmplaced: useVirtualEmplaced,
       );
     }
-    if (_totalUnitCount(attGroups) <= 0) {
-      return _finishAndLogQuickBattleResult(
+    if (totalUnitCount(attGroups) <= 0) {
+      return finisher.finish(
         winner: QuickBattleWinner.defender,
-        attackerCasualties: attCasualties,
-        defenderCasualties: defCasualties,
         provinceFlips: false,
-        input: input,
-        mutableGuns: mutableGuns,
-        useVirtualEmplaced: useVirtualEmplaced,
       );
     }
   }
 
   return _resolveQuickBattleRoundLimitOutcome(
-    input: input,
+    finisher,
     attGroups: attGroups,
     defGroups: defGroups,
-    attackerCasualties: attCasualties,
-    defenderCasualties: defCasualties,
-    mutableGuns: mutableGuns,
-    useVirtualEmplaced: useVirtualEmplaced,
   );
 }
 
-QuickBattleResult _resolveQuickBattleRoundLimitOutcome({
-  required QuickBattleInput input,
+QuickBattleResult _resolveQuickBattleRoundLimitOutcome(
+  QuickBattleFinisher finisher, {
   required List<QuickBattleGroup> attGroups,
   required List<QuickBattleGroup> defGroups,
-  required List<String> attackerCasualties,
-  required List<String> defenderCasualties,
-  required List<_MutableEmplacedGun> mutableGuns,
-  required bool useVirtualEmplaced,
 }) {
+  final input = finisher.input;
   final finalAttStr =
-      _effectiveStrength(attGroups, input.attackerDeployment.laneTerrain) *
+      effectiveStrength(attGroups, input.attackerDeployment.laneTerrain) *
       input.attackerLeaderMultiplier;
   final finalDefStr =
-      _effectiveStrength(defGroups, input.defenderDeployment.laneTerrain) *
+      effectiveStrength(defGroups, input.defenderDeployment.laneTerrain) *
           input.defenderLeaderMultiplier +
-      (useVirtualEmplaced ? _aliveGunStrengthSum(mutableGuns) : 0.0);
+      (finisher.useVirtualEmplaced
+          ? aliveGunStrengthSum(finisher.mutableGuns)
+          : 0.0);
 
   if (finalAttStr > finalDefStr * 1.2) {
-    return _finishAndLogQuickBattleResult(
+    return finisher.finish(
       winner: QuickBattleWinner.attacker,
-      attackerCasualties: attackerCasualties,
-      defenderCasualties: defenderCasualties,
       provinceFlips: true,
-      input: input,
-      mutableGuns: mutableGuns,
-      useVirtualEmplaced: useVirtualEmplaced,
     );
   }
   if (finalDefStr > finalAttStr * 1.2) {
-    return _finishAndLogQuickBattleResult(
+    return finisher.finish(
       winner: QuickBattleWinner.defender,
-      attackerCasualties: attackerCasualties,
-      defenderCasualties: defenderCasualties,
       provinceFlips: false,
-      input: input,
-      mutableGuns: mutableGuns,
-      useVirtualEmplaced: useVirtualEmplaced,
     );
   }
-  return _finishAndLogQuickBattleResult(
+  return finisher.finish(
     winner: QuickBattleWinner.mutualExhaustion,
-    attackerCasualties: attackerCasualties,
-    defenderCasualties: defenderCasualties,
     provinceFlips: false,
-    input: input,
-    mutableGuns: mutableGuns,
-    useVirtualEmplaced: useVirtualEmplaced,
   );
 }
 

--- a/packages/colonizethis_combat/lib/src/combat/quick_battle_resolver.dart
+++ b/packages/colonizethis_combat/lib/src/combat/quick_battle_resolver.dart
@@ -5,6 +5,7 @@ import 'package:colonizethis_combat/src/logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'package:colonizethis_world/colonizethis_world.dart';
+import 'combat_effective_strength.dart';
 import 'conflict_detection.dart';
 
 part 'quick_battle_resolver_engine.dart';

--- a/packages/colonizethis_combat/lib/src/combat/quick_battle_resolver_engine.dart
+++ b/packages/colonizethis_combat/lib/src/combat/quick_battle_resolver_engine.dart
@@ -189,10 +189,10 @@ double _defenderLossFractionFromAttackerStrike({
   required _ActionModifiers attMods,
   required _ActionModifiers defMods,
 }) {
-  final wallHp = input.fortLevel >= 1 && input.fortLevel <= 3
-      ? wallHpByFortLevel[input.fortLevel]
-      : 0.0;
-  final effAttForRatio = (effAtt - wallHp).clamp(0.0, double.infinity);
+  final effAttForRatio = combatEffectiveAttackForRatio(
+    effAtt: effAtt,
+    fortLevel: input.fortLevel,
+  );
   final ratio = effDef > 0 ? effAttForRatio / effDef : 10.0;
   return (_targetLossFraction(ratio) *
           attMods.casualtiesDealtModifier *
@@ -228,15 +228,13 @@ double _attackerEffectiveStrength({
   required _ActionModifiers attMods,
 }) {
   final terrainMod = terrainModifiers[input.provinceTerrain] ?? (1.0, 1.0);
-  var effAtt =
-      _effectiveStrength(attGroups, input.attackerDeployment.laneTerrain) *
-      attMods.offenseModifier *
-      input.attackerLeaderMultiplier *
-      terrainMod.$1;
-  if (input.fortLevel >= 1 && input.fortLevel <= 3) {
-    effAtt *= (1.0 - fortDamageReduction[input.fortLevel]);
-  }
-  return effAtt;
+  return combatEffectiveAttackerStrength(
+    base: _effectiveStrength(attGroups, input.attackerDeployment.laneTerrain),
+    fortLevel: input.fortLevel,
+    factor1: attMods.offenseModifier,
+    factor2: input.attackerLeaderMultiplier,
+    factor3: terrainMod.$1,
+  );
 }
 
 double _defenderEffectiveStrength({
@@ -247,20 +245,17 @@ double _defenderEffectiveStrength({
   required bool useVirtualEmplaced,
 }) {
   final terrainMod = terrainModifiers[input.provinceTerrain] ?? (1.0, 1.0);
-  var effDef =
-      _effectiveStrength(defGroups, input.defenderDeployment.laneTerrain) *
-      defMods.offenseModifier *
-      input.defenderLeaderMultiplier *
-      terrainMod.$2;
-  if (input.fortLevel >= 1 && input.fortLevel <= 3) {
-    if (useVirtualEmplaced) {
-      effDef += _aliveGunStrengthSum(mutableGuns);
-    } else {
-      effDef +=
-          fortGunCount[input.fortLevel] * fortEmplacedStrength[input.fortLevel];
-    }
-  }
-  return effDef;
+  final emplaced = useVirtualEmplaced
+      ? _aliveGunStrengthSum(mutableGuns)
+      : combatDefaultEmplacedStrength(input.fortLevel);
+  return combatEffectiveDefenderStrength(
+    base: _effectiveStrength(defGroups, input.defenderDeployment.laneTerrain),
+    fortLevel: input.fortLevel,
+    factor1: defMods.offenseModifier,
+    factor2: input.defenderLeaderMultiplier,
+    factor3: terrainMod.$2,
+    emplacedStrength: emplaced,
+  );
 }
 
 List<String> _pickDefenderLosses({

--- a/packages/colonizethis_combat/lib/src/combat/quick_battle_resolver_engine.dart
+++ b/packages/colonizethis_combat/lib/src/combat/quick_battle_resolver_engine.dart
@@ -1,10 +1,28 @@
-part of 'quick_battle_resolver.dart';
+/// Quick Battle round-engine helpers: group bookkeeping, command-point limits,
+/// effective-strength and casualty-fraction math.
+///
+/// SPEC/program/quick-battle-resolution.md.
+///
+/// Extracted from the `quick_battle_resolver.dart` part-file group into a
+/// regular library so these helpers can be imported (and unit-tested)
+/// independently. Helpers consumed by the resolver are package-public; helpers
+/// used only within this file remain private.
+library;
 
-List<QuickBattleGroup> _copyGroups(List<QuickBattleGroup> groups) => groups
+import 'dart:math';
+
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import 'combat_effective_strength.dart';
+import 'quick_battle_action_modifiers.dart';
+import 'quick_battle_emplaced_guns.dart';
+
+List<QuickBattleGroup> copyGroups(List<QuickBattleGroup> groups) => groups
     .map((g) => g.copyWith(unitIds: List<String>.from(g.unitIds)))
     .toList();
 
-int _rollCommandPoints(Random rng) {
+int rollCommandPoints(Random rng) {
   final span = quickBattleCpPerRoundMax - quickBattleCpPerRoundMin;
   if (span <= 0) return quickBattleCpPerRoundMin;
   return quickBattleCpPerRoundMin + rng.nextInt(span + 1);
@@ -22,10 +40,7 @@ int _actionCost(QuickBattleAction action) {
   }
 }
 
-List<QuickBattleAction> _limitActionsByCp(
-  List<QuickBattleAction> actions,
-  int cp,
-) {
+List<QuickBattleAction> limitActionsByCp(List<QuickBattleAction> actions, int cp) {
   final result = <QuickBattleAction>[];
   var spent = 0;
   for (final a in actions) {
@@ -37,58 +52,7 @@ List<QuickBattleAction> _limitActionsByCp(
   return result;
 }
 
-class _ActionModifiers {
-  const _ActionModifiers({
-    required this.offenseModifier,
-    required this.casualtiesDealtModifier,
-    required this.casualtiesTakenModifier,
-  });
-
-  final double offenseModifier;
-  final double casualtiesDealtModifier;
-  final double casualtiesTakenModifier;
-}
-
-_ActionModifiers _aggregateActionModifiers(List<QuickBattleAction> actions) {
-  var offense = 1.0;
-  var dealt = 1.0;
-  var taken = 1.0;
-
-  for (final a in actions) {
-    switch (a) {
-      case QuickBattleAction.volleyFire:
-        dealt += 0.15;
-        break;
-      case QuickBattleAction.defendEntrench:
-        offense += 0.0;
-        taken -= 0.15;
-        break;
-      case QuickBattleAction.maneuver:
-        offense += 0.05;
-        break;
-      case QuickBattleAction.fallBackRefuseFlank:
-        offense -= 0.2;
-        taken -= 0.25;
-        break;
-      case QuickBattleAction.assaultCharge:
-        offense += 0.25;
-        taken += 0.1;
-        break;
-    }
-  }
-
-  offense = offense.clamp(0.5, 1.5);
-  dealt = dealt.clamp(0.5, 1.5);
-  taken = taken.clamp(0.5, 1.5);
-
-  return _ActionModifiers(
-    offenseModifier: offense,
-    casualtiesDealtModifier: dealt,
-    casualtiesTakenModifier: taken,
-  );
-}
-
-double _effectiveStrength(
+double effectiveStrength(
   List<QuickBattleGroup> groups,
   Map<String, QuickBattleLaneTerrain> laneTerrain,
 ) {
@@ -118,7 +82,7 @@ double _effectiveStrength(
   return total;
 }
 
-List<String> _pickCasualties(
+List<String> pickCasualties(
   List<QuickBattleGroup> groups,
   double fraction,
   Random rng,
@@ -133,7 +97,7 @@ List<String> _pickCasualties(
   return allIds.take(count).toList();
 }
 
-List<QuickBattleGroup> _removeCasualties(
+List<QuickBattleGroup> removeCasualties(
   List<QuickBattleGroup> groups,
   List<String> casualties,
 ) {
@@ -148,7 +112,7 @@ List<QuickBattleGroup> _removeCasualties(
       .toList();
 }
 
-List<QuickBattleGroup> _degradeCohesion(List<QuickBattleGroup> groups) {
+List<QuickBattleGroup> degradeCohesion(List<QuickBattleGroup> groups) {
   return groups
       .map(
         (g) => g.copyWith(
@@ -158,10 +122,10 @@ List<QuickBattleGroup> _degradeCohesion(List<QuickBattleGroup> groups) {
       .toList();
 }
 
-int _totalUnitCount(List<QuickBattleGroup> groups) =>
+int totalUnitCount(List<QuickBattleGroup> groups) =>
     groups.fold(0, (s, g) => s + g.unitIds.length);
 
-bool _attackerActsFirst(QuickBattleInput input) {
+bool attackerActsFirst(QuickBattleInput input) {
   final attackerInitiative =
       input.attackerCavalryShare * initiativeCavalryShareWeight +
       input.attackerGeneralMedals * initiativeGeneralMedalWeight;
@@ -178,16 +142,16 @@ bool _attackerActsFirst(QuickBattleInput input) {
 /// precomputed effective strengths.
 ///
 /// Callers compute `effAtt` and `effDef` once at the round level via
-/// [_attackerEffectiveStrength] and [_defenderEffectiveStrength] and only
+/// [attackerEffectiveStrength] and [defenderEffectiveStrength] and only
 /// recompute the side whose state has changed between strikes. This avoids
-/// the previous O(4) `_effectiveStrength` invocations per round, where the
+/// the previous O(4) [effectiveStrength] invocations per round, where the
 /// striker side's strength was identical across both loss-fraction calls.
-double _defenderLossFractionFromAttackerStrike({
+double defenderLossFractionFromAttackerStrike({
   required QuickBattleInput input,
   required double effAtt,
   required double effDef,
-  required _ActionModifiers attMods,
-  required _ActionModifiers defMods,
+  required ActionModifiers attMods,
+  required ActionModifiers defMods,
 }) {
   final effAttForRatio = combatEffectiveAttackForRatio(
     effAtt: effAtt,
@@ -201,13 +165,13 @@ double _defenderLossFractionFromAttackerStrike({
 }
 
 /// Computes the attacker loss fraction from a defender strike using
-/// precomputed effective strengths. See [_defenderLossFractionFromAttackerStrike]
+/// precomputed effective strengths. See [defenderLossFractionFromAttackerStrike]
 /// for the round-level caching contract.
-double _attackerLossFractionFromDefenderStrike({
+double attackerLossFractionFromDefenderStrike({
   required double effAtt,
   required double effDef,
-  required _ActionModifiers attMods,
-  required _ActionModifiers defMods,
+  required ActionModifiers attMods,
+  required ActionModifiers defMods,
 }) {
   final ratio = effAtt > 0 ? effDef / effAtt : 10.0;
   return (_targetLossFraction(ratio) *
@@ -222,14 +186,14 @@ double _targetLossFraction(double strikerToTargetRatio) {
   return 0.4;
 }
 
-double _attackerEffectiveStrength({
+double attackerEffectiveStrength({
   required QuickBattleInput input,
   required List<QuickBattleGroup> attGroups,
-  required _ActionModifiers attMods,
+  required ActionModifiers attMods,
 }) {
   final terrainMod = terrainModifiers[input.provinceTerrain] ?? (1.0, 1.0);
   return combatEffectiveAttackerStrength(
-    base: _effectiveStrength(attGroups, input.attackerDeployment.laneTerrain),
+    base: effectiveStrength(attGroups, input.attackerDeployment.laneTerrain),
     fortLevel: input.fortLevel,
     factor1: attMods.offenseModifier,
     factor2: input.attackerLeaderMultiplier,
@@ -237,19 +201,19 @@ double _attackerEffectiveStrength({
   );
 }
 
-double _defenderEffectiveStrength({
+double defenderEffectiveStrength({
   required QuickBattleInput input,
   required List<QuickBattleGroup> defGroups,
-  required _ActionModifiers defMods,
-  required List<_MutableEmplacedGun> mutableGuns,
+  required ActionModifiers defMods,
+  required List<MutableEmplacedGun> mutableGuns,
   required bool useVirtualEmplaced,
 }) {
   final terrainMod = terrainModifiers[input.provinceTerrain] ?? (1.0, 1.0);
   final emplaced = useVirtualEmplaced
-      ? _aliveGunStrengthSum(mutableGuns)
+      ? aliveGunStrengthSum(mutableGuns)
       : combatDefaultEmplacedStrength(input.fortLevel);
   return combatEffectiveDefenderStrength(
-    base: _effectiveStrength(defGroups, input.defenderDeployment.laneTerrain),
+    base: effectiveStrength(defGroups, input.defenderDeployment.laneTerrain),
     fortLevel: input.fortLevel,
     factor1: defMods.offenseModifier,
     factor2: input.defenderLeaderMultiplier,
@@ -258,23 +222,23 @@ double _defenderEffectiveStrength({
   );
 }
 
-List<String> _pickDefenderLosses({
+List<String> pickDefenderLosses({
   required List<QuickBattleGroup> groups,
   required double fraction,
   required Random rng,
-  required List<_MutableEmplacedGun> mutableGuns,
+  required List<MutableEmplacedGun> mutableGuns,
   required bool useVirtualEmplaced,
 }) {
-  if (!useVirtualEmplaced) return _pickCasualties(groups, fraction, rng);
-  final regimentCount = _totalUnitCount(groups);
-  final gunHpPool = _sumAliveGunHp(mutableGuns);
+  if (!useVirtualEmplaced) return pickCasualties(groups, fraction, rng);
+  final regimentCount = totalUnitCount(groups);
+  final gunHpPool = sumAliveGunHp(mutableGuns);
   final totalSlots = regimentCount + gunHpPool;
   final gunHpLoss = totalSlots > 0 && gunHpPool > 0
       ? min(gunHpPool, max(0, (fraction * gunHpPool).round()))
       : 0;
-  _applyRoundRobinGunHpDamage(mutableGuns, gunHpLoss);
+  applyRoundRobinGunHpDamage(mutableGuns, gunHpLoss);
   final regFrac = regimentCount > 0 && totalSlots > 0
       ? (fraction * regimentCount / totalSlots).clamp(0.0, 1.0)
       : 0.0;
-  return _pickCasualties(groups, regFrac, rng);
+  return pickCasualties(groups, regFrac, rng);
 }

--- a/packages/colonizethis_combat/lib/src/combat/quick_battle_resolver_outcome.dart
+++ b/packages/colonizethis_combat/lib/src/combat/quick_battle_resolver_outcome.dart
@@ -1,119 +1,79 @@
-part of 'quick_battle_resolver.dart';
+/// Quick Battle terminal-outcome construction and logging.
+///
+/// SPEC/program/quick-battle-resolution.md.
+///
+/// Hosts [QuickBattleFinisher], which bundles the battle-invariant inputs
+/// (input, accumulated casualty lists, mutable emplaced guns) so each of the
+/// resolver's terminal outcomes only supplies the varying `winner` and
+/// `provinceFlips`.
+library;
 
-QuickBattleResult _finishAndLogQuickBattleResult({
-  required QuickBattleWinner winner,
-  required List<String> attackerCasualties,
-  required List<String> defenderCasualties,
-  required bool provinceFlips,
-  required QuickBattleInput input,
-  required List<_MutableEmplacedGun> mutableGuns,
-  required bool useVirtualEmplaced,
-}) {
-  final result = _finishResult(
-    winner: winner,
-    attackerCasualties: attackerCasualties,
-    defenderCasualties: defenderCasualties,
-    provinceFlips: provinceFlips,
-    input: input,
-    mutableGuns: mutableGuns,
-    useVirtualEmplaced: useVirtualEmplaced,
-  );
-  combatLog.d(
-    'quick_battle end winner=${result.winner.name} '
-    'flip=${result.provinceFlips} fortDowngrade=${result.fortDowngradeFromDestroyedEmplaced}',
-  );
-  return result;
-}
+import 'package:colonizethis_combat/src/logging.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
 
-class _MutableEmplacedGun {
-  _MutableEmplacedGun({
-    required this.id,
-    required this.maxHp,
-    required this.hp,
-    required this.attackStrength,
-    required this.defenseStrength,
+import 'quick_battle_emplaced_guns.dart';
+
+/// Builds and logs the final [QuickBattleResult] from the battle-invariant
+/// state captured once per resolution.
+///
+/// Previously each of the seven terminal outcomes called a free function with
+/// the same five-argument invariant set repeated inline; capturing those once
+/// here removes that duplication.
+class QuickBattleFinisher {
+  QuickBattleFinisher({
+    required this.input,
+    required this.attackerCasualties,
+    required this.defenderCasualties,
+    required this.mutableGuns,
+    required this.useVirtualEmplaced,
   });
 
-  final String id;
-  final int maxHp;
-  int hp;
-  final double attackStrength;
-  final double defenseStrength;
-}
+  final QuickBattleInput input;
+  final List<String> attackerCasualties;
+  final List<String> defenderCasualties;
+  final List<MutableEmplacedGun> mutableGuns;
+  final bool useVirtualEmplaced;
 
-QuickBattleResult _finishResult({
-  required QuickBattleWinner winner,
-  required List<String> attackerCasualties,
-  required List<String> defenderCasualties,
-  required bool provinceFlips,
-  required QuickBattleInput input,
-  required List<_MutableEmplacedGun> mutableGuns,
-  required bool useVirtualEmplaced,
-}) {
-  final outcomes = useVirtualEmplaced
-      ? mutableGuns
-            .map(
-              (g) => QuickBattleEmplacedGunOutcome(
-                id: g.id,
-                hp: g.hp.clamp(0, g.maxHp),
-                destroyed: g.hp <= 0,
-              ),
-            )
-            .toList()
-      : const <QuickBattleEmplacedGunOutcome>[];
-  final downgrade =
-      useVirtualEmplaced &&
-      input.emplacedGuns.isNotEmpty &&
-      mutableGuns.isNotEmpty &&
-      mutableGuns.every((g) => g.hp <= 0);
-  return QuickBattleResult(
-    winner: winner,
-    attackerCasualties: attackerCasualties,
-    defenderCasualties: defenderCasualties,
-    provinceFlips: provinceFlips,
-    fortDowngradeFromDestroyedEmplaced: downgrade,
-    emplacedGunOutcomes: outcomes,
-  );
-}
-
-double _aliveGunStrengthSum(List<_MutableEmplacedGun> guns) {
-  var s = 0.0;
-  for (final g in guns) {
-    if (g.hp > 0) {
-      s += g.attackStrength + g.defenseStrength;
-    }
+  /// Constructs the result for [winner]/[provinceFlips] and logs the outcome.
+  QuickBattleResult finish({
+    required QuickBattleWinner winner,
+    required bool provinceFlips,
+  }) {
+    final result = _buildResult(winner: winner, provinceFlips: provinceFlips);
+    combatLog.d(
+      'quick_battle end winner=${result.winner.name} '
+      'flip=${result.provinceFlips} fortDowngrade=${result.fortDowngradeFromDestroyedEmplaced}',
+    );
+    return result;
   }
-  return s;
-}
 
-int _sumAliveGunHp(List<_MutableEmplacedGun> guns) {
-  var s = 0;
-  for (final g in guns) {
-    if (g.hp > 0) s += g.hp;
-  }
-  return s;
-}
-
-void _applyRoundRobinGunHpDamage(List<_MutableEmplacedGun> guns, int amount) {
-  if (amount <= 0) return;
-  // Sort once up front by id for determinism; then remove dead guns in-place
-  // instead of rebuilding the whole list from [guns] on each death.
-  final alive = guns.where((g) => g.hp > 0).toList()
-    ..sort((a, b) => a.id.compareTo(b.id));
-  if (alive.isEmpty) return;
-  var remaining = amount;
-  var idx = 0;
-  while (remaining > 0 && alive.isNotEmpty) {
-    idx = idx % alive.length;
-    final target = alive[idx];
-    target.hp -= 1;
-    remaining--;
-    if (target.hp <= 0) {
-      alive.removeAt(idx);
-      // idx stays the same so the next gun (now shifted into this slot) is
-      // processed next; no need to increment.
-    } else {
-      idx++;
-    }
+  QuickBattleResult _buildResult({
+    required QuickBattleWinner winner,
+    required bool provinceFlips,
+  }) {
+    final outcomes = useVirtualEmplaced
+        ? mutableGuns
+              .map(
+                (g) => QuickBattleEmplacedGunOutcome(
+                  id: g.id,
+                  hp: g.hp.clamp(0, g.maxHp),
+                  destroyed: g.hp <= 0,
+                ),
+              )
+              .toList()
+        : const <QuickBattleEmplacedGunOutcome>[];
+    final downgrade =
+        useVirtualEmplaced &&
+        input.emplacedGuns.isNotEmpty &&
+        mutableGuns.isNotEmpty &&
+        mutableGuns.every((g) => g.hp <= 0);
+    return QuickBattleResult(
+      winner: winner,
+      attackerCasualties: attackerCasualties,
+      defenderCasualties: defenderCasualties,
+      provinceFlips: provinceFlips,
+      fortDowngradeFromDestroyedEmplaced: downgrade,
+      emplacedGunOutcomes: outcomes,
+    );
   }
 }

--- a/packages/colonizethis_combat/test/combat_effective_strength_test.dart
+++ b/packages/colonizethis_combat/test/combat_effective_strength_test.dart
@@ -1,0 +1,122 @@
+// Copyright 2024 Robert W. Guenther
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:colonizethis_combat/src/combat/combat_effective_strength.dart';
+import 'package:colonizethis_test/test.dart';
+
+void main() {
+  group('combatEffectiveAttackerStrength', () {
+    test('multiplies base by all factors when no fort applies', () {
+      final eff = combatEffectiveAttackerStrength(
+        base: 10.0,
+        fortLevel: 0,
+        factor1: 1.1,
+        factor2: 1.05,
+        factor3: 0.9,
+      );
+
+      expect(eff, equals(10.0 * 1.1 * 1.05 * 0.9));
+    });
+
+    test('omitted factors are the identity (bit-exact)', () {
+      final full = combatEffectiveAttackerStrength(
+        base: 13.0,
+        fortLevel: 0,
+        factor1: 1.1,
+        factor2: 1.0,
+        factor3: 1.0,
+      );
+      final partial = combatEffectiveAttackerStrength(
+        base: 13.0,
+        fortLevel: 0,
+        factor1: 1.1,
+      );
+
+      expect(partial, equals(full));
+    });
+
+    test('applies fort damage reduction inside the siege range', () {
+      // fortDamageReduction[2] == 0.45 -> attacker scaled by 0.55.
+      final eff = combatEffectiveAttackerStrength(
+        base: 10.0,
+        fortLevel: 2,
+        factor1: 2.0,
+      );
+
+      expect(eff, equals(10.0 * 2.0 * (1.0 - 0.45)));
+    });
+
+    test('does not apply reduction outside the siege range', () {
+      final eff = combatEffectiveAttackerStrength(
+        base: 10.0,
+        fortLevel: 4,
+        factor1: 2.0,
+      );
+
+      expect(eff, equals(20.0));
+    });
+  });
+
+  group('combatEffectiveDefenderStrength', () {
+    test('multiplies base by factors and ignores emplaced without fort', () {
+      final eff = combatEffectiveDefenderStrength(
+        base: 8.0,
+        fortLevel: 0,
+        factor1: 1.2,
+        emplacedStrength: 100.0,
+      );
+
+      expect(eff, equals(8.0 * 1.2));
+    });
+
+    test('adds emplaced strength inside the siege range', () {
+      final eff = combatEffectiveDefenderStrength(
+        base: 8.0,
+        fortLevel: 1,
+        factor1: 1.0,
+        emplacedStrength: 5.0,
+      );
+
+      expect(eff, equals(8.0 + 5.0));
+    });
+  });
+
+  group('combatEffectiveAttackForRatio', () {
+    test('returns effAtt unchanged outside the siege range', () {
+      expect(
+        combatEffectiveAttackForRatio(effAtt: 42.0, fortLevel: 0),
+        equals(42.0),
+      );
+    });
+
+    test('subtracts wall HP inside the siege range', () {
+      // wallHpByFortLevel[2] == 20.0
+      expect(
+        combatEffectiveAttackForRatio(effAtt: 50.0, fortLevel: 2),
+        equals(30.0),
+      );
+    });
+
+    test('clamps to zero when wall HP exceeds effAtt', () {
+      // wallHpByFortLevel[3] == 30.0
+      expect(
+        combatEffectiveAttackForRatio(effAtt: 5.0, fortLevel: 3),
+        equals(0.0),
+      );
+    });
+  });
+
+  group('combatDefaultEmplacedStrength', () {
+    test('returns 0 outside the siege range', () {
+      expect(combatDefaultEmplacedStrength(0), equals(0.0));
+      expect(combatDefaultEmplacedStrength(4), equals(0.0));
+    });
+
+    test('returns gunCount * emplacedStrength inside the siege range', () {
+      // fortGunCount[2] == 2, fortEmplacedStrength[2] == 4.0
+      expect(combatDefaultEmplacedStrength(2), equals(2 * 4.0));
+      // fortGunCount[1] == 1, fortEmplacedStrength[1] == 3.0
+      expect(combatDefaultEmplacedStrength(1), equals(1 * 3.0));
+    });
+  });
+}

--- a/packages/colonizethis_combat/test/deterministic_rng_test.dart
+++ b/packages/colonizethis_combat/test/deterministic_rng_test.dart
@@ -1,0 +1,29 @@
+import 'package:colonizethis_combat/src/combat/deterministic_rng.dart';
+import 'package:colonizethis_test/test.dart';
+
+void main() {
+  group('DeterministicRng', () {
+    test('same seed produces identical sequence', () {
+      final a = DeterministicRng(42);
+      final b = DeterministicRng(42);
+
+      for (var i = 0; i < 20; i++) {
+        expect(a.nextInt(1000), equals(b.nextInt(1000)));
+      }
+    });
+
+    test('different seeds diverge', () {
+      final a = DeterministicRng(1);
+      final b = DeterministicRng(2);
+
+      expect(a.nextInt(1000), isNot(equals(b.nextInt(1000))));
+    });
+
+    test('nextInt returns 0 for non-positive max', () {
+      final rng = DeterministicRng(7);
+
+      expect(rng.nextInt(0), equals(0));
+      expect(rng.nextInt(-1), equals(0));
+    });
+  });
+}

--- a/packages/colonizethis_combat/test/military_strength_test.dart
+++ b/packages/colonizethis_combat/test/military_strength_test.dart
@@ -317,4 +317,27 @@ void main() {
       expect(effectiveEraForFaction(game, 'unknown'), equals(4));
     });
   });
+
+  group('cavalryFraction', () {
+    test('returns 0 when unit list is empty', () {
+      expect(cavalryFraction([], {}), equals(0.0));
+    });
+
+    test('counts cavalry share over all unit ids', () {
+      final unitsById = {
+        'u1': testUnit(id: 'u1', type: 'squires', locationProvinceId: 'p1'),
+        'u2': testUnit(id: 'u2', type: 'musketeers', locationProvinceId: 'p2'),
+      };
+
+      expect(cavalryFraction(['u1', 'u2'], unitsById), equals(0.5));
+    });
+
+    test('missing units still count toward denominator', () {
+      final unitsById = {
+        'u1': testUnit(id: 'u1', type: 'squires', locationProvinceId: 'p1'),
+      };
+
+      expect(cavalryFraction(['u1', 'missing'], unitsById), equals(0.5));
+    });
+  });
 }

--- a/packages/colonizethis_combat/test/quick_battle_action_modifiers_test.dart
+++ b/packages/colonizethis_combat/test/quick_battle_action_modifiers_test.dart
@@ -1,0 +1,93 @@
+import 'package:colonizethis_combat/src/combat/quick_battle_action_modifiers.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+void main() {
+  group('aggregateActionModifiers', () {
+    test('no actions yields neutral 1.0 modifiers', () {
+      final m = aggregateActionModifiers(const []);
+
+      expect(m.offenseModifier, 1.0);
+      expect(m.casualtiesDealtModifier, 1.0);
+      expect(m.casualtiesTakenModifier, 1.0);
+    });
+
+    test('volleyFire raises casualties dealt only', () {
+      final m = aggregateActionModifiers(const [QuickBattleAction.volleyFire]);
+
+      expect(m.casualtiesDealtModifier, closeTo(1.15, 1e-9));
+      expect(m.offenseModifier, 1.0);
+      expect(m.casualtiesTakenModifier, 1.0);
+    });
+
+    test('defendEntrench lowers casualties taken only', () {
+      final m = aggregateActionModifiers(const [
+        QuickBattleAction.defendEntrench,
+      ]);
+
+      expect(m.casualtiesTakenModifier, closeTo(0.85, 1e-9));
+      expect(m.offenseModifier, 1.0);
+      expect(m.casualtiesDealtModifier, 1.0);
+    });
+
+    test('maneuver raises offense only', () {
+      final m = aggregateActionModifiers(const [QuickBattleAction.maneuver]);
+
+      expect(m.offenseModifier, closeTo(1.05, 1e-9));
+      expect(m.casualtiesDealtModifier, 1.0);
+      expect(m.casualtiesTakenModifier, 1.0);
+    });
+
+    test('fallBackRefuseFlank lowers offense and casualties taken', () {
+      final m = aggregateActionModifiers(const [
+        QuickBattleAction.fallBackRefuseFlank,
+      ]);
+
+      expect(m.offenseModifier, closeTo(0.8, 1e-9));
+      expect(m.casualtiesTakenModifier, closeTo(0.75, 1e-9));
+      expect(m.casualtiesDealtModifier, 1.0);
+    });
+
+    test('assaultCharge raises offense and casualties taken', () {
+      final m = aggregateActionModifiers(const [
+        QuickBattleAction.assaultCharge,
+      ]);
+
+      expect(m.offenseModifier, closeTo(1.25, 1e-9));
+      expect(m.casualtiesTakenModifier, closeTo(1.1, 1e-9));
+      expect(m.casualtiesDealtModifier, 1.0);
+    });
+
+    test('combined actions sum deltas in order', () {
+      final m = aggregateActionModifiers(const [
+        QuickBattleAction.maneuver,
+        QuickBattleAction.volleyFire,
+      ]);
+
+      expect(m.offenseModifier, closeTo(1.05, 1e-9));
+      expect(m.casualtiesDealtModifier, closeTo(1.15, 1e-9));
+      expect(m.casualtiesTakenModifier, 1.0);
+    });
+
+    test('repeated assaultCharge clamps offense to 1.5 upper bound', () {
+      final m = aggregateActionModifiers(const [
+        QuickBattleAction.assaultCharge,
+        QuickBattleAction.assaultCharge,
+        QuickBattleAction.assaultCharge,
+      ]);
+
+      expect(m.offenseModifier, 1.5);
+    });
+
+    test('repeated fallBackRefuseFlank clamps casualties taken to 0.5 floor', () {
+      final m = aggregateActionModifiers(const [
+        QuickBattleAction.fallBackRefuseFlank,
+        QuickBattleAction.fallBackRefuseFlank,
+        QuickBattleAction.fallBackRefuseFlank,
+      ]);
+
+      expect(m.casualtiesTakenModifier, 0.5);
+      expect(m.offenseModifier, 0.5);
+    });
+  });
+}

--- a/packages/colonizethis_combat/test/quick_battle_emplaced_guns_test.dart
+++ b/packages/colonizethis_combat/test/quick_battle_emplaced_guns_test.dart
@@ -1,0 +1,96 @@
+import 'package:colonizethis_combat/src/combat/quick_battle_emplaced_guns.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+MutableEmplacedGun _gun(String id, int hp, {double att = 2.0, double def = 3.0}) =>
+    MutableEmplacedGun(
+      id: id,
+      maxHp: 4,
+      hp: hp,
+      attackStrength: att,
+      defenseStrength: def,
+    );
+
+void main() {
+  group('MutableEmplacedGun.fromInput', () {
+    test('copies all fields from immutable input gun', () {
+      const input = QuickBattleEmplacedGun(
+        id: 'g0',
+        maxHp: 5,
+        hp: 3,
+        attackStrength: 1.5,
+        defenseStrength: 2.5,
+        rng: 7,
+      );
+
+      final m = MutableEmplacedGun.fromInput(input);
+
+      expect(m.id, 'g0');
+      expect(m.maxHp, 5);
+      expect(m.hp, 3);
+      expect(m.attackStrength, 1.5);
+      expect(m.defenseStrength, 2.5);
+    });
+  });
+
+  group('aliveGunStrengthSum', () {
+    test('sums attack+defense over alive guns and skips dead', () {
+      final guns = [_gun('a', 4), _gun('b', 0), _gun('c', 2)];
+
+      expect(aliveGunStrengthSum(guns), closeTo(10.0, 1e-9));
+    });
+
+    test('empty list yields 0.0', () {
+      expect(aliveGunStrengthSum(const []), 0.0);
+    });
+  });
+
+  group('sumAliveGunHp', () {
+    test('sums hp over alive guns only', () {
+      final guns = [_gun('a', 4), _gun('b', 0), _gun('c', 2)];
+
+      expect(sumAliveGunHp(guns), 6);
+    });
+  });
+
+  group('applyRoundRobinGunHpDamage', () {
+    test('non-positive amount is a no-op', () {
+      final guns = [_gun('a', 4), _gun('b', 4)];
+
+      applyRoundRobinGunHpDamage(guns, 0);
+      applyRoundRobinGunHpDamage(guns, -3);
+
+      expect(guns.map((g) => g.hp), [4, 4]);
+    });
+
+    test('distributes damage round-robin by id order', () {
+      final guns = [_gun('b', 4), _gun('a', 4)];
+
+      applyRoundRobinGunHpDamage(guns, 3);
+
+      // Sorted by id: a then b. 3 points → a,b,a → a:2, b:3.
+      final byId = {for (final g in guns) g.id: g.hp};
+      expect(byId['a'], 2);
+      expect(byId['b'], 3);
+    });
+
+    test('skips fully destroyed guns and keeps damaging survivors', () {
+      final guns = [_gun('a', 1), _gun('b', 4)];
+
+      applyRoundRobinGunHpDamage(guns, 4);
+
+      // a starts at 1: first hit kills it; remaining 3 all land on b.
+      final byId = {for (final g in guns) g.id: g.hp};
+      expect(byId['a'], 0);
+      expect(byId['b'], 1);
+    });
+
+    test('damage exceeding total HP drives all guns to zero', () {
+      final guns = [_gun('a', 2), _gun('b', 2)];
+
+      applyRoundRobinGunHpDamage(guns, 99);
+
+      expect(guns.every((g) => g.hp <= 0), isTrue);
+    });
+  });
+}

--- a/tool/check_combat_no_private_aggregate_strength.dart
+++ b/tool/check_combat_no_private_aggregate_strength.dart
@@ -1,0 +1,53 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+/// SPEC: SPEC/program/repo-lint.md (Refs #3433).
+///
+/// Enforces that `combat_resolver_probabilistic.dart` uses the shared
+/// `aggregateStrength` from `military_strength.dart` instead of redefining a
+/// private `_aggregateStrength` copy.
+const _targetRelative =
+    'packages/colonizethis_combat/lib/src/combat/combat_resolver_probabilistic.dart';
+
+final RegExp _privateAggregateStrength = RegExp(
+  r'(?:^|\n)\s*(?:double|num)\s+_aggregateStrength\s*\(',
+  multiLine: true,
+);
+
+void main(List<String> args) {
+  exit(runCheckCombatNoPrivateAggregateStrength(Directory.current.path));
+}
+
+int runCheckCombatNoPrivateAggregateStrength(
+  String repoRoot, {
+  void Function(String line)? info,
+  void Function(String line)? err,
+}) {
+  final logI = info ?? stdout.writeln;
+  final logE = err ?? stderr.writeln;
+
+  final root = p.normalize(repoRoot);
+  final targetPath = p.join(root, _targetRelative);
+  final file = File(targetPath);
+  if (!file.existsSync()) {
+    logE('ERROR: Missing combat probabilistic resolver: $_targetRelative');
+    return 1;
+  }
+
+  final content = file.readAsStringSync();
+  final match = _privateAggregateStrength.firstMatch(content);
+  if (match == null) {
+    logI('check_combat_no_private_aggregate_strength: no violations found.');
+    return 0;
+  }
+
+  final lineNumber =
+      '\n'.allMatches(content.substring(0, match.start)).length + 1;
+  logE(
+    'check_combat_no_private_aggregate_strength: found private '
+    '`_aggregateStrength` in $_targetRelative:$lineNumber. '
+    'Use the public `aggregateStrength` from military_strength.dart instead.',
+  );
+  return 1;
+}

--- a/tool/ct_repo_lint_manifest.yaml
+++ b/tool/ct_repo_lint_manifest.yaml
@@ -385,6 +385,13 @@ rules:
     runner: dart
     script: tool/check_combat_no_logic_deps.dart
 
+  - rule_id: repo.combat_no_private_aggregate_strength
+    group: architecture
+    title: combat probabilistic resolver must use shared aggregateStrength (Refs #3433)
+    spec: SPEC/program/repo-lint.md
+    runner: dart
+    script: tool/check_combat_no_private_aggregate_strength.dart
+
   - rule_id: repo.economy_no_logic_deps
     group: architecture
     title: colonizethis_economy must not depend on colonizethis_logic in lib/ (Refs #3290 Phase 1)


### PR DESCRIPTION
## Summary

Deduplicates, performance-tunes, and abstracts the combat resolution code in `packages/colonizethis_combat/lib/src/combat/`. The three resolvers (auto-resolve, Quick Battle, probabilistic) shared core strength/modifier math that had diverged into near-copies; this consolidates the shared computation, removes an O(n²) casualty-selection inner loop, and extracts general-purpose utilities. No combat behavior, rules, or balance changes.

> Note: the issue refinement text places combat under `packages/colonizethis_logic/lib/src/combat/`, but the code actually lives in `packages/colonizethis_combat/lib/src/combat/` on `dev`. This PR targets the real package; all paths below reflect repo reality.

## Done in this push (Refs #3433)

Deduplication / abstraction:
- Removed the private `_aggregateStrength` copy from `combat_resolver_probabilistic.dart`; all call sites use the public `aggregateStrength`.
- `_defenderEffectiveLevel` now delegates to `effectiveEraForFaction`.
- Added a single shared `cavalryFraction` utility (in `military_strength.dart`) used by the input builder and attacker-initiative sort.
- Centralized the effective-strength pipeline in `combat_effective_strength.dart`, used by all three resolvers.
- Extracted the deterministic LCG RNG into `deterministic_rng.dart`.
- Extracted the emplaced-gun subsystem into `quick_battle_emplaced_guns.dart`.
- Converted `quick_battle_resolver.dart` part files to regular imports (`@visibleForTesting` where needed).
- Moved `QuickBattleAction` modifier data into `quick_battle_action_modifiers.dart`.
- Consolidated the repeated `_finishAndLogQuickBattleResult` build-and-log pattern.

Performance:
- Replaced the O(n²) `removeAt`-based casualty selection in `_selectCasualtiesWeighted` with an alive-mask approach (no inner-loop `removeAt`).
- Precomputed naval flee/intercept scores once per side.

CI / enforcement:
- Added `repo.combat_no_private_aggregate_strength` lint rule (+ `tool/check_combat_no_private_aggregate_strength.dart`) to prevent re-introducing the private `_aggregateStrength` copy.

Tests:
- Added focused unit tests for the newly public utilities: `combat_effective_strength_test.dart`, `deterministic_rng_test.dart`, `military_strength_test.dart` (cavalryFraction), `quick_battle_action_modifiers_test.dart`, `quick_battle_emplaced_guns_test.dart`.

## Verification
- `dart analyze` in `colonizethis_combat`: zero errors (pre-existing unused-import warnings in untouched test files only).
- `dart test` in `colonizethis_combat`: all 167 tests pass (determinism/perf invariants included).
- `tool/check_combat_no_private_aggregate_strength.dart`: no violations.

## Scope / deferred
Full issue slice implemented; no items deferred. SPEC follow-up: none required (structural refactor, no behavioral change).

Refs #3433

Made with [Cursor](https://cursor.com)