### PR TITLE
refactor: deduplicate colonizethis_world ownership and topology helpers (#3504)

### DIFF
--- a/packages/colonizethis_world/lib/src/world/capital_and_gp_fall_terminal.dart
+++ b/packages/colonizethis_world/lib/src/world/capital_and_gp_fall_terminal.dart
@@ -1,5 +1,39 @@
 part of 'capital_and_gp_fall.dart';
 
+RegionData _transferFactionProvinceAndUnits(
+  RegionData region, {
+  required String fromFactionId,
+  required String toFactionId,
+}) {
+  final updatedProvinces = region.provinces
+      .map(
+        (p) => p.ownerId == fromFactionId ? p.copyWith(ownerId: toFactionId) : p,
+      )
+      .toList();
+  final remainingUnits = region.units
+      .where((u) => u.ownerId != fromFactionId)
+      .toList();
+  return RegionData(provinces: updatedProvinces, units: remainingUnits);
+}
+
+WorldState _transferFactionWorldStateAssets(
+  WorldState worldState, {
+  required String fromFactionId,
+  required String toFactionId,
+}) {
+  final updatedWorldState = worldState.mapBothRegions(
+    (_, region) => _transferFactionProvinceAndUnits(
+      region,
+      fromFactionId: fromFactionId,
+      toFactionId: toFactionId,
+    ),
+  );
+  final remainingFleets = worldState.fleets
+      .where((f) => f.ownerId != fromFactionId)
+      .toList();
+  return updatedWorldState.copyWith(fleets: remainingFleets);
+}
+
 /// Terminal fall for **Minor Nations** and **Tribes** after combat resolution
 /// and capital reassignment. Parallel to [applyGreatPowerFall] but the
 /// eligibility check is **no owned provinces in the original capital region**
@@ -72,25 +106,11 @@ Game _applyTerminalFallForFaction({
   ).ownsAnyInRegion(factionId, originalRegionId);
   if (hasProvinceInOriginalRegion) return game;
 
-  RegionData transferRegion(RegionData region) {
-    final updatedProvinces = region.provinces
-        .map(
-          (p) => p.ownerId == factionId ? p.copyWith(ownerId: conquerorId) : p,
-        )
-        .toList();
-    final remainingUnits = region.units
-        .where((u) => u.ownerId != factionId)
-        .toList();
-    return RegionData(provinces: updatedProvinces, units: remainingUnits);
-  }
-
-  final updatedWorldState = game.worldState.mapBothRegions(
-    (_, region) => transferRegion(region),
+  final nextWorldState = _transferFactionWorldStateAssets(
+    game.worldState,
+    fromFactionId: factionId,
+    toFactionId: conquerorId,
   );
-  final remainingFleets = game.worldState.fleets
-      .where((f) => f.ownerId != factionId)
-      .toList();
-  final nextWorldState = updatedWorldState.copyWith(fleets: remainingFleets);
   var next = game.withWorldState(nextWorldState);
   next = removeFaction(next);
   worldLog.i(
@@ -136,27 +156,11 @@ Game applyGreatPowerFall(
 
     final conquerorId = prevCapitalOwner;
 
-    RegionData transferRegion(RegionData region) {
-      final updatedProvinces = region.provinces
-          .map(
-            (p) => p.ownerId == playerId ? p.copyWith(ownerId: conquerorId) : p,
-          )
-          .toList();
-      final remainingUnits = region.units
-          .where((u) => u.ownerId != playerId)
-          .toList();
-      return RegionData(provinces: updatedProvinces, units: remainingUnits);
-    }
-
-    final updatedWorldState = game.worldState.mapBothRegions(
-      (_, region) => transferRegion(region),
+    final nextWorldState = _transferFactionWorldStateAssets(
+      game.worldState,
+      fromFactionId: playerId,
+      toFactionId: conquerorId,
     );
-
-    final remainingFleets = game.worldState.fleets
-        .where((f) => f.ownerId != playerId)
-        .toList();
-
-    final nextWorldState = updatedWorldState.copyWith(fleets: remainingFleets);
     game = game
         .withWorldState(nextWorldState)
         .mapPlayers(

--- a/packages/colonizethis_world/lib/src/world/capital_reassignment.dart
+++ b/packages/colonizethis_world/lib/src/world/capital_reassignment.dart
@@ -55,6 +55,20 @@ WorldState applyGreatPowerCapitalProvinceTownDevelopment(
   );
 }
 
+Game _setCapitalForFactionReassignment({
+  required Game game,
+  required String provinceId,
+  required CapitalTile tile,
+  required Game Function(Game) applyUpdate,
+}) {
+  if (tile.provinceId != provinceId) {
+    throw CapitalReassignmentFatalError(
+      'Capital tile province ${tile.provinceId} does not match $provinceId',
+    );
+  }
+  return applyUpdate(game);
+}
+
 /// Sets [playerId]'s capital after runtime reassignment (combat). Updates **only** player
 /// `capitalProvinceId` and `capitalTile`; does not place ports, roads, or change province
 /// `townTileKey`. SPEC/game/capital-and-connectivity § Capital loss and reassignment.
@@ -64,15 +78,15 @@ Game setCapitalForReassignment({
   required String provinceId,
   required CapitalTile tile,
 }) {
-  if (tile.provinceId != provinceId) {
-    throw CapitalReassignmentFatalError(
-      'Capital tile province ${tile.provinceId} does not match $provinceId',
-    );
-  }
-  return game.mapPlayers((p) {
-    if (p.id != playerId) return p;
-    return p.copyWith(capitalProvinceId: provinceId, capitalTile: tile);
-  });
+  return _setCapitalForFactionReassignment(
+    game: game,
+    provinceId: provinceId,
+    tile: tile,
+    applyUpdate: (g) => g.mapPlayers((p) {
+      if (p.id != playerId) return p;
+      return p.copyWith(capitalProvinceId: provinceId, capitalTile: tile);
+    }),
+  );
 }
 
 /// Sets [minorId]'s capital after runtime reassignment (combat / debug flip).
@@ -82,19 +96,21 @@ Game setCapitalForMinorReassignment({
   required String provinceId,
   required CapitalTile tile,
 }) {
-  if (tile.provinceId != provinceId) {
-    throw CapitalReassignmentFatalError(
-      'Capital tile province ${tile.provinceId} does not match $provinceId',
-    );
-  }
-  final updatedMinors = game.minorNations
-      .map(
-        (m) => m.id != minorId
-            ? m
-            : m.copyWith(capitalProvinceId: provinceId, capitalTile: tile),
-      )
-      .toList();
-  return game.copyWith(minorNations: updatedMinors);
+  return _setCapitalForFactionReassignment(
+    game: game,
+    provinceId: provinceId,
+    tile: tile,
+    applyUpdate: (g) {
+      final updatedMinors = g.minorNations
+          .map(
+            (m) => m.id != minorId
+                ? m
+                : m.copyWith(capitalProvinceId: provinceId, capitalTile: tile),
+          )
+          .toList();
+      return g.copyWith(minorNations: updatedMinors);
+    },
+  );
 }
 
 /// Sets [tribeId]'s capital after runtime reassignment (combat / debug flip).
@@ -104,17 +120,19 @@ Game setCapitalForTribeReassignment({
   required String provinceId,
   required CapitalTile tile,
 }) {
-  if (tile.provinceId != provinceId) {
-    throw CapitalReassignmentFatalError(
-      'Capital tile province ${tile.provinceId} does not match $provinceId',
-    );
-  }
-  final updatedTribes = game.tribes
-      .map(
-        (t) => t.id != tribeId
-            ? t
-            : t.copyWith(capitalProvinceId: provinceId, capitalTile: tile),
-      )
-      .toList();
-  return game.copyWith(tribes: updatedTribes);
+  return _setCapitalForFactionReassignment(
+    game: game,
+    provinceId: provinceId,
+    tile: tile,
+    applyUpdate: (g) {
+      final updatedTribes = g.tribes
+          .map(
+            (t) => t.id != tribeId
+                ? t
+                : t.copyWith(capitalProvinceId: provinceId, capitalTile: tile),
+          )
+          .toList();
+      return g.copyWith(tribes: updatedTribes);
+    },
+  );
 }

--- a/packages/colonizethis_world/lib/src/world/connectivity_propagation.dart
+++ b/packages/colonizethis_world/lib/src/world/connectivity_propagation.dart
@@ -232,9 +232,12 @@ Set<String> _seaConnectedPortKeysForCapital({
         : (ProvinceId.isPrefixed(capital.provinceId)
               ? ProvinceId.localIdFrom(capital.provinceId)
               : capital.provinceId);
-    final capitalSeaZones = seaZonesAdjacentToProvince(
+    final capitalSeaZones = seaZoneIdsAdjacentToProvince(
       topology,
       provinceIdForLookup,
+      regionId: ProvinceId.isPrefixed(capital.provinceId)
+          ? ProvinceId.regionIdFrom(capital.provinceId)
+          : null,
     );
     final seaReachable = seaZonesReachableBySeaPath(
       topology,

--- a/packages/colonizethis_world/lib/src/world/connectivity_resolver.dart
+++ b/packages/colonizethis_world/lib/src/world/connectivity_resolver.dart
@@ -10,6 +10,7 @@ import 'diplomatic_relation_lookup.dart';
 import 'connectivity_blockade_target.dart';
 import 'port_seaboard_registry_key.dart';
 import 'province_traversal.dart';
+import 'naval.dart';
 import 'topology_helpers.dart';
 
 part 'connectivity_metrics.dart';

--- a/packages/colonizethis_world/lib/src/world/movement.dart
+++ b/packages/colonizethis_world/lib/src/world/movement.dart
@@ -282,8 +282,9 @@ _applyOneCivilianMoveOrder(
     onCivilianMoveOrderTrace: onCivilianMoveOrderTrace,
   );
   if (precheck != null) return precheck;
-  final unit = _findCivilianMoveUnit(ow, nw, order.unitId);
-  if (unit == null) return (ow: ow, nw: nw, applied: 0, ignored: 1);
+  final found = _findCivilianUnitAndRegion(ow, nw, order.unitId);
+  if (found == null) return (ow: ow, nw: nw, applied: 0, ignored: 1);
+  final unit = found.unit;
   final prepared = _prepareMovedCivilianUnit(unit, order.destinationTileKey);
   if (prepared == null) {
     onCivilianMoveOrderTrace?.call(
@@ -294,7 +295,7 @@ _applyOneCivilianMoveOrder(
     );
     return (ow: ow, nw: nw, applied: 0, ignored: 1);
   }
-  final srcRegion = _regionHoldingUnit(ow, nw, unit.id);
+  final srcRegion = found.regionId;
   if (srcRegion.isEmpty) {
     onCivilianMoveOrderTrace?.call(
       playerId: playerId,
@@ -338,8 +339,8 @@ _precheckCivilianMoveOrder(
   MoveOrder order, {
   CivilianMoveOrderTraceCallback? onCivilianMoveOrderTrace,
 }) {
-  final unit = _findCivilianMoveUnit(ow, nw, order.unitId);
-  if (unit == null) {
+  final found = _findCivilianUnitAndRegion(ow, nw, order.unitId);
+  if (found == null) {
     return _ignoredMove(
       ow,
       nw,
@@ -349,6 +350,7 @@ _precheckCivilianMoveOrder(
       onCivilianMoveOrderTrace: onCivilianMoveOrderTrace,
     );
   }
+  final unit = found.unit;
   final ownerMismatch = _ownerMismatchPrecheck(
     ow,
     nw,
@@ -415,24 +417,18 @@ _ownerMismatchPrecheck(
   return (ow: ow, nw: nw, applied: 0, ignored: 1);
 }
 
-Unit? _findCivilianMoveUnit(List<Unit> ow, List<Unit> nw, String id) {
+({Unit unit, String regionId})? _findCivilianUnitAndRegion(
+  List<Unit> ow,
+  List<Unit> nw,
+  String unitId,
+) {
   for (final u in ow) {
-    if (u.id == id) return u;
+    if (u.id == unitId) return (unit: u, regionId: kRegionOldWorld);
   }
   for (final u in nw) {
-    if (u.id == id) return u;
+    if (u.id == unitId) return (unit: u, regionId: kRegionNewWorld);
   }
   return null;
-}
-
-String _regionHoldingUnit(List<Unit> ow, List<Unit> nw, String unitId) {
-  for (final u in ow) {
-    if (u.id == unitId) return kRegionOldWorld;
-  }
-  for (final u in nw) {
-    if (u.id == unitId) return kRegionNewWorld;
-  }
-  return '';
 }
 
 ({Unit moved, String destRegion})? _prepareMovedCivilianUnit(

--- a/packages/colonizethis_world/lib/src/world/naval.dart
+++ b/packages/colonizethis_world/lib/src/world/naval.dart
@@ -112,7 +112,7 @@ bool isAdjacentSeaZone(
 }
 
 /// True when both ids are **sea-zone** topology nodes sharing an undirected edge (S–S only).
-/// At-sea fleet moves use this; undock uses [seaZonesAdjacentToProvince].
+/// At-sea fleet moves use this; undock uses [seaZoneIdsAdjacentToProvince].
 bool isAdjacentSeaSeaZone(
   MapTopology topology,
   String seaZoneIdA,
@@ -233,7 +233,11 @@ NavalMoveTopologyPicks navalMoveTopologyPicksForFleet({
         adjacentProvinceIdsForDock: [],
       );
     }
-    final undock = seaZonesAdjacentToProvince(topology, provinceNodeId).toList()
+    final undock = seaZoneIdsAdjacentToProvince(
+      topology,
+      rl.localId,
+      regionId: rl.regionId,
+    ).toList()
       ..sort();
     return NavalMoveTopologyPicks(
       adjacentSeaZoneIds: undock,

--- a/packages/colonizethis_world/lib/src/world/province_ownership_transfer.dart
+++ b/packages/colonizethis_world/lib/src/world/province_ownership_transfer.dart
@@ -69,24 +69,6 @@ Map<String, String> _clearPurchasedTilesForProvince(
   return filtered;
 }
 
-int _countPurchasedTilesForProvince(
-  WorldState worldState,
-  String conqueredProvinceId,
-) {
-  final existing = worldState.purchasedTilesByTileKey;
-  if (existing.isEmpty) {
-    return 0;
-  }
-  var removed = 0;
-  for (final tileKey in existing.keys) {
-    final provinceId = Unit.provinceIdFromTileKey(tileKey);
-    if (provinceId == conqueredProvinceId) {
-      removed++;
-    }
-  }
-  return removed;
-}
-
 int _spyTimerRemovalsForProvince(
   Map<String, Map<String, int>> spyRevealTurnsByPlayer,
   String provinceId,
@@ -126,15 +108,20 @@ int _civilianRelocationCountBefore(Game game, Set<String> changedProvinceIds) {
   return count;
 }
 
-typedef _CanonicalProvinceTransferRow = ({
+typedef _CanonicalProvinceTransferContext = ({
   Province province,
   String canonicalProvinceId,
-});
-
-typedef _CanonicalProvinceTransferContext = ({
-  _CanonicalProvinceTransferRow row,
   RegionData region,
   int provinceIndex,
+});
+
+typedef _CanonicalProvinceTransferOutcome = ({
+  Game game,
+  ProvinceOwnershipVisibilitySummary visibilitySummary,
+  int regimentsTransferred,
+  int inPortFleetsTransferred,
+  int purchasedLandEntriesRemoved,
+  int spyTimersCleared,
 });
 
 _CanonicalProvinceTransferContext _resolveValidatedCanonicalTransfer(
@@ -179,7 +166,12 @@ _CanonicalProvinceTransferContext _resolveValidatedCanonicalTransfer(
       '$canonicalId',
     );
   }
-  return (row: row, region: region, provinceIndex: provinceIndex);
+  return (
+    province: row.province,
+    canonicalProvinceId: canonicalId,
+    region: region,
+    provinceIndex: provinceIndex,
+  );
 }
 
 /// Single-province canonical ownership transfer: province owner, resident
@@ -206,7 +198,7 @@ Game applyCanonicalSingleProvinceOwnershipTransfer(
   ).game;
 }
 
-({Game game, ProvinceOwnershipVisibilitySummary visibilitySummary})
+_CanonicalProvinceTransferOutcome
 _applyCanonicalSingleProvinceOwnershipTransferFromResolved(
   Game game, {
   required String targetProvinceId,
@@ -217,37 +209,48 @@ _applyCanonicalSingleProvinceOwnershipTransferFromResolved(
 }) {
   final region = ctx.region;
   final pIdx = ctx.provinceIndex;
-  final canonicalId = ctx.row.canonicalProvinceId;
-  final regionId = ctx.row.province.regionId;
+  final canonicalId = ctx.canonicalProvinceId;
+  final regionId = ctx.province.regionId;
 
   final updatedProvinces = List<Province>.from(region.provinces)
     ..[pIdx] = region.provinces[pIdx].copyWith(ownerId: newOwnerId);
 
+  var regimentsTransferred = 0;
   final updatedUnits = region.units.map((u) {
     if ((u.locationProvinceId == targetProvinceId ||
             u.locationProvinceId == canonicalId) &&
         u.ownerId == oldOwnerId &&
         isMilitaryUnit(u.type)) {
+      regimentsTransferred++;
       return u.copyWith(ownerId: newOwnerId);
     }
     return u;
   }).toList();
 
+  var inPortFleetsTransferred = 0;
   final updatedFleets = game.worldState.fleets.map((f) {
     final inPort = f.inPortAtProvinceId;
     if ((inPort == targetProvinceId || inPort == canonicalId) &&
         f.ownerId == oldOwnerId) {
+      inPortFleetsTransferred++;
       return f.copyWith(ownerId: newOwnerId);
     }
     return f;
   }).toList();
 
+  var purchasedLandEntriesRemoved = 0;
   final purchasedAfter = _clearPurchasedTilesForProvince(
     game.worldState,
     canonicalId,
-    (_) {},
+    (removed) => purchasedLandEntriesRemoved = removed,
   );
 
+  final spyTimersCleared = _spyTimerRemovalsForProvince(
+    game.worldState.spyRevealTurnsByPlayer,
+    canonicalId,
+    oldOwnerId,
+    newOwnerId,
+  );
   final spyNext = clearSpyRevealTimersForProvinceOwnershipTransfer(
     game.worldState.spyRevealTurnsByPlayer,
     canonicalId,
@@ -288,7 +291,14 @@ _applyCanonicalSingleProvinceOwnershipTransferFromResolved(
     worldState: reconcileArmiesAfterUnitsChanged(nextGame.worldState, nextGame),
   );
 
-  return (game: nextGame, visibilitySummary: visOutcome.visibilitySummary);
+  return (
+    game: nextGame,
+    visibilitySummary: visOutcome.visibilitySummary,
+    regimentsTransferred: regimentsTransferred,
+    inPortFleetsTransferred: inPortFleetsTransferred,
+    purchasedLandEntriesRemoved: purchasedLandEntriesRemoved,
+    spyTimersCleared: spyTimersCleared,
+  );
 }
 
 ({Game game, ProvinceOwnershipVisibilitySummary visibilitySummary})
@@ -315,13 +325,17 @@ _applyCanonicalSingleProvinceOwnershipTransferCore(
     oldOwnerId: oldOwnerId,
     newOwnerId: newOwnerId,
   );
-  return _applyCanonicalSingleProvinceOwnershipTransferFromResolved(
+  final outcome = _applyCanonicalSingleProvinceOwnershipTransferFromResolved(
     game,
     targetProvinceId: targetProvinceId,
     oldOwnerId: oldOwnerId,
     newOwnerId: newOwnerId,
     ctx: ctx,
     relocateIllegalCivilians: relocateIllegalCivilians,
+  );
+  return (
+    game: outcome.game,
+    visibilitySummary: outcome.visibilitySummary,
   );
 }
 
@@ -361,40 +375,7 @@ applyCanonicalSingleProvinceOwnershipTransferWithResult(
     oldOwnerId: oldOwnerId,
     newOwnerId: newOwnerId,
   );
-  final row = ctx.row;
-  final region = ctx.region;
-  final canonicalId = row.canonicalProvinceId;
-
-  var regimentsTransferred = 0;
-  for (final u in region.units) {
-    if ((u.locationProvinceId == targetProvinceId ||
-            u.locationProvinceId == canonicalId) &&
-        u.ownerId == oldOwnerId &&
-        isMilitaryUnit(u.type)) {
-      regimentsTransferred++;
-    }
-  }
-
-  var inPortFleetsTransferred = 0;
-  for (final f in game.worldState.fleets) {
-    final inPort = f.inPortAtProvinceId;
-    if ((inPort == targetProvinceId || inPort == canonicalId) &&
-        f.ownerId == oldOwnerId) {
-      inPortFleetsTransferred++;
-    }
-  }
-
-  final purchasedLandEntriesRemoved = _countPurchasedTilesForProvince(
-    game.worldState,
-    canonicalId,
-  );
-
-  final spyTimersCleared = _spyTimerRemovalsForProvince(
-    game.worldState.spyRevealTurnsByPlayer,
-    canonicalId,
-    oldOwnerId,
-    newOwnerId,
-  );
+  final canonicalId = ctx.canonicalProvinceId;
 
   final civilianRelocations = _civilianRelocationCountBefore(game, {
     targetProvinceId,
@@ -416,10 +397,10 @@ applyCanonicalSingleProvinceOwnershipTransferWithResult(
       provinceId: targetProvinceId,
       oldOwnerId: oldOwnerId,
       newOwnerId: newOwnerId,
-      regimentsTransferred: regimentsTransferred,
-      inPortFleetsTransferred: inPortFleetsTransferred,
-      purchasedLandEntriesRemoved: purchasedLandEntriesRemoved,
-      spyTimersCleared: spyTimersCleared,
+      regimentsTransferred: core.regimentsTransferred,
+      inPortFleetsTransferred: core.inPortFleetsTransferred,
+      purchasedLandEntriesRemoved: core.purchasedLandEntriesRemoved,
+      spyTimersCleared: core.spyTimersCleared,
       civilianRelocations: civilianRelocations,
       visibilitySummary: core.visibilitySummary,
     ),

--- a/packages/colonizethis_world/lib/src/world/topology_helpers.dart
+++ b/packages/colonizethis_world/lib/src/world/topology_helpers.dart
@@ -5,6 +5,8 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_world/src/utils/expando_index.dart';
 import 'package:colonizethis_world/src/utils/graph_traversal.dart';
 
+import 'naval.dart' show seaZoneIdsAdjacentToProvince;
+
 /// Topology helpers shared by movement and connectivity. SPEC/game/map-topology.md.
 ///
 /// `MapTopology` is immutable (const constructor, final fields), so per-topology
@@ -191,18 +193,14 @@ Set<String> seaZonesReachableBySeaPath(
 }
 
 /// Sea zone ids adjacent to province [provinceNodeId] in topology (P–S edges).
+///
+/// Prefer [seaZoneIdsAdjacentToProvince] from `naval.dart` for prefixed province
+/// ids and region-scoped resolution.
 Set<String> seaZonesAdjacentToProvince(
   MapTopology topology,
   String provinceNodeId,
 ) {
-  final seaZoneIds = seaZoneNodeIds(topology);
-  final out = <String>{};
-  for (final edge in topology.edges) {
-    if (edge.id1 != provinceNodeId && edge.id2 != provinceNodeId) continue;
-    final other = edge.id1 == provinceNodeId ? edge.id2 : edge.id1;
-    if (seaZoneIds.contains(other)) out.add(other);
-  }
-  return out;
+  return seaZoneIdsAdjacentToProvince(topology, provinceNodeId);
 }
 
 /// All node ids directly adjacent to [nodeId] in [topology] regardless of node


### PR DESCRIPTION
## Summary
Implements all six behaviour-preserving refactors from #3504 in `packages/colonizethis_world`:

1. **Capital fall transfer dedup** — extracted `_transferFactionProvinceAndUnits` / `_transferFactionWorldStateAssets` for minor/tribe terminal fall and GP fall.
2. **Ownership transfer single-pass counts** — `applyCanonicalSingleProvinceOwnershipTransferWithResult` snapshots civilian relocation count before mutation; regiment/fleet/purchased/spy counts are tallied during the mutation pass.
3. **Capital setter unification** — `_setCapitalForFactionReassignment` parameterizes the three `setCapitalFor*` functions while preserving distinct `mapPlayers` vs `copyWith` update paths.
4. **Civilian unit scan merge** — `_findCivilianUnitAndRegion` replaces duplicate `_findCivilianMoveUnit` / `_regionHoldingUnit` scans.
5. **Sea-zone adjacency consolidation** — world lib callers (`connectivity_propagation`, naval undock) route through `seaZoneIdsAdjacentToProvince`; `topology_helpers.seaZonesAdjacentToProvince` is now a thin wrapper for backward-compatible exports.
6. **Flattened transfer context** — `_CanonicalProvinceTransferContext` inlines province fields (drops nested `.row.` indirection).

## Deferred
None — all issue ACs are covered in this PR.

## Tests
- `dart test` on:
  - `test/world/province_ownership_transfer_test.dart`
  - `test/world/capital_and_gp_fall_terminal_test.dart`
  - `test/world/capital_reassignment_setters_test.dart`
  - `test/world/movement_helpers_test.dart`
  - `test/world/naval_topology_test.dart`
  - `test/topology_helpers_test.dart`
- `dart analyze` on all touched lib files (clean)

Refs #3504

Made with [Cursor](https://cursor.com)