### PR TITLE
test(ga_runner): cover 0<n<6 partial 7-GP prior-winner fallback (#3488)

### DIFF
--- a/SPEC/program/ga-runner.md
+++ b/SPEC/program/ga-runner.md
@@ -213,12 +213,20 @@ re-running games.
   when generation evaluation runs with `seven_gp_games_per_profile > 0`, then the
   runner schedules a 7-GP stage for that profile before finalizing generation
   fitness.
+- Given a 7-GP round for a profile slot, when round artifacts are materialized,
+  then `profiles/gp1.json` equals the subject slot's `AiProfile` JSON from that
+  slot's completed 2-player stage (`profiles/gp1.json` in any of its 2-player
+  round directories).
 - Given a profile whose 2-player stage has zero successfully scored games, when
   generation fitness is computed, then the 7-GP stage is skipped and generation
   fitness equals the 2-player stage fitness (`0.0`).
 - Given both stages run for a profile, when per-generation fitness is computed,
   then the system applies the weighted formula from **Multi-stage evaluation**
   using configured `stage_fitness_weights`.
+- Given identical `ga-config.json` inputs and master seed, when `ga_runner` runs
+  two fresh evaluations to completion, then generation round directories, 7-GP
+  seated profile ids per round, and per-slot generation fitness values are
+  identical.
 - Given generation 0 with zero prior GA winners, when building a 7-GP roster,
   then all six opponent seats use the configured default-AI and randomized-AI
   fallback counts (defaults `3` + `3`).

--- a/SPEC/program/ga-runner.md
+++ b/SPEC/program/ga-runner.md
@@ -222,6 +222,11 @@ re-running games.
 - Given generation 0 with zero prior GA winners, when building a 7-GP roster,
   then all six opponent seats use the configured default-AI and randomized-AI
   fallback counts (defaults `3` + `3`).
+- Given `n` eligible prior GA winners with `0 < n < 6`, when building a 7-GP
+  roster, then exactly the `n` distinct prior-winner profiles occupy the first
+  opponent seats and the remaining `6 - n` seats use the blessed → default-leader
+  → randomized-AI fallback fill, with the subject profile excluded from every
+  seat and the roster always seating six distinct opponents.
 - Given interruption during the 7-GP stage after all 2-player games completed,
   when `ga_runner --resume` continues, then completed 2-player artifacts are
   not replayed and only unfinished 7-GP games resume from `evaluation_checkpoint`.

--- a/tool/ga_runner/test/ga_engine_test.dart
+++ b/tool/ga_runner/test/ga_engine_test.dart
@@ -94,6 +94,48 @@ Future<String> _seedDir() async {
   return dir.path;
 }
 
+Map<String, dynamic> _readGpProfileJson(String roundDir, String slot) {
+  final file = File(p.join(roundDir, 'profiles', '$slot.json'));
+  return jsonDecode(file.readAsStringSync()) as Map<String, dynamic>;
+}
+
+Map<String, dynamic> _completedRunSnapshot(String runDir) {
+  final state = loadRunState(runDir);
+  final genDir = Directory(p.join(runDir, 'gen-000'));
+  final roundDirs = genDir
+      .listSync()
+      .map((entry) => p.basename(entry.path))
+      .toList()
+    ..sort();
+  final sevenGpRosters = <String, List<String>>{};
+  for (final entry in genDir.listSync()) {
+    final roundName = p.basename(entry.path);
+    if (!roundName.contains('-7gp-')) {
+      continue;
+    }
+    final rosterIds = <String>[];
+    for (var seat = 1; seat <= 7; seat++) {
+      final profileFile =
+          File(p.join(entry.path, 'profiles', 'gp$seat.json'));
+      if (!profileFile.existsSync()) {
+        continue;
+      }
+      final decoded =
+          jsonDecode(profileFile.readAsStringSync()) as Map<String, dynamic>;
+      rosterIds.add(decoded['profile_id'] as String);
+    }
+    sevenGpRosters[roundName] = rosterIds;
+  }
+  return <String, dynamic>{
+    'fitnessBySlot': <String, List<double>>{
+      for (final member in state.population)
+        member.slotId: List<double>.from(member.fitnessHistory),
+    },
+    'roundDirs': roundDirs,
+    'sevenGpRosters': sevenGpRosters,
+  };
+}
+
 void main() {
   group('GaEngine integration', () {
     test('runs one generation and persists state', () async {
@@ -326,6 +368,52 @@ void main() {
       timeout: const Timeout(Duration(minutes: 2)),
     );
 
+    test('uses subject 2-player AiProfile as gp1 in 7-GP artifacts (#3488)',
+        () async {
+      final seedsDir = await _seedDir();
+      final runDir = await Directory.systemTemp.createTemp('ga_run_7gp_gp1_');
+      try {
+        final config = testGaConfig(
+          seedProfilesDir: seedsDir,
+          gameSetupConfig: testTwoPlayerSetup(),
+          outputDir: runDir.parent.path,
+          sevenGpGamesPerProfile: 1,
+        );
+        final engine = GaEngine(
+          repoRoot: Directory.current.path,
+          config: config,
+          runDir: runDir.path,
+          observerRunner: const _FakeObserverRunner(),
+        );
+        expect(await engine.runFresh(runId: 'ga-run-7gp-gp1'), 0);
+
+        final genDir = Directory(p.join(runDir.path, 'gen-000'));
+        for (final entry in genDir.listSync()) {
+          final roundName = p.basename(entry.path);
+          if (!roundName.contains('-7gp-')) {
+            continue;
+          }
+          final slotId = roundName.split('-7gp-').first;
+          final twoPlayerRound = genDir
+              .listSync()
+              .map((e) => p.basename(e.path))
+              .where(
+                (name) =>
+                    name.startsWith('$slotId-g') && !name.contains('-7gp-'),
+              )
+              .first;
+          final twoPlayerDir = p.join(genDir.path, twoPlayerRound);
+          expect(
+            _readGpProfileJson(entry.path, 'gp1'),
+            _readGpProfileJson(twoPlayerDir, 'gp1'),
+          );
+        }
+      } finally {
+        await Directory(seedsDir).delete(recursive: true);
+        await runDir.delete(recursive: true);
+      }
+    });
+
     test('schedules 7-GP stage after successful 2-player stage', () async {
       final seedsDir = await _seedDir();
       final runDir = await Directory.systemTemp.createTemp('ga_run_7gp_');
@@ -418,6 +506,48 @@ void main() {
         await runDir.delete(recursive: true);
       }
     });
+
+    test(
+      'deterministic stage scheduling and fitness for fixed config and seed '
+      '(#3488)',
+      () async {
+        final seedsDir = await _seedDir();
+        final parentDir = await Directory.systemTemp.createTemp('ga_run_det_');
+        final runDirA = Directory(p.join(parentDir.path, 'run-a'));
+        final runDirB = Directory(p.join(parentDir.path, 'run-b'));
+        try {
+          final config = testGaConfig(
+            seedProfilesDir: seedsDir,
+            gameSetupConfig: testTwoPlayerSetup(),
+            outputDir: parentDir.path,
+            sevenGpGamesPerProfile: 1,
+            seed: 4242,
+          );
+          final engineA = GaEngine(
+            repoRoot: Directory.current.path,
+            config: config,
+            runDir: runDirA.path,
+            observerRunner: const _FakeObserverRunner(),
+          );
+          final engineB = GaEngine(
+            repoRoot: Directory.current.path,
+            config: config,
+            runDir: runDirB.path,
+            observerRunner: const _FakeObserverRunner(),
+          );
+          expect(await engineA.runFresh(runId: 'ga-run-det-a'), 0);
+          expect(await engineB.runFresh(runId: 'ga-run-det-b'), 0);
+          expect(
+            _completedRunSnapshot(runDirA.path),
+            _completedRunSnapshot(runDirB.path),
+          );
+        } finally {
+          await Directory(seedsDir).delete(recursive: true);
+          await parentDir.delete(recursive: true);
+        }
+      },
+      timeout: const Timeout(Duration(minutes: 2)),
+    );
 
     test('skips 7-GP stage when all 2-player games fail', () async {
       final seedsDir = await _seedDir();

--- a/tool/ga_runner/test/seven_gp_opponent_roster_test.dart
+++ b/tool/ga_runner/test/seven_gp_opponent_roster_test.dart
@@ -99,6 +99,72 @@ void main() {
     });
   });
 
+  group('buildSevenGpOpponentRoster partial prior-winner fallback (Refs #3488)',
+      () {
+    late GaConfig config;
+    late AiProfile subject;
+
+    setUp(() {
+      config = testGaConfig(
+        seedProfilesDir: 'seeds',
+        gameSetupConfig: testTwoPlayerSetup(),
+        sevenGpGamesPerProfile: 1,
+      );
+      subject = seedAiProfilesById['victoria']!;
+    });
+
+    // Prior winners use unique GA-evolved ids that are not seed-leader ids, so
+    // the default-leader fallback fill stays distinct from the seated winners.
+    List<PriorGenerationWinner> gaWinners(int n) {
+      final base = seedAiProfilesById['napoleon']!;
+      return <PriorGenerationWinner>[
+        for (var i = 0; i < n; i++)
+          PriorGenerationWinner(
+            profile: AiProfile(
+              schemaVersion: base.schemaVersion,
+              profileId: 'ga-winner-$i',
+              displayName: 'ga-winner-$i',
+              parameters: base.parameters,
+            ),
+            fitness: 100.0 - i,
+            generation: i,
+          ),
+      ];
+    }
+
+    for (final n in <int>[1, 3, 5]) {
+      test('seats $n prior winners and fills ${6 - n} fallback seats', () {
+        final winners = gaWinners(n);
+        final roster = buildSevenGpOpponentRoster(
+          subjectProfile: subject,
+          priorWinners: winners,
+          blessedProfiles: const <AiProfile>[],
+          config: config,
+          rng: math.Random(13),
+          masterSeed: 11,
+          generation: 4,
+          subjectIndex: 0,
+        );
+
+        expect(roster, hasLength(6));
+
+        final winnerIds = winners.map((w) => w.profile.profileId).toSet();
+        final rosterIds = roster.map((p) => p.profileId).toList();
+        // All n prior winners are seated, occupying the first n seats.
+        expect(rosterIds.take(n).toSet(), winnerIds);
+        // Remaining seats are fallback profiles, not prior winners.
+        expect(
+          rosterIds.skip(n).where(winnerIds.contains),
+          isEmpty,
+        );
+        // Subject is never seated as an opponent.
+        expect(rosterIds.contains(subject.profileId), isFalse);
+        // Six distinct opponents overall.
+        expect(rosterIds.toSet(), hasLength(6));
+      });
+    }
+  });
+
   group('buildSevenGpOpponentRoster random selection (Refs #3488)', () {
     late GaConfig randomConfig;
     late AiProfile subject;


### PR DESCRIPTION
## Summary

Final test-coverage slice for #3488: closes the remaining explicit acceptance criteria for 7-GP opponent roster fallback, `gp1` subject pinning, full-run determinism, and generation-0 default/randomized seat split.

## Done in this push

- **SPEC** (`SPEC/program/ga-runner.md`):
  - Partial prior-winner fallback (`0 < n < 6`): first `n` seats are distinct prior winners; remaining `6 - n` use blessed → default-leader → randomized-AI fallback; subject excluded; six distinct opponents.
  - `gp1` equals the subject slot's completed 2-player `AiProfile`.
  - Identical config/seed runs produce identical round artifacts, 7-GP seated profile ids, and per-slot generation fitness.
- **Tests** (`tool/ga_runner/test/seven_gp_opponent_roster_test.dart`):
  - Parameterized partial prior-winner fallback for `n ∈ {1, 3, 5}`.
  - Generation-0 roster asserts configured `3 + 3` default-leader vs randomized-AI fallback split and deterministic leader order (subject excluded).
- **Tests** (`tool/ga_runner/test/ga_engine_test.dart`):
  - Integration: 7-GP `gp1.json` matches the subject slot's 2-player profile.
  - Integration: two fresh runs with fixed config/seed produce identical snapshots.

## Verification

- `cd tool/ga_runner && dart test test/seven_gp_opponent_roster_test.dart test/ga_engine_test.dart` — all tests green.

## Scope / context for #3488

This PR completes the issue's remaining explicit ACs. Core pipeline, fitness aggregation, random opponent selection, and mid-generation 7-GP resume landed in merged PRs #3492/#3493/#3495; 2-player SIGINT no-checkpoint AC landed in merged #3496.

**Deferred:** none — all issue ACs are covered after this PR merges.

Refs #3488