### PR TITLE
feat: military/naval unit panel header primary pills (#3514)

### DIFF
--- a/SPEC/ui/military-units-panel.md
+++ b/SPEC/ui/military-units-panel.md
@@ -21,6 +21,7 @@
 - **Desktop / wide:** Side panel / bottom sheet; map visible.
 - **Mobile / narrow:** [mobile-adaptation.md](mobile-adaptation.md).
 - **Train button:** Header **Train** closes panel and emits `OpenDialogEvent(trainMilitaryDialogId)` for [train-military-dialog.md](train-military-dialog.md).
+- **Header action chrome (mockup `.train-btn` primary; issue #3514 owner decisions #5 / #15):** The header **Train** and **Combine** actions render as compact **primary** pills via `CtActionTextButton(primary: true)` — gradient surface, 1 px `EditorialMonoclePalette.accentDim` border (lifting to `--accent` on hover), `--accent` label foreground, and **no nine-patch corner brackets**. The select-all checkbox is unchanged. Bus emissions and enable/disable rules are unchanged: **Train** is disabled in observe (read-only) mode; **Combine** is enabled only when `canCombineArmySelection` holds for the current selection. The `pixel-art-ui-catalog.md` § `CtActionTextButton` entry documents the primary variant.
 
 ---
 
@@ -126,6 +127,8 @@ Side panel or bottom sheet (viewport-dependent); **Land** and **Naval** branches
 - Given the naval subsection is present, when the user views the panel, then fleet grouping and ship-type rows match [naval-units-panel.md](naval-units-panel.md) and are unchanged in behavior from the pre-army naval specification.
 
 - Given the user taps **Train**, when the action completes, then the UI layer closes the panel and opens the Train Military dialog via `AppEventBus` per [train-military-dialog.md](train-military-dialog.md).
+
+- Given the Military Units panel is open (issue #3514 owner decisions #5 / #15), when the header **Train** and **Combine** actions render, then the UI layer renders each as a `CtActionTextButton` with `primary == true` (compact primary gradient pill, no `CtNinePatchButton` corner-bracket chrome), and tapping **Train** still emits `OpenDialogEvent(trainMilitaryDialogId)`.
 
 - Given the Widgetbook “Military Units Panel” **With map** story, when the user selects an army row, then the map highlights and centers on that army’s province tile and switches region tab when needed.
 

--- a/SPEC/ui/naval-units-panel.md
+++ b/SPEC/ui/naval-units-panel.md
@@ -58,6 +58,8 @@ For every **sea‑going** fleet (any fleet that is **not** the Home Fleet), the 
 
 When the shell opens the panel via **`OpenNavalUnitsPanelEvent`** with `locationScopeKey`, optional `initialSelectedFleetId`, and optional `tileScopeTileKey`, the list shows only fleets at that location scope, the title uses the tile-scoped string, and the **Tile** header action emits **`OpenMapTileDetailEvent`** for `tileScopeTileKey` (after **`ClosePanelEvent`**, same pattern as civilians).
 
+**Header action chrome (mockup `.train-btn` primary; issue #3514 owner decisions #5 / #15):** The header actions — tile-scope **Tile** and **Combine** — render as compact **primary** pills via `CtActionTextButton(primary: true)` — gradient surface, 1 px `EditorialMonoclePalette.accentDim` border (lifting to `--accent` on hover), `--accent` label foreground, and **no nine-patch corner brackets**. The select-all checkbox is unchanged. The naval panel has **no** Train action. Bus emissions and enable/disable rules are unchanged: **Tile** is disabled when `tileScopeTileKey` is empty; **Combine** is enabled only when the current selection is combinable. The `pixel-art-ui-catalog.md` § `CtActionTextButton` entry documents the primary variant.
+
 ---
 
 ## Scope: which fleets are shown
@@ -248,6 +250,8 @@ The first implementation pass for [#2866](https://github.com/) (PR #2906 + #2919
 - **Given** the Naval Units panel is open and the user expands a fleet row, **when** the fleet has one or more ships, **then** the UI layer shows a composition table with one row per ship type (including type name, count, and role tag) and a capabilities section (cargo capacity for the Home Fleet, strength summary for sea-going fleets) as defined in this spec.
 
 - **Given** the Naval Units panel is open and the user expands a fleet that includes ships of type `carrack`, **when** the user reads the composition row for that type, **then** the UI layer shows **Carrack** (or the mapped `shipTypeDisplayName` label) with the count, and does **not** show the raw id string `carrack:` as the row title.
+
+- **Given** the Naval Units panel is open (issue #3514 owner decisions #5 / #15), **when** the header **Combine** action (and the tile-scope **Tile** action, when present) renders, **then** the UI layer renders each as a `CtActionTextButton` with `primary == true` (compact primary gradient pill), and the header mounts no `CtNinePatchButton` descendant for its actions.
 
 - **Given** the Naval Units panel is open and renders one or more at-sea fleets, **when** the UI shows sea-zone location labels (group headers or row subtitles), **then** the UI resolves and displays sea-zone display names from world-state sea-zone naming data (prefixed key) and does not show raw `seaZoneId` values as user-facing labels.
 

--- a/app/lib/features/game/widgets/military_units_panel.dart
+++ b/app/lib/features/game/widgets/military_units_panel.dart
@@ -13,6 +13,7 @@ import '../../../l10n/l10n.dart';
 import '../../../widgets/ct_icon_action.dart';
 import '../../../widgets/ct_nine_patch_button.dart';
 import '../../../widgets/ct_spacing.dart';
+import 'chrome/ct_action_text_button.dart';
 import 'game_panel_contract.dart';
 import 'utils/military_tree_builder.dart';
 import 'move_army_dialog.dart';
@@ -184,21 +185,21 @@ class _MilitaryUnitsPanelState extends State<MilitaryUnitsPanel> {
           ),
         ),
         const SizedBox(width: 4),
-        CtNinePatchButton(
+        // Combine adopts the compact **primary** header pill
+        // (`CtActionTextButton(primary: true)`) per SPEC/ui/military-units-panel.md
+        // § Header actions and issue #3514 owner decisions #5 / #15.
+        CtActionTextButton(
+          primary: true,
           onPressed: canCombine ? () => _performCombine(flat) : null,
           enabled: canCombine,
-          padding: const EdgeInsets.symmetric(
-            horizontal: 10,
-            vertical: CtSpacing.s,
-          ),
-          minHeight: 32,
-          child: Text(l10n.common_combine),
+          label: l10n.common_combine,
         ),
       ],
-      CtNinePatchButton(
+      CtActionTextButton(
+        primary: true,
         onPressed: readOnly ? null : _openTrainDialog,
         enabled: !readOnly,
-        child: Text(l10n.common_train),
+        label: l10n.common_train,
       ),
     ];
   }

--- a/app/lib/features/game/widgets/naval_units_panel.dart
+++ b/app/lib/features/game/widgets/naval_units_panel.dart
@@ -13,8 +13,7 @@ import '../../../config/ct_e2e.dart';
 import '../../../config/ct_e2e_last_panel_snapshot.dart';
 import '../../../config/ui_screen_ids.dart';
 import '../../../l10n/l10n.dart';
-import '../../../widgets/ct_nine_patch_button.dart';
-import '../../../widgets/ct_spacing.dart';
+import 'chrome/ct_action_text_button.dart';
 import 'fleet_expansion_tile.dart';
 import 'game_panel_contract.dart';
 import 'utils/naval_tree_builder.dart';
@@ -499,9 +498,13 @@ class _NavalUnitsPanelState extends State<NavalUnitsPanel> {
       title: tileScopeActive
           ? l10n.naval_units_title_tile
           : l10n.naval_units_title,
+      // Header actions render as compact **primary** pills
+      // (`CtActionTextButton(primary: true)`) per SPEC/ui/naval-units-panel.md
+      // § Header actions and issue #3514 owner decisions #5 / #15.
       actions: [
         if (tileScopeActive)
-          CtNinePatchButton(
+          CtActionTextButton(
+            primary: true,
             enabled: widget.tileScopeTileKey!.isNotEmpty,
             onPressed: () {
               final key = widget.tileScopeTileKey!;
@@ -510,12 +513,7 @@ class _NavalUnitsPanelState extends State<NavalUnitsPanel> {
                 widget.bus.emit(OpenMapTileDetailEvent(tileKey: key));
               });
             },
-            padding: const EdgeInsets.symmetric(
-              horizontal: 10,
-              vertical: CtSpacing.s,
-            ),
-            minHeight: 32,
-            child: Text(l10n.civilian_units_tile),
+            label: l10n.civilian_units_tile,
           ),
         if (tileScopeActive && hasAny && flat.isNotEmpty)
           const SizedBox(width: 4),
@@ -533,15 +531,11 @@ class _NavalUnitsPanelState extends State<NavalUnitsPanel> {
             ),
           ),
           const SizedBox(width: 4),
-          CtNinePatchButton(
+          CtActionTextButton(
+            primary: true,
             onPressed: canCombine ? () => _performCombine(flat) : null,
             enabled: canCombine,
-            padding: const EdgeInsets.symmetric(
-              horizontal: 10,
-              vertical: CtSpacing.s,
-            ),
-            minHeight: 32,
-            child: Text(l10n.common_combine),
+            label: l10n.common_combine,
           ),
         ],
       ],

--- a/app/test/military_units_panel_test_part1_test.dart
+++ b/app/test/military_units_panel_test_part1_test.dart
@@ -12,7 +12,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:colonizethis_app/features/game/utils/map_location_resolver.dart';
 import 'package:colonizethis_app/features/game/widgets/move_army_dialog.dart';
 import 'package:colonizethis_app/features/game/widgets/military_units_panel.dart';
+import 'package:colonizethis_app/features/game/widgets/chrome/ct_action_text_button.dart';
 import 'package:colonizethis_app/features/game/widgets/units/shared/units_entity_action_row.dart';
+import 'package:colonizethis_app/features/game/widgets/units/shared/units_panel_shell.dart';
 import 'package:colonizethis_app/core/services/app_event_handler_scope.dart';
 import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
 import 'package:colonizethis_app/widgets/ct_panel.dart';
@@ -147,6 +149,65 @@ void main() {
 
         expect(find.text('No military units'), findsOneWidget);
         expect(find.byType(ListTile), findsNothing);
+      },
+    );
+
+    testWidgets('header Train renders as a primary CtActionTextButton pill '
+        '(no CtNinePatchButton header chrome) — #3514 owner decisions #5/#15', (
+      WidgetTester tester,
+    ) async {
+      // Empty roster isolates the header so the only button chrome is the
+      // Train pill (no row Move/Split CtNinePatchButtons, no Combine).
+      await tester.pumpWidget(
+        buildPanel(game: game, humanPlayerId: humanPlayerIdWithNoUnits),
+      );
+      await tester.pumpAndSettle();
+
+      final headerButtons = find.descendant(
+        of: find.byType(UnitsPanelShell),
+        matching: find.byType(CtActionTextButton),
+      );
+      expect(headerButtons, findsOneWidget);
+      final train = tester.widget<CtActionTextButton>(headerButtons.first);
+      expect(train.primary, isTrue);
+      expect(train.label, 'Train');
+      expect(find.byType(CtNinePatchButton), findsNothing);
+    });
+
+    testWidgets(
+      'header Combine renders as a primary CtActionTextButton pill when a '
+      'combinable roster is present — #3514 owner decisions #5/#15',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(
+          buildPanel(game: game, humanPlayerId: humanPlayerIdWithUnits),
+        );
+        await tester.pumpAndSettle();
+
+        final combine = find.ancestor(
+          of: find.text('Combine'),
+          matching: find.byType(CtActionTextButton),
+        );
+        // Combine only renders for a non-empty roster; when present it must be
+        // a primary pill and never a CtNinePatchButton.
+        if (combine.evaluate().isNotEmpty) {
+          expect(
+            tester.widget<CtActionTextButton>(combine.first).primary,
+            isTrue,
+          );
+          expect(
+            find.ancestor(
+              of: find.text('Combine'),
+              matching: find.byType(CtNinePatchButton),
+            ),
+            findsNothing,
+          );
+        }
+        final train = find.ancestor(
+          of: find.text('Train'),
+          matching: find.byType(CtActionTextButton),
+        );
+        expect(train, findsOneWidget);
+        expect(tester.widget<CtActionTextButton>(train.first).primary, isTrue);
       },
     );
 

--- a/app/test/naval_units_panel_test_part1_test.dart
+++ b/app/test/naval_units_panel_test_part1_test.dart
@@ -20,6 +20,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:colonizethis_app/features/game/widgets/move_fleet_dialog.dart';
 import 'package:colonizethis_app/features/game/widgets/naval_units_panel.dart';
+import 'package:colonizethis_app/features/game/widgets/chrome/ct_action_text_button.dart';
 import 'package:colonizethis_app/features/game/widgets/units/shared/units_entity_action_row.dart';
 import 'package:colonizethis_app/features/game/widgets/units/shared/units_panel_shell.dart';
 import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
@@ -159,6 +160,30 @@ void main() {
       if (find.byType(ExpansionTile).evaluate().isNotEmpty) {
         expect(find.byType(UnitsEntityActionRow), findsAtLeastNWidgets(1));
       }
+    });
+
+    testWidgets('header Combine renders as a primary CtActionTextButton pill '
+        '(no CtNinePatchButton header chrome) — #3514 owner decisions #5/#15', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        buildPanel(game: game, humanPlayerId: humanPlayerIdWithFleets),
+      );
+      await tester.pumpAndSettle();
+
+      final combine = find.ancestor(
+        of: find.text('Combine'),
+        matching: find.byType(CtActionTextButton),
+      );
+      expect(combine, findsOneWidget);
+      expect(tester.widget<CtActionTextButton>(combine.first).primary, isTrue);
+      expect(
+        find.ancestor(
+          of: find.text('Combine'),
+          matching: find.byType(CtNinePatchButton),
+        ),
+        findsNothing,
+      );
     });
 
     testWidgets(
@@ -804,7 +829,7 @@ void main() {
         );
 
         final combineButtons = find.widgetWithText(
-          CtNinePatchButton,
+          CtActionTextButton,
           'Combine',
         );
         expect(combineButtons, findsOneWidget);
@@ -816,7 +841,7 @@ void main() {
         expect(
           find.descendant(
             of: homeFleetFinder,
-            matching: find.widgetWithText(CtNinePatchButton, 'Combine'),
+            matching: find.widgetWithText(CtActionTextButton, 'Combine'),
           ),
           findsNothing,
         );
@@ -925,7 +950,7 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(
-          find.widgetWithText(CtNinePatchButton, 'Combine'),
+          find.widgetWithText(CtActionTextButton, 'Combine'),
           findsOneWidget,
         );
       },

--- a/app/test/naval_units_panel_test_part2_test.dart
+++ b/app/test/naval_units_panel_test_part2_test.dart
@@ -20,6 +20,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:colonizethis_app/features/game/widgets/move_fleet_dialog.dart';
 import 'package:colonizethis_app/features/game/widgets/naval_units_panel.dart';
+import 'package:colonizethis_app/features/game/widgets/chrome/ct_action_text_button.dart';
 import 'package:colonizethis_app/features/game/widgets/units/shared/units_entity_action_row.dart';
 import 'package:colonizethis_app/features/game/widgets/units/shared/units_panel_shell.dart';
 import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
@@ -145,6 +146,7 @@ void main() {
       ),
     );
   }
+
   group('NavalUnitsPanel', () {
     testWidgets(
       'AC: Header checkbox selects all fleets then second interaction clears',
@@ -354,7 +356,7 @@ void main() {
       await tester.tap(cb2);
       await tester.pumpAndSettle();
 
-      final combineFinder = find.widgetWithText(CtNinePatchButton, 'Combine');
+      final combineFinder = find.widgetWithText(CtActionTextButton, 'Combine');
       await tester.ensureVisible(combineFinder);
       await tester.tap(combineFinder);
       await tester.pumpAndSettle();
@@ -460,8 +462,8 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        final combineBtn = tester.widget<CtNinePatchButton>(
-          find.widgetWithText(CtNinePatchButton, 'Combine'),
+        final combineBtn = tester.widget<CtActionTextButton>(
+          find.widgetWithText(CtActionTextButton, 'Combine'),
         );
         expect(combineBtn.enabled, isFalse);
       },
@@ -563,7 +565,7 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        await tester.tap(find.widgetWithText(CtNinePatchButton, 'Combine'));
+        await tester.tap(find.widgetWithText(CtActionTextButton, 'Combine'));
         await tester.pumpAndSettle();
         expect(find.text('Transfer Ships to Home Fleet'), findsOneWidget);
         await tester.tap(find.byKey(CtTransferListKeys.leftMoveAll('fluyte')));
@@ -693,7 +695,7 @@ void main() {
         }
 
         final combineBtnFinder = find.widgetWithText(
-          CtNinePatchButton,
+          CtActionTextButton,
           'Combine',
         );
         await tester.scrollUntilVisible(combineBtnFinder, 120);
@@ -804,8 +806,8 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        final combineBtn = tester.widget<CtNinePatchButton>(
-          find.widgetWithText(CtNinePatchButton, 'Combine'),
+        final combineBtn = tester.widget<CtActionTextButton>(
+          find.widgetWithText(CtActionTextButton, 'Combine'),
         );
         expect(combineBtn.enabled, isFalse);
       },
@@ -908,8 +910,8 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        final combineBtn = tester.widget<CtNinePatchButton>(
-          find.widgetWithText(CtNinePatchButton, 'Combine'),
+        final combineBtn = tester.widget<CtActionTextButton>(
+          find.widgetWithText(CtActionTextButton, 'Combine'),
         );
         expect(combineBtn.enabled, isFalse);
       },
@@ -1010,16 +1012,15 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        final combineBtn = tester.widget<CtNinePatchButton>(
-          find.widgetWithText(CtNinePatchButton, 'Combine'),
+        final combineBtn = tester.widget<CtActionTextButton>(
+          find.widgetWithText(CtActionTextButton, 'Combine'),
         );
         expect(combineBtn.enabled, isTrue);
 
-        await tester.tap(find.widgetWithText(CtNinePatchButton, 'Combine'));
+        await tester.tap(find.widgetWithText(CtActionTextButton, 'Combine'));
         await tester.pumpAndSettle();
         expect(find.text('Transfer Ships to Home Fleet'), findsOneWidget);
       },
     );
-
   });
 }

--- a/app/test/naval_units_panel_test_part3_test.dart
+++ b/app/test/naval_units_panel_test_part3_test.dart
@@ -20,6 +20,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:colonizethis_app/features/game/widgets/move_fleet_dialog.dart';
 import 'package:colonizethis_app/features/game/widgets/naval_units_panel.dart';
+import 'package:colonizethis_app/features/game/widgets/chrome/ct_action_text_button.dart';
 import 'package:colonizethis_app/features/game/widgets/units/shared/units_entity_action_row.dart';
 import 'package:colonizethis_app/features/game/widgets/units/shared/units_panel_shell.dart';
 import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
@@ -145,6 +146,7 @@ void main() {
       ),
     );
   }
+
   group('NavalUnitsPanel', () {
     testWidgets(
       'AC: Home Fleet transfer moves selected ships and keeps source when ships remain',
@@ -252,7 +254,7 @@ void main() {
           find.descendant(of: sourceFinder, matching: find.byType(Checkbox)),
         );
         await tester.pumpAndSettle();
-        await tester.tap(find.widgetWithText(CtNinePatchButton, 'Combine'));
+        await tester.tap(find.widgetWithText(CtActionTextButton, 'Combine'));
         await tester.pumpAndSettle();
 
         final moveOneFluyte = find.byKey(
@@ -385,8 +387,8 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        final combineBtn = tester.widget<CtNinePatchButton>(
-          find.widgetWithText(CtNinePatchButton, 'Combine'),
+        final combineBtn = tester.widget<CtActionTextButton>(
+          find.widgetWithText(CtActionTextButton, 'Combine'),
         );
         expect(combineBtn.enabled, isFalse);
       },
@@ -491,12 +493,12 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        final combineBtn = tester.widget<CtNinePatchButton>(
-          find.widgetWithText(CtNinePatchButton, 'Combine'),
+        final combineBtn = tester.widget<CtActionTextButton>(
+          find.widgetWithText(CtActionTextButton, 'Combine'),
         );
         expect(combineBtn.enabled, isTrue);
 
-        await tester.tap(find.widgetWithText(CtNinePatchButton, 'Combine'));
+        await tester.tap(find.widgetWithText(CtActionTextButton, 'Combine'));
         await tester.pumpAndSettle();
 
         expect(updated, isNotNull);
@@ -602,7 +604,7 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        await tester.tap(find.widgetWithText(CtNinePatchButton, 'Combine'));
+        await tester.tap(find.widgetWithText(CtActionTextButton, 'Combine'));
         await tester.pumpAndSettle();
 
         expect(updated, isNotNull);
@@ -707,8 +709,8 @@ void main() {
           expect(tester.widget<Checkbox>(cb).value, isTrue);
         }
 
-        final combineBtn = tester.widget<CtNinePatchButton>(
-          find.widgetWithText(CtNinePatchButton, 'Combine'),
+        final combineBtn = tester.widget<CtActionTextButton>(
+          find.widgetWithText(CtActionTextButton, 'Combine'),
         );
         expect(combineBtn.enabled, isTrue);
       },
@@ -816,7 +818,10 @@ void main() {
           await tester.pumpAndSettle();
         }
 
-        final combineFinder = find.widgetWithText(CtNinePatchButton, 'Combine');
+        final combineFinder = find.widgetWithText(
+          CtActionTextButton,
+          'Combine',
+        );
         await tester.scrollUntilVisible(combineFinder, 120);
         await tester.pumpAndSettle();
         await tester.tap(combineFinder);
@@ -943,8 +948,8 @@ void main() {
         expect(removedFinder, findsNothing);
         expect(tester.widget<Checkbox>(staysCb).value, isTrue);
 
-        final combineBtn = tester.widget<CtNinePatchButton>(
-          find.widgetWithText(CtNinePatchButton, 'Combine'),
+        final combineBtn = tester.widget<CtActionTextButton>(
+          find.widgetWithText(CtActionTextButton, 'Combine'),
         );
         expect(combineBtn.enabled, isFalse);
       },
@@ -1055,7 +1060,7 @@ void main() {
           findsOne,
         );
 
-        await tester.tap(find.widgetWithText(CtNinePatchButton, 'Combine'));
+        await tester.tap(find.widgetWithText(CtActionTextButton, 'Combine'));
         await tester.pumpAndSettle();
 
         expect(updated, isNotNull);
@@ -1065,6 +1070,5 @@ void main() {
         expect(mergedIds, ['cs1', 'cs2']);
       },
     );
-
   });
 }

--- a/app/test/naval_units_panel_test_part4_test.dart
+++ b/app/test/naval_units_panel_test_part4_test.dart
@@ -20,6 +20,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:colonizethis_app/features/game/widgets/move_fleet_dialog.dart';
 import 'package:colonizethis_app/features/game/widgets/naval_units_panel.dart';
+import 'package:colonizethis_app/features/game/widgets/chrome/ct_action_text_button.dart';
 import 'package:colonizethis_app/features/game/widgets/units/shared/units_entity_action_row.dart';
 import 'package:colonizethis_app/features/game/widgets/units/shared/units_panel_shell.dart';
 import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
@@ -788,7 +789,7 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        await tester.tap(find.widgetWithText(CtNinePatchButton, 'Combine'));
+        await tester.tap(find.widgetWithText(CtActionTextButton, 'Combine'));
         await tester.pumpAndSettle();
         expect(find.text('Transfer Ships to Home Fleet'), findsOneWidget);
         await tester.tap(find.byKey(CtTransferListKeys.leftMoveAll('fluyte')));


### PR DESCRIPTION
## Summary

Slice of #3514 (Align unit panels visual chrome with HTML mockups). Migrates the **military** and **naval** unit-panel **header** actions from `CtNinePatchButton` to the compact **primary** pill `CtActionTextButton(primary: true)`, mirroring the already-merged civilian header work (#3520) and per owner decisions **#5 / #15** (Train / Combine / Tile adopt the mockup `.train-btn` / `.hdr-btn` primary pill family).

`Refs #3514`

## Done in this push

- **Military panel:** header **Train** and **Combine** now render as `CtActionTextButton(primary: true)` (no nine-patch corner brackets). Bus emissions, `_performCombine` enablement, and the select-all checkbox are unchanged.
- **Naval panel:** header tile-scope **Tile** and **Combine** now render as `CtActionTextButton(primary: true)`. Removed the now-unused `CtNinePatchButton` / `CtSpacing` imports from the naval panel. Naval has no Train action.
- **SPEC:** added a *Header action chrome* bullet + a header-pill AC to `SPEC/ui/military-units-panel.md` and `SPEC/ui/naval-units-panel.md`, cross-referencing the `pixel-art-ui-catalog.md` § `CtActionTextButton` primary variant.
- **Tests:**
  - New positive ACs: military header Train (empty-roster isolates header → single primary pill, no `CtNinePatchButton`) and Combine; naval header Combine as primary pill with no `CtNinePatchButton` header descendant.
  - Updated all existing naval header-Combine widget tests (part1–part4) from `CtNinePatchButton` to `CtActionTextButton` finders/casts (mechanical; tap/`.enabled` surface unchanged).

## Verification

- `flutter test` for `military_units_panel_test_part1` and `naval_units_panel_test_part1-4` → all pass.
- Regression sweep: `military_units_panel_test_part2/3/5`, `naval_units_panel_test_part5`, `naval_units_panel_mockup_fidelity_test`, `unit_panels_widgetbook_dark_chrome_test`, `widgetbook_unit_panels_theme_test` → all pass.
- `flutter analyze` (changed lib files) clean; `dart format` clean.

## Deferred for #3514 (follow-up commits on this PR / later slices)

- Row-action pill migration (`_CivilianUnitCardActions`, shared `UnitsEntityActionRow` Move/Split, circular icon-only locate at rightmost).
- Military/naval entity rows → mockup bordered gradient card chrome (replacing bare `ExpansionTile`).
- Bottom-sheet host sizing/chrome (mockup max width/height, 2 px `accent-dim` top border, top radius) in `app_event_handler.dart`.
- Per-line mockup typography tokens and military/naval mockup parity edits.
- Widget golden captures for `UNIT10001` / `UNIT20001` / `UNIT30001`.

Civilian header pills, the `CtActionTextButton(primary:)` catalog variant, the catalog SPEC entry, and the civilian mockup `Status:` line already landed via #3520.

Made with [Cursor](https://cursor.com)