### PR TITLE
feat: unit-panel bottom-sheet host chrome (UnitsPanelSheetSurface) (#3514)

### DIFF
--- a/SPEC/ui/components/README.md
+++ b/SPEC/ui/components/README.md
@@ -18,4 +18,5 @@ Create `<kebab-name>.md` before duplicating composite layout in multiple screen 
 | `ProductionAllocationRow` | [`production-allocation-row.md`](production-allocation-row.md) | `GAME20001` (production panel). |
 | `TrainDialogChrome` | [`train-dialog-chrome.md`](train-dialog-chrome.md) | `UNIT40001` (train civilians dialog), `UNIT50001` (train military dialog). |
 | `UnitsEntityActionRow` | [`units-entity-action-row.md`](units-entity-action-row.md) | `UNIT10001` (civilian units panel), `UNIT20001` (military units panel), `UNIT30001` (naval units panel). |
+| `UnitsPanelSheetSurface` | [`units-panel-sheet-surface.md`](units-panel-sheet-surface.md) | `UNIT10001` (civilian units panel), `UNIT20001` (military units panel), `UNIT30001` (naval units panel). |
 | `UnitsPanelShell` | [`units-panel-shell.md`](units-panel-shell.md) | `UNIT10001` (civilian units panel), `UNIT20001` (military units panel), `UNIT30001` (naval units panel). |

--- a/SPEC/ui/components/units-panel-sheet-surface.md
+++ b/SPEC/ui/components/units-panel-sheet-surface.md
@@ -1,0 +1,103 @@
+# UnitsPanelSheetSurface (component)
+
+**SPEC/ui/components** — Bottom-sheet host chrome shared by the three unit panels (Civilian, Military, Naval). Implementation: [`app/lib/features/game/widgets/units/shared/units_panel_sheet_surface.dart`](../../../app/lib/features/game/widgets/units/shared/units_panel_sheet_surface.dart). Catalog atoms: [`pixel-art-ui-catalog.md`](../pixel-art-ui-catalog.md) § *Editorial-monocle palette*, § *Radius tokens*.
+
+This composite is **not** a screen and has **no** stable screen ID. It is the modal-bottom-sheet frame chrome for the three unit-panel screen specs listed under [Consumers](#consumers).
+
+---
+
+## Purpose
+
+The three unit panels (`UNIT10001`, `UNIT20001`, `UNIT30001`) mount inside a `showModalBottomSheet` host in [`app_event_handler.dart`](../../../app/lib/core/services/app_event_handler.dart). Without bespoke chrome the sheet renders with the bare Material surface, which diverges from the per-panel HTML mockups. `UnitsPanelSheetSurface` paints the mockup `.sheet` frame so the modal host matches the mockups while the inner [`UnitsPanelShell`](units-panel-shell.md) keeps owning the panel body. Tracking issue: [#3514](https://github.com/waigore/colonizethisv3/issues/3514) (owner decision #4).
+
+The mockup `.sheet` rule reproduced is:
+
+```css
+.sheet {
+  background: linear-gradient(180deg, var(--surface) 0%, var(--bg-deep) 100%);
+  border-top: 2px solid var(--accent-dim);
+  border-radius: 4px 4px 0 0;
+}
+```
+
+---
+
+## Widget contract
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `child` | `Widget` | required | Panel content rendered inside the decorated sheet (typically a `UnitsPanelShell`-based panel, optionally wrapped in a height `ConstrainedBox` by the host). |
+
+Exposed constants:
+
+- `UnitsPanelSheetSurface.topEdgeWidth = 2.0` — width of the `--accent-dim` top edge.
+- `UnitsPanelSheetSurface.topCornerRadius = CtRadius.medium` (`4` dp) — top corner radius.
+
+The surface contributes only the outer frame; it does **not** constrain the panel's own sizing. Mockup `max-width` / `max-height` sizing parity (Civilian `680` / Military `720` / Naval sidebar `340`) is tracked as follow-up work on #3514.
+
+---
+
+## Layout / wireframe
+
+```text
+DecoratedBox(
+  decoration: BoxDecoration(
+    gradient: LinearGradient(topCenter -> bottomCenter,
+      [EditorialMonoclePalette.surface, EditorialMonoclePalette.bgDeep]),
+    border: Border(top: BorderSide(EditorialMonoclePalette.accentDim, 2.0)),
+    borderRadius: BorderRadius.vertical(top: Radius.circular(4)),
+  ),
+  child: child,            -- panel content (UnitsPanelShell-based)
+)
+```
+
+The host passes `showModalBottomSheet(backgroundColor: Colors.transparent, elevation: 0, ...)` so the Material sheet contributes no competing surface behind this frame.
+
+---
+
+## Behavior
+
+1. **Gradient background.** Vertical `surface → bgDeep` gradient mirrors `.sheet { background: linear-gradient(180deg, var(--surface) 0%, var(--bg-deep) 100%) }`.
+2. **Top edge.** A 2 dp `--accent-dim` top `BorderSide` mirrors `.sheet { border-top: 2px solid var(--accent-dim) }`.
+3. **Top corner radius.** A 4 dp top-left/top-right radius (bottom radii `0`) mirrors `.sheet { border-radius: 4px 4px 0 0 }`.
+4. **No internal state.** The composite is a `StatelessWidget`; it adds no padding, height cap, or sizing of its own.
+
+---
+
+## States and variants
+
+The composite has no internal state and no variants. The same frame is painted for all three consumers and for all panel content states (populated, empty, observe read-only).
+
+---
+
+## Consumers
+
+| Screen ID | Spec | Notes |
+|-----------|------|-------|
+| `UNIT10001` | [`civilian-units-panel.md`](../civilian-units-panel.md) | Bottom-sheet host (`isScrollControlled: true`). |
+| `UNIT20001` | [`military-units-panel.md`](../military-units-panel.md) | Bottom-sheet host. |
+| `UNIT30001` | [`naval-units-panel.md`](../naval-units-panel.md) | Bottom-sheet host. |
+
+---
+
+## Acceptance criteria (Given–When–Then)
+
+- **Given** a `UnitsPanelSheetSurface` mounted with any `child`, **When** the tree settles, **Then** exactly one `DecoratedBox` wraps the child whose `BoxDecoration.border.top` is a `BorderSide` of `EditorialMonoclePalette.accentDim` with `width == 2.0`.
+- **Given** a `UnitsPanelSheetSurface` mounted with any `child`, **When** the tree settles, **Then** the wrapping `DecoratedBox` has a `BoxDecoration.borderRadius` whose `topLeft` and `topRight` radii equal `4.0` and whose `bottomLeft` and `bottomRight` radii equal `0.0`.
+- **Given** a `UnitsPanelSheetSurface` mounted with any `child`, **When** the tree settles, **Then** the wrapping `BoxDecoration.gradient` is a `LinearGradient` whose `colors` are `[EditorialMonoclePalette.surface, EditorialMonoclePalette.bgDeep]`.
+- **Given** a `UnitsPanelSheetSurface` mounted with a keyed `child`, **When** the tree settles, **Then** the child remains reachable in the subtree (the surface is a pure wrapper that does not replace its content).
+
+---
+
+## Tests
+
+- `app/test/units_panel_sheet_surface_test.dart` — widget tests pinning the gradient, 2 dp `accent-dim` top edge, and 4 dp top corner radius, and the pass-through of the child.
+
+---
+
+## Related
+
+- Inner body chrome: [`units-panel-shell.md`](units-panel-shell.md).
+- Catalog: [`pixel-art-ui-catalog.md`](../pixel-art-ui-catalog.md) § *Editorial-monocle palette*, § *Radius tokens*.
+- Host: [`app_event_handler.dart`](../../../app/lib/core/services/app_event_handler.dart) `_openCivilianUnitsPanel` / `_openMilitaryUnitsPanel` / `_openNavalUnitsPanel`.
+- Tracking issue: [#3514](https://github.com/waigore/colonizethisv3/issues/3514) (owner decision #4).

--- a/SPEC/ui/components/units-panel-shell.md
+++ b/SPEC/ui/components/units-panel-shell.md
@@ -8,7 +8,7 @@ This composite is **not** a screen and has **no** stable screen ID. It is the ca
 
 ## Purpose
 
-Consolidates the constrained-panel + `CtPanel` + `CtTopBar` + scrollable-list / empty-state chrome shared by the Civilian, Military, and Naval unit panels so each panel composes only its row content. Callers supply a title, optional trailing actions, the `hasContent` predicate, list children for the populated branch, and the `emptyMessage` for the empty branch; the composite owns the `ConstrainedBox`, outer `Padding`, `CtPanel`, `CtTopBar` (no back button), `ListView`, and the muted-italic empty-state copy. Tracking issue: [#2914](https://github.com/waigore/colonizethisv3/issues/2914) S9.
+Consolidates the constrained-panel + `CtPanel` + `CtTopBar` + scrollable-list / empty-state chrome shared by the Civilian, Military, and Naval unit panels so each panel composes only its row content. Callers supply a title, trailing actions, `hasContent`, list children, and `emptyMessage`; the composite owns the `ConstrainedBox`, `Padding`, `CtPanel`, `CtTopBar` (no back button), `ListView`, and muted-italic empty copy. The outer modal bottom-sheet frame is the sibling [`UnitsPanelSheetSurface`](units-panel-sheet-surface.md). Tracking issue: [#2914](https://github.com/waigore/colonizethisv3/issues/2914) S9.
 
 ---
 
@@ -107,6 +107,7 @@ Each consumer spec links back here for the chrome contract instead of redeclarin
 
 ## Related
 
+- Bottom-sheet host frame: [`units-panel-sheet-surface.md`](units-panel-sheet-surface.md).
 - Catalog: [`pixel-art-ui-catalog.md`](../pixel-art-ui-catalog.md) § *CtPanel*, § *CtTopBar*, § *Editorial-monocle palette*.
 - Shared skeleton: [`ct-panel-with-top-bar.md`](ct-panel-with-top-bar.md).
 - Hosting surfaces: [`empire-overview.md`](../empire-overview.md), [`in-game-shell-narrow.md`](../in-game-shell-narrow.md), [`mobile-adaptation.md`](../mobile-adaptation.md) § 7.

--- a/app/lib/core/services/app_event_handler.dart
+++ b/app/lib/core/services/app_event_handler.dart
@@ -42,6 +42,7 @@ import '../../features/game/widgets/civilian_units_panel.dart';
 import '../../features/game/widgets/military_units_panel.dart';
 import '../../features/game/widgets/naval_units_panel.dart';
 import '../../features/game/widgets/pause_menu_panel.dart';
+import '../../features/game/widgets/units/shared/units_panel_sheet_surface.dart';
 import '../../providers/app_event_bus_provider.dart';
 import '../../providers/game_service_provider.dart';
 import '../../providers/games_provider.dart';
@@ -290,6 +291,12 @@ class AppEventHandler {
     await showModalBottomSheet<void>(
       context: nav.context,
       isScrollControlled: true,
+      // Transparent Material surface so UnitsPanelSheetSurface owns the
+      // mockup `.sheet` chrome (gradient + 2 px accent-dim top edge + 4 dp
+      // top radius). SPEC/ui/components/units-panel-shell.md § Bottom-sheet
+      // host chrome (#3514 owner decision #4).
+      backgroundColor: Colors.transparent,
+      elevation: 0,
       builder: (ctx) => Consumer(
         builder: (context, ref, _) {
           final game = ref.watch(currentGameProvider);
@@ -309,7 +316,8 @@ class AppEventHandler {
           final maxHeight = kCtE2EEnabled
               ? MediaQuery.sizeOf(context).height * 0.92
               : MediaQuery.sizeOf(context).height * (isNarrow ? 0.33 : 0.5);
-          return ConstrainedBox(
+          return UnitsPanelSheetSurface(
+            child: ConstrainedBox(
             constraints: BoxConstraints(maxHeight: maxHeight),
             child: CivilianUnitsPanel(
               game: game,
@@ -332,6 +340,7 @@ class AppEventHandler {
               buildImprovementShortcutTargetTileKey:
                   event.buildImprovementShortcutTargetTileKey,
             ),
+            ),
           );
         },
       ),
@@ -350,6 +359,10 @@ class AppEventHandler {
     if (nav == null) return;
     await showModalBottomSheet<void>(
       context: nav.context,
+      // Transparent Material surface so UnitsPanelSheetSurface owns the
+      // mockup `.sheet` chrome (#3514 owner decision #4).
+      backgroundColor: Colors.transparent,
+      elevation: 0,
       builder: (ctx) => Consumer(
         builder: (context, ref, _) {
           final game = ref.watch(currentGameProvider);
@@ -365,13 +378,15 @@ class AppEventHandler {
           final bus = ref.watch(appEventBusProvider);
           final mapData = ref.watch(gameServiceProvider).getMapData(game.id);
           final draftOrders = ref.watch(currentOrdersProvider);
-          return MilitaryUnitsPanel(
-            game: game,
-            humanPlayerId: humanPlayerId,
-            bus: bus,
-            readOnly: readOnly,
-            topology: mapData?.combinedTopology ?? const MapTopology(),
-            draftOrders: draftOrders,
+          return UnitsPanelSheetSurface(
+            child: MilitaryUnitsPanel(
+              game: game,
+              humanPlayerId: humanPlayerId,
+              bus: bus,
+              readOnly: readOnly,
+              topology: mapData?.combinedTopology ?? const MapTopology(),
+              draftOrders: draftOrders,
+            ),
           );
         },
       ),
@@ -385,6 +400,10 @@ class AppEventHandler {
     if (nav == null) return;
     await showModalBottomSheet<void>(
       context: nav.context,
+      // Transparent Material surface so UnitsPanelSheetSurface owns the
+      // mockup `.sheet` chrome (#3514 owner decision #4).
+      backgroundColor: Colors.transparent,
+      elevation: 0,
       builder: (ctx) => Consumer(
         builder: (context, ref, _) {
           final game = ref.watch(currentGameProvider);
@@ -400,18 +419,20 @@ class AppEventHandler {
           final bus = ref.watch(appEventBusProvider);
           final mapData = ref.watch(gameServiceProvider).getMapData(game.id);
           final draftOrders = ref.watch(currentOrdersProvider);
-          return NavalUnitsPanel(
-            game: game,
-            humanPlayerId: humanPlayerId,
-            bus: bus,
-            readOnly: readOnly,
-            topology: mapData?.combinedTopology ?? const MapTopology(),
-            draftOrders: draftOrders,
-            tileMapByRegion: mapData?.tileMapByRegion,
-            topologyByRegion: mapData?.topologyByRegion,
-            locationScopeKey: event.locationScopeKey,
-            initialSelectedFleetId: event.initialSelectedFleetId,
-            tileScopeTileKey: event.tileScopeTileKey,
+          return UnitsPanelSheetSurface(
+            child: NavalUnitsPanel(
+              game: game,
+              humanPlayerId: humanPlayerId,
+              bus: bus,
+              readOnly: readOnly,
+              topology: mapData?.combinedTopology ?? const MapTopology(),
+              draftOrders: draftOrders,
+              tileMapByRegion: mapData?.tileMapByRegion,
+              topologyByRegion: mapData?.topologyByRegion,
+              locationScopeKey: event.locationScopeKey,
+              initialSelectedFleetId: event.initialSelectedFleetId,
+              tileScopeTileKey: event.tileScopeTileKey,
+            ),
           );
         },
       ),

--- a/app/lib/features/game/widgets/units/shared/units_panel_sheet_surface.dart
+++ b/app/lib/features/game/widgets/units/shared/units_panel_sheet_surface.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+
+import '../../../../../config/editorial_monocle_palette.dart';
+import '../../../../../widgets/ct_radius.dart';
+
+/// Bottom-sheet host chrome shared by the three unit panels (Civilian
+/// `UNIT10001`, Military `UNIT20001`, Naval `UNIT30001`).
+///
+/// Paints the mockup `.sheet` treatment so the modal bottom-sheet host that
+/// mounts each panel matches the HTML mockups instead of the bare Material
+/// sheet surface (`SPEC/ui/components/units-panel-shell.md` § Bottom-sheet
+/// host chrome, owner decision #4 in issue #3514):
+///
+/// - a `surface → bg-deep` vertical gradient background
+///   (`.sheet { background: linear-gradient(180deg, var(--surface) 0%,
+///   var(--bg-deep) 100%) }`),
+/// - a 2 px `--accent-dim` top edge (`.sheet { border-top: 2px solid
+///   var(--accent-dim) }`), and
+/// - a 4 px top corner radius (`.sheet { border-radius: 4px 4px 0 0 }`).
+///
+/// Hosts pass `showModalBottomSheet(backgroundColor: Colors.transparent,
+/// elevation: 0, ...)` so this surface owns the visible sheet frame. The
+/// panel content (`UnitsPanelShell`) is rendered as the [child]; this widget
+/// only contributes the outer sheet chrome and does not constrain the
+/// panel's own sizing.
+class UnitsPanelSheetSurface extends StatelessWidget {
+  const UnitsPanelSheetSurface({super.key, required this.child});
+
+  /// The panel content mounted inside the decorated sheet (typically a
+  /// `UnitsPanelShell`-based panel, optionally wrapped in a height
+  /// `ConstrainedBox` by the host).
+  final Widget child;
+
+  /// Width of the 2 px `--accent-dim` top edge. Mirrors the mockup
+  /// `.sheet { border-top: 2px solid var(--accent-dim) }` rule.
+  static const double topEdgeWidth = 2.0;
+
+  /// Top corner radius (`CtRadius.medium` = 4 dp) mirroring the mockup
+  /// `.sheet { border-radius: 4px 4px 0 0 }` rule.
+  static const double topCornerRadius = CtRadius.medium;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+          colors: <Color>[
+            EditorialMonoclePalette.surface,
+            EditorialMonoclePalette.bgDeep,
+          ],
+        ),
+        border: Border(
+          top: BorderSide(
+            color: EditorialMonoclePalette.accentDim,
+            width: topEdgeWidth,
+          ),
+        ),
+        borderRadius: const BorderRadius.vertical(
+          top: Radius.circular(topCornerRadius),
+        ),
+      ),
+      child: child,
+    );
+  }
+}

--- a/app/test/spec_components_units_panel_sheet_surface_test.dart
+++ b/app/test/spec_components_units_panel_sheet_surface_test.dart
@@ -1,0 +1,116 @@
+/// Pins the [`SPEC/ui/components/units-panel-sheet-surface.md`](
+/// ../../../SPEC/ui/components/units-panel-sheet-surface.md) component spec
+/// authored for issue #3514 (Align unit panels visual chrome — bottom-sheet
+/// host chrome, owner decision #4).
+///
+/// `UnitsPanelSheetSurface` is the shared modal-bottom-sheet frame consumed
+/// by three player-unit screen specs (stable ids `UNIT10001`, `UNIT20001`,
+/// `UNIT30001`). Per `colonizethis-ui-documentation.mdc` § *Component specs*,
+/// a composite reused by multiple screen specs must have its own
+/// `kebab-name.md` under `SPEC/ui/components/`.
+///
+/// These are deliberately static-text checks (file reads + regex searches);
+/// the runtime Given–When–Then contract is exercised by
+/// `app/test/units_panel_sheet_surface_test.dart`.
+///
+/// Refs #3514.
+library;
+
+import 'dart:io' show File;
+
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter_test/flutter_test.dart';
+
+const String _kSpecPath = '../SPEC/ui/components/units-panel-sheet-surface.md';
+const String _kComponentsReadmePath = '../SPEC/ui/components/README.md';
+
+String _readSpec() => File(_kSpecPath).readAsStringSync();
+
+void main() {
+  suppressLogsForTests();
+
+  group('SPEC/ui/components/units-panel-sheet-surface.md (#3514)', () {
+    test('spec file exists and is non-empty', () {
+      final file = File(_kSpecPath);
+      expect(
+        file.existsSync(),
+        isTrue,
+        reason:
+            'The composite-component spec for UnitsPanelSheetSurface must '
+            'live at SPEC/ui/components/units-panel-sheet-surface.md per '
+            'colonizethis-ui-documentation.mdc § Component specs.',
+      );
+      expect(file.readAsStringSync().trim(), isNotEmpty);
+    });
+
+    test('spec declares the canonical component-spec sections', () {
+      final body = _readSpec();
+      for (final heading in <String>[
+        '## Purpose',
+        '## Widget contract',
+        '## Layout / wireframe',
+        '## Behavior',
+        '## Consumers',
+        '## Acceptance criteria (Given–When–Then)',
+        '## Tests',
+        '## Related',
+      ]) {
+        expect(
+          body,
+          contains(heading),
+          reason: 'spec must declare the canonical "$heading" section.',
+        );
+      }
+    });
+
+    test('spec lists all three unit-panel consumers by stable screen ID', () {
+      final body = _readSpec();
+      for (final consumerId in <String>['UNIT10001', 'UNIT20001', 'UNIT30001']) {
+        expect(
+          body,
+          contains(consumerId),
+          reason: 'spec must enumerate consumer screen ID $consumerId.',
+        );
+      }
+    });
+
+    test('spec encodes the canonical sheet-chrome tokens and constants', () {
+      final body = _readSpec();
+      for (final token in <String>[
+        'topEdgeWidth',
+        'topCornerRadius',
+        'accent-dim',
+        'EditorialMonoclePalette.surface',
+        'EditorialMonoclePalette.bgDeep',
+      ]) {
+        expect(
+          body,
+          contains(token),
+          reason:
+              'spec must restate the canonical sheet-chrome marker "$token" '
+              'so the host-chrome contract is documented at the SPEC level.',
+        );
+      }
+    });
+
+    test('spec is at most 1000 words (colonizethis-spec-required.mdc)', () {
+      final words = _readSpec()
+          .split(RegExp(r'\s+'))
+          .where((token) => token.isNotEmpty)
+          .toList();
+      expect(
+        words.length <= 1000,
+        isTrue,
+        reason:
+            'SPEC documents must stay under the 1000-word ceiling. Current '
+            'word count is ${words.length}.',
+      );
+    });
+
+    test('components README index lists the UnitsPanelSheetSurface row', () {
+      final body = File(_kComponentsReadmePath).readAsStringSync();
+      expect(body, contains('UnitsPanelSheetSurface'));
+      expect(body, contains('units-panel-sheet-surface.md'));
+    });
+  });
+}

--- a/app/test/units_panel_sheet_surface_test.dart
+++ b/app/test/units_panel_sheet_surface_test.dart
@@ -1,0 +1,125 @@
+// Widget tests for the shared bottom-sheet host chrome used by the three
+// unit panels (Civilian UNIT10001, Military UNIT20001, Naval UNIT30001).
+//
+// Pins the mockup `.sheet` treatment painted by [UnitsPanelSheetSurface]:
+// a `surface -> bgDeep` gradient background, a 2 dp `--accent-dim` top
+// edge, and a 4 dp top corner radius (bottom radii 0). These mirror the
+// per-panel HTML mockup rule
+// `.sheet { background: linear-gradient(180deg, var(--surface) 0%,
+//   var(--bg-deep) 100%); border-top: 2px solid var(--accent-dim);
+//   border-radius: 4px 4px 0 0 }`.
+//
+// SPEC: SPEC/ui/components/units-panel-sheet-surface.md.
+// Refs #3514 (owner decision #4).
+
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:colonizethis_app/config/editorial_monocle_palette.dart';
+import 'package:colonizethis_app/features/game/widgets/units/shared/units_panel_sheet_surface.dart';
+
+/// Resolves the [BoxDecoration] painted by the [UnitsPanelSheetSurface]
+/// `DecoratedBox` that directly wraps the surface child.
+BoxDecoration _surfaceDecoration(WidgetTester tester) {
+  final Finder decorated = find.descendant(
+    of: find.byType(UnitsPanelSheetSurface),
+    matching: find.byType(DecoratedBox),
+  );
+  expect(
+    decorated,
+    findsOneWidget,
+    reason:
+        'UnitsPanelSheetSurface must paint exactly one DecoratedBox frame '
+        'so the bottom-sheet host chrome is unambiguous.',
+  );
+  final DecoratedBox box = tester.widget<DecoratedBox>(decorated);
+  expect(box.decoration, isA<BoxDecoration>());
+  return box.decoration as BoxDecoration;
+}
+
+Future<void> _pumpSurface(WidgetTester tester, {Key? childKey}) {
+  return tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: UnitsPanelSheetSurface(
+          child: SizedBox(
+            key: childKey,
+            width: 100,
+            height: 100,
+            child: const Text('panel body'),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  suppressLogsForTests();
+
+  group('UnitsPanelSheetSurface (#3514 bottom-sheet host chrome)', () {
+    testWidgets(
+      'paints a 2 dp accent-dim top edge (BorderSide width == topEdgeWidth)',
+      (WidgetTester tester) async {
+        await _pumpSurface(tester);
+
+        final BoxDecoration decoration = _surfaceDecoration(tester);
+        final Border? border = decoration.border as Border?;
+        expect(border, isNotNull);
+        expect(border!.top.width, UnitsPanelSheetSurface.topEdgeWidth);
+        expect(border.top.width, 2.0);
+        expect(border.top.color, EditorialMonoclePalette.accentDim);
+        // Only the top edge is painted (matching `border-top: 2px ...`).
+        expect(border.bottom, BorderSide.none);
+        expect(border.left, BorderSide.none);
+        expect(border.right, BorderSide.none);
+      },
+    );
+
+    testWidgets(
+      'rounds only the top corners by 4 dp (border-radius: 4px 4px 0 0)',
+      (WidgetTester tester) async {
+        await _pumpSurface(tester);
+
+        final BoxDecoration decoration = _surfaceDecoration(tester);
+        final BorderRadius radius = decoration.borderRadius! as BorderRadius;
+        expect(
+          radius.topLeft.x,
+          UnitsPanelSheetSurface.topCornerRadius,
+        );
+        expect(radius.topLeft.x, 4.0);
+        expect(radius.topRight.x, 4.0);
+        expect(radius.bottomLeft.x, 0.0);
+        expect(radius.bottomRight.x, 0.0);
+      },
+    );
+
+    testWidgets(
+      'fills with the surface -> bgDeep vertical gradient',
+      (WidgetTester tester) async {
+        await _pumpSurface(tester);
+
+        final BoxDecoration decoration = _surfaceDecoration(tester);
+        final LinearGradient gradient = decoration.gradient! as LinearGradient;
+        expect(gradient.colors, <Color>[
+          EditorialMonoclePalette.surface,
+          EditorialMonoclePalette.bgDeep,
+        ]);
+        expect(gradient.begin, Alignment.topCenter);
+        expect(gradient.end, Alignment.bottomCenter);
+      },
+    );
+
+    testWidgets(
+      'is a pure wrapper that keeps the child reachable',
+      (WidgetTester tester) async {
+        const Key childKey = Key('sheet-child');
+        await _pumpSurface(tester, childKey: childKey);
+
+        expect(find.byKey(childKey), findsOneWidget);
+        expect(find.text('panel body'), findsOneWidget);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Implements the **bottom-sheet host chrome** slice of #3514 (owner decision #4) for the three in-game unit panels — Civilian (`UNIT10001`), Military (`UNIT20001`), Naval (`UNIT30001`).

The panels mount via `showModalBottomSheet` in `app_event_handler.dart`, which previously rendered the bare Material sheet surface — diverging from the per-panel HTML mockups' `.sheet` treatment. This PR adds the shared mockup sheet frame.

## Done in this push

- **New shared widget** `UnitsPanelSheetSurface` (`app/lib/features/game/widgets/units/shared/units_panel_sheet_surface.dart`) painting the mockup `.sheet` rule:
  - `surface → bgDeep` vertical gradient background,
  - **2 dp `--accent-dim` top edge** (`border-top: 2px solid var(--accent-dim)`),
  - **4 dp top corner radius** (`border-radius: 4px 4px 0 0`, `CtRadius.medium`).
- **Hosts wired** (`app_event_handler.dart` `_openCivilianUnitsPanel` / `_openMilitaryUnitsPanel` / `_openNavalUnitsPanel`): each wraps its panel in `UnitsPanelSheetSurface` and passes `backgroundColor: Colors.transparent` + `elevation: 0` so the surface owns the visible sheet frame.
- **SPEC:** new `SPEC/ui/components/units-panel-sheet-surface.md` (full component spec + Given–When–Then ACs), `SPEC/ui/components/README.md` index row, and a cross-reference from `units-panel-shell.md` (kept at the ≤1000-word limit).

## ACs covered now

- Sheet chrome portion of the issue's first AC and owner decision #4: the unit-panel bottom-sheet hosts paint a 2 dp `accent-dim` top edge and top corner radius (now spec-pinned and widget-tested).

## Deferred (follow-up on #3514, same issue)

- Mockup `max-width` / `max-height` **sizing** parity (Civilian `680`/`55vh`, Military `720`, Naval sidebar `340`) — the surface intentionally does not constrain inner panel sizing in this slice.
- Region/location header restyling, per-line typography tokens, civilian mockup `Status:` line, and widget goldens (the row-action compact pills, circular locate, and header primary pills already landed via #3520/#3523/#3524/#3525).

## Tests

- `app/test/units_panel_sheet_surface_test.dart` — pins the gradient colors/direction, the 2 dp `accent-dim` top `BorderSide` (and that only the top edge is painted), the `4/4/0/0` corner radii, and child pass-through.
- `app/test/spec_components_units_panel_sheet_surface_test.dart` — spec-pin (sections, three consumer IDs, chrome tokens, ≤1000 words, README row).
- Re-ran impacted suites green: `units_panel_shared_widgets_test`, `unit_panels_320dp_min_viewport_test`, `spec_components_units_panel_shell_test` (39 tests pass).
- `flutter analyze` clean on touched files (two pre-existing `dead_code`/`dead_null_aware` warnings in the civilian builder are unchanged from `dev` and out of scope).

Refs #3514

Made with [Cursor](https://cursor.com)