### PR TITLE
feat: observer --profiles per-GP AI personality overrides (#3437)

### DIFF
--- a/SPEC/ai/ai-profile-overrides.md
+++ b/SPEC/ai/ai-profile-overrides.md
@@ -1,0 +1,51 @@
+# AI Profile Overrides (decision-path wiring)
+
+**SPEC/ai** — Authorizes wiring `AiProfile` parameter overrides into the live Full-AI decision path so external tools (Observer `--profiles`, GA runner) can replace hardcoded AI-behavior constants per Great Power. Derives from [ai-parameter-registry.md](ai-parameter-registry.md) (profile/registry contract) and [ai-personalities.md](ai-personalities.md). Tracked by GitHub **#3437** (consumed by GA runner **#3439**).
+
+---
+
+## Purpose
+
+`AiProfile` (#3436) defines the registry-keyed parameter set but does not change AI behavior. This spec defines how a resolved profile, supplied per `playerId`, overrides the parameters the Full-AI planner would otherwise read from `ai_personality_config.dart` and `ai_victory_config.dart`.
+
+Overrides are injected as an **optional parameter** into the AI entrypoints (`observer → AI`), never via global state, preserving determinism and the `colonizethis-logic-ai-decoupling` one-way boundary (no `logic → AI` edge is introduced).
+
+---
+
+## Override carrier
+
+`AIConfig` gains two optional fields, both defaulting to `null`:
+
+- `parameterOverrides` — the active profile's full `parameters` map (registry-keyed `name → num`), or `null` when no profile is active.
+- `profileId` — the active profile's `profile_id`, or `null`.
+
+When `parameterOverrides` is `null`, AI behavior is **byte-for-byte identical** to the no-profile path.
+
+## Override-resolution rule
+
+For each registry-declared parameter `name`, the **effective value** is:
+
+- the profile value `parameterOverrides[name]` **when** that value differs from `AiParameterRegistry.defaults[name]` (i.e. the profile sets a non-default value);
+- otherwise the leader's hardcoded value (the existing `getXForLeader` / constant lookup).
+
+This honors the issue rule "override applies to registry-declared parameters with non-default values": a parameter left at (or explicitly set to) the registry default keeps the leader's hardcoded value, so a seed profile that mirrors a leader reproduces that leader's behavior.
+
+## Scope of this slice (#3437)
+
+In scope now: the **personality categories** (`personality_domain`, `personality_goal`, `personality_threshold`). These resolve through `resolveDomainWeights`, `resolveGoalWeights`, and `resolveThresholds` in `colonizethis_data`, replacing the bare `getDomainWeightsForLeader` / `getGoalWeightsForLeader` / `getThresholdsForLeader` lookups at every `AIConfig`-consuming call site (goal selection, planner-context base weights, economy/build/research/diplomacy scoring, and the AI trace builder).
+
+Deferred (separate follow-up): `victory_config` category overrides (the `k*` constants are referenced as bare top-level `const`s across the AI package and require a dedicated config-threading design to preserve the turn-resolution budget and determinism); and the colonial-acquisition war-vs-alliance bias, which threads a bare `personalityId` through phase-planner dispatch rather than `AIConfig`. Until then those read leader defaults even when a profile is active.
+
+## Trace
+
+The active `profileId` is recorded under the existing `TurnTraceAiSection.state.decisionContext.profileId`, so no logic-level trace schema change is required. When no profile is active for a Great Power, the key is `null`.
+
+---
+
+## Acceptance criteria
+
+- Given an `AIConfig` with `parameterOverrides == null`, when `resolveDomainWeights`/`resolveGoalWeights`/`resolveThresholds` run for that config's `personalityId`, then each returned value equals the corresponding `getXForLeader(personalityId)` value.
+- Given a profile whose `personalityDomainWeights.military` differs from the registry default and whose other keys equal the registry default, when `resolveDomainWeights` runs for a leader, then only `military` takes the profile value and `economy`/`diplomacy`/`research` keep the leader's hardcoded values.
+- Given a profile key whose value equals the registry default, when the matching `resolveX` runs, then the leader's hardcoded value is kept (the default-valued key does not override).
+- Given a Great Power planned with an active profile, when its `TurnTraceAiSection` is built, then `state.decisionContext.profileId` equals the profile's `profile_id`; given no active profile, then `state.decisionContext.profileId` is `null`.
+- Given `generateOrdersForGameFullAI` called with `profiles == null`, when orders are generated, then the emitted orders and trace are identical to a call that omits `profiles`.

--- a/SPEC/program/run_observer_game-tool.md
+++ b/SPEC/program/run_observer_game-tool.md
@@ -19,6 +19,7 @@ melos run run_observer_game -- [options]
 | `--seed <int>` | Optional; matches `init_game` / `GameSetupConfig` semantics when omitted vs set. |
 | `--max-turns <int>` | Optional; default = campaign calendar cap turn **T** (`yearAtTurn(T)==1800` under game mapping; **201** for `gdd01`). Lower values shorten runs. |
 | `--config <path>` | Optional JSON `GameSetupConfig` consistent with **`init_game`**. |
+| `--profiles <dir>` | Optional directory of per-GP `AiProfile` JSON files keyed `<playerId>.json`; overrides AI personality params at decision time (see § Per-GP AI profiles). |
 | `--verify-conquest` | After success: turn-1 vs turn-100 OW per-GP net +3 provinces (exit **5** on failure; requires `--max-turns >= 100` or no cap). |
 | `--verify-colonial-expansion` | After success: turn-150 snapshot checks NW GP ownership and extractable improvement ratio (exit **6** on failure; requires `--max-turns >= 150` or no cap). |
 | `--verify-workforce` | After success: turn-100 snapshot checks every Great Power `gp1`–`gp6` has `peasants >= 15` AND `apprentices + journeymen + masters >= 8` (exit **8** on failure; requires `--max-turns >= 100` or no cap; Refs #2692 S10). |
@@ -28,6 +29,16 @@ melos run run_observer_game -- [options]
 ## Full-AI setup (no post-init override)
 
 The observer always builds a **fully-AI** game **at init** by forcing `GameSetupConfig.humanGreatPowerSlotIndices = {}` (empty) regardless of any `--config` JSON or `--seed` override (see [game-setup-pipeline.md](game-setup-pipeline.md) § Human/AI slot assignment). Consequently every Great Power has `isHuman == false` and `aiControlByGpId[gpId] == true` from creation; the tool does **not** mutate `aiControlByGpId` after init. Snapshot player rollups therefore report `"isHuman": false` for every GP including `gp1`.
+
+## Per-GP AI profiles (`--profiles`, Refs #3437)
+
+`--profiles <dir>` loads `AiProfile` JSON (`SPEC/ai/ai-parameter-registry.md`) per Great Power and overrides hardcoded AI personality parameters at decision time per [ai-profile-overrides.md](../ai/ai-profile-overrides.md):
+
+- Files are keyed by **`playerId`**: `<dir>/<playerId>.json` (the in-game player id, e.g. `gp1.json`). The set of GPs comes from the loaded setup (`game.players`), **not** from scanning the directory.
+- A GP without a matching file uses its default hardcoded personality. Files not matching any GP `playerId` are ignored and logged at **warn** (`session` sub-prefix `observer:profile_unmatched`).
+- Each matched file is parsed via `AiProfile.fromJson`. A missing directory or any unparseable/invalid profile file aborts the run with a clear **stderr** message and exit **9** (`profile_load_failed`) before the turn loop starts; valid profiles log one **info** line `observer:profiles_loaded count=<n>`.
+- The loaded `Map<String, AiProfile>` (keyed by `playerId`) is passed into `generateOrdersForGameFullAI`; each GP's active `profile_id` appears in its turn trace under `state.decisionContext.profileId`.
+- Omitting `--profiles` is byte-for-byte identical to prior behavior.
 
 ## Artifact layout
 
@@ -120,6 +131,9 @@ CI: **≥ 80% line coverage on `tool/run_observer_game/lib/`** (`quality` workfl
 ## Acceptance (tool-specific)
 
 - Given `melos run run_observer_game -- --help`, when the command completes, then exit code is **0** and stdout describes options and artifact layout at a high level.
+- Given `--profiles <dir>` pointing at a directory containing `<playerId>.json` for a Great Power whose personality weights differ from that leader's defaults, when a turn is resolved, then that GP's turn-trace `state.decisionContext.profileId` equals the profile's `profile_id` and its `thresholds.derived.domainWeights` differ from a run without `--profiles`.
+- Given `--profiles <dir>` where `<dir>` does not exist or contains an unparseable `<playerId>.json`, when the tool runs, then it writes a clear stderr message and exits **9** without resolving turns.
+- Given `--profiles <dir>` containing a file that matches no Great Power `playerId`, when the tool runs, then that file is ignored, a `session` warn line `observer:profile_unmatched` is logged, and the run proceeds normally.
 - Given a successful multi-turn run (**S4+**), when outputs are written, then layout matches § Artifact layout and summary matches **#2498** ACs.
 - Given a successful run that resolves **N ≥ 1** turns, when `run-summary.json` is written, then `runSummarySchemaVersion` is `2`, `turn_processing_wall_clock_ms_by_turn` is a list of exactly **N** non-negative integers, `turn_processing_wall_clock_budget_ms` equals `kTurnProcessingWallClockBudgetMs` (`15000`), and `max_turn_processing_wall_clock_ms` equals the maximum of that list.
 - Given a run with `--max-turns 0`, when `run-summary.json` is written, then `turn_processing_wall_clock_ms_by_turn` is an empty list, `max_turn_processing_wall_clock_ms` is `0`, and `turns_over_wall_clock_budget` is `0`.

--- a/docs/project-tools.md
+++ b/docs/project-tools.md
@@ -58,6 +58,7 @@ melos run run_observer_game -- [options]
 - `--seed <n>` — optional RNG seed
 - `--max-turns <n>` — optional turn cap (default = calendar-1800 turn for the mapping)
 - `--config <path>` — optional `GameSetupConfig` JSON (`init_game`-compatible)
+- `--profiles <dir>` — optional directory of per-GP `AiProfile` JSON files keyed `<playerId>.json`; overrides AI personality params at decision time (Refs **#3437**). Missing GPs use defaults; unmatched files are ignored (warn); a missing dir or invalid profile aborts with exit **9**.
 
 Full observer loop (Full AI + traces + snapshots + `run-summary.json`) is implemented per GitHub **#2498**; use `--max-turns` for short CI-style runs. Each resolved turn’s **Full AI + trusted resolve** segment shares the **15 s** wall-clock budget with the app (`kTurnProcessingWallClockBudgetMs`; enforced by `colonizethis_ai` perf test on turn 1 of `GameSetupConfig.defaultConfig`; Refs **#2507**).
 

--- a/packages/colonizethis_ai/lib/src/planning/ai_trace_builder.dart
+++ b/packages/colonizethis_ai/lib/src/planning/ai_trace_builder.dart
@@ -27,9 +27,18 @@ TurnTraceAiSection buildAiTraceSection({
   PhasePlanOutcome? phasePlan,
   DomainGateData? domainGateData,
 }) {
-  final domainWeights = getDomainWeightsForLeader(config.personalityId);
-  final goalWeights = getGoalWeightsForLeader(config.personalityId);
-  final thresholds = getThresholdsForLeader(config.personalityId);
+  final domainWeights = resolveDomainWeights(
+    config.personalityId,
+    overrides: config.parameterOverrides,
+  );
+  final goalWeights = resolveGoalWeights(
+    config.personalityId,
+    overrides: config.parameterOverrides,
+  );
+  final thresholds = resolveThresholds(
+    config.personalityId,
+    overrides: config.parameterOverrides,
+  );
   final selectedScore = goalScores[primaryGoal] ?? 0;
   final agendaConquerModifier = getAgendaConquerModifier(config.hiddenAgendaId);
   final agendaDiplomacyModifier = getAgendaDiplomacyModifier(
@@ -95,6 +104,7 @@ TurnTraceAiSection buildAiTraceSection({
         'leaderId': config.leaderId,
         'personalityId': config.personalityId,
         'hiddenAgendaId': config.hiddenAgendaId,
+        'profileId': config.profileId,
       },
     },
     thresholds: <String, Object?>{

--- a/packages/colonizethis_ai/lib/src/planning/build_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/build_planner.dart
@@ -112,7 +112,10 @@ BuildUnitOrder? pickBuildOrder({
       candidates = regimentsOnly;
     }
   }
-  final thresholds = getThresholdsForLeader(config.personalityId);
+  final thresholds = resolveThresholds(
+    config.personalityId,
+    overrides: config.parameterOverrides,
+  );
   final scores = candidates.map((o) {
     final unitType = o.unitType;
     final isShip = ShipEconomyCatalog.byId.containsKey(unitType);

--- a/packages/colonizethis_ai/lib/src/planning/diplomatic_candidate_scoring.dart
+++ b/packages/colonizethis_ai/lib/src/planning/diplomatic_candidate_scoring.dart
@@ -31,7 +31,10 @@ List<int> computeDiplomaticCandidateScores({
   PhasePlanOutcome? phasePlan,
 }) {
   final agendaId = config.hiddenAgendaId;
-  final thresholds = getThresholdsForLeader(config.personalityId);
+  final thresholds = resolveThresholds(
+    config.personalityId,
+    overrides: config.parameterOverrides,
+  );
   var maxRelationForDeclareWar = getDeclareWarMaxRelationScore(agendaId);
   final behindVictoryPace =
       snapshot.conquest.provincesToVictory >

--- a/packages/colonizethis_ai/lib/src/planning/economy_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/economy_planner.dart
@@ -356,7 +356,10 @@ CargoPreference _cargoPreference(
   ColonialSummary colonial = const ColonialSummary(),
   bool belowQuotaPeaceTreasuryRecovery = false,
 }) {
-  final domainWeights = getDomainWeightsForLeader(config.personalityId);
+  final domainWeights = resolveDomainWeights(
+    config.personalityId,
+    overrides: config.parameterOverrides,
+  );
   final agendaId = config.hiddenAgendaId;
   // Trade-oriented agendas/personalities favour cargo.
   var economyWeight = domainWeights.economy;

--- a/packages/colonizethis_ai/lib/src/planning/full_ai_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/full_ai_planner.dart
@@ -21,6 +21,7 @@ StrategicOrderResult generateOrdersForPlayerFullAI(
   OrderSuggestionAPI? orderSuggestionApi,
   void Function(DialogueEvent)? onDialogue,
   void Function(PortraitMoodEvent)? onMood,
+  Map<String, AiProfile>? profiles,
 }) {
   return generateOrdersForPlayerFullAIWithTrace(
     game,
@@ -30,6 +31,7 @@ StrategicOrderResult generateOrdersForPlayerFullAI(
     orderSuggestionApi: orderSuggestionApi,
     onDialogue: onDialogue,
     onMood: onMood,
+    profiles: profiles,
   ).result;
 }
 
@@ -46,6 +48,7 @@ StrategicOrderTraceResult generateOrdersForPlayerFullAIWithTrace(
   void Function(String phaseId)? onStagedPlannerProgress,
   Orders? sameTurnPriorDiplomaticOrders,
   bool growthStagePlannerEnabled = kGrowthStagePlannerEnabled,
+  Map<String, AiProfile>? profiles,
 }) {
   final player = game.playerById(playerId);
   if (player == null || !isAiControlled(game, player.id)) {
@@ -71,10 +74,13 @@ StrategicOrderTraceResult generateOrdersForPlayerFullAIWithTrace(
     personalityId: player.personalityId,
   );
   final agendaId = game.hiddenAgendaByGpId[playerId] ?? 'peacemaker';
+  final activeProfile = profiles?[playerId];
   final config = AIConfig(
     leaderId: leaderId,
     personalityId: personalityKey,
     hiddenAgendaId: agendaId,
+    parameterOverrides: activeProfile?.parameters,
+    profileId: activeProfile?.profileId,
   );
   final suggestionAPI = orderSuggestionApi ?? const DefaultOrderSuggestionAPI();
   final traced = generateStrategicOrdersWithTrace(
@@ -120,6 +126,7 @@ FullAIResult generateOrdersForGameFullAI(
   void Function(PortraitMoodEvent)? onMood,
   void Function(String phaseId)? onStagedPlannerProgress,
   bool growthStagePlannerEnabled = kGrowthStagePlannerEnabled,
+  Map<String, AiProfile>? profiles,
 }) {
   final totalStopwatch = Stopwatch()..start();
   var planningGame = game;
@@ -164,6 +171,7 @@ FullAIResult generateOrdersForGameFullAI(
       onStagedPlannerProgress: onStagedPlannerProgress,
       sameTurnPriorDiplomaticOrders: sameTurnPriorDiplomaticOrders,
       growthStagePlannerEnabled: growthStagePlannerEnabled,
+      profiles: profiles,
     );
     _log.i(
       'full_ai player_complete gameId=${game.id} playerId=$playerId '

--- a/packages/colonizethis_ai/lib/src/planning/goal_manager.dart
+++ b/packages/colonizethis_ai/lib/src/planning/goal_manager.dart
@@ -54,8 +54,14 @@ Map<StrategicGoal, int> evaluateStrategicGoalScores(
             hasColonialAcquisitionTargets(snapshot.colonial) &&
             !shouldSuppressNewWorldColonialOrders(snapshot: snapshot);
   final colonialPressureScale = effectiveColonialPressureWeight ?? 1.0;
-  final weights = getGoalWeightsForLeader(config.personalityId);
-  final thresholds = getThresholdsForLeader(config.personalityId);
+  final weights = resolveGoalWeights(
+    config.personalityId,
+    overrides: config.parameterOverrides,
+  );
+  final thresholds = resolveThresholds(
+    config.personalityId,
+    overrides: config.parameterOverrides,
+  );
 
   var defend = weights.defend;
   var expand = weights.expand;
@@ -196,7 +202,10 @@ String majorConstraintForStrategicGoal(
   AIWorldSnapshot snapshot,
   AIConfig config,
 ) {
-  final thresholds = getThresholdsForLeader(config.personalityId);
+  final thresholds = resolveThresholds(
+    config.personalityId,
+    overrides: config.parameterOverrides,
+  );
   return switch (selected) {
     StrategicGoal.defend =>
       snapshot.threats.capitalThreatened

--- a/packages/colonizethis_ai/lib/src/planning/planner_context.dart
+++ b/packages/colonizethis_ai/lib/src/planning/planner_context.dart
@@ -54,8 +54,10 @@ class PlannerContext {
   Map<String, String?> get provinceOwner =>
       _provinceOwner ??= getProvinceOwnerMap(game);
 
-  PersonalityDomainWeights get domainWeights =>
-      getDomainWeightsForLeader(config.personalityId);
+  PersonalityDomainWeights get domainWeights => resolveDomainWeights(
+    config.personalityId,
+    overrides: config.parameterOverrides,
+  );
 
   /// Move / army-move / conquest base weight (military vs economy vs fallback).
   int resolveMilitaryEconomyWeight({int fallback = 50}) {

--- a/packages/colonizethis_ai/lib/src/planning/research_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/research_planner.dart
@@ -55,7 +55,10 @@ Orders runResearchPlanner({required PlannerContext ctx}) {
     return ctx.orders;
   }
 
-  final thresholds = getThresholdsForLeader(ctx.config.personalityId);
+  final thresholds = resolveThresholds(
+    ctx.config.personalityId,
+    overrides: ctx.config.parameterOverrides,
+  );
   final chosen = selectWeightedCandidate(
     candidates: researchCandidates,
     seed: ctx.seeds.researchSeed,

--- a/packages/colonizethis_data/lib/colonizethis_data.dart
+++ b/packages/colonizethis_data/lib/colonizethis_data.dart
@@ -39,6 +39,7 @@ export 'src/turn_processing_wall_clock_budget.dart';
 export 'src/unit_roles.dart';
 export 'src/leader_bonuses.dart';
 export 'src/ai_personality_config.dart';
+export 'src/ai_personality_overrides.dart';
 export 'src/ai_victory_config.dart';
 export 'src/ai_parameter_registry.dart';
 export 'src/ai_profile.dart';

--- a/packages/colonizethis_data/lib/src/ai_personality_overrides.dart
+++ b/packages/colonizethis_data/lib/src/ai_personality_overrides.dart
@@ -1,0 +1,125 @@
+/// Resolves personality weight/threshold sets for a leader, applying optional
+/// per-profile [AiProfile] parameter overrides.
+///
+/// Implements the override-resolution rule in `SPEC/ai/ai-profile-overrides.md`:
+/// a registry-keyed override value replaces the leader's hardcoded value only
+/// when it differs from the registry default; a `null` override map yields the
+/// leader's hardcoded values unchanged (byte-identical no-profile path).
+/// Refs #3437.
+library;
+
+import 'ai_parameter_registry.dart';
+import 'ai_personality_config.dart';
+
+/// Effective value for registry key [name]: the [overrides] value when present
+/// and different from the registry default, else [base].
+int _resolveInt(String name, Map<String, num>? overrides, int base) {
+  if (overrides == null) return base;
+  final value = overrides[name];
+  if (value == null) return base;
+  final defaultValue = AiParameterRegistry.defaults[name];
+  if (defaultValue != null && value == defaultValue) return base;
+  return value.round();
+}
+
+/// Domain weights for [personalityId] with optional profile [overrides].
+PersonalityDomainWeights resolveDomainWeights(
+  String personalityId, {
+  Map<String, num>? overrides,
+}) {
+  final base = getDomainWeightsForLeader(personalityId);
+  if (overrides == null) return base;
+  return PersonalityDomainWeights(
+    economy: _resolveInt(
+      'personalityDomainWeights.economy',
+      overrides,
+      base.economy,
+    ),
+    military: _resolveInt(
+      'personalityDomainWeights.military',
+      overrides,
+      base.military,
+    ),
+    diplomacy: _resolveInt(
+      'personalityDomainWeights.diplomacy',
+      overrides,
+      base.diplomacy,
+    ),
+    research: _resolveInt(
+      'personalityDomainWeights.research',
+      overrides,
+      base.research,
+    ),
+  );
+}
+
+/// Goal weights for [personalityId] with optional profile [overrides].
+PersonalityGoalWeights resolveGoalWeights(
+  String personalityId, {
+  Map<String, num>? overrides,
+}) {
+  final base = getGoalWeightsForLeader(personalityId);
+  if (overrides == null) return base;
+  return PersonalityGoalWeights(
+    defend: _resolveInt('personalityGoalWeights.defend', overrides, base.defend),
+    expand: _resolveInt('personalityGoalWeights.expand', overrides, base.expand),
+    conquer: _resolveInt(
+      'personalityGoalWeights.conquer',
+      overrides,
+      base.conquer,
+    ),
+    trade: _resolveInt('personalityGoalWeights.trade', overrides, base.trade),
+    tech: _resolveInt('personalityGoalWeights.tech', overrides, base.tech),
+    diplomacy: _resolveInt(
+      'personalityGoalWeights.diplomacy',
+      overrides,
+      base.diplomacy,
+    ),
+  );
+}
+
+/// Thresholds for [personalityId] with optional profile [overrides].
+PersonalityThresholds resolveThresholds(
+  String personalityId, {
+  Map<String, num>? overrides,
+}) {
+  final base = getThresholdsForLeader(personalityId);
+  if (overrides == null) return base;
+  return PersonalityThresholds(
+    warLikelihood: _resolveInt(
+      'personalityThresholds.warLikelihood',
+      overrides,
+      base.warLikelihood,
+    ),
+    peaceTendency: _resolveInt(
+      'personalityThresholds.peaceTendency',
+      overrides,
+      base.peaceTendency,
+    ),
+    allianceTendency: _resolveInt(
+      'personalityThresholds.allianceTendency',
+      overrides,
+      base.allianceTendency,
+    ),
+    researchNaval: _resolveInt(
+      'personalityThresholds.researchNaval',
+      overrides,
+      base.researchNaval,
+    ),
+    researchMilitary: _resolveInt(
+      'personalityThresholds.researchMilitary',
+      overrides,
+      base.researchMilitary,
+    ),
+    researchEconomic: _resolveInt(
+      'personalityThresholds.researchEconomic',
+      overrides,
+      base.researchEconomic,
+    ),
+    researchExploration: _resolveInt(
+      'personalityThresholds.researchExploration',
+      overrides,
+      base.researchExploration,
+    ),
+  );
+}

--- a/packages/colonizethis_data/test/ai_personality_overrides_test.dart
+++ b/packages/colonizethis_data/test/ai_personality_overrides_test.dart
@@ -1,0 +1,89 @@
+import 'package:colonizethis_test/test.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+
+void main() {
+  group('resolveDomainWeights', () {
+    test('null overrides returns the leader hardcoded weights', () {
+      final base = getDomainWeightsForLeader('napoleon');
+      final resolved = resolveDomainWeights('napoleon');
+      expect(resolved.economy, base.economy);
+      expect(resolved.military, base.military);
+      expect(resolved.diplomacy, base.diplomacy);
+      expect(resolved.research, base.research);
+    });
+
+    test('non-default override value replaces only that field', () {
+      // napoleon hardcoded: economy 50, military 90, diplomacy 30, research 50.
+      // Registry default for these domain keys is 50. 95 != 50 -> overrides;
+      // other keys are absent -> keep napoleon's hardcoded values.
+      final resolved = resolveDomainWeights(
+        'napoleon',
+        overrides: const {'personalityDomainWeights.economy': 95},
+      );
+      expect(resolved.economy, 95);
+      expect(resolved.military, 90, reason: 'untouched key keeps leader value');
+      expect(resolved.diplomacy, 30);
+      expect(resolved.research, 50);
+    });
+
+    test('override equal to registry default does not override', () {
+      // Registry default for personalityDomainWeights.military is 50; napoleon
+      // hardcoded military is 90. A profile value equal to the default must keep
+      // the leader value (only non-default profile values override).
+      final resolved = resolveDomainWeights(
+        'napoleon',
+        overrides: const {'personalityDomainWeights.military': 50},
+      );
+      expect(resolved.military, 90);
+    });
+
+    test('non-integer override is rounded to int', () {
+      final resolved = resolveDomainWeights(
+        'napoleon',
+        overrides: const {'personalityDomainWeights.economy': 70.6},
+      );
+      expect(resolved.economy, 71);
+    });
+  });
+
+  group('resolveGoalWeights', () {
+    test('null overrides returns the leader hardcoded goal weights', () {
+      final base = getGoalWeightsForLeader('victoria');
+      final resolved = resolveGoalWeights('victoria');
+      expect(resolved.conquer, base.conquer);
+      expect(resolved.trade, base.trade);
+    });
+
+    test('non-default override replaces the field', () {
+      // victoria hardcoded conquer is 10; registry default goal weight is 25.
+      final resolved = resolveGoalWeights(
+        'victoria',
+        overrides: const {'personalityGoalWeights.conquer': 99},
+      );
+      expect(resolved.conquer, 99);
+      expect(resolved.trade, getGoalWeightsForLeader('victoria').trade);
+    });
+  });
+
+  group('resolveThresholds', () {
+    test('null overrides returns the leader hardcoded thresholds', () {
+      final base = getThresholdsForLeader('napoleon');
+      final resolved = resolveThresholds('napoleon');
+      expect(resolved.warLikelihood, base.warLikelihood);
+      expect(resolved.peaceTendency, base.peaceTendency);
+    });
+
+    test('non-default override replaces the field', () {
+      // napoleon hardcoded warLikelihood is 80; registry default threshold is 50.
+      final resolved = resolveThresholds(
+        'napoleon',
+        overrides: const {'personalityThresholds.warLikelihood': 5},
+      );
+      expect(resolved.warLikelihood, 5);
+      expect(
+        resolved.peaceTendency,
+        getThresholdsForLeader('napoleon').peaceTendency,
+      );
+    });
+  });
+}

--- a/packages/colonizethis_models/lib/src/ai_config.dart
+++ b/packages/colonizethis_models/lib/src/ai_config.dart
@@ -10,6 +10,8 @@ class AIConfig {
     required this.personalityId,
     required this.hiddenAgendaId,
     this.difficultyModifiers = const {},
+    this.parameterOverrides,
+    this.profileId,
   });
 
   /// Canonical leader id (e.g. 'victoria', 'napoleon').
@@ -27,4 +29,14 @@ class AIConfig {
   /// Difficulty-derived modifiers (e.g. starting resources, ruleset modifiers).
   /// Keys are modifier names; values are numeric or per-ruleset.
   final Map<String, num> difficultyModifiers;
+
+  /// Active `AiProfile` parameter overrides (registry-keyed `name -> num`), or
+  /// `null` when no profile is active. When `null`, AI behavior is identical to
+  /// the no-profile path. Applied per the override-resolution rule in
+  /// `SPEC/ai/ai-profile-overrides.md` (Refs #3437).
+  final Map<String, num>? parameterOverrides;
+
+  /// Active profile id (`profile_id`) for trace provenance, or `null` when no
+  /// profile is active. SPEC/ai/ai-profile-overrides.md (Refs #3437).
+  final String? profileId;
 }

--- a/tool/run_observer_game/lib/observer_profiles.dart
+++ b/tool/run_observer_game/lib/observer_profiles.dart
@@ -1,0 +1,72 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:colonizethis_data/colonizethis_data.dart';
+
+import 'package_logger.dart';
+
+final _log = packageLogger('session');
+
+/// Process exit code when `--profiles` loading fails (Refs #3437).
+const int kExitProfileLoadFailed = 9;
+
+/// Thrown when `--profiles` cannot be loaded: a missing directory or an
+/// unparseable / schema-invalid matched profile file. The run must abort with
+/// [kExitProfileLoadFailed] before resolving turns.
+/// SPEC/program/run_observer_game-tool.md § Per-GP AI profiles.
+class ObserverProfileLoadException implements Exception {
+  ObserverProfileLoadException(this.message);
+
+  /// User-facing failure description (written to stderr by the caller).
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+/// Loads per-Great-Power [AiProfile]s from [dir], keyed by `playerId`.
+///
+/// Reads `<dir>/<playerId>.json` for each id in [playerIds]. A Great Power
+/// without a matching file is omitted from the result (it keeps its default
+/// hardcoded personality). Files in [dir] that match no id in [playerIds] are
+/// ignored and logged once at `warning`. Throws [ObserverProfileLoadException]
+/// when [dir] does not exist or any matched file is unparseable or invalid.
+Map<String, AiProfile> loadObserverProfiles({
+  required String dir,
+  required Iterable<String> playerIds,
+}) {
+  final directory = Directory(dir);
+  if (!directory.existsSync()) {
+    throw ObserverProfileLoadException('profiles directory not found: $dir');
+  }
+
+  final idSet = playerIds.toSet();
+  final loaded = <String, AiProfile>{};
+  for (final id in idSet) {
+    final file = File('${directory.path}/$id.json');
+    if (!file.existsSync()) continue;
+    try {
+      final decoded = jsonDecode(file.readAsStringSync());
+      if (decoded is! Map<String, dynamic>) {
+        throw const FormatException('profile JSON must be a JSON object');
+      }
+      loaded[id] = AiProfile.fromJson(decoded);
+    } on Object catch (e) {
+      throw ObserverProfileLoadException(
+        'failed to load profile for "$id" (${file.path}): $e',
+      );
+    }
+  }
+
+  for (final entity in directory.listSync().whereType<File>()) {
+    final name = entity.uri.pathSegments.last;
+    if (!name.endsWith('.json')) continue;
+    final id = name.substring(0, name.length - '.json'.length);
+    if (!idSet.contains(id)) {
+      _log.w('observer:profile_unmatched file=${entity.path}');
+    }
+  }
+
+  _log.i('observer:profiles_loaded count=${loaded.length}');
+  return loaded;
+}

--- a/tool/run_observer_game/lib/observer_session_runner.dart
+++ b/tool/run_observer_game/lib/observer_session_runner.dart
@@ -8,6 +8,7 @@ import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'observer_minimal_trace.dart';
+import 'observer_profiles.dart';
 import 'observer_snapshot_v1.dart';
 import 'package_logger.dart';
 
@@ -22,6 +23,7 @@ Future<int> runObserverSession({
   bool verifyConquest = false,
   bool verifyColonialExpansion = false,
   bool verifyWorkforce = false,
+  String? profilesDir,
   int verifyArtifactCapBytes = kObserverVerifyArtifactSizeCapBytes,
 }) async {
   late final InitGameResult init;
@@ -37,6 +39,23 @@ Future<int> runObserverSession({
   } on Object catch (e, st) {
     _sessionLog.e('observer:init_failed', error: e, stackTrace: st);
     return 2;
+  }
+
+  // Per-GP AI profile overrides (Refs #3437). Loaded before the turn loop so a
+  // missing directory or invalid profile aborts the run with a clear error and
+  // exit code; null when --profiles is not passed (byte-identical default path).
+  Map<String, AiProfile>? profiles;
+  if (profilesDir != null) {
+    try {
+      profiles = loadObserverProfiles(
+        dir: profilesDir,
+        playerIds: [for (final p in init.game.players) p.id],
+      );
+    } on ObserverProfileLoadException catch (e) {
+      _sessionLog.e('observer:profile_load_failed', error: e);
+      stderr.writeln('Error: ${e.message}');
+      return kExitProfileLoadFailed;
+    }
   }
 
   final minimalTraceMode =
@@ -130,6 +149,7 @@ Future<int> runObserverSession({
         before,
         init.combinedTopology,
         tileMapByRegion: init.tileMapByRegion,
+        profiles: profiles,
       );
       final gameForResolution = fullAi.game;
 

--- a/tool/run_observer_game/lib/run_observer_game_cli.dart
+++ b/tool/run_observer_game/lib/run_observer_game_cli.dart
@@ -5,6 +5,7 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 
 import 'observer_colonial_verify.dart';
 import 'observer_conquest_verify.dart';
+import 'observer_profiles.dart';
 import 'observer_session_runner.dart';
 import 'observer_workforce_verify.dart';
 import 'setup_config_parser.dart';
@@ -84,6 +85,15 @@ Future<int> runObserverGameCli(
       'config',
       help: 'Optional JSON GameSetupConfig path (init_game-compatible).',
     )
+    ..addOption(
+      'profiles',
+      help:
+          'Optional directory of per-GP AiProfile JSON files keyed '
+          '<playerId>.json; overrides AI personality params at decision time. '
+          'Missing GPs use defaults; unmatched files are ignored (warn). '
+          'A missing dir or invalid profile aborts with exit '
+          '$kExitProfileLoadFailed.',
+    )
     ..addFlag(
       'verify-conquest',
       help:
@@ -158,6 +168,11 @@ Future<int> runObserverGameCli(
       ? null
       : configPathRaw;
 
+  final profilesRaw = results['profiles'] as String?;
+  final profilesDir = profilesRaw == null || profilesRaw.trim().isEmpty
+      ? null
+      : profilesRaw.trim();
+
   GameSetupConfig setup;
   try {
     setup = gameSetupFromObserverCli(
@@ -218,6 +233,7 @@ Future<int> runObserverGameCli(
     verifyConquest: verifyConquest,
     verifyColonialExpansion: verifyColonial,
     verifyWorkforce: verifyWorkforce,
+    profilesDir: profilesDir,
   );
   if (sessionCode != 0) {
     return sessionCode;

--- a/tool/run_observer_game/test/observer_profiles_integration_test.dart
+++ b/tool/run_observer_game/test/observer_profiles_integration_test.dart
@@ -1,0 +1,153 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:colonizethis_test/test.dart';
+
+import 'package:colonizethis_data/colonizethis_data.dart';
+
+import 'package:run_observer_game/observer_profiles.dart';
+import 'package:run_observer_game/observer_session_runner.dart';
+
+/// Small deterministic 2-player setup matching the existing observer smoke
+/// tests, so a single turn resolves quickly.
+GameSetupConfig _smokeSetup() => GameSetupConfig(
+  selectedGreatPowerIds: const ['england', 'france'],
+  continentCount: 4,
+  minorNationCount: 2,
+  tribeCount: 2,
+  numProvincesOldWorld: 14,
+  numProvincesNewWorld: 6,
+  minProvincesPerMinor: 2,
+  seed: 11,
+  // Force a fully-AI game (matches the observer CLI) so every GP plans via
+  // Full AI and emits a turn-trace AI section.
+  humanGreatPowerSlotIndices: const <int>{},
+);
+
+/// Reads the single merged turn-trace JSON under [outputRoot] and returns the
+/// AI section for [factionId].
+Map<String, Object?> _aiSectionForFaction(String outputRoot, String factionId) {
+  final gameDir = Directory('$outputRoot/observer-traces')
+      .listSync()
+      .whereType<Directory>()
+      .single;
+  final mergedTrace = gameDir
+      .listSync()
+      .whereType<File>()
+      .map((f) => f.uri.pathSegments.last)
+      .firstWhere(
+        (n) =>
+            n.endsWith('.json') &&
+            !n.endsWith('.snapshot.json') &&
+            n != 'run-summary.json',
+      );
+  final doc =
+      jsonDecode(File('${gameDir.path}/$mergedTrace').readAsStringSync())
+          as Map<String, dynamic>;
+  final ai = (doc['ai'] as List<dynamic>).cast<Map<String, dynamic>>();
+  return ai.firstWhere((s) => s['factionId'] == factionId);
+}
+
+Map<String, Object?> _domainWeights(Map<String, Object?> aiSection) {
+  final thresholds = aiSection['thresholds'] as Map<String, dynamic>;
+  final derived = thresholds['derived'] as Map<String, dynamic>;
+  return derived['domainWeights'] as Map<String, dynamic>;
+}
+
+void main() {
+  group('observer --profiles overrides AI behavior (Refs #3437)', () {
+    test(
+      'profile changes domain weights and records profileId in trace',
+      () async {
+        // Baseline run: no profiles.
+        final baseDir = Directory.systemTemp.createTempSync('obs_prof_base_');
+        addTearDown(() => baseDir.deleteSync(recursive: true));
+        final baseCode = await runObserverSession(
+          outputRoot: baseDir.path,
+          setupConfig: _smokeSetup(),
+          maxTurnsCap: 1,
+        );
+        expect(baseCode, 0);
+
+        final baseGp1 = _aiSectionForFaction(baseDir.path, 'gp1');
+        final baseState = baseGp1['state'] as Map<String, dynamic>;
+        final baseContext =
+            baseState['decisionContext'] as Map<String, dynamic>;
+        expect(
+          baseContext['profileId'],
+          isNull,
+          reason: 'no --profiles => profileId is null',
+        );
+        final baseWeights = _domainWeights(baseGp1);
+
+        // Profiled run: gp1.json with non-default domain weights.
+        final profilesDir = Directory.systemTemp.createTempSync('obs_prof_in_');
+        addTearDown(() => profilesDir.deleteSync(recursive: true));
+        File('${profilesDir.path}/gp1.json').writeAsStringSync(
+          jsonEncode(<String, dynamic>{
+            'schema_version': 1,
+            'profile_id': 'gp1_test',
+            'display_name': 'GP1 (test)',
+            'parameters': <String, num>{
+              'personalityDomainWeights.economy': 5,
+              'personalityDomainWeights.military': 95,
+            },
+          }),
+        );
+
+        final outDir = Directory.systemTemp.createTempSync('obs_prof_out_');
+        addTearDown(() => outDir.deleteSync(recursive: true));
+        final code = await runObserverSession(
+          outputRoot: outDir.path,
+          setupConfig: _smokeSetup(),
+          maxTurnsCap: 1,
+          profilesDir: profilesDir.path,
+        );
+        expect(code, 0);
+
+        final gp1 = _aiSectionForFaction(outDir.path, 'gp1');
+        final state = gp1['state'] as Map<String, dynamic>;
+        final context = state['decisionContext'] as Map<String, dynamic>;
+        expect(context['profileId'], 'gp1_test');
+
+        final weights = _domainWeights(gp1);
+        expect(weights['economy'], 5);
+        expect(weights['military'], 95);
+        expect(
+          weights,
+          isNot(baseWeights),
+          reason: 'profile overrides must change the trace domain weights',
+        );
+      },
+      timeout: const Timeout(Duration(minutes: 15)),
+    );
+
+    test(
+      'invalid profile aborts the run with kExitProfileLoadFailed',
+      () async {
+        final profilesDir = Directory.systemTemp.createTempSync('obs_prof_bad_');
+        addTearDown(() => profilesDir.deleteSync(recursive: true));
+        File('${profilesDir.path}/gp1.json')
+            .writeAsStringSync('{ not valid json');
+
+        final outDir = Directory.systemTemp.createTempSync('obs_prof_baderr_');
+        addTearDown(() => outDir.deleteSync(recursive: true));
+        final code = await runObserverSession(
+          outputRoot: outDir.path,
+          setupConfig: _smokeSetup(),
+          maxTurnsCap: 1,
+          profilesDir: profilesDir.path,
+        );
+
+        expect(code, kExitProfileLoadFailed);
+        // No turns resolved => no merged trace directory contents.
+        final traceRoot = Directory('${outDir.path}/observer-traces');
+        final games = traceRoot.existsSync()
+            ? traceRoot.listSync().whereType<Directory>().toList()
+            : <Directory>[];
+        expect(games, isEmpty);
+      },
+      timeout: const Timeout(Duration(minutes: 15)),
+    );
+  });
+}

--- a/tool/run_observer_game/test/observer_profiles_test.dart
+++ b/tool/run_observer_game/test/observer_profiles_test.dart
@@ -1,0 +1,126 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:colonizethis_test/test.dart';
+
+import 'package:run_observer_game/observer_profiles.dart';
+
+String _profileJson(String profileId, Map<String, num> parameters) {
+  return jsonEncode(<String, dynamic>{
+    'schema_version': 1,
+    'profile_id': profileId,
+    'display_name': profileId,
+    'parameters': parameters,
+  });
+}
+
+void main() {
+  group('loadObserverProfiles', () {
+    test('loads matched <playerId>.json files keyed by playerId', () {
+      final dir = Directory.systemTemp.createTempSync('obs_profiles_ok_');
+      addTearDown(() => dir.deleteSync(recursive: true));
+      File('${dir.path}/england.json').writeAsStringSync(
+        _profileJson('eng', const {'personalityDomainWeights.economy': 5}),
+      );
+      File('${dir.path}/france.json').writeAsStringSync(
+        _profileJson('fra', const {'personalityDomainWeights.military': 95}),
+      );
+
+      final loaded = loadObserverProfiles(
+        dir: dir.path,
+        playerIds: const ['england', 'france', 'spain'],
+      );
+
+      expect(loaded.keys.toSet(), {'england', 'france'});
+      expect(loaded['england']!.profileId, 'eng');
+      expect(loaded['france']!.profileId, 'fra');
+    });
+
+    test('Great Power without a matching file is omitted (uses default)', () {
+      final dir = Directory.systemTemp.createTempSync('obs_profiles_missing_');
+      addTearDown(() => dir.deleteSync(recursive: true));
+      File('${dir.path}/england.json').writeAsStringSync(
+        _profileJson('eng', const {'personalityDomainWeights.economy': 5}),
+      );
+
+      final loaded = loadObserverProfiles(
+        dir: dir.path,
+        playerIds: const ['england', 'france'],
+      );
+
+      expect(loaded.containsKey('england'), isTrue);
+      expect(
+        loaded.containsKey('france'),
+        isFalse,
+        reason: 'no france.json -> france keeps default personality',
+      );
+    });
+
+    test('unmatched .json file is ignored (not loaded)', () {
+      final dir = Directory.systemTemp.createTempSync('obs_profiles_extra_');
+      addTearDown(() => dir.deleteSync(recursive: true));
+      File('${dir.path}/england.json').writeAsStringSync(
+        _profileJson('eng', const {'personalityDomainWeights.economy': 5}),
+      );
+      File('${dir.path}/atlantis.json').writeAsStringSync(
+        _profileJson('atl', const {'personalityDomainWeights.economy': 5}),
+      );
+
+      final loaded = loadObserverProfiles(
+        dir: dir.path,
+        playerIds: const ['england', 'france'],
+      );
+
+      expect(loaded.keys.toSet(), {'england'});
+    });
+
+    test('missing directory throws ObserverProfileLoadException', () {
+      final dir = Directory.systemTemp.createTempSync('obs_profiles_nodir_');
+      final missing = '${dir.path}/does-not-exist';
+      dir.deleteSync(recursive: true);
+
+      expect(
+        () => loadObserverProfiles(
+          dir: missing,
+          playerIds: const ['england'],
+        ),
+        throwsA(isA<ObserverProfileLoadException>()),
+      );
+    });
+
+    test('unparseable matched file throws ObserverProfileLoadException', () {
+      final dir = Directory.systemTemp.createTempSync('obs_profiles_bad_');
+      addTearDown(() => dir.deleteSync(recursive: true));
+      File('${dir.path}/england.json').writeAsStringSync('{ not valid json');
+
+      expect(
+        () => loadObserverProfiles(
+          dir: dir.path,
+          playerIds: const ['england'],
+        ),
+        throwsA(isA<ObserverProfileLoadException>()),
+      );
+    });
+
+    test('invalid schema_version matched file throws', () {
+      final dir = Directory.systemTemp.createTempSync('obs_profiles_schema_');
+      addTearDown(() => dir.deleteSync(recursive: true));
+      File('${dir.path}/england.json').writeAsStringSync(
+        jsonEncode(<String, dynamic>{
+          'schema_version': 99,
+          'profile_id': 'eng',
+          'display_name': 'eng',
+          'parameters': <String, num>{},
+        }),
+      );
+
+      expect(
+        () => loadObserverProfiles(
+          dir: dir.path,
+          playerIds: const ['england'],
+        ),
+        throwsA(isA<ObserverProfileLoadException>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Implements the Observer `--profiles` flag (Refs #3437): `run_observer_game` loads per-Great-Power `AiProfile` JSON (keyed `<playerId>.json`, e.g. `gp1.json`) and overrides AI **personality** parameters at decision time, recording the active `profileId` in the turn trace. Omitting `--profiles` is byte-for-byte identical to today. Builds on the `AiProfile` / `AiParameterRegistry` primitives from #3436 (now merged to `dev`).

## Done in this push

- **`AIConfig`** (`colonizethis_models`): optional `parameterOverrides` (registry-keyed `name -> num`) and `profileId`, both defaulting `null` (no new package dependency).
- **Resolvers** (`colonizethis_data/ai_personality_overrides.dart`): `resolveDomainWeights` / `resolveGoalWeights` / `resolveThresholds` apply a profile value only when it differs from the registry default; `null` overrides return the leader's hardcoded weights unchanged.
- **AI planner** (`colonizethis_ai`): the 8 personality lookup call sites (goal selection, planner-context base weights, economy/build/research/diplomacy scoring) and `ai_trace_builder` now use the resolvers; `generateOrdersForPlayerFullAI(WithTrace)` and `generateOrdersForGameFullAI` accept an optional `Map<String, AiProfile>? profiles` and set `parameterOverrides` + `profileId` on `AIConfig`. Trace `state.decisionContext.profileId` carries the active id (no logic schema change).
- **Observer** (`tool/run_observer_game`): `--profiles <dir>` documented in `--help`; profiles loaded before the turn loop keyed by `game.players` ids; missing GP files use defaults; unmatched files warn (`observer:profile_unmatched`); a missing dir or invalid profile aborts with exit **9** (`profile_load_failed`); the map is passed into `generateOrdersForGameFullAI`.
- **SPEC**: new `SPEC/ai/ai-profile-overrides.md` (override-resolution rule + ACs) and a `--profiles` section/ACs in `SPEC/program/run_observer_game-tool.md`.
- **Docs**: `docs/project-tools.md` observer `--profiles` entry.

## Tests

- `packages/colonizethis_data/test/ai_personality_overrides_test.dart` — null-override parity, non-default override, default-equal no-op, rounding (positive + negative).
- `tool/run_observer_game/test/observer_profiles_test.dart` — load by playerId, missing-GP omission, unmatched-ignore, missing dir / unparseable / bad schema throw.
- `tool/run_observer_game/test/observer_profiles_integration_test.dart` — runs a 1-turn all-AI session and asserts the GP trace `profileId` and changed `domainWeights` vs a baseline run; invalid profile aborts with exit 9.
- Full suites green locally: `colonizethis_data` (333), `colonizethis_models` (295), `colonizethis_ai` (2052), `run_observer_game` CLI/session smoke (15). Analyzer clean on touched files.

## Deferred (out of scope here, follow-up)

- **`victory_config` category overrides:** the `k*` constants are referenced as bare top-level `const`s across ~50 AI files and require a dedicated config-threading design to preserve the 15 s turn-resolution budget and determinism.
- **Colonial-acquisition war-vs-alliance bias:** threads a bare `personalityId` through phase-planner dispatch rather than `AIConfig`; left on leader default for this slice.

Both are documented as deferred in `SPEC/ai/ai-profile-overrides.md`. The personality categories overridden here (domain/goal/threshold weights) are the high-impact AI knobs and already change AI behavior end-to-end, as the integration test shows.

Refs #3437

Made with [Cursor](https://cursor.com)