### PR TITLE
feat(ga_runner): add random 7-GP opponent selection mode (#3488)

### DIFF
--- a/SPEC/program/ga-runner.md
+++ b/SPEC/program/ga-runner.md
@@ -33,7 +33,7 @@ error; **130** SIGINT (last completed generation persisted).
 | `seven_gp_games_per_profile` | 1 | Observer games per profile in the 7-GP stage (`0` disables the stage) |
 | `stage_fitness_weights.two_player` | 0.5 | Weight for 2-player stage fitness |
 | `stage_fitness_weights.seven_gp` | 0.5 | Weight for 7-GP stage fitness |
-| `seven_gp_opponent_selection` | `top_fitness` | Opponent ranking policy (`top_fitness` only in v2) |
+| `seven_gp_opponent_selection` | `top_fitness` | Prior-winner ordering policy: `top_fitness` (fitness desc, generation asc tiebreak) or `random` (deterministic seeded shuffle). Other values fail config parse (exit `1`) |
 | `seven_gp_fallback_default_ai_seats` | 3 | Default-AI seats when prior-winner pool is insufficient |
 | `seven_gp_fallback_randomized_ai_seats` | 3 | Randomized-AI seats when prior-winner pool is insufficient |
 | `seven_gp_use_blessed_profiles` | false | Include blessed manifest profiles in opponent pool |
@@ -67,9 +67,22 @@ Per profile, per generation:
 Stages run for every profile before selection/evolution. Round artifacts:
 `gen-NNN/<slot>-gXX` (2-player) and `gen-NNN/<slot>-7gp-gXX` (7-GP).
 
+**Opponent selection modes (`seven_gp_opponent_selection`):** Selects the order
+in which eligible prior-generation winners are seated into the six opponent
+seats before blessed/default/randomized fallback fill. Selection never reorders
+the downstream blessed → default-leader → randomized fallback stages and never
+seats the subject profile.
+
+- `top_fitness` (default): rank prior winners by fitness descending, breaking
+  ties by generation ascending, then seat in that order.
+- `random`: seat prior winners in a deterministic seeded shuffle. The shuffle
+  RNG is seeded by `deriveSevenGpSelectionSeed(master_seed, generation,
+  subjectIndex)` so the seating order is identical for fixed master seed,
+  generation, subject index, and prior-winner pool, and is independent of the
+  randomized-AI fallback RNG stream.
+
 **Deferred (follow-up):** per-stage mid-generation resume (`evaluation_stage` in
-`run-state.json`) and alternate `seven_gp_opponent_selection` modes beyond
-`top_fitness`.
+`run-state.json`).
 
 ## Master seed resolution (Refs #3486)
 
@@ -199,6 +212,21 @@ re-running games.
 - Given generation 0 with zero prior GA winners, when building a 7-GP roster,
   then all six opponent seats use the configured default-AI and randomized-AI
   fallback counts (defaults `3` + `3`).
+- Given a `ga-config.json` whose `seven_gp_opponent_selection` is `random`, when
+  `GaConfig.fromJson` parses it, then the system does not throw and
+  `config.sevenGpOpponentSelection == 'random'`.
+- Given a `ga-config.json` whose `seven_gp_opponent_selection` is any value
+  other than `top_fitness` or `random` (for example `most_wins`), when
+  `GaConfig.fromJson` parses it, then the system throws a `FormatException`
+  (CLI exit **1**) naming the allowed values.
+- Given `seven_gp_opponent_selection = random` and a fixed master seed,
+  generation, subject index, and prior-winner pool of at least two distinct
+  winners, when `buildSevenGpOpponentRoster` runs twice, then both invocations
+  seat the prior winners in the identical order (deterministic seeded shuffle).
+- Given `seven_gp_opponent_selection = random`, when the roster is built, then
+  the subject profile is never seated as an opponent and every eligible prior
+  winner (up to the six seats) is seated before blessed/default/randomized
+  fallback fill.
 
 ### Master seed resolution ACs (Refs #3486)
 

--- a/tool/ga_runner/lib/config/ga_config.dart
+++ b/tool/ga_runner/lib/config/ga_config.dart
@@ -4,6 +4,13 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 
 import '../setup/ga_setup_profile.dart';
 
+/// Allowed `seven_gp_opponent_selection` prior-winner ordering policies.
+/// SPEC/program/ga-runner.md § Opponent selection modes. Refs #3488.
+const List<String> kSevenGpOpponentSelectionModes = <String>[
+  'top_fitness',
+  'random',
+];
+
 /// Weights for combining 2-player and 7-GP stage fitness. Refs #3488.
 class StageFitnessWeights {
   const StageFitnessWeights({
@@ -164,9 +171,10 @@ class GaConfig {
     );
     final sevenGpOpponentSelection =
         json['seven_gp_opponent_selection'] as String? ?? 'top_fitness';
-    if (sevenGpOpponentSelection != 'top_fitness') {
+    if (!kSevenGpOpponentSelectionModes.contains(sevenGpOpponentSelection)) {
       throw FormatException(
-        'seven_gp_opponent_selection must be top_fitness '
+        'seven_gp_opponent_selection must be one of '
+        '${kSevenGpOpponentSelectionModes.join(', ')} '
         '(got $sevenGpOpponentSelection)',
       );
     }

--- a/tool/ga_runner/lib/engine/ga_seeds.dart
+++ b/tool/ga_runner/lib/engine/ga_seeds.dart
@@ -36,3 +36,20 @@ int deriveSevenGpSeatSeed(
     (subjectIndex * 9973) ^
     (seatIndex * 1009) ^
     _kSevenGpGameSalt;
+
+/// Salt XOR so the `random` opponent-selection shuffle seed never collides with
+/// per-seat randomized-AI seeds for the same tuple inputs.
+const int _kSevenGpSelectionSalt = 0x5E1EC7;
+
+/// Seed for the deterministic `random` `seven_gp_opponent_selection` shuffle of
+/// the prior-generation-winner pool. Independent of [deriveSevenGpSeatSeed] so
+/// reordering prior winners does not perturb the randomized-AI fallback stream.
+int deriveSevenGpSelectionSeed(
+  int masterSeed,
+  int generation,
+  int subjectIndex,
+) =>
+    masterSeed ^
+    (generation * 1000003) ^
+    (subjectIndex * 9973) ^
+    _kSevenGpSelectionSalt;

--- a/tool/ga_runner/lib/setup/seven_gp_opponent_roster.dart
+++ b/tool/ga_runner/lib/setup/seven_gp_opponent_roster.dart
@@ -43,20 +43,15 @@ List<AiProfile> buildSevenGpOpponentRoster({
     usedProfileIds.add(profile.profileId);
   }
 
-  if (config.sevenGpOpponentSelection == 'top_fitness') {
-    final ranked = List<PriorGenerationWinner>.from(priorWinners)
-      ..sort((a, b) {
-        final byFitness = b.fitness.compareTo(a.fitness);
-        if (byFitness != 0) return byFitness;
-        return a.generation.compareTo(b.generation);
-      });
-    for (final winner in ranked) {
-      tryAdd(winner.profile);
-    }
-  } else {
-    throw StateError(
-      'unsupported seven_gp_opponent_selection: ${config.sevenGpOpponentSelection}',
-    );
+  final ordered = _orderPriorWinners(
+    priorWinners: priorWinners,
+    selection: config.sevenGpOpponentSelection,
+    masterSeed: masterSeed,
+    generation: generation,
+    subjectIndex: subjectIndex,
+  );
+  for (final winner in ordered) {
+    tryAdd(winner.profile);
   }
 
   if (config.sevenGpUseBlessedProfiles) {
@@ -108,4 +103,46 @@ List<AiProfile> buildSevenGpOpponentRoster({
     );
   }
   return opponents;
+}
+
+/// Orders the prior-generation-winner pool for seating per the configured
+/// [selection] policy. SPEC/program/ga-runner.md § Opponent selection modes.
+/// Refs #3488.
+///
+/// * `top_fitness`: fitness descending, generation ascending tiebreak.
+/// * `random`: deterministic seeded shuffle keyed by
+///   [deriveSevenGpSelectionSeed] so the order is identical for fixed master
+///   seed, generation, subject index, and pool.
+List<PriorGenerationWinner> _orderPriorWinners({
+  required List<PriorGenerationWinner> priorWinners,
+  required String selection,
+  required int masterSeed,
+  required int generation,
+  required int subjectIndex,
+}) {
+  final ordered = List<PriorGenerationWinner>.from(priorWinners);
+  switch (selection) {
+    case 'top_fitness':
+      ordered.sort((a, b) {
+        final byFitness = b.fitness.compareTo(a.fitness);
+        if (byFitness != 0) return byFitness;
+        return a.generation.compareTo(b.generation);
+      });
+      return ordered;
+    case 'random':
+      final selectionRng = math.Random(
+        deriveSevenGpSelectionSeed(masterSeed, generation, subjectIndex),
+      );
+      for (var i = ordered.length - 1; i > 0; i--) {
+        final j = selectionRng.nextInt(i + 1);
+        final tmp = ordered[i];
+        ordered[i] = ordered[j];
+        ordered[j] = tmp;
+      }
+      return ordered;
+    default:
+      throw StateError(
+        'unsupported seven_gp_opponent_selection: $selection',
+      );
+  }
 }

--- a/tool/ga_runner/test/ga_config_test.dart
+++ b/tool/ga_runner/test/ga_config_test.dart
@@ -250,5 +250,43 @@ void main() {
         throwsA(isA<FormatException>()),
       );
     });
+
+    test('accepts random seven_gp_opponent_selection (Refs #3488)', () {
+      final config = GaConfig.fromJson(<String, dynamic>{
+        'seed_profiles_dir': 'seeds/',
+        'seed': 7,
+        'game_player_count': 2,
+        'seven_gp_opponent_selection': 'random',
+        'game_setup_config': <String, dynamic>{
+          'selectedGreatPowerIds': <String>['england', 'france'],
+          'minorNationCount': 3,
+          'tribeCount': 3,
+        },
+      });
+      expect(config.sevenGpOpponentSelection, 'random');
+    });
+
+    test('rejects unknown seven_gp_opponent_selection (Refs #3488)', () {
+      expect(
+        () => GaConfig.fromJson(<String, dynamic>{
+          'seed_profiles_dir': 'seeds/',
+          'seed': 7,
+          'game_player_count': 2,
+          'seven_gp_opponent_selection': 'most_wins',
+          'game_setup_config': <String, dynamic>{
+            'selectedGreatPowerIds': <String>['england', 'france'],
+            'minorNationCount': 3,
+            'tribeCount': 3,
+          },
+        }),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            allOf(contains('top_fitness'), contains('random')),
+          ),
+        ),
+      );
+    });
   });
 }

--- a/tool/ga_runner/test/seven_gp_opponent_roster_test.dart
+++ b/tool/ga_runner/test/seven_gp_opponent_roster_test.dart
@@ -98,4 +98,107 @@ void main() {
       expect(a, b);
     });
   });
+
+  group('buildSevenGpOpponentRoster random selection (Refs #3488)', () {
+    late GaConfig randomConfig;
+    late AiProfile subject;
+    late List<PriorGenerationWinner> winners;
+
+    setUp(() {
+      randomConfig = testGaConfig(
+        seedProfilesDir: 'seeds',
+        gameSetupConfig: testTwoPlayerSetup(),
+        sevenGpGamesPerProfile: 1,
+        sevenGpOpponentSelection: 'random',
+      );
+      subject = seedAiProfilesById['victoria']!;
+      // Four distinct non-subject prior winners with descending fitness so a
+      // shuffle is meaningfully distinguishable from the fitness ordering.
+      final ids = seedAiProfileLeaderIds
+          .where((id) => seedAiProfilesById[id]!.profileId != subject.profileId)
+          .take(4)
+          .toList();
+      winners = <PriorGenerationWinner>[
+        for (var i = 0; i < ids.length; i++)
+          PriorGenerationWinner(
+            profile: seedAiProfilesById[ids[i]]!,
+            fitness: 100.0 - i,
+            generation: i,
+          ),
+      ];
+    });
+
+    List<AiProfile> buildWith({required int seed, int generation = 3}) =>
+        buildSevenGpOpponentRoster(
+          subjectProfile: subject,
+          priorWinners: winners,
+          blessedProfiles: const <AiProfile>[],
+          config: randomConfig,
+          rng: math.Random(seed),
+          masterSeed: 11,
+          generation: generation,
+          subjectIndex: 0,
+        );
+
+    test('is deterministic for fixed master seed, generation, and inputs', () {
+      final a = buildWith(seed: 7).map((p) => p.profileId).toList();
+      final b = buildWith(seed: 7).map((p) => p.profileId).toList();
+      expect(a, b);
+    });
+
+    test('seats every eligible prior winner before fallback and excludes '
+        'the subject', () {
+      final roster = buildWith(seed: 7);
+      expect(roster, hasLength(6));
+      final winnerIds = winners.map((w) => w.profile.profileId).toSet();
+      // Prior winners are seated first (shuffled), before blessed/default/
+      // randomized fallback fill.
+      expect(
+        roster.take(winners.length).map((p) => p.profileId).toSet(),
+        winnerIds,
+      );
+      expect(
+        roster.map((p) => p.profileId).contains(subject.profileId),
+        isFalse,
+      );
+    });
+
+    test('shuffle order is not the top-fitness order for at least one '
+        'generation seed (mode actually reorders)', () {
+      List<String> topFitnessOrder() => (List<PriorGenerationWinner>.from(
+            winners,
+          )..sort((a, b) {
+              final byFitness = b.fitness.compareTo(a.fitness);
+              if (byFitness != 0) return byFitness;
+              return a.generation.compareTo(b.generation);
+            }))
+          .map((w) => w.profile.profileId)
+          .toList();
+
+      final topOrder = topFitnessOrder();
+      // Scan a handful of generation seeds; the deterministic shuffle must
+      // differ from the strict fitness ordering for at least one of them.
+      final reordered = <int>[for (var g = 0; g < 8; g++) g].any((g) {
+        final order = buildWith(seed: 7, generation: g)
+            .take(winners.length)
+            .map((p) => p.profileId)
+            .toList();
+        return !_listEquals(order, topOrder);
+      });
+      expect(
+        reordered,
+        isTrue,
+        reason: 'random selection must produce an order distinct from '
+            'top_fitness for at least one generation seed.',
+      );
+    });
+  });
+}
+
+bool _listEquals(List<String> a, List<String> b) {
+  if (a.length != b.length) return false;
+  for (var i = 0; i < a.length; i++) {
+    if (a[i] != b[i]) return false;
+  }
+  return true;
 }

--- a/tool/ga_runner/test/test_ga_config.dart
+++ b/tool/ga_runner/test/test_ga_config.dart
@@ -18,6 +18,7 @@ GaConfig testGaConfig({
   String outputDir = 'output/',
   int seed = 11,
   int sevenGpGamesPerProfile = 0,
+  String sevenGpOpponentSelection = 'top_fitness',
   StageFitnessWeights stageFitnessWeights = const StageFitnessWeights(
     twoPlayer: 0.5,
     sevenGp: 0.5,
@@ -45,7 +46,7 @@ GaConfig testGaConfig({
     seed: seed,
     sevenGpGamesPerProfile: sevenGpGamesPerProfile,
     stageFitnessWeights: stageFitnessWeights,
-    sevenGpOpponentSelection: 'top_fitness',
+    sevenGpOpponentSelection: sevenGpOpponentSelection,
     sevenGpFallbackDefaultAiSeats: 3,
     sevenGpFallbackRandomizedAiSeats: 3,
     sevenGpUseBlessedProfiles: false,


### PR DESCRIPTION
## Summary
- Implements the **deferred** alternate `seven_gp_opponent_selection` slice from the now-merged PR #3492 (issue #3488): adds a deterministic **`random`** opponent-selection mode alongside the existing `top_fitness` default.
- `random` seats prior-generation winners via a seeded Fisher–Yates shuffle keyed by `deriveSevenGpSelectionSeed(masterSeed, generation, subjectIndex)`, so seating order is identical for fixed master seed / generation / subject index / prior-winner pool, and is independent of the randomized-AI fallback RNG stream.
- Config now accepts `top_fitness` (default) or `random` and rejects any other value at parse time (`FormatException`, CLI exit `1`).

## SPEC
- `SPEC/program/ga-runner.md` — config table row for `seven_gp_opponent_selection` updated; new **§ Opponent selection modes** documents both policies; deferral note trimmed to resume-only; added ACs for `random` acceptance, unknown-value rejection, shuffle determinism, and subject exclusion / prior-winner seating.

## Implementation
- `tool/ga_runner/lib/engine/ga_seeds.dart` — new `deriveSevenGpSelectionSeed` (salted so it never collides with per-seat randomized-AI seeds).
- `tool/ga_runner/lib/config/ga_config.dart` — `kSevenGpOpponentSelectionModes` allow-list + validation.
- `tool/ga_runner/lib/setup/seven_gp_opponent_roster.dart` — `_orderPriorWinners` orders the prior-winner pool per the configured policy; downstream blessed → default-leader → randomized fallback fill and subject exclusion unchanged.

## Tests
- Config: accepts `random`; rejects unknown value naming allowed modes.
- Roster: `random` determinism for fixed seed/inputs; seats every eligible prior winner before fallback + excludes subject; reorders vs `top_fitness` for at least one generation seed.
- `cd tool/ga_runner && dart test` — green (127 total; 30 in config+roster suites).

## Scope / deferred
- Covers AC "non-default selection modes are honored deterministically for fixed seed and inputs."
- Still deferred on #3488 (separate slice): per-stage mid-generation resume (`evaluation_stage` / per-profile stage flags in `run-state.json`) and SIGINT persistence during partial 7-GP work.

Refs #3488

Made with [Cursor](https://cursor.com)