### PR TITLE
feat: per-player cotton-weaving recipe availability gate (#3470)

### DIFF
--- a/SPEC/game/production-recipes.md
+++ b/SPEC/game/production-recipes.md
@@ -36,6 +36,18 @@ The following recipes are defined for current product:
 
 ---
 
+## Technology-gated recipes
+
+Most recipes are always available. A recipe MAY declare a **required technology id**; such a recipe is **available per player** only when that player has the technology in its `techUnlocked` set. Gating is per player and deterministic.
+
+- **Fabric (cotton)** (`fabric_from_cotton`) requires `cotton_weaving` ([tech-tree-new-world.md](tech-tree-new-world.md)). Until the player researches `cotton_weaving`, that player cannot produce fabric from cotton.
+- **Fabric (wool)** (`fabric_from_wool`) is **always available** (no technology gate).
+- A recipe with no required technology id is always available to every player.
+
+The gate is enforced wherever recipe availability is evaluated for a player: production assignment/feasibility, order projections and suggestions, and the AI economy planner's recipe candidate selection. A player that has not unlocked the required technology never has a tech-gated recipe assigned, suggested, or scored. The recipe definition stays in the program-level catalog; availability is computed from the player's `techUnlocked` set, not by removing the recipe from the catalog.
+
+---
+
 ## Examples
 
 - Timber ×2, Iron ×2 → Cast Iron (labour per unit from constants).
@@ -81,3 +93,19 @@ Testable conditions for "done": recipe structure (output commodity + quantity, i
 - Given the System has executed the Production phase for a player and at least one recipe ran  
   When the phase completes  
   Then the System records which recipes ran and the quantity produced per recipe (e.g. productionByRecipe: recipe id → quantity produced) so that order projections and inspection can use it; see [order-projections.md](../program/order-projections.md) (§ productionByRecipe) and [economy-models.md](../program/economy-models.md).
+
+- Given a recipe declares no required technology id  
+  When the System evaluates whether that recipe is available to any player  
+  Then the System reports the recipe as available regardless of the player's `techUnlocked` set.
+
+- Given the `fabric_from_cotton` recipe declares required technology id `cotton_weaving`, and a player whose `techUnlocked` set does not contain `cotton_weaving` mapped to `true`  
+  When the System evaluates recipe availability for that player (production assignment, feasibility, order suggestion, or AI economy planning)  
+  Then the System reports `fabric_from_cotton` as not available to that player while `fabric_from_wool` remains available.
+
+- Given the `fabric_from_cotton` recipe declares required technology id `cotton_weaving`, and a player whose `techUnlocked` set maps `cotton_weaving` to `true`  
+  When the System evaluates recipe availability for that player  
+  Then the System reports `fabric_from_cotton` as available to that player.
+
+- Given an AI-controlled player whose `techUnlocked` set does not contain `cotton_weaving` mapped to `true`  
+  When the AI economy planner scores and allocates production recipes for that player  
+  Then the AI economy planner does not score, assign labour to, or suggest `fabric_from_cotton`.

--- a/packages/colonizethis_ai/lib/src/planning/economy_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/economy_planner.dart
@@ -294,6 +294,7 @@ EconomyPlan runEconomyPlanner({
     effectiveLabour: effectiveLabour,
     config: config,
     seeds: seeds,
+    techUnlocked: player.techUnlocked,
     militaryRebuildCrisis: militaryRebuildCrisis,
     regimentBuildInputProductionBoost: growthStagePlannerEnabled
         ? false
@@ -414,6 +415,7 @@ List<AssignedRecipe> _allocateLabour({
   required int effectiveLabour,
   required AIConfig config,
   required AISeedBundle seeds,
+  Map<String, bool>? techUnlocked,
   bool militaryRebuildCrisis = false,
   bool regimentBuildInputProductionBoost = false,
   Set<String> missingRegimentBuildInputIds = const {},
@@ -447,6 +449,7 @@ List<AssignedRecipe> _allocateLabour({
       feedstockReserve: feedstockReserve,
       feedstockReserveOutputIds: feedstockReserveOutputIds,
       labourByRecipe: labourByRecipe,
+      techUnlocked: techUnlocked,
       onStateUpdated: (nextVirtual, nextRemainingLabour) {
         virtual = nextVirtual;
         remainingLabour = nextRemainingLabour;
@@ -457,6 +460,16 @@ List<AssignedRecipe> _allocateLabour({
   // Build feasible recipes with scores. Feasible = can run at least 1 full run.
   final candidates = <ScoredRecipe>[];
   for (final recipe in recipes) {
+    // Skip recipes the player has not unlocked (e.g. `fabric_from_cotton`
+    // requires `cotton_weaving`) so the AI never assigns labour to or suggests
+    // a tech-locked recipe. SPEC/game/production-recipes.md
+    // § Technology-gated recipes; Refs #3470 Slice C.
+    if (!ProductionRecipesCatalog.isRecipeAvailableForPlayer(
+      recipe,
+      techUnlocked,
+    )) {
+      continue;
+    }
     if (castIronLabourPeasantRecruitFabricBoost &&
         recipe.outputCommodityId == CommodityCatalog.fabric.id) {
       continue;
@@ -579,6 +592,7 @@ void _assignCastIronLabourFabricPrePass({
   required Set<String> feedstockReserveOutputIds,
   required Map<String, int> labourByRecipe,
   required void Function(Stockpile virtual, int remainingLabour) onStateUpdated,
+  Map<String, bool>? techUnlocked,
 }) {
   final fabricId = CommodityCatalog.fabric.id;
   final fabricRecipes = ProductionRecipesCatalog.producing(fabricId).toList()
@@ -586,6 +600,14 @@ void _assignCastIronLabourFabricPrePass({
   var nextVirtual = virtual;
   var nextRemainingLabour = remainingLabour;
   for (final recipe in fabricRecipes) {
+    // Tech-locked fabric recipes (e.g. `fabric_from_cotton` without
+    // `cotton_weaving`) are not assignable. Refs #3470 Slice C.
+    if (!ProductionRecipesCatalog.isRecipeAvailableForPlayer(
+      recipe,
+      techUnlocked,
+    )) {
+      continue;
+    }
     if (nextRemainingLabour < recipe.labourPerOutput) continue;
     final feasibilityStock =
         feedstockReserveOutputIds.contains(recipe.outputCommodityId)

--- a/packages/colonizethis_ai/test/economy_planner_cotton_weaving_gate_test.dart
+++ b/packages/colonizethis_ai/test/economy_planner_cotton_weaving_gate_test.dart
@@ -1,0 +1,140 @@
+/// Slice C — cotton weaving recipe gate in the AI economy planner (Refs #3470).
+///
+/// SPEC/game/production-recipes.md § Technology-gated recipes:
+/// `fabric_from_cotton` is available only to a player whose `techUnlocked` set
+/// maps `cotton_weaving` to `true`. The AI economy planner must never score,
+/// assign labour to, or suggest a tech-locked recipe.
+library;
+
+import 'package:colonizethis_ai/colonizethis_ai.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+const _topology = MapTopology(nodes: [], edges: []);
+
+/// A single-GP game whose only fabric feedstock is [cotton] cotton (no wool),
+/// so the only feasible fabric recipe is `fabric_from_cotton`. [techUnlocked]
+/// controls whether the GP has researched `cotton_weaving`.
+Game _cottonOnlyGame({
+  required int cotton,
+  Map<String, bool>? techUnlocked,
+}) {
+  const ow = 'oldWorld';
+  return Game(
+    id: 'g-cotton-gate',
+    worldState: WorldState(
+      turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 50),
+      oldWorld: const RegionData(
+        provinces: [
+          Province(id: '$ow|p0', regionId: ow, ownerId: 'gp1'),
+        ],
+      ),
+      newWorld: const RegionData(),
+    ),
+    players: [
+      Player(
+        id: 'gp1',
+        displayName: 'GP1',
+        isHuman: false,
+        capitalProvinceId: '$ow|p0',
+        treasury: 100,
+        stockpile: const Stockpile()
+            .applyDelta(CommodityCatalog.grain.id, 30)
+            .applyDelta(CommodityCatalog.cotton.id, cotton),
+        workerPool: const WorkerPool(peasants: 12),
+        techUnlocked: techUnlocked,
+      ),
+    ],
+  );
+}
+
+Set<String> _assignedRecipeIds(EconomyPlan plan) =>
+    plan.productionAssignments.map((a) => a.recipeId).toSet();
+
+void main() {
+  const config = AIConfig(
+    leaderId: 'victoria',
+    personalityId: 'victoria',
+    hiddenAgendaId: 'merchant',
+  );
+  final seeds = AISeedBundle.fromTurnSeed(42);
+
+  EconomyPlan planFor(Map<String, bool>? techUnlocked) {
+    final game = _cottonOnlyGame(cotton: 100, techUnlocked: techUnlocked);
+    return runEconomyPlanner(
+      game: game,
+      view: buildPlayerView(game, _topology, 'gp1'),
+      config: config,
+      seeds: seeds,
+    );
+  }
+
+  group('cotton weaving recipe gate (Refs #3470 Slice C)', () {
+    test(
+      'fabric_from_cotton is NOT assigned for a GP without cotton_weaving '
+      '(null techUnlocked)',
+      () {
+        final plan = planFor(null);
+        expect(
+          _assignedRecipeIds(plan),
+          isNot(contains(ProductionRecipesCatalog.fabricFromCotton.id)),
+          reason: 'A GP that has not researched cotton_weaving must never be '
+              'assigned the tech-locked fabric_from_cotton recipe.',
+        );
+      },
+    );
+
+    test(
+      'fabric_from_cotton is NOT assigned when cotton_weaving is explicitly '
+      'false',
+      () {
+        final plan = planFor(const {kTechIdCottonWeaving: false});
+        expect(
+          _assignedRecipeIds(plan),
+          isNot(contains(ProductionRecipesCatalog.fabricFromCotton.id)),
+        );
+      },
+    );
+
+    test(
+      'no fabric is produced at all when cotton is the only feedstock and '
+      'cotton_weaving is locked',
+      () {
+        // With cotton the only fabric input and the recipe locked, the planner
+        // has no feasible fabric path, so no fabric-producing recipe appears.
+        final plan = planFor(null);
+        final fabricRecipeIds = ProductionRecipesCatalog.all
+            .where((r) => r.outputCommodityId == CommodityCatalog.fabric.id)
+            .map((r) => r.id)
+            .toSet();
+        expect(
+          _assignedRecipeIds(plan).intersection(fabricRecipeIds),
+          isEmpty,
+          reason: 'fabric_from_wool needs wool (none held) and '
+              'fabric_from_cotton is locked, so no fabric recipe is feasible.',
+        );
+      },
+    );
+
+    test(
+      'fabric_from_cotton IS assigned once cotton_weaving is unlocked',
+      () {
+        final plan = planFor(const {kTechIdCottonWeaving: true});
+        expect(
+          _assignedRecipeIds(plan),
+          contains(ProductionRecipesCatalog.fabricFromCotton.id),
+          reason: 'With cotton_weaving unlocked and cotton on hand, the only '
+              'feasible fabric recipe (fabric_from_cotton) must be assigned.',
+        );
+      },
+    );
+
+    test('gating is deterministic across identical runs', () {
+      const tech = {kTechIdCottonWeaving: true};
+      expect(_assignedRecipeIds(planFor(tech)), equals(_assignedRecipeIds(planFor(tech))));
+      expect(_assignedRecipeIds(planFor(null)), equals(_assignedRecipeIds(planFor(null))));
+    });
+  });
+}

--- a/packages/colonizethis_data/lib/src/production_recipes.dart
+++ b/packages/colonizethis_data/lib/src/production_recipes.dart
@@ -1,6 +1,7 @@
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'commodities.dart';
+import 'tech_ids.dart';
 
 /// Production recipes for Phase 2.
 /// SPEC/game/production-recipes.md
@@ -11,6 +12,7 @@ class ProductionRecipe {
     required this.outputQuantity,
     required this.inputQuantities,
     required this.labourPerOutput,
+    this.requiredTechId,
   });
 
   /// Stable id for referring to this recipe from logic or scripts.
@@ -27,6 +29,12 @@ class ProductionRecipe {
 
   /// Labour required per output unit.
   final int labourPerOutput;
+
+  /// Technology id this recipe requires before a player may use it, or `null`
+  /// when the recipe is always available. Gating is per player and evaluated
+  /// against the player's `techUnlocked` set. SPEC/game/production-recipes.md
+  /// § Technology-gated recipes.
+  final String? requiredTechId;
 }
 
 class ProductionRecipesCatalog {
@@ -53,7 +61,8 @@ class ProductionRecipesCatalog {
     labourPerOutput: 2,
   );
 
-  /// 2 cotton → 1 fabric.
+  /// 2 cotton → 1 fabric. Tech-gated: requires `cotton_weaving` per player
+  /// (SPEC/game/tech-tree-new-world.md, SPEC/game/production-recipes.md).
   static final ProductionRecipe fabricFromCotton = ProductionRecipe(
     id: 'fabric_from_cotton',
     outputCommodityId: CommodityCatalog.fabric.id,
@@ -62,6 +71,7 @@ class ProductionRecipesCatalog {
       CommodityCatalog.cotton.id: 2,
     },
     labourPerOutput: 2,
+    requiredTechId: kTechIdCottonWeaving,
   );
 
   /// 2 sugarCane → 1 refinedSugar.
@@ -181,4 +191,31 @@ class ProductionRecipesCatalog {
   /// O(1) lookup backed by [byOutputCommodityId]. Refs #3288.
   static List<ProductionRecipe> producing(CommodityId commodityId) =>
       byOutputCommodityId[commodityId] ?? const <ProductionRecipe>[];
+
+  /// Whether [recipe] is available to a player with the given [techUnlocked]
+  /// set. A recipe with no `requiredTechId` is always available. A tech-gated
+  /// recipe is available only when its `requiredTechId` maps to `true` in
+  /// [techUnlocked]; a `null`, missing, or `false` entry means locked.
+  /// Gating is per player. SPEC/game/production-recipes.md
+  /// § Technology-gated recipes.
+  static bool isRecipeAvailableForPlayer(
+    ProductionRecipe recipe,
+    Map<String, bool>? techUnlocked,
+  ) {
+    final requiredTechId = recipe.requiredTechId;
+    if (requiredTechId == null) return true;
+    return techUnlocked?[requiredTechId] == true;
+  }
+
+  /// The subset of [all] available to a player with the given [techUnlocked]
+  /// set, preserving [all] order. Recipes whose `requiredTechId` is not
+  /// unlocked are excluded. SPEC/game/production-recipes.md
+  /// § Technology-gated recipes.
+  static List<ProductionRecipe> availableForPlayer(
+    Map<String, bool>? techUnlocked,
+  ) =>
+      [
+        for (final recipe in all)
+          if (isRecipeAvailableForPlayer(recipe, techUnlocked)) recipe,
+      ];
 }

--- a/packages/colonizethis_data/test/production_recipe_availability_test.dart
+++ b/packages/colonizethis_data/test/production_recipe_availability_test.dart
@@ -1,0 +1,115 @@
+import 'package:colonizethis_test/test.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+
+/// Slice C — cotton weaving recipe gate (Refs #3470).
+/// SPEC/game/production-recipes.md § Technology-gated recipes.
+void main() {
+  group('ProductionRecipe.requiredTechId', () {
+    test('fabric_from_cotton requires cotton_weaving', () {
+      expect(
+        ProductionRecipesCatalog.fabricFromCotton.requiredTechId,
+        kTechIdCottonWeaving,
+      );
+    });
+
+    test('fabric_from_wool has no required tech', () {
+      expect(ProductionRecipesCatalog.fabricFromWool.requiredTechId, isNull);
+    });
+
+    test('non-gated recipes declare no required tech', () {
+      final gated = ProductionRecipesCatalog.all
+          .where((r) => r.requiredTechId != null)
+          .map((r) => r.id)
+          .toSet();
+      expect(gated, {'fabric_from_cotton'});
+    });
+  });
+
+  group('isRecipeAvailableForPlayer', () {
+    test('non-gated recipe is available regardless of techUnlocked', () {
+      expect(
+        ProductionRecipesCatalog.isRecipeAvailableForPlayer(
+          ProductionRecipesCatalog.fabricFromWool,
+          null,
+        ),
+        isTrue,
+      );
+      expect(
+        ProductionRecipesCatalog.isRecipeAvailableForPlayer(
+          ProductionRecipesCatalog.fabricFromWool,
+          const {},
+        ),
+        isTrue,
+      );
+    });
+
+    test('gated recipe unavailable when tech missing, null, or false', () {
+      // Null techUnlocked.
+      expect(
+        ProductionRecipesCatalog.isRecipeAvailableForPlayer(
+          ProductionRecipesCatalog.fabricFromCotton,
+          null,
+        ),
+        isFalse,
+      );
+      // Empty / missing entry.
+      expect(
+        ProductionRecipesCatalog.isRecipeAvailableForPlayer(
+          ProductionRecipesCatalog.fabricFromCotton,
+          const {},
+        ),
+        isFalse,
+      );
+      // Explicit false.
+      expect(
+        ProductionRecipesCatalog.isRecipeAvailableForPlayer(
+          ProductionRecipesCatalog.fabricFromCotton,
+          const {kTechIdCottonWeaving: false},
+        ),
+        isFalse,
+      );
+    });
+
+    test('gated recipe available when tech unlocked', () {
+      expect(
+        ProductionRecipesCatalog.isRecipeAvailableForPlayer(
+          ProductionRecipesCatalog.fabricFromCotton,
+          const {kTechIdCottonWeaving: true},
+        ),
+        isTrue,
+      );
+    });
+  });
+
+  group('availableForPlayer', () {
+    test('excludes fabric_from_cotton without cotton_weaving but keeps wool',
+        () {
+      final available = ProductionRecipesCatalog.availableForPlayer(const {});
+      final ids = available.map((r) => r.id).toSet();
+      expect(ids, contains('fabric_from_wool'));
+      expect(ids, isNot(contains('fabric_from_cotton')));
+      // All other always-available recipes remain present.
+      expect(available.length, ProductionRecipesCatalog.all.length - 1);
+    });
+
+    test('includes fabric_from_cotton once cotton_weaving is unlocked', () {
+      final available = ProductionRecipesCatalog.availableForPlayer(
+        const {kTechIdCottonWeaving: true},
+      );
+      final ids = available.map((r) => r.id).toSet();
+      expect(ids, contains('fabric_from_cotton'));
+      expect(ids, contains('fabric_from_wool'));
+      expect(available.length, ProductionRecipesCatalog.all.length);
+    });
+
+    test('preserves catalog order', () {
+      final available = ProductionRecipesCatalog.availableForPlayer(
+        const {kTechIdCottonWeaving: true},
+      );
+      expect(
+        available.map((r) => r.id).toList(),
+        ProductionRecipesCatalog.all.map((r) => r.id).toList(),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Implements the **core gameplay logic** of **Slice C — cotton weaving recipe gate** from the umbrella tech-effects issue. `fabric_from_cotton` becomes a per-player, technology-dependent recipe gated on `cotton_weaving`; `fabric_from_wool` remains always available.

`Refs #3470` (umbrella stays open; Slice B and Slice D are already on `dev`).

## Done in this push

- **Data layer (`colonizethis_data`)**
  - Add optional `requiredTechId` to `ProductionRecipe`; set `fabric_from_cotton.requiredTechId = cotton_weaving`.
  - Add `ProductionRecipesCatalog.isRecipeAvailableForPlayer(recipe, techUnlocked)` and `availableForPlayer(techUnlocked)` so callers compute per-player availability from `techUnlocked` without mutating the program-level catalog.
- **AI economy planner (`colonizethis_ai`)**
  - Thread the player's `techUnlocked` into labour allocation and skip tech-locked recipes in both the candidate-scoring loop and the fabric pre-pass, so the AI never scores, assigns labour to, or suggests `fabric_from_cotton` without the tech.
- **SPEC**
  - `SPEC/game/production-recipes.md`: new *Technology-gated recipes* section + Given/When/Then ACs (non-gated always available; cotton gate locked vs unlocked; AI planner does not suggest the locked recipe).

## Tests

- `packages/colonizethis_data/test/production_recipe_availability_test.dart` — positive/negative coverage of `requiredTechId`, `isRecipeAvailableForPlayer` (null/missing/false/true), and `availableForPlayer` filtering + order preservation.
- `packages/colonizethis_ai/test/economy_planner_cotton_weaving_gate_test.dart` — cotton-only GP: `fabric_from_cotton` not assigned when tech is null/false (and no fabric produced), assigned once `cotton_weaving` is unlocked, deterministic.

Verification run locally:
- `colonizethis_data`: full suite green (350 tests).
- `colonizethis_ai`: full suite green (2059 passed, 12 skipped, 0 failed) — confirms no seed/observer regression from the behavior change (GPs start with empty `techUnlocked`).

## ACs covered now vs. deferred

Covered (Slice C): AC1 (feasibility/availability for AI planning + data API), AC2 (available once unlocked), AC3 (AI planner does not suggest `fabric_from_cotton`).

**Deferred to follow-up PR(s) on #3470:**
- Slice C ACs 4–6 — human-side production-panel locked-recipe UI (visible but grayed, localized `(locked)` marker), Widgetbook variant, screen documentation, and `SPEC/ui/production-panel.md` / `production-allocation-row.md` updates.
- Order-validation hard gate and feedstock-helper/order-projection wiring for the human production path.

## Test plan

- [ ] CI `quality` + package tests green
- [ ] Confirm no observer/seed regression in full AI shard runs

Made with [Cursor](https://cursor.com)