### PR TITLE
feat: tech-gated general cap with setup/research sync and load reconciliation (#3470)

### DIFF
--- a/SPEC/game/military-generals.md
+++ b/SPEC/game/military-generals.md
@@ -18,7 +18,14 @@ Each Great Power has a **general cap**: the maximum (and minimum) number of gene
   - If `national_bureaucracy` **or** `improved_infantry_tactics` is in `techUnlocked`, set `capBase = max(capBase, 3)`.
   - If `nationalism` is in `techUnlocked`, set `capBase = max(capBase, 4)`.
   The faction’s **general cap** is `capBase`. When the cap increases (e.g. from 1 to 2), the system immediately creates additional generals so that total general count equals the new cap; new generals start at 0 medals. **Stacking:** `national_bureaucracy` and `improved_infantry_tactics` do not stack—only one of them is required for cap 3; researching both does not increase the cap further.
-- **Scope:** The cap is per faction (global), not per region.
+- **Scope:** The cap is per faction (global), not per region. The cap applies to **Great Powers only**; Minor Nations and Tribes have no general cap and no generals.
+
+### Persistence and load reconciliation (spawn-only)
+
+The System **persists** each Great Power's effective general cap (`Player.generalCap`) in the save file. On **load** the System reconciles each GP's `generals` roster to its effective cap:
+
+- The effective cap is the persisted `Player.generalCap`. When a loaded save has **no** persisted cap (legacy migration), the System derives it from `techUnlocked` via the cap-stacking rules above (minimum 1).
+- Reconciliation is **spawn-only**: when the roster has fewer generals than the cap, the System spawns missing generals with 0 medals until the roster size equals the cap. The System **never deletes** generals; a roster that already **exceeds** the cap is retained (above-cap rosters are tolerated, not trimmed). Cap growth is therefore monotonic.
 
 ### Assignment (pre-Combat phase)
 

--- a/packages/colonizethis_data/lib/colonizethis_data.dart
+++ b/packages/colonizethis_data/lib/colonizethis_data.dart
@@ -17,6 +17,7 @@ export 'src/locked_partition_topology_gates.dart';
 export 'src/tech_definition.dart';
 export 'src/tech_ids.dart';
 export 'src/tech_extraction.dart';
+export 'src/general_cap.dart';
 export 'src/tech_effect_summary.dart';
 export 'src/riches_prices.dart';
 export 'src/production_recipes.dart';

--- a/packages/colonizethis_data/lib/src/general_cap.dart
+++ b/packages/colonizethis_data/lib/src/general_cap.dart
@@ -1,0 +1,96 @@
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import 'tech_ids.dart';
+
+/// Initial general cap for every Great Power at game start.
+/// SPEC/game/military-generals.md § Count and tech-gated cap.
+const int kInitialGeneralCap = 1;
+
+/// Computes the tech-gated general cap from a Great Power's unlocked techs.
+///
+/// Stacking rules per SPEC/game/military-generals.md (non-stacking maxima):
+/// - base 1; `organised_regiments` → 2;
+/// - `national_bureaucracy` OR `improved_infantry_tactics` → 3 (no double count);
+/// - `nationalism` → 4.
+int generalCapForUnlockedTechs(Map<String, bool>? techUnlocked) {
+  final t = techUnlocked ?? const <String, bool>{};
+  var cap = kInitialGeneralCap;
+  if (t[kTechIdOrganisedRegiments] == true && cap < 2) cap = 2;
+  if ((t[kTechIdNationalBureaucracy] == true ||
+          t[kTechIdImprovedInfantryTactics] == true) &&
+      cap < 3) {
+    cap = 3;
+  }
+  if (t[kTechIdNationalism] == true && cap < 4) cap = 4;
+  return cap;
+}
+
+/// Re-derives each Great Power's general cap from unlocked techs, persists it on
+/// the [Player], and spawns generals (0 medals) so each GP roster reaches the
+/// cap.
+///
+/// Spawn-only: existing generals are never deleted and rosters that already
+/// exceed the cap are retained. Used at game setup and after the Research phase
+/// when tech unlocks may raise a cap. SPEC/game/military-generals.md.
+Game syncGeneralCapsFromTech(Game game) =>
+    _applyGeneralCaps(game, (p) => generalCapForUnlockedTechs(p.techUnlocked));
+
+/// Load-time reconciliation of the generals roster against each Great Power's
+/// effective general cap.
+///
+/// Uses the persisted [Player.generalCap] when present; otherwise derives the
+/// cap from unlocked techs (legacy-save migration default). Spawn-only per
+/// SPEC/game/military-generals.md: spawns missing generals (0 medals) up to the
+/// effective cap, never deletes generals, and tolerates above-cap rosters.
+Game reconcileGeneralsToGeneralCap(Game game) => _applyGeneralCaps(
+  game,
+  (p) => p.generalCap ?? generalCapForUnlockedTechs(p.techUnlocked),
+);
+
+/// Sets each GP's persisted cap from [capFor] and appends 0-medal generals so the
+/// roster size is at least the cap. Never removes generals. Returns the original
+/// [game] unchanged when no cap or roster change is needed.
+Game _applyGeneralCaps(Game game, int Function(Player) capFor) {
+  final usedIds = <String>{for (final g in game.generals) g.id};
+  final ownerCounts = <String, int>{};
+  for (final g in game.generals) {
+    ownerCounts[g.ownerId] = (ownerCounts[g.ownerId] ?? 0) + 1;
+  }
+
+  final spawned = <General>[];
+  final nextPlayers = <Player>[];
+  var changed = false;
+  for (final player in game.players) {
+    final cap = capFor(player);
+    if (player.generalCap != cap) {
+      changed = true;
+      nextPlayers.add(player.copyWith(generalCap: cap));
+    } else {
+      nextPlayers.add(player);
+    }
+    final existingCount = ownerCounts[player.id] ?? 0;
+    for (var i = existingCount; i < cap; i++) {
+      final id = _nextGeneralId(player.id, usedIds);
+      usedIds.add(id);
+      spawned.add(General(id: id, ownerId: player.id, medals: 0));
+      changed = true;
+    }
+  }
+
+  if (!changed) return game;
+  return game.copyWith(
+    players: nextPlayers,
+    generals: spawned.isEmpty
+        ? game.generals
+        : <General>[...game.generals, ...spawned],
+  );
+}
+
+/// Smallest `${ownerId}_gen_$n` id not already present in [usedIds] (deterministic).
+String _nextGeneralId(String ownerId, Set<String> usedIds) {
+  var n = 0;
+  while (usedIds.contains('${ownerId}_gen_$n')) {
+    n++;
+  }
+  return '${ownerId}_gen_$n';
+}

--- a/packages/colonizethis_data/test/general_cap_test.dart
+++ b/packages/colonizethis_data/test/general_cap_test.dart
@@ -1,0 +1,241 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:test/test.dart';
+
+Game _gameWith({
+  required List<Player> players,
+  List<General> generals = const [],
+}) {
+  return Game(
+    id: 'g',
+    worldState: WorldState(
+      turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+      oldWorld: const RegionData(),
+      newWorld: const RegionData(),
+    ),
+    players: players,
+    generals: generals,
+  );
+}
+
+Player _gp(String id, {Map<String, bool>? tech, int? cap}) => Player(
+  id: id,
+  displayName: id,
+  isHuman: false,
+  techUnlocked: tech,
+  generalCap: cap,
+);
+
+List<General> _generalsFor(Game game, String ownerId) =>
+    game.generals.where((g) => g.ownerId == ownerId).toList();
+
+void main() {
+  group('generalCapForUnlockedTechs (SPEC/game/military-generals.md)', () {
+    test('null or empty techs → cap 1', () {
+      expect(generalCapForUnlockedTechs(null), 1);
+      expect(generalCapForUnlockedTechs(const {}), 1);
+    });
+
+    test('organised_regiments → cap 2', () {
+      expect(generalCapForUnlockedTechs({kTechIdOrganisedRegiments: true}), 2);
+    });
+
+    test('national_bureaucracy → cap 3', () {
+      expect(generalCapForUnlockedTechs({kTechIdNationalBureaucracy: true}), 3);
+    });
+
+    test('improved_infantry_tactics → cap 3', () {
+      expect(
+        generalCapForUnlockedTechs({kTechIdImprovedInfantryTactics: true}),
+        3,
+      );
+    });
+
+    test(
+      'national_bureaucracy + improved_infantry_tactics do not stack → 3',
+      () {
+        expect(
+          generalCapForUnlockedTechs({
+            kTechIdNationalBureaucracy: true,
+            kTechIdImprovedInfantryTactics: true,
+          }),
+          3,
+        );
+      },
+    );
+
+    test('nationalism → cap 4', () {
+      expect(generalCapForUnlockedTechs({kTechIdNationalism: true}), 4);
+    });
+
+    test('false-valued tech entries are ignored', () {
+      expect(generalCapForUnlockedTechs({kTechIdOrganisedRegiments: false}), 1);
+    });
+  });
+
+  group('syncGeneralCapsFromTech', () {
+    test('GP at start has cap 1 and exactly one general with 0 medals', () {
+      final game = syncGeneralCapsFromTech(_gameWith(players: [_gp('gp1')]));
+      expect(game.players.single.generalCap, 1);
+      final generals = _generalsFor(game, 'gp1');
+      expect(generals.length, 1);
+      expect(generals.single.medals, 0);
+    });
+
+    test(
+      'organised_regiments raises cap to 2 and spawns a 0-medal general',
+      () {
+        var game = syncGeneralCapsFromTech(_gameWith(players: [_gp('gp1')]));
+        // Researcher gains a medal on the existing general before tech unlock.
+        game = game.copyWith(
+          generals: [game.generals.single.copyWith(medals: 3)],
+          players: [
+            game.players.single.copyWith(
+              techUnlocked: {kTechIdOrganisedRegiments: true},
+            ),
+          ],
+        );
+        game = syncGeneralCapsFromTech(game);
+        expect(game.players.single.generalCap, 2);
+        final generals = _generalsFor(game, 'gp1');
+        expect(generals.length, 2);
+        // Existing general (with medals) preserved; the new one starts at 0.
+        expect(generals.where((g) => g.medals == 3).length, 1);
+        expect(generals.where((g) => g.medals == 0).length, 1);
+      },
+    );
+
+    test('national_bureaucracy gives cap 3 with three generals', () {
+      final game = syncGeneralCapsFromTech(
+        _gameWith(
+          players: [
+            _gp('gp1', tech: {kTechIdNationalBureaucracy: true}),
+          ],
+        ),
+      );
+      expect(game.players.single.generalCap, 3);
+      expect(_generalsFor(game, 'gp1').length, 3);
+    });
+
+    test('nationalism gives cap 4 with four generals', () {
+      final game = syncGeneralCapsFromTech(
+        _gameWith(
+          players: [
+            _gp('gp1', tech: {kTechIdNationalism: true}),
+          ],
+        ),
+      );
+      expect(game.players.single.generalCap, 4);
+      expect(_generalsFor(game, 'gp1').length, 4);
+    });
+
+    test('researching both nb and iit keeps cap at 3 (no stack)', () {
+      final game = syncGeneralCapsFromTech(
+        _gameWith(
+          players: [
+            _gp(
+              'gp1',
+              tech: {
+                kTechIdNationalBureaucracy: true,
+                kTechIdImprovedInfantryTactics: true,
+              },
+            ),
+          ],
+        ),
+      );
+      expect(game.players.single.generalCap, 3);
+      expect(_generalsFor(game, 'gp1').length, 3);
+    });
+
+    test('multiple GPs each get independent caps and unique general ids', () {
+      final game = syncGeneralCapsFromTech(
+        _gameWith(
+          players: [
+            _gp('gp1'),
+            _gp('gp2', tech: {kTechIdOrganisedRegiments: true}),
+          ],
+        ),
+      );
+      expect(game.players[0].generalCap, 1);
+      expect(game.players[1].generalCap, 2);
+      expect(_generalsFor(game, 'gp1').length, 1);
+      expect(_generalsFor(game, 'gp2').length, 2);
+      final ids = game.generals.map((g) => g.id).toSet();
+      expect(ids.length, game.generals.length);
+    });
+  });
+
+  group('reconcileGeneralsToGeneralCap (load-time, spawn-only)', () {
+    test('persisted cap with short roster spawns missing generals', () {
+      final game = reconcileGeneralsToGeneralCap(
+        _gameWith(
+          players: [_gp('gp1', cap: 3)],
+          generals: const [General(id: 'gp1_gen_0', ownerId: 'gp1', medals: 2)],
+        ),
+      );
+      final generals = _generalsFor(game, 'gp1');
+      expect(generals.length, 3);
+      expect(generals.where((g) => g.medals == 0).length, 2);
+      expect(generals.where((g) => g.id == 'gp1_gen_0').single.medals, 2);
+      expect(game.players.single.generalCap, 3);
+    });
+
+    test('legacy save without generalCap defaults to derived tech cap', () {
+      final game = reconcileGeneralsToGeneralCap(
+        _gameWith(
+          players: [
+            _gp('gp1', tech: {kTechIdNationalism: true}),
+          ],
+        ),
+      );
+      expect(game.players.single.generalCap, 4);
+      expect(_generalsFor(game, 'gp1').length, 4);
+    });
+
+    test('legacy save without generalCap and no tech defaults to 1', () {
+      final game = reconcileGeneralsToGeneralCap(
+        _gameWith(players: [_gp('gp1')]),
+      );
+      expect(game.players.single.generalCap, 1);
+      expect(_generalsFor(game, 'gp1').length, 1);
+    });
+
+    test('roster exceeding persisted cap is retained (never trimmed)', () {
+      final game = reconcileGeneralsToGeneralCap(
+        _gameWith(
+          players: [_gp('gp1', cap: 1)],
+          generals: const [
+            General(id: 'gp1_gen_0', ownerId: 'gp1', medals: 1),
+            General(id: 'gp1_gen_1', ownerId: 'gp1', medals: 2),
+            General(id: 'gp1_gen_2', ownerId: 'gp1', medals: 0),
+          ],
+        ),
+      );
+      final generals = _generalsFor(game, 'gp1');
+      expect(generals.length, 3);
+      expect(game.players.single.generalCap, 1);
+    });
+
+    test('idempotent when roster already matches cap', () {
+      final first = reconcileGeneralsToGeneralCap(
+        _gameWith(players: [_gp('gp1', cap: 2)]),
+      );
+      final second = reconcileGeneralsToGeneralCap(first);
+      expect(second.generals.length, first.generals.length);
+      expect(identical(second, first), isTrue);
+    });
+  });
+
+  group('Player.generalCap persistence', () {
+    test('round-trips through JSON', () {
+      final player = _gp('gp1', cap: 3);
+      expect(Player.fromJson(player.toJson()).generalCap, 3);
+    });
+
+    test('absent from JSON decodes to null (legacy)', () {
+      final json = _gp('gp1').toJson();
+      expect(json.containsKey('generalCap'), isFalse);
+      expect(Player.fromJson(json).generalCap, isNull);
+    });
+  });
+}

--- a/packages/colonizethis_data/test/general_cap_test.dart
+++ b/packages/colonizethis_data/test/general_cap_test.dart
@@ -1,6 +1,6 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
-import 'package:test/test.dart';
+import 'package:colonizethis_test/test.dart';
 
 Game _gameWith({
   required List<Player> players,

--- a/packages/colonizethis_logic/test/characterization/game_setup_snapshot_test.dart
+++ b/packages/colonizethis_logic/test/characterization/game_setup_snapshot_test.dart
@@ -258,5 +258,24 @@ void main() {
     test('turnTimeMapping is set', () {
       expect(result.game.turnTimeMapping, isNotNull);
     });
+
+    test(
+      'each GP starts with general cap 1 and exactly one 0-medal general',
+      () {
+        // SPEC/game/military-generals.md § Count and tech-gated cap.
+        for (final p in result.game.players) {
+          expect(
+            p.generalCap,
+            1,
+            reason: '${p.id} must start at general cap 1',
+          );
+          final generals = result.game.generals
+              .where((g) => g.ownerId == p.id)
+              .toList();
+          expect(generals.length, 1, reason: '${p.id} must have one general');
+          expect(generals.single.medals, 0);
+        }
+      },
+    );
   });
 }

--- a/packages/colonizethis_models/lib/src/player.dart
+++ b/packages/colonizethis_models/lib/src/player.dart
@@ -20,6 +20,7 @@ class Player {
     this.personalityId,
     this.researchProgressByTechId,
     this.researchSlots,
+    this.generalCap,
   });
 
   final String id;
@@ -58,6 +59,11 @@ class Player {
   /// Default is 3; University tech can raise this to 4. When null, treat as 3.
   final int? researchSlots;
 
+  /// Tech-gated general cap for this Great Power (min/max generals in the pool).
+  /// 1 at game start; grows with military/diplomacy techs. Null in legacy saves
+  /// (treated as derive-from-tech or 1 on load). SPEC/game/military-generals.md.
+  final int? generalCap;
+
   Map<String, dynamic> toJson() => {
     'id': id,
     'displayName': displayName,
@@ -77,6 +83,7 @@ class Player {
         researchProgressByTechId!.isNotEmpty)
       'researchProgressByTechId': researchProgressByTechId,
     if (researchSlots != null) 'researchSlots': researchSlots,
+    if (generalCap != null) 'generalCap': generalCap,
   };
 
   static Player fromJson(Map<String, dynamic> json) {
@@ -150,6 +157,7 @@ class Player {
       personalityId: json['personalityId'] as String?,
       researchProgressByTechId: _readResearchProgress(),
       researchSlots: (json['researchSlots'] as num?)?.toInt(),
+      generalCap: (json['generalCap'] as num?)?.toInt(),
     );
   }
 
@@ -168,6 +176,7 @@ class Player {
     String? personalityId,
     Map<String, int>? researchProgressByTechId,
     int? researchSlots,
+    int? generalCap,
   }) {
     return Player(
       id: id ?? this.id,
@@ -185,6 +194,7 @@ class Player {
       researchProgressByTechId:
           researchProgressByTechId ?? this.researchProgressByTechId,
       researchSlots: researchSlots ?? this.researchSlots,
+      generalCap: generalCap ?? this.generalCap,
     );
   }
 
@@ -209,7 +219,8 @@ class Player {
             researchProgressByTechId,
             other.researchProgressByTechId,
           ) &&
-          researchSlots == other.researchSlots;
+          researchSlots == other.researchSlots &&
+          generalCap == other.generalCap;
 
   @override
   int get hashCode => Object.hash(
@@ -229,6 +240,7 @@ class Player {
         ? null
         : Object.hashAll(researchProgressByTechId!.entries),
     researchSlots,
+    generalCap,
   );
 
   static bool _mapEquals(Map<String, bool>? a, Map<String, bool>? b) {

--- a/packages/colonizethis_save/lib/src/game_save_adapter.dart
+++ b/packages/colonizethis_save/lib/src/game_save_adapter.dart
@@ -133,7 +133,9 @@ class GameSaveAdapter {
           'Invalid save payload for gameId=$gameId',
         );
       }
-      final game = Game.fromJson(Map<String, dynamic>.from(gameRaw));
+      final game = reconcileGeneralsToGeneralCap(
+        Game.fromJson(Map<String, dynamic>.from(gameRaw)),
+      );
       _log.i('loaded gameId=$gameId');
       return game;
     } catch (e, st) {
@@ -166,7 +168,9 @@ class GameSaveAdapter {
         'Invalid save payload for gameId=$gameId',
       );
     }
-    final game = Game.fromJson(Map<String, dynamic>.from(gameRaw));
+    final game = reconcileGeneralsToGeneralCap(
+      Game.fromJson(Map<String, dynamic>.from(gameRaw)),
+    );
     _log.i('loaded strict gameId=$gameId');
     return game;
   }

--- a/packages/colonizethis_save/test/game_save_adapter_test.dart
+++ b/packages/colonizethis_save/test/game_save_adapter_test.dart
@@ -60,6 +60,64 @@ void main() {
       expect(adapter.load(box, 'missing'), isNull);
     });
 
+    test('load reconciles generals to persisted general cap (spawn-only)', () {
+      // SPEC/game/military-generals.md: persisted cap drives spawn-only
+      // reconciliation; existing generals (and medals) are preserved.
+      final game = Game(
+        id: 'capgame',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 3),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(id: 'gp1', displayName: 'Spain', isHuman: true, generalCap: 3),
+        ],
+        generals: const [General(id: 'gp1_gen_0', ownerId: 'gp1', medals: 2)],
+      );
+      adapter.save(box, game);
+      final loaded = adapter.load(box, 'capgame');
+      expect(loaded, isNotNull);
+      final generals = loaded!.generals
+          .where((g) => g.ownerId == 'gp1')
+          .toList();
+      expect(generals.length, 3);
+      expect(generals.where((g) => g.id == 'gp1_gen_0').single.medals, 2);
+      expect(generals.where((g) => g.medals == 0).length, 2);
+      expect(loaded.players.single.generalCap, 3);
+    });
+
+    test('legacy save without generalCap derives cap from tech on load', () {
+      // SPEC/game/military-generals.md: migration default derives cap from
+      // unlocked techs when no persisted cap exists.
+      final game = Game(
+        id: 'legacycap',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 7),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(
+            id: 'gp1',
+            displayName: 'France',
+            isHuman: false,
+            techUnlocked: {kTechIdNationalism: true},
+          ),
+        ],
+      );
+      // Sanity: no generalCap persisted in JSON for a legacy player.
+      expect(
+        (game.toJson()['players'] as List).first,
+        isNot(contains('generalCap')),
+      );
+      adapter.save(box, game);
+      final loaded = adapter.load(box, 'legacycap');
+      expect(loaded, isNotNull);
+      expect(loaded!.players.single.generalCap, 4);
+      expect(loaded.generals.where((g) => g.ownerId == 'gp1').length, 4);
+    });
+
     test('listGameIds returns saved ids and excludes map-data keys', () {
       final game = Game(
         id: 'g1',

--- a/packages/colonizethis_save/test/game_save_adapter_test.dart
+++ b/packages/colonizethis_save/test/game_save_adapter_test.dart
@@ -108,7 +108,7 @@ void main() {
       );
       // Sanity: no generalCap persisted in JSON for a legacy player.
       expect(
-        (game.toJson()['players'] as List).first,
+        (game.toJson()['players'] as List<Object?>).first,
         isNot(contains('generalCap')),
       );
       adapter.save(box, game);

--- a/packages/colonizethis_setup/lib/src/setup/game_setup_create.dart
+++ b/packages/colonizethis_setup/lib/src/setup/game_setup_create.dart
@@ -217,6 +217,10 @@ GameSetupResult createGameFromGeneratedMaps({
   );
   game = ensureMilitaryArmiesForGame(game);
 
+  // Initialize each Great Power's general cap (1 at start) and spawn one
+  // general per GP. SPEC/game/military-generals.md § Count and tech-gated cap.
+  game = syncGeneralCapsFromTech(game);
+
   // Map tint / UI swatches: runtime player ids (gp1..gpN) → GDD default RGB for
   // the semantic Great Power in each setup slot (see greatPowerDefaultColorRgb).
   // Province.ownerId uses gpN; without this, factionOwnershipColorMap misses

--- a/packages/colonizethis_turn/lib/src/turn/research_resolver.dart
+++ b/packages/colonizethis_turn/lib/src/turn/research_resolver.dart
@@ -280,8 +280,13 @@ Game resolveResearchPhase(Game game, Orders orders) {
   turnLog.i(
     'research phase end turn=$turn playersWithOrders=$playersWithOrders',
   );
-  return state.copyWith(
+  final resolvedState = state.copyWith(
     players: updatedPlayers,
     dossierEvidenceEntries: [...state.dossierEvidenceEntries, ...extraEvidence],
   );
+
+  // Tech unlocks this phase may raise a GP's general cap; recompute caps and
+  // spawn new generals (0 medals) so each roster matches its cap.
+  // SPEC/game/military-generals.md § Count and tech-gated cap.
+  return syncGeneralCapsFromTech(resolvedState);
 }

--- a/packages/colonizethis_turn/test/research_phase_general_cap_test.dart
+++ b/packages/colonizethis_turn/test/research_phase_general_cap_test.dart
@@ -1,0 +1,79 @@
+import 'package:colonizethis_test/test.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import 'research_phase_test_support.dart';
+
+int _generalCountFor(Game game, String playerId) =>
+    game.generals.where((g) => g.ownerId == playerId).length;
+
+void main() {
+  group('Research phase general cap (SPEC/game/military-generals.md)', () {
+    test(
+      'completing organised_regiments raises cap to 2 and spawns a general',
+      () {
+        final game = researchPhaseTestBaseGame(
+          treasury: 5000,
+          techUnlocked: const {kTechIdLandEnclosure: true},
+        );
+        final orders = Orders(
+          researchOrdersByPlayerId: {
+            'p1': const [
+              ResearchOrder(
+                slotIndex: 0,
+                techId: kTechIdOrganisedRegiments,
+                funding: ResearchFundingLevel.maximum,
+              ),
+            ],
+          },
+        );
+
+        final next = requireTurnResolutionComplete(
+          resolveTurnForGame(
+            game: game,
+            topology: const MapTopology(),
+            orders: orders,
+          ),
+        );
+        final player = next.players.single;
+        expect(player.techUnlocked![kTechIdOrganisedRegiments], isTrue);
+        expect(player.generalCap, 2);
+        expect(_generalCountFor(next, 'p1'), 2);
+        expect(
+          next.generals.where((g) => g.ownerId == 'p1' && g.medals == 0).length,
+          2,
+        );
+      },
+    );
+
+    test('researching a non-military tech leaves cap at 1', () {
+      final game = researchPhaseTestBaseGame(
+        treasury: 5000,
+        techUnlocked: const {kTechIdLandEnclosure: true},
+      );
+      final orders = Orders(
+        researchOrdersByPlayerId: {
+          'p1': const [
+            ResearchOrder(
+              slotIndex: 0,
+              techId: kTechIdCropRotation,
+              funding: ResearchFundingLevel.maximum,
+            ),
+          ],
+        },
+      );
+
+      final next = requireTurnResolutionComplete(
+        resolveTurnForGame(
+          game: game,
+          topology: const MapTopology(),
+          orders: orders,
+        ),
+      );
+      final player = next.players.single;
+      expect(player.generalCap, 1);
+      expect(_generalCountFor(next, 'p1'), 1);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Implements **Slice A — General cap (GPs only)** of #3470. Slices B (privateering) and D (catalog audit guard) already landed on `dev` via #3473.

Great Powers now have a tech-gated general cap:

- Initial cap **1** at game start (each GP spawns exactly one 0-medal general).
- Cap **2** when `organised_regiments` is unlocked.
- Cap **3** when `national_bureaucracy` **or** `improved_infantry_tactics` is unlocked (non-stacking).
- Cap **4** when `nationalism` is unlocked.
- Cap increases during the **Research phase** spawn new 0-medal generals immediately so `generals.length == generalCap`.
- **Great Powers only** — minors/tribes excluded.
- `generalCap` is **persisted** on `Player` and reconciled on load.

**Load-time reconciliation (spawn-only):** missing generals (roster shorter than persisted cap) are spawned with 0 medals; existing generals are **never deleted**, and above-cap rosters are retained without trimming. Legacy saves without `generalCap` default to the cap derived from `techUnlocked` (or 1 when no tech), then reconcile.

## SPEC

- `SPEC/game/military-generals.md` — cap-stacking rules, spawn-only load reconciliation contract, and Given/When/Then ACs.

## Implementation

- `colonizethis_data/src/general_cap.dart` — `generalCapForUnlockedTechs`, `syncGeneralCapsFromTech`, `reconcileGeneralsToGeneralCap` (spawn-only).
- `colonizethis_models/src/player.dart` — persisted nullable `generalCap` (round-trips through JSON; absent decodes to null/legacy).
- `colonizethis_setup` game setup — GPs start at cap 1 with one 0-medal general.
- `colonizethis_turn` research resolver — cap raise + general spawn on unlocking tech completion.
- `colonizethis_save` adapter — load-time reconciliation.

## Tests

- `colonizethis_data/test/general_cap_test.dart` — cap stacking (incl. non-stacking nb+iit), sync spawns, spawn-only reconciliation, above-cap retention, legacy defaults, JSON round-trip. (20 cases)
- `colonizethis_turn/test/research_phase_general_cap_test.dart` — cap raise + spawn during Research phase.
- `colonizethis_save/test/game_save_adapter_test.dart` — persistence/load reconciliation cases.
- `colonizethis_logic/test/characterization/game_setup_snapshot_test.dart` — initial cap 1 / one 0-medal general.

Commands run (all green): `dart test` for the four files above; `dart analyze` clean on changed libs.

## Scope

- **Done in this push:** Slice A (general cap) end-to-end with tests and SPEC.
- **Deferred / out of scope for this PR:** Slice C (cotton weaving recipe gate + production-panel UI) remains for follow-up under #3470.

Refs #3470

Made with [Cursor](https://cursor.com)