### PR TITLE
feat(ga_runner): persist and resume mid-generation 7-GP evaluation (#3488)

### DIFF
--- a/SPEC/program/ga-runner.md
+++ b/SPEC/program/ga-runner.md
@@ -81,8 +81,18 @@ seats the subject profile.
   generation, subject index, and prior-winner pool, and is independent of the
   randomized-AI fallback RNG stream.
 
-**Deferred (follow-up):** per-stage mid-generation resume (`evaluation_stage` in
-`run-state.json`).
+### Mid-generation resume (Refs #3488)
+
+When SIGINT arrives during the **7-GP stage** after all 2-player games for the
+in-progress generation have completed, the runner persists an
+`evaluation_checkpoint` in `run-state.json` with `evaluation_stage: seven_gp`,
+per-slot stage score arrays, and the next `profile_index` / `game_index`. The
+`current_generation` field remains at the last **fully completed** generation.
+
+`ga_runner --resume` continues the interrupted generation from the checkpoint:
+completed 2-player artifacts are not replayed; only unfinished 7-GP games run.
+SIGINT during the 2-player stage still abandons the in-progress generation with
+no checkpoint (unchanged).
 
 ## Master seed resolution (Refs #3486)
 
@@ -212,6 +222,12 @@ re-running games.
 - Given generation 0 with zero prior GA winners, when building a 7-GP roster,
   then all six opponent seats use the configured default-AI and randomized-AI
   fallback counts (defaults `3` + `3`).
+- Given interruption during the 7-GP stage after all 2-player games completed,
+  when `ga_runner --resume` continues, then completed 2-player artifacts are
+  not replayed and only unfinished 7-GP games resume from `evaluation_checkpoint`.
+- Given interruption during the 2-player stage, when `ga_runner --resume`
+  continues, then the runner resumes at the last fully completed generation
+  (no partial 2-player checkpoint).
 - Given a `ga-config.json` whose `seven_gp_opponent_selection` is `random`, when
   `GaConfig.fromJson` parses it, then the system does not throw and
   `config.sevenGpOpponentSelection == 'random'`.

--- a/tool/ga_runner/lib/engine/ga_engine.dart
+++ b/tool/ga_runner/lib/engine/ga_engine.dart
@@ -216,77 +216,30 @@ class GaEngine {
       for (final m in population) m.slotId: <double>[],
     };
 
-    if (checkpoint != null) {
-      for (final entry in checkpoint.twoPlayerScores.entries) {
-        twoPlayerScores[entry.key] = List<double>.from(entry.value);
-      }
-      for (final entry in checkpoint.sevenGpScores.entries) {
-        sevenGpScores[entry.key] = List<double>.from(entry.value);
-      }
-    }
+    _restoreScoresFromCheckpoint(
+      checkpoint: checkpoint,
+      twoPlayerScores: twoPlayerScores,
+      sevenGpScores: sevenGpScores,
+    );
 
     final skipTwoPlayer =
         checkpoint != null && checkpoint.generation == generation;
 
     if (!skipTwoPlayer) {
-      for (var profileIndex = 0; profileIndex < population.length; profileIndex++) {
-        final subject = population[profileIndex];
-        for (var gameIndex = 0; gameIndex < config.gamesPerProfile; gameIndex++) {
-          if (shouldStop()) {
-            _log.i('ga:evaluation_interrupted generation=$generation');
-            return (
-              fitnessBySlot: const <String, double>{},
-              complete: false,
-              checkpoint: null,
-            );
-          }
-          final opponentIndex = _pickOpponentIndex(
-            subjectIndex: profileIndex,
-            populationLength: population.length,
-            rng: rng,
-          );
-          final opponent = population[opponentIndex];
-          final roundDir =
-              '$runDir/gen-${generation.toString().padLeft(3, '0')}/'
-              '${subject.slotId}-g${gameIndex.toString().padLeft(2, '0')}';
-          final gameSeed = deriveGameSeed(
-            config.seed,
-            generation,
-            profileIndex,
-            gameIndex,
-          );
-          final setup = withGameSeed(config.gameSetupConfig, gameSeed);
-          final capitals = resolveCapitalProvinces(setup);
-          await materializeRoundArtifacts(
-            roundDir: roundDir,
-            setup: setup,
-            profileA: subject.profile,
-            profileB: opponent.profile,
-            capitalProvinces: capitals,
-          );
-
-          final score = await _runObserverAndScore(
-            roundDir: roundDir,
-            gameSeed: gameSeed,
-            generation: generation,
-            profileSlotId: subject.slotId,
-            gameIndex: gameIndex,
-            stageLabel: 'two_player',
-          );
-          if (score != null) {
-            twoPlayerScores[subject.slotId]!.add(score);
-          }
-        }
+      final interrupted = await _evaluateTwoPlayerStage(
+        generation: generation,
+        population: population,
+        rng: rng,
+        twoPlayerScores: twoPlayerScores,
+      );
+      if (interrupted) {
+        return (
+          fitnessBySlot: const <String, double>{},
+          complete: false,
+          checkpoint: null,
+        );
       }
     }
-
-    final priorWinners = loadPriorGenerationWinners(
-      runDir: runDir,
-      beforeGeneration: generation,
-    );
-    final blessedProfiles = config.sevenGpUseBlessedProfiles
-        ? _loadBlessedProfiles()
-        : const <AiProfile>[];
 
     final sevenGpStartProfile = checkpoint?.generation == generation
         ? checkpoint!.profileIndex
@@ -295,8 +248,126 @@ class GaEngine {
         ? checkpoint!.gameIndex
         : 0;
 
+    final sevenGpCheckpoint = await _evaluateSevenGpStage(
+      generation: generation,
+      population: population,
+      twoPlayerScores: twoPlayerScores,
+      sevenGpScores: sevenGpScores,
+      startProfileIndex: sevenGpStartProfile,
+      startGameIndex: sevenGpStartGame,
+    );
+    if (sevenGpCheckpoint != null) {
+      return (
+        fitnessBySlot: const <String, double>{},
+        complete: false,
+        checkpoint: sevenGpCheckpoint,
+      );
+    }
+
+    return (
+      fitnessBySlot: {
+        for (final member in population)
+          member.slotId: combineStageFitness(
+            twoPlayerFitness: meanStageFitness(twoPlayerScores[member.slotId]!),
+            sevenGpFitness: config.sevenGpGamesPerProfile == 0 ||
+                    twoPlayerScores[member.slotId]!.isEmpty
+                ? null
+                : meanStageFitness(sevenGpScores[member.slotId]!),
+            weights: config.stageFitnessWeights,
+            sevenGpSkipped: twoPlayerScores[member.slotId]!.isEmpty,
+          ),
+      },
+      complete: true,
+      checkpoint: null,
+    );
+  }
+
+  void _restoreScoresFromCheckpoint({
+    required GaEvaluationCheckpoint? checkpoint,
+    required Map<String, List<double>> twoPlayerScores,
+    required Map<String, List<double>> sevenGpScores,
+  }) {
+    if (checkpoint == null) return;
+    for (final entry in checkpoint.twoPlayerScores.entries) {
+      twoPlayerScores[entry.key] = List<double>.from(entry.value);
+    }
+    for (final entry in checkpoint.sevenGpScores.entries) {
+      sevenGpScores[entry.key] = List<double>.from(entry.value);
+    }
+  }
+
+  Future<bool> _evaluateTwoPlayerStage({
+    required int generation,
+    required List<PopulationMember> population,
+    required math.Random rng,
+    required Map<String, List<double>> twoPlayerScores,
+  }) async {
+    for (var profileIndex = 0; profileIndex < population.length; profileIndex++) {
+      final subject = population[profileIndex];
+      for (var gameIndex = 0; gameIndex < config.gamesPerProfile; gameIndex++) {
+        if (shouldStop()) {
+          _log.i('ga:evaluation_interrupted generation=$generation');
+          return true;
+        }
+        final opponentIndex = _pickOpponentIndex(
+          subjectIndex: profileIndex,
+          populationLength: population.length,
+          rng: rng,
+        );
+        final opponent = population[opponentIndex];
+        final roundDir =
+            '$runDir/gen-${generation.toString().padLeft(3, '0')}/'
+            '${subject.slotId}-g${gameIndex.toString().padLeft(2, '0')}';
+        final gameSeed = deriveGameSeed(
+          config.seed,
+          generation,
+          profileIndex,
+          gameIndex,
+        );
+        final setup = withGameSeed(config.gameSetupConfig, gameSeed);
+        final capitals = resolveCapitalProvinces(setup);
+        await materializeRoundArtifacts(
+          roundDir: roundDir,
+          setup: setup,
+          profileA: subject.profile,
+          profileB: opponent.profile,
+          capitalProvinces: capitals,
+        );
+
+        final score = await _runObserverAndScore(
+          roundDir: roundDir,
+          gameSeed: gameSeed,
+          generation: generation,
+          profileSlotId: subject.slotId,
+          gameIndex: gameIndex,
+          stageLabel: 'two_player',
+        );
+        if (score != null) {
+          twoPlayerScores[subject.slotId]!.add(score);
+        }
+      }
+    }
+    return false;
+  }
+
+  Future<GaEvaluationCheckpoint?> _evaluateSevenGpStage({
+    required int generation,
+    required List<PopulationMember> population,
+    required Map<String, List<double>> twoPlayerScores,
+    required Map<String, List<double>> sevenGpScores,
+    required int startProfileIndex,
+    required int startGameIndex,
+  }) async {
+    final priorWinners = loadPriorGenerationWinners(
+      runDir: runDir,
+      beforeGeneration: generation,
+    );
+    final blessedProfiles = config.sevenGpUseBlessedProfiles
+        ? _loadBlessedProfiles()
+        : const <AiProfile>[];
+
     for (
-      var profileIndex = sevenGpStartProfile;
+      var profileIndex = startProfileIndex;
       profileIndex < population.length;
       profileIndex++
     ) {
@@ -319,24 +390,19 @@ class GaEngine {
         subjectIndex: profileIndex,
       );
 
-      final gameStartIndex = profileIndex == sevenGpStartProfile
-          ? sevenGpStartGame
-          : 0;
+      final gameStartIndex =
+          profileIndex == startProfileIndex ? startGameIndex : 0;
       for (var gameIndex = gameStartIndex;
           gameIndex < config.sevenGpGamesPerProfile;
           gameIndex++) {
         if (shouldStop()) {
           _log.i('ga:evaluation_interrupted generation=$generation');
-          return (
-            fitnessBySlot: const <String, double>{},
-            complete: false,
-            checkpoint: GaEvaluationCheckpoint(
-              generation: generation,
-              twoPlayerScores: _copyScoreMap(twoPlayerScores),
-              sevenGpScores: _copyScoreMap(sevenGpScores),
-              profileIndex: profileIndex,
-              gameIndex: gameIndex,
-            ),
+          return GaEvaluationCheckpoint(
+            generation: generation,
+            twoPlayerScores: _copyScoreMap(twoPlayerScores),
+            sevenGpScores: _copyScoreMap(sevenGpScores),
+            profileIndex: profileIndex,
+            gameIndex: gameIndex,
           );
         }
         final roundDir =
@@ -375,23 +441,7 @@ class GaEngine {
         }
       }
     }
-
-    return (
-      fitnessBySlot: {
-        for (final member in population)
-          member.slotId: combineStageFitness(
-            twoPlayerFitness: meanStageFitness(twoPlayerScores[member.slotId]!),
-            sevenGpFitness: config.sevenGpGamesPerProfile == 0 ||
-                    twoPlayerScores[member.slotId]!.isEmpty
-                ? null
-                : meanStageFitness(sevenGpScores[member.slotId]!),
-            weights: config.stageFitnessWeights,
-            sevenGpSkipped: twoPlayerScores[member.slotId]!.isEmpty,
-          ),
-      },
-      complete: true,
-      checkpoint: null,
-    );
+    return null;
   }
 
   Map<String, List<double>> _copyScoreMap(Map<String, List<double>> source) =>

--- a/tool/ga_runner/lib/engine/ga_engine.dart
+++ b/tool/ga_runner/lib/engine/ga_engine.dart
@@ -65,7 +65,8 @@ class GaEngine {
   }
 
   Future<int> resume(GaRunState state) async {
-    if (state.currentGeneration >= state.config.maxGenerations - 1) {
+    if (state.evaluationCheckpoint == null &&
+        state.currentGeneration >= state.config.maxGenerations - 1) {
       await exportBestOverallProfile(runDir, state.bestOverall);
       _log.i('ga:already_complete generation=${state.currentGeneration}');
       return 0;
@@ -73,11 +74,13 @@ class GaEngine {
     final rng = math.Random(
       state.config.seed + (state.currentGeneration + 1) * 1009,
     );
+    final startGeneration = state.evaluationCheckpoint?.generation ??
+        state.currentGeneration + 1;
     return _runGenerations(
       state,
       state.population,
       rng,
-      startGeneration: state.currentGeneration + 1,
+      startGeneration: startGeneration,
     );
   }
 
@@ -90,6 +93,7 @@ class GaEngine {
     var current = population;
     var bestOverall = state.bestOverall;
     var convergence = state.convergence;
+    var evaluationCheckpoint = state.evaluationCheckpoint;
 
     for (var gen = startGeneration; gen < config.maxGenerations; gen++) {
       if (shouldStop()) {
@@ -98,15 +102,33 @@ class GaEngine {
       }
 
       _log.i('ga:generation_start index=$gen');
+      final resumeCheckpoint =
+          evaluationCheckpoint?.generation == gen ? evaluationCheckpoint : null;
       final evaluation = await _evaluateGeneration(
         generation: gen,
         population: current,
         rng: rng,
+        checkpoint: resumeCheckpoint,
       );
       if (!evaluation.complete) {
+        if (evaluation.checkpoint != null) {
+          await persistRunState(
+            runDir,
+            GaRunState(
+              runId: state.runId,
+              config: config,
+              currentGeneration: state.currentGeneration,
+              population: current,
+              bestOverall: bestOverall,
+              convergence: convergence,
+              evaluationCheckpoint: evaluation.checkpoint,
+            ),
+          );
+        }
         _log.i('ga:interrupted generation=$gen');
         return 130;
       }
+      evaluationCheckpoint = null;
       final fitnessBySlot = evaluation.fitnessBySlot;
 
       for (final member in current) {
@@ -147,6 +169,7 @@ class GaEngine {
         population: current,
         bestOverall: bestOverall,
         convergence: convergence,
+        evaluationCheckpoint: null,
       );
       await writeProfileFiles(runDir, current);
       await persistRunState(runDir, nextState);
@@ -175,10 +198,16 @@ class GaEngine {
     return 0;
   }
 
-  Future<({Map<String, double> fitnessBySlot, bool complete})> _evaluateGeneration({
+  Future<
+      ({
+        Map<String, double> fitnessBySlot,
+        bool complete,
+        GaEvaluationCheckpoint? checkpoint,
+      })> _evaluateGeneration({
     required int generation,
     required List<PopulationMember> population,
     required math.Random rng,
+    GaEvaluationCheckpoint? checkpoint,
   }) async {
     final twoPlayerScores = <String, List<double>>{
       for (final m in population) m.slotId: <double>[],
@@ -187,48 +216,66 @@ class GaEngine {
       for (final m in population) m.slotId: <double>[],
     };
 
-    for (var profileIndex = 0; profileIndex < population.length; profileIndex++) {
-      final subject = population[profileIndex];
-      for (var gameIndex = 0; gameIndex < config.gamesPerProfile; gameIndex++) {
-        if (shouldStop()) {
-          _log.i('ga:evaluation_interrupted generation=$generation');
-          return (fitnessBySlot: const <String, double>{}, complete: false);
-        }
-        final opponentIndex = _pickOpponentIndex(
-          subjectIndex: profileIndex,
-          populationLength: population.length,
-          rng: rng,
-        );
-        final opponent = population[opponentIndex];
-        final roundDir =
-            '$runDir/gen-${generation.toString().padLeft(3, '0')}/'
-            '${subject.slotId}-g${gameIndex.toString().padLeft(2, '0')}';
-        final gameSeed = deriveGameSeed(
-          config.seed,
-          generation,
-          profileIndex,
-          gameIndex,
-        );
-        final setup = withGameSeed(config.gameSetupConfig, gameSeed);
-        final capitals = resolveCapitalProvinces(setup);
-        await materializeRoundArtifacts(
-          roundDir: roundDir,
-          setup: setup,
-          profileA: subject.profile,
-          profileB: opponent.profile,
-          capitalProvinces: capitals,
-        );
+    if (checkpoint != null) {
+      for (final entry in checkpoint.twoPlayerScores.entries) {
+        twoPlayerScores[entry.key] = List<double>.from(entry.value);
+      }
+      for (final entry in checkpoint.sevenGpScores.entries) {
+        sevenGpScores[entry.key] = List<double>.from(entry.value);
+      }
+    }
 
-        final score = await _runObserverAndScore(
-          roundDir: roundDir,
-          gameSeed: gameSeed,
-          generation: generation,
-          profileSlotId: subject.slotId,
-          gameIndex: gameIndex,
-          stageLabel: 'two_player',
-        );
-        if (score != null) {
-          twoPlayerScores[subject.slotId]!.add(score);
+    final skipTwoPlayer =
+        checkpoint != null && checkpoint.generation == generation;
+
+    if (!skipTwoPlayer) {
+      for (var profileIndex = 0; profileIndex < population.length; profileIndex++) {
+        final subject = population[profileIndex];
+        for (var gameIndex = 0; gameIndex < config.gamesPerProfile; gameIndex++) {
+          if (shouldStop()) {
+            _log.i('ga:evaluation_interrupted generation=$generation');
+            return (
+              fitnessBySlot: const <String, double>{},
+              complete: false,
+              checkpoint: null,
+            );
+          }
+          final opponentIndex = _pickOpponentIndex(
+            subjectIndex: profileIndex,
+            populationLength: population.length,
+            rng: rng,
+          );
+          final opponent = population[opponentIndex];
+          final roundDir =
+              '$runDir/gen-${generation.toString().padLeft(3, '0')}/'
+              '${subject.slotId}-g${gameIndex.toString().padLeft(2, '0')}';
+          final gameSeed = deriveGameSeed(
+            config.seed,
+            generation,
+            profileIndex,
+            gameIndex,
+          );
+          final setup = withGameSeed(config.gameSetupConfig, gameSeed);
+          final capitals = resolveCapitalProvinces(setup);
+          await materializeRoundArtifacts(
+            roundDir: roundDir,
+            setup: setup,
+            profileA: subject.profile,
+            profileB: opponent.profile,
+            capitalProvinces: capitals,
+          );
+
+          final score = await _runObserverAndScore(
+            roundDir: roundDir,
+            gameSeed: gameSeed,
+            generation: generation,
+            profileSlotId: subject.slotId,
+            gameIndex: gameIndex,
+            stageLabel: 'two_player',
+          );
+          if (score != null) {
+            twoPlayerScores[subject.slotId]!.add(score);
+          }
         }
       }
     }
@@ -241,7 +288,18 @@ class GaEngine {
         ? _loadBlessedProfiles()
         : const <AiProfile>[];
 
-    for (var profileIndex = 0; profileIndex < population.length; profileIndex++) {
+    final sevenGpStartProfile = checkpoint?.generation == generation
+        ? checkpoint!.profileIndex
+        : 0;
+    final sevenGpStartGame = checkpoint?.generation == generation
+        ? checkpoint!.gameIndex
+        : 0;
+
+    for (
+      var profileIndex = sevenGpStartProfile;
+      profileIndex < population.length;
+      profileIndex++
+    ) {
       final subject = population[profileIndex];
       final scoredTwoPlayer = twoPlayerScores[subject.slotId]!;
       if (config.sevenGpGamesPerProfile == 0 || scoredTwoPlayer.isEmpty) {
@@ -253,18 +311,33 @@ class GaEngine {
         priorWinners: priorWinners,
         blessedProfiles: blessedProfiles,
         config: config,
-        rng: rng,
+        rng: math.Random(
+          deriveSevenGpRosterSeed(config.seed, generation, profileIndex),
+        ),
         masterSeed: config.seed,
         generation: generation,
         subjectIndex: profileIndex,
       );
 
-      for (var gameIndex = 0;
+      final gameStartIndex = profileIndex == sevenGpStartProfile
+          ? sevenGpStartGame
+          : 0;
+      for (var gameIndex = gameStartIndex;
           gameIndex < config.sevenGpGamesPerProfile;
           gameIndex++) {
         if (shouldStop()) {
           _log.i('ga:evaluation_interrupted generation=$generation');
-          return (fitnessBySlot: const <String, double>{}, complete: false);
+          return (
+            fitnessBySlot: const <String, double>{},
+            complete: false,
+            checkpoint: GaEvaluationCheckpoint(
+              generation: generation,
+              twoPlayerScores: _copyScoreMap(twoPlayerScores),
+              sevenGpScores: _copyScoreMap(sevenGpScores),
+              profileIndex: profileIndex,
+              gameIndex: gameIndex,
+            ),
+          );
         }
         final roundDir =
             '$runDir/gen-${generation.toString().padLeft(3, '0')}/'
@@ -317,8 +390,12 @@ class GaEngine {
           ),
       },
       complete: true,
+      checkpoint: null,
     );
   }
+
+  Map<String, List<double>> _copyScoreMap(Map<String, List<double>> source) =>
+      source.map((k, v) => MapEntry(k, List<double>.from(v)));
 
   List<AiProfile> _loadBlessedProfiles() {
     final manifest = BlessedProfileManifest.readFile(

--- a/tool/ga_runner/lib/engine/ga_seeds.dart
+++ b/tool/ga_runner/lib/engine/ga_seeds.dart
@@ -53,3 +53,18 @@ int deriveSevenGpSelectionSeed(
     (generation * 1000003) ^
     (subjectIndex * 9973) ^
     _kSevenGpSelectionSalt;
+
+const int _kSevenGpRosterSalt = 0x57057E2;
+
+/// Per-subject RNG seed for randomized-AI base-profile picks in 7-GP rosters.
+/// Deterministic for resume so mid-generation continuation does not depend on
+/// shared [Random] consumption order.
+int deriveSevenGpRosterSeed(
+  int masterSeed,
+  int generation,
+  int subjectIndex,
+) =>
+    masterSeed ^
+    (generation * 1000003) ^
+    (subjectIndex * 9973) ^
+    _kSevenGpRosterSalt;

--- a/tool/ga_runner/lib/persistence/run_state.dart
+++ b/tool/ga_runner/lib/persistence/run_state.dart
@@ -9,6 +9,76 @@ import '../genetics/population.dart';
 /// Supported `run-state.json` schema version.
 const int kGaRunStateSchemaVersion = 1;
 
+/// Mid-generation evaluation checkpoint when SIGINT arrives during the 7-GP
+/// stage after all 2-player games completed. Refs #3488.
+class GaEvaluationCheckpoint {
+  const GaEvaluationCheckpoint({
+    required this.generation,
+    required this.twoPlayerScores,
+    required this.sevenGpScores,
+    required this.profileIndex,
+    required this.gameIndex,
+  });
+
+  /// Generation index being evaluated (not yet persisted as complete).
+  final int generation;
+
+  /// Per-slot successfully scored 2-player game totals.
+  final Map<String, List<double>> twoPlayerScores;
+
+  /// Per-slot successfully scored 7-GP game totals (may be partial).
+  final Map<String, List<double>> sevenGpScores;
+
+  /// Next profile index in the 7-GP loop.
+  final int profileIndex;
+
+  /// Next game index within [profileIndex]'s 7-GP stage.
+  final int gameIndex;
+
+  static const String stageSevenGp = 'seven_gp';
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+    'generation': generation,
+    'evaluation_stage': stageSevenGp,
+    'two_player_scores': twoPlayerScores.map(
+      (k, v) => MapEntry(k, List<double>.from(v)),
+    ),
+    'seven_gp_scores': sevenGpScores.map(
+      (k, v) => MapEntry(k, List<double>.from(v)),
+    ),
+    'profile_index': profileIndex,
+    'game_index': gameIndex,
+  };
+
+  factory GaEvaluationCheckpoint.fromJson(Map<String, dynamic> json) {
+    final stage = json['evaluation_stage'] as String?;
+    if (stage != stageSevenGp) {
+      throw FormatException(
+        'unsupported evaluation_stage $stage (expected $stageSevenGp)',
+      );
+    }
+    return GaEvaluationCheckpoint(
+      generation: (json['generation'] as num).toInt(),
+      twoPlayerScores: _readScoreMap(json['two_player_scores']),
+      sevenGpScores: _readScoreMap(json['seven_gp_scores']),
+      profileIndex: (json['profile_index'] as num).toInt(),
+      gameIndex: (json['game_index'] as num).toInt(),
+    );
+  }
+
+  static Map<String, List<double>> _readScoreMap(Object? raw) {
+    if (raw is! Map<String, dynamic>) {
+      throw const FormatException('checkpoint score map must be an object');
+    }
+    return raw.map(
+      (k, v) => MapEntry(
+        k,
+        (v as List<dynamic>).map((e) => (e as num).toDouble()).toList(),
+      ),
+    );
+  }
+}
+
 /// Serializable GA run state. SPEC/program/ga-runner.md.
 class GaRunState {
   GaRunState({
@@ -18,6 +88,7 @@ class GaRunState {
     required this.population,
     required this.bestOverall,
     required this.convergence,
+    this.evaluationCheckpoint,
   });
 
   final String runId;
@@ -26,6 +97,9 @@ class GaRunState {
   final List<PopulationMember> population;
   final GaBestOverall bestOverall;
   final GaConvergence convergence;
+
+  /// Non-null when a generation was interrupted during the 7-GP stage.
+  final GaEvaluationCheckpoint? evaluationCheckpoint;
 
   Map<String, dynamic> toJson() => <String, dynamic>{
     'schema_version': kGaRunStateSchemaVersion,
@@ -42,6 +116,8 @@ class GaRunState {
     ],
     'best_overall': bestOverall.toJson(),
     'convergence': convergence.toJson(),
+    if (evaluationCheckpoint != null)
+      'evaluation_checkpoint': evaluationCheckpoint!.toJson(),
   };
 
   factory GaRunState.fromJson(Map<String, dynamic> json, String runDir) {
@@ -98,6 +174,14 @@ class GaRunState {
     if (convJson is! Map<String, dynamic>) {
       throw const FormatException('convergence must be an object');
     }
+    final checkpointJson = json['evaluation_checkpoint'];
+    GaEvaluationCheckpoint? checkpoint;
+    if (checkpointJson != null) {
+      if (checkpointJson is! Map<String, dynamic>) {
+        throw const FormatException('evaluation_checkpoint must be an object');
+      }
+      checkpoint = GaEvaluationCheckpoint.fromJson(checkpointJson);
+    }
     return GaRunState(
       runId: json['run_id'] as String? ?? 'unknown',
       config: config,
@@ -105,6 +189,7 @@ class GaRunState {
       population: population,
       bestOverall: GaBestOverall.fromJson(bestJson),
       convergence: GaConvergence.fromJson(convJson),
+      evaluationCheckpoint: checkpoint,
     );
   }
 }
@@ -122,15 +207,25 @@ class GaBestOverall {
 
   Map<String, dynamic> toJson() => <String, dynamic>{
     'profile_id': profileId,
-    'fitness': fitness,
+    if (fitness.isFinite) 'fitness': fitness,
     'generation': generation,
   };
 
-  factory GaBestOverall.fromJson(Map<String, dynamic> json) => GaBestOverall(
-    profileId: json['profile_id'] as String? ?? '',
-    fitness: (json['fitness'] as num?)?.toDouble() ?? 0.0,
-    generation: (json['generation'] as num?)?.toInt() ?? 0,
-  );
+  factory GaBestOverall.fromJson(Map<String, dynamic> json) {
+    final generation = (json['generation'] as num?)?.toInt() ?? 0;
+    final rawFitness = json['fitness'];
+    final double fitness;
+    if (rawFitness == null) {
+      fitness = generation < 0 ? double.negativeInfinity : 0.0;
+    } else {
+      fitness = (rawFitness as num).toDouble();
+    }
+    return GaBestOverall(
+      profileId: json['profile_id'] as String? ?? '',
+      fitness: fitness,
+      generation: generation,
+    );
+  }
 }
 
 class GaConvergence {

--- a/tool/ga_runner/test/ga_engine_test.dart
+++ b/tool/ga_runner/test/ga_engine_test.dart
@@ -319,6 +319,66 @@ void main() {
       }
     });
 
+    test('resumes 7-GP stage from checkpoint without replaying 2-player games',
+        () async {
+      final seedsDir = await _seedDir();
+      final runDir = await Directory.systemTemp.createTemp('ga_run_7gp_resume_');
+      var gamesCompleted = 0;
+      const stopAfterGames = 3;
+      try {
+        final config = testGaConfig(
+          seedProfilesDir: seedsDir,
+          gameSetupConfig: testTwoPlayerSetup(),
+          outputDir: runDir.parent.path,
+          sevenGpGamesPerProfile: 1,
+        );
+        final engine = GaEngine(
+          repoRoot: Directory.current.path,
+          config: config,
+          runDir: runDir.path,
+          observerRunner: _FakeObserverRunner(
+            onGameComplete: () => gamesCompleted++,
+          ),
+          shouldStop: () => gamesCompleted >= stopAfterGames,
+        );
+        expect(await engine.runFresh(runId: 'ga-run-7gp-resume'), 130);
+        final interrupted = loadRunState(runDir.path);
+        expect(interrupted.evaluationCheckpoint, isNotNull);
+        expect(interrupted.evaluationCheckpoint!.generation, 0);
+        expect(interrupted.currentGeneration, -1);
+        expect(
+          Directory('${runDir.path}/gen-000')
+              .listSync()
+              .where((e) => e.path.contains('-7gp-')),
+          hasLength(1),
+        );
+
+        gamesCompleted = 0;
+        final resumeEngine = GaEngine(
+          repoRoot: Directory.current.path,
+          config: config,
+          runDir: runDir.path,
+          observerRunner: _FakeObserverRunner(
+            onGameComplete: () => gamesCompleted++,
+          ),
+        );
+        expect(await resumeEngine.resume(interrupted), 0);
+        expect(gamesCompleted, 1);
+        expect(
+          Directory('${runDir.path}/gen-000')
+              .listSync()
+              .where((e) => e.path.contains('-7gp-')),
+          hasLength(2),
+        );
+        final completed = loadRunState(runDir.path);
+        expect(completed.evaluationCheckpoint, isNull);
+        expect(completed.currentGeneration, 0);
+      } finally {
+        await Directory(seedsDir).delete(recursive: true);
+        await runDir.delete(recursive: true);
+      }
+    });
+
     test('skips 7-GP stage when all 2-player games fail', () async {
       final seedsDir = await _seedDir();
       final runDir = await Directory.systemTemp.createTemp('ga_run_7gp_skip_');

--- a/tool/ga_runner/test/run_state_test.dart
+++ b/tool/ga_runner/test/run_state_test.dart
@@ -175,5 +175,59 @@ void main() {
         await dir.delete(recursive: true);
       }
     });
+
+    test('round-trips evaluation_checkpoint for 7-GP resume (#3488)', () async {
+      final dir = await Directory.systemTemp.createTemp('ga_state_ckpt_');
+      try {
+        final config = testGaConfig(
+          seedProfilesDir: 'seeds',
+          gameSetupConfig: testTwoPlayerSetup(),
+        );
+        final members = <PopulationMember>[
+          PopulationMember(
+            slotId: 'profile-000',
+            profile: seedAiProfilesById['victoria']!,
+          ),
+        ];
+        await writeProfileFiles(dir.path, members);
+        final checkpoint = GaEvaluationCheckpoint(
+          generation: 0,
+          twoPlayerScores: <String, List<double>>{
+            'profile-000': <double>[12.0],
+          },
+          sevenGpScores: <String, List<double>>{
+            'profile-000': <double>[],
+          },
+          profileIndex: 0,
+          gameIndex: 0,
+        );
+        await persistRunState(
+          dir.path,
+          GaRunState(
+            runId: 'ga-run-ckpt',
+            config: config,
+            currentGeneration: -1,
+            population: members,
+            bestOverall: const GaBestOverall(
+              profileId: '',
+              fitness: double.negativeInfinity,
+              generation: -1,
+            ),
+            convergence: GaConvergence(),
+            evaluationCheckpoint: checkpoint,
+          ),
+        );
+
+        final loaded = loadRunState(dir.path);
+        expect(loaded.evaluationCheckpoint?.generation, 0);
+        expect(loaded.evaluationCheckpoint?.profileIndex, 0);
+        expect(
+          loaded.evaluationCheckpoint?.twoPlayerScores['profile-000'],
+          <double>[12.0],
+        );
+      } finally {
+        await dir.delete(recursive: true);
+      }
+    });
   });
 }


### PR DESCRIPTION
## Summary
- Adds `evaluation_checkpoint` to `run-state.json` so a SIGINT during the 7-GP stage (after all 2-player games for the in-progress generation finish) persists partial progress and `--resume` continues only unfinished 7-GP games.
- Skips replaying the 2-player stage when resuming from a `seven_gp` checkpoint; clears the checkpoint when the generation completes.
- Uses per-subject `deriveSevenGpRosterSeed` for randomized-AI base-profile picks so roster construction stays deterministic across resume.

## SPEC
- `SPEC/program/ga-runner.md`: documents mid-generation resume semantics and ACs; removes the prior deferral note for this slice.

## Tests
- `cd tool/ga_runner && dart test` — green (129 tests)
- New integration test: interrupt mid-7-GP, resume completes generation without extra 2-player games
- New persistence test: `evaluation_checkpoint` round-trip

## Scope / deferred
- **Done:** AC for 7-GP-stage SIGINT resume (partial generation continuation); 2-player-stage SIGINT behavior unchanged (no checkpoint).
- **Deferred:** none for this slice — prior PRs #3492/#3493 landed core pipeline and `random` opponent selection.

Refs #3488

Made with [Cursor](https://cursor.com)