### PR TITLE
refactor: dedup economy extraction/cost-check + dealmatcher index (#3517)

### DIFF
--- a/packages/colonizethis_economy/lib/src/economy/build_cost.dart
+++ b/packages/colonizethis_economy/lib/src/economy/build_cost.dart
@@ -1,6 +1,8 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
+import 'cost_check.dart';
+
 /// Shared build-order cost and eligibility. Single source of truth for validation
 /// and application. SPEC/program/orders.md § Build orders.
 /// Used by BuildOrderValidator and orders_application.
@@ -97,20 +99,33 @@ typedef _BuildDeductionPlan = ({
   required bool requiresPeasant,
   required bool subtractOnePeasant,
 }) {
-  if (unlockingTechId != null &&
-      (player.techUnlocked?[unlockingTechId] != true)) {
-    return (failReason: 'Required technology not unlocked', plan: null);
-  }
-  if (requiresPeasant && workers.peasants <= 0) {
-    return (failReason: 'Insufficient workers', plan: null);
-  }
-  if (treasury < buildTreasuryCost) {
-    return (failReason: 'Insufficient treasury', plan: null);
-  }
-  for (final e in buildInputs.entries) {
-    if (stockpile.quantityOf(e.key) < e.value) {
-      return (failReason: 'Insufficient materials', plan: null);
-    }
+  // Canonical order, first failure: tech → workers → treasury → materials.
+  // Shared with recruit-worker affordability via [checkPreconditionsInOrder]
+  // (Refs #3517 Cluster 2).
+  final failReason = checkPreconditionsInOrder([
+    (
+      failReason: 'Required technology not unlocked',
+      check: () =>
+          unlockingTechId == null ||
+          player.techUnlocked?[unlockingTechId] == true,
+    ),
+    (
+      failReason: 'Insufficient workers',
+      check: () => !(requiresPeasant && workers.peasants <= 0),
+    ),
+    (
+      failReason: 'Insufficient treasury',
+      check: () => treasury >= buildTreasuryCost,
+    ),
+    (
+      failReason: 'Insufficient materials',
+      check: () => buildInputs.entries.every(
+        (e) => stockpile.quantityOf(e.key) >= e.value,
+      ),
+    ),
+  ]);
+  if (failReason != null) {
+    return (failReason: failReason, plan: null);
   }
   return (
     failReason: null,

--- a/packages/colonizethis_economy/lib/src/economy/cost_check.dart
+++ b/packages/colonizethis_economy/lib/src/economy/cost_check.dart
@@ -1,0 +1,39 @@
+/// Shared "canonical order, first failure" cost-check idiom for the economy
+/// layer.
+///
+/// Recruit-worker affordability ([canAffordRecruitWorker], `worker_action_cost.dart`)
+/// and build-unit affordability (`_resolveBuildPlanForCatalog`, `build_cost.dart`)
+/// both evaluate a fixed priority sequence of preconditions and return the
+/// first failing reason string. This helper centralizes that control flow so
+/// the canonical priority order (tech → workers → treasury → materials) and the
+/// failure-reason vocabulary stay consistent across both paths (Refs #3517
+/// Cluster 2).
+///
+/// The helper is pure and silent (no logging, no global scans) so it is safe on
+/// the turn-resolution hot path per
+/// `.cursor/rules/colonizethis-turn-resolution-budget.mdc`.
+library;
+
+/// A single precondition in a cost-check sequence.
+///
+/// [check] returns `true` when the precondition is satisfied and `false` when
+/// it fails; [failReason] is the user-visible reason string returned when
+/// [check] evaluates to `false`.
+typedef CostPrecondition = ({String failReason, bool Function() check});
+
+/// Evaluates [preconditions] in list order and returns the [failReason] of the
+/// first record whose [check] returns `false`, or `null` when every [check]
+/// passes.
+///
+/// Evaluation short-circuits: once a [check] fails, no later [check] closures
+/// run. Callers therefore order the records by canonical priority (e.g.
+/// tech → workers → treasury → materials) so the surfaced reason matches the
+/// highest-priority unmet precondition.
+String? checkPreconditionsInOrder(List<CostPrecondition> preconditions) {
+  for (final precondition in preconditions) {
+    if (!precondition.check()) {
+      return precondition.failReason;
+    }
+  }
+  return null;
+}

--- a/packages/colonizethis_economy/lib/src/economy/non_gp_extraction_shared.dart
+++ b/packages/colonizethis_economy/lib/src/economy/non_gp_extraction_shared.dart
@@ -4,7 +4,6 @@ import 'package:colonizethis_world/colonizethis_world.dart';
 
 import 'economy_resource_constants.dart';
 import 'tile_extraction_pipeline.dart';
-import 'tile_extraction_yield.dart';
 import 'package:colonizethis_economy/src/logging.dart';
 
 /// Shared per-faction / per-tile traversal helpers for the non-Great-Power
@@ -150,73 +149,46 @@ NonGpTileContribution? _computeNonGpTileContribution({
   required Set<String> portTileKeys,
   required Map<String, Province> provincesByFullId,
 }) {
-  if (!connectedTileKeys.contains(tileKey)) {
-    return null;
-  }
-
-  final tileContext = resolveTileKeyExtractionContext(
-    tileKey: tileKey,
+  // Thin non-Great-Power wrapper over the shared [computeTileYieldContribution]
+  // orchestration with the two non-GP knobs: a fixed default tech cap for every
+  // resource (Minors and Tribes do not research tech) and unconditional mineral
+  // exclusion (non-GP factions never prospect). SPEC/game/extraction-and-
+  // improvements.md § Non-Great-Power extraction. Refs #3517 Cluster 1.
+  final contribution = computeTileYieldContribution(
+    game: game,
     tileMapByRegion: tileMapByRegion,
-    provincesByFullId: provincesByFullId,
-    logContext: 'non_gp_extraction',
-  );
-  if (tileContext == null) {
-    return null;
-  }
-
-  final commodityId = tileContext.commodityId;
-  if (kMineralResourceIds.contains(commodityId)) {
-    // Non-GP factions never prospect — exclude minerals unconditionally per
-    // SPEC/game/extraction-and-improvements.md § Non-Great-Power extraction.
-    return null;
-  }
-
-  final province = tileContext.province;
-  final provinceId = tileContext.provinceId;
-
-  final townDevelopmentCap = province.townDevelopmentLevel;
-  final townTileKey = province.townTileKey;
-  final townTileIsPort =
-      townTileKey != null && portTileKeys.contains(townTileKey);
-
-  // Non-GP tech cap is the package-wide default (1) for every resource: Minors
-  // and Tribes do not research tech. The remaining production / transport /
-  // town-development math is shared with the GP helper via
-  // computeEffectiveTileYield so the two stay provably in lockstep.
-  final isCapitalProvince = provinceId == factionCapitalProvinceId;
-  final usesRoadRule = connectedByRoadRule.contains(tileKey);
-  final effective = computeEffectiveTileYield(
-    tileState: game.worldState.tileState,
     tileKey: tileKey,
-    techCap: defaultExtractionCap,
-    townDevelopmentCap: townDevelopmentCap,
-    townTileIsPort: townTileIsPort,
-    isCapitalProvince: isCapitalProvince,
-    usesRoadRule: usesRoadRule,
-    portTileKeys: portTileKeys,
+    connectedTileKeys: connectedTileKeys,
     pathTransportCap: pathTransportCap,
+    connectedByRoadRule: connectedByRoadRule,
+    portTileKeys: portTileKeys,
+    capitalProvinceId: factionCapitalProvinceId,
+    capitalRegionId: factionCapitalRegionId,
+    logContext: 'non_gp_extraction',
+    provincesByFullId: provincesByFullId,
+    techCapForCommodity: (_) => defaultExtractionCap,
+    isCommodityExtractable: (_, commodityId) =>
+        !kMineralResourceIds.contains(commodityId),
   );
-  if (effective <= 0) {
+  if (contribution == null) {
     return null;
   }
   // The faction-capital-region check is preserved for parity with the GP
   // helper; in current SPEC every owned non-GP tile is same-region, so this
   // branch is informational only — non-GP output is always land-only.
-  final isLandRelativeToCapital =
-      tileContext.regionId == factionCapitalRegionId;
-  if (!isLandRelativeToCapital) {
+  if (!contribution.isLandRelativeToCapital) {
     // Non-GP factions cannot own tiles outside their capital region under
     // current SPEC; emit a debug log and skip so this stays observable if a
     // future ruleset changes that invariant.
     economyLog.d(
       'non_gp_extraction skip overseas tile factionCapitalRegionId='
-      '$factionCapitalRegionId tileRegionId=${tileContext.regionId} '
+      '$factionCapitalRegionId tileRegionId=${contribution.regionId} '
       'tileKey=$tileKey',
     );
     return null;
   }
   return NonGpTileContribution(
-    commodityId: tileContext.commodityId,
-    units: effective,
+    commodityId: contribution.commodityId,
+    units: contribution.units,
   );
 }

--- a/packages/colonizethis_economy/lib/src/economy/resource_extractor.dart
+++ b/packages/colonizethis_economy/lib/src/economy/resource_extractor.dart
@@ -5,7 +5,6 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import 'economy_resource_constants.dart';
 import 'game_lookup_helpers.dart';
 import 'tile_extraction_pipeline.dart';
-import 'tile_extraction_yield.dart';
 import 'package:colonizethis_world/colonizethis_world.dart';
 
 /// Per-player extraction totals: land (same region as capital) vs overseas.
@@ -153,59 +152,38 @@ TileExtractionContribution? computeTileExtractionContributionForPlayer({
   /// rows are resolved by id in O(1) instead of scanning the region list per tile.
   Map<String, Province>? provincesByFullId,
 }) {
-  if (!connectedTileKeys.contains(tileKey)) {
-    return null;
-  }
-
-  final tileContext = resolveTileKeyExtractionContext(
-    tileKey: tileKey,
-    tileMapByRegion: tileMapByRegion,
-    provincesByFullId: provincesByFullId,
+  // Thin Great-Power wrapper over the shared [computeTileYieldContribution]
+  // orchestration: per-resource (or per-player) tech cap and the mineral
+  // Prospecting Gate (minerals require the tile to be prospected). Refs #3517
+  // Cluster 1.
+  final contribution = computeTileYieldContribution(
     game: game,
-    logContext: 'extraction',
-  );
-  if (tileContext == null) {
-    return null;
-  }
-
-  final commodityId = tileContext.commodityId;
-  final techCap =
-      techCapForPlayerAndResource?.call(player.id, commodityId) ??
-      techCapForPlayer(player.id);
-  final isMineral = kMineralResourceIds.contains(commodityId);
-  if (isMineral && !prospectedTileKeys.contains(tileKey)) {
-    return null;
-  }
-
-  final province = tileContext.province;
-  final provinceId = tileContext.provinceId;
-  final townDevelopmentCap = province.townDevelopmentLevel;
-  final townTileKey = province.townTileKey;
-  final townTileIsPort =
-      townTileKey != null && portTileKeys.contains(townTileKey);
-
-  final isCapitalProvince = provinceId == player.capitalProvinceId;
-  final usesRoadRule = connectedByRoadRule.contains(tileKey);
-  final effectiveCapped = computeEffectiveTileYield(
-    tileState: game.worldState.tileState,
+    tileMapByRegion: tileMapByRegion,
     tileKey: tileKey,
-    techCap: techCap,
-    townDevelopmentCap: townDevelopmentCap,
-    townTileIsPort: townTileIsPort,
-    isCapitalProvince: isCapitalProvince,
-    usesRoadRule: usesRoadRule,
-    portTileKeys: portTileKeys,
+    connectedTileKeys: connectedTileKeys,
     pathTransportCap: pathTransportCap,
+    connectedByRoadRule: connectedByRoadRule,
+    portTileKeys: portTileKeys,
+    capitalProvinceId: player.capitalProvinceId,
+    capitalRegionId: capitalRegionId,
+    logContext: 'extraction',
+    provincesByFullId: provincesByFullId,
+    techCapForCommodity: (commodityId) =>
+        techCapForPlayerAndResource?.call(player.id, commodityId) ??
+        techCapForPlayer(player.id),
+    isCommodityExtractable: (tileKey, commodityId) =>
+        !kMineralResourceIds.contains(commodityId) ||
+        prospectedTileKeys.contains(tileKey),
   );
-  if (effectiveCapped <= 0) {
+  if (contribution == null) {
     return null;
   }
 
   return TileExtractionContribution(
     tileKey: tileKey,
-    commodityId: commodityId,
-    units: effectiveCapped,
-    isLandRelativeToCapital: tileContext.regionId == capitalRegionId,
+    commodityId: contribution.commodityId,
+    units: contribution.units,
+    isLandRelativeToCapital: contribution.isLandRelativeToCapital,
   );
 }
 

--- a/packages/colonizethis_economy/lib/src/economy/tile_extraction_pipeline.dart
+++ b/packages/colonizethis_economy/lib/src/economy/tile_extraction_pipeline.dart
@@ -15,6 +15,8 @@ import 'package:colonizethis_economy/src/logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_world/colonizethis_world.dart';
 
+import 'tile_extraction_yield.dart';
+
 /// Tile key resolved through map lookup to a [Resource] and [CommodityId].
 class TileKeyResourceContext {
   const TileKeyResourceContext({
@@ -129,5 +131,121 @@ TileKeyExtractionContext? resolveTileKeyExtractionContext({
   return TileKeyExtractionContext(
     resourceContext: resourceContext,
     province: province,
+  );
+}
+
+/// Effective per-tile extraction yield for one connected tile, shared by the
+/// Great-Power and non-Great-Power extraction paths.
+///
+/// [units] is the computed effective extracted quantity (always `> 0`;
+/// non-yielding tiles return `null` from [computeTileYieldContribution]).
+/// [regionId] / [isLandRelativeToCapital] classify the tile against the
+/// caller's capital region so callers decide whether to keep overseas
+/// contributions (Great Powers) or drop them (non-GP factions).
+class TileYieldContribution {
+  const TileYieldContribution({
+    required this.commodityId,
+    required this.units,
+    required this.regionId,
+    required this.isLandRelativeToCapital,
+  });
+
+  final CommodityId commodityId;
+  final int units;
+  final String regionId;
+
+  /// True when the tile's region matches the caller-supplied capital region.
+  final bool isLandRelativeToCapital;
+}
+
+/// Computes the effective extraction contribution for one connected [tileKey],
+/// hosting the orchestration shared by the Great-Power
+/// ([computeTileExtractionContributionForPlayer], `resource_extractor.dart`)
+/// and non-Great-Power (`_computeNonGpTileContribution`,
+/// `non_gp_extraction_shared.dart`) paths.
+///
+/// The two call sites diverge only by the three documented non-GP
+/// simplifications (`SPEC/game/extraction-and-improvements.md` § Non-Great-Power
+/// extraction), supplied here as knobs so the shared production / transport-cap
+/// / town-development math stays provably in lockstep (Refs #3517 Cluster 1):
+///
+///   * [techCapForCommodity] resolves the per-resource tech cap (Great Powers
+///     use the player / per-resource cap; non-GP factions use the package
+///     default for every resource).
+///   * [isCommodityExtractable] is the mineral gate (Great Powers require the
+///     tile to be prospected for mineral commodities; non-GP factions exclude
+///     minerals unconditionally). Returning `false` skips the tile.
+///   * [capitalProvinceId] selects the capital-province yield branch and
+///     [capitalRegionId] drives [TileYieldContribution.isLandRelativeToCapital].
+///
+/// Returns `null` when the tile contributes no extraction units: not in
+/// [connectedTileKeys], an invalid tile key, missing map / province / resource,
+/// a gated commodity, or computed effective units `<= 0`.
+TileYieldContribution? computeTileYieldContribution({
+  required Game game,
+  required Map<String, TileMapResult> tileMapByRegion,
+  required String tileKey,
+  required Set<String> connectedTileKeys,
+  required Map<String, int> pathTransportCap,
+  required Set<String> connectedByRoadRule,
+  required Set<String> portTileKeys,
+  required String? capitalProvinceId,
+  required String? capitalRegionId,
+  required String logContext,
+  required int Function(CommodityId commodityId) techCapForCommodity,
+  required bool Function(String tileKey, CommodityId commodityId)
+  isCommodityExtractable,
+  Map<String, Province>? provincesByFullId,
+}) {
+  if (!connectedTileKeys.contains(tileKey)) {
+    return null;
+  }
+
+  final tileContext = resolveTileKeyExtractionContext(
+    tileKey: tileKey,
+    tileMapByRegion: tileMapByRegion,
+    provincesByFullId: provincesByFullId,
+    game: game,
+    logContext: logContext,
+  );
+  if (tileContext == null) {
+    return null;
+  }
+
+  final commodityId = tileContext.commodityId;
+  if (!isCommodityExtractable(tileKey, commodityId)) {
+    return null;
+  }
+
+  final techCap = techCapForCommodity(commodityId);
+  final province = tileContext.province;
+  final provinceId = tileContext.provinceId;
+  final townDevelopmentCap = province.townDevelopmentLevel;
+  final townTileKey = province.townTileKey;
+  final townTileIsPort =
+      townTileKey != null && portTileKeys.contains(townTileKey);
+
+  final isCapitalProvince = provinceId == capitalProvinceId;
+  final usesRoadRule = connectedByRoadRule.contains(tileKey);
+  final effective = computeEffectiveTileYield(
+    tileState: game.worldState.tileState,
+    tileKey: tileKey,
+    techCap: techCap,
+    townDevelopmentCap: townDevelopmentCap,
+    townTileIsPort: townTileIsPort,
+    isCapitalProvince: isCapitalProvince,
+    usesRoadRule: usesRoadRule,
+    portTileKeys: portTileKeys,
+    pathTransportCap: pathTransportCap,
+  );
+  if (effective <= 0) {
+    return null;
+  }
+
+  return TileYieldContribution(
+    commodityId: commodityId,
+    units: effective,
+    regionId: tileContext.regionId,
+    isLandRelativeToCapital: tileContext.regionId == capitalRegionId,
   );
 }

--- a/packages/colonizethis_economy/lib/src/economy/worker_action_cost.dart
+++ b/packages/colonizethis_economy/lib/src/economy/worker_action_cost.dart
@@ -14,6 +14,8 @@ library;
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
+import 'cost_check.dart';
+
 /// Rejection reason vocabulary (matches GDD § Order rejection reasons).
 ///
 /// These strings are part of the user-visible UI contract; do not change
@@ -42,21 +44,31 @@ const String kRecruitWorkerTechLocked = 'Required technology not unlocked';
 ) {
   final row = WorkerActionEconomyCatalog.forTier(order.targetTier);
   final tech = player.techUnlocked ?? const <String, bool>{};
-  for (final techId in row.requiredTechIds) {
-    if (tech[techId] != true) {
-      return (canAfford: false, reason: kRecruitWorkerTechLocked);
-    }
-  }
-  if (row.consumesPeasant && workers.peasants <= 0) {
-    return (canAfford: false, reason: kRecruitWorkerInsufficientWorkers);
-  }
-  if (treasury < row.treasuryCost) {
-    return (canAfford: false, reason: kRecruitWorkerInsufficientTreasury);
-  }
-  for (final entry in row.materialCosts.entries) {
-    if (stockpile.quantityOf(entry.key) < entry.value) {
-      return (canAfford: false, reason: kRecruitWorkerInsufficientMaterials);
-    }
+  // Canonical order, first failure: tech → workers → treasury → materials.
+  // Shared with build-unit affordability via [checkPreconditionsInOrder]
+  // (Refs #3517 Cluster 2).
+  final reason = checkPreconditionsInOrder([
+    (
+      failReason: kRecruitWorkerTechLocked,
+      check: () => row.requiredTechIds.every((techId) => tech[techId] == true),
+    ),
+    (
+      failReason: kRecruitWorkerInsufficientWorkers,
+      check: () => !(row.consumesPeasant && workers.peasants <= 0),
+    ),
+    (
+      failReason: kRecruitWorkerInsufficientTreasury,
+      check: () => treasury >= row.treasuryCost,
+    ),
+    (
+      failReason: kRecruitWorkerInsufficientMaterials,
+      check: () => row.materialCosts.entries.every(
+        (entry) => stockpile.quantityOf(entry.key) >= entry.value,
+      ),
+    ),
+  ]);
+  if (reason != null) {
+    return (canAfford: false, reason: reason);
   }
   return (canAfford: true, reason: null);
 }

--- a/packages/colonizethis_economy/lib/src/economy/world_market/deal_matcher.dart
+++ b/packages/colonizethis_economy/lib/src/economy/world_market/deal_matcher.dart
@@ -153,19 +153,21 @@ class DealMatcher {
     );
     final bidStatesByFaction = _indexOrdersByFaction(inputs.bidsByFactionId);
 
+    // Pre-build the per-commodity views once (Refs #3517 Cluster 3) so the
+    // matching loop below is an O(1) lookup instead of re-scanning every order
+    // state for each commodity.
+    final offerStatesByCommodity = _indexStatesByCommodity(offerStatesByFaction);
+    final bidStatesByCommodity = _indexStatesByCommodity(bidStatesByFaction);
+
     final purchasedTileIndex = inputs.purchasedTileIndex;
     final firstRightEnabled =
         purchasedTileIndex != null && purchasedTileIndex.isNotEmpty;
 
     for (final commodityId in commodityIds) {
-      final commodityOffers = _orderedStatesForCommodity(
-        offerStatesByFaction,
-        commodityId,
-      );
-      final commodityBids = _orderedStatesForCommodity(
-        bidStatesByFaction,
-        commodityId,
-      );
+      final commodityOffers =
+          offerStatesByCommodity[commodityId] ?? const <_OrderState>[];
+      final commodityBids =
+          bidStatesByCommodity[commodityId] ?? const <_OrderState>[];
 
       final totalOfferQuantity = _sumInputQuantity(commodityOffers);
       final totalBidQuantity = _sumInputQuantity(commodityBids);

--- a/packages/colonizethis_economy/lib/src/economy/world_market/deal_matcher_indexing.dart
+++ b/packages/colonizethis_economy/lib/src/economy/world_market/deal_matcher_indexing.dart
@@ -48,16 +48,23 @@ Map<String, List<_OrderState>> _indexOrdersByFaction(
   return result;
 }
 
-List<_OrderState> _orderedStatesForCommodity(
+/// Groups every order state by [TradeOrder.commodityId] in a single pass,
+/// preserving the exact ordering the per-commodity scan produced (faction
+/// order from [_indexOrdersByFaction] insertion — alphabetical — then
+/// faction-local index). Built once in the [DealMatcher.matchDeals] prologue so
+/// the per-commodity matching loop is an O(1) map lookup instead of an
+/// O(total-states) re-scan for every commodity, avoiding the duplicate global
+/// scan flagged by `colonizethis-turn-resolution-budget.mdc` (Refs #3517
+/// Cluster 3). The grouped lists reference the same mutable [_OrderState]
+/// objects as [statesByFaction], so `remaining` decrements during matching stay
+/// visible to the carry-forward pass.
+Map<CommodityId, List<_OrderState>> _indexStatesByCommodity(
   Map<String, List<_OrderState>> statesByFaction,
-  CommodityId commodityId,
 ) {
-  final out = <_OrderState>[];
+  final out = <CommodityId, List<_OrderState>>{};
   for (final entry in statesByFaction.entries) {
     for (final state in entry.value) {
-      if (state.order.commodityId == commodityId) {
-        out.add(state);
-      }
+      (out[state.order.commodityId] ??= <_OrderState>[]).add(state);
     }
   }
   return out;

--- a/packages/colonizethis_economy/test/cost_check_test.dart
+++ b/packages/colonizethis_economy/test/cost_check_test.dart
@@ -1,0 +1,65 @@
+import 'package:colonizethis_economy/src/economy/cost_check.dart';
+import 'package:colonizethis_test/test.dart';
+
+void main() {
+  group('checkPreconditionsInOrder (Refs #3517 Cluster 2)', () {
+    test('returns null when every check passes', () {
+      final reason = checkPreconditionsInOrder([
+        (failReason: 'a', check: () => true),
+        (failReason: 'b', check: () => true),
+        (failReason: 'c', check: () => true),
+      ]);
+      expect(reason, isNull);
+    });
+
+    test('returns the first failing reason in list order', () {
+      final reason = checkPreconditionsInOrder([
+        (failReason: 'tech', check: () => true),
+        (failReason: 'workers', check: () => false),
+        (failReason: 'treasury', check: () => false),
+      ]);
+      expect(reason, 'workers');
+    });
+
+    test('honours canonical priority: earlier failure wins over later', () {
+      final reason = checkPreconditionsInOrder([
+        (failReason: 'tech', check: () => false),
+        (failReason: 'materials', check: () => false),
+      ]);
+      expect(reason, 'tech');
+    });
+
+    test('short-circuits: no later check runs once one fails', () {
+      final evaluated = <String>[];
+      final reason = checkPreconditionsInOrder([
+        (
+          failReason: 'first',
+          check: () {
+            evaluated.add('first');
+            return true;
+          },
+        ),
+        (
+          failReason: 'second',
+          check: () {
+            evaluated.add('second');
+            return false;
+          },
+        ),
+        (
+          failReason: 'third',
+          check: () {
+            evaluated.add('third');
+            return true;
+          },
+        ),
+      ]);
+      expect(reason, 'second');
+      expect(evaluated, ['first', 'second']);
+    });
+
+    test('empty precondition list passes (returns null)', () {
+      expect(checkPreconditionsInOrder(const []), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Internal, behavior-preserving refactor of `packages/colonizethis_economy` per #3517. No extraction / consumption / world-market semantics or SPEC behavior change; no `app/` changes; no new hot-path logging.

## Done in this push (Clusters 1–3)

- **Cluster 1 (dedup):** Extracted a shared `computeTileYieldContribution` in `tile_extraction_pipeline.dart` hosting the per-tile extraction orchestration. The Great-Power (`computeTileExtractionContributionForPlayer`, `resource_extractor.dart`) and non-Great-Power (`_computeNonGpTileContribution`, `non_gp_extraction_shared.dart`) call sites are now thin wrappers that supply the three diverging knobs — tech-cap source, mineral gate predicate, and capital-region classification — keeping the GP/non-GP yield math provably in lockstep. The GP wrapper public signature is unchanged.
- **Cluster 2 (abstraction):** Added a shared `checkPreconditionsInOrder` helper (`cost_check.dart`) that evaluates a `List<CostPrecondition>` in order and returns the first failing reason (or `null`). `canAffordRecruitWorker` (`worker_action_cost.dart`) and `_resolveBuildPlanForCatalog` (`build_cost.dart`) migrate to it, preserving the canonical **tech → workers → treasury → materials** order and the existing failure-reason vocabulary. Short-circuit semantics are preserved.
- **Cluster 3 (perf):** `DealMatcher.matchDeals` now pre-builds a per-commodity index once (`_indexStatesByCommodity`) so the matching loop is an O(1) map lookup instead of an O(total-states) re-scan per commodity. Ordering (faction-alphabetical, then faction-local index) is byte-identical to the prior `_orderedStatesForCommodity` output; the grouped lists reference the same mutable `_OrderState` objects so carry-forward is unaffected. Avoids the duplicate global scan flagged by `colonizethis-turn-resolution-budget.mdc`.

## Deferred (follow-up)

- **Cluster 4 (cross-package `ExtractionTotals` hoist):** the `forecastOverseasShippedTonnageForPlayer` overload + hoisting `ExtractionTotals` once above the repeated `runTreasuryPlanner` invocations and threading it through `colonizethis_ai`/`ai_api.dart`. Deferred as a separate, riskier cross-package slice to keep this PR focused and low-risk. Not implemented here.
- **Cluster 2 CI enforcement:** the proposed `custom_lint`/manifest rule asserting cost-check functions use the shared helper is not added in this push; the helper carries a doc comment naming the canonical order + reason contract.

## ACs covered now

- Cluster 1/2/3 target-state items in #3517 § Expected behavior (1–3). Cluster 4 (item 4) and the Cluster 2 CI rule remain follow-up.

## Tests

- New `packages/colonizethis_economy/test/cost_check_test.dart` covering check-order determinism, first-failure selection, short-circuit (no later check runs), and empty-list pass.
- Existing economy suite unchanged and green: `dart test` in `packages/colonizethis_economy` → **all 430 tests pass**.
- `dart analyze lib test` clean for all touched files; `colonizethis_logic` `dart analyze lib` → no issues.

Refs #3517

Made with [Cursor](https://cursor.com)