### PR TITLE
fix: overlay-specific load-error copy for first-contact herald (#3463)

### DIFF
--- a/SPEC/ui/tribe-first-contact-overlay.md
+++ b/SPEC/ui/tribe-first-contact-overlay.md
@@ -18,7 +18,7 @@
 
 Same chrome contract as `OVL10001`: `CtFullScreenDialogueShell` + centered `CtDialogShell`, title `tribeFirstContactOverlay_title` (`First Contact`), `CtBrassDivider`, Yarn body. Scrim uses `EditorialMonoclePalette.dialogScrim`.
 
-Yarn node `tribe_first_contact` receives variables `tribeName` (Tribe `displayName`) and `capitalName` (capital province `displayName`, or local id fallback), bound via Jenny's `$`-prefixed names (`setVariable(r'$tribeName', …)`) so the asset's `{$tribeName}` / `{$capitalName}` interpolation resolves without a Jenny `NameError` (#3463). Dismissal invokes `onDismissed` once; host marks herald shown and dequeues. If the Yarn asset fails to load or run, the overlay surfaces a dismissible error whose Continue control restores the playable game screen (never an indefinitely blocking spinner).
+Yarn node `tribe_first_contact` receives variables `tribeName` (Tribe `displayName`) and `capitalName` (capital province `displayName`, or local id fallback), bound via Jenny's `$`-prefixed names (`setVariable(r'$tribeName', …)`) so the asset's `{$tribeName}` / `{$capitalName}` interpolation resolves without a Jenny `NameError` (#3463). Dismissal invokes `onDismissed` once; host marks herald shown and dequeues. If the Yarn asset fails to load or run, the overlay surfaces a dismissible error using its own overlay-specific copy (`tribeFirstContactOverlay_loadError`, "Could not load first-contact dialogue: …") — not the reused intro copy (`game_intro_loadError`) of `OVL10001` — whose Continue control restores the playable game screen (never an indefinitely blocking spinner).
 
 ---
 
@@ -28,3 +28,4 @@ Yarn node `tribe_first_contact` receives variables `tribeName` (Tribe `displayNa
 - **AC-3/AC-5 (relation):** Given contact detection, when sync runs, then `Game.diplomacyRelations` contains the GP–Tribe pair at `AT_PEACE`, score 50, Neutral — logic tests in `gp_tribe_first_contact_test.dart`.
 - **AC-7 (no premature herald):** Given a new game where the GP has zero non-`unknown` New World tiles, when `syncGpTribeFirstContact` runs, then no herald appears and no GP–Tribe relation is persisted solely from sea-reachable colonial intel.
 - **AC-8 (no dialogue deadlock):** Given the Yarn asset fails to load or run, when the player taps Continue, then the game screen becomes playable and the herald does not re-block input.
+- **AC-9 (overlay-specific load-error copy):** Given the Yarn asset fails to load or run, when the error surface renders, then it shows the overlay-specific `tribeFirstContactOverlay_loadError` text ("Could not load first-contact dialogue: …") and never the intro overlay's `game_intro_loadError` ("Could not load intro dialogue: …") copy.

--- a/app/lib/features/game/dialogue/tribe_first_contact_overlay.dart
+++ b/app/lib/features/game/dialogue/tribe_first_contact_overlay.dart
@@ -121,7 +121,7 @@ class _TribeFirstContactOverlayState extends State<TribeFirstContactOverlay> {
             const CtBrassDivider(),
             const SizedBox(height: 14),
             Text(
-              l10n.game_intro_loadError('$_loadError'),
+              l10n.tribeFirstContactOverlay_loadError('$_loadError'),
               style: theme.textTheme.bodyMedium?.copyWith(
                 color: EditorialMonoclePalette.accentDim,
               ),

--- a/app/lib/l10n/app_localizations_contract.dart
+++ b/app/lib/l10n/app_localizations_contract.dart
@@ -627,6 +627,9 @@ abstract class AppLocalizations {
   /// Display-font title for the tribe first-contact herald overlay (OVL80001).
   String get tribeFirstContactOverlay_title;
 
+  /// Error shown when the tribe first-contact herald (OVL80001) Yarn dialogue fails to load.
+  String tribeFirstContactOverlay_loadError(String error);
+
   /// Error shown when overture dialogue fails to load.
   String game_overture_loadError(String error);
 

--- a/app/lib/l10n/app_localizations_en_part2.dart
+++ b/app/lib/l10n/app_localizations_en_part2.dart
@@ -192,6 +192,11 @@ mixin _AppLocalizationsEnStrings2 on AppLocalizations {
   String get tribeFirstContactOverlay_title => 'First Contact';
 
   @override
+  String tribeFirstContactOverlay_loadError(String error) {
+    return 'Could not load first-contact dialogue: $error';
+  }
+
+  @override
   String game_overture_loadError(String error) {
     return 'Could not load overture dialogue: $error';
   }

--- a/app/lib/l10n/arb/app_en.arb
+++ b/app/lib/l10n/arb/app_en.arb
@@ -1032,6 +1032,15 @@
   "@tribeFirstContactOverlay_title": {
     "description": "Display-font title for the tribe first-contact herald overlay (OVL80001)."
   },
+  "tribeFirstContactOverlay_loadError": "Could not load first-contact dialogue: {error}",
+  "@tribeFirstContactOverlay_loadError": {
+    "description": "Error shown when the tribe first-contact herald (OVL80001) Yarn dialogue fails to load.",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "game_overture_loadError": "Could not load overture dialogue: {error}",
   "@game_overture_loadError": {
     "description": "Error shown when overture dialogue fails to load.",

--- a/app/test/tribe_first_contact_overlay_test.dart
+++ b/app/test/tribe_first_contact_overlay_test.dart
@@ -85,6 +85,11 @@ void main() {
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 200));
 
+      // AC-6 diagnostics: the load-error copy is overlay-specific (OVL80001),
+      // not the reused "intro dialogue" string from OVL10001 (#3463).
+      expect(find.textContaining('first-contact dialogue'), findsOneWidget);
+      expect(find.textContaining('intro dialogue'), findsNothing);
+
       await tester.tap(find.text('Continue'));
       await tester.pump();
 


### PR DESCRIPTION
## Summary

The First Contact herald (`OVL80001`) reused the intro overlay's copy
(`game_intro_loadError` — "Could not load **intro** dialogue: …") on a Yarn
load/run failure, obscuring which overlay actually failed. This was the one
remaining P0 proposed-fix item in #3463 that had not yet landed.

This PR adds a dedicated `tribeFirstContactOverlay_loadError` string
("Could not load **first-contact** dialogue: …") and renders it on the
overlay's error surface. The Continue control still dequeues / marks-shown
so the game stays playable (no re-block).

## Done in this push

- New l10n key `tribeFirstContactOverlay_loadError(error)` in `app_en.arb`,
  contract, and the English implementation part.
- `TribeFirstContactOverlay` now renders the overlay-specific error copy
  instead of `game_intro_loadError`.
- SPEC `SPEC/ui/tribe-first-contact-overlay.md` updated; added **AC-9**
  (overlay-specific load-error copy).
- Strengthened the existing error-path widget test to assert the
  first-contact copy renders and the intro copy does not.

## Context (already merged via #3466 / #3467)

ACs 1–8 of #3463 already landed on `dev`:
- Yarn `$`-prefixed bindings before `parse` (AC-3/AC-4) — #3466
- Herald-trigger narrowing to non-`unknown` NW tile visibility via
  `discoveredTribeIdsForFirstContact` (AC-1/AC-2) — #3466
- `repo.dialogue_yarn_variable_bindings` CI gate (AC-5) — #3466
- Production-yarn fixtures / interpolation tests (AC-7) — #3466
- New Game init e2e smoke (AC-8 dependency #3465) — #3467

## Tests

- `flutter test app/test/tribe_first_contact_overlay_test.dart` → green
  (2 tests, including the strengthened error-path assertion).
- `flutter analyze` on touched files → no `error`-severity issues (only the
  pre-existing snake_case `info` lints shared by all l10n part files).

Refs #3463

Made with [Cursor](https://cursor.com)