### PR TITLE
test(ui): add em-dash price column alignment AC for trade market (#3487)

### DIFF
--- a/app/lib/features/game/screens/trade_screen.dart
+++ b/app/lib/features/game/screens/trade_screen.dart
@@ -288,6 +288,12 @@ class TradeScreen extends ConsumerWidget {
   /// inside the trailing market-price column (Refs `#3487`).
   static const double marketRowPriceColumnInnerGap = 4;
 
+  /// When non-null, overrides [ResourceRules.defaultRules] for Market tab
+  /// price formatting only. Widget tests set this to exercise the em-dash
+  /// fallback path without a catalog default (Refs `#3487` AC4).
+  @visibleForTesting
+  static ResourceRules? marketPriceResourceRulesOverride;
+
   /// Asset path of the treasury-coin glyph rendered next to each
   /// Market row's integer price (Refs `#3093` — row-icons slice). Same
   /// asset family as the game tab bar treasury chip
@@ -1354,9 +1360,11 @@ class _MarketTabContent extends ConsumerWidget {
   /// canonical em-dash glyph is a defensive fallback retained for future
   /// commodity additions that ship without a catalog default.
   static String _formatPrice(int? price, {required CommodityId commodityId}) {
+    final ResourceRules rules =
+        TradeScreen.marketPriceResourceRulesOverride ??
+        ResourceRules.defaultRules;
     final int? effective =
-        price ?? ResourceRules.defaultRules
-            .defaultMarketPriceForCommodityId(commodityId);
+        price ?? rules.defaultMarketPriceForCommodityId(commodityId);
     if (effective == null) return priceUnknownGlyph;
     return effective.toString();
   }

--- a/app/test/trade_screen_market_tab_price_column_test.dart
+++ b/app/test/trade_screen_market_tab_price_column_test.dart
@@ -76,15 +76,42 @@ double _priceTextRight(
   String priceText,
 ) {
   final Finder priceFinder = find.descendant(
-    of: find.byKey(TradeScreen.marketCommodityRowKey(commodityId)),
+    of: _trailingPriceRowFinder(commodityId),
     matching: find.text(priceText),
   );
   expect(priceFinder, findsOneWidget);
   return tester.getTopRight(priceFinder).dx;
 }
 
+Finder _trailingPriceRowFinder(CommodityId commodityId) {
+  final Finder coinFinder = find.byKey(
+    TradeScreen.marketRowPriceCoinIconKey(commodityId),
+  );
+  return find.ancestor(
+    of: coinFinder,
+    matching: find.byWidgetPredicate(
+      (Widget widget) =>
+          widget is Row && widget.mainAxisSize == MainAxisSize.min,
+    ),
+  );
+}
+
+/// Empty [ResourceRules] so `_formatPrice` can render the em-dash fallback
+/// for commodities absent from `worldMarketState.prices` (Refs #3487 AC4).
+ResourceRules _emptyMarketPriceRules() {
+  return ResourceRules(
+    regionRule: const <Resource, ResourceRegionRule>{},
+    allowedTerrains: const <Resource, List<TerrainType>>{},
+    defaultMarketPrice: const <Resource, int>{},
+  );
+}
+
 void main() {
   suppressLogsForTests();
+
+  tearDown(() {
+    TradeScreen.marketPriceResourceRulesOverride = null;
+  });
 
   group('TradeScreen Market tab price column alignment (#3487)', () {
     testWidgets(
@@ -191,6 +218,47 @@ void main() {
           closeTo(sugarPriceRight, 1),
           reason: 'Short and long commodity names must not stagger the price '
               'column.',
+        );
+      },
+    );
+
+    testWidgets(
+      'em-dash price fallback shares the trailing column with integer '
+      'prices',
+      (tester) async {
+        TradeScreen.marketPriceResourceRulesOverride = _emptyMarketPriceRules();
+
+        await _pumpTradeScreen(
+          tester,
+          game: _buildGame(
+            prices: const <CommodityId, int>{'timber': 5},
+          ),
+        );
+
+        final double integerPriceRight =
+            _priceTextRight(tester, 'timber', '5');
+        final double emDashPriceRight = _priceTextRight(
+          tester,
+          'iron',
+          // ignore: avoid_hardcoded_strings_in_widgets
+          '—',
+        );
+
+        expect(
+          emDashPriceRight,
+          closeTo(integerPriceRight, 1),
+          reason: 'Em-dash fallback must right-align in the same column as '
+              'integer prices.',
+        );
+
+        final coinFinder = find.descendant(
+          of: find.byKey(TradeScreen.marketCommodityRowKey('iron')),
+          matching: find.byKey(TradeScreen.marketRowPriceCoinIconKey('iron')),
+        );
+        expect(
+          coinFinder,
+          findsOneWidget,
+          reason: 'Treasury-coin glyph must remain mounted for em-dash rows.',
         );
       },
     );


### PR DESCRIPTION
## Summary
- Closes the verification gap on **#3487 AC4**: adds a widget test that pumps `TradeScreen` with the em-dash price fallback and asserts the price glyph shares the same right-aligned trailing column as integer prices.
- Introduces `@visibleForTesting TradeScreen.marketPriceResourceRulesOverride` so tests can exercise the defensive no-catalog-default path without affecting production rules.
- Tightens geometry finders to scope price text under the coin+price trailing `Row` (avoids collision with the quantity-idle em-dash).

## SPEC
- No SPEC change — behavior was already implemented in #3490; this PR only adds the missing AC4 test coverage called out in verification.

## Tests
- `cd app && flutter test test/trade_screen_market_tab_price_column_test.dart` — green (6 tests)

## Scope / deferred
- **Done:** AC4 em-dash fallback alignment test + coin glyph mount pin.
- **Deferred:** none for #3487 — all listed ACs should now have test coverage once this merges.

Refs #3487


Made with [Cursor](https://cursor.com)