### PR TITLE
feat: GA fitness tech-unlock economic blend (#3472)

### DIFF
--- a/SPEC/program/ga-fitness.md
+++ b/SPEC/program/ga-fitness.md
@@ -56,6 +56,25 @@ scores `0` for that component. **Exception:** province share is already a
 | Military (0.4) | regiment count; province share; strength proxy | sum of `regiments=` over `militaryArmySummariesSorted` for `owner=playerId`; province share (same as economic); `regimentLikeUnitCountHint` (fallback `greatPowerPowerScore` when the hint is absent) |
 | Diplomatic (0.2) | alliance count; non-war relations | `diplomacyRelationSummariesSorted` rows involving the player with `lvl=allied`; rows involving the player that are `peace` |
 
+### Economic tech-unlock blend (#3472)
+
+After the Economic category mean (`economicRaw`) is computed, the System folds in
+research progress so the GA rewards tech investment as part of economic fitness:
+
+```
+techUnlockFraction = clamp(|techUnlocked| / 113, 0, 1)   // 113 = catalog size (SPEC/game/tech-tree.md)
+economic = economicRaw × (1 - w) + techUnlockFraction × w  // w ∈ [0.05, 0.20]
+```
+
+`|techUnlocked|` is the count of the player's `techUnlockedIds` in the snapshot
+(`0` when the field is absent). `w` (`kTechUnlockEconomicWeight`) is a fixed code
+constant within `[0.05, 0.20]` (default `0.10`); its exact value inside that band
+is **GA-tunable and deferred** (numeric tuning is out of scope for #3472). The
+blend rewards research without dominating treasury, workers, or province share, and
+keeps `economic ∈ [0, 1]`. The Military and Diplomatic categories are unaffected.
+The blended `economic` is the value reported in `FitnessScore.economic` and used as
+the `economic` term in the base formula.
+
 ### Win multiplier
 
 `winMultiplier = 2.0` when `playerId == runSummary['declared_winner_player_id']`,
@@ -100,8 +119,20 @@ in `diplomacyRelationSummariesSorted`).
   returns one `FitnessScore` per player keyed by `playerId`, each with
   `economic`, `military`, `diplomatic`, and `total` fields.
 - Given two players where one has strictly greater treasury, workers, and
-  provinces and all else equal, when scored, then the stronger player's `economic`
-  is `1.0` and is greater than the weaker player's `economic`.
+  provinces, equal `techUnlockedIds`, and all else equal, when scored, then the
+  stronger player's `economic` equals `(1 - w) × 1.0 + w × techUnlockFraction` and
+  is greater than the weaker player's `economic`.
+- Given a player whose snapshot lists `N` entries in `techUnlockedIds` (`N >= 0`),
+  when the economic score is computed, then the System blends
+  `techUnlockFraction = clamp(N / 113, 0, 1)` into economic as
+  `economic = economicRaw × (1 - w) + techUnlockFraction × w` with the fixed
+  constant `w = kTechUnlockEconomicWeight ∈ [0.05, 0.20]`.
+- Given two players with identical economic raw inputs (treasury, workers,
+  province share) where one has strictly more entries in `techUnlockedIds`, when
+  scored, then the player with more unlocked techs has a strictly greater
+  `economic` score.
+- Given a player whose snapshot has no `techUnlockedIds` field, when scored, then
+  `techUnlockFraction` is `0` and `economic` equals `economicRaw × (1 - w)`.
 - Given a component whose game-wide max raw value is `0` across all players, when
   scored, then every player's normalized value for that component is `0` and does
   not produce a division-by-zero error.

--- a/tool/ga_runner/lib/fitness/fitness_function.dart
+++ b/tool/ga_runner/lib/fitness/fitness_function.dart
@@ -25,6 +25,16 @@ const double kMilitaryHeavyBrokePenalty = -30.0;
 /// Regiment-to-(regiment+worker) ratio above which "military-heavy" applies.
 const double kMilitaryHeavyRatioThreshold = 0.9;
 
+/// Total tech-catalog size used to normalize tech-unlock progress
+/// (`SPEC/game/tech-tree.md`; the #3470 Slice D audit enforces this count).
+const int kTechCatalogSize = 113;
+
+/// Weight blending tech-unlock progress into the economic category score
+/// (`economic = economicRaw × (1 - w) + techUnlockFraction × w`). Fixed constant
+/// within `[0.05, 0.20]` per SPEC/program/ga-fitness.md; exact value inside the
+/// band is GA-tunable and deferred (#3472).
+const double kTechUnlockEconomicWeight = 0.10;
+
 const List<String> _kWorkerTiers = <String>[
   'peasants',
   'apprentices',
@@ -72,7 +82,7 @@ Map<String, FitnessScore> computeFitness(
         .length;
   }
 
-  final economic = _categoryWithDirect(
+  final economicRaw = _categoryWithDirect(
     normalizedColumns: <List<double>>[
       [for (final p in players) p.treasury],
       [for (final p in players) p.workerTotal.toDouble()],
@@ -81,6 +91,10 @@ Map<String, FitnessScore> computeFitness(
       [for (final p in players) p.provinceShare],
     ],
   );
+  final economic = <double>[
+    for (var i = 0; i < players.length; i++)
+      _blendTechUnlock(economicRaw[i], players[i].techUnlockCount),
+  ];
   final military = _categoryWithDirect(
     normalizedColumns: <List<double>>[
       [for (final p in players) p.regimentCount.toDouble()],
@@ -137,6 +151,14 @@ double _shapingPenalties(
   return sum;
 }
 
+/// Folds tech-unlock progress into the raw economic score per
+/// SPEC/program/ga-fitness.md § Economic tech-unlock blend.
+double _blendTechUnlock(double economicRaw, int techUnlockCount) {
+  final fraction = (techUnlockCount / kTechCatalogSize).clamp(0.0, 1.0);
+  return economicRaw * (1 - kTechUnlockEconomicWeight) +
+      fraction * kTechUnlockEconomicWeight;
+}
+
 /// Equal-weight mean of per-component normalized values for each player.
 List<double> _category(List<List<double>> rawColumns) =>
     _categoryWithDirect(normalizedColumns: rawColumns, directColumns: const []);
@@ -185,11 +207,14 @@ List<_PlayerRaw> _parsePlayers(Map<String, dynamic> snapshot) {
         treasury: _numOf(entry, 'treasuryPounds').toDouble(),
         workerTotal: _workerTotal(entry['workerPool']),
         strengthProxy: _strengthProxy(entry),
+        techUnlockCount: _techUnlockCount(entry['techUnlockedIds']),
       ),
     );
   }
   return players;
 }
+
+int _techUnlockCount(Object? ids) => ids is List<Object?> ? ids.length : 0;
 
 int _workerTotal(Object? pool) {
   if (pool is! Map<Object?, Object?>) return 0;
@@ -285,12 +310,14 @@ class _PlayerRaw {
     required this.treasury,
     required this.workerTotal,
     required this.strengthProxy,
+    required this.techUnlockCount,
   });
 
   final String playerId;
   final double treasury;
   final int workerTotal;
   final double strengthProxy;
+  final int techUnlockCount;
 
   int provinceCount = 0;
   double provinceShare = 0.0;

--- a/tool/ga_runner/test/fitness_function_test.dart
+++ b/tool/ga_runner/test/fitness_function_test.dart
@@ -13,6 +13,7 @@ Map<String, dynamic> _player(
   int masters = 0,
   num? strengthHint,
   num? powerScore,
+  int? techUnlockedCount,
 }) => <String, dynamic>{
   'playerId': id,
   'treasuryPounds': treasury,
@@ -24,7 +25,17 @@ Map<String, dynamic> _player(
   },
   if (strengthHint != null) 'regimentLikeUnitCountHint': strengthHint,
   if (powerScore != null) 'greatPowerPowerScore': powerScore,
+  if (techUnlockedCount != null)
+    'techUnlockedIds': <String>[
+      for (var i = 0; i < techUnlockedCount; i++) 'tech_$i',
+    ],
 };
+
+/// Folds the economic raw score into the tech-unlock-blended value the same way
+/// `computeFitness` does, for tests whose players carry no `techUnlockedIds`
+/// (techUnlockFraction == 0): `economic = economicRaw × (1 - w)`.
+double _econNoTech(double economicRaw) =>
+    economicRaw * (1 - kTechUnlockEconomicWeight);
 
 Map<String, String?> _prov(String id, String? ownerId) => <String, String?>{
   'id': id,
@@ -74,7 +85,7 @@ void main() {
   });
 
   group('category normalization', () {
-    test('strictly stronger player gets economic 1.0 and beats weaker', () {
+    test('strictly stronger player gets top economic and beats weaker', () {
       final scores = computeFitness(
         _snapshot(
           players: [
@@ -86,7 +97,7 @@ void main() {
         _summary(null),
         capitalProvinceByPlayerId: const {},
       );
-      expect(scores['A']!.economic, closeTo(8 / 9, 1e-9));
+      expect(scores['A']!.economic, closeTo(_econNoTech(8 / 9), 1e-9));
       expect(scores['A']!.economic, greaterThan(scores['B']!.economic));
     });
 
@@ -112,7 +123,7 @@ void main() {
       );
       // Only treasury varies; floored A treasury is 0, B is max → A economic 0.
       expect(scores['A']!.economic, 0.0);
-      expect(scores['B']!.economic, closeTo(1.0 / 3.0, 1e-9));
+      expect(scores['B']!.economic, closeTo(_econNoTech(1.0 / 3.0), 1e-9));
     });
 
     test('diplomatic counts allied-only alliances and non-war relations', () {
@@ -151,7 +162,9 @@ void main() {
         _summary('A'),
         capitalProvinceByPlayerId: const {'A': 'pA1'},
       );
-      expect(scores['A']!.total, closeTo(2.0, 1e-9));
+      // Dominator economic raw 1.0 → blended _econNoTech(1.0); mil 1.0, dip 1.0.
+      final base = 0.4 * _econNoTech(1.0) + 0.4 * 1.0 + 0.2 * 1.0;
+      expect(scores['A']!.total, closeTo(base * 2.0, 1e-9));
     });
 
     test('non-winner uses multiplier 1.0 (same dominator → base 1.0)', () {
@@ -160,7 +173,8 @@ void main() {
         _summary(null),
         capitalProvinceByPlayerId: const {'A': 'pA1'},
       );
-      expect(scores['A']!.total, closeTo(1.0, 1e-9));
+      final base = 0.4 * _econNoTech(1.0) + 0.4 * 1.0 + 0.2 * 1.0;
+      expect(scores['A']!.total, closeTo(base, 1e-9));
     });
   });
 
@@ -175,8 +189,9 @@ void main() {
         _summary(null),
         capitalProvinceByPlayerId: const {'A': 'p1'},
       );
-      // base = 0.4*(0+1+1)/3 + 0.4*1 = 0.6666667; penalty -50.
-      expect(scores['A']!.total, closeTo(0.6666667 - 50.0, 1e-6));
+      // econRaw=(0+1+1)/3=2/3 blended; mil=1.0; penalty -50.
+      final base = 0.4 * _econNoTech(2 / 3) + 0.4 * 1.0;
+      expect(scores['A']!.total, closeTo(base - 50.0, 1e-6));
     });
 
     test('zero regiments applies -80', () {
@@ -188,8 +203,9 @@ void main() {
         _summary(null),
         capitalProvinceByPlayerId: const {'A': 'p1'},
       );
-      // base = 0.4*1 + 0.4*(0+1+1)/3 = 0.6666667; penalty -80.
-      expect(scores['A']!.total, closeTo(0.6666667 - 80.0, 1e-6));
+      // econRaw=1.0 blended; mil=(0+1+1)/3=2/3; penalty -80.
+      final base = 0.4 * _econNoTech(1.0) + 0.4 * (2 / 3);
+      expect(scores['A']!.total, closeTo(base - 80.0, 1e-6));
     });
 
     test('capital loss applies -100; absent capital id skips penalty', () {
@@ -209,9 +225,10 @@ void main() {
         // A's capital p1 is owned by B → loss; B has no capital provided → skip.
         capitalProvinceByPlayerId: const {'A': 'p1'},
       );
-      // base = 0.4*(1+1+0.5)/3 + 0.4*(1+0.5+1)/3 ≈ 0.6666667; penalty -100.
-      expect(scores['A']!.total, closeTo(0.6666667 - 100.0, 1e-6));
-      expect(scores['B']!.total, closeTo(0.6666667, 1e-6));
+      // econRaw=mil=(1+1+0.5)/3=5/6; A blended econ; penalty -100.
+      final base = 0.4 * _econNoTech(5 / 6) + 0.4 * (5 / 6);
+      expect(scores['A']!.total, closeTo(base - 100.0, 1e-6));
+      expect(scores['B']!.total, closeTo(base, 1e-6));
     });
 
     test('military-heavy + broke adds -30 on top of bankruptcy', () {
@@ -224,9 +241,10 @@ void main() {
         _summary(null),
         capitalProvinceByPlayerId: const {'A': 'p1'},
       );
-      // base = 0.4*(0+0+1)/3 + 0.4*1 = 0.5333333; ratio 10/10=1.0 > 0.9 and
+      // econRaw=(0+0+1)/3=1/3 blended; mil=1.0; ratio 10/10=1.0 > 0.9 and
       // treasury 0 → -30, plus bankruptcy -50 → -80 total penalties.
-      expect(scores['A']!.total, closeTo(0.5333333 - 80.0, 1e-6));
+      final base = 0.4 * _econNoTech(1 / 3) + 0.4 * 1.0;
+      expect(scores['A']!.total, closeTo(base - 80.0, 1e-6));
     });
   });
 
@@ -358,8 +376,102 @@ void main() {
         _summary(null),
         capitalProvinceByPlayerId: const {'A': 'p1'},
       );
-      // No parseable regiments → zero-regiment penalty -80.
-      expect(scores['A']!.total, closeTo(0.6666667 - 80.0, 1e-6));
+      // econRaw=1.0 blended; mil=(0+1+1)/3=2/3; zero-regiment penalty -80.
+      final base = 0.4 * _econNoTech(1.0) + 0.4 * (2 / 3);
+      expect(scores['A']!.total, closeTo(base - 80.0, 1e-6));
+    });
+  });
+
+  group('economic tech-unlock blend (#3472)', () {
+    test('absent techUnlockedIds → fraction 0, economic = raw × (1 - w)', () {
+      final scores = computeFitness(
+        _snapshot(
+          players: [
+            _player('A', treasury: 100, peasants: 10),
+            _player('B', treasury: 10, peasants: 2),
+          ],
+          provinces: [_prov('p1', 'A'), _prov('p2', 'A'), _prov('p3', 'B')],
+        ),
+        _summary(null),
+        capitalProvinceByPlayerId: const {},
+      );
+      // A economicRaw = (1 + 1 + 2/3) / 3 = 8/9, no tech → ×(1 - w).
+      expect(scores['A']!.economic, closeTo(_econNoTech(8 / 9), 1e-9));
+    });
+
+    test('full catalog unlocked with zero economic raw → economic == w', () {
+      final scores = computeFitness(
+        _snapshot(
+          players: [_player('A', techUnlockedCount: kTechCatalogSize)],
+        ),
+        _summary(null),
+        capitalProvinceByPlayerId: const {},
+      );
+      // Single player, no treasury/workers/provinces → economicRaw 0.
+      // fraction = 113/113 = 1.0 → economic = 0×(1-w) + 1.0×w = w.
+      expect(scores['A']!.economic, closeTo(kTechUnlockEconomicWeight, 1e-9));
+    });
+
+    test('techUnlockFraction is clamped to 1.0 above catalog size', () {
+      final scores = computeFitness(
+        _snapshot(
+          players: [_player('A', techUnlockedCount: kTechCatalogSize + 50)],
+        ),
+        _summary(null),
+        capitalProvinceByPlayerId: const {},
+      );
+      expect(scores['A']!.economic, closeTo(kTechUnlockEconomicWeight, 1e-9));
+    });
+
+    test('partial unlock blends proportionally with zero economic raw', () {
+      const count = 30;
+      final scores = computeFitness(
+        _snapshot(players: [_player('A', techUnlockedCount: count)]),
+        _summary(null),
+        capitalProvinceByPlayerId: const {},
+      );
+      final expected =
+          (count / kTechCatalogSize) * kTechUnlockEconomicWeight;
+      expect(scores['A']!.economic, closeTo(expected, 1e-9));
+    });
+
+    test('more unlocked techs → strictly greater economic at equal raw', () {
+      // Both players have identical treasury, workers, and province share.
+      final scores = computeFitness(
+        _snapshot(
+          players: [
+            _player('A', treasury: 100, peasants: 10, techUnlockedCount: 40),
+            _player('B', treasury: 100, peasants: 10, techUnlockedCount: 5),
+          ],
+          provinces: [_prov('pa', 'A'), _prov('pb', 'B')],
+        ),
+        _summary(null),
+        capitalProvinceByPlayerId: const {},
+      );
+      expect(
+        scores['A']!.economic,
+        greaterThan(scores['B']!.economic),
+      );
+    });
+
+    test('tech unlocks do not affect military or diplomatic scores', () {
+      final scores = computeFitness(
+        _snapshot(
+          players: [
+            _player('A', treasury: 100, techUnlockedCount: kTechCatalogSize),
+            _player('B', treasury: 100, techUnlockedCount: 0),
+          ],
+          provinces: [_prov('pa', 'A'), _prov('pb', 'B')],
+          armies: const [
+            'army:a owner=A region=r regiments=5',
+            'army:b owner=B region=r regiments=5',
+          ],
+        ),
+        _summary(null),
+        capitalProvinceByPlayerId: const {},
+      );
+      expect(scores['A']!.military, closeTo(scores['B']!.military, 1e-9));
+      expect(scores['A']!.diplomatic, closeTo(scores['B']!.diplomatic, 1e-9));
     });
   });
 }


### PR DESCRIPTION
## Summary

Implements **AC11** of #3472 (the GA-fitness slice explicitly deferred from the merged core PR #3474): the GA economic fitness score now rewards research progress.

`computeFitness` folds tech-unlock progress into the economic category:

```
techUnlockFraction = clamp(|techUnlockedIds| / 113, 0, 1)   // 113 = catalog size (SPEC/game/tech-tree.md)
economic = economicRaw × (1 - w) + techUnlockFraction × w   // w = kTechUnlockEconomicWeight = 0.10, band [0.05, 0.20]
```

- Uses the existing snapshot field `techUnlockedIds` (ObserverSnapshot v4); absent field → fraction `0`.
- Military and diplomatic categories are unaffected; `economic` stays in `[0, 1]`.
- The exact value of `w` within `[0.05, 0.20]` is **GA-tunable and deferred** per the issue (numeric tuning out of scope); default `0.10`.

## SPEC

- `SPEC/program/ga-fitness.md`: new **§ Economic tech-unlock blend (#3472)** with the formula and `[0.05, 0.20]` bound; updated the "stronger player economic" AC and added three new ACs (blend formula, monotonicity, absent-field).

## Implementation

- `tool/ga_runner/lib/fitness/fitness_function.dart`: added `kTechCatalogSize`, `kTechUnlockEconomicWeight`, `_blendTechUnlock`, parse `techUnlockedIds` count, blend `economicRaw → economic`.

## Tests (`tool/ga_runner/test/fitness_function_test.dart`)

New `economic tech-unlock blend (#3472)` group:
- absent `techUnlockedIds` → `economic = raw × (1 - w)` (negative control)
- full catalog → `economic == w` at zero raw
- fraction clamped to `1.0` above catalog size
- partial unlock blends proportionally
- more unlocked techs ⇒ strictly greater economic at equal raw (monotonicity)
- tech unlocks do not affect military/diplomatic (category isolation)

Existing economic/total expectations updated to account for the blend, expressed via the weight constant so they stay robust to `w`.

Verification: `dart test` in `tool/ga_runner` → **97 passing**; `dart analyze` clean on the changed files (3 pre-existing warnings remain in unrelated `lib/bless/` files on `dev`).

## Scope

- **Done in this PR:** AC11 (GA fitness tech-unlock component + SPEC).
- **Deferred (separate PRs for #3472):** category diversification (AC9), war/stalled slot-fill caps (AC7), turn-trace multi-slot fields (AC10).

Refs #3472

Made with [Cursor](https://cursor.com)