### PR TITLE
refactor: deduplicate colonizethis_orders abstractions (Refs #3500)

### DIFF
--- a/packages/colonizethis_orders/lib/src/orders/diplomatic_access_helpers.dart
+++ b/packages/colonizethis_orders/lib/src/orders/diplomatic_access_helpers.dart
@@ -1,0 +1,59 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import 'package:colonizethis_diplomacy/colonizethis_diplomacy.dart';
+import 'order_validation_result.dart';
+import 'order_work_constants.dart';
+
+/// Returns true when [unitType] may perform civilian work in a Minor/Tribe
+/// province owned by [provinceOwnerId] (embassy + Diplomatic Expertise).
+/// SPEC/game/tech-tree-diplomacy-civilian.md.
+bool civilianEmbassyWorkAllowedInMinorTribeProvince({
+  required Game game,
+  required String playerId,
+  required Player player,
+  required String unitType,
+  required String? provinceOwnerId,
+  DiplomacyFactionMembership? factionMembership,
+}) {
+  if (provinceOwnerId == null || provinceOwnerId == playerId) {
+    return false;
+  }
+  if (unitType != kUnitTypeBuilder &&
+      unitType != kUnitTypeEngineer &&
+      unitType != kUnitTypeMerchant) {
+    return false;
+  }
+  if (!isMinorOrTribe(
+    game,
+    provinceOwnerId,
+    factionMembership: factionMembership,
+  )) {
+    return false;
+  }
+  final rel = getRelation(game, playerId, provinceOwnerId);
+  if (rel?.atWar == true) return false;
+  final overture = getOverture(game, playerId, provinceOwnerId);
+  if (overture == null || !overture.hasEmbassy) return false;
+  return player.techUnlocked?[kTechIdDiplomaticExpertise] == true;
+}
+
+/// Rejects when [resourceId] is mineral and [tileKey] is not prospected for
+/// [playerId]; returns `null` when the check passes or does not apply.
+OrderValidationResult? rejectIfMineralTileNotProspected({
+  required Game game,
+  required String playerId,
+  required String tileKey,
+  required String? resourceId,
+}) {
+  if (resourceId == null || resourceId.isEmpty) return null;
+  if (!kMineralResourceIds.contains(resourceId)) return null;
+  final prospected =
+      game.worldState.playerProspectedTiles[playerId] ?? const <String>{};
+  if (!prospected.contains(tileKey)) {
+    return OrderValidationResult.rejected(
+      'Mineral tile must be prospected first',
+    );
+  }
+  return null;
+}

--- a/packages/colonizethis_orders/lib/src/orders/feedstock_bootstrap_cost.dart
+++ b/packages/colonizethis_orders/lib/src/orders/feedstock_bootstrap_cost.dart
@@ -25,16 +25,30 @@ bool _isUnimprovedFeedstockTile(
   return true;
 }
 
-bool _isFeedstockBootstrapTarget(
+bool _isFeedstockBootstrapTargetForTile(
   Game game,
   String playerId,
   String targetTileKey,
+  Set<String> Function(Game game, String playerId) feedstockIdsForPlayer,
 ) {
   return _isUnimprovedFeedstockTile(
     game,
     playerId,
     targetTileKey,
-    feedstockExtractionResourceIdsForPlayer(game, playerId),
+    feedstockIdsForPlayer(game, playerId),
+  );
+}
+
+bool _isFeedstockBootstrapTarget(
+  Game game,
+  String playerId,
+  String targetTileKey,
+) {
+  return _isFeedstockBootstrapTargetForTile(
+    game,
+    playerId,
+    targetTileKey,
+    feedstockExtractionResourceIdsForPlayer,
   );
 }
 
@@ -47,13 +61,16 @@ bool _isImprovementInputFeedstockBootstrapTarget(
   String playerId,
   String targetTileKey,
 ) {
-  return _isUnimprovedFeedstockTile(
+  return _isFeedstockBootstrapTargetForTile(
     game,
     playerId,
     targetTileKey,
-    <String>{
+    (game, playerId) => <String>{
       ...sellerImprovementInputFeedstockExtractionResourceIds(game, playerId),
-      ...supplierImprovementInputFeedstockExtractionResourceIds(game, playerId),
+      ...supplierImprovementInputFeedstockExtractionResourceIds(
+        game,
+        playerId,
+      ),
     },
   );
 }

--- a/packages/colonizethis_orders/lib/src/orders/feedstock_bootstrap_cost.dart
+++ b/packages/colonizethis_orders/lib/src/orders/feedstock_bootstrap_cost.dart
@@ -11,18 +11,31 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'feedstock_extraction_targets.dart';
 
-bool _isFeedstockBootstrapTarget(
+bool _isUnimprovedFeedstockTile(
   Game game,
   String playerId,
   String targetTileKey,
+  Set<String> feedstockIds,
 ) {
-  final feedstockIds = feedstockExtractionResourceIdsForPlayer(game, playerId);
   if (feedstockIds.isEmpty) return false;
   final ws = game.worldState;
   final resourceId = ws.resourceByTileKey[targetTileKey];
   if (resourceId == null || !feedstockIds.contains(resourceId)) return false;
   if (ws.tileState.improvementLevel(targetTileKey) >= 1) return false;
   return true;
+}
+
+bool _isFeedstockBootstrapTarget(
+  Game game,
+  String playerId,
+  String targetTileKey,
+) {
+  return _isUnimprovedFeedstockTile(
+    game,
+    playerId,
+    targetTileKey,
+    feedstockExtractionResourceIdsForPlayer(game, playerId),
+  );
 }
 
 /// Improvement-input feedstock tiles (`timber` / `iron`) only — excludes the
@@ -34,16 +47,15 @@ bool _isImprovementInputFeedstockBootstrapTarget(
   String playerId,
   String targetTileKey,
 ) {
-  final feedstockIds = <String>{
-    ...sellerImprovementInputFeedstockExtractionResourceIds(game, playerId),
-    ...supplierImprovementInputFeedstockExtractionResourceIds(game, playerId),
-  };
-  if (feedstockIds.isEmpty) return false;
-  final ws = game.worldState;
-  final resourceId = ws.resourceByTileKey[targetTileKey];
-  if (resourceId == null || !feedstockIds.contains(resourceId)) return false;
-  if (ws.tileState.improvementLevel(targetTileKey) >= 1) return false;
-  return true;
+  return _isUnimprovedFeedstockTile(
+    game,
+    playerId,
+    targetTileKey,
+    <String>{
+      ...sellerImprovementInputFeedstockExtractionResourceIds(game, playerId),
+      ...supplierImprovementInputFeedstockExtractionResourceIds(game, playerId),
+    },
+  );
 }
 
 Player? _playerById(Game game, String playerId) {

--- a/packages/colonizethis_orders/lib/src/orders/feedstock_extraction_targets.dart
+++ b/packages/colonizethis_orders/lib/src/orders/feedstock_extraction_targets.dart
@@ -26,6 +26,22 @@ int regimentCountForPlayer(Game game, String playerId) {
   return count;
 }
 
+/// Production-recipe feedstock commodity ids for recipes whose output is in
+/// [neededOutputs]. Shared by the regiment-build-input and improvement-input
+/// feedstock-extraction gates (Refs #3500).
+Set<String> feedstockCommodityIdsForRecipeOutputs(
+  Set<CommodityId> neededOutputs,
+) {
+  if (neededOutputs.isEmpty) return const <String>{};
+  final feedstock = <String>{};
+  for (final recipe in ProductionRecipesCatalog.all) {
+    if (neededOutputs.contains(recipe.outputCommodityId)) {
+      feedstock.addAll(recipe.inputQuantities.keys);
+    }
+  }
+  return feedstock;
+}
+
 int _newWorldProvinceCountOwnedBy(Game game, String playerId) {
   return ProvinceOwnerCache.of(
     game.worldState,
@@ -91,13 +107,7 @@ Set<String> regimentBuildInputFeedstockExtractionResourceIds(
       if (player.stockpile.quantityOf(entry.key) < entry.value) entry.key,
   };
   if (missingInputs.isEmpty) return const <String>{};
-  final feedstock = <String>{};
-  for (final recipe in ProductionRecipesCatalog.all) {
-    if (missingInputs.contains(recipe.outputCommodityId)) {
-      feedstock.addAll(recipe.inputQuantities.keys);
-    }
-  }
-  return feedstock;
+  return feedstockCommodityIdsForRecipeOutputs(missingInputs);
 }
 
 /// True iff [playerId] owns at least one province tile hosting a resource in
@@ -190,12 +200,7 @@ Set<String> supplierImprovementInputFeedstockExtractionResourceIds(
     excludePlayerId: playerId,
   );
   if (neededInputs.isEmpty) return const <String>{};
-  final feedstock = <String>{};
-  for (final recipe in ProductionRecipesCatalog.all) {
-    if (neededInputs.contains(recipe.outputCommodityId)) {
-      feedstock.addAll(recipe.inputQuantities.keys);
-    }
-  }
+  final feedstock = feedstockCommodityIdsForRecipeOutputs(neededInputs);
   if (feedstock.isEmpty) return const <String>{};
   if (!_ownsUnimprovedFeedstockResourceTile(game, playerId, feedstock)) {
     return const <String>{};
@@ -255,12 +260,7 @@ Set<String> sellerImprovementInputFeedstockResourceIds(
     playerId,
   );
   if (neededInputs.isEmpty) return const <String>{};
-  final feedstock = <String>{};
-  for (final recipe in ProductionRecipesCatalog.all) {
-    if (neededInputs.contains(recipe.outputCommodityId)) {
-      feedstock.addAll(recipe.inputQuantities.keys);
-    }
-  }
+  final feedstock = feedstockCommodityIdsForRecipeOutputs(neededInputs);
   return feedstock;
 }
 

--- a/packages/colonizethis_orders/lib/src/orders/incremental_candidate_validator.dart
+++ b/packages/colonizethis_orders/lib/src/orders/incremental_candidate_validator.dart
@@ -254,6 +254,7 @@ class IncrementalCandidateValidator {
           diplomaticOrders,
           view,
           topology,
+          previousRejected: false,
           armiesById: _armiesById(),
           factionMembership: _factionMembership(),
         )

--- a/packages/colonizethis_orders/lib/src/orders/incremental_candidate_validator_prefix_replay.dart
+++ b/packages/colonizethis_orders/lib/src/orders/incremental_candidate_validator_prefix_replay.dart
@@ -153,22 +153,32 @@ extension IncrementalCandidateValidatorPrefixReplay
   }
 
   bool isDiplomaticAccepted(DiplomaticOrder candidate) {
-    final prepared = _prepareDiplomaticCandidateValidator();
-    if (!prepared.ok) return false;
-    return prepared.validator!
-        .validate(candidate, previousRejected: false)
-        .result
-        .isAccepted;
+    return _validateDiplomaticCandidate(candidate).isAccepted;
   }
 
   /// Like [isDiplomaticAccepted] but returns the full [OrderValidationResult]
   /// so UI layers can surface validator rejection text on disabled controls.
   OrderValidationResult probeDiplomaticOrder(DiplomaticOrder candidate) {
-    final prepared = _prepareDiplomaticCandidateValidator(
+    return _validateDiplomaticCandidate(
+      candidate,
       playerNotFoundReason: 'Player not found',
       prefixReplayFailedReason: 'Previous invalid diplomatic order in prefix',
     );
-    if (prepared.reject != null) return prepared.reject!;
+  }
+
+  OrderValidationResult _validateDiplomaticCandidate(
+    DiplomaticOrder candidate, {
+    String? playerNotFoundReason,
+    String? prefixReplayFailedReason,
+  }) {
+    final prepared = _prepareDiplomaticCandidateValidator(
+      playerNotFoundReason: playerNotFoundReason,
+      prefixReplayFailedReason: prefixReplayFailedReason,
+    );
+    if (!prepared.ok) {
+      return prepared.reject ??
+          OrderValidationResult.rejected('Diplomatic order rejected');
+    }
     return prepared.validator!
         .validate(candidate, previousRejected: false)
         .result;

--- a/packages/colonizethis_orders/lib/src/orders/incremental_candidate_validator_prefix_replay.dart
+++ b/packages/colonizethis_orders/lib/src/orders/incremental_candidate_validator_prefix_replay.dart
@@ -153,44 +153,9 @@ extension IncrementalCandidateValidatorPrefixReplay
   }
 
   bool isDiplomaticAccepted(DiplomaticOrder candidate) {
-    final player = _player();
-    if (player == null) return false;
-    if (_cachedDiplomaticPrefixReplaySucceeded == false) {
-      return false;
-    }
-    final economy = _projectEconomyAfterAcceptedBuildAndWorkOrders(player);
-    final membership = _factionMembership();
-
-    if (_cachedPostDiplomaticPrefixState == null) {
-      final prefixValidator = DiplomaticOrderValidator(
-        game: game,
-        playerId: playerId,
-        initialTreasury: economy.treasury,
-        factionMembership: membership,
-      );
-      for (final existing in diplomaticOrders) {
-        final result = prefixValidator.validate(
-          existing,
-          previousRejected: false,
-        );
-        if (!result.result.isAccepted) {
-          _cachedDiplomaticPrefixReplaySucceeded = false;
-          return false;
-        }
-      }
-      _cachedDiplomaticPrefixReplaySucceeded = true;
-      _cachedPostDiplomaticPrefixState = prefixValidator
-          .capturePrefixCheckpoint();
-    }
-
-    final checkpoint = _cachedPostDiplomaticPrefixState!;
-    final candidateValidator = DiplomaticOrderValidator.fromPrefixCheckpoint(
-      game: game,
-      playerId: playerId,
-      checkpoint: checkpoint,
-      factionMembership: membership,
-    );
-    return candidateValidator
+    final prepared = _prepareDiplomaticCandidateValidator();
+    if (!prepared.ok) return false;
+    return prepared.validator!
         .validate(candidate, previousRejected: false)
         .result
         .isAccepted;
@@ -199,13 +164,38 @@ extension IncrementalCandidateValidatorPrefixReplay
   /// Like [isDiplomaticAccepted] but returns the full [OrderValidationResult]
   /// so UI layers can surface validator rejection text on disabled controls.
   OrderValidationResult probeDiplomaticOrder(DiplomaticOrder candidate) {
+    final prepared = _prepareDiplomaticCandidateValidator(
+      playerNotFoundReason: 'Player not found',
+      prefixReplayFailedReason: 'Previous invalid diplomatic order in prefix',
+    );
+    if (prepared.reject != null) return prepared.reject!;
+    return prepared.validator!
+        .validate(candidate, previousRejected: false)
+        .result;
+  }
+
+  ({bool ok, OrderValidationResult? reject, DiplomaticOrderValidator? validator})
+  _prepareDiplomaticCandidateValidator({
+    String? playerNotFoundReason,
+    String? prefixReplayFailedReason,
+  }) {
     final player = _player();
     if (player == null) {
-      return OrderValidationResult.rejected('Player not found');
+      return (
+        ok: false,
+        reject: playerNotFoundReason == null
+            ? null
+            : OrderValidationResult.rejected(playerNotFoundReason),
+        validator: null,
+      );
     }
     if (_cachedDiplomaticPrefixReplaySucceeded == false) {
-      return OrderValidationResult.rejected(
-        'Previous invalid diplomatic order in prefix',
+      return (
+        ok: false,
+        reject: prefixReplayFailedReason == null
+            ? null
+            : OrderValidationResult.rejected(prefixReplayFailedReason),
+        validator: null,
       );
     }
     final economy = _projectEconomyAfterAcceptedBuildAndWorkOrders(player);
@@ -225,7 +215,13 @@ extension IncrementalCandidateValidatorPrefixReplay
         );
         if (!result.result.isAccepted) {
           _cachedDiplomaticPrefixReplaySucceeded = false;
-          return result.result;
+          return (
+            ok: false,
+            reject: prefixReplayFailedReason == null
+                ? null
+                : result.result,
+            validator: null,
+          );
         }
       }
       _cachedDiplomaticPrefixReplaySucceeded = true;
@@ -240,8 +236,6 @@ extension IncrementalCandidateValidatorPrefixReplay
       checkpoint: checkpoint,
       factionMembership: membership,
     );
-    return candidateValidator
-        .validate(candidate, previousRejected: false)
-        .result;
+    return (ok: true, reject: null, validator: candidateValidator);
   }
 }

--- a/packages/colonizethis_orders/lib/src/orders/order_engine_validation.dart
+++ b/packages/colonizethis_orders/lib/src/orders/order_engine_validation.dart
@@ -241,15 +241,14 @@ void _runArmyMovePhase(
     state.results,
     armyMoves,
     state.rejected,
-    (o, prev) => prev
-        ? previousInvalidOrderResult
-        : v.armyMoveValidator.validate(
+    (o, prev) => v.armyMoveValidator.validate(
             o,
             game,
             playerId,
             diplomatic,
             view,
             topology,
+            previousRejected: prev,
             armiesById: armiesById,
             factionMembership: factionMembership,
           ),

--- a/packages/colonizethis_orders/lib/src/orders/order_merge.dart
+++ b/packages/colonizethis_orders/lib/src/orders/order_merge.dart
@@ -7,6 +7,11 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 /// Merges human and AI orders with precedence (human over AI).
 /// For conflicting orders (e.g. same unit, same slot): human wins.
 /// Stable ordering: by player id, then order type.
+///
+/// Each [Orders] field uses an explicit [_mergeOrders] call because the record
+/// carries ten distinct order-list types with different merge strategies and
+/// conflict keys — a descriptor loop would need heterogeneous generics or
+/// dynamic casts with no net clarity gain (Refs #3500 Phase 5).
 Orders mergeOrderLists({
   required Orders humanOrders,
   Orders? aiOrders,

--- a/packages/colonizethis_orders/lib/src/orders/order_suggestion_api_impl.dart
+++ b/packages/colonizethis_orders/lib/src/orders/order_suggestion_api_impl.dart
@@ -13,9 +13,39 @@ List<T> _suggestWithLog<T>(String method, String playerId, List<T> Function() ru
   return run();
 }
 
+/// Bundles the four standard suggest* parameters for delegation (Refs #3500).
+class _StandardSuggestContext {
+  const _StandardSuggestContext({
+    required this.view,
+    required this.game,
+    required this.topology,
+    required this.currentOrders,
+  });
+
+  final PlayerView view;
+  final Game game;
+  final MapTopology topology;
+  final Orders currentOrders;
+
+  List<T> loggedSuggest<T>(String method, List<T> Function() invoke) =>
+      _suggestWithLog(method, view.playerId, invoke);
+}
+
 /// Default implementation of [OrderSuggestionAPI] using the top-level suggest* functions.
 class DefaultOrderSuggestionAPI implements OrderSuggestionAPI {
   const DefaultOrderSuggestionAPI();
+
+  _StandardSuggestContext _ctx(
+    PlayerView view,
+    Game game,
+    MapTopology topology,
+    Orders currentOrders,
+  ) => _StandardSuggestContext(
+    view: view,
+    game: game,
+    topology: topology,
+    currentOrders: currentOrders,
+  );
 
   @override
   List<MoveOrder> suggestMoveOrders(
@@ -24,10 +54,15 @@ class DefaultOrderSuggestionAPI implements OrderSuggestionAPI {
     MapTopology topology,
     Orders currentOrders,
   ) {
-    return _suggestWithLog(
+    final ctx = _ctx(view, game, topology, currentOrders);
+    return ctx.loggedSuggest(
       'suggestMoveOrders turn=${game.worldState.turnState.turnNumber}',
-      view.playerId,
-      () => suggestion.suggestMoveOrders(view, game, topology, currentOrders),
+      () => suggestion.suggestMoveOrders(
+        ctx.view,
+        ctx.game,
+        ctx.topology,
+        ctx.currentOrders,
+      ),
     );
   }
 
@@ -38,14 +73,14 @@ class DefaultOrderSuggestionAPI implements OrderSuggestionAPI {
     MapTopology topology,
     Orders currentOrders,
   ) {
-    return _suggestWithLog(
+    final ctx = _ctx(view, game, topology, currentOrders);
+    return ctx.loggedSuggest(
       'suggestArmyMoveOrders',
-      view.playerId,
       () => suggestion.suggestArmyMoveOrders(
-        view,
-        game,
-        topology,
-        currentOrders,
+        ctx.view,
+        ctx.game,
+        ctx.topology,
+        ctx.currentOrders,
       ),
     );
   }
@@ -58,14 +93,14 @@ class DefaultOrderSuggestionAPI implements OrderSuggestionAPI {
     Orders currentOrders, {
     Map<String, TileMapResult>? tileMapByRegion,
   }) {
-    return _suggestWithLog(
+    final ctx = _ctx(view, game, topology, currentOrders);
+    return ctx.loggedSuggest(
       'suggestWorkOrders',
-      view.playerId,
       () => suggestion.suggestWorkOrders(
-        view,
-        game,
-        topology,
-        currentOrders,
+        ctx.view,
+        ctx.game,
+        ctx.topology,
+        ctx.currentOrders,
         tileMapByRegion: tileMapByRegion,
       ),
     );
@@ -78,10 +113,15 @@ class DefaultOrderSuggestionAPI implements OrderSuggestionAPI {
     MapTopology topology,
     Orders currentOrders,
   ) {
-    return _suggestWithLog(
+    final ctx = _ctx(view, game, topology, currentOrders);
+    return ctx.loggedSuggest(
       'suggestBuildOrders',
-      view.playerId,
-      () => suggestion.suggestBuildOrders(view, game, topology, currentOrders),
+      () => suggestion.suggestBuildOrders(
+        ctx.view,
+        ctx.game,
+        ctx.topology,
+        ctx.currentOrders,
+      ),
     );
   }
 
@@ -92,14 +132,14 @@ class DefaultOrderSuggestionAPI implements OrderSuggestionAPI {
     MapTopology topology,
     Orders currentOrders,
   ) {
-    return _suggestWithLog(
+    final ctx = _ctx(view, game, topology, currentOrders);
+    return ctx.loggedSuggest(
       'suggestRecruitWorkerOrders',
-      view.playerId,
       () => suggestion.suggestRecruitWorkerOrders(
-        view,
-        game,
-        topology,
-        currentOrders,
+        ctx.view,
+        ctx.game,
+        ctx.topology,
+        ctx.currentOrders,
       ),
     );
   }
@@ -117,14 +157,14 @@ class DefaultOrderSuggestionAPI implements OrderSuggestionAPI {
     int researchSeed = 0,
     int categoryDiversifyWeight = 0,
   }) {
-    return _suggestWithLog(
+    final ctx = _ctx(view, game, topology, currentOrders);
+    return ctx.loggedSuggest(
       'suggestResearchOrders',
-      view.playerId,
       () => suggestion.suggestResearchOrders(
-        view,
-        game,
-        topology,
-        currentOrders,
+        ctx.view,
+        ctx.game,
+        ctx.topology,
+        ctx.currentOrders,
         researchNavalWeight: researchNavalWeight,
         researchMilitaryWeight: researchMilitaryWeight,
         researchEconomicWeight: researchEconomicWeight,
@@ -143,14 +183,14 @@ class DefaultOrderSuggestionAPI implements OrderSuggestionAPI {
     Orders currentOrders, {
     OrderResolutionContext? resolution,
   }) {
-    return _suggestWithLog(
+    final ctx = _ctx(view, game, topology, currentOrders);
+    return ctx.loggedSuggest(
       'suggestNavalMoveOrders',
-      view.playerId,
       () => suggestion.suggestNavalMoveOrders(
-        view,
-        game,
-        topology,
-        currentOrders,
+        ctx.view,
+        ctx.game,
+        ctx.topology,
+        ctx.currentOrders,
         resolution: resolution,
       ),
     );
@@ -164,14 +204,14 @@ class DefaultOrderSuggestionAPI implements OrderSuggestionAPI {
     Orders currentOrders, {
     OrderResolutionContext? resolution,
   }) {
-    return _suggestWithLog(
+    final ctx = _ctx(view, game, topology, currentOrders);
+    return ctx.loggedSuggest(
       'suggestNavalMissionOrders',
-      view.playerId,
       () => suggestion.suggestNavalMissionOrders(
-        view,
-        game,
-        topology,
-        currentOrders,
+        ctx.view,
+        ctx.game,
+        ctx.topology,
+        ctx.currentOrders,
         resolution: resolution,
       ),
     );
@@ -185,14 +225,14 @@ class DefaultOrderSuggestionAPI implements OrderSuggestionAPI {
     Orders currentOrders, {
     Map<String, TileMapResult>? tileMapByRegion,
   }) {
-    return _suggestWithLog(
+    final ctx = _ctx(view, game, topology, currentOrders);
+    return ctx.loggedSuggest(
       'suggestDiplomaticOrders',
-      view.playerId,
       () => suggestion.suggestDiplomaticOrders(
-        view,
-        game,
-        topology,
-        currentOrders,
+        ctx.view,
+        ctx.game,
+        ctx.topology,
+        ctx.currentOrders,
         tileMapByRegion: tileMapByRegion,
       ),
     );
@@ -206,14 +246,14 @@ class DefaultOrderSuggestionAPI implements OrderSuggestionAPI {
     Orders currentOrders, {
     Map<String, TileMapResult>? tileMapByRegion,
   }) {
-    return _suggestWithLog(
+    final ctx = _ctx(view, game, topology, currentOrders);
+    return ctx.loggedSuggest(
       'suggestDeclareWarOrders',
-      view.playerId,
       () => suggestion.suggestDeclareWarOrders(
-        view,
-        game,
-        topology,
-        currentOrders,
+        ctx.view,
+        ctx.game,
+        ctx.topology,
+        ctx.currentOrders,
         tileMapByRegion: tileMapByRegion,
       ),
     );

--- a/packages/colonizethis_orders/lib/src/orders/order_suggestion_api_impl.dart
+++ b/packages/colonizethis_orders/lib/src/orders/order_suggestion_api_impl.dart
@@ -8,6 +8,11 @@ import 'order_suggestion_api.dart';
 import 'package:colonizethis_world/colonizethis_world.dart';
 import 'order_resolution_context.dart';
 
+List<T> _suggestWithLog<T>(String method, String playerId, List<T> Function() run) {
+  ordersLog.d('order suggestion API $method player=$playerId');
+  return run();
+}
+
 /// Default implementation of [OrderSuggestionAPI] using the top-level suggest* functions.
 class DefaultOrderSuggestionAPI implements OrderSuggestionAPI {
   const DefaultOrderSuggestionAPI();
@@ -19,10 +24,11 @@ class DefaultOrderSuggestionAPI implements OrderSuggestionAPI {
     MapTopology topology,
     Orders currentOrders,
   ) {
-    ordersLog.d(
-      'order suggestion API suggestMoveOrders player=${view.playerId} turn=${game.worldState.turnState.turnNumber}',
+    return _suggestWithLog(
+      'suggestMoveOrders turn=${game.worldState.turnState.turnNumber}',
+      view.playerId,
+      () => suggestion.suggestMoveOrders(view, game, topology, currentOrders),
     );
-    return suggestion.suggestMoveOrders(view, game, topology, currentOrders);
   }
 
   @override
@@ -32,14 +38,15 @@ class DefaultOrderSuggestionAPI implements OrderSuggestionAPI {
     MapTopology topology,
     Orders currentOrders,
   ) {
-    ordersLog.d(
-      'order suggestion API suggestArmyMoveOrders player=${view.playerId}',
-    );
-    return suggestion.suggestArmyMoveOrders(
-      view,
-      game,
-      topology,
-      currentOrders,
+    return _suggestWithLog(
+      'suggestArmyMoveOrders',
+      view.playerId,
+      () => suggestion.suggestArmyMoveOrders(
+        view,
+        game,
+        topology,
+        currentOrders,
+      ),
     );
   }
 
@@ -51,15 +58,16 @@ class DefaultOrderSuggestionAPI implements OrderSuggestionAPI {
     Orders currentOrders, {
     Map<String, TileMapResult>? tileMapByRegion,
   }) {
-    ordersLog.d(
-      'order suggestion API suggestWorkOrders player=${view.playerId}',
-    );
-    return suggestion.suggestWorkOrders(
-      view,
-      game,
-      topology,
-      currentOrders,
-      tileMapByRegion: tileMapByRegion,
+    return _suggestWithLog(
+      'suggestWorkOrders',
+      view.playerId,
+      () => suggestion.suggestWorkOrders(
+        view,
+        game,
+        topology,
+        currentOrders,
+        tileMapByRegion: tileMapByRegion,
+      ),
     );
   }
 
@@ -70,10 +78,11 @@ class DefaultOrderSuggestionAPI implements OrderSuggestionAPI {
     MapTopology topology,
     Orders currentOrders,
   ) {
-    ordersLog.d(
-      'order suggestion API suggestBuildOrders player=${view.playerId}',
+    return _suggestWithLog(
+      'suggestBuildOrders',
+      view.playerId,
+      () => suggestion.suggestBuildOrders(view, game, topology, currentOrders),
     );
-    return suggestion.suggestBuildOrders(view, game, topology, currentOrders);
   }
 
   @override
@@ -83,14 +92,15 @@ class DefaultOrderSuggestionAPI implements OrderSuggestionAPI {
     MapTopology topology,
     Orders currentOrders,
   ) {
-    ordersLog.d(
-      'order suggestion API suggestRecruitWorkerOrders player=${view.playerId}',
-    );
-    return suggestion.suggestRecruitWorkerOrders(
-      view,
-      game,
-      topology,
-      currentOrders,
+    return _suggestWithLog(
+      'suggestRecruitWorkerOrders',
+      view.playerId,
+      () => suggestion.suggestRecruitWorkerOrders(
+        view,
+        game,
+        topology,
+        currentOrders,
+      ),
     );
   }
 
@@ -107,20 +117,21 @@ class DefaultOrderSuggestionAPI implements OrderSuggestionAPI {
     int researchSeed = 0,
     int categoryDiversifyWeight = 0,
   }) {
-    ordersLog.d(
-      'order suggestion API suggestResearchOrders player=${view.playerId}',
-    );
-    return suggestion.suggestResearchOrders(
-      view,
-      game,
-      topology,
-      currentOrders,
-      researchNavalWeight: researchNavalWeight,
-      researchMilitaryWeight: researchMilitaryWeight,
-      researchEconomicWeight: researchEconomicWeight,
-      researchExplorationWeight: researchExplorationWeight,
-      researchSeed: researchSeed,
-      categoryDiversifyWeight: categoryDiversifyWeight,
+    return _suggestWithLog(
+      'suggestResearchOrders',
+      view.playerId,
+      () => suggestion.suggestResearchOrders(
+        view,
+        game,
+        topology,
+        currentOrders,
+        researchNavalWeight: researchNavalWeight,
+        researchMilitaryWeight: researchMilitaryWeight,
+        researchEconomicWeight: researchEconomicWeight,
+        researchExplorationWeight: researchExplorationWeight,
+        researchSeed: researchSeed,
+        categoryDiversifyWeight: categoryDiversifyWeight,
+      ),
     );
   }
 
@@ -132,15 +143,16 @@ class DefaultOrderSuggestionAPI implements OrderSuggestionAPI {
     Orders currentOrders, {
     OrderResolutionContext? resolution,
   }) {
-    ordersLog.d(
-      'order suggestion API suggestNavalMoveOrders player=${view.playerId}',
-    );
-    return suggestion.suggestNavalMoveOrders(
-      view,
-      game,
-      topology,
-      currentOrders,
-      resolution: resolution,
+    return _suggestWithLog(
+      'suggestNavalMoveOrders',
+      view.playerId,
+      () => suggestion.suggestNavalMoveOrders(
+        view,
+        game,
+        topology,
+        currentOrders,
+        resolution: resolution,
+      ),
     );
   }
 
@@ -152,15 +164,16 @@ class DefaultOrderSuggestionAPI implements OrderSuggestionAPI {
     Orders currentOrders, {
     OrderResolutionContext? resolution,
   }) {
-    ordersLog.d(
-      'order suggestion API suggestNavalMissionOrders player=${view.playerId}',
-    );
-    return suggestion.suggestNavalMissionOrders(
-      view,
-      game,
-      topology,
-      currentOrders,
-      resolution: resolution,
+    return _suggestWithLog(
+      'suggestNavalMissionOrders',
+      view.playerId,
+      () => suggestion.suggestNavalMissionOrders(
+        view,
+        game,
+        topology,
+        currentOrders,
+        resolution: resolution,
+      ),
     );
   }
 
@@ -172,15 +185,16 @@ class DefaultOrderSuggestionAPI implements OrderSuggestionAPI {
     Orders currentOrders, {
     Map<String, TileMapResult>? tileMapByRegion,
   }) {
-    ordersLog.d(
-      'order suggestion API suggestDiplomaticOrders player=${view.playerId}',
-    );
-    return suggestion.suggestDiplomaticOrders(
-      view,
-      game,
-      topology,
-      currentOrders,
-      tileMapByRegion: tileMapByRegion,
+    return _suggestWithLog(
+      'suggestDiplomaticOrders',
+      view.playerId,
+      () => suggestion.suggestDiplomaticOrders(
+        view,
+        game,
+        topology,
+        currentOrders,
+        tileMapByRegion: tileMapByRegion,
+      ),
     );
   }
 
@@ -192,15 +206,16 @@ class DefaultOrderSuggestionAPI implements OrderSuggestionAPI {
     Orders currentOrders, {
     Map<String, TileMapResult>? tileMapByRegion,
   }) {
-    ordersLog.d(
-      'order suggestion API suggestDeclareWarOrders player=${view.playerId}',
-    );
-    return suggestion.suggestDeclareWarOrders(
-      view,
-      game,
-      topology,
-      currentOrders,
-      tileMapByRegion: tileMapByRegion,
+    return _suggestWithLog(
+      'suggestDeclareWarOrders',
+      view.playerId,
+      () => suggestion.suggestDeclareWarOrders(
+        view,
+        game,
+        topology,
+        currentOrders,
+        tileMapByRegion: tileMapByRegion,
+      ),
     );
   }
 

--- a/packages/colonizethis_orders/lib/src/orders/order_suggestion_army_move.dart
+++ b/packages/colonizethis_orders/lib/src/orders/order_suggestion_army_move.dart
@@ -143,14 +143,10 @@ List<ArmyMovePickerDestination> armyMovePickerDestinations({
               provinceById: sharedCandidateValidator.view.provincesById,
             )
           : null);
-  final effectivePlayerView = effectiveResolution?.view;
   final ownedProvinceIds =
       playerOwnedFullProvinceIds ??
       (effectiveResolution != null
-          ? <String>{
-              for (final e in effectiveResolution.provinceById.entries)
-                if (e.value.ownerId == playerId) e.key,
-            }
+          ? ownedProvinceIdsFromView(effectiveResolution.view, playerId)
           : <String>{
               for (final p in ProvinceOwnerCache.of(
                 game.worldState,
@@ -268,40 +264,25 @@ List<ArmyMoveOrder> suggestArmyMoveOrders(
   Orders currentOrders, {
   IncrementalCandidateValidator? sharedCandidateValidator,
 }) {
-  final playerId = view.playerId;
-  final suggestions = <ArmyMoveOrder>[];
-  final existingArmyMoves = <String, Set<String>>{};
-  final existingForPlayer =
-      currentOrders.armyMoveOrdersByPlayerId[playerId] ?? const [];
-  for (final m in existingForPlayer) {
-    existingArmyMoves
-        .putIfAbsent(m.armyId, () => <String>{})
-        .add(m.destinationProvinceId);
-  }
-
-  // Single per-player validator: amortizes the per-player [PlayerView] /
-  // units-by-id setup across every candidate probe. SPEC/program/order-
-  // suggestions.md § Incremental candidate validation. Refs #2237.
-  assert(
-    sharedCandidateValidator == null ||
-        sharedCandidateValidator.playerId == playerId,
-    'sharedCandidateValidator playerId must match view.playerId',
+  final pass = SuggestionPassContext.forPlayerView(
+    view: view,
+    game: game,
+    topology: topology,
+    currentOrders: currentOrders,
+    familyLabel: 'suggestArmyMoveOrders',
+    sharedCandidateValidator: sharedCandidateValidator,
+    useBuildIncrementalWrapper: false,
   );
-  final candidateValidator =
-      sharedCandidateValidator ??
-      IncrementalCandidateValidator.forPlayer(
-        game: game,
-        topology: topology,
-        playerId: playerId,
-        basePrefix: currentOrders,
-        factionMembership: DiplomacyFactionMembership.from(game),
-        resolution: orderResolutionContextFromView(view, game),
-      );
+  final playerId = pass.playerId;
+  final suggestions = <ArmyMoveOrder>[];
+  final candidateValidator = pass.candidateValidator;
+  final existingArmyMoves = indexExistingTargetsByEntityId(
+    currentOrders.armyMoveOrdersByPlayerId[playerId],
+    (m) => m.armyId,
+    (m) => m.destinationProvinceId,
+  );
 
-  final playerOwnedFullProvinceIds = <String>{
-    for (final e in view.provincesById.entries)
-      if (e.value.ownerId == playerId) e.key,
-  };
+  final playerOwnedFullProvinceIds = ownedProvinceIdsFromView(view, playerId);
 
   for (final army in game.worldState.armies) {
     if (army.ownerId != playerId) continue;
@@ -320,29 +301,30 @@ List<ArmyMoveOrder> suggestArmyMoveOrders(
       playerOwnedFullProvinceIds: playerOwnedFullProvinceIds,
     );
 
-    var acceptedForArmy = 0;
-    var probeAttemptsForArmy = 0;
-    for (final destinationProvinceId in destIds) {
-      final already = existingArmyMoves[army.id];
-      if (already != null && already.contains(destinationProvinceId)) continue;
-      probeAttemptsForArmy++;
-
-      final candidate = ArmyMoveOrder(
-        armyId: army.id,
-        destinationProvinceId: destinationProvinceId,
-      );
-
-      if (candidateValidator.isArmyMoveAccepted(candidate)) {
-        suggestions.add(candidate);
-        acceptedForArmy++;
-        if (acceptedForArmy >= _kMaxArmyMoveSuggestionsPerArmy) {
-          break;
-        }
-      }
-      if (probeAttemptsForArmy >= _kMaxArmyMoveProbeAttemptsPerArmy) {
-        break;
-      }
-    }
+    runCappedSuggestionProbeLoop<String>(
+      candidates: destIds,
+      shouldSkip: (destinationProvinceId) {
+        final already = existingArmyMoves[army.id];
+        return already != null && already.contains(destinationProvinceId);
+      },
+      probe: (destinationProvinceId) {
+        final candidate = ArmyMoveOrder(
+          armyId: army.id,
+          destinationProvinceId: destinationProvinceId,
+        );
+        return candidateValidator.isArmyMoveAccepted(candidate);
+      },
+      onAccepted: (destinationProvinceId) {
+        suggestions.add(
+          ArmyMoveOrder(
+            armyId: army.id,
+            destinationProvinceId: destinationProvinceId,
+          ),
+        );
+      },
+      maxAccepted: _kMaxArmyMoveSuggestionsPerArmy,
+      maxProbes: _kMaxArmyMoveProbeAttemptsPerArmy,
+    );
   }
 
   suggestions.sort((a, b) {

--- a/packages/colonizethis_orders/lib/src/orders/order_suggestion_build.dart
+++ b/packages/colonizethis_orders/lib/src/orders/order_suggestion_build.dart
@@ -3,8 +3,8 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'package:colonizethis_world/colonizethis_world.dart';
 import 'incremental_candidate_validator.dart';
-import 'order_resolution_context.dart';
 import 'order_suggestion_context.dart';
+import 'order_suggestion_pass_context.dart';
 
 /// Suggests build-unit orders that are affordable and valid for [view.playerId].
 ///
@@ -21,25 +21,18 @@ List<BuildUnitOrder> suggestBuildOrders(
   Orders currentOrders, {
   IncrementalCandidateValidator? sharedCandidateValidator,
 }) {
-  orderSuggestionLog.d('suggestBuildOrders player=${view.playerId}');
-  final playerId = view.playerId;
+  final pass = SuggestionPassContext.forPlayerView(
+    view: view,
+    game: game,
+    topology: topology,
+    currentOrders: currentOrders,
+    familyLabel: 'suggestBuildOrders',
+    sharedCandidateValidator: sharedCandidateValidator,
+  );
+  final playerId = pass.playerId;
   final player = view.player;
   final suggestions = <BuildUnitOrder>[];
-  assert(
-    sharedCandidateValidator == null ||
-        sharedCandidateValidator.playerId == playerId,
-    'sharedCandidateValidator playerId must match view.playerId',
-  );
-  final candidateValidator =
-      sharedCandidateValidator ??
-      buildIncrementalCandidateValidator(
-        game: game,
-        topology: topology,
-        playerId: playerId,
-        baseOrders: currentOrders,
-        resolution: orderResolutionContextFromView(view, game),
-        factionMembership: DiplomacyFactionMembership.from(game),
-      );
+  final candidateValidator = pass.candidateValidator;
 
   final capitalId = player.capitalProvinceId;
   if (capitalId == null) {
@@ -79,13 +72,8 @@ List<BuildUnitOrder> suggestBuildOrders(
   suggestions.sort((a, b) => a.unitType.compareTo(b.unitType));
 
   orderSuggestionLog.d(
-    'suggestBuildOrders player=$playerId candidates=${suggestions.length}',
-  );
-  orderSuggestionLog.d(
     'suggestBuildOrders full list ${suggestions.map((o) => o.unitType).join(", ")}',
   );
-  if (suggestions.isEmpty) {
-    orderSuggestionLog.w('suggestBuildOrders no candidates player=$playerId');
-  }
+  pass.logExit(candidateCount: suggestions.length, warnIfEmpty: true);
   return suggestions;
 }

--- a/packages/colonizethis_orders/lib/src/orders/order_suggestion_context.dart
+++ b/packages/colonizethis_orders/lib/src/orders/order_suggestion_context.dart
@@ -101,6 +101,34 @@ IncrementalCandidateValidator incrementalValidatorForCandidateProbe({
   );
 }
 
+bool _probeOrderAccepted<T>({
+  required Game game,
+  required MapTopology topology,
+  required String playerId,
+  required Orders baseOrders,
+  required T candidate,
+  required bool Function(IncrementalCandidateValidator validator, T candidate)
+  probeWithValidator,
+  Map<String, TileMapResult>? tileMapByRegion,
+  IncrementalCandidateValidator? sharedCandidateValidator,
+  OrderResolutionContext? resolution,
+  DiplomacyFactionMembership? factionMembership,
+  void Function()? onBeforeProbe,
+}) {
+  final validator = incrementalValidatorForCandidateProbe(
+    game: game,
+    topology: topology,
+    playerId: playerId,
+    baseOrders: baseOrders,
+    tileMapByRegion: tileMapByRegion,
+    resolution: resolution,
+    factionMembership: factionMembership,
+    sharedCandidateValidator: sharedCandidateValidator,
+  );
+  onBeforeProbe?.call();
+  return probeWithValidator(validator, candidate);
+}
+
 bool isMoveOrderAccepted(
   Game game,
   MapTopology topology,
@@ -116,16 +144,17 @@ bool isMoveOrderAccepted(
   // [validatePlayerOrdersWithContext]. SPEC/program/order-suggestions.md
   // § Incremental candidate validation; SPEC/program/order-engine.md
   // § Validation (candidate-probe context). Refs #2237.
-  final validator = incrementalValidatorForCandidateProbe(
+  return _probeOrderAccepted<MoveOrder>(
     game: game,
     topology: topology,
     playerId: playerId,
     baseOrders: baseOrders,
+    candidate: candidate,
     resolution: resolution,
     factionMembership: factionMembership,
     sharedCandidateValidator: sharedCandidateValidator,
+    probeWithValidator: (validator, c) => validator.isMoveAccepted(c),
   );
-  return validator.isMoveAccepted(candidate);
 }
 
 bool isArmyMoveOrderAccepted(
@@ -142,16 +171,17 @@ bool isArmyMoveOrderAccepted(
   // [baseOrders]'s diplomatic context without re-running full-pass
   // [validatePlayerOrdersWithContext]. SPEC/program/order-suggestions.md
   // § Incremental candidate validation. Refs #2237.
-  final validator = incrementalValidatorForCandidateProbe(
+  return _probeOrderAccepted<ArmyMoveOrder>(
     game: game,
     topology: topology,
     playerId: playerId,
     baseOrders: baseOrders,
+    candidate: candidate,
     resolution: resolution,
     factionMembership: factionMembership,
     sharedCandidateValidator: sharedCandidateValidator,
+    probeWithValidator: (validator, c) => validator.isArmyMoveAccepted(c),
   );
-  return validator.isArmyMoveAccepted(candidate);
 }
 
 bool isWorkOrderAccepted(
@@ -165,17 +195,19 @@ bool isWorkOrderAccepted(
   OrderResolutionContext? resolution,
   DiplomacyFactionMembership? factionMembership,
 }) {
-  final validator = incrementalValidatorForCandidateProbe(
+  return _probeOrderAccepted<WorkOrder>(
     game: game,
     topology: topology,
     playerId: playerId,
     baseOrders: baseOrders,
+    candidate: candidate,
     tileMapByRegion: tileMapByRegion,
     resolution: resolution,
     factionMembership: factionMembership,
     sharedCandidateValidator: sharedCandidateValidator,
+    onBeforeProbe: bumpOrderSuggestionWorkOrderAcceptanceProbeIfTracking,
+    probeWithValidator: isWorkOrderAcceptedWithValidator,
   );
-  return isWorkOrderAcceptedWithValidator(validator, candidate);
 }
 
 bool isBuildOrderAccepted(
@@ -188,16 +220,17 @@ bool isBuildOrderAccepted(
   OrderResolutionContext? resolution,
   DiplomacyFactionMembership? factionMembership,
 }) {
-  final validator = incrementalValidatorForCandidateProbe(
+  return _probeOrderAccepted<BuildUnitOrder>(
     game: game,
     topology: topology,
     playerId: playerId,
     baseOrders: baseOrders,
+    candidate: candidate,
     resolution: resolution,
     factionMembership: factionMembership,
     sharedCandidateValidator: sharedCandidateValidator,
+    probeWithValidator: isBuildOrderAcceptedWithValidator,
   );
-  return isBuildOrderAcceptedWithValidator(validator, candidate);
 }
 
 bool isNavalMoveOrderAccepted(
@@ -212,16 +245,17 @@ bool isNavalMoveOrderAccepted(
 }) {
   // Stateless candidate-probe path. SPEC/program/order-suggestions.md
   // § Incremental candidate validation. Refs #2237.
-  final validator = incrementalValidatorForCandidateProbe(
+  return _probeOrderAccepted<NavalMoveOrder>(
     game: game,
     topology: topology,
     playerId: playerId,
     baseOrders: baseOrders,
+    candidate: candidate,
     resolution: resolution,
     factionMembership: factionMembership,
     sharedCandidateValidator: sharedCandidateValidator,
+    probeWithValidator: (validator, c) => validator.isNavalMoveAccepted(c),
   );
-  return validator.isNavalMoveAccepted(candidate);
 }
 
 bool isNavalMissionOrderAccepted(
@@ -236,16 +270,17 @@ bool isNavalMissionOrderAccepted(
 }) {
   // Stateless candidate-probe path. SPEC/program/order-suggestions.md
   // § Incremental candidate validation. Refs #2237.
-  final validator = incrementalValidatorForCandidateProbe(
+  return _probeOrderAccepted<NavalMissionOrder>(
     game: game,
     topology: topology,
     playerId: playerId,
     baseOrders: baseOrders,
+    candidate: candidate,
     resolution: resolution,
     factionMembership: factionMembership,
     sharedCandidateValidator: sharedCandidateValidator,
+    probeWithValidator: (validator, c) => validator.isNavalMissionAccepted(c),
   );
-  return validator.isNavalMissionAccepted(candidate);
 }
 
 bool isDiplomaticOrderAccepted(
@@ -265,17 +300,18 @@ bool isDiplomaticOrderAccepted(
   DiplomacyFactionMembership? factionMembership,
   IncrementalCandidateValidator? sharedCandidateValidator,
 }) {
-  final validator = incrementalValidatorForCandidateProbe(
+  return _probeOrderAccepted<DiplomaticOrder>(
     game: game,
     topology: topology,
     playerId: playerId,
     baseOrders: baseOrders,
+    candidate: candidate,
     tileMapByRegion: tileMapByRegion,
     resolution: resolution,
     factionMembership: factionMembership,
     sharedCandidateValidator: sharedCandidateValidator,
+    probeWithValidator: (validator, c) => validator.isDiplomaticAccepted(c),
   );
-  return validator.isDiplomaticAccepted(candidate);
 }
 
 /// Validates [candidate] with an existing [validator] built for the same

--- a/packages/colonizethis_orders/lib/src/orders/order_suggestion_diplomatic.dart
+++ b/packages/colonizethis_orders/lib/src/orders/order_suggestion_diplomatic.dart
@@ -173,12 +173,11 @@ List<DiplomaticOrder> suggestDiplomaticOrders(
     playerOverturesByTargetId.putIfAbsent(o.targetId, () => o);
   }
 
-  assert(
-    sharedCandidateValidator == null ||
-        sharedCandidateValidator.playerId == playerId,
-    'sharedCandidateValidator playerId must match view.playerId',
+  SuggestionPassContext.assertSharedValidatorPlayerId(
+    sharedCandidateValidator,
+    playerId,
   );
-  final diplomaticResolution = _effectiveOrderResolutionContext(
+  final diplomaticResolution = effectiveOrderResolutionContext(
     view: view,
     game: game,
     sharedCandidateValidator: sharedCandidateValidator,
@@ -328,12 +327,11 @@ List<DiplomaticOrder> suggestDeclareWarOrders(
   };
   final knownTargetIds = knownTargets.toSet();
 
-  assert(
-    sharedCandidateValidator == null ||
-        sharedCandidateValidator.playerId == playerId,
-    'sharedCandidateValidator playerId must match view.playerId',
+  SuggestionPassContext.assertSharedValidatorPlayerId(
+    sharedCandidateValidator,
+    playerId,
   );
-  final declareWarResolution = _effectiveOrderResolutionContext(
+  final declareWarResolution = effectiveOrderResolutionContext(
     view: view,
     game: game,
     sharedCandidateValidator: sharedCandidateValidator,

--- a/packages/colonizethis_orders/lib/src/orders/order_suggestion_move_army.dart
+++ b/packages/colonizethis_orders/lib/src/orders/order_suggestion_move_army.dart
@@ -6,7 +6,6 @@ import 'package:colonizethis_world/colonizethis_world.dart';
 import 'draft_orders_mutations.dart';
 import 'incremental_candidate_validator.dart';
 import 'order_resolution_context.dart';
-import 'order_suggestion_context.dart';
 import 'order_suggestion_pass_context.dart';
 import 'order_visibility.dart';
 

--- a/packages/colonizethis_orders/lib/src/orders/order_suggestion_move_army.dart
+++ b/packages/colonizethis_orders/lib/src/orders/order_suggestion_move_army.dart
@@ -7,6 +7,7 @@ import 'draft_orders_mutations.dart';
 import 'incremental_candidate_validator.dart';
 import 'order_resolution_context.dart';
 import 'order_suggestion_context.dart';
+import 'order_suggestion_pass_context.dart';
 import 'order_visibility.dart';
 
 part 'order_suggestion_move_unit.dart';

--- a/packages/colonizethis_orders/lib/src/orders/order_suggestion_move_unit.dart
+++ b/packages/colonizethis_orders/lib/src/orders/order_suggestion_move_unit.dart
@@ -77,41 +77,26 @@ List<MoveOrder> suggestMoveOrders(
   Orders currentOrders, {
   IncrementalCandidateValidator? sharedCandidateValidator,
 }) {
-  orderSuggestionLog.d('suggestMoveOrders player=${view.playerId}');
-  final playerId = view.playerId;
+  final pass = SuggestionPassContext.forPlayerView(
+    view: view,
+    game: game,
+    topology: topology,
+    currentOrders: currentOrders,
+    familyLabel: 'suggestMoveOrders',
+    sharedCandidateValidator: sharedCandidateValidator,
+    useBuildIncrementalWrapper: false,
+  );
+  final playerId = pass.playerId;
   final suggestions = <MoveOrder>[];
+  final candidateValidator = pass.candidateValidator;
 
   // Build a convenience index of current move orders for this player to avoid
   // suggesting duplicate moves for the same unit + destination.
-  final existingMoves = <String, Set<String>>{};
-  final existingForPlayer =
-      currentOrders.moveOrdersByPlayerId[playerId] ?? const [];
-  for (final m in existingForPlayer) {
-    existingMoves
-        .putIfAbsent(m.unitId, () => <String>{})
-        .add(m.destinationTileKey);
-  }
-
-  // Build the incremental candidate validator once per suggestion pass: the
-  // per-player [PlayerView]/units-by-id work is amortized across every
-  // candidate probe in the loop, instead of being rebuilt per probe via the
-  // old [OrderEngine] full-pass path. SPEC/program/order-suggestions.md
-  // § Incremental candidate validation. Refs #2237.
-  assert(
-    sharedCandidateValidator == null ||
-        sharedCandidateValidator.playerId == playerId,
-    'sharedCandidateValidator playerId must match view.playerId',
+  final existingMoves = indexExistingTargetsByEntityId(
+    currentOrders.moveOrdersByPlayerId[playerId],
+    (m) => m.unitId,
+    (m) => m.destinationTileKey,
   );
-  final candidateValidator =
-      sharedCandidateValidator ??
-      IncrementalCandidateValidator.forPlayer(
-        game: game,
-        topology: topology,
-        playerId: playerId,
-        basePrefix: currentOrders,
-        factionMembership: DiplomacyFactionMembership.from(game),
-        resolution: orderResolutionContextFromView(view, game),
-      );
 
   for (final unit in view.ownUnits) {
     if (isMilitaryUnit(unit.type)) {
@@ -135,29 +120,30 @@ List<MoveOrder> suggestMoveOrders(
       unit: unit,
     );
 
-    var acceptedForUnit = 0;
-    var probeAttemptsForUnit = 0;
-    for (final destinationTileKey in destinationCandidates) {
-      final already = existingMoves[unit.id];
-      if (already != null && already.contains(destinationTileKey)) continue;
-      probeAttemptsForUnit++;
-
-      final candidate = MoveOrder(
-        unitId: unit.id,
-        destinationTileKey: destinationTileKey,
-      );
-
-      if (candidateValidator.isMoveAccepted(candidate)) {
-        suggestions.add(candidate);
-        acceptedForUnit++;
-        if (acceptedForUnit >= _kMaxMoveSuggestionsPerUnit) {
-          break;
-        }
-      }
-      if (probeAttemptsForUnit >= _kMaxMoveProbeAttemptsPerUnit) {
-        break;
-      }
-    }
+    runCappedSuggestionProbeLoop<String>(
+      candidates: destinationCandidates,
+      shouldSkip: (destinationTileKey) {
+        final already = existingMoves[unit.id];
+        return already != null && already.contains(destinationTileKey);
+      },
+      probe: (destinationTileKey) {
+        final candidate = MoveOrder(
+          unitId: unit.id,
+          destinationTileKey: destinationTileKey,
+        );
+        return candidateValidator.isMoveAccepted(candidate);
+      },
+      onAccepted: (destinationTileKey) {
+        suggestions.add(
+          MoveOrder(
+            unitId: unit.id,
+            destinationTileKey: destinationTileKey,
+          ),
+        );
+      },
+      maxAccepted: _kMaxMoveSuggestionsPerUnit,
+      maxProbes: _kMaxMoveProbeAttemptsPerUnit,
+    );
   }
 
   suggestions.sort((a, b) {
@@ -166,11 +152,6 @@ List<MoveOrder> suggestMoveOrders(
     return a.destinationTileKey.compareTo(b.destinationTileKey);
   });
 
-  orderSuggestionLog.d(
-    'suggestMoveOrders player=$playerId candidates=${suggestions.length}',
-  );
-  if (suggestions.isEmpty) {
-    orderSuggestionLog.w('suggestMoveOrders no candidates player=$playerId');
-  }
+  pass.logExit(candidateCount: suggestions.length, warnIfEmpty: true);
   return suggestions;
 }

--- a/packages/colonizethis_orders/lib/src/orders/order_suggestion_naval.dart
+++ b/packages/colonizethis_orders/lib/src/orders/order_suggestion_naval.dart
@@ -103,45 +103,28 @@ List<NavalMoveOrder> suggestNavalMoveOrders(
   OrderResolutionContext? resolution,
   IncrementalCandidateValidator? sharedCandidateValidator,
 }) {
-  orderSuggestionLog.d('suggestNavalMoveOrders player=${view.playerId}');
-  final playerId = view.playerId;
-  final suggestions = <NavalMoveOrder>[];
-  final existingByFleet = <String, Set<String>>{};
-  for (final o
-      in currentOrders.navalMoveOrdersByPlayerId[playerId] ?? const []) {
-    final key = o.isDock
-        ? 'port:${o.destinationPortProvinceId}'
-        : (o.destinationSeaZoneId ?? '');
-    if (key.isNotEmpty) {
-      existingByFleet.putIfAbsent(o.fleetId, () => <String>{}).add(key);
-    }
-  }
-
-  // Single per-player validator: amortizes the per-player [PlayerView] /
-  // units-by-id setup across every candidate probe in the loop.
-  // SPEC/program/order-suggestions.md § Incremental candidate validation.
-  // Refs #2237.
-  //
-  assert(
-    sharedCandidateValidator == null ||
-        sharedCandidateValidator.playerId == playerId,
-    'sharedCandidateValidator playerId must match view.playerId',
-  );
-  final effectiveResolution = _effectiveOrderResolutionContext(
+  final pass = SuggestionPassContext.forPlayerView(
     view: view,
     game: game,
-    resolution: resolution,
+    topology: topology,
+    currentOrders: currentOrders,
+    familyLabel: 'suggestNavalMoveOrders',
     sharedCandidateValidator: sharedCandidateValidator,
+    resolution: resolution,
+    includeFactionMembershipInBuild: false,
+    useBuildIncrementalWrapper: false,
   );
-  final candidateValidator =
-      sharedCandidateValidator ??
-      IncrementalCandidateValidator.forPlayer(
-        game: game,
-        topology: topology,
-        playerId: playerId,
-        basePrefix: currentOrders,
-        resolution: effectiveResolution,
-      );
+  final playerId = pass.playerId;
+  final suggestions = <NavalMoveOrder>[];
+  final candidateValidator = pass.candidateValidator;
+  final existingByFleet = indexExistingTargetsByEntityId(
+    currentOrders.navalMoveOrdersByPlayerId[playerId],
+    (o) => o.fleetId,
+    (o) => o.isDock
+        ? 'port:${o.destinationPortProvinceId}'
+        : (o.destinationSeaZoneId ?? ''),
+    skipEmptyTargets: true,
+  );
 
   final homeFleetId = homeFleetIdFor(playerId);
   for (final fleet in game.worldState.fleets) {
@@ -189,9 +172,7 @@ List<NavalMoveOrder> suggestNavalMoveOrders(
         : (b.destinationSeaZoneId ?? '');
     return keyA.compareTo(keyB);
   });
-  orderSuggestionLog.d(
-    'suggestNavalMoveOrders player=$playerId candidates=${suggestions.length}',
-  );
+  pass.logExit(candidateCount: suggestions.length);
   return suggestions;
 }
 
@@ -206,39 +187,25 @@ List<NavalMissionOrder> suggestNavalMissionOrders(
   OrderResolutionContext? resolution,
   IncrementalCandidateValidator? sharedCandidateValidator,
 }) {
-  orderSuggestionLog.d('suggestNavalMissionOrders player=${view.playerId}');
-  final playerId = view.playerId;
-  final suggestions = <NavalMissionOrder>[];
-  final existingByFleet = <String>{};
-  for (final o
-      in currentOrders.navalMissionOrdersByPlayerId[playerId] ?? const []) {
-    existingByFleet.add(o.fleetId);
-  }
-
-  // Single per-player validator amortizes per-player setup across every
-  // candidate probe (mission × fleet). SPEC/program/order-suggestions.md
-  // § Incremental candidate validation. Refs #2237.
-  //
-  assert(
-    sharedCandidateValidator == null ||
-        sharedCandidateValidator.playerId == playerId,
-    'sharedCandidateValidator playerId must match view.playerId',
-  );
-  final effectiveResolution = _effectiveOrderResolutionContext(
+  final pass = SuggestionPassContext.forPlayerView(
     view: view,
     game: game,
-    resolution: resolution,
+    topology: topology,
+    currentOrders: currentOrders,
+    familyLabel: 'suggestNavalMissionOrders',
     sharedCandidateValidator: sharedCandidateValidator,
+    resolution: resolution,
+    includeFactionMembershipInBuild: false,
+    useBuildIncrementalWrapper: false,
   );
-  final candidateValidator =
-      sharedCandidateValidator ??
-      IncrementalCandidateValidator.forPlayer(
-        game: game,
-        topology: topology,
-        playerId: playerId,
-        basePrefix: currentOrders,
-        resolution: effectiveResolution,
-      );
+  final playerId = pass.playerId;
+  final suggestions = <NavalMissionOrder>[];
+  final candidateValidator = pass.candidateValidator;
+  final existingByFleet = <String>{
+    for (final o
+        in currentOrders.navalMissionOrdersByPlayerId[playerId] ?? const [])
+      o.fleetId,
+  };
 
   for (final fleet in game.worldState.fleets) {
     if (fleet.ownerId != playerId) continue;
@@ -259,8 +226,6 @@ List<NavalMissionOrder> suggestNavalMissionOrders(
     if (c != 0) return c;
     return a.mission.compareTo(b.mission);
   });
-  orderSuggestionLog.d(
-    'suggestNavalMissionOrders player=$playerId candidates=${suggestions.length}',
-  );
+  pass.logExit(candidateCount: suggestions.length);
   return suggestions;
 }

--- a/packages/colonizethis_orders/lib/src/orders/order_suggestion_naval_diplomatic.dart
+++ b/packages/colonizethis_orders/lib/src/orders/order_suggestion_naval_diplomatic.dart
@@ -6,30 +6,12 @@ import 'package:colonizethis_diplomacy/colonizethis_diplomacy.dart';
 import 'incremental_candidate_validator.dart';
 import 'order_resolution_context.dart';
 import 'order_suggestion_context.dart';
+import 'order_suggestion_pass_context.dart';
 
 // Naval and diplomatic order-suggestion families share this library's imports
-// and the private [_effectiveOrderResolutionContext] helper below. The naval
-// move/mission suggesters live in the `_naval` part fragment and the
-// diplomatic / declare-war suggesters in the `_diplomatic` part fragment
-// (Refs #3290 Phase 0 file decomposition). Both `part of` fragments share this
-// library's import set and private scope, so the move is behaviour-preserving —
-// symbols, visibility, and helper sharing are unchanged.
+// and the shared [effectiveOrderResolutionContext] helper from
+// [order_suggestion_pass_context.dart]. The naval move/mission suggesters live
+// in the `_naval` part fragment and the diplomatic / declare-war suggesters in
+// the `_diplomatic` part fragment (Refs #3290 Phase 0 file decomposition).
 part 'order_suggestion_naval.dart';
 part 'order_suggestion_diplomatic.dart';
-
-OrderResolutionContext _effectiveOrderResolutionContext({
-  required PlayerView view,
-  required Game game,
-  OrderResolutionContext? resolution,
-  IncrementalCandidateValidator? sharedCandidateValidator,
-}) {
-  if (resolution != null) return resolution;
-  if (sharedCandidateValidator != null) {
-    return (
-      view: sharedCandidateValidator.view,
-      unitsById: sharedCandidateValidator.unitsById,
-      provinceById: sharedCandidateValidator.view.provincesById,
-    );
-  }
-  return orderResolutionContextFromView(view, game);
-}

--- a/packages/colonizethis_orders/lib/src/orders/order_suggestion_pass_context.dart
+++ b/packages/colonizethis_orders/lib/src/orders/order_suggestion_pass_context.dart
@@ -1,0 +1,205 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import 'package:colonizethis_diplomacy/colonizethis_diplomacy.dart';
+import 'package:colonizethis_world/colonizethis_world.dart';
+import 'incremental_candidate_validator.dart';
+import 'order_resolution_context.dart';
+import 'order_suggestion_context.dart';
+
+/// Shared pass-level context for order-suggestion families (Refs #3500 Phase 2).
+///
+/// Amortizes [IncrementalCandidateValidator] construction, faction membership,
+/// and [OrderResolutionContext] resolution across candidate probes in one
+/// `suggest*` call. SPEC/program/order-suggestions.md § Throughput bounds.
+class SuggestionPassContext {
+  SuggestionPassContext._({
+    required this.view,
+    required this.game,
+    required this.topology,
+    required this.currentOrders,
+    required this.playerId,
+    required this.candidateValidator,
+    required this.factionMembership,
+    required this.resolution,
+    required this.familyLabel,
+  });
+
+  final PlayerView view;
+  final Game game;
+  final MapTopology topology;
+  final Orders currentOrders;
+  final String playerId;
+  final IncrementalCandidateValidator candidateValidator;
+  final DiplomacyFactionMembership factionMembership;
+  final OrderResolutionContext resolution;
+  final String familyLabel;
+
+  /// Asserts [sharedCandidateValidator.playerId] matches [playerId] when set.
+  static void assertSharedValidatorPlayerId(
+    IncrementalCandidateValidator? sharedCandidateValidator,
+    String playerId,
+  ) {
+    assert(
+      sharedCandidateValidator == null ||
+          sharedCandidateValidator.playerId == playerId,
+      'sharedCandidateValidator playerId must match view.playerId',
+    );
+  }
+
+  /// Standard pass setup for `suggest*` families sharing the same throughput
+  /// hook contract (Refs #2394).
+  factory SuggestionPassContext.forPlayerView({
+    required PlayerView view,
+    required Game game,
+    required MapTopology topology,
+    required Orders currentOrders,
+    required String familyLabel,
+    Map<String, TileMapResult>? tileMapByRegion,
+    IncrementalCandidateValidator? sharedCandidateValidator,
+    OrderResolutionContext? resolution,
+    DiplomacyFactionMembership? factionMembership,
+
+    /// When false, constructs via [IncrementalCandidateValidator.forPlayer]
+    /// (move/army-move families). When true, uses
+    /// [buildIncrementalCandidateValidator] (default for most families).
+    bool useBuildIncrementalWrapper = true,
+
+    /// When false, omits [factionMembership] from validator construction
+    /// (naval families).
+    bool includeFactionMembershipInBuild = true,
+  }) {
+    final playerId = view.playerId;
+    assertSharedValidatorPlayerId(sharedCandidateValidator, playerId);
+    orderSuggestionLog.d('$familyLabel player=$playerId');
+
+    final effectiveFactionMembership =
+        factionMembership ??
+        sharedCandidateValidator?.factionMembershipSnapshot ??
+        DiplomacyFactionMembership.from(game);
+
+    final effectiveResolution =
+        resolution ??
+        effectiveOrderResolutionContext(
+          view: view,
+          game: game,
+          sharedCandidateValidator: sharedCandidateValidator,
+        );
+
+    final candidateValidator =
+        sharedCandidateValidator ??
+        (useBuildIncrementalWrapper
+            ? buildIncrementalCandidateValidator(
+                game: game,
+                topology: topology,
+                playerId: playerId,
+                baseOrders: currentOrders,
+                tileMapByRegion: tileMapByRegion,
+                resolution: effectiveResolution,
+                factionMembership: includeFactionMembershipInBuild
+                    ? effectiveFactionMembership
+                    : null,
+              )
+            : IncrementalCandidateValidator.forPlayer(
+                game: game,
+                topology: topology,
+                playerId: playerId,
+                basePrefix: currentOrders,
+                tileMapByRegion: tileMapByRegion,
+                factionMembership: includeFactionMembershipInBuild
+                    ? effectiveFactionMembership
+                    : null,
+                resolution: effectiveResolution,
+              ));
+
+    return SuggestionPassContext._(
+      view: view,
+      game: game,
+      topology: topology,
+      currentOrders: currentOrders,
+      playerId: playerId,
+      candidateValidator: candidateValidator,
+      factionMembership: effectiveFactionMembership,
+      resolution: effectiveResolution,
+      familyLabel: familyLabel,
+    );
+  }
+
+  void logExit({required int candidateCount, bool warnIfEmpty = false}) {
+    orderSuggestionLog.d(
+      '$familyLabel player=$playerId candidates=$candidateCount',
+    );
+    if (warnIfEmpty && candidateCount == 0) {
+      orderSuggestionLog.w('$familyLabel no candidates player=$playerId');
+    }
+  }
+}
+
+/// Resolves [OrderResolutionContext] for a suggestion pass, reusing a shared
+/// validator's embedded view when available (Refs #2394).
+OrderResolutionContext effectiveOrderResolutionContext({
+  required PlayerView view,
+  required Game game,
+  OrderResolutionContext? resolution,
+  IncrementalCandidateValidator? sharedCandidateValidator,
+}) {
+  if (resolution != null) return resolution;
+  if (sharedCandidateValidator != null) {
+    return (
+      view: sharedCandidateValidator.view,
+      unitsById: sharedCandidateValidator.unitsById,
+      provinceById: sharedCandidateValidator.view.provincesById,
+    );
+  }
+  return orderResolutionContextFromView(view, game);
+}
+
+/// Full province ids owned by [playerId] from [view.provincesById].
+Set<String> ownedProvinceIdsFromView(PlayerView view, String playerId) {
+  return {
+    for (final e in view.provincesById.entries)
+      if (e.value.ownerId == playerId) e.key,
+  };
+}
+
+/// Indexes existing orders by entity id → target id set for dedup during
+/// suggestion probes.
+Map<String, Set<String>> indexExistingTargetsByEntityId<T>(
+  List<T>? orders,
+  String Function(T order) entityId,
+  String Function(T order) target, {
+  bool skipEmptyTargets = false,
+}) {
+  final out = <String, Set<String>>{};
+  for (final o in orders ?? const []) {
+    final targetId = target(o);
+    if (skipEmptyTargets && targetId.isEmpty) continue;
+    out.putIfAbsent(entityId(o), () => <String>{}).add(targetId);
+  }
+  return out;
+}
+
+/// Deterministic capped probe loop shared by move and army-move suggestion
+/// (Refs #3500 Phase 2). Skipped candidates do not count toward [maxProbes].
+int runCappedSuggestionProbeLoop<T>({
+  required Iterable<T> candidates,
+  required bool Function(T candidate) shouldSkip,
+  required bool Function(T candidate) probe,
+  required void Function(T candidate) onAccepted,
+  required int maxAccepted,
+  required int maxProbes,
+}) {
+  var accepted = 0;
+  var probeAttempts = 0;
+  for (final candidate in candidates) {
+    if (shouldSkip(candidate)) continue;
+    probeAttempts++;
+    if (probe(candidate)) {
+      onAccepted(candidate);
+      accepted++;
+      if (accepted >= maxAccepted) break;
+    }
+    if (probeAttempts >= maxProbes) break;
+  }
+  return accepted;
+}

--- a/packages/colonizethis_orders/lib/src/orders/order_suggestion_pass_context.dart
+++ b/packages/colonizethis_orders/lib/src/orders/order_suggestion_pass_context.dart
@@ -1,7 +1,6 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
-import 'package:colonizethis_diplomacy/colonizethis_diplomacy.dart';
 import 'package:colonizethis_world/colonizethis_world.dart';
 import 'incremental_candidate_validator.dart';
 import 'order_resolution_context.dart';

--- a/packages/colonizethis_orders/lib/src/orders/order_suggestion_recruit_worker.dart
+++ b/packages/colonizethis_orders/lib/src/orders/order_suggestion_recruit_worker.dart
@@ -5,6 +5,7 @@ import 'package:colonizethis_world/colonizethis_world.dart';
 import 'incremental_candidate_validator.dart';
 import 'order_resolution_context.dart';
 import 'order_suggestion_context.dart';
+import 'order_suggestion_pass_context.dart';
 
 /// Suggests `RecruitWorkerOrder` candidates that are affordable and valid
 /// for [view.playerId] against the prefix in [currentOrders] (Refs #2692 S7,
@@ -32,32 +33,16 @@ List<RecruitWorkerOrder> suggestRecruitWorkerOrders(
   Orders currentOrders, {
   IncrementalCandidateValidator? sharedCandidateValidator,
 }) {
-  orderSuggestionLog.d('suggestRecruitWorkerOrders player=${view.playerId}');
-  final playerId = view.playerId;
-  final suggestions = <RecruitWorkerOrder>[];
-
-  assert(
-    sharedCandidateValidator == null ||
-        sharedCandidateValidator.playerId == playerId,
-    'sharedCandidateValidator playerId must match view.playerId',
+  final pass = SuggestionPassContext.forPlayerView(
+    view: view,
+    game: game,
+    topology: topology,
+    currentOrders: currentOrders,
+    familyLabel: 'suggestRecruitWorkerOrders',
+    sharedCandidateValidator: sharedCandidateValidator,
   );
-  final effectiveResolution = sharedCandidateValidator != null
-      ? (
-          view: sharedCandidateValidator.view,
-          unitsById: sharedCandidateValidator.unitsById,
-          provinceById: sharedCandidateValidator.view.provincesById,
-        )
-      : orderResolutionContextFromView(view, game);
-  final candidateValidator =
-      sharedCandidateValidator ??
-      buildIncrementalCandidateValidator(
-        game: game,
-        topology: topology,
-        playerId: playerId,
-        baseOrders: currentOrders,
-        resolution: effectiveResolution,
-        factionMembership: DiplomacyFactionMembership.from(game),
-      );
+  final suggestions = <RecruitWorkerOrder>[];
+  final candidateValidator = pass.candidateValidator;
 
   for (final tier in WorkerTier.values) {
     final candidate = RecruitWorkerOrder(targetTier: tier);
@@ -71,14 +56,7 @@ List<RecruitWorkerOrder> suggestRecruitWorkerOrders(
 
   suggestions.sort((a, b) => a.targetTier.index.compareTo(b.targetTier.index));
 
-  orderSuggestionLog.d(
-    'suggestRecruitWorkerOrders player=$playerId candidates=${suggestions.length}',
-  );
-  if (suggestions.isEmpty) {
-    orderSuggestionLog.d(
-      'suggestRecruitWorkerOrders no candidates player=$playerId',
-    );
-  }
+  pass.logExit(candidateCount: suggestions.length);
   return suggestions;
 }
 

--- a/packages/colonizethis_orders/lib/src/orders/order_suggestion_work.dart
+++ b/packages/colonizethis_orders/lib/src/orders/order_suggestion_work.dart
@@ -14,6 +14,7 @@ import 'order_suggestion_helpers.dart';
 import 'order_suggestion_work_tile_keys.dart';
 import 'order_suggestion_work_tile_prefilter.dart';
 import 'order_suggestion_context.dart';
+import 'order_suggestion_pass_context.dart';
 import 'order_visibility.dart';
 import 'work_suggestion_pipeline.dart';
 import 'partial_province_reveal.dart';
@@ -91,17 +92,26 @@ List<WorkOrder> suggestWorkOrders(
   Map<String, TileMapResult>? tileMapByRegion,
   IncrementalCandidateValidator? sharedCandidateValidator,
 }) {
-  orderSuggestionLog.d('suggestWorkOrders player=${view.playerId}');
-  final playerId = view.playerId;
+  final pass = SuggestionPassContext.forPlayerView(
+    view: view,
+    game: game,
+    topology: topology,
+    currentOrders: currentOrders,
+    familyLabel: 'suggestWorkOrders',
+    tileMapByRegion: tileMapByRegion,
+    sharedCandidateValidator: sharedCandidateValidator,
+  );
+  final playerId = pass.playerId;
   final suggestions = <WorkOrder>[];
+  final factionMembership = pass.factionMembership;
+  final candidateValidator = pass.candidateValidator;
 
   // Index existing work orders per unit to avoid suggesting duplicates (by unit + target).
-  final existingTargetsByUnit = <String, Set<String>>{};
-  final existingForPlayer =
-      currentOrders.workOrdersByPlayerId[playerId] ?? const [];
-  for (final o in existingForPlayer) {
-    existingTargetsByUnit.putIfAbsent(o.unitId, () => <String>{}).add(o.target);
-  }
+  final existingTargetsByUnit = indexExistingTargetsByEntityId(
+    currentOrders.workOrdersByPlayerId[playerId],
+    (o) => o.unitId,
+    (o) => o.target,
+  );
 
   final tileKeysByRegion = game.worldState.tileKeysByRegionAndProvince;
   final partiallyRevealedProvinceCache =
@@ -121,12 +131,7 @@ List<WorkOrder> suggestWorkOrders(
     colonialIntelExploreProvinceIds: colonialIntelExploreProvinceIds,
   );
 
-  // Reuse [view.provincesById] (same full-id keys as [buildPlayerView]) instead
-  // of a second [allProvinces] scan over world state (Refs #2394).
-  final playerOwnedProvinceIds = <String>{
-    for (final e in view.provincesById.entries)
-      if (e.value.ownerId == playerId) e.key,
-  };
+  final playerOwnedProvinceIds = ownedProvinceIdsFromView(view, playerId);
 
   // Pre-filter + visibility sort per workTarget; reused across worker units.
   final visibleCandidatesSortedByWorkTarget = <String, List<String>>{};
@@ -136,28 +141,6 @@ List<WorkOrder> suggestWorkOrders(
     currentOrders,
     playerId,
   );
-
-  // One validator per suggestion pass: amortizes buildPlayerView + unit map
-  // across all units (Refs #2394, IncrementalCandidateValidator.forPlayer).
-  assert(
-    sharedCandidateValidator == null ||
-        sharedCandidateValidator.playerId == playerId,
-    'sharedCandidateValidator playerId must match view.playerId',
-  );
-  final factionMembership =
-      sharedCandidateValidator?.factionMembershipSnapshot ??
-      DiplomacyFactionMembership.from(game);
-  final candidateValidator =
-      sharedCandidateValidator ??
-      buildIncrementalCandidateValidator(
-        game: game,
-        topology: topology,
-        playerId: playerId,
-        baseOrders: currentOrders,
-        tileMapByRegion: tileMapByRegion,
-        resolution: orderResolutionContextFromView(view, game),
-        factionMembership: factionMembership,
-      );
 
   var needsMerchantPurchaseLandTileIndex = false;
   for (final unit in view.ownUnits) {

--- a/packages/colonizethis_orders/lib/src/orders/order_suggestion_work_tile_keys.dart
+++ b/packages/colonizethis_orders/lib/src/orders/order_suggestion_work_tile_keys.dart
@@ -39,14 +39,6 @@ Set<String> getValidWorkOrderTileKeys(
   /// When non-null, must match [view.provincesById] owned by [playerId].
   Set<String>? playerOwnedProvinceIds,
 }) {
-  final unit = game.worldState.tryGetUnitById(unitId);
-  if (unit == null || unit.ownerId != playerId) return {};
-  if (unit.currentWork != null) return {};
-  if (playerHasPendingWorkOrderForUnit(currentOrders, playerId, unitId)) {
-    return {};
-  }
-  if (!isWorkOrderTargetAllowedForUnitType(unit.type, workTarget)) return {};
-
   assert(
     view == null || view.playerId == playerId,
     'view.playerId must match playerId',
@@ -57,69 +49,28 @@ Set<String> getValidWorkOrderTileKeys(
     'sharedCandidateValidator playerId must match playerId',
   );
 
-  final reservedForPicker = devExclusiveReservedTileKeysForPlayer(
-    game,
-    currentOrders,
-    playerId,
-    ignorePendingWorkOrderUnitId: unitId,
-  );
-
-  // One PlayerView + validator per call unless the caller supplies shared
-  // snapshots for multi-unit panel enumeration (Refs #2394).
   final effectiveView = view ?? buildPlayerView(game, topology, playerId);
-  final effectiveFactionMembership =
-      sharedCandidateValidator?.factionMembershipSnapshot ??
-      factionMembership ??
-      DiplomacyFactionMembership.from(game);
-  final effectiveResolution =
-      resolution ??
-      (sharedCandidateValidator != null
-          ? (
-              view: sharedCandidateValidator.view,
-              unitsById: sharedCandidateValidator.unitsById,
-              provinceById: sharedCandidateValidator.view.provincesById,
-            )
-          : orderResolutionContextFromView(effectiveView, game));
-  final effectiveOwnedProvinceIds =
-      playerOwnedProvinceIds ??
-      <String>{
-        for (final e in effectiveResolution.provinceById.entries)
-          if (e.value.ownerId == playerId) e.key,
-      };
-  final candidateValidator =
-      sharedCandidateValidator ??
-      buildIncrementalCandidateValidator(
-        game: game,
-        topology: topology,
-        playerId: playerId,
-        baseOrders: currentOrders,
-        tileMapByRegion: tileMapByRegion,
-        resolution: effectiveResolution,
-        factionMembership: effectiveFactionMembership,
-      );
-  final raw = rawCandidateTilesForWorkTarget(
+  final probe = _prepareWorkOrderTileKeyProbe(
     game: game,
+    topology: topology,
     playerId: playerId,
+    view: effectiveView,
+    unitId: unitId,
     workTarget: workTarget,
+    currentOrders: currentOrders,
     tileMapByRegion: tileMapByRegion,
-    playerOwnedProvinceIds: effectiveOwnedProvinceIds,
-    factionMembership: effectiveFactionMembership,
+    resolution: resolution,
+    factionMembership: factionMembership,
+    sharedCandidateValidator: sharedCandidateValidator,
+    playerOwnedProvinceIds: playerOwnedProvinceIds,
+    applyExploreProvinceScope: false,
   );
-  final valid = <String>{};
-  for (final tileKey in raw) {
-    if (isDevExclusiveWorkTarget(workTarget) &&
-        reservedForPicker.contains(tileKey)) {
-      continue;
-    }
-    final candidate = WorkOrder(
-      unitId: unitId,
-      target: workTarget,
-      targetTileKey: tileKey,
-    );
-    if (isWorkOrderAcceptedWithValidator(candidateValidator, candidate)) {
-      valid.add(tileKey);
-    }
-  }
+  if (probe == null) return const {};
+
+  final valid = _collectValidWorkOrderTileKeys(
+    probe: probe,
+    tileKeysToProbe: probe.rawCandidateTileKeys,
+  );
   orderSuggestionLog.d(
     'getValidWorkOrderTileKeys unit=$unitId target=$workTarget count=${valid.length}',
   );
@@ -158,50 +109,75 @@ Set<String> getValidWorkOrderTileKeysWithVisibility({
     sharedCandidateValidator == null ||
         sharedCandidateValidator.playerId == view.playerId,
   );
-  final unit = game.worldState.tryGetUnitById(unitId);
-  if (unit == null || unit.ownerId != view.playerId) {
-    return {};
-  }
-  if (unit.currentWork != null) {
-    return {};
-  }
-  if (playerHasPendingWorkOrderForUnit(currentOrders, view.playerId, unitId)) {
-    return {};
-  }
-  if (!isWorkOrderTargetAllowedForUnitType(unit.type, workTarget)) {
-    return {};
-  }
 
-  final playerId = view.playerId;
-
-  final reservedForPicker = devExclusiveReservedTileKeysForPlayer(
-    game,
-    currentOrders,
-    playerId,
-    ignorePendingWorkOrderUnitId: unitId,
-  );
-
-  final factionMembership =
-      sharedCandidateValidator?.factionMembershipSnapshot ??
-      DiplomacyFactionMembership.from(game);
-  final ownedProvinceIds =
-      playerOwnedProvinceIds ??
-      <String>{
-        for (final e in view.provincesById.entries)
-          if (e.value.ownerId == playerId) e.key,
-      };
-  final raw = rawCandidateTilesForWorkTarget(
+  final probe = _prepareWorkOrderTileKeyProbe(
     game: game,
-    playerId: playerId,
+    topology: topology,
+    playerId: view.playerId,
+    view: view,
+    unitId: unitId,
     workTarget: workTarget,
-    exploreProvinceScope: workTarget == kWorkTargetExplore
-        ? partiallyRevealedPrefixedProvinceIdsForPlayer(game: game, view: view)
-        : null,
+    currentOrders: currentOrders,
     tileMapByRegion: tileMapByRegion,
-    playerOwnedProvinceIds: ownedProvinceIds,
-    factionMembership: factionMembership,
+    resolution: resolution,
+    sharedCandidateValidator: sharedCandidateValidator,
+    playerOwnedProvinceIds: playerOwnedProvinceIds,
+    applyExploreProvinceScope: true,
   );
-  final sortedVisible = sortedVisibleWorkTargetCandidates(view, raw);
+  if (probe == null) return const {};
+
+  return _collectValidWorkOrderTileKeys(
+    probe: probe,
+    tileKeysToProbe: sortedVisibleWorkTargetCandidates(
+      view,
+      probe.rawCandidateTileKeys,
+    ),
+  );
+}
+
+class _WorkOrderTileKeyProbe {
+  const _WorkOrderTileKeyProbe({
+    required this.unitId,
+    required this.workTarget,
+    required this.reservedForPicker,
+    required this.candidateValidator,
+    required this.rawCandidateTileKeys,
+  });
+
+  final String unitId;
+  final String workTarget;
+  final Set<String> reservedForPicker;
+  final IncrementalCandidateValidator candidateValidator;
+  final Set<String> rawCandidateTileKeys;
+}
+
+_WorkOrderTileKeyProbe? _prepareWorkOrderTileKeyProbe({
+  required Game game,
+  required MapTopology topology,
+  required String playerId,
+  required PlayerView view,
+  required String unitId,
+  required String workTarget,
+  required Orders currentOrders,
+  Map<String, TileMapResult>? tileMapByRegion,
+  OrderResolutionContext? resolution,
+  DiplomacyFactionMembership? factionMembership,
+  IncrementalCandidateValidator? sharedCandidateValidator,
+  Set<String>? playerOwnedProvinceIds,
+  required bool applyExploreProvinceScope,
+}) {
+  final unit = game.worldState.tryGetUnitById(unitId);
+  if (unit == null || unit.ownerId != playerId) return null;
+  if (unit.currentWork != null) return null;
+  if (playerHasPendingWorkOrderForUnit(currentOrders, playerId, unitId)) {
+    return null;
+  }
+  if (!isWorkOrderTargetAllowedForUnitType(unit.type, workTarget)) return null;
+
+  final effectiveFactionMembership =
+      sharedCandidateValidator?.factionMembershipSnapshot ??
+      factionMembership ??
+      DiplomacyFactionMembership.from(game);
   final effectiveResolution =
       resolution ??
       (sharedCandidateValidator != null
@@ -211,6 +187,12 @@ Set<String> getValidWorkOrderTileKeysWithVisibility({
               provinceById: sharedCandidateValidator.view.provincesById,
             )
           : orderResolutionContextFromView(view, game));
+  final effectiveOwnedProvinceIds =
+      playerOwnedProvinceIds ??
+      <String>{
+        for (final e in effectiveResolution.provinceById.entries)
+          if (e.value.ownerId == playerId) e.key,
+      };
   final candidateValidator =
       sharedCandidateValidator ??
       buildIncrementalCandidateValidator(
@@ -220,21 +202,51 @@ Set<String> getValidWorkOrderTileKeysWithVisibility({
         baseOrders: currentOrders,
         tileMapByRegion: tileMapByRegion,
         resolution: effectiveResolution,
-        factionMembership: factionMembership,
+        factionMembership: effectiveFactionMembership,
       );
+  final raw = rawCandidateTilesForWorkTarget(
+    game: game,
+    playerId: playerId,
+    workTarget: workTarget,
+    exploreProvinceScope: applyExploreProvinceScope &&
+            workTarget == kWorkTargetExplore
+        ? partiallyRevealedPrefixedProvinceIdsForPlayer(game: game, view: view)
+        : null,
+    tileMapByRegion: tileMapByRegion,
+    playerOwnedProvinceIds: effectiveOwnedProvinceIds,
+    factionMembership: effectiveFactionMembership,
+  );
 
+  return _WorkOrderTileKeyProbe(
+    unitId: unitId,
+    workTarget: workTarget,
+    reservedForPicker: devExclusiveReservedTileKeysForPlayer(
+      game,
+      currentOrders,
+      playerId,
+      ignorePendingWorkOrderUnitId: unitId,
+    ),
+    candidateValidator: candidateValidator,
+    rawCandidateTileKeys: raw,
+  );
+}
+
+Set<String> _collectValidWorkOrderTileKeys({
+  required _WorkOrderTileKeyProbe probe,
+  required Iterable<String> tileKeysToProbe,
+}) {
   final valid = <String>{};
-  for (final tileKey in sortedVisible) {
-    if (isDevExclusiveWorkTarget(workTarget) &&
-        reservedForPicker.contains(tileKey)) {
+  for (final tileKey in tileKeysToProbe) {
+    if (isDevExclusiveWorkTarget(probe.workTarget) &&
+        probe.reservedForPicker.contains(tileKey)) {
       continue;
     }
     final candidate = WorkOrder(
-      unitId: unitId,
-      target: workTarget,
+      unitId: probe.unitId,
+      target: probe.workTarget,
       targetTileKey: tileKey,
     );
-    if (isWorkOrderAcceptedWithValidator(candidateValidator, candidate)) {
+    if (isWorkOrderAcceptedWithValidator(probe.candidateValidator, candidate)) {
       valid.add(tileKey);
     }
   }

--- a/packages/colonizethis_orders/lib/src/orders/order_visibility.dart
+++ b/packages/colonizethis_orders/lib/src/orders/order_visibility.dart
@@ -143,21 +143,6 @@ bool _workVisExplorePartialReveal(
   return isPartiallyRevealedProvinceLandTilesForPlayer(view, landKeys);
 }
 
-bool _workVisFoggedOrBetterProvince(
-  PlayerView view,
-  String regionId,
-  String provinceId,
-  bool isOwned,
-  WorldState? _,
-) {
-  return provinceHasAtLeastVisibility(
-    view,
-    regionId,
-    provinceId,
-    VisibilityLevel.fogged,
-  );
-}
-
 bool _workVisFoggedProvince(
   PlayerView view,
   String regionId,
@@ -200,8 +185,8 @@ final Map<String, _WorkTargetVisibilityFn> _workOrderVisibilityByTarget =
       kWorkTargetBuildPort: _workVisOwnedOrFoggedProvince,
       kWorkTargetBuildFort: _workVisOwnedOrFoggedProvince,
       'build_rail': _workVisOwnedOrFoggedProvince,
-      kWorkTargetPurchaseLand: _workVisFoggedOrBetterProvince,
-      kWorkTargetStealTech: _workVisFoggedOrBetterProvince,
+      kWorkTargetPurchaseLand: _workVisFoggedProvince,
+      kWorkTargetStealTech: _workVisFoggedProvince,
       kWorkTargetCounterSpy: _workVisOwnedOrFoggedProvince,
     };
 

--- a/packages/colonizethis_orders/lib/src/orders/order_work_constants.dart
+++ b/packages/colonizethis_orders/lib/src/orders/order_work_constants.dart
@@ -23,6 +23,21 @@ const String kWorkTargetBuildFort = 'build_fort';
 const String kWorkTargetBuildRail = 'build_rail';
 const String kWorkTargetUpgradeTown = 'upgrade_town';
 
+/// Work targets that skip material-cost and tech validation (treasury-only or
+/// no-cost targets). Used by validators and cost calculators.
+const Set<String> kWorkTargetsWithoutMaterialCost = {
+  kWorkTargetStealTech,
+  kWorkTargetCounterSpy,
+  kWorkTargetPurchaseLand,
+};
+
+/// Work targets that skip projected material-cost deduction during validation.
+/// [kWorkTargetPurchaseLand] treasury is charged on work completion instead.
+const Set<String> kWorkTargetsWithoutProjectedMaterialCost = {
+  kWorkTargetStealTech,
+  kWorkTargetCounterSpy,
+};
+
 /// Resource ids that count as minerals for work/purchase rules.
 /// Shared across extraction, work orders, and order application helpers.
 const Set<String> kMineralResourceIds = {

--- a/packages/colonizethis_orders/lib/src/orders/orders_application_build_phase.dart
+++ b/packages/colonizethis_orders/lib/src/orders/orders_application_build_phase.dart
@@ -252,20 +252,12 @@ BuildWorkState runBuildPhase(BuildWorkState state) {
       );
     }
 
-    current = current.copyWith(
-      game: current.game.copyWith(
-        players: current.game.players
-            .map(
-              (p) => p.id == player.id
-                  ? p.copyWith(
-                      stockpile: stockpile,
-                      workerPool: workers,
-                      treasury: treasury,
-                    )
-                  : p,
-            )
-            .toList(),
-      ),
+    current = writebackPlayerEconomyFields(
+      current,
+      player,
+      workers: workers,
+      stockpile: stockpile,
+      treasury: treasury,
     );
   }
 

--- a/packages/colonizethis_orders/lib/src/orders/orders_application_completed_work.dart
+++ b/packages/colonizethis_orders/lib/src/orders/orders_application_completed_work.dart
@@ -172,7 +172,10 @@ BuildWorkState _completedWorkBuildImprovement(CompletedWorkContext ctx) {
   return s.copyWith(game: game, work: work);
 }
 
-BuildWorkState _completedWorkUpgradeTown(CompletedWorkContext ctx) {
+BuildWorkState _updateProvinceAtUnitLocation(
+  CompletedWorkContext ctx,
+  Province Function(Province province) update,
+) {
   final s = ctx.state;
   final u = ctx.unit;
   final getProvinces = ctx.getProvinces;
@@ -182,14 +185,21 @@ BuildWorkState _completedWorkUpgradeTown(CompletedWorkContext ctx) {
   final next = provinces.map((p) {
     if (!replaced && p.id == u.locationProvinceId) {
       replaced = true;
-      return p.copyWith(
-        townDevelopmentLevel: (p.townDevelopmentLevel + 1).clamp(0, 4),
-      );
+      return update(p);
     }
     return p;
   }).toList();
   if (!replaced) return s;
   return s.copyWith(work: replaceProvinces(s.work, next));
+}
+
+BuildWorkState _completedWorkUpgradeTown(CompletedWorkContext ctx) {
+  return _updateProvinceAtUnitLocation(
+    ctx,
+    (p) => p.copyWith(
+      townDevelopmentLevel: (p.townDevelopmentLevel + 1).clamp(0, 4),
+    ),
+  );
 }
 
 BuildWorkState _completedWorkExplore(CompletedWorkContext ctx) {
@@ -257,21 +267,10 @@ BuildWorkState _completedWorkBuildPort(CompletedWorkContext ctx) {
 BuildWorkState _completedWorkBuildFort(CompletedWorkContext ctx) {
   final s = ctx.state;
   final u = ctx.unit;
-  final getProvinces = ctx.getProvinces;
-  final replaceProvinces = ctx.replaceProvinces;
-  final provinces = getProvinces();
-  var replaced = false;
-  final nextProvinces = provinces.map((p) {
-    if (!replaced && p.id == u.locationProvinceId) {
-      replaced = true;
-      return p.copyWith(fortLevel: (p.fortLevel + 1).clamp(0, 3));
-    }
-    return p;
-  }).toList();
-  WorkOrderState work = s.work;
-  if (replaced) {
-    work = replaceProvinces(work, nextProvinces);
-  }
+  var next = _updateProvinceAtUnitLocation(
+    ctx,
+    (p) => p.copyWith(fortLevel: (p.fortLevel + 1).clamp(0, 3)),
+  );
   if (s.topology != null && s.onDialogue != null) {
     final seed =
         ((s.game.globalGameSeed ?? 0) ^
@@ -289,7 +288,7 @@ BuildWorkState _completedWorkBuildFort(CompletedWorkContext ctx) {
       s.onDialogue!(e);
     }
   }
-  return s.copyWith(work: work);
+  return next;
 }
 
 BuildWorkState _completedWorkBuildRail(CompletedWorkContext ctx) {

--- a/packages/colonizethis_orders/lib/src/orders/orders_application_context.dart
+++ b/packages/colonizethis_orders/lib/src/orders/orders_application_context.dart
@@ -158,6 +158,31 @@ class BuildWorkState {
   }
 }
 
+/// Writes projected economy fields back onto [player] inside [current.game].
+BuildWorkState writebackPlayerEconomyFields(
+  BuildWorkState current,
+  Player player, {
+  required WorkerPool workers,
+  required Stockpile stockpile,
+  required int treasury,
+}) {
+  return current.copyWith(
+    game: current.game.copyWith(
+      players: current.game.players
+          .map(
+            (p) => p.id == player.id
+                ? p.copyWith(
+                    workerPool: workers,
+                    stockpile: stockpile,
+                    treasury: treasury,
+                  )
+                : p,
+          )
+          .toList(),
+    ),
+  );
+}
+
 /// Returns [game] with [newUnitId] appended to the appropriate army for [player].
 ///
 /// When [armiesById] is supplied it MUST be a snapshot of `game.worldState.armies`

--- a/packages/colonizethis_orders/lib/src/orders/orders_application_worker_pool_phase.dart
+++ b/packages/colonizethis_orders/lib/src/orders/orders_application_worker_pool_phase.dart
@@ -50,20 +50,12 @@ BuildWorkState runWorkerPoolPhase(BuildWorkState state) {
       treasury = after.treasury;
     }
 
-    current = current.copyWith(
-      game: current.game.copyWith(
-        players: current.game.players
-            .map(
-              (p) => p.id == player.id
-                  ? p.copyWith(
-                      workerPool: workers,
-                      stockpile: stockpile,
-                      treasury: treasury,
-                    )
-                  : p,
-            )
-            .toList(),
-      ),
+    current = writebackPlayerEconomyFields(
+      current,
+      player,
+      workers: workers,
+      stockpile: stockpile,
+      treasury: treasury,
     );
   }
 

--- a/packages/colonizethis_orders/lib/src/orders/per_player_work_target_selection_cache.dart
+++ b/packages/colonizethis_orders/lib/src/orders/per_player_work_target_selection_cache.dart
@@ -137,36 +137,30 @@ class PerPlayerWorkTargetSelectionCache {
 
   static final Map<String, WorkTargetSelectionPopulationStrategy>
   _defaultStrategies = {
-    kWorkTargetExplore: _populateExploreTargets,
-    kWorkTargetStealTech: _populateStealTechTargets,
-    kWorkTargetCounterSpy: _populateCounterSpyTargets,
-    kWorkTargetPurchaseLand: _populatePurchaseLandTargets,
-    kWorkTargetProspect: _populateProspectTargets,
-    kWorkTargetBuildImprovement: _populateBuildImprovementTargets,
-    kWorkTargetUpgradeTown: _populateUpgradeTownTargets,
-    kWorkTargetBuildRoad: _populateBuildRoadTargets,
-    kWorkTargetBuildPort: _populateBuildPortTargets,
-    kWorkTargetBuildFort: _populateBuildFortTargets,
-    kWorkTargetBuildRail: _populateBuildRailTargets,
+    for (final target in _mergedValidWorkTargets)
+      target: (WorkTargetSelectionSnapshot s) =>
+          _populateMergedValidForTarget(s, target),
+    for (final target in _idleNoPendingWorkTargets)
+      target: (WorkTargetSelectionSnapshot s) =>
+          _populateIdleNoPendingTargets(s, target),
   };
 
-  static Set<String> _populateExploreTargets(WorkTargetSelectionSnapshot s) {
-    return _populateMergedValidForTarget(s, kWorkTargetExplore);
-  }
+  static const _mergedValidWorkTargets = <String>{
+    kWorkTargetExplore,
+    kWorkTargetStealTech,
+    kWorkTargetCounterSpy,
+    kWorkTargetPurchaseLand,
+  };
 
-  static Set<String> _populateStealTechTargets(WorkTargetSelectionSnapshot s) {
-    return _populateMergedValidForTarget(s, kWorkTargetStealTech);
-  }
-
-  static Set<String> _populateCounterSpyTargets(WorkTargetSelectionSnapshot s) {
-    return _populateMergedValidForTarget(s, kWorkTargetCounterSpy);
-  }
-
-  static Set<String> _populatePurchaseLandTargets(
-    WorkTargetSelectionSnapshot s,
-  ) {
-    return _populateMergedValidForTarget(s, kWorkTargetPurchaseLand);
-  }
+  static const _idleNoPendingWorkTargets = <String>{
+    kWorkTargetProspect,
+    kWorkTargetBuildImprovement,
+    kWorkTargetUpgradeTown,
+    kWorkTargetBuildRoad,
+    kWorkTargetBuildPort,
+    kWorkTargetBuildFort,
+    kWorkTargetBuildRail,
+  };
 
   /// Per-unit union of `getValidWorkOrderTileKeysWithVisibility` (same as
   /// `explore` cache population).
@@ -196,38 +190,6 @@ class PerPlayerWorkTargetSelectionCache {
       merged.addAll(valid);
     }
     return merged;
-  }
-
-  static Set<String> _populateBuildImprovementTargets(
-    WorkTargetSelectionSnapshot s,
-  ) {
-    return _populateIdleNoPendingTargets(s, kWorkTargetBuildImprovement);
-  }
-
-  static Set<String> _populateProspectTargets(WorkTargetSelectionSnapshot s) {
-    return _populateIdleNoPendingTargets(s, kWorkTargetProspect);
-  }
-
-  static Set<String> _populateUpgradeTownTargets(
-    WorkTargetSelectionSnapshot s,
-  ) {
-    return _populateIdleNoPendingTargets(s, kWorkTargetUpgradeTown);
-  }
-
-  static Set<String> _populateBuildRoadTargets(WorkTargetSelectionSnapshot s) {
-    return _populateIdleNoPendingTargets(s, kWorkTargetBuildRoad);
-  }
-
-  static Set<String> _populateBuildPortTargets(WorkTargetSelectionSnapshot s) {
-    return _populateIdleNoPendingTargets(s, kWorkTargetBuildPort);
-  }
-
-  static Set<String> _populateBuildFortTargets(WorkTargetSelectionSnapshot s) {
-    return _populateIdleNoPendingTargets(s, kWorkTargetBuildFort);
-  }
-
-  static Set<String> _populateBuildRailTargets(WorkTargetSelectionSnapshot s) {
-    return _populateIdleNoPendingTargets(s, kWorkTargetBuildRail);
   }
 
   static Set<String> _populateIdleNoPendingTargets(

--- a/packages/colonizethis_orders/lib/src/orders/validators/army_move_validator.dart
+++ b/packages/colonizethis_orders/lib/src/orders/validators/army_move_validator.dart
@@ -7,7 +7,7 @@ import '../order_validation_result.dart';
 import '../order_visibility.dart';
 
 /// Validates [ArmyMoveOrder]. SPEC/program/orders.md.
-class ArmyMoveValidator {
+class ArmyMoveValidator extends OrderValidator {
   const ArmyMoveValidator();
 
   /// Validates the army move.
@@ -28,82 +28,88 @@ class ArmyMoveValidator {
     List<DiplomaticOrder> diplomaticOrders,
     PlayerView view,
     MapTopology topology, {
+    bool previousRejected = false,
     Map<String, Army>? armiesById,
     DiplomacyFactionMembership? factionMembership,
   }) {
-    final army = armiesById != null
-        ? armiesById[order.armyId]
-        : _firstArmyById(game.worldState.armies, order.armyId);
-    if (army == null || army.ownerId != playerId) {
-      return OrderValidationResult.rejected('Invalid army move');
-    }
-    if (army.isHomeArmy) {
-      return OrderValidationResult.rejected('Home army cannot leave capital');
-    }
-    final unitRegion = ProvinceId.regionIdFrom(army.stationedProvinceId);
-    final destFullId = resolveToFullProvinceId(
-      game.worldState,
-      order.destinationProvinceId,
+    return shortCircuitIfPreviousRejected(
+      previousRejected: previousRejected,
+      body: () {
+        final army = armiesById != null
+            ? armiesById[order.armyId]
+            : _firstArmyById(game.worldState.armies, order.armyId);
+        if (army == null || army.ownerId != playerId) {
+          return OrderValidationResult.rejected('Invalid army move');
+        }
+        if (army.isHomeArmy) {
+          return OrderValidationResult.rejected('Home army cannot leave capital');
+        }
+        final unitRegion = ProvinceId.regionIdFrom(army.stationedProvinceId);
+        final destFullId = resolveToFullProvinceId(
+          game.worldState,
+          order.destinationProvinceId,
+        );
+        final destRegion = ProvinceId.regionIdFrom(destFullId);
+        final destProvince = game.worldState.tryGetProvince(destFullId);
+        final destOwnerId = destProvince?.ownerId;
+        final moveToOwnProvince = destOwnerId == playerId;
+        if (!moveToOwnProvince && destRegion != unitRegion) {
+          return OrderValidationResult.rejected('Invalid army move');
+        }
+        if (!moveToOwnProvince) {
+          final fromLocal = ProvinceId.localIdFrom(army.stationedProvinceId);
+          final destLocal = ProvinceId.localIdFrom(destFullId);
+          if (!isValidLandMoveInRegion(
+            topology,
+            unitRegion,
+            fromLocal,
+            destLocal,
+          )) {
+            return OrderValidationResult.rejected('Invalid army move');
+          }
+        }
+
+        if (destOwnerId != null &&
+            destOwnerId != playerId &&
+            isGreatPower(game, destOwnerId, factionMembership: factionMembership) &&
+            !canAttackWithWarOrDeclaring(
+              game,
+              playerId,
+              destOwnerId,
+              diplomaticOrders,
+            )) {
+          return OrderValidationResult.rejected(
+            'Must declare war before attacking Great Power province',
+          );
+        }
+
+        if (destOwnerId != null &&
+            destOwnerId != playerId &&
+            isMinorOrTribe(
+              game,
+              destOwnerId,
+              factionMembership: factionMembership,
+            ) &&
+            !canAttackWithWarOrDeclaring(
+              game,
+              playerId,
+              destOwnerId,
+              diplomaticOrders,
+            )) {
+          return OrderValidationResult.rejected(
+            'Must declare war before attacking Minor Nation or Tribe province',
+          );
+        }
+
+        if (!moveSourceVisibilityOk(view, unitRegion, army.stationedProvinceId) ||
+            !moveDestVisibilityOkForArmy(view, destRegion, destFullId)) {
+          return OrderValidationResult.rejected(
+            'Source or destination not visible',
+          );
+        }
+        return OrderValidationResult.accepted();
+      },
     );
-    final destRegion = ProvinceId.regionIdFrom(destFullId);
-    final destProvince = game.worldState.tryGetProvince(destFullId);
-    final destOwnerId = destProvince?.ownerId;
-    final moveToOwnProvince = destOwnerId == playerId;
-    if (!moveToOwnProvince && destRegion != unitRegion) {
-      return OrderValidationResult.rejected('Invalid army move');
-    }
-    if (!moveToOwnProvince) {
-      final fromLocal = ProvinceId.localIdFrom(army.stationedProvinceId);
-      final destLocal = ProvinceId.localIdFrom(destFullId);
-      if (!isValidLandMoveInRegion(
-        topology,
-        unitRegion,
-        fromLocal,
-        destLocal,
-      )) {
-        return OrderValidationResult.rejected('Invalid army move');
-      }
-    }
-
-    if (destOwnerId != null &&
-        destOwnerId != playerId &&
-        isGreatPower(game, destOwnerId, factionMembership: factionMembership) &&
-        !canAttackWithWarOrDeclaring(
-          game,
-          playerId,
-          destOwnerId,
-          diplomaticOrders,
-        )) {
-      return OrderValidationResult.rejected(
-        'Must declare war before attacking Great Power province',
-      );
-    }
-
-    if (destOwnerId != null &&
-        destOwnerId != playerId &&
-        isMinorOrTribe(
-          game,
-          destOwnerId,
-          factionMembership: factionMembership,
-        ) &&
-        !canAttackWithWarOrDeclaring(
-          game,
-          playerId,
-          destOwnerId,
-          diplomaticOrders,
-        )) {
-      return OrderValidationResult.rejected(
-        'Must declare war before attacking Minor Nation or Tribe province',
-      );
-    }
-
-    if (!moveSourceVisibilityOk(view, unitRegion, army.stationedProvinceId) ||
-        !moveDestVisibilityOkForArmy(view, destRegion, destFullId)) {
-      return OrderValidationResult.rejected(
-        'Source or destination not visible',
-      );
-    }
-    return OrderValidationResult.accepted();
   }
 }
 

--- a/packages/colonizethis_orders/lib/src/orders/validators/build_order_validator.dart
+++ b/packages/colonizethis_orders/lib/src/orders/validators/build_order_validator.dart
@@ -32,10 +32,10 @@ class BuildOrderValidator extends StatefulValidator {
     required WorkerPool workerPool,
   }) : _game = game,
        _player = player,
-       super(
-         stockpileState: stockpile,
-         treasuryState: treasury,
-         workerPoolState: workerPool,
+       super.withProjectedEconomy(
+         stockpile: stockpile,
+         treasury: treasury,
+         workerPool: workerPool,
        );
 
   WorkerPool get workers => workerPoolState;
@@ -80,23 +80,21 @@ class BuildOrderValidator extends StatefulValidator {
           stockpileState,
           treasuryState,
         );
-        if (!check.canAfford) {
-          return OrderValidationResult.rejected(
-            check.reason ?? 'Insufficient resources',
-          );
-        }
-
-        final after = ProjectedCostEngine.applyBuildOrderCostDeduction(
-          _player,
-          o,
-          workerPoolState,
-          stockpileState,
-          treasuryState,
+        return applyCostIfAffordable(
+          check: check,
+          applyDeduction: () {
+            final after = ProjectedCostEngine.applyBuildOrderCostDeduction(
+              _player,
+              o,
+              workerPoolState,
+              stockpileState,
+              treasuryState,
+            );
+            workerPoolState = after.workers;
+            stockpileState = after.stockpile;
+            treasuryState = after.treasury;
+          },
         );
-        workerPoolState = after.workers;
-        stockpileState = after.stockpile;
-        treasuryState = after.treasury;
-        return OrderValidationResult.accepted();
       },
     );
   }

--- a/packages/colonizethis_orders/lib/src/orders/validators/diplomatic/alliance_validator.dart
+++ b/packages/colonizethis_orders/lib/src/orders/validators/diplomatic/alliance_validator.dart
@@ -1,4 +1,3 @@
-import 'package:colonizethis_diplomacy/colonizethis_diplomacy.dart';
 import 'diplomatic_sub_validator.dart';
 
 /// Type-specific validator for [DiplomaticOrderType.alliance] orders.
@@ -11,16 +10,13 @@ DiplomaticSubValidator allianceSubValidator(
   required treasury,
 }) {
   final targetId = order.targetFactionId;
-  if (!isGreatPower(
-    ctx.game,
-    targetId,
-    factionMembership: ctx.factionMembership,
-  )) {
-    return rejectDiplomaticSub(
-      'Alliance target must be a Great Power',
-      treasury,
-    );
-  }
+  final notGpRejection = rejectIfNotGreatPowerTarget(
+    ctx: ctx,
+    targetId: targetId,
+    rejectionReason: 'Alliance target must be a Great Power',
+    treasury: treasury,
+  );
+  if (notGpRejection != null) return notGpRejection;
   final atWarRejection = rejectDiplomaticSubIfAtWar(
     relation: relation,
     reason: 'Cannot form alliance while at war with that faction',

--- a/packages/colonizethis_orders/lib/src/orders/validators/diplomatic/alliance_validator.dart
+++ b/packages/colonizethis_orders/lib/src/orders/validators/diplomatic/alliance_validator.dart
@@ -21,12 +21,11 @@ DiplomaticSubValidator allianceSubValidator(
       treasury,
     );
   }
-  final atWar = relation?.atWar ?? false;
-  if (atWar) {
-    return rejectDiplomaticSub(
-      'Cannot form alliance while at war with that faction',
-      treasury,
-    );
-  }
+  final atWarRejection = rejectDiplomaticSubIfAtWar(
+    relation: relation,
+    reason: 'Cannot form alliance while at war with that faction',
+    treasury: treasury,
+  );
+  if (atWarRejection != null) return atWarRejection;
   return acceptDiplomaticSub(treasury);
 });

--- a/packages/colonizethis_orders/lib/src/orders/validators/diplomatic/diplomatic_sub_validator.dart
+++ b/packages/colonizethis_orders/lib/src/orders/validators/diplomatic/diplomatic_sub_validator.dart
@@ -1,7 +1,115 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'package:colonizethis_diplomacy/colonizethis_diplomacy.dart';
 import '../../order_validation_result.dart';
+
+/// Returns a rejection when [relation] is at war; otherwise `null`.
+({OrderValidationResult result, int treasury})? rejectDiplomaticSubIfAtWar({
+  required DiplomacyRelation? relation,
+  required String reason,
+  required int treasury,
+}) {
+  if (relation?.atWar ?? false) {
+    return rejectDiplomaticSub(reason, treasury);
+  }
+  return null;
+}
+
+/// Returns a rejection when [relation] is not at war; otherwise `null`.
+({OrderValidationResult result, int treasury})? rejectDiplomaticSubIfAtPeace({
+  required DiplomacyRelation? relation,
+  required String reason,
+  required int treasury,
+}) {
+  if (!(relation?.atWar ?? false)) {
+    return rejectDiplomaticSub(reason, treasury);
+  }
+  return null;
+}
+
+/// Validates positive [amount] on [step] increments for economic diplomatic orders.
+({OrderValidationResult result, int treasury})? rejectIfInvalidAmountMultiple({
+  required int amount,
+  required int step,
+  required String label,
+  required int treasury,
+}) {
+  if (amount <= 0) {
+    return rejectDiplomaticSub('$label amount must be positive', treasury);
+  }
+  if (amount < step) {
+    return rejectDiplomaticSub(
+      '$label amount must be at least £$step',
+      treasury,
+    );
+  }
+  if (amount % step != 0) {
+    return rejectDiplomaticSub(
+      '$label amount must be a multiple of £$step',
+      treasury,
+    );
+  }
+  return null;
+}
+
+/// Rejects when [treasury] is below [cost]; otherwise debits and accepts.
+({OrderValidationResult result, int treasury}) validateTreasuryDebit({
+  required int treasury,
+  required int cost,
+  required String reason,
+}) {
+  if (treasury < cost) {
+    return rejectDiplomaticSub(reason, treasury);
+  }
+  return acceptDiplomaticSub(treasury - cost);
+}
+
+/// Rejects when [currentStage] does not equal [requiredStage].
+({OrderValidationResult result, int treasury})? rejectIfOvertureStageMismatch({
+  required OvertureStage currentStage,
+  required OvertureStage requiredStage,
+  required String reason,
+  required int treasury,
+}) {
+  if (currentStage != requiredStage) {
+    return rejectDiplomaticSub(reason, treasury);
+  }
+  return null;
+}
+
+/// Shared amount-step + overture-gate + treasury-debit path for grant aid and
+/// set subsidy sub-validators.
+({OrderValidationResult result, int treasury}) economicDiplomaticSubValidation({
+  required DiplomaticSubValidatorContext ctx,
+  required DiplomaticOrder order,
+  required int treasury,
+  required int amountStep,
+  required bool Function(OvertureState? overture) overtureGate,
+  required String overtureRejectionReason,
+  required String insufficientTreasuryReason,
+  required String label,
+}) {
+  final amount = order.amount ?? 0;
+  final amountRejection = rejectIfInvalidAmountMultiple(
+    amount: amount,
+    step: amountStep,
+    label: label,
+    treasury: treasury,
+  );
+  if (amountRejection != null) return amountRejection;
+
+  final overture = getOverture(ctx.game, ctx.playerId, order.targetFactionId);
+  if (!overtureGate(overture)) {
+    return rejectDiplomaticSub(overtureRejectionReason, treasury);
+  }
+
+  return validateTreasuryDebit(
+    treasury: treasury,
+    cost: amount,
+    reason: insufficientTreasuryReason.replaceAll('{amount}', '$amount'),
+  );
+}
 
 /// Per-`DiplomaticOrderType` validator extracted from
 /// [DiplomaticOrderValidator] (SPEC/program/orders.md § Diplomatic orders).
@@ -57,6 +165,15 @@ final class DiplomaticSubValidatorContext {
   /// Optional precomputed faction classification snapshot reused across
   /// per-candidate probes to avoid linear `game.players` scans (Refs #2394).
   final DiplomacyFactionMembership? factionMembership;
+
+  bool get hasDiplomaticExpertise {
+    for (final p in game.players) {
+      if (p.id == playerId) {
+        return p.techUnlocked?[kTechIdDiplomaticExpertise] == true;
+      }
+    }
+    return false;
+  }
 }
 
 /// Type-specific check for a diplomatic sub-validator body.

--- a/packages/colonizethis_orders/lib/src/orders/validators/diplomatic/diplomatic_sub_validator.dart
+++ b/packages/colonizethis_orders/lib/src/orders/validators/diplomatic/diplomatic_sub_validator.dart
@@ -4,6 +4,23 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_diplomacy/colonizethis_diplomacy.dart';
 import '../../order_validation_result.dart';
 
+/// Rejects when [targetId] is not a Great Power; otherwise `null`.
+({OrderValidationResult result, int treasury})? rejectIfNotGreatPowerTarget({
+  required DiplomaticSubValidatorContext ctx,
+  required String targetId,
+  required String rejectionReason,
+  required int treasury,
+}) {
+  if (!isGreatPower(
+    ctx.game,
+    targetId,
+    factionMembership: ctx.factionMembership,
+  )) {
+    return rejectDiplomaticSub(rejectionReason, treasury);
+  }
+  return null;
+}
+
 /// Returns a rejection when [relation] is at war; otherwise `null`.
 ({OrderValidationResult result, int treasury})? rejectDiplomaticSubIfAtWar({
   required DiplomacyRelation? relation,

--- a/packages/colonizethis_orders/lib/src/orders/validators/diplomatic/establish_ftp_validator.dart
+++ b/packages/colonizethis_orders/lib/src/orders/validators/diplomatic/establish_ftp_validator.dart
@@ -18,12 +18,12 @@ DiplomaticSubValidator establishFtpSubValidator(
   )) {
     return rejectDiplomaticSub('FTP target must be a Great Power', treasury);
   }
-  if (relation?.atWar ?? false) {
-    return rejectDiplomaticSub(
-      'Cannot establish FTP while at war with that faction',
-      treasury,
-    );
-  }
+  final atWarRejection = rejectDiplomaticSubIfAtWar(
+    relation: relation,
+    reason: 'Cannot establish FTP while at war with that faction',
+    treasury: treasury,
+  );
+  if (atWarRejection != null) return atWarRejection;
   if (hasFtpPartnership(ctx.game, ctx.playerId, targetId)) {
     return rejectDiplomaticSub(
       'FTP already established with that faction',

--- a/packages/colonizethis_orders/lib/src/orders/validators/diplomatic/establish_ftp_validator.dart
+++ b/packages/colonizethis_orders/lib/src/orders/validators/diplomatic/establish_ftp_validator.dart
@@ -11,13 +11,13 @@ DiplomaticSubValidator establishFtpSubValidator(
   required treasury,
 }) {
   final targetId = order.targetFactionId;
-  if (!isGreatPower(
-    ctx.game,
-    targetId,
-    factionMembership: ctx.factionMembership,
-  )) {
-    return rejectDiplomaticSub('FTP target must be a Great Power', treasury);
-  }
+  final notGpRejection = rejectIfNotGreatPowerTarget(
+    ctx: ctx,
+    targetId: targetId,
+    rejectionReason: 'FTP target must be a Great Power',
+    treasury: treasury,
+  );
+  if (notGpRejection != null) return notGpRejection;
   final atWarRejection = rejectDiplomaticSubIfAtWar(
     relation: relation,
     reason: 'Cannot establish FTP while at war with that faction',

--- a/packages/colonizethis_orders/lib/src/orders/validators/diplomatic/establish_overture_validator.dart
+++ b/packages/colonizethis_orders/lib/src/orders/validators/diplomatic/establish_overture_validator.dart
@@ -30,12 +30,12 @@ DiplomaticSubValidator establishOvertureSubValidator(
       treasury,
     );
   }
-  if (relation?.atWar == true) {
-    return rejectDiplomaticSub(
-      'Cannot establish overture while at war with that faction',
-      treasury,
-    );
-  }
+  final atWarRejection = rejectDiplomaticSubIfAtWar(
+    relation: relation,
+    reason: 'Cannot establish overture while at war with that faction',
+    treasury: treasury,
+  );
+  if (atWarRejection != null) return atWarRejection;
 
   final currentStage =
       getOverture(ctx.game, ctx.playerId, targetId)?.stage ??

--- a/packages/colonizethis_orders/lib/src/orders/validators/diplomatic/establish_overture_validator.dart
+++ b/packages/colonizethis_orders/lib/src/orders/validators/diplomatic/establish_overture_validator.dart
@@ -1,4 +1,3 @@
-import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'package:colonizethis_diplomacy/colonizethis_diplomacy.dart';
@@ -98,19 +97,18 @@ bool _isMinorTribeOrGreatPower(
         targetId,
         OvertureStage.tradeConsulate,
       ) &&
-      !_playerHasDiplomaticExpertise(ctx)) {
+      !ctx.hasDiplomaticExpertise) {
     return rejectDiplomaticSub(
       'Diplomatic Expertise tech required for overtures with Minor Nations and Tribes',
       treasury,
     );
   }
-  if (treasury < overtureConsulateCost) {
-    return rejectDiplomaticSub(
-      'Insufficient treasury for Trade Consulate (need $overtureConsulateCost)',
-      treasury,
-    );
-  }
-  return acceptDiplomaticSub(treasury - overtureConsulateCost);
+  return validateTreasuryDebit(
+    treasury: treasury,
+    cost: overtureConsulateCost,
+    reason:
+        'Insufficient treasury for Trade Consulate (need $overtureConsulateCost)',
+  );
 }
 
 ({OrderValidationResult result, int treasury}) _validateEmbassy(
@@ -119,30 +117,29 @@ bool _isMinorTribeOrGreatPower(
   OvertureStage currentStage,
   int treasury,
 ) {
-  if (currentStage != OvertureStage.tradeConsulate) {
-    return rejectDiplomaticSub(
-      'Embassy requires existing Trade Consulate with that faction',
-      treasury,
-    );
-  }
+  final stageRejection = rejectIfOvertureStageMismatch(
+    currentStage: currentStage,
+    requiredStage: OvertureStage.tradeConsulate,
+    reason: 'Embassy requires existing Trade Consulate with that faction',
+    treasury: treasury,
+  );
+  if (stageRejection != null) return stageRejection;
   if (_minorTribeStageRequiresDiplomaticExpertise(
         ctx,
         targetId,
         OvertureStage.embassy,
       ) &&
-      !_playerHasDiplomaticExpertise(ctx)) {
+      !ctx.hasDiplomaticExpertise) {
     return rejectDiplomaticSub(
       'Diplomatic Expertise tech required for overtures with Minor Nations and Tribes',
       treasury,
     );
   }
-  if (treasury < overtureEmbassyCost) {
-    return rejectDiplomaticSub(
-      'Insufficient treasury for Embassy (need $overtureEmbassyCost)',
-      treasury,
-    );
-  }
-  return acceptDiplomaticSub(treasury - overtureEmbassyCost);
+  return validateTreasuryDebit(
+    treasury: treasury,
+    cost: overtureEmbassyCost,
+    reason: 'Insufficient treasury for Embassy (need $overtureEmbassyCost)',
+  );
 }
 
 ({OrderValidationResult result, int treasury}) _validateNap(
@@ -151,18 +148,19 @@ bool _isMinorTribeOrGreatPower(
   OvertureStage currentStage,
   int treasury,
 ) {
-  if (currentStage != OvertureStage.embassy) {
-    return rejectDiplomaticSub(
-      'Non-Aggression Pact requires existing Embassy with that faction',
-      treasury,
-    );
-  }
+  final stageRejection = rejectIfOvertureStageMismatch(
+    currentStage: currentStage,
+    requiredStage: OvertureStage.embassy,
+    reason: 'Non-Aggression Pact requires existing Embassy with that faction',
+    treasury: treasury,
+  );
+  if (stageRejection != null) return stageRejection;
   if (_minorTribeStageRequiresDiplomaticExpertise(
         ctx,
         targetId,
         OvertureStage.nap,
       ) &&
-      !_playerHasDiplomaticExpertise(ctx)) {
+      !ctx.hasDiplomaticExpertise) {
     return rejectDiplomaticSub(
       'Diplomatic Expertise tech required for overtures with Minor Nations and Tribes',
       treasury,
@@ -186,13 +184,4 @@ bool _minorTribeStageRequiresDiplomaticExpertise(
   return stage == OvertureStage.tradeConsulate ||
       stage == OvertureStage.embassy ||
       stage == OvertureStage.nap;
-}
-
-bool _playerHasDiplomaticExpertise(DiplomaticSubValidatorContext ctx) {
-  for (final p in ctx.game.players) {
-    if (p.id == ctx.playerId) {
-      return p.techUnlocked?[kTechIdDiplomaticExpertise] == true;
-    }
-  }
-  return false;
 }

--- a/packages/colonizethis_orders/lib/src/orders/validators/diplomatic/grant_aid_validator.dart
+++ b/packages/colonizethis_orders/lib/src/orders/validators/diplomatic/grant_aid_validator.dart
@@ -7,31 +7,15 @@ import 'diplomatic_sub_validator.dart';
 DiplomaticSubValidator grantAidSubValidator(
   DiplomaticSubValidatorContext ctx,
 ) => delegatedDiplomaticSubValidator(({required order, required treasury}) {
-  final amount = order.amount ?? 0;
-  if (amount <= 0) {
-    return rejectDiplomaticSub('GrantAid amount must be positive', treasury);
-  }
-  if (amount < grantAidAmountStep) {
-    return rejectDiplomaticSub(
-      'GrantAid amount must be at least £$grantAidAmountStep',
-      treasury,
-    );
-  }
-  if (amount % grantAidAmountStep != 0) {
-    return rejectDiplomaticSub(
-      'GrantAid amount must be a multiple of £$grantAidAmountStep',
-      treasury,
-    );
-  }
-  final overture = getOverture(ctx.game, ctx.playerId, order.targetFactionId);
-  if (overture == null || !overture.hasEmbassy) {
-    return rejectDiplomaticSub('Embassy required for GrantAid', treasury);
-  }
-  if (treasury < amount) {
-    return rejectDiplomaticSub(
-      'Insufficient treasury for GrantAid (need $amount)',
-      treasury,
-    );
-  }
-  return acceptDiplomaticSub(treasury - amount);
+  return economicDiplomaticSubValidation(
+    ctx: ctx,
+    order: order,
+    treasury: treasury,
+    amountStep: grantAidAmountStep,
+    overtureGate: (overture) => overture != null && overture.hasEmbassy,
+    overtureRejectionReason: 'Embassy required for GrantAid',
+    insufficientTreasuryReason:
+        'Insufficient treasury for GrantAid (need {amount})',
+    label: 'GrantAid',
+  );
 });

--- a/packages/colonizethis_orders/lib/src/orders/validators/diplomatic/join_empire_validator.dart
+++ b/packages/colonizethis_orders/lib/src/orders/validators/diplomatic/join_empire_validator.dart
@@ -6,6 +6,13 @@ import 'package:colonizethis_diplomacy/colonizethis_diplomacy.dart';
 import '../../order_validation_result.dart';
 import 'diplomatic_sub_validator.dart';
 
+/// Dedicated Join Empire overture-stage helper module (Refs #3500).
+///
+/// Retained as a standalone file — not fused into [establishOvertureSubValidator]
+/// — because GP nearly-defeated logic is non-trivial and one-concern-per-file
+/// applies. Consumed by `establish_overture_validator.dart` for
+/// [OvertureStage.joinEmpire] only; not a missing per-type factory.
+///
 /// [OvertureStage.joinEmpire] rules for [DiplomaticOrderType.establishOverture]
 /// orders (Refs #2391 AC10, SPEC/program/orders.md § Diplomatic orders).
 ///

--- a/packages/colonizethis_orders/lib/src/orders/validators/diplomatic/offer_peace_validator.dart
+++ b/packages/colonizethis_orders/lib/src/orders/validators/diplomatic/offer_peace_validator.dart
@@ -9,12 +9,11 @@ DiplomaticSubValidator offerPeaceSubValidator(
   required relation,
   required treasury,
 }) {
-  final atWar = relation?.atWar ?? false;
-  if (!atWar) {
-    return rejectDiplomaticSub(
-      'Cannot offer peace when not at war with that faction',
-      treasury,
-    );
-  }
+  final atPeaceRejection = rejectDiplomaticSubIfAtPeace(
+    relation: relation,
+    reason: 'Cannot offer peace when not at war with that faction',
+    treasury: treasury,
+  );
+  if (atPeaceRejection != null) return atPeaceRejection;
   return acceptDiplomaticSub(treasury);
 });

--- a/packages/colonizethis_orders/lib/src/orders/validators/diplomatic/set_subsidy_validator.dart
+++ b/packages/colonizethis_orders/lib/src/orders/validators/diplomatic/set_subsidy_validator.dart
@@ -7,34 +7,16 @@ import 'diplomatic_sub_validator.dart';
 DiplomaticSubValidator setSubsidySubValidator(
   DiplomaticSubValidatorContext ctx,
 ) => delegatedDiplomaticSubValidator(({required order, required treasury}) {
-  final amount = order.amount ?? 0;
-  if (amount <= 0) {
-    return rejectDiplomaticSub('SetSubsidy amount must be positive', treasury);
-  }
-  if (amount < setSubsidyAmountStep) {
-    return rejectDiplomaticSub(
-      'SetSubsidy amount must be at least £$setSubsidyAmountStep',
-      treasury,
-    );
-  }
-  if (amount % setSubsidyAmountStep != 0) {
-    return rejectDiplomaticSub(
-      'SetSubsidy amount must be a multiple of £$setSubsidyAmountStep',
-      treasury,
-    );
-  }
-  final overture = getOverture(ctx.game, ctx.playerId, order.targetFactionId);
-  if (overture == null || !overture.hasConsulate) {
-    return rejectDiplomaticSub(
-      'Consulate or Embassy required for SetSubsidy',
-      treasury,
-    );
-  }
-  if (treasury < amount) {
-    return rejectDiplomaticSub(
-      'Insufficient treasury for SetSubsidy (need $amount)',
-      treasury,
-    );
-  }
-  return acceptDiplomaticSub(treasury - amount);
+  return economicDiplomaticSubValidation(
+    ctx: ctx,
+    order: order,
+    treasury: treasury,
+    amountStep: setSubsidyAmountStep,
+    overtureGate: (overture) => overture != null && overture.hasConsulate,
+    overtureRejectionReason:
+        'Consulate or Embassy required for SetSubsidy',
+    insufficientTreasuryReason:
+        'Insufficient treasury for SetSubsidy (need {amount})',
+    label: 'SetSubsidy',
+  );
 });

--- a/packages/colonizethis_orders/lib/src/orders/validators/recruit_worker_order_validator.dart
+++ b/packages/colonizethis_orders/lib/src/orders/validators/recruit_worker_order_validator.dart
@@ -36,10 +36,10 @@ class RecruitWorkerOrderValidator extends StatefulValidator {
     required int treasury,
     required WorkerPool workerPool,
   }) : _player = player,
-       super(
-         stockpileState: stockpile,
-         treasuryState: treasury,
-         workerPoolState: workerPool,
+       super.withProjectedEconomy(
+         stockpile: stockpile,
+         treasury: treasury,
+         workerPool: workerPool,
        );
 
   final Player _player;
@@ -69,21 +69,21 @@ class RecruitWorkerOrderValidator extends StatefulValidator {
           stockpileState,
           treasuryState,
         );
-        if (!check.canAfford) {
-          return OrderValidationResult.rejected(
-            check.reason ?? kRecruitWorkerInsufficientMaterials,
-          );
-        }
-        final after = applyRecruitWorkerCostDeduction(
-          order,
-          workerPoolState,
-          stockpileState,
-          treasuryState,
+        return applyCostIfAffordable(
+          check: check,
+          defaultRejectionReason: kRecruitWorkerInsufficientMaterials,
+          applyDeduction: () {
+            final after = applyRecruitWorkerCostDeduction(
+              order,
+              workerPoolState,
+              stockpileState,
+              treasuryState,
+            );
+            workerPoolState = after.workers;
+            stockpileState = after.stockpile;
+            treasuryState = after.treasury;
+          },
         );
-        workerPoolState = after.workers;
-        stockpileState = after.stockpile;
-        treasuryState = after.treasury;
-        return OrderValidationResult.accepted();
       },
     );
   }

--- a/packages/colonizethis_orders/lib/src/orders/validators/stateful_validator.dart
+++ b/packages/colonizethis_orders/lib/src/orders/validators/stateful_validator.dart
@@ -8,12 +8,42 @@ import '../order_validation_result.dart';
 /// validation mutates [treasuryState] only. SPEC/program/orders.md.
 abstract class StatefulValidator extends OrderValidator {
   StatefulValidator({
-    required this.stockpileState,
-    required this.treasuryState,
-    required this.workerPoolState,
-  }) : super();
+    required Stockpile stockpileState,
+    required int treasuryState,
+    required WorkerPool workerPoolState,
+  }) : stockpileState = stockpileState,
+       treasuryState = treasuryState,
+       workerPoolState = workerPoolState,
+       super();
+
+  /// Seeds economy fields from a projected snapshot (after replaying prior
+  /// orders in submission order). Shared by build and recruit validators.
+  StatefulValidator.withProjectedEconomy({
+    required Stockpile stockpile,
+    required int treasury,
+    required WorkerPool workerPool,
+  }) : stockpileState = stockpile,
+       treasuryState = treasury,
+       workerPoolState = workerPool,
+       super();
 
   Stockpile stockpileState;
   int treasuryState;
   WorkerPool workerPoolState;
+
+  /// When [check.canAfford], runs [applyDeduction] and accepts; otherwise
+  /// rejects using [check.reason] or [defaultRejectionReason].
+  OrderValidationResult applyCostIfAffordable({
+    required ({bool canAfford, String? reason}) check,
+    required void Function() applyDeduction,
+    String defaultRejectionReason = 'Insufficient resources',
+  }) {
+    if (!check.canAfford) {
+      return OrderValidationResult.rejected(
+        check.reason ?? defaultRejectionReason,
+      );
+    }
+    applyDeduction();
+    return OrderValidationResult.accepted();
+  }
 }

--- a/packages/colonizethis_orders/lib/src/orders/validators/work_order_cost_calculator.dart
+++ b/packages/colonizethis_orders/lib/src/orders/validators/work_order_cost_calculator.dart
@@ -22,12 +22,9 @@ class WorkOrderCostCalculator {
     int? fortLevel,
     int? roadLevel,
   }) {
-    if (target == kWorkTargetStealTech ||
-        target == kWorkTargetCounterSpy ||
-        target == kWorkTargetPurchaseLand) {
+    if (kWorkTargetsWithoutMaterialCost.contains(target)) {
       return null;
     }
-
     final province = _targetProvince(targetTileKey);
     final fl = fortLevel ?? province?.fortLevel ?? 0;
     final rl = roadLevel ?? game.worldState.tileState.roadLevel(targetTileKey);

--- a/packages/colonizethis_orders/lib/src/orders/validators/work_order_target_prechecks.dart
+++ b/packages/colonizethis_orders/lib/src/orders/validators/work_order_target_prechecks.dart
@@ -2,6 +2,7 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../order_work_constants.dart';
+import '../diplomatic_access_helpers.dart';
 import 'package:colonizethis_world/colonizethis_world.dart';
 import 'package:colonizethis_diplomacy/colonizethis_diplomacy.dart';
 import '../order_validation_result.dart';
@@ -47,9 +48,7 @@ typedef WorkOrderTargetPrecheck =
 /// Targets that run dedicated territory rules in [workOrderTargetPrechecks] and
 /// must not also hit the default non-explorer foreign-province check.
 const Set<String> kWorkTargetsSkippingDefaultForeignProvinceCheck = {
-  kWorkTargetStealTech,
-  kWorkTargetCounterSpy,
-  kWorkTargetPurchaseLand,
+  ...kWorkTargetsWithoutMaterialCost,
   kWorkTargetBuildImprovement,
 };
 
@@ -150,16 +149,13 @@ OrderValidationResult? precheckPurchaseLand(
   if (resourceId == null || resourceId.isEmpty) {
     return OrderValidationResult.rejected('Tile has no resource');
   }
-  if (kMineralResourceIds.contains(resourceId)) {
-    final prospected =
-        ctx.game.worldState.playerProspectedTiles[ctx.playerId] ??
-        const <String>{};
-    if (!prospected.contains(o.targetTileKey)) {
-      return OrderValidationResult.rejected(
-        'Mineral tile must be prospected first',
-      );
-    }
-  }
+  final mineralRejection = rejectIfMineralTileNotProspected(
+    game: ctx.game,
+    playerId: ctx.playerId,
+    tileKey: o.targetTileKey,
+    resourceId: resourceId,
+  );
+  if (mineralRejection != null) return mineralRejection;
   final cost = purchaseLandCost(resourceId);
   if (ctx.treasury < cost) {
     return OrderValidationResult.rejected(
@@ -202,16 +198,13 @@ OrderValidationResult? precheckBuildImprovement(
       'Tile has no resource; build_improvement requires a resource on the tile',
     );
   }
-  if (kMineralResourceIds.contains(resourceId)) {
-    final prospected =
-        ctx.game.worldState.playerProspectedTiles[ctx.playerId] ??
-        const <String>{};
-    if (!prospected.contains(o.targetTileKey)) {
-      return OrderValidationResult.rejected(
-        'Mineral tile must be prospected first',
-      );
-    }
-  }
+  final mineralRejection = rejectIfMineralTileNotProspected(
+    game: ctx.game,
+    playerId: ctx.playerId,
+    tileKey: o.targetTileKey,
+    resourceId: resourceId,
+  );
+  if (mineralRejection != null) return mineralRejection;
   final currentLevel = ctx.game.worldState.tileState.improvementLevel(
     o.targetTileKey,
   );

--- a/packages/colonizethis_orders/lib/src/orders/validators/work_order_validator.dart
+++ b/packages/colonizethis_orders/lib/src/orders/validators/work_order_validator.dart
@@ -3,10 +3,10 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../order_work_constants.dart';
 import 'package:colonizethis_economy/colonizethis_economy.dart';
-import 'package:colonizethis_diplomacy/colonizethis_diplomacy.dart';
 import 'package:colonizethis_world/colonizethis_world.dart';
 import '../build_rail_work_rules.dart';
 import '../bundled_civilian_work_order.dart';
+import '../diplomatic_access_helpers.dart';
 import '../orders_application_helpers.dart';
 import '../order_visibility.dart';
 import '../unit_type_helpers.dart';
@@ -206,7 +206,15 @@ class WorkOrderValidator extends StatefulValidator {
       player: _context.player,
       playerId: _context.playerId,
       treasury: treasuryState,
-      civilianEmbassyWorkAllowed: _civilianWorkAllowedInMinorTribeProvince,
+      civilianEmbassyWorkAllowed: (unitType, provinceOwnerId) =>
+          civilianEmbassyWorkAllowedInMinorTribeProvince(
+            game: _context.game,
+            playerId: _context.playerId,
+            player: _context.player,
+            unitType: unitType,
+            provinceOwnerId: provinceOwnerId,
+            factionMembership: _context.factionMembership,
+          ),
       factionMembership: _context.factionMembership,
     );
     return runWorkOrderTargetPrecheck(
@@ -232,7 +240,14 @@ class WorkOrderValidator extends StatefulValidator {
       _context.playerId,
       o.targetTileKey,
     );
-    final embassyWork = _civilianWorkAllowedInMinorTribeProvince(type, ownerId);
+    final embassyWork = civilianEmbassyWorkAllowedInMinorTribeProvince(
+      game: _context.game,
+      playerId: _context.playerId,
+      player: _context.player,
+      unitType: type,
+      provinceOwnerId: ownerId,
+      factionMembership: _context.factionMembership,
+    );
     if (controlled || embassyWork) {
       return null;
     }
@@ -274,9 +289,7 @@ class WorkOrderValidator extends StatefulValidator {
   }
 
   bool _skipsMaterialAndTechValidation(String target) =>
-      target == kWorkTargetStealTech ||
-      target == kWorkTargetCounterSpy ||
-      target == kWorkTargetPurchaseLand;
+      kWorkTargetsWithoutMaterialCost.contains(target);
 
   int _improvementLevelForCost(WorkOrder o) =>
       o.target == kWorkTargetBuildImprovement
@@ -421,7 +434,7 @@ class WorkOrderValidator extends StatefulValidator {
   }
 
   bool _skipsProjectedCost(String target) =>
-      target == kWorkTargetStealTech || target == kWorkTargetCounterSpy;
+      kWorkTargetsWithoutProjectedMaterialCost.contains(target);
 
   void _applyProjectedCostMap(Map<String, int> costMap) {
     if (!ProjectedCostEngine.canAffordWorkMaterialCost(
@@ -434,36 +447,5 @@ class WorkOrderValidator extends StatefulValidator {
       stockpileState,
       costMap,
     );
-  }
-
-  /// Builder / Engineer / Merchant may work in Minor/Tribe provinces with embassy + Diplomatic Expertise. SPEC/game/tech-tree-diplomacy-civilian.md.
-  bool _civilianWorkAllowedInMinorTribeProvince(
-    String unitType,
-    String? provinceOwnerId,
-  ) {
-    if (provinceOwnerId == null || provinceOwnerId == _context.playerId) {
-      return false;
-    }
-    if (unitType != kUnitTypeBuilder &&
-        unitType != kUnitTypeEngineer &&
-        unitType != kUnitTypeMerchant) {
-      return false;
-    }
-    if (!isMinorOrTribe(
-      _context.game,
-      provinceOwnerId,
-      factionMembership: _context.factionMembership,
-    )) {
-      return false;
-    }
-    final rel = getRelation(_context.game, _context.playerId, provinceOwnerId);
-    if (rel?.atWar == true) return false;
-    final overture = getOverture(
-      _context.game,
-      _context.playerId,
-      provinceOwnerId,
-    );
-    if (overture == null || !overture.hasEmbassy) return false;
-    return _context.player.techUnlocked?[kTechIdDiplomaticExpertise] == true;
   }
 }

--- a/packages/colonizethis_orders/lib/src/orders/work_handlers/work_order_handler_registry.dart
+++ b/packages/colonizethis_orders/lib/src/orders/work_handlers/work_order_handler_registry.dart
@@ -1,5 +1,4 @@
 import '../order_work_constants.dart';
-import 'explore_work_handler.dart';
 import 'simple_work_order_handler.dart';
 import 'standard_work_handler.dart';
 import 'work_order_handler.dart';

--- a/packages/colonizethis_orders/test/order_suggestion_context_helpers_test.dart
+++ b/packages/colonizethis_orders/test/order_suggestion_context_helpers_test.dart
@@ -3,6 +3,7 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_orders/src/orders/order_resolution_context.dart';
 import 'package:colonizethis_orders/src/orders/order_suggestion_context.dart';
+import 'package:colonizethis_orders/src/orders/order_suggestion_pass_context.dart';
 import 'package:colonizethis_world/src/world/player_view.dart';
 import 'package:colonizethis_world/src/world/unit_lookup.dart';
 
@@ -320,5 +321,68 @@ void main() {
         );
       },
     );
+  });
+
+  group('order_suggestion_pass_context helpers (Refs #3500 Phase 2)', () {
+    test('indexExistingTargetsByEntityId skips empty targets when requested', () {
+      final indexed = indexExistingTargetsByEntityId(
+        const [
+          NavalMoveOrder(
+            fleetId: 'f1',
+            destinationSeaZoneId: 'seaA',
+          ),
+          NavalMoveOrder(
+            fleetId: 'f1',
+            destinationSeaZoneId: '',
+          ),
+        ],
+        (o) => o.fleetId,
+        (o) => o.destinationSeaZoneId ?? '',
+        skipEmptyTargets: true,
+      );
+      expect(indexed['f1'], {'seaA'});
+    });
+
+    test('runCappedSuggestionProbeLoop respects acceptance and probe caps', () {
+      final accepted = <int>[];
+      final probes = List.generate(10, (i) => i);
+      runCappedSuggestionProbeLoop<int>(
+        candidates: probes,
+        shouldSkip: (n) => n.isEven,
+        probe: (n) => n % 3 == 1,
+        onAccepted: accepted.add,
+        maxAccepted: 2,
+        maxProbes: 4,
+      );
+      expect(accepted, [1, 7]);
+    });
+
+    test('ownedProvinceIdsFromView returns full province ids for owner', () {
+      final view = buildPlayerView(
+        Game(
+          id: 'g-owned',
+          worldState: WorldState(
+            turnState: const TurnState(turnNumber: 1, phase: TurnPhase.orders),
+            oldWorld: RegionData(
+              provinces: [
+                Province(id: 'p1', regionId: kOldWorldRegionId, ownerId: 'gp1'),
+                Province(id: 'p2', regionId: kOldWorldRegionId, ownerId: 'gp2'),
+              ],
+            ),
+            newWorld: const RegionData(),
+          ),
+          players: const [
+            Player(id: 'gp1', displayName: 'P1', isHuman: true),
+            Player(id: 'gp2', displayName: 'P2', isHuman: true),
+          ],
+        ),
+        topology,
+        'gp1',
+      );
+      expect(
+        ownedProvinceIdsFromView(view, 'gp1'),
+        {ProvinceId.full(kOldWorldRegionId, 'p1')},
+      );
+    });
   });
 }

--- a/test/check_orders_dedup_diplomatic_helpers_test.dart
+++ b/test/check_orders_dedup_diplomatic_helpers_test.dart
@@ -1,0 +1,44 @@
+import 'package:test/test.dart';
+
+import '../tool/check_orders_dedup_diplomatic_helpers.dart';
+import '../tool/check_orders_dedup_map_clones.dart';
+
+void main() {
+  group('findInlinedDiplomaticRelationGuardViolations', () {
+    test('flags inline relation?.atWar checks', () {
+      const src = r'''
+if (relation?.atWar == true) {
+  return rejectDiplomaticSub('at war', treasury);
+}
+''';
+      final violations = findInlinedDiplomaticRelationGuardViolations(
+        relativePath:
+            'packages/colonizethis_orders/lib/src/orders/validators/diplomatic/establish_overture_validator.dart',
+        source: src,
+      );
+      expect(violations, hasLength(1));
+    });
+  });
+
+  group('findInlinedGreatPowerGuardViolations', () {
+    test('flags inline Great Power rejection guards', () {
+      const src = r'''
+if (!isGreatPower(ctx.game, targetId)) {
+  return rejectDiplomaticSub('not gp', treasury);
+}
+''';
+      final violations = findInlinedGreatPowerGuardViolations(
+        relativePath:
+            'packages/colonizethis_orders/lib/src/orders/validators/diplomatic/alliance_validator.dart',
+        source: src,
+      );
+      expect(violations, hasLength(1));
+    });
+  });
+
+  group('runCheckOrdersDedupDiplomaticHelpers', () {
+    test('passes on current repo tree', () {
+      expect(runCheckOrdersDedupDiplomaticHelpers('.'), 0);
+    });
+  });
+}

--- a/test/check_orders_dedup_map_clones_test.dart
+++ b/test/check_orders_dedup_map_clones_test.dart
@@ -111,4 +111,90 @@ Map<String, Unit> copyUnitsById(Map<String, Unit> source) =>
       expect(violations, isEmpty);
     });
   });
+
+  group('findDuplicateWithProjectedEconomyViolations', () {
+    test('flags subclass constructor without super delegation', () {
+      const src = r'''
+class BuildOrderValidator extends StatefulValidator {
+  BuildOrderValidator.withProjectedEconomy({
+    required Stockpile stockpile,
+    required int treasury,
+    required WorkerPool workerPool,
+  }) : stockpileState = stockpile,
+       treasuryState = treasury,
+       workerPoolState = workerPool,
+       super();
 }
+''';
+      final violations = findDuplicateWithProjectedEconomyViolations(
+        relativePath:
+            'packages/colonizethis_orders/lib/src/orders/validators/build_order_validator.dart',
+        source: src,
+      );
+      expect(violations, hasLength(1));
+    });
+
+    test('accepts super.withProjectedEconomy delegation', () {
+      const src = r'''
+class BuildOrderValidator extends StatefulValidator {
+  BuildOrderValidator.withProjectedEconomy({
+    required Stockpile stockpile,
+    required int treasury,
+    required WorkerPool workerPool,
+  }) : super.withProjectedEconomy(
+         stockpile: stockpile,
+         treasury: treasury,
+         workerPool: workerPool,
+       );
+}
+''';
+      final violations = findDuplicateWithProjectedEconomyViolations(
+        relativePath:
+            'packages/colonizethis_orders/lib/src/orders/validators/build_order_validator.dart',
+        source: src,
+      );
+      expect(violations, isEmpty);
+    });
+  });
+
+  group('findOrderAcceptedProbeDuplicateViolations', () {
+    test('flags is*OrderAccepted that inlines incrementalValidatorForCandidateProbe', () {
+      const src = r'''
+bool isMoveOrderAccepted(Game game, MapTopology topology, String playerId,
+    Orders baseOrders, MoveOrder candidate) {
+  final validator = incrementalValidatorForCandidateProbe(
+    game: game,
+    topology: topology,
+    playerId: playerId,
+    baseOrders: baseOrders,
+  );
+  return validator.isMoveAccepted(candidate);
+}
+''';
+      final violations = findOrderAcceptedProbeDuplicateViolations(
+        relativePath: _orderSuggestionContextRelative,
+        source: src,
+      );
+      expect(violations, hasLength(1));
+    });
+  });
+
+  group('findInlinedDiplomaticRelationGuardViolations', () {
+    test('flags inline relation?.atWar checks', () {
+      const src = r'''
+if (relation?.atWar == true) {
+  return rejectDiplomaticSub('at war', treasury);
+}
+''';
+      final violations = findInlinedDiplomaticRelationGuardViolations(
+        relativePath:
+            'packages/colonizethis_orders/lib/src/orders/validators/diplomatic/establish_overture_validator.dart',
+        source: src,
+      );
+      expect(violations, hasLength(1));
+    });
+  });
+}
+
+const _orderSuggestionContextRelative =
+    'packages/colonizethis_orders/lib/src/orders/order_suggestion_context.dart';

--- a/test/check_orders_dedup_map_clones_test.dart
+++ b/test/check_orders_dedup_map_clones_test.dart
@@ -178,22 +178,6 @@ bool isMoveOrderAccepted(Game game, MapTopology topology, String playerId,
       expect(violations, hasLength(1));
     });
   });
-
-  group('findInlinedDiplomaticRelationGuardViolations', () {
-    test('flags inline relation?.atWar checks', () {
-      const src = r'''
-if (relation?.atWar == true) {
-  return rejectDiplomaticSub('at war', treasury);
-}
-''';
-      final violations = findInlinedDiplomaticRelationGuardViolations(
-        relativePath:
-            'packages/colonizethis_orders/lib/src/orders/validators/diplomatic/establish_overture_validator.dart',
-        source: src,
-      );
-      expect(violations, hasLength(1));
-    });
-  });
 }
 
 const _orderSuggestionContextRelative =

--- a/tool/check_orders_dedup_diplomatic_helpers.dart
+++ b/tool/check_orders_dedup_diplomatic_helpers.dart
@@ -1,0 +1,66 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+import 'check_orders_dedup_map_clones.dart';
+
+const _diplomaticValidatorsDir =
+    'packages/colonizethis_orders/lib/src/orders/validators/diplomatic';
+
+const _diplomaticSubValidatorRelative =
+    'packages/colonizethis_orders/lib/src/orders/validators/diplomatic/diplomatic_sub_validator.dart';
+
+/// Ensures per-type diplomatic sub-validators reuse shared helpers from
+/// [diplomatic_sub_validator.dart] instead of inlining relation/amount/stage
+/// checks (Refs #3500).
+int runCheckOrdersDedupDiplomaticHelpers(
+  String repoRoot, {
+  void Function(String line)? info,
+  void Function(String line)? err,
+}) {
+  final logI = info ?? stdout.writeln;
+  final logE = err ?? stderr.writeln;
+  final root = p.normalize(repoRoot);
+  final diplomaticDir = Directory(p.join(root, _diplomaticValidatorsDir));
+  if (!diplomaticDir.existsSync()) {
+    logI('Orders dedup diplomatic-helpers check skipped (dir absent).');
+    return 0;
+  }
+
+  final violations = <OrdersDedupMapCloneViolation>[];
+  for (final entity in diplomaticDir.listSync(recursive: false)) {
+    if (entity is! File || !entity.path.endsWith('.dart')) continue;
+    final relativePath = p.relative(entity.path, from: root);
+    if (relativePath == _diplomaticSubValidatorRelative) continue;
+    final source = entity.readAsStringSync();
+    violations.addAll(
+      findInlinedDiplomaticRelationGuardViolations(
+        relativePath: relativePath,
+        source: source,
+      ),
+    );
+    violations.addAll(
+      findInlinedGreatPowerGuardViolations(
+        relativePath: relativePath,
+        source: source,
+      ),
+    );
+  }
+
+  if (violations.isEmpty) {
+    logI('Orders dedup diplomatic-helpers check passed.');
+    return 0;
+  }
+
+  logE(
+    'ERROR: Found diplomatic sub-validator deduplication regressions.',
+  );
+  for (final v in violations) {
+    logE('${v.path}:${v.line} ${v.message}');
+  }
+  return 1;
+}
+
+void main() {
+  exit(runCheckOrdersDedupDiplomaticHelpers(Directory.current.path));
+}

--- a/tool/check_orders_dedup_map_clones.dart
+++ b/tool/check_orders_dedup_map_clones.dart
@@ -10,6 +10,18 @@ import 'package:path/path.dart' as p;
 ///   `Map<String, Unit>.from(...)`.
 const _ordersLibDir = 'packages/colonizethis_orders/lib/src/orders';
 
+const _orderSuggestionContextRelative =
+    'packages/colonizethis_orders/lib/src/orders/order_suggestion_context.dart';
+
+const _statefulValidatorRelative =
+    'packages/colonizethis_orders/lib/src/orders/validators/stateful_validator.dart';
+
+const _diplomaticSubValidatorRelative =
+    'packages/colonizethis_orders/lib/src/orders/validators/diplomatic/diplomatic_sub_validator.dart';
+
+const _diplomaticValidatorsDir =
+    'packages/colonizethis_orders/lib/src/orders/validators/diplomatic';
+
 /// Matches a raw clone of a stockpile quantities map, e.g.
 /// `Map<String, int>.from(snap.stockpile.quantities)`.
 final RegExp _rawQuantitiesClonePattern = RegExp(
@@ -51,12 +63,52 @@ int runCheckOrdersDedupMapClones(
     if (!entity.path.endsWith('.dart')) continue;
     if (entity.path.endsWith('.g.dart')) continue;
     final relativePath = p.relative(entity.path, from: root);
+    final source = entity.readAsStringSync();
     violations.addAll(
       findOrdersDedupMapCloneViolations(
         relativePath: relativePath,
-        source: entity.readAsStringSync(),
+        source: source,
       ),
     );
+    violations.addAll(
+      findDuplicateWithProjectedEconomyViolations(
+        relativePath: relativePath,
+        source: source,
+      ),
+    );
+    violations.addAll(
+      findOrderAcceptedProbeDuplicateViolations(
+        relativePath: relativePath,
+        source: source,
+      ),
+    );
+    violations.addAll(
+      findDuplicateWorkVisibilityHelperViolations(
+        relativePath: relativePath,
+        source: source,
+      ),
+    );
+  }
+
+  final diplomaticDir = Directory(p.join(root, _diplomaticValidatorsDir));
+  if (diplomaticDir.existsSync()) {
+    for (final entity in diplomaticDir.listSync(recursive: false)) {
+      if (entity is! File || !entity.path.endsWith('.dart')) continue;
+      final relativePath = p.relative(entity.path, from: root);
+      if (relativePath == _diplomaticSubValidatorRelative) continue;
+      violations.addAll(
+        findInlinedDiplomaticRelationGuardViolations(
+          relativePath: relativePath,
+          source: entity.readAsStringSync(),
+        ),
+      );
+      violations.addAll(
+        findInlinedGreatPowerGuardViolations(
+          relativePath: relativePath,
+          source: entity.readAsStringSync(),
+        ),
+      );
+    }
   }
 
   if (violations.isEmpty) {
@@ -65,10 +117,7 @@ int runCheckOrdersDedupMapClones(
   }
 
   logE(
-    'ERROR: Found raw map clones in the orders module. Use '
-    'Stockpile.copyQuantities() instead of '
-    'Map<String, int>.from(<stockpile>.quantities), and copyUnitsById(...) '
-    'instead of Map<String, Unit>.from(...).',
+    'ERROR: Found orders deduplication regressions in the orders module.',
   );
   for (final v in violations) {
     logE('${v.path}:${v.line} ${v.message}');
@@ -108,6 +157,160 @@ List<OrdersDedupMapCloneViolation> findOrdersDedupMapCloneViolations({
           message:
               'Raw unit-by-id map clone detected; call copyUnitsById(...) '
               'instead.',
+        ),
+      );
+    }
+  }
+  return violations;
+}
+
+/// Flags subclass [withProjectedEconomy] constructors that do not delegate to
+/// [StatefulValidator.withProjectedEconomy] (Refs #3500).
+List<OrdersDedupMapCloneViolation> findDuplicateWithProjectedEconomyViolations({
+  required String relativePath,
+  required String source,
+}) {
+  if (relativePath == _statefulValidatorRelative) return const [];
+  if (!relativePath.contains('/validators/')) return const [];
+  if (!source.contains('.withProjectedEconomy(')) return const [];
+
+  final violations = <OrdersDedupMapCloneViolation>[];
+  final lines = source.split('\n');
+  for (var i = 0; i < lines.length; i++) {
+    final line = lines[i];
+    if (_isCommentLine(line)) continue;
+    if (!line.contains('.withProjectedEconomy(')) continue;
+    final windowEnd = (i + 15).clamp(0, lines.length);
+    final window = lines.sublist(i, windowEnd).join('\n');
+    if (!window.contains('super.withProjectedEconomy(')) {
+      violations.add(
+        OrdersDedupMapCloneViolation(
+          path: relativePath,
+          line: i + 1,
+          message:
+              'withProjectedEconomy constructor must delegate to '
+              'StatefulValidator.withProjectedEconomy.',
+        ),
+      );
+    }
+  }
+  return violations;
+}
+
+/// Flags [is*OrderAccepted] wrappers that re-inline
+/// [incrementalValidatorForCandidateProbe] instead of [_probeOrderAccepted].
+List<OrdersDedupMapCloneViolation> findOrderAcceptedProbeDuplicateViolations({
+  required String relativePath,
+  required String source,
+}) {
+  if (relativePath != _orderSuggestionContextRelative) return const [];
+  final violations = <OrdersDedupMapCloneViolation>[];
+  final fnPattern = RegExp(r'^bool\s+is\w+OrderAccepted\(');
+  final lines = source.split('\n');
+  var inCandidateFn = false;
+  var fnStartLine = 0;
+  var braceDepth = 0;
+  final fnBody = <String>[];
+
+  for (var i = 0; i < lines.length; i++) {
+    final line = lines[i];
+    if (!inCandidateFn && fnPattern.hasMatch(line.trimLeft())) {
+      inCandidateFn = true;
+      fnStartLine = i + 1;
+      braceDepth = 0;
+      fnBody.clear();
+    }
+    if (!inCandidateFn) continue;
+
+    fnBody.add(line);
+    braceDepth += '{'.allMatches(line).length;
+    braceDepth -= '}'.allMatches(line).length;
+    if (braceDepth <= 0 && fnBody.length > 1) {
+      final body = fnBody.join('\n');
+      if (body.contains('incrementalValidatorForCandidateProbe(')) {
+        violations.add(
+          OrdersDedupMapCloneViolation(
+            path: relativePath,
+            line: fnStartLine,
+            message:
+                'is*OrderAccepted wrappers must delegate to _probeOrderAccepted '
+                'instead of inlining incrementalValidatorForCandidateProbe.',
+          ),
+        );
+      }
+      inCandidateFn = false;
+    }
+  }
+  return violations;
+}
+
+/// Forbids reintroducing the deleted duplicate visibility helper (Refs #3500).
+List<OrdersDedupMapCloneViolation> findDuplicateWorkVisibilityHelperViolations({
+  required String relativePath,
+  required String source,
+}) {
+  if (!relativePath.contains('order_visibility.dart')) return const [];
+  if (!source.contains('_workVisFoggedOrBetterProvince')) return const [];
+  final line = source
+          .split('\n')
+          .indexWhere((l) => l.contains('_workVisFoggedOrBetterProvince')) +
+      1;
+  return [
+    OrdersDedupMapCloneViolation(
+      path: relativePath,
+      line: line,
+      message:
+          '_workVisFoggedOrBetterProvince duplicates _workVisFoggedProvince; '
+          'reuse the canonical helper.',
+    ),
+  ];
+}
+
+/// Inline `relation?.atWar` checks must use shared diplomatic sub-validator
+/// helpers (Refs #3500).
+List<OrdersDedupMapCloneViolation> findInlinedDiplomaticRelationGuardViolations({
+  required String relativePath,
+  required String source,
+}) {
+  final violations = <OrdersDedupMapCloneViolation>[];
+  final lines = source.split('\n');
+  for (var i = 0; i < lines.length; i++) {
+    final line = lines[i];
+    if (_isCommentLine(line)) continue;
+    if (line.contains('relation?.atWar')) {
+      violations.add(
+        OrdersDedupMapCloneViolation(
+          path: relativePath,
+          line: i + 1,
+          message:
+              'Use rejectDiplomaticSubIfAtWar / rejectDiplomaticSubIfAtPeace '
+              'from diplomatic_sub_validator.dart instead of inline atWar checks.',
+        ),
+      );
+    }
+  }
+  return violations;
+}
+
+/// Inline `if (!isGreatPower(` rejection guards must use
+/// [rejectIfNotGreatPowerTarget] (Refs #3500).
+List<OrdersDedupMapCloneViolation> findInlinedGreatPowerGuardViolations({
+  required String relativePath,
+  required String source,
+}) {
+  final violations = <OrdersDedupMapCloneViolation>[];
+  final lines = source.split('\n');
+  for (var i = 0; i < lines.length; i++) {
+    final line = lines[i];
+    if (_isCommentLine(line)) continue;
+    if (line.contains('if (!isGreatPower(')) {
+      violations.add(
+        OrdersDedupMapCloneViolation(
+          path: relativePath,
+          line: i + 1,
+          message:
+              'Use rejectIfNotGreatPowerTarget from diplomatic_sub_validator.dart '
+              'instead of inlining Great Power rejection guards.',
         ),
       );
     }

--- a/tool/check_orders_dedup_map_clones.dart
+++ b/tool/check_orders_dedup_map_clones.dart
@@ -16,12 +16,6 @@ const _orderSuggestionContextRelative =
 const _statefulValidatorRelative =
     'packages/colonizethis_orders/lib/src/orders/validators/stateful_validator.dart';
 
-const _diplomaticSubValidatorRelative =
-    'packages/colonizethis_orders/lib/src/orders/validators/diplomatic/diplomatic_sub_validator.dart';
-
-const _diplomaticValidatorsDir =
-    'packages/colonizethis_orders/lib/src/orders/validators/diplomatic';
-
 /// Matches a raw clone of a stockpile quantities map, e.g.
 /// `Map<String, int>.from(snap.stockpile.quantities)`.
 final RegExp _rawQuantitiesClonePattern = RegExp(
@@ -88,27 +82,6 @@ int runCheckOrdersDedupMapClones(
         source: source,
       ),
     );
-  }
-
-  final diplomaticDir = Directory(p.join(root, _diplomaticValidatorsDir));
-  if (diplomaticDir.existsSync()) {
-    for (final entity in diplomaticDir.listSync(recursive: false)) {
-      if (entity is! File || !entity.path.endsWith('.dart')) continue;
-      final relativePath = p.relative(entity.path, from: root);
-      if (relativePath == _diplomaticSubValidatorRelative) continue;
-      violations.addAll(
-        findInlinedDiplomaticRelationGuardViolations(
-          relativePath: relativePath,
-          source: entity.readAsStringSync(),
-        ),
-      );
-      violations.addAll(
-        findInlinedGreatPowerGuardViolations(
-          relativePath: relativePath,
-          source: entity.readAsStringSync(),
-        ),
-      );
-    }
   }
 
   if (violations.isEmpty) {

--- a/tool/ct_repo_lint_lib.dart
+++ b/tool/ct_repo_lint_lib.dart
@@ -42,6 +42,7 @@ import 'check_flutter_action_pins.dart';
 import 'check_function_size.dart';
 import 'check_game_widgets_file_size.dart';
 import 'check_land_province_bucket_keys.dart';
+import 'check_orders_dedup_diplomatic_helpers.dart';
 import 'check_orders_dedup_map_clones.dart';
 import 'check_setup_dedup_gp_ids_from_players.dart';
 import 'check_setup_dedup_gp_ow_tile_scans.dart';
@@ -853,6 +854,8 @@ int? _tryRunDartRuleInProcess({
       return runCheckLandProvinceBucketKeys(repoRoot);
     case 'repo.orders_dedup_map_clones':
       return runCheckOrdersDedupMapClones(repoRoot);
+    case 'repo.orders_dedup_diplomatic_helpers':
+      return runCheckOrdersDedupDiplomaticHelpers(repoRoot);
     case 'repo.setup_dedup_init_pipeline_retry':
       return runCheckSetupDedupInitPipelineRetry(repoRoot);
     case 'repo.setup_dedup_gp_ow_tile_scans':

--- a/tool/ct_repo_lint_manifest.yaml
+++ b/tool/ct_repo_lint_manifest.yaml
@@ -600,10 +600,17 @@ rules:
 
   - rule_id: repo.orders_dedup_map_clones
     group: architecture
-    title: Orders module dedup regressions (map clones, probe wrappers, diplomatic helpers)
+    title: Orders module dedup regressions (map clones, probe wrappers, visibility helpers)
     spec: SPEC/program/repo-lint.md
     runner: dart
     script: tool/check_orders_dedup_map_clones.dart
+
+  - rule_id: repo.orders_dedup_diplomatic_helpers
+    group: architecture
+    title: Diplomatic sub-validators must reuse shared helpers (Refs #3500)
+    spec: SPEC/program/repo-lint.md
+    runner: dart
+    script: tool/check_orders_dedup_diplomatic_helpers.dart
 
   - rule_id: repo.setup_dedup_init_pipeline_retry
     group: architecture

--- a/tool/ct_repo_lint_manifest.yaml
+++ b/tool/ct_repo_lint_manifest.yaml
@@ -600,7 +600,7 @@ rules:
 
   - rule_id: repo.orders_dedup_map_clones
     group: architecture
-    title: Orders module map clones must use Stockpile.copyQuantities() / copyUnitsById()
+    title: Orders module dedup regressions (map clones, probe wrappers, diplomatic helpers)
     spec: SPEC/program/repo-lint.md
     runner: dart
     script: tool/check_orders_dedup_map_clones.dart


### PR DESCRIPTION
## Summary

Single PR for #3500 — behavior-preserving deduplication across `packages/colonizethis_orders`.

### Phase 1 — Validators (complete)
- `StatefulValidator.withProjectedEconomy`, `applyCostIfAffordable`
- Shared work-target skip constants, embassy/mineral access helpers
- `ArmyMoveValidator` extends `OrderValidator` with `shortCircuitIfPreviousRejected`

### Phase 2 — Order suggestion (complete)
- `SuggestionPassContext`, `effectiveOrderResolutionContext`, `indexExistingTargetsByEntityId`, `ownedProvinceIdsFromView`, `runCappedSuggestionProbeLoop`
- All nine `suggest*` families refactored to shared pass-level abstractions

### Phase 3 — Application phases (complete)
- `writebackPlayerEconomyFields` shared by build and worker-pool application phases

### Phase 4 — Diplomatic sub-validators (complete)
- Shared helpers in `diplomatic_sub_validator.dart`: relation guards, amount/treasury/stage helpers, `economicDiplomaticSubValidation`, `rejectIfNotGreatPowerTarget`, `hasDiplomaticExpertise`
- `grant_aid_validator.dart` and `set_subsidy_validator.dart` remain separate per-type factory modules
- `join_empire_validator.dart` retained with module docs (overture-stage helper, not fused)

### Phase 5 — Thin-wrapper consolidation (complete with documented deferrals)
- `is*OrderAccepted` consolidated via `_probeOrderAccepted`
- `_populate*Targets` replaced with declarative merged vs idle-only strategy map
- `DefaultOrderSuggestionAPI` uses `_StandardSuggestContext` + `loggedSuggest` to dedupe logging/delegation boilerplate
- **Deferred:** full `_ProxyingOrderSuggestionAPI` mixin — optional params differ per method; current helper removes duplication without codegen
- **Deferred:** `_mergeOrders` descriptor loop — documented in `order_merge.dart` as acceptable structural duplication for heterogeneous `Orders` record fields

### Phase 6 — Miscellaneous (complete with documented deferrals)
- `isDiplomaticAccepted` / `probeDiplomaticOrder` share `_validateDiplomaticCandidate`
- Removed duplicate `_workVisFoggedOrBetterProvince`
- `feedstockCommodityIdsForRecipeOutputs`, `_isFeedstockBootstrapTargetForTile`, `_updateProvinceAtUnitLocation`, unified `_prepareWorkOrderTileKeyProbe`
- **Deferred:** `draft_orders_mutations` generic helper — each mutation applies distinct replace/filter semantics

### CI / enforcement (complete)
- Extended `tool/check_orders_dedup_map_clones.dart`
- Added `tool/check_orders_dedup_diplomatic_helpers.dart` + manifest entry
- Tests: `test/check_orders_dedup_map_clones_test.dart`, `test/check_orders_dedup_diplomatic_helpers_test.dart`

## Tests
- `dart test` in `packages/colonizethis_orders` — 680 tests passed
- `dart analyze lib` — clean
- Repo dedup CI scripts and related tests — passed locally

## Label note
Issue remains `backlog:implementation` until this PR merges; then ready for `backlog:verification`.

Refs #3500