### PR TITLE
chore(skills): require widget golden proof for UI issue verification

### DIFF
--- a/.cursor/skills/verify-github-issue/SKILL.md
+++ b/.cursor/skills/verify-github-issue/SKILL.md
@@ -1,82 +1,74 @@
 ---
 name: verify-github-issue
-description: Verifies one open GitHub issue against acceptance criteria, specs, tests, and CONTRIBUTING workflow; uses the gh CLI directly to read the issue and post a consolidated verification comment; proposes concrete gap fixes when work is incomplete. Use when the user gives an issue number or issue URL and wants verification or gap analysis aligned with dev-branch PRs.
+description: Verifies one open GitHub issue against acceptance criteria, specs, tests, and CONTRIBUTING; posts a verification comment via gh. UI issues require passing widget goldens on latest dev with PNG proof uploaded to the issue (hard-fail if goldens cannot be captured or fix is not merged). Never relabels issues.
 ---
 
 # Verify a GitHub issue (ColonizeThis)
 
 ## When this applies
 
-The user supplies an **issue reference**: issue **number** (e.g. `42`) and repo context if not obvious, or a **full issue URL**. If they only give a GitHub **username**, ask whether they meant an **issue number/URL** or assignee-based triage.
+Issue **number** or **URL**. If only a GitHub username is given, ask for issue number/URL.
 
-## Non-negotiables (repo policy)
+## Policy
 
-Follow **[AGENTS.md](../../../AGENTS.md)** (Cursor rules under `.cursor/rules/`) and **[CONTRIBUTING.md](../../../CONTRIBUTING.md)** for all implementation and PR guidance.
+Follow **[AGENTS.md](../../../AGENTS.md)** and **[CONTRIBUTING.md](../../../CONTRIBUTING.md)**. SPEC-first. PRs target **`dev`**.
 
-**Hard failures to avoid** (treat as checklist, not suggestions):
+**Hard-fail** (never **Complete**):
 
-- Skipping or hand-waving **acceptance criteria** from the issue (and linked **SPEC** ACs if referenced).
-- Claiming “done” without **tests** that cover the change and meet coverage gates (**90%** logic/ai/map; **80%** elsewhere — see `colonizethis-testing.mdc` and CONTRIBUTING).
-- Opening or describing a PR that does **not** target **`dev`** (default branch for PRs per CONTRIBUTING).
+- ACs hand-waved or untested (coverage: 90% logic/ai/map, 80% elsewhere).
+- Fix not on **`origin/dev`** (local-only or unmerged PR).
+- **UI issue** without passing widget golden + PNG proof on the issue comment.
+- Any golden test failure, missing golden mapping for a visual AC, or gist upload/embed failure.
 
-Also respect **SPEC-first** (`colonizethis-spec-required.mdc`): no behavior that contradicts GDD/TDD; extend SPEC before implementing unauthorized scope.
-
-## GitHub CLI (`gh`) — required path
-
-Use the **`gh`** binary **directly** from the workspace repo clone. Issue **read** uses **`gh issue view`**; posting the verification uses **`gh issue comment`**.
+**Never** change labels, milestones, or issue state — **`gh issue comment` only**.
 
 ## Workflow
 
-1. **Load the issue**  
-   Run **`gh issue view <n> --json title,body,labels,state,url`** (add **`--repo owner/name`** when the issue is not on the clone’s default remote). Confirm state is **open**.
+1. `gh issue view <n> --json title,body,labels,state,url` — issue must be open.
+2. Extract ACs from body/comments; flag vague ACs before claiming complete.
+3. **`git fetch origin && git checkout dev && git pull`** — verify only on **latest `dev`**. Unmerged or local-only work → **Gaps remain**.
+4. Map ACs → code, SPEC, tests, merged PR(s) referencing the issue.
+5. Run relevant tests (`melos`, `cd app && flutter test …`).
+6. **UI issues** (see below): widget golden procedure + gist upload.
+7. `gh issue comment <n> --body-file …` using the template below.
 
-2. **Extract requirements**  
-   From the issue body (and comments): goals, **acceptance criteria**, links to SPEC/files, edge cases. If ACs are missing or vague, **state that gap** and propose minimal AC text before claiming full verification.
+### UI issues
 
-3. **Trace to code and specs**  
-   Search the repo for implementations, related PRs/commits, and SPEC sections. Map each AC item to: implemented / partial / missing / unknown.
+**UI** = references `SPEC/ui/` or screen registry / IDs, user-visible ACs (CONTRIBUTING § UI changes), or merged player-app UI code under `app/lib/features|widgets|ui` / `app/lib/features/game/flame/`.
 
-4. **Verify tests and quality gates**  
-   Identify or run relevant tests (`melos`, `flutter test` per project conventions in AGENTS/testing rule). Note coverage expectations from CONTRIBUTING; flag if tests are absent or clearly insufficient.
+**Exempt:** ctdev-only surfaces (`SPEC/program/ctdev-app.md`).
 
-5. **Branch and PR posture**  
-   Any fix must be described as a PR **into `dev`**, following CONTRIBUTING pre-PR checklist (SPEC/AC updates, logging alignment if applicable, coverage).
+**Proof:** widget `matchesGoldenFile` only — not integration screenshots, e2e text snapshots, or Widgetbook.
 
-6. **Post the verification on GitHub**  
-   **Always** publish the result as an **issue comment** on that issue (same number/repo as step 1) using **`gh issue comment`**: `gh issue comment <n> --body-file <path>` or `gh issue comment <n> --body "<markdown>"`. Use **`--repo owner/name`** when the issue is not on the clone’s default remote.
+1. `rg 'matchesGoldenFile' app/test --glob '*_test.dart' -l`
+2. Map **each visual AC to the letter of the issue** to a passing golden (one golden may cover several ACs). No mappable golden → **Gaps remain**; remedy: add host test in `app/test/` + PNG in `app/test/goldens/` (package UI → host in `app/test/`).
+3. `cd app && flutter test test/<file>.dart` — no `--update-goldens`. Fail or missing PNG → **Gaps remain**.
+4. Copy passing PNGs to `tmp/verify-issue-<n>/`, upload via **`gh gist create --public`**, embed raw URLs (`https://gist.githubusercontent.com/OWNER/GIST_ID/raw/<file>.png`) in the comment. Upload/embed failure → **Gaps remain**. Delete `tmp/verify-issue-<n>/` after posting.
 
-7. **Comment body**
+Follow existing golden patterns: `AppThemes.editorialMonocle`, `suppressLogsForTests()`, deterministic fixtures (`province_build_improvement_shortcut_host_goldens_test.dart`, `region_map_*_test.dart`).
 
-   **If there are gaps**  
-   - List each gap with severity (blocks “verified complete” vs follow-up).  
-   - Propose a **concrete** remedy: files to touch, SPEC updates, test cases, and PR scope.
-
-   **If fully addressed**  
-   - Summarize evidence: AC → implementation → tests → target branch (`dev`).
-
-   In both cases, use a neutral, factual tone. The **only** required GitHub write for this skill is the verification **comment**—not labels, milestones, or issue state.
-
-## Verification comment template
-
-Use a neutral, factual tone:
+## Comment template
 
 ```markdown
 **Verification** (ACs / SPEC / tests)
 
-- [AC summary bullets tied to code/tests; mark partial/missing where applicable]
+- [AC bullets → code/tests; partial/missing marked]
 
-Implementation: [PR link or commit refs if known]. Tests: [what was run / added]. PR targets `dev` per CONTRIBUTING.
+Implementation: [merged PR on `dev`]. Tests: [commands run].
+
+**Visual proof** (UI only)
+
+| AC | Golden test | PNG |
+|----|-------------|-----|
+| … | `app/test/<file>.dart` | ![…](https://gist.githubusercontent.com/OWNER/GIST_ID/raw/file.png) |
+
+`dev` @ `<sha>` — golden run **pass**.
 
 Outcome: [Complete | Gaps remain — see above].
 ```
 
-If some work exists but is not merged yet, state that verification is **conditional on merge** and list what must land before a “complete” outcome.
+**Complete** only when ACs are met on **merged `dev`**, tests pass, and UI proof is embedded. Unmerged PR → **Gaps remain**.
 
 ## Tools
 
-- **`gh`** for GitHub: `gh issue view`, **`gh issue comment`**.  
-- Repo search and test commands per AGENTS/CONTRIBUTING; do not invent branch or review policy.
-
-## Additional resources
-
-- [reference.md](reference.md) — CONTRIBUTING/AGENTS excerpts and command hints
+`gh` (issue view/comment, gist create), `rg`, `cd app && flutter test`, `curl -sfI` (gist URLs). Commands: [reference.md](reference.md).

--- a/.cursor/skills/verify-github-issue/reference.md
+++ b/.cursor/skills/verify-github-issue/reference.md
@@ -1,28 +1,45 @@
 # Reference: verify-github-issue
 
-## CONTRIBUTING (summary)
+## Baseline
 
-- PRs via Pull Request only; **default target branch: `dev`**.
-- Pre-PR: SPEC/ACs updated; implementation and tests aligned; logging aligned if logging changed; coverage gates (90% / 80%).
+- PRs → **`dev`**. Coverage 90% (logic/ai/map) / 80% (elsewhere).
+- App tests: **`cd app && flutter test`** — not `dart test` from repo root.
+- UI proof: widget goldens in `app/test/`, PNGs in `app/test/goldens/`.
 
-Source: repo root `CONTRIBUTING.md`.
-
-## AGENTS (summary)
-
-- `.cursor/rules/*.mdc` are the implementation/review source of truth.
-- SPEC-first; coverage and test commands per `colonizethis-testing.mdc`; acceptance criteria quality per `colonizethis-acceptance-criteria.mdc`.
-
-Source: repo root `AGENTS.md`.
-
-## Example `gh` commands
+## Verify on dev
 
 ```bash
-# View issue (JSON for scripting)
-gh issue view 42 --json title,body,state,labels,url
-
-# Post verification result as an issue comment (user must be logged in)
-gh issue comment 42 --body-file verification.md
-# or: gh issue comment 42 --body "$(cat verification.md)"
+git fetch origin && git checkout dev && git pull
 ```
 
-Replace `42` with the issue number; run from a clone of the repo with `gh auth login` completed. This skill’s GitHub write is the comment only.
+## Golden discovery and run
+
+```bash
+rg 'matchesGoldenFile' app/test --glob '*_test.dart' -l
+cd app && flutter test test/<file>.dart   # never --update-goldens
+```
+
+## Gist upload + comment
+
+```bash
+ISSUE=42
+PROOF_DIR="tmp/verify-issue-${ISSUE}"
+mkdir -p "$PROOF_DIR"
+cp app/test/goldens/<file>.png "$PROOF_DIR/"
+
+GIST_URL=$(gh gist create --public "$PROOF_DIR"/*.png -d "Verify #${ISSUE}" 2>&1 | tail -1)
+GIST_ID="${GIST_URL##*/}"
+OWNER=$(gh api "gists/${GIST_ID}" --jq .owner.login)
+# Embed: https://gist.githubusercontent.com/${OWNER}/${GIST_ID}/raw/<file>.png
+
+gh issue comment "$ISSUE" --body-file verification.md
+rm -rf "$PROOF_DIR"
+```
+
+## gh
+
+```bash
+gh issue view 42 --json title,body,state,labels,url
+gh issue comment 42 --body-file verification.md
+gh pr list --state merged --search "Refs #42" --json number,url,mergeCommit
+```

--- a/.grok/skills/verify-github-issue/SKILL.md
+++ b/.grok/skills/verify-github-issue/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: verify-github-issue
-description: Verifies one open GitHub issue against acceptance criteria, specs, tests, and CONTRIBUTING workflow; uses the gh CLI directly to read the issue and post a consolidated verification comment; proposes concrete gap fixes when work is incomplete. Use when the user gives an issue number or issue URL and wants verification or gap analysis aligned with dev-branch PRs.
+description: Verifies one open GitHub issue against acceptance criteria, specs, tests, and CONTRIBUTING; posts a verification comment via gh. UI issues require passing widget goldens on latest dev with PNG proof uploaded to the issue (hard-fail if goldens cannot be captured or fix is not merged). Never relabels issues.
 ---
 
 **Thin Grok shim** (repo `.grok/skills/`).
 
-Source of truth: `.cursor/skills/verify-github-issue/SKILL.md` (plus its sibling `reference.md`).
+Source of truth: `.cursor/skills/verify-github-issue/SKILL.md` (plus `reference.md`). OpenCode: `.opencode/skills/verify-github-issue/SKILL.md`.
 
-Read the SKILL.md and reference.md in full. Enforce the hard failures to avoid, gh-direct usage, full workflow (load → extract → trace → verify tests/gates → post comment), and verification comment template exactly. This is a core dependency for backlog-verify-agent and many related-skill pointers.
+Read the SKILL.md and reference.md in full. Enforce latest-`dev` verification, merged fix required for Complete, UI widget golden + gist proof, hard-fail rules, and `gh issue comment` only (no relabels).

--- a/.opencode/skills/verify-github-issue/SKILL.md
+++ b/.opencode/skills/verify-github-issue/SKILL.md
@@ -1,1 +1,19 @@
-../../../.cursor/skills/verify-github-issue/SKILL.md
+---
+name: verify-github-issue
+description: Verifies one open GitHub issue against acceptance criteria, specs, tests, and CONTRIBUTING; posts a verification comment via gh. UI issues require passing widget goldens on latest dev with PNG proof uploaded to the issue (hard-fail if goldens cannot be captured or fix is not merged). Never relabels issues.
+---
+
+# Verify a GitHub issue (OpenCode)
+
+## Source of truth
+
+Use **`.cursor/skills/verify-github-issue/SKILL.md`** and **`reference.md`** as the authoritative workflow, hard-fail rules, UI golden proof procedure, comment template, and command cookbook.
+
+## OpenCode adaptation
+
+When running in OpenCode:
+
+- Read both Cursor files in full before verifying.
+- Verify only on **latest `origin/dev`** (`git fetch && git checkout dev && git pull`). Local-only or unmerged fixes → **Gaps remain**.
+- **Complete** only when the fix is **merged on `dev`**, ACs pass, tests pass, and (for UI issues) widget golden PNGs are embedded in the issue comment via public gist.
+- Post **`gh issue comment` only** — never relabel, close, or change milestones (unlike `backlog-verify-agent`, which may relabel after applying this skill).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,7 @@ Skills live under `.cursor/skills/<name>/SKILL.md` (source of truth for all agen
 | `refine-github-issue` | Refine an open issue from comment feedback (repro, root cause, priorities); update the body or return numbered clarifications when feedback conflicts with SPEC. |
 | `review-pr` | Review an open pull request against issue alignment, acceptance-criteria coverage, architecture conventions, and linting compliance; post all findings as a PR comment with strict YES/CONDITIONAL YES/NO outcomes. |
 | `review-github-issue` | Review an issue for **purpose ↔ proposed method** coherence and internal consistency; repo/SPEC/test evidence only when needed to show the method cannot satisfy the purpose. Consolidated comment with priorities and remedies; use **`verify-github-issue`** for AC↔implementation closure. |
-| `verify-github-issue` | Verify one open issue against ACs/specs/tests; post results as an issue comment; gap analysis when incomplete. |
+| `verify-github-issue` | Verify one open issue against ACs/specs/tests on merged `dev`; UI issues need widget golden PNG proof on the issue comment; post via `gh issue comment` only. OpenCode: `.opencode/skills/verify-github-issue/`. |
 | `document-app-ui` | Document player-app screens/UI changes per `colonizethis-ui-documentation.mdc` (stable 8-char IDs, layout/behavior/variants, Widgetbook, registry, `UiScreenIds`). OpenCode: `.opencode/skills/document-app-ui/`. |
 
 ## Contributing


### PR DESCRIPTION
## Summary

- Updates `verify-github-issue` to require verification on merged `dev`, widget golden tests for UI issues, and PNG proof embedded in the issue comment via public gist (hard-fail otherwise).
- Adds command cookbook in `reference.md`; aligns OpenCode thin wrapper (replaces symlink), Grok shim, and `AGENTS.md` index entry.

## Test plan

- [x] Skill files are internally consistent (Cursor = source of truth; OpenCode defers to Cursor + `reference.md`)
- [ ] Manual: run skill against a UI issue with existing goldens and confirm gist + comment workflow
- [ ] Manual: run skill against a non-UI issue — no golden proof required


Made with [Cursor](https://cursor.com)