### PR TITLE
fix: align GAME40001 tech-slots mockup parity slice (#3510)

### DIFF
--- a/SPEC/ui/mockups/GAME40001-technology-panel.html
+++ b/SPEC/ui/mockups/GAME40001-technology-panel.html
@@ -148,9 +148,14 @@ function renderAll(){
     return `<div class="tech-chip">${icn(t.iconFile)}<span>${t.name}</span></div>`;
   }).join('');
 
-  const maxSlots=variant==='all'?4:3;
+  // Active slot count: 4 with University (the `all` variant), otherwise 3.
+  // The slots container always renders exactly four cards in slot-index
+  // order — the active slots followed by a locked Slot 4 placeholder when
+  // the player has fewer than four active slots — matching
+  // SPEC/ui/technology-panel.md § Slot behaviour. Refs #3510.
+  const activeSlots=variant==='all'?4:3;
   let slotsHtml='';
-  for(let i=1;i<=maxSlots;i++){
+  for(let i=1;i<=activeSlots;i++){
     const assigned=currentResearch[i];
     const t=assigned?techCatalog.find(x=>x.id===assigned.tech):null;
     const pct=assigned?(assigned.progress/assigned.cost*100):0;
@@ -170,11 +175,15 @@ function renderAll(){
         </div>
       `:`<div class="slot-empty">No tech assigned</div>`}
     </div>`;
-    if(i>=3&&variant==='all')slotsHtml+=`<div class="slot-card" style="opacity:.45">
-      <div class="slot-header"><span class="slot-label">Slot 4 (University)</span></div>
-      <div class="slot-empty">Requires University tech</div>
-    </div>`;
   }
+  // Locked Slot 4 placeholder: rendered exactly once when fewer than four
+  // active slots exist (default / empty variants), at the same card width
+  // as Slots 1–3. The `all` variant already renders a live Slot 4 above and
+  // therefore renders no locked placeholder. Refs #3510.
+  if(activeSlots<4)slotsHtml+=`<div class="slot-card" style="opacity:.45">
+    <div class="slot-header"><span class="slot-label">Slot 4 (University)</span></div>
+    <div class="slot-empty">Requires University tech</div>
+  </div>`;
   document.getElementById('slots-container').innerHTML=slotsHtml;
 }
 

--- a/SPEC/ui/technology-panel.md
+++ b/SPEC/ui/technology-panel.md
@@ -40,6 +40,8 @@ Slots tab content: vertical list of slot rows (label, assigned tech + progress, 
 
 The body of the Slots tab MUST render the following sections in this top-to-bottom order, matching the mockup body markup in [`mockups/GAME40001-technology-panel.html`](mockups/GAME40001-technology-panel.html) where `.researched-heading` + `.researched-grid` precede `.slots-heading` + `#slots-container`:
 
+The Slots tab body MUST NOT render a dev-only panel header block. The mockup `.content` block opens directly with `.researched-heading`; there is no per-player title or slot-count line above it. Specifically, the body MUST NOT render the legacy `technologyPanel_title` (`"Technology - {playerName}"`) line nor the legacy `technologyPanel_researchSlotsCount` (`"Research slots: {slots}"`) line. The player identity and the `Technology` title are already carried by the `CtTopBar` chrome (§ Top bar). Refs #3510.
+
 1. **Researched Techs** — `CtSectionLabel` heading (`technologyPanel_researchedTechsHeading`) followed by the read-only `ResearchedTechChip` `Wrap` grid (or the empty-state line when the player has no researched techs).
 2. **Section divider** — a single `CtBrassDivider` separates the Researched Techs block from the Research Slots block below it.
 3. **Research Slots** — `CtSectionLabel` heading (`technologyPanel_researchSlotsHeading`) followed by the four slot cards per § Slot behaviour.
@@ -109,6 +111,7 @@ The panel does **not** show locked techs in the assignment list. When there are 
 
 - **Slots:** The Slots tab always renders exactly four slot cards in slot-index order regardless of `player.researchSlots`. The active slot count remains `player.researchSlots` (default 3; 4 with University); the locked-slot rule below covers the fourth card when the player has not researched University.
 - **Locked slot 4 (University):** When `player.researchSlots` is `null` or strictly less than `4`, the fourth slot card renders as a **locked placeholder**:
+  - The card uses the same slot-card chrome and occupies the **same card width** as Slots 1–3 (it stretches to the full panel content width; only its opacity, header label, and body content differ). Refs #3510.
   - The card body is rendered at exactly `0.45` opacity (the mockup `.slot-card[style="opacity:.45"]` value).
   - The slot header label reads exactly `"Slot 4 (University)"` (no other content in the header).
   - In place of the assigned-tech body / progress / empty-state, the card body shows exactly one footnote line `"Requires University tech"` in `--muted` italic.
@@ -160,6 +163,12 @@ The Choose-tech dialog is the dark editorial-monocle modal opened by the slot ca
 - **Given** `player.researchSlots` is greater than or equal to `4`, **when** the fourth slot card is rendered, **then** the UI layer renders the card at full opacity (not the locked `0.45`), uses the standard slot label `"Slot 4"`, and renders Cancel (when assigned) and Choose tech buttons as on the other active slots.
 
 - **Slots tab section ordering (Refs #2864 S0/S6):** **Given** the Slots tab is rendered for any player on any viewport, **when** the body widget tree is laid out, **then** the `CtSectionLabel` carrying the localized `technologyPanel_researchedTechsHeading` text appears at a strictly smaller vertical offset (smaller `Offset.dy`) than the `CtSectionLabel` carrying the localized `technologyPanel_researchSlotsHeading` text, matching the mockup body markup (`SPEC/ui/mockups/GAME40001-technology-panel.html`: `.researched-heading` precedes `.slots-heading`).
+
+- **No dev-only panel header block (Refs #3510):** **Given** the Slots tab is rendered for any player on any viewport, **when** the panel body widget tree is inspected, **then** the UI layer renders no `Text` carrying the localized `technologyPanel_title` (`"Technology - {playerName}"`) string and no `Text` carrying the localized `technologyPanel_researchSlotsCount` (`"Research slots: {slots}"`) string, matching the mockup which opens directly with the `Researched Techs` heading.
+
+- **Locked Slot 4 same width as active slots (Refs #3510):** **Given** `player.researchSlots` is `null` or strictly less than `4`, **when** the Slots tab is rendered, **then** the locked `LockedResearchSlotCard` fourth-slot card and each active `ResearchSlotCard` are laid out at the same width (within ±1 logical px) so the locked placeholder is not visually narrower or wider than Slots 1–3.
+
+- **Mockup locked Slot 4 parity (Refs #3510):** **Given** the `SPEC/ui/mockups/GAME40001-technology-panel.html` `slots-container` is rendered, **when** the default / empty variant is active (`activeSlots < 4`), **then** it shows exactly four `.slot-card` elements — three active slots plus exactly one locked `Slot 4 (University)` placeholder — and **when** the `all` variant is active (`activeSlots === 4`), then it shows exactly four `.slot-card` elements (Slots 1–4 live) and no locked Slot 4 placeholder.
 
 - **Top bar present (dark chrome):** **Given** the Technology screen is mounted for the viewed player on any viewport, **when** the screen builds its chrome, **then** the UI layer renders a `CtTopBar` instance above the body whose `title` equals `"Technology"`, whose `backButtonLabel` equals `"Map"`, and whose leading `icon` is the pixel-art asset `assets/icons/32/ui_icon_technology.png` sized 18 × 18 logical px (no fallback to the legacy `CtScreenShell` parchment chrome).
 

--- a/app/lib/features/game/widgets/technology_panel.dart
+++ b/app/lib/features/game/widgets/technology_panel.dart
@@ -87,18 +87,12 @@ class TechnologyPanel extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text(
-          l10n.technologyPanel_title(player.displayName),
-          style: Theme.of(context).textTheme.titleMedium,
-        ),
-        const SizedBox(height: 8),
-        Text(
-          l10n.technologyPanel_researchSlotsCount(slots),
-          style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                color: EditorialMonoclePalette.muted,
-              ),
-        ),
-        const SizedBox(height: 12),
+        // No dev-only panel header block: the per-player title and the
+        // research-slot count line are intentionally omitted so the Slots
+        // tab body opens directly with the Researched Techs heading, matching
+        // the mockup (`SPEC/ui/mockups/GAME40001-technology-panel.html` opens
+        // with `.researched-heading`). Player identity and the `Technology`
+        // title are carried by the `CtTopBar` chrome. Refs #3510.
         // Researched Techs renders ABOVE Research Slots per
         // SPEC/ui/technology-panel.md § Layout / wireframe > Body section
         // ordering and matches the mockup body markup in
@@ -128,7 +122,13 @@ class TechnologyPanel extends StatelessWidget {
         const SizedBox(height: 12),
         CtSectionLabel(l10n.technologyPanel_researchSlotsHeading),
         const SizedBox(height: 6),
+        // Stretch every slot card to the full panel content width so the
+        // locked Slot 4 placeholder is the same width as the active Slots
+        // 1–3 (mockup `.slot-card` is a full-width block element).
+        // SPEC/ui/technology-panel.md § Slot behaviour > Locked slot 4.
+        // Refs #3510.
         Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
           children: List.generate(
             kTechnologyResearchSlotCount,
             (index) => _buildResearchSlot(

--- a/app/test/technology_panel_test.dart
+++ b/app/test/technology_panel_test.dart
@@ -21,7 +21,9 @@ void main() {
     player = game.players.isNotEmpty ? game.players.first : _dummyPlayer();
   });
 
-  testWidgets('TechnologyPanel builds and shows player name and research slots', (WidgetTester tester) async {
+  testWidgets(
+    'TechnologyPanel builds and omits the dev-only header block (Refs #3510)',
+    (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
@@ -36,10 +38,12 @@ void main() {
     );
     await tester.pumpAndSettle();
     expect(find.byType(TechnologyPanel), findsOneWidget);
-    expect(find.textContaining(player.displayName), findsOneWidget);
-    expect(find.textContaining('Research slots:'), findsOneWidget);
-    // Dark theme uses an explicit section heading, not a count line, for
-    // the researched-techs grid (Refs #2864 S2).
+    // SPEC/ui/technology-panel.md § Slots tab — section ordering: the body
+    // MUST NOT render the legacy dev-only header block (per-player title
+    // `Technology - {name}` or `Research slots: N` count line). Refs #3510.
+    expect(find.textContaining('Technology - '), findsNothing);
+    expect(find.textContaining('Research slots:'), findsNothing);
+    // Body opens directly with the Researched Techs section heading.
     expect(find.text('RESEARCHED TECHS'), findsOneWidget);
     expect(find.text('None yet'), findsOneWidget);
   });
@@ -149,7 +153,9 @@ void main() {
     expect(find.textContaining('RP'), findsOneWidget);
   });
 
-  testWidgets('TechnologyPanel shows custom research slots when set', (WidgetTester tester) async {
+  testWidgets(
+    'TechnologyPanel omits the research-slot count line even at 4 slots (Refs #3510)',
+    (WidgetTester tester) async {
     const slots = 4;
     final withSlots = player.copyWith(researchSlots: slots);
     final gameWithSlots = game.copyWith(
@@ -168,7 +174,57 @@ void main() {
       ),
     );
     await tester.pumpAndSettle();
-    expect(find.text('Research slots: $slots'), findsOneWidget);
+    // The dev-only count line is removed regardless of slot count; with
+    // 4 active slots there is also no locked placeholder. Refs #3510.
+    expect(find.textContaining('Research slots:'), findsNothing);
+    expect(find.byType(ResearchSlotCard), findsNWidgets(4));
+    expect(find.byType(LockedResearchSlotCard), findsNothing);
+  });
+
+  testWidgets(
+    'Locked Slot 4 renders the same width as the active slot cards (Refs #3510)',
+    (WidgetTester tester) async {
+    final withLockedSlot = player.copyWith(researchSlots: 3);
+    final gameWithLockedSlot = game.copyWith(
+      players: [withLockedSlot, ...game.players.skip(1)],
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 600,
+            child: SingleChildScrollView(
+              child: TechnologyPanel(
+                game: gameWithLockedSlot,
+                player: withLockedSlot,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(ResearchSlotCard), findsNWidgets(3));
+    expect(find.byType(LockedResearchSlotCard), findsOneWidget);
+
+    final double lockedWidth =
+        tester.getSize(find.byType(LockedResearchSlotCard)).width;
+    final List<double> activeWidths = <double>[
+      for (final element in find.byType(ResearchSlotCard).evaluate())
+        tester.getSize(find.byWidget(element.widget)).width,
+    ];
+    expect(activeWidths, isNotEmpty);
+    for (final double activeWidth in activeWidths) {
+      expect(
+        (lockedWidth - activeWidth).abs(),
+        lessThanOrEqualTo(1.0),
+        reason:
+            'SPEC/ui/technology-panel.md § Slot behaviour > Locked slot 4: '
+            'the locked Slot 4 card must render at the same width as the '
+            'active slot cards (Refs #3510).',
+      );
+    }
   });
 
   testWidgets('TechnologyPanel "Choose tech" shows no-techs modal when none available',


### PR DESCRIPTION
## Summary

First parity slice for the **GAME40001 Technology Slots** tab, converging implementation, `SPEC/ui/technology-panel.md`, and `SPEC/ui/mockups/GAME40001-technology-panel.html` on one contract. Tracked by #3510.

## Done in this push (Refs #3510)

- **Mockup HTML bug fixes (issue § Mockup HTML bugs to fix):**
  - Default/empty variants now render exactly **3 active slots + one locked `Slot 4 (University)` placeholder** (previously the locked card was never rendered).
  - The `all` variant renders exactly **4 live slots and no locked placeholder** (previously it duplicated Slot 4).
- **Remove dev-only panel header block (AC: no header block):** the Slots body no longer renders `Technology - {player}` or `Research slots: N`; it opens directly with the Researched Techs heading, matching the mockup. Player identity + `Technology` title remain in the `CtTopBar` chrome.
- **Locked Slot 4 same width as active slots (AC: locked-slot width):** slot cards now stretch to the full panel content width, so the locked placeholder matches Slots 1–3 (mockup `.slot-card` is a full-width block).
- **SPEC + ACs:** `SPEC/ui/technology-panel.md` § Layout / § Slot behaviour updated with new Given–When–Then ACs (no dev-only header block; locked Slot 4 same width; mockup locked-Slot-4 parity).

## Tests

- `app/test/technology_panel_test.dart`: updated header-presence assertions to header-absence; repurposed the slot-count test; added a locked-Slot-4 width-parity test.
- Verified green locally:
  - `flutter test test/technology_panel_test.dart test/technology_panel_dark_chrome_test.dart test/widgetbook_technology_slots_variants_test.dart test/technology_screen_dark_chrome_test.dart test/technology_screen_320dp_min_viewport_test.dart` → all pass.
  - `flutter test test/technology_panel_interaction_test.dart test/technology_panel_choose_tech_dialog_test.dart` → all pass.
  - `flutter analyze` on touched files → no issues.

## Deferred (follow-up commits on this PR)

Disclosed per scope triage — the remaining #3510 ACs:
- Compact, mockup-faithful slot action controls (replacing large `CtNinePatchButton` chrome) **and** the 44×44 dp mobile touch-target AC.
- Mockup-faithful section-heading restyle (vs current `CtSectionLabel`).
- Side-by-side golden parity coverage at the desktop + 360×640 mobile viewports.

Refs #3510

Made with [Cursor](https://cursor.com)