### PR TITLE
refactor: centralize combat RNG construction in combat_rng.dart (#3448)

### DIFF
--- a/packages/colonizethis_combat/lib/colonizethis_combat.dart
+++ b/packages/colonizethis_combat/lib/colonizethis_combat.dart
@@ -3,6 +3,7 @@ library colonizethis_combat;
 
 export 'src/combat/battle_general_assignment.dart';
 export 'src/combat/combat_effective_strength.dart';
+export 'src/combat/combat_rng.dart';
 export 'src/combat/combat_mode_selection.dart';
 export 'src/combat/combat_resolver.dart';
 export 'src/combat/combat_resolver_probabilistic.dart';

--- a/packages/colonizethis_combat/lib/src/combat/battle_general_assignment.dart
+++ b/packages/colonizethis_combat/lib/src/combat/battle_general_assignment.dart
@@ -2,6 +2,7 @@ import 'dart:math';
 
 import 'package:colonizethis_models/colonizethis_models.dart';
 
+import 'combat_rng.dart';
 import 'conflict_detection.dart';
 import 'leader_bonus_helpers.dart';
 
@@ -32,16 +33,6 @@ class BattleGeneralAssignment {
   final int defenderMedals;
 }
 
-Random _preCombatBindingRng(Game game) {
-  return Random(
-    Object.hash(
-      game.globalGameSeed ?? 0,
-      game.worldState.turnState.turnNumber,
-      'preCombatGenerals',
-    ),
-  );
-}
-
 /// Runs one pre-combat pass and binds generals to attacking armies and
 /// primary defending armies across all provided battle contexts.
 List<BattleContext> bindGeneralsForCombatPhase({
@@ -49,7 +40,7 @@ List<BattleContext> bindGeneralsForCombatPhase({
   required List<BattleContext> contexts,
   required CombatPhaseGeneralLedger ledger,
 }) {
-  final rng = _preCombatBindingRng(game);
+  final rng = preCombatBindingRng(game);
   final defenderUsedByFaction = <String, Set<String>>{};
   final generalsByFaction = <String, List<General>>{};
   for (final general in game.generals) {
@@ -213,16 +204,5 @@ BattleGeneralAssignment assignGeneralsForBattleContext({
     attackerByFactionId: attackerByFactionId,
     defenderGeneralId: ctx.defenderGeneralId,
     defenderMedals: ctx.defenderGeneralMedals,
-  );
-}
-
-Random battleAssignmentRng(Game game, BattleContext ctx) {
-  return Random(
-    Object.hash(
-      game.globalGameSeed ?? 0,
-      game.worldState.turnState.turnNumber,
-      ctx.regionId,
-      ctx.provinceId,
-    ),
   );
 }

--- a/packages/colonizethis_combat/lib/src/combat/combat_resolver.dart
+++ b/packages/colonizethis_combat/lib/src/combat/combat_resolver.dart
@@ -8,6 +8,7 @@ import 'package:colonizethis_world/colonizethis_world.dart';
 import 'battle_general_assignment.dart';
 import 'combat_constants.dart';
 import 'combat_engagement.dart';
+import 'combat_rng.dart';
 import 'combat_types.dart';
 import 'conflict_detection.dart';
 import 'leader_bonus_helpers.dart';

--- a/packages/colonizethis_combat/lib/src/combat/combat_resolver_probabilistic.dart
+++ b/packages/colonizethis_combat/lib/src/combat/combat_resolver_probabilistic.dart
@@ -10,6 +10,7 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'combat_effective_strength.dart';
+import 'combat_rng.dart';
 import 'combat_types.dart';
 import 'military_strength.dart';
 
@@ -93,7 +94,7 @@ ProbabilisticEngagementOutcome resolveEngagementProbabilistic({
   double attackerMoraleMultiplier = 1.0,
   double defenderMoraleMultiplier = 1.0,
 }) {
-  final rng = random ?? Random(seed ?? 0);
+  final rng = random ?? probabilisticEngagementRng(seed);
 
   var attList = attackerUnits.map((u) => u.copyWith()).toList();
   var defList = defenderUnits.map((u) => u.copyWith()).toList();

--- a/packages/colonizethis_combat/lib/src/combat/combat_rng.dart
+++ b/packages/colonizethis_combat/lib/src/combat/combat_rng.dart
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import 'dart:math';
+
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import 'conflict_detection.dart';
+import 'deterministic_rng.dart';
+
+/// Single seam for constructing every random-number generator used by combat
+/// resolution (Refs #3448).
+///
+/// All combat RNG must be built here so the seed recipes have one source of
+/// truth and stay aligned with the determinism contract in
+/// `SPEC/program/combat-resolution.md` (§3 binding recipe, "No global RNG
+/// access; callers provide explicit seed when randomness is needed"). Each
+/// factory below documents whether it derives its seed from the game replay
+/// state (`globalGameSeed` + turn + context identity) or from a caller-supplied
+/// per-engagement seed.
+///
+/// These factories are intentionally thin wrappers around `Random` /
+/// [DeterministicRng]: they preserve the exact construction expressions that
+/// previously lived inline in the resolvers, so observable outcomes are
+/// identical for any fixed input.
+
+/// Seed token mixed into the pre-Combat general-binding hash. Matches the recipe
+/// in `SPEC/program/combat-resolution.md` §3 ("Binding RNG").
+const String kPreCombatBindingSeedToken = 'preCombatGenerals';
+
+/// RNG for the once-per-phase pre-Combat general binding pass.
+///
+/// Replay-stable: seeded from `hash(globalGameSeed, turnNumber,
+/// "preCombatGenerals")` per `SPEC/program/combat-resolution.md` §3 so
+/// auto-resolve and Quick Battle input build produce identical bindings.
+Random preCombatBindingRng(Game game) {
+  return Random(
+    Object.hash(
+      game.globalGameSeed ?? 0,
+      game.worldState.turnState.turnNumber,
+      kPreCombatBindingSeedToken,
+    ),
+  );
+}
+
+/// RNG for per-`BattleContext` general assignment and initiative tie-breaks.
+///
+/// Replay-stable: seeded from `hash(globalGameSeed, turnNumber, regionId,
+/// provinceId)` so each province battle is deterministic and independent.
+Random battleAssignmentRng(Game game, BattleContext ctx) {
+  return Random(
+    Object.hash(
+      game.globalGameSeed ?? 0,
+      game.worldState.turnState.turnNumber,
+      ctx.regionId,
+      ctx.provinceId,
+    ),
+  );
+}
+
+/// RNG for the Quick Battle resolver pipeline.
+///
+/// Caller-seeded: the per-engagement `seed` is supplied on `QuickBattleInput`;
+/// the same seed yields an identical Quick Battle outcome.
+Random quickBattleRng(int seed) => Random(seed);
+
+/// RNG for the probabilistic per-engagement resolver.
+///
+/// Caller-seeded with a nullable seed; a `null` seed falls back to `0` so
+/// repeated calls without an explicit seed remain deterministic.
+Random probabilisticEngagementRng(int? seed) => Random(seed ?? 0);
+
+/// RNG for naval combat (interception filtering and sea-battle resolution).
+///
+/// Replay-stable: callers pass a seed derived from game + sea-zone identity;
+/// uses the 31-bit LCG [DeterministicRng] for replay-stable rolls.
+DeterministicRng navalCombatRng(int seed) => DeterministicRng(seed);

--- a/packages/colonizethis_combat/lib/src/combat/conflict_detection.dart
+++ b/packages/colonizethis_combat/lib/src/combat/conflict_detection.dart
@@ -3,6 +3,8 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'package:colonizethis_world/colonizethis_world.dart';
 
+import 'pre_combat_index.dart';
+
 /// Battle context for one contested province. SPEC/program/combat-resolution.md.
 class BattleContext {
   const BattleContext({
@@ -109,20 +111,18 @@ class AttackingSide {
 /// Attackers are attacking armies (not faction-aggregated sides).
 List<BattleContext> detectConflicts(Game game, Orders orders) {
   final contexts = <BattleContext>[];
-  final armyById = {for (final a in game.worldState.armies) a.id: a};
+  final index = PreCombatMovementIndex.build(game, orders);
+  final armyById = index.armiesById;
+  final gpIds = index.greatPowerIds;
   final armiesByOwnerAndProvince = _indexArmiesByOwnerAndProvince(
     game.worldState.armies,
   );
   final unitById = game.worldState.allUnitsById;
-  final gpIds = {for (final p in game.players) p.id};
 
   void processRegion(RegionData region) {
     if (region.units.isEmpty) return;
 
-    final unitsByProvince = <String, List<Unit>>{};
-    for (final u in region.units) {
-      unitsByProvince.putIfAbsent(u.locationProvinceId, () => []).add(u);
-    }
+    final unitsByProvince = unitsByProvinceIndex(region);
 
     final movedArmyIdsByProvince = <String, List<String>>{};
     final movedIntoByFaction = <String, Set<String>>{};
@@ -141,27 +141,15 @@ List<BattleContext> detectConflicts(Game game, Orders orders) {
             .add(factionId);
       }
     }
-    for (final entry in orders.armyMoveOrdersByPlayerId.entries) {
-      final factionId = entry.key;
-      if (!gpIds.contains(factionId)) continue;
-      for (final order in entry.value) {
-        final army = armyById[order.armyId];
-        if (army == null || army.ownerId != factionId) continue;
-        if (army.isHomeArmy) continue;
-        final destFull = ProvinceId.isPrefixed(order.destinationProvinceId)
-            ? order.destinationProvinceId
-            : ProvinceId.full(
-                ProvinceId.regionIdFrom(army.stationedProvinceId),
-                order.destinationProvinceId,
-              );
-        movedArmyIdsByProvince
-            .putIfAbsent(destFull, () => <String>[])
-            .add(army.id);
-        movedIntoByFaction.putIfAbsent(destFull, () => {}).add(factionId);
-      }
+    for (final move in index.greatPowerArmyMoves) {
+      final destFull = move.destinationProvinceId;
+      movedArmyIdsByProvince
+          .putIfAbsent(destFull, () => <String>[])
+          .add(move.army.id);
+      movedIntoByFaction.putIfAbsent(destFull, () => {}).add(move.factionId);
     }
 
-    final provinceById = {for (final p in region.provinces) p.id: p};
+    final provinceById = provincesByIdIndex(region);
 
     for (final entry in unitsByProvince.entries) {
       final provinceId = entry.key;

--- a/packages/colonizethis_combat/lib/src/combat/naval_combat_resolver.dart
+++ b/packages/colonizethis_combat/lib/src/combat/naval_combat_resolver.dart
@@ -7,7 +7,7 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'package:colonizethis_world/src/world/diplomatic_relation_lookup.dart';
 import 'package:colonizethis_world/colonizethis_world.dart';
-import 'deterministic_rng.dart';
+import 'combat_rng.dart';
 import 'military_strength.dart';
 
 /// Mission factor for Patrol interception probability.
@@ -232,7 +232,7 @@ List<BattleContextSea> filterBattlesByInterception(
   int seed,
 ) {
   if (battles.isEmpty) return battles;
-  final rng = DeterministicRng(seed);
+  final rng = navalCombatRng(seed);
 
   // Pre-index moved fleets at sea by (seaZoneId, ownerId) to avoid O(fleets)
   // scan per battle.
@@ -334,7 +334,7 @@ NavalBattleResult resolveSeaBattle(
   bool side2CanRetreat = true,
   Map<String, double> navalFeedingCoverageByPlayerId = const {},
 }) {
-  final rng = DeterministicRng(seed);
+  final rng = navalCombatRng(seed);
   final cov1 = navalFeedingCoverageByPlayerId[battle.side1.ownerId] ?? 1.0;
   final cov2 = navalFeedingCoverageByPlayerId[battle.side2.ownerId] ?? 1.0;
   final m1 = moraleMultiplierForFeedingCoverage(cov1);

--- a/packages/colonizethis_combat/lib/src/combat/pre_combat_index.dart
+++ b/packages/colonizethis_combat/lib/src/combat/pre_combat_index.dart
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+/// Shared pre-combat movement / province indexing for the combat phase
+/// (Refs #3448).
+///
+/// `applyUnopposedProvinceCaptures` (unopposed_province_capture.dart) and
+/// `detectConflicts` (conflict_detection.dart) both run at the start of the
+/// combat phase and previously rebuilt the same indexes nearly verbatim: the
+/// Great Power id set, the army-by-id map, per-region units-by-province and
+/// provinces-by-id maps, and the army-move destination normalization (the
+/// `ProvinceId` prefixing footgun). Centralizing them here gives one source of
+/// truth and keeps both consumers byte-identical for any fixed input.
+///
+/// SPEC/program/combat-resolution.md (conflict detection, pre-Combat indexing).
+/// These helpers are pure and deterministic: same inputs always yield the same
+/// outputs and the same iteration order.
+
+/// A Great Power army move with its destination resolved to a prefixed
+/// (`regionId|localId`) province id and the common eligibility guards already
+/// applied (owner is a Great Power, army exists, owner matches, not a home
+/// army).
+class ResolvedArmyMove {
+  const ResolvedArmyMove({
+    required this.factionId,
+    required this.army,
+    required this.destinationProvinceId,
+  });
+
+  /// Owning Great Power faction id (key of `armyMoveOrdersByPlayerId`).
+  final String factionId;
+
+  /// The moving army.
+  final Army army;
+
+  /// Destination province id, always prefixed (`regionId|localId`).
+  final String destinationProvinceId;
+}
+
+/// Normalizes an [ArmyMoveOrder] destination to a prefixed province id.
+///
+/// Already-prefixed destinations pass through unchanged; bare local ids are
+/// qualified with the region of the army's stationed province. Always use a
+/// prefixed (regionId, provinceId) id for province lookup — never a bare local
+/// id (see `colonizethis-core-principles` province-lookup rule).
+String resolveArmyMoveDestinationProvinceId(Army army, ArmyMoveOrder order) {
+  return ProvinceId.isPrefixed(order.destinationProvinceId)
+      ? order.destinationProvinceId
+      : ProvinceId.full(
+          ProvinceId.regionIdFrom(army.stationedProvinceId),
+          order.destinationProvinceId,
+        );
+}
+
+/// Indexes a region's combat units by their location province id.
+///
+/// Insertion order within each list follows `region.units` order.
+Map<String, List<Unit>> unitsByProvinceIndex(RegionData region) {
+  final unitsByProvince = <String, List<Unit>>{};
+  for (final u in region.units) {
+    unitsByProvince.putIfAbsent(u.locationProvinceId, () => []).add(u);
+  }
+  return unitsByProvince;
+}
+
+/// Indexes a region's provinces by their (prefixed) province id.
+Map<String, Province> provincesByIdIndex(RegionData region) {
+  return {for (final p in region.provinces) p.id: p};
+}
+
+/// Pre-combat movement index shared by unopposed capture and conflict
+/// detection.
+///
+/// Holds the game-wide pieces (Great Power ids, army-by-id, and resolved Great
+/// Power army moves) that are independent of any single region, so they are
+/// computed once per combat-phase pass instead of per region.
+class PreCombatMovementIndex {
+  const PreCombatMovementIndex._({
+    required this.greatPowerIds,
+    required this.armiesById,
+    required this.greatPowerArmyMoves,
+  });
+
+  /// All Great Power (player) faction ids.
+  final Set<String> greatPowerIds;
+
+  /// Every army keyed by its id.
+  final Map<String, Army> armiesById;
+
+  /// Great Power army moves with destinations resolved, in deterministic order
+  /// (player-entry order, then per-order order within each player).
+  final List<ResolvedArmyMove> greatPowerArmyMoves;
+
+  /// Builds the index from [game] and [orders].
+  factory PreCombatMovementIndex.build(Game game, Orders orders) {
+    final greatPowerIds = {for (final p in game.players) p.id};
+    final armiesById = {for (final a in game.worldState.armies) a.id: a};
+
+    final moves = <ResolvedArmyMove>[];
+    for (final entry in orders.armyMoveOrdersByPlayerId.entries) {
+      final factionId = entry.key;
+      if (!greatPowerIds.contains(factionId)) continue;
+      for (final order in entry.value) {
+        final army = armiesById[order.armyId];
+        if (army == null || army.ownerId != factionId) continue;
+        if (army.isHomeArmy) continue;
+        moves.add(
+          ResolvedArmyMove(
+            factionId: factionId,
+            army: army,
+            destinationProvinceId: resolveArmyMoveDestinationProvinceId(
+              army,
+              order,
+            ),
+          ),
+        );
+      }
+    }
+
+    return PreCombatMovementIndex._(
+      greatPowerIds: greatPowerIds,
+      armiesById: armiesById,
+      greatPowerArmyMoves: moves,
+    );
+  }
+}

--- a/packages/colonizethis_combat/lib/src/combat/quick_battle_resolver.dart
+++ b/packages/colonizethis_combat/lib/src/combat/quick_battle_resolver.dart
@@ -1,9 +1,8 @@
-import 'dart:math';
-
 import 'package:colonizethis_combat/src/logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'package:colonizethis_world/colonizethis_world.dart';
+import 'combat_rng.dart';
 import 'conflict_detection.dart';
 import 'quick_battle_action_modifiers.dart';
 import 'quick_battle_emplaced_guns.dart';
@@ -38,7 +37,7 @@ QuickBattleResult resolveQuickBattle(
     'quick_battle start province=${input.provinceId} '
     'seed=${input.seed} rounds=${input.maxRounds}',
   );
-  final rng = Random(input.seed);
+  final rng = quickBattleRng(input.seed);
   var attGroups = copyGroups(input.attackerDeployment.groups);
   var defGroups = copyGroups(input.defenderDeployment.groups);
   final attCasualties = <String>[];

--- a/packages/colonizethis_combat/lib/src/combat/unopposed_province_capture.dart
+++ b/packages/colonizethis_combat/lib/src/combat/unopposed_province_capture.dart
@@ -4,42 +4,28 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_world/src/world/diplomatic_relation_lookup.dart';
 import 'package:colonizethis_world/colonizethis_world.dart';
 
+import 'pre_combat_index.dart';
+
 /// Applies immediate province flips when a Great Power army moves into an
 /// enemy-owned province that has no defending combat units (and no third-party
 /// combat presence). SPEC/game/combat.md § Unopposed capture.
 ///
 /// Runs at the start of the combat phase, before [detectConflicts].
 Game applyUnopposedProvinceCaptures(Game game, Orders orders) {
-  final gpIds = {for (final p in game.players) p.id};
-  final armyById = {for (final a in game.worldState.armies) a.id: a};
+  final index = PreCombatMovementIndex.build(game, orders);
   var state = game;
 
   void processRegion(RegionData region) {
-    final provinceById = {for (final p in region.provinces) p.id: p};
-    final unitsByProvince = <String, List<Unit>>{};
-    for (final u in region.units) {
-      unitsByProvince.putIfAbsent(u.locationProvinceId, () => []).add(u);
-    }
+    final provinceById = provincesByIdIndex(region);
+    final unitsByProvince = unitsByProvinceIndex(region);
 
     final movedGpIdsByProvince = <String, Set<String>>{};
-    for (final entry in orders.armyMoveOrdersByPlayerId.entries) {
-      final factionId = entry.key;
-      if (!gpIds.contains(factionId)) continue;
-      for (final order in entry.value) {
-        final army = armyById[order.armyId];
-        if (army == null || army.ownerId != factionId) continue;
-        if (army.isHomeArmy) continue;
-        final destFull = ProvinceId.isPrefixed(order.destinationProvinceId)
-            ? order.destinationProvinceId
-            : ProvinceId.full(
-                ProvinceId.regionIdFrom(army.stationedProvinceId),
-                order.destinationProvinceId,
-              );
-        if (!provinceById.containsKey(destFull)) continue;
-        movedGpIdsByProvince
-            .putIfAbsent(destFull, () => <String>{})
-            .add(factionId);
-      }
+    for (final move in index.greatPowerArmyMoves) {
+      final destFull = move.destinationProvinceId;
+      if (!provinceById.containsKey(destFull)) continue;
+      movedGpIdsByProvince
+          .putIfAbsent(destFull, () => <String>{})
+          .add(move.factionId);
     }
 
     final sortedProvinceIds = movedGpIdsByProvince.keys.toList()..sort();

--- a/packages/colonizethis_combat/test/combat_rng_test.dart
+++ b/packages/colonizethis_combat/test/combat_rng_test.dart
@@ -1,0 +1,115 @@
+import 'dart:math';
+
+import 'package:colonizethis_combat/colonizethis_combat.dart';
+import 'package:colonizethis_combat/src/combat/deterministic_rng.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+List<int> _take(Random rng, int n) =>
+    List<int>.generate(n, (_) => rng.nextInt(1 << 30));
+
+List<int> _takeDet(DeterministicRng rng, int n) =>
+    List<int>.generate(n, (_) => rng.nextInt(1 << 30));
+
+Game _buildGame({int? seed, required int turn}) => Game(
+  id: 'g',
+  globalGameSeed: seed,
+  worldState: WorldState(
+    turnState: TurnState(phase: TurnPhase.orders, turnNumber: turn),
+    oldWorld: const RegionData(),
+    newWorld: const RegionData(),
+  ),
+  players: const [],
+);
+
+void main() {
+  group('combat_rng factories (#3448)', () {
+    test('quickBattleRng matches Random(seed) sequence', () {
+      expect(_take(quickBattleRng(42), 8), _take(Random(42), 8));
+    });
+
+    test('quickBattleRng is deterministic for a fixed seed', () {
+      expect(_take(quickBattleRng(7), 8), _take(quickBattleRng(7), 8));
+    });
+
+    test('probabilisticEngagementRng falls back to 0 for a null seed', () {
+      expect(_take(probabilisticEngagementRng(null), 8), _take(Random(0), 8));
+    });
+
+    test('probabilisticEngagementRng matches Random(seed) for non-null seed', () {
+      expect(_take(probabilisticEngagementRng(13), 8), _take(Random(13), 8));
+    });
+
+    test('navalCombatRng matches DeterministicRng(seed) sequence', () {
+      expect(
+        _takeDet(navalCombatRng(123), 8),
+        _takeDet(DeterministicRng(123), 8),
+      );
+    });
+
+    test('navalCombatRng is deterministic for a fixed seed', () {
+      expect(_takeDet(navalCombatRng(5), 8), _takeDet(navalCombatRng(5), 8));
+    });
+
+    group('game-seeded factories', () {
+      test('preCombatBindingRng matches the SPEC §3 hash recipe', () {
+        final game = _buildGame(seed: 99, turn: 4);
+        final expected = Random(Object.hash(99, 4, kPreCombatBindingSeedToken));
+        expect(_take(preCombatBindingRng(game), 8), _take(expected, 8));
+      });
+
+      test('preCombatBindingRng treats a null globalGameSeed as 0', () {
+        final game = _buildGame(turn: 1);
+        final expected = Random(Object.hash(0, 1, kPreCombatBindingSeedToken));
+        expect(_take(preCombatBindingRng(game), 8), _take(expected, 8));
+      });
+
+      test('battleAssignmentRng matches hash(seed, turn, region, province)', () {
+        final game = _buildGame(seed: 12, turn: 6);
+        const ctx = BattleContext(
+          provinceId: 'oldWorld|P3',
+          regionId: 'oldWorld',
+          defenderFactionId: 'd',
+          defenderUnitIds: [],
+          attackers: [
+            AttackingSide(factionId: 'a', unitIds: ['u1']),
+          ],
+          fortLevel: 0,
+          terrain: 'plains',
+        );
+        final expected = Random(Object.hash(12, 6, 'oldWorld', 'oldWorld|P3'));
+        expect(_take(battleAssignmentRng(game, ctx), 8), _take(expected, 8));
+      });
+
+      test('battleAssignmentRng differs across provinces', () {
+        final game = _buildGame(seed: 12, turn: 6);
+        const ctxA = BattleContext(
+          provinceId: 'oldWorld|P1',
+          regionId: 'oldWorld',
+          defenderFactionId: 'd',
+          defenderUnitIds: [],
+          attackers: [
+            AttackingSide(factionId: 'a', unitIds: ['u1']),
+          ],
+          fortLevel: 0,
+          terrain: 'plains',
+        );
+        const ctxB = BattleContext(
+          provinceId: 'oldWorld|P2',
+          regionId: 'oldWorld',
+          defenderFactionId: 'd',
+          defenderUnitIds: [],
+          attackers: [
+            AttackingSide(factionId: 'a', unitIds: ['u1']),
+          ],
+          fortLevel: 0,
+          terrain: 'plains',
+        );
+        expect(
+          _take(battleAssignmentRng(game, ctxA), 8),
+          isNot(_take(battleAssignmentRng(game, ctxB), 8)),
+        );
+      });
+    });
+  });
+}

--- a/packages/colonizethis_combat/test/pre_combat_index_test.dart
+++ b/packages/colonizethis_combat/test/pre_combat_index_test.dart
@@ -1,0 +1,205 @@
+import 'package:colonizethis_combat/src/combat/pre_combat_index.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+const _ow = 'oldWorld';
+
+Army _army(
+  String id, {
+  required String ownerId,
+  String stationedProvinceId = '$_ow|p1',
+  bool isHomeArmy = false,
+}) => Army(
+  id: id,
+  ownerId: ownerId,
+  regionId: _ow,
+  stationedProvinceId: stationedProvinceId,
+  regimentUnitIds: const [],
+  isHomeArmy: isHomeArmy,
+);
+
+Game _game({
+  List<Player> players = const [
+    Player(id: 'p1', displayName: 'P1', isHuman: true),
+    Player(id: 'p2', displayName: 'P2', isHuman: false),
+  ],
+  List<Army> armies = const [],
+  RegionData? oldWorld,
+}) => Game(
+  id: 'g',
+  worldState: WorldState(
+    turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+    oldWorld: oldWorld ?? const RegionData(),
+    newWorld: const RegionData(),
+    armies: armies,
+  ),
+  players: players,
+);
+
+void main() {
+  group('resolveArmyMoveDestinationProvinceId (#3448)', () {
+    test('passes through an already-prefixed destination unchanged', () {
+      final army = _army('a1', ownerId: 'p1', stationedProvinceId: '$_ow|p1');
+      const order = ArmyMoveOrder(
+        armyId: 'a1',
+        destinationProvinceId: '$_ow|p2',
+      );
+      expect(resolveArmyMoveDestinationProvinceId(army, order), '$_ow|p2');
+    });
+
+    test('qualifies a bare local id with the army stationed region', () {
+      final army = _army('a1', ownerId: 'p1', stationedProvinceId: '$_ow|p1');
+      const order = ArmyMoveOrder(armyId: 'a1', destinationProvinceId: 'p2');
+      expect(resolveArmyMoveDestinationProvinceId(army, order), '$_ow|p2');
+    });
+  });
+
+  group('unitsByProvinceIndex (#3448)', () {
+    test('groups combat units by province, preserving region.units order', () {
+      final region = RegionData(
+        units: [
+          Unit(
+            id: 'u1',
+            type: 'grenadiers',
+            ownerId: 'p1',
+            locationProvinceId: '$_ow|a',
+          ),
+          Unit(
+            id: 'u2',
+            type: 'grenadiers',
+            ownerId: 'p1',
+            locationProvinceId: '$_ow|b',
+          ),
+          Unit(
+            id: 'u3',
+            type: 'grenadiers',
+            ownerId: 'p2',
+            locationProvinceId: '$_ow|a',
+          ),
+        ],
+      );
+      final index = unitsByProvinceIndex(region);
+      expect(index.keys.toSet(), {'$_ow|a', '$_ow|b'});
+      expect(index['$_ow|a']!.map((u) => u.id).toList(), ['u1', 'u3']);
+      expect(index['$_ow|b']!.map((u) => u.id).toList(), ['u2']);
+    });
+
+    test('returns an empty map for a region without units', () {
+      expect(unitsByProvinceIndex(const RegionData()), isEmpty);
+    });
+  });
+
+  group('provincesByIdIndex (#3448)', () {
+    test('maps each province id to its province', () {
+      const region = RegionData(
+        provinces: [
+          Province(id: '$_ow|p1', regionId: _ow, ownerId: 'p1'),
+          Province(id: '$_ow|p2', regionId: _ow, ownerId: 'p2'),
+        ],
+      );
+      final index = provincesByIdIndex(region);
+      expect(index.keys.toSet(), {'$_ow|p1', '$_ow|p2'});
+      expect(index['$_ow|p1']!.ownerId, 'p1');
+    });
+  });
+
+  group('PreCombatMovementIndex.build (#3448)', () {
+    test(
+      'greatPowerIds contains every player id and armiesById every army',
+      () {
+        final game = _game(
+          armies: [
+            _army('a1', ownerId: 'p1'),
+            _army('a2', ownerId: 'p2'),
+          ],
+        );
+        final index = PreCombatMovementIndex.build(game, const Orders());
+        expect(index.greatPowerIds, {'p1', 'p2'});
+        expect(index.armiesById.keys.toSet(), {'a1', 'a2'});
+        expect(index.armiesById['a1']!.ownerId, 'p1');
+      },
+    );
+
+    test(
+      'includes Great Power army moves with destinations resolved in order',
+      () {
+        final game = _game(
+          armies: [
+            _army('a1', ownerId: 'p1', stationedProvinceId: '$_ow|p1'),
+            _army('a2', ownerId: 'p1', stationedProvinceId: '$_ow|p5'),
+          ],
+        );
+        final orders = Orders(
+          armyMoveOrdersByPlayerId: const {
+            'p1': [
+              ArmyMoveOrder(armyId: 'a1', destinationProvinceId: '$_ow|p2'),
+              ArmyMoveOrder(armyId: 'a2', destinationProvinceId: 'p6'),
+            ],
+          },
+        );
+        final index = PreCombatMovementIndex.build(game, orders);
+        expect(
+          index.greatPowerArmyMoves
+              .map(
+                (m) => '${m.factionId}:${m.army.id}:${m.destinationProvinceId}',
+              )
+              .toList(),
+          ['p1:a1:$_ow|p2', 'p1:a2:$_ow|p6'],
+        );
+      },
+    );
+
+    test('skips moves from factions that are not Great Powers', () {
+      final game = _game(
+        players: const [Player(id: 'p1', displayName: 'P1', isHuman: true)],
+        armies: [_army('a1', ownerId: 'minor1')],
+      );
+      final orders = Orders(
+        armyMoveOrdersByPlayerId: const {
+          'minor1': [
+            ArmyMoveOrder(armyId: 'a1', destinationProvinceId: '$_ow|p2'),
+          ],
+        },
+      );
+      final index = PreCombatMovementIndex.build(game, orders);
+      expect(index.greatPowerArmyMoves, isEmpty);
+    });
+
+    test('skips home armies', () {
+      final game = _game(
+        armies: [_army('a1', ownerId: 'p1', isHomeArmy: true)],
+      );
+      final orders = Orders(
+        armyMoveOrdersByPlayerId: const {
+          'p1': [ArmyMoveOrder(armyId: 'a1', destinationProvinceId: '$_ow|p2')],
+        },
+      );
+      final index = PreCombatMovementIndex.build(game, orders);
+      expect(index.greatPowerArmyMoves, isEmpty);
+    });
+
+    test('skips orders for unknown army ids', () {
+      final game = _game(armies: [_army('a1', ownerId: 'p1')]);
+      final orders = Orders(
+        armyMoveOrdersByPlayerId: const {
+          'p1': [
+            ArmyMoveOrder(armyId: 'ghost', destinationProvinceId: '$_ow|p2'),
+          ],
+        },
+      );
+      final index = PreCombatMovementIndex.build(game, orders);
+      expect(index.greatPowerArmyMoves, isEmpty);
+    });
+
+    test('skips orders whose army owner differs from the ordering faction', () {
+      final game = _game(armies: [_army('a1', ownerId: 'p2')]);
+      final orders = Orders(
+        armyMoveOrdersByPlayerId: const {
+          'p1': [ArmyMoveOrder(armyId: 'a1', destinationProvinceId: '$_ow|p2')],
+        },
+      );
+      final index = PreCombatMovementIndex.build(game, orders);
+      expect(index.greatPowerArmyMoves, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Refactor slices for #3448 (combat package dedup / RNG seam). Each slice preserves combat resolution semantics, determinism, and the 15 s turn budget contract.

Refs #3448

## Slice 1 — single combat RNG seam (`combat_rng.dart`)

Every random-number generator used by combat resolution is constructed through named factory functions in one module (`combat_rng.dart`), each documented with its replay-vs-sim seed contract and aligned with the determinism contract in `SPEC/program/combat-resolution.md` (§3 binding recipe; "No global RNG access; callers provide explicit seed").

Routes the six prior inline RNG construction sites on `dev` through `combat_rng.dart`:

- `preCombatBindingRng(game)` and `battleAssignmentRng(game, ctx)` — **moved** out of `battle_general_assignment.dart` (the private `_preCombatBindingRng` is removed; `battleAssignmentRng` keeps the same public name and is now exported via the new module).
- `quickBattleRng(seed)` — was `Random(input.seed)` in `quick_battle_resolver.dart`.
- `probabilisticEngagementRng(seed)` — was `Random(seed ?? 0)` in `combat_resolver_probabilistic.dart`.
- `navalCombatRng(seed)` — was the two `DeterministicRng(seed)` sites in `naval_combat_resolver.dart` (interception filter + sea-battle resolve).

The factories are **thin wrappers** that preserve the exact prior construction expressions, so observable outcomes (casualties, winners, flips, general binding, ordering) are identical for any fixed seed/input.

## Slice 2 — shared pre-combat movement index (`pre_combat_index.dart`)

Deduplicates the near-verbatim pre-combat indexing that was shared between `applyUnopposedProvinceCaptures` (`unopposed_province_capture.dart`) and `detectConflicts` (`conflict_detection.dart`) into one pure, deterministic `PreCombatMovementIndex` module:

- `greatPowerIds` (player id set) and `armiesById` (army-by-id map).
- `unitsByProvinceIndex(region)` / `provincesByIdIndex(region)` per-region helpers.
- `resolveArmyMoveDestinationProvinceId(army, order)` — centralizes the `ProvinceId` prefix normalization footgun (bare local → `regionId|localId`).
- `greatPowerArmyMoves` — GP army moves with destinations resolved and the common eligibility guards (GP faction, army exists, owner matches, not a home army) applied **once per combat-phase pass** instead of per region.

Both consumers now read from the shared index; iteration order and all resolution outcomes are preserved byte-for-byte (verified by the existing conflict-detection / unopposed-capture suites staying green).

No SPEC change required for either slice (pure internal dedup with identical contracts, per the issue's investigation notes).

## Deferred (remaining for #3448, not in this PR)

- Single source of truth for strength-ratio → loss fraction (`combat_loss_profile.dart` vs `quick_battle_resolver_engine.dart`).
- Defensive-copy reduction + a static guard (modeled on `orders_dedup_map_clones`), including an optional RNG-seam enforcement check.

## Tests

- `combat_rng_test.dart` — asserts each factory's seed recipe, determinism, and per-province divergence for `battleAssignmentRng`.
- `pre_combat_index_test.dart` (new) — positive/negative cases for destination resolution (prefixed pass-through, bare-local qualification), the per-region index helpers, and `PreCombatMovementIndex.build` (GP id set, army index, resolved moves in deterministic order; skips non-GP factions, home armies, unknown army ids, and owner mismatches).
- `dart test` in `packages/colonizethis_combat` → **188 passing** (existing naval / quick-battle / probabilistic / general-binding / conflict-detection / unopposed-capture suites unchanged and green).
- `dart analyze lib test` → no new issues from these changes (the 5 reported items are pre-existing unused/unnecessary imports in untouched test files).

Made with [Cursor](https://cursor.com)