### PR TITLE
feat: add .grok/skills/ thin shims for native Grok support

### DIFF
--- a/.grok/config.toml
+++ b/.grok/config.toml
@@ -1,0 +1,3 @@
+# Project-scoped Grok configuration (ColonizeThis)
+# Thin skill shims live in .grok/skills/ and delegate to the source of truth
+# under .cursor/skills/. No extra paths or disables are required for normal use.

--- a/.grok/skills/backlog-implement-agent/SKILL.md
+++ b/.grok/skills/backlog-implement-agent/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: backlog-implement-agent
+description: Optimizes code throughput across open issues labeled backlog:implementation. Each run does substantial work and never waits for CI, reviews, or merges. Unblocks stalled PRs (conflicts, failing checks, or open with checks not running) via strict fix-pr toward merge readiness, then moves on. Only PRs that reference those labelled issues. Applies strict implement-github-issue for new work. Each PR targets exactly one issue. Relabels to backlog:verification only when an issue is fully done.
+---
+
+**Thin Grok shim** (repo `.grok/skills/`).
+
+Source of truth: `.cursor/skills/backlog-implement-agent/SKILL.md`
+
+Read that file (and any reference files it points to) in full with your tools, then follow its instructions, required dependencies (especially implement-github-issue and fix-pr), workflow, and guardrails exactly. Obey all its internal cross-references to other `.cursor/skills/` entries.

--- a/.grok/skills/backlog-refine-agent/SKILL.md
+++ b/.grok/skills/backlog-refine-agent/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: backlog-refine-agent
+description: Picks one open GitHub issue labeled backlog:refinement, applies refine-github-issue strictly against all comment feedback, updates the issue body directly, and relabels to backlog:review when fully resolved or backlog:clarification when uncertainties remain.
+---
+
+**Thin Grok shim** (repo `.grok/skills/`).
+
+Source of truth: `.cursor/skills/backlog-refine-agent/SKILL.md`
+
+Read that file in full, then follow its workflow and required dependency on refine-github-issue exactly (including all cross-references to other `.cursor/skills/` files).

--- a/.grok/skills/backlog-review-agent/SKILL.md
+++ b/.grok/skills/backlog-review-agent/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: backlog-review-agent
+description: Picks an open GitHub issue labeled backlog:review, performs a strict purpose↔method review using review-github-issue criteria, posts a consolidated review comment, and advances the issue to backlog:implementation or backlog:refinement based on whether all P0/P1/P2 items are addressed.
+---
+
+**Thin Grok shim** (repo `.grok/skills/`).
+
+Source of truth: `.cursor/skills/backlog-review-agent/SKILL.md`
+
+Read the full file and strictly follow its analysis method and required dependency on review-github-issue (plus cross-references).

--- a/.grok/skills/backlog-verify-agent/SKILL.md
+++ b/.grok/skills/backlog-verify-agent/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: backlog-verify-agent
+description: Picks one open GitHub issue labeled backlog:verification, applies verify-github-issue strictly to confirm implementation completeness, posts a verification comment, and relabels to backlog:acceptance when complete or backlog:implementation when gaps remain.
+---
+
+**Thin Grok shim** (repo `.grok/skills/`).
+
+Source of truth: `.cursor/skills/backlog-verify-agent/SKILL.md`
+
+Read the full authoritative file and apply its workflow + strict dependency on verify-github-issue exactly.

--- a/.grok/skills/clean-local-branches/SKILL.md
+++ b/.grok/skills/clean-local-branches/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: clean-local-branches
+description: Deletes local git branch refs that are not the primary development branch `dev` and not the head branch of an open pull request; never deletes branches on the remote. Use when pruning merged or stale local branches, tidying a clone, or when the user asks to remove old local branches without affecting GitHub/remotes.
+---
+
+**Thin Grok shim** (repo `.grok/skills/`).
+
+Source of truth: `.cursor/skills/clean-local-branches/SKILL.md`
+
+Read the full file and follow its rules, preconditions, and prohibitions exactly.

--- a/.grok/skills/consolidate-prs/SKILL.md
+++ b/.grok/skills/consolidate-prs/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: consolidate-prs
+description: Collapses multiple open pull requests that target the same GitHub issue into one consolidated PR, unblocks any stalled contributor PRs via strict `fix-pr` first, then cancels in-progress GitHub Actions runs that are no longer attached to any open PR. Use when the user asks to consolidate, merge, or de-duplicate open PRs by issue and tidy CI usage.
+---
+
+**Thin Grok shim** (repo `.grok/skills/`).
+
+Source of truth: `.cursor/skills/consolidate-prs/SKILL.md`
+
+Read the full file (including its required dependencies section). Follow its non-negotiables, workflow (especially the mandatory use of fix-pr for stalled PRs and clean-local-branches), and output requirements exactly. Honor all `.cursor/skills/` cross-references inside it.

--- a/.grok/skills/create-github-issue/SKILL.md
+++ b/.grok/skills/create-github-issue/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: create-github-issue
+description: |-
+  Turns an informal issue report into a structured GitHub issue with reproduction steps, expected vs actual behavior, read-only SPEC/code investigation, and a proposed fix scope—without modifying the repository.
+
+  Always clarify requirements with the user first by reading relevant specs/code, analyzing the report against current behavior, and presenting requirement clarifications as a numbered list.
+
+  Attempts to open the issue via GitHub CLI (gh); falls back to a paste-ready draft if gh is missing, unauthenticated, or creation fails.
+
+  Use when the user describes a bug, regression, or gap and wants a filed issue, triage narrative, or fix direction before implementation.
+---
+
+**Thin Grok shim** (repo `.grok/skills/`).
+
+Source of truth: `.cursor/skills/create-github-issue/SKILL.md`
+
+Read the complete file and follow its strict read-only scope, mandatory clarification step, investigation, drafting, and gh creation/fallback workflow exactly.

--- a/.grok/skills/document-app-ui/SKILL.md
+++ b/.grok/skills/document-app-ui/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: document-app-ui
+description: Documents player-app UI screens and UI changes with stable 8-char screen IDs, exhaustive layout/behavior/variant specs, Widgetbook linkage, and code bindings. Use when adding or modifying screens, dialogs, overlays, routes, or when the user asks to document app UI or reconcile UI specs with implementation.
+---
+
+**Thin Grok shim** (repo `.grok/skills/`).
+
+Source of truth: `.cursor/skills/document-app-ui/SKILL.md`
+
+Read the full file and follow its authority (colonizethis-ui-documentation.mdc), ID assignment, spec content checklist, implementation alignment, Widgetbook, and output format exactly. Related skills (implement-github-issue, verify-github-issue) are referenced from within the authoritative copy.

--- a/.grok/skills/fix-pr/SKILL.md
+++ b/.grok/skills/fix-pr/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: fix-pr
+description: Diagnoses and unblocks a pull request by checking PR status, failing checks, quality gates, and merge conflicts, then applying the minimal compliant fix and verifying results. Use when the user provides a PR URL or PR number and asks to fix or unblock the PR.
+---
+
+**Thin Grok shim** (repo `.grok/skills/`).
+
+Source of truth: `.cursor/skills/fix-pr/SKILL.md` (plus its sibling `reference.md`).
+
+Read both the SKILL.md and reference.md from the .cursor location. Follow the non-negotiables, workflow (context, conflicts, reproduce, minimal fix, verify), and output format exactly. This is a core dependency for consolidate-prs, manage-pr-agent, and backlog agents.

--- a/.grok/skills/implement-github-issue/SKILL.md
+++ b/.grok/skills/implement-github-issue/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: implement-github-issue
+description: Implements work from a GitHub issue number or URL after validating the issue for clear problem statement, design or technical approach, and test-targetable acceptance criteria; updates SPEC and ACs when gaps exist; adds positive and negative tests mapped to ACs; runs tests; keeps at most one open PR per issue on dev (stack slices as commits on that PR; if an early merge lands before the issue is finished, open one follow-up PR for the remainder) with a conventional-prefix title; references the issue without closing it. Use when the user gives an issue ID or URL and wants implementation with tests and a non-closing PR.
+---
+
+**Thin Grok shim** (repo `.grok/skills/`).
+
+Source of truth: `.cursor/skills/implement-github-issue/SKILL.md` (plus its sibling `reference.md`).
+
+Read the full SKILL.md and reference.md. Enforce the non-negotiables (SPEC, one PR per issue targeting dev, conventional title with Refs #N, test gates, etc.), issue quality gate, scope triage, and full workflow exactly.

--- a/.grok/skills/interpret-ai-traces/SKILL.md
+++ b/.grok/skills/interpret-ai-traces/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: interpret-ai-traces
+description: Interprets ColonizeThis full-AI turn-trace JSON (from `run_observer_game` or app/ctdev exports) to explain why a deterministic AI emitted specific orders and to spot performance bottlenecks. Use when the user supplies a merged turn trace, asks why the AI did/did not do X on turn N, asks why a GP chose a goal/phase/target, asks why orders were suppressed, or wants to optimize next-turn resolution against the 15-second budget.
+---
+
+**Thin Grok shim** (repo `.grok/skills/`).
+
+Source of truth: `.cursor/skills/interpret-ai-traces/SKILL.md`
+
+Read the full file (including all required SPEC sections and the step-by-step behavior + perf workflows). Follow the anti-patterns, quick reference, and final conclusion format exactly.

--- a/.grok/skills/manage-pr-agent/SKILL.md
+++ b/.grok/skills/manage-pr-agent/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: manage-pr-agent
+description: Keeps open pull requests moving through CI and GitHub workflows in an orderly manner. Enforces one open PR per GitHub issue (via consolidate-prs) and maintains a running-CI quota of 2 PRs (both floor and ceiling) by pausing excess via `[skip ci]` empty commits **and cancelling** their in-flight `pull_request` runs (before and after the skip commit). Whenever the quota has headroom and any open PRs exist, fills it by any means necessary: resuming paused PRs, updating mergeable-but-behind PR branches against base, and unblocking stalled PRs via fix-pr (older PRs first). Performs actions once and then ends the run without waiting for merges, CI, or unblock confirmation. Use when the user asks to tidy, throttle, unblock, or generally manage in-flight PRs.
+---
+
+**Thin Grok shim** (repo `.grok/skills/`).
+
+Source of truth: `.cursor/skills/manage-pr-agent/SKILL.md`
+
+Read the full file. Strictly apply its required dependencies (consolidate-prs + fix-pr), non-negotiables, 4-phase workflow (discover, consolidate, maintain quota of 2, end), and detailed output report format. Never wait for CI/merges.

--- a/.grok/skills/merge-dev-into-android-build/SKILL.md
+++ b/.grok/skills/merge-dev-into-android-build/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: merge-dev-into-android-build
+description: Creates and merges a pull request from dev into build/app/android to trigger Android APK build workflows. Use when the user asks to produce an Android APK build via branch merge, especially when conflicts may occur and should be resolved in favor of dev.
+---
+
+**Thin Grok shim** (repo `.grok/skills/`).
+
+Source of truth: `.cursor/skills/merge-dev-into-android-build/SKILL.md`
+
+Read the full file and execute its preflight, merge resolution favoring dev, PR creation/merge, and verification steps exactly.

--- a/.grok/skills/plan-feature/SKILL.md
+++ b/.grok/skills/plan-feature/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: plan-feature
+description: Plans a user-provided feature idea by reading SPEC and code (read-only), analyzing scope, proposing a design aligned with existing architecture, optionally clarifying underspecified requirements with focused questions, and opening a GitHub issue that documents requirements, assumptions, design, subtasks with dependencies, and acceptance criteria—without modifying the repository. Use when the user wants a feature scoped and filed as an issue before any implementation, spec edits, or PR work.
+---
+
+**Thin Grok shim** (repo `.grok/skills/`).
+
+Source of truth: `.cursor/skills/plan-feature/SKILL.md`
+
+Read the full file (strict read-only scope, architectural alignment notes, workflow through gh issue creation or fallback, and quality bar). Follow all related-skill pointers inside it (create-github-issue, document-app-ui, verify-github-issue).

--- a/.grok/skills/refactoring-opportunity-github-issue/SKILL.md
+++ b/.grok/skills/refactoring-opportunity-github-issue/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: refactoring-opportunity-github-issue
+description: Analyzes `app/` or one `packages/*` workspace package on the latest `origin/dev` baseline for refactoring opportunities using ColonizeThis `.cursor/rules` (plus sound Dart/Flutter practice), de-duplicates against open GitHub issues, proposes focused CI enforcement (AST-first; extend existing gates before adding new ones), and produces a structured GitHub issue another developer can implement. Use when the user asks for refactor scouting, package-level tech-debt triage, or a filing-ready issue from evidence-based findings scoped to app or a package.
+---
+
+**Thin Grok shim** (repo `.grok/skills/`).
+
+Source of truth: `.cursor/skills/refactoring-opportunity-github-issue/SKILL.md` (plus its `references/ci-and-rules.md`).
+
+Read the SKILL.md in full plus the references file it cites. Follow the strict scope (app/ or single packages/*), dev baseline sync, de-dupe, rule loading, analysis, CI proposal, and issue drafting/filing process exactly. Related skills (create-github-issue, document-app-ui, review-github-issue, verify-github-issue) are called out inside the authoritative copy.

--- a/.grok/skills/refine-github-issue/SKILL.md
+++ b/.grok/skills/refine-github-issue/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: refine-github-issue
+description: |-
+  Refines an open GitHub issue using feedback in issue comments: tightens reproduction steps and root-cause analysis, resolves internal inconsistencies, and clarifies subtask priorities and dependencies. Works each feedback item explicitly—updates the issue body when the point is accurate and reasonable, otherwise returns numbered clarification questions for the user. Use when the user asks to address issue feedback, refine an issue from reviewer comments, reconcile comments with the description, or refresh an issue after triage discussion.
+
+  Examples:
+  - user: "Apply the feedback on #88" → map each comment to concrete edits or numbered pushbacks
+  - user: "Update the issue from the last three comments" → merge non-conflicting clarifications into the body
+  - user: "Comments say repro is wrong—fix the issue text" → verify against thread, edit body or ask numbered questions if ambiguous
+---
+
+**Thin Grok shim** (repo `.grok/skills/`).
+
+Source of truth: `.cursor/skills/refine-github-issue/SKILL.md`
+
+Read the full file and follow its non-negotiables, feedback inventory/evaluation, body update rules, reporting, and quality bar exactly. Related skills noted inside point to review-github-issue and verify-github-issue.

--- a/.grok/skills/report-codebase-size/SKILL.md
+++ b/.grok/skills/report-codebase-size/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: report-codebase-size
+description: Reports ColonizeThis codebase size using pytool/project_stats.py with reproducible totals and category breakdowns. Use when the user asks for repository size, LOC counts, file counts, language/category distribution, or package-level code/test sizing.
+---
+
+**Thin Grok shim** (repo `.grok/skills/`).
+
+Source of truth: `.cursor/skills/report-codebase-size/SKILL.md`
+
+Read the full file and run the canonical `pytool/project_stats.py --root . --json` (or python fallback). Report exactly per its rules and template; do not estimate.

--- a/.grok/skills/review-github-issue/SKILL.md
+++ b/.grok/skills/review-github-issue/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: review-github-issue
+description: |-
+  Reviews a GitHub issue for coherence between its stated purpose and its proposed approach (design, scope, ACs). Produces a consolidated comment: primary focus is purpose↔method gaps and internal contradictions; code/spec/test evidence only when needed to show the proposed method cannot satisfy the purpose. Use before implementation; use verify-github-issue for AC↔implementation/SPEC/tests verification posted on the issue.
+
+  Examples:
+  - user: "Review issue #42" → state purpose, assess whether the proposed method plausibly achieves it, flag internal gaps; repo evidence only if method cannot satisfy purpose
+  - user: "Audit this bug report" → extract goal vs proposed fix; flag mismatches, missing how, contradictions in the text
+  - user: "Find gaps in issue before starting work" → purpose–method alignment and thin-issue contradictions first; defer full AC→code mapping to verify
+  - user: "Triage this issue" → clarify purpose, scope, and whether the described approach hangs together
+---
+
+**Thin Grok shim** (repo `.grok/skills/`).
+
+Source of truth: `.cursor/skills/review-github-issue/SKILL.md`
+
+Read the full file (including its boundary table vs verify-github-issue, workflow, priority framing, and output template). Follow the non-negotiables and "primary analysis first, conditional deep trace only when needed" rule exactly. Note its sync comment with the opencode copy is preserved in the source.

--- a/.grok/skills/review-pr/SKILL.md
+++ b/.grok/skills/review-pr/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: review-pr
+description: Reviews an open pull request against issue alignment, acceptance-criteria test coverage, architecture conventions, and linting compliance with strict YES/NO outcomes. Use when the user asks to review, audit, or gate a PR for merge readiness.
+---
+
+**Thin Grok shim** (repo `.grok/skills/`).
+
+Source of truth: `.cursor/skills/review-pr/SKILL.md`
+
+Read the full file. Apply the exact non-negotiables (strict YES/CONDITIONAL YES/NO with rules on when conditional is allowed), required checklist order, scoring, and output format (including mandatory PR comment publication).

--- a/.grok/skills/verify-github-issue/SKILL.md
+++ b/.grok/skills/verify-github-issue/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: verify-github-issue
+description: Verifies one open GitHub issue against acceptance criteria, specs, tests, and CONTRIBUTING workflow; uses the gh CLI directly to read the issue and post a consolidated verification comment; proposes concrete gap fixes when work is incomplete. Use when the user gives an issue number or issue URL and wants verification or gap analysis aligned with dev-branch PRs.
+---
+
+**Thin Grok shim** (repo `.grok/skills/`).
+
+Source of truth: `.cursor/skills/verify-github-issue/SKILL.md` (plus its sibling `reference.md`).
+
+Read the SKILL.md and reference.md in full. Enforce the hard failures to avoid, gh-direct usage, full workflow (load → extract → trace → verify tests/gates → post comment), and verification comment template exactly. This is a core dependency for backlog-verify-agent and many related-skill pointers.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ For complete details, read the relevant rule file(s) in `.cursor/rules/`.
 
 ## Project agent skills
 
-Skills live under `.cursor/skills/<name>/SKILL.md`. When a skill matches the task, read and follow it.
+Skills live under `.cursor/skills/<name>/SKILL.md` (source of truth for all agents). Grok discovers thin shims at `.grok/skills/<name>/SKILL.md` (repo priority) that delegate by reading the Cursor files. When a skill matches the task, read and follow the authoritative `.cursor/skills/` version (and any referenced `reference.md` or sibling skills it names).
 
 | Skill | Use when |
 |-------|----------|


### PR DESCRIPTION
## Summary
Adds native support for the project's 19 agent skills when using **Grok**, while keeping `.cursor/skills/` as the single source of truth.

## Changes
* New `.grok/skills/<name>/SKILL.md` (thin shims) for every skill:
  * Preserves original `name` + `description` (enables `/skill-name` and description-driven auto-invocation).
  * Delegates by telling the agent to read the full authoritative file from the corresponding `.cursor/skills/<name>/SKILL.md` (plus any sibling `reference.md` or `references/` directory) and follow it exactly.
* Minimal `.grok/config.toml`.
* One small update to `AGENTS.md` (under "Project agent skills") documenting both locations and the delegation rule.

## Cross-references
No other files were touched. The key cross-references inside the `.cursor/skills/` definitions (e.g. `consolidate-prs` → `fix-pr`, `manage-pr-agent` → `consolidate-prs` + `fix-pr`, all `backlog-*` agents, `refactoring-opportunity-github-issue`, `plan-feature`, `review-*`, etc.) already use explicit `.cursor/skills/…/SKILL.md` paths in their "Required dependencies", "Read and apply strictly", and workflow sections. This made clean delegation possible without edits.

## Result
* Skills now load at highest (repo) priority for any Grok session whose working directory is inside the checkout.
* Full set of project skills becomes available as slash commands (`/implement-github-issue`, `/document-app-ui`, `/fix-pr`, `/consolidate-prs`, `/manage-pr-agent`, all backlog agents, `/review-pr`, `/verify-github-issue`, `/plan-feature`, etc.).
* Automatic invocation based on task description works.
* `grok inspect` surfaces them with project source.
* No per-user configuration or symlinks into `~/.grok` / `~/.cursor` are required — teammates get them automatically.

`.cursor/skills/` (and the `.opencode/skills/` copies) remain the maintained source of truth for Cursor and OpenCode users.

This is the minimal set of changes requested to wire the existing skills for native Grok usage.