### PR TITLE
test(ga_runner): strengthen 7-GP roster AC coverage (#3488)

### DIFF
--- a/tool/ga_runner/test/ga_config_test.dart
+++ b/tool/ga_runner/test/ga_config_test.dart
@@ -251,6 +251,33 @@ void main() {
       );
     });
 
+    test('parses seven_gp_use_blessed_profiles (Refs #3488)', () {
+      final enabled = GaConfig.fromJson(<String, dynamic>{
+        'seed_profiles_dir': 'seeds/',
+        'seed': 7,
+        'game_player_count': 2,
+        'seven_gp_use_blessed_profiles': true,
+        'game_setup_config': <String, dynamic>{
+          'selectedGreatPowerIds': <String>['england', 'france'],
+          'minorNationCount': 3,
+          'tribeCount': 3,
+        },
+      });
+      expect(enabled.sevenGpUseBlessedProfiles, isTrue);
+
+      final disabled = GaConfig.fromJson(<String, dynamic>{
+        'seed_profiles_dir': 'seeds/',
+        'seed': 7,
+        'game_player_count': 2,
+        'game_setup_config': <String, dynamic>{
+          'selectedGreatPowerIds': <String>['england', 'france'],
+          'minorNationCount': 3,
+          'tribeCount': 3,
+        },
+      });
+      expect(disabled.sevenGpUseBlessedProfiles, isFalse);
+    });
+
     test('accepts random seven_gp_opponent_selection (Refs #3488)', () {
       final config = GaConfig.fromJson(<String, dynamic>{
         'seed_profiles_dir': 'seeds/',

--- a/tool/ga_runner/test/seven_gp_opponent_roster_test.dart
+++ b/tool/ga_runner/test/seven_gp_opponent_roster_test.dart
@@ -191,6 +191,94 @@ void main() {
     }
   });
 
+  group('buildSevenGpOpponentRoster blessed profiles (Refs #3488)', () {
+    late GaConfig blessedConfig;
+    late AiProfile subject;
+
+    AiProfile blessedProfile(String id) {
+      final base = seedAiProfilesById['napoleon']!;
+      return AiProfile(
+        schemaVersion: base.schemaVersion,
+        profileId: id,
+        displayName: id,
+        parameters: base.parameters,
+      );
+    }
+
+    setUp(() {
+      blessedConfig = testGaConfig(
+        seedProfilesDir: 'seeds',
+        gameSetupConfig: testTwoPlayerSetup(),
+        sevenGpGamesPerProfile: 1,
+        sevenGpUseBlessedProfiles: true,
+      );
+      subject = seedAiProfilesById['victoria']!;
+    });
+
+    test('seats blessed profiles after prior winners and before fallback fill',
+        () {
+      final blessed = <AiProfile>[
+        blessedProfile('blessed-alpha'),
+        blessedProfile('blessed-beta'),
+      ];
+      final priorWinner = PriorGenerationWinner(
+        profile: seedAiProfilesById['napoleon']!,
+        fitness: 50,
+        generation: 1,
+      );
+      final roster = buildSevenGpOpponentRoster(
+        subjectProfile: subject,
+        priorWinners: <PriorGenerationWinner>[priorWinner],
+        blessedProfiles: blessed,
+        config: blessedConfig,
+        rng: math.Random(5),
+        masterSeed: 11,
+        generation: 2,
+        subjectIndex: 0,
+      );
+
+      expect(roster, hasLength(6));
+      expect(roster.first.profileId, priorWinner.profile.profileId);
+      expect(
+        roster
+            .skip(1)
+            .take(blessed.length)
+            .map((profile) => profile.profileId)
+            .toList(),
+        blessed.map((profile) => profile.profileId).toList(),
+      );
+      expect(
+        roster.map((profile) => profile.profileId).contains(subject.profileId),
+        isFalse,
+      );
+    });
+
+    test('ignores blessed profiles when config disables them', () {
+      final disabledConfig = testGaConfig(
+        seedProfilesDir: 'seeds',
+        gameSetupConfig: testTwoPlayerSetup(),
+        sevenGpGamesPerProfile: 1,
+        sevenGpUseBlessedProfiles: false,
+      );
+      final blessed = <AiProfile>[blessedProfile('blessed-only')];
+      final roster = buildSevenGpOpponentRoster(
+        subjectProfile: subject,
+        priorWinners: const <PriorGenerationWinner>[],
+        blessedProfiles: blessed,
+        config: disabledConfig,
+        rng: math.Random(5),
+        masterSeed: 11,
+        generation: 0,
+        subjectIndex: 0,
+      );
+
+      expect(
+        roster.map((profile) => profile.profileId).contains('blessed-only'),
+        isFalse,
+      );
+    });
+  });
+
   group('buildSevenGpOpponentRoster random selection (Refs #3488)', () {
     late GaConfig randomConfig;
     late AiProfile subject;

--- a/tool/ga_runner/test/seven_gp_opponent_roster_test.dart
+++ b/tool/ga_runner/test/seven_gp_opponent_roster_test.dart
@@ -22,7 +22,8 @@ void main() {
       subject = seedAiProfilesById['victoria']!;
     });
 
-    test('fills six seats from default + randomized AI when no prior winners', () {
+    test('fills six seats from default + randomized AI when no prior winners',
+        () {
       final roster = buildSevenGpOpponentRoster(
         subjectProfile: subject,
         priorWinners: const <PriorGenerationWinner>[],
@@ -38,6 +39,31 @@ void main() {
         roster.map((p) => p.profileId).contains(subject.profileId),
         isFalse,
       );
+
+      final subjectLeaderId = seedAiProfileLeaderIds.firstWhere(
+        (leaderId) => seedAiProfilesById[leaderId]!.profileId == subject.profileId,
+      );
+      final expectedDefaultLeaderProfileIds = seedAiProfileLeaderIds
+          .where((leaderId) => leaderId != subjectLeaderId)
+          .take(config.sevenGpFallbackDefaultAiSeats)
+          .map((leaderId) => seedAiProfilesById[leaderId]!.profileId)
+          .toList();
+      final seedProfileIds =
+          seedAiProfiles.map((profile) => profile.profileId).toSet();
+      final defaultLeaderIds = roster
+          .map((profile) => profile.profileId)
+          .where(seedProfileIds.contains)
+          .toList();
+      final randomizedIds = roster
+          .map((profile) => profile.profileId)
+          .where((id) => id.startsWith('seven-gp-rand-'))
+          .toList();
+      expect(defaultLeaderIds, hasLength(config.sevenGpFallbackDefaultAiSeats));
+      expect(
+        randomizedIds,
+        hasLength(config.sevenGpFallbackRandomizedAiSeats),
+      );
+      expect(defaultLeaderIds, orderedEquals(expectedDefaultLeaderProfileIds));
     });
 
     test('excludes subject profile from opponents', () {

--- a/tool/ga_runner/test/test_ga_config.dart
+++ b/tool/ga_runner/test/test_ga_config.dart
@@ -19,6 +19,7 @@ GaConfig testGaConfig({
   int seed = 11,
   int sevenGpGamesPerProfile = 0,
   String sevenGpOpponentSelection = 'top_fitness',
+  bool sevenGpUseBlessedProfiles = false,
   StageFitnessWeights stageFitnessWeights = const StageFitnessWeights(
     twoPlayer: 0.5,
     sevenGp: 0.5,
@@ -49,7 +50,7 @@ GaConfig testGaConfig({
     sevenGpOpponentSelection: sevenGpOpponentSelection,
     sevenGpFallbackDefaultAiSeats: 3,
     sevenGpFallbackRandomizedAiSeats: 3,
-    sevenGpUseBlessedProfiles: false,
+    sevenGpUseBlessedProfiles: sevenGpUseBlessedProfiles,
   );
 }
 


### PR DESCRIPTION
## Summary
- Strengthens the generation-0 `buildSevenGpOpponentRoster` test to assert the configured default-AI vs randomized-AI seat split (`3` + `3` by default) and deterministic default-leader ordering when no prior GA winners exist.
- Adds blessed-profile roster tests: when `seven_gp_use_blessed_profiles` is enabled, blessed profiles seat after prior winners and before fallback fill; when disabled, blessed profiles are ignored.
- Adds `GaConfig.fromJson` test for `seven_gp_use_blessed_profiles` parsing (default `false`, explicit `true`).

## AC coverage (this PR)
- Generation 0 with zero prior winners → configured `3` + `3` fallback split
- Blessed → default-leader → randomized fallback ordering when blessed profiles enabled
- Config gate for `seven_gp_use_blessed_profiles`

## Deferred
- None for #3488 roster/config ACs; engine integration with on-disk blessed manifest assets is covered indirectly via `_loadBlessedProfiles` in production code and roster unit tests with injected profiles.

## Test plan
- [x] `cd tool/ga_runner && dart test test/seven_gp_opponent_roster_test.dart test/ga_engine_test.dart test/stage_fitness_test.dart test/ga_config_test.dart`

Refs #3488