### PR TITLE
feat: mockup left-bar region headers + semi-bold location labels on unit panels (#3514)

### DIFF
--- a/SPEC/ui/military-units-panel.md
+++ b/SPEC/ui/military-units-panel.md
@@ -88,6 +88,19 @@ Side panel or bottom sheet (viewport-dependent); **Land** and **Naval** branches
 ## Components
 
 - `MilitaryUnitsPanel`, [move-army-dialog.md](move-army-dialog.md), naval subsection widgets.
+- `RegionSectionHeader` (`app/lib/features/game/widgets/units/shared/region_section_header.dart`) — rendered with the `RegionHeaderVariant.leftBar` chrome on this panel (Refs #3514); see § Region / location header chrome.
+- `LocationSectionHeader` (`app/lib/features/game/widgets/units/shared/location_section_header.dart`) — province / sea-zone sub-header; see § Region / location header chrome.
+
+---
+
+## Region / location header chrome (Refs #3514)
+
+The region and location group headers follow the military mockup
+(`SPEC/ui/mockups/UNIT20001-military-units-panel.html`) for **visual chrome**;
+the displayed text content (`name — region` on the location line) is unchanged.
+
+- **Region header (`.region-label`):** Each region grouping heading (`Old World` / `New World`) renders via `RegionSectionHeader` with `variant: RegionHeaderVariant.leftBar` — an upper-cased `EditorialMonoclePalette.muted` Cinzel display label (`editorialMonocleDisplayFontFamily`, `12` logical px, `FontWeight.w600`) preceded by a `3` dp `EditorialMonoclePalette.accentDim` **left** border (`RegionSectionHeader.leftBarWidth`) with `6 × 3` dp inner padding. The bottom-border `CtSectionLabel` chrome (`RegionHeaderVariant.bottomBorder`) is **not** used on this panel.
+- **Location / province header (`.province-label`):** Each province (or sea-zone) sub-header renders via `LocationSectionHeader` as an indented body-font line in `EditorialMonoclePalette.fg` at `0.8` opacity (`LocationSectionHeader.labelOpacity`), `FontWeight.w600`. The previous muted `titleSmall` styling is replaced; the leading `CtSpacing.ml` indent is retained.
 
 ---
 
@@ -131,6 +144,10 @@ Side panel or bottom sheet (viewport-dependent); **Land** and **Naval** branches
 - Given the user taps **Train**, when the action completes, then the UI layer closes the panel and opens the Train Military dialog via `AppEventBus` per [train-military-dialog.md](train-military-dialog.md).
 
 - Given the Military Units panel is open (issue #3514 owner decisions #5 / #15), when the header **Train** and **Combine** actions render, then the UI layer renders each as a `CtActionTextButton` with `primary == true` (compact primary gradient pill, no `CtNinePatchButton` corner-bracket chrome), and tapping **Train** still emits `OpenDialogEvent(trainMilitaryDialogId)`.
+
+- **Region header left-bar chrome (Refs #3514):** Given the Military Units panel is open with armies grouped into at least one region, when a region group heading renders, then the UI layer renders it via a `RegionSectionHeader` whose `variant` is `RegionHeaderVariant.leftBar` (mockup `.region-label` left-accent-bar chrome), and renders no `CtSectionLabel` bottom-border region heading on this panel.
+
+- **Location header semi-bold fg chrome (Refs #3514):** Given the Military Units panel is open with at least one province (or sea-zone) group, when the location sub-header renders, then the UI layer renders its `LocationSectionHeader` `Text` with `FontWeight.w600` and a colour resolving to `EditorialMonoclePalette.fg` at `0.8` opacity (mockup `.province-label`), while the displayed `name — region` line content is unchanged.
 - Given an army row with Move, Split, and Locate actions (issue #3514 owner decision #6), when the row renders, then the UI layer renders **Move** and **Split** as `CtActionTextButton` pills and renders **Locate** as the rightmost `CtCircularLocateButton` (icon-only circular pill), with no `CtNinePatchButton` row-action chrome.
 - Given an army row whose Locate control is tapped, when the press is handled, then the UI layer emits the same `LocateMapTileEvent` tile key as before the Locate control moved into the actions cluster.
 - Given a collapsed army row (issue #3514 AC-6), when the row renders, then the UI layer wraps the row in a `UnitsEntityCard` that paints a `DecoratedBox` whose decoration uses `UnitsEntityCard.collapsedGradient` (vertical `EditorialMonoclePalette.bgDeep` → `EditorialMonoclePalette.surface`) and a 1 px `EditorialMonoclePalette.border` outline, and the row mounts no bare-Material `ExpansionTile` background fill (its `backgroundColor` and `collapsedBackgroundColor` are `Colors.transparent`).

--- a/SPEC/ui/naval-units-panel.md
+++ b/SPEC/ui/naval-units-panel.md
@@ -116,6 +116,20 @@ Side panel (CtPanel) beside map on wide viewports; scrollable fleet tree grouped
 ## Components
 
 - `NavalUnitsPanel`, [move-fleet-dialog.md](move-fleet-dialog.md), [transfer-to-home-fleet-dialog.md](transfer-to-home-fleet-dialog.md).
+- `RegionSectionHeader` (`app/lib/features/game/widgets/units/shared/region_section_header.dart`) — rendered with the `RegionHeaderVariant.leftBar` chrome on this panel (Refs #3514); see § Region / location header chrome.
+- `LocationSectionHeader` (`app/lib/features/game/widgets/units/shared/location_section_header.dart`) — location (Home Fleet / port / sea-zone) sub-header; see § Region / location header chrome.
+
+---
+
+## Region / location header chrome (Refs #3514)
+
+The region and location group headers follow the naval mockup
+(`SPEC/ui/mockups/UNIT30001-naval-units-panel.html`) for **visual chrome**;
+the displayed header text content (`name — region` on location headers) is
+unchanged.
+
+- **Region header (`.region-heading`):** Each region grouping heading (`Old World` / `New World`) renders via `RegionSectionHeader` with `variant: RegionHeaderVariant.leftBar` — an upper-cased `EditorialMonoclePalette.muted` Cinzel display label (`editorialMonocleDisplayFontFamily`, `12` logical px, `FontWeight.w600`) preceded by a `3` dp `EditorialMonoclePalette.accentDim` **left** border (`RegionSectionHeader.leftBarWidth`) with `6 × 3` dp inner padding. The bottom-border `CtSectionLabel` chrome (`RegionHeaderVariant.bottomBorder`) is **not** used on this panel.
+- **Location header (`.location-label`):** Each location sub-header (Home Fleet / In Port / At Sea / named node) renders via `LocationSectionHeader` as an indented body-font line in `EditorialMonoclePalette.fg` at `0.8` opacity (`LocationSectionHeader.labelOpacity`), `FontWeight.w600`. The previous muted `titleSmall` styling is replaced; the leading `CtSpacing.ml` indent is retained.
 
 ---
 
@@ -290,4 +304,8 @@ The first implementation pass for [#2866](https://github.com/) (PR #2906 + #2919
 - **(R28)** **Given** the Naval Units panel is open and shows a fleet **in port** at a province, **when** the user reads the row subtitle, **then** the location line ends with the literal localised qualifier `(in port)` (e.g. `Old World — London (in port)`), resolved via `AppLocalizations.naval_units_locInPort`; for a fleet **at sea** in a sea zone the location line ends with `(at sea)` (e.g. `New World — Caribbean Sea (at sea)`), resolved via `AppLocalizations.naval_units_locAtSea`. No English string for either qualifier is hard-coded in widgets.
 
 - **(R29)** **Given** the Naval Units panel is open and the user expands any fleet row, **when** the expanded content finishes rendering, **then** the UI layer renders (a) a single `Table` widget with one row per ship type with columns `Type`, `×Count`, `Role` and **not** a per-ship-type stack of `ListTile`s, (b) a single `Total ships: X · Warships: Y · Merchants: Z` summary line below the table (one `Text` widget, **not** three separate `ListTile`s) and a retained `Strength: V` line, and (c) for the Home Fleet only, a `Cargo capacity: X holds` line between the table and the summary line (non-home fleets render no cargo line).
+
+- **Region header left-bar chrome (Refs #3514):** **Given** the Naval Units panel is open with fleets grouped into at least one region, **when** a region group heading renders, **then** the UI layer renders it via a `RegionSectionHeader` whose `variant` is `RegionHeaderVariant.leftBar` (mockup `.region-heading` left-accent-bar chrome), and renders no `CtSectionLabel` bottom-border region heading on this panel.
+
+- **Location header semi-bold fg chrome (Refs #3514):** **Given** the Naval Units panel is open with at least one location (Home Fleet / port / sea-zone) group, **when** the location sub-header renders, **then** the UI layer renders its `LocationSectionHeader` `Text` with `FontWeight.w600` and a colour resolving to `EditorialMonoclePalette.fg` at `0.8` opacity (mockup `.location-label`), while the displayed `name — region` line content is unchanged.
 

--- a/app/lib/features/game/widgets/military_units_panel.dart
+++ b/app/lib/features/game/widgets/military_units_panel.dart
@@ -216,7 +216,10 @@ class _MilitaryUnitsPanelState extends State<MilitaryUnitsPanel> {
   ) {
     return [
       for (final group in groups) ...[
-        RegionSectionHeader(label: regionDisplayLabel(group.regionKey)),
+        RegionSectionHeader(
+          label: regionDisplayLabel(group.regionKey),
+          variant: RegionHeaderVariant.leftBar,
+        ),
         ..._buildProvinceLocationChildren(group, l10n),
         ..._buildSeaLocationChildren(group, l10n),
       ],

--- a/app/lib/features/game/widgets/naval_units_panel.dart
+++ b/app/lib/features/game/widgets/naval_units_panel.dart
@@ -542,7 +542,10 @@ class _NavalUnitsPanelState extends State<NavalUnitsPanel> {
       hasContent: hasAny,
       listChildren: [
         for (final group in tree) ...[
-          RegionSectionHeader(label: regionDisplayLabel(group.regionId)),
+          RegionSectionHeader(
+            label: regionDisplayLabel(group.regionId),
+            variant: RegionHeaderVariant.leftBar,
+          ),
           if (group.homeFleet != null)
             FleetExpansionTile(
               row: group.homeFleet!,

--- a/app/lib/features/game/widgets/units/shared/location_section_header.dart
+++ b/app/lib/features/game/widgets/units/shared/location_section_header.dart
@@ -6,7 +6,11 @@ import '../../../../../widgets/ct_spacing.dart';
 
 /// Sub-header for a province or sea zone within a region in military/naval panels.
 ///
-/// Uses `--muted` for the location line (`Refs #2866` S2/S3).
+/// Matches the military/naval mockup `.province-label` / `.location-label`
+/// chrome (`Refs #3514`): an indented body-font line in semi-bold
+/// [EditorialMonoclePalette.fg] at `0.8` opacity. The displayed line content
+/// (`name — region`) is unchanged (`Refs #2866` S2/S3) — only the visual
+/// chrome is brought into mockup parity.
 class LocationSectionHeader extends StatelessWidget {
   const LocationSectionHeader({
     super.key,
@@ -16,6 +20,10 @@ class LocationSectionHeader extends StatelessWidget {
 
   final String label;
   final String regionLabel;
+
+  /// Foreground opacity for the location line (mockup `.province-label`
+  /// `opacity:.8`).
+  static const double labelOpacity = 0.8;
 
   @override
   Widget build(BuildContext context) {
@@ -27,9 +35,9 @@ class LocationSectionHeader extends StatelessWidget {
       ),
       child: Text(
         appL10n(context).locationSection_headerLine(label, regionLabel),
-        style: Theme.of(context).textTheme.titleSmall?.copyWith(
-          color: EditorialMonoclePalette.muted,
-          fontWeight: FontWeight.w500,
+        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+          color: EditorialMonoclePalette.fg.withValues(alpha: labelOpacity),
+          fontWeight: FontWeight.w600,
         ),
       ),
     );

--- a/app/lib/features/game/widgets/units/shared/region_section_header.dart
+++ b/app/lib/features/game/widgets/units/shared/region_section_header.dart
@@ -1,21 +1,83 @@
 import 'package:flutter/material.dart';
 
+import '../../../../../config/editorial_monocle_palette.dart';
+import '../../../../../config/themes.dart';
 import '../../../../../widgets/ct_section_label.dart';
 import '../../../../../widgets/ct_spacing.dart';
 
+/// Visual chrome variants for [RegionSectionHeader].
+///
+/// The civilian units panel (`UNIT10001`) keeps the catalog [CtSectionLabel]
+/// bottom-border treatment ([RegionHeaderVariant.bottomBorder]); the military
+/// (`UNIT20001`) and naval (`UNIT30001`) panels use the mockup left-accent-bar
+/// treatment ([RegionHeaderVariant.leftBar]) per their HTML mockups
+/// (`.region-label` / `.region-heading`, `border-left:3px var(--accent-dim)`).
+enum RegionHeaderVariant { bottomBorder, leftBar }
+
 /// Section title for a world region (Old World / New World) in units panels.
 ///
-/// Implements `Refs #2866` S1–S3 region grouping via [CtSectionLabel] (#2859).
+/// Implements `Refs #2866` S1–S3 region grouping. The default
+/// [RegionHeaderVariant.bottomBorder] renders via [CtSectionLabel] (#2859). The
+/// [RegionHeaderVariant.leftBar] variant matches the military/naval mockup
+/// `.region-label` / `.region-heading` chrome — an upper-cased muted Cinzel
+/// display label with a 3 dp [EditorialMonoclePalette.accentDim] left bar and
+/// `6 × 3` dp inner padding (Refs #3514).
 class RegionSectionHeader extends StatelessWidget {
-  const RegionSectionHeader({super.key, required this.label});
+  const RegionSectionHeader({
+    super.key,
+    required this.label,
+    this.variant = RegionHeaderVariant.bottomBorder,
+  });
 
   final String label;
 
+  /// Visual chrome treatment; see [RegionHeaderVariant].
+  final RegionHeaderVariant variant;
+
+  /// Left bar thickness for [RegionHeaderVariant.leftBar] (mockup `3px`).
+  static const double leftBarWidth = 3;
+
   @override
   Widget build(BuildContext context) {
+    if (variant == RegionHeaderVariant.leftBar) {
+      return _buildLeftBar(context);
+    }
     return Padding(
       padding: const EdgeInsets.only(top: CtSpacing.m, bottom: 4),
       child: CtSectionLabel(label),
+    );
+  }
+
+  Widget _buildLeftBar(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final TextStyle baseStyle =
+        theme.textTheme.labelSmall ?? const TextStyle(fontSize: 11);
+    final TextStyle effectiveStyle = baseStyle.copyWith(
+      color: EditorialMonoclePalette.muted,
+      fontFamily: editorialMonocleDisplayFontFamily,
+      fontSize: 12,
+      fontWeight: FontWeight.w600,
+      letterSpacing: 0.72,
+    );
+    return Padding(
+      padding: const EdgeInsets.only(top: CtSpacing.m, bottom: 4),
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          border: Border(
+            left: BorderSide(
+              color: EditorialMonoclePalette.accentDim,
+              width: leftBarWidth,
+            ),
+          ),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: CtSpacing.s,
+            vertical: 3,
+          ),
+          child: Text(label.toUpperCase(), style: effectiveStyle),
+        ),
+      ),
     );
   }
 }

--- a/app/test/units_panel_shared_widgets_test.dart
+++ b/app/test/units_panel_shared_widgets_test.dart
@@ -43,6 +43,40 @@ void main() {
       expect(find.byType(CtSectionLabel), findsOneWidget);
       expect(find.text('OLD WORLD'), findsOneWidget);
     });
+
+    testWidgets(
+      'leftBar variant renders a left accent-dim bar without CtSectionLabel '
+      '(Refs #3514)',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: Scaffold(
+              body: RegionSectionHeader(
+                label: 'New World',
+                variant: RegionHeaderVariant.leftBar,
+              ),
+            ),
+          ),
+        );
+
+        // Mockup `.region-label` / `.region-heading` chrome: upper-cased label,
+        // no bottom-border CtSectionLabel.
+        expect(find.text('NEW WORLD'), findsOneWidget);
+        expect(find.byType(CtSectionLabel), findsNothing);
+
+        final DecoratedBox decoratedBox = tester.widget<DecoratedBox>(
+          find.descendant(
+            of: find.byType(RegionSectionHeader),
+            matching: find.byType(DecoratedBox),
+          ),
+        );
+        final Border border =
+            (decoratedBox.decoration as BoxDecoration).border! as Border;
+        expect(border.left.width, RegionSectionHeader.leftBarWidth);
+        expect(border.left.color, EditorialMonoclePalette.accentDim);
+        expect(border.bottom, BorderSide.none);
+      },
+    );
   });
 
   group('LocationSectionHeader', () {
@@ -59,6 +93,34 @@ void main() {
       );
       expect(find.text('Province A — New World'), findsOneWidget);
     });
+
+    testWidgets(
+      'renders semi-bold fg-at-0.8 chrome per mockup .province-label '
+      '(Refs #3514)',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: Scaffold(
+              body: LocationSectionHeader(
+                label: 'Province A',
+                regionLabel: 'New World',
+              ),
+            ),
+          ),
+        );
+
+        final Text text = tester.widget<Text>(
+          find.text('Province A — New World'),
+        );
+        expect(text.style?.fontWeight, FontWeight.w600);
+        expect(
+          text.style?.color,
+          EditorialMonoclePalette.fg.withValues(
+            alpha: LocationSectionHeader.labelOpacity,
+          ),
+        );
+      },
+    );
   });
 
   group('UnitsPanelShell', () {


### PR DESCRIPTION
## Summary

Advances issue #3514 (unit-panel mockup chrome parity) by implementing one of the
slices explicitly deferred in PR #3533 — the **region / location header restyling**
for the military (`UNIT20001`) and naval (`UNIT30001`) units panels.

## Done in this push

- **`RegionSectionHeader`** gains a `RegionHeaderVariant.leftBar` treatment matching
  the mockup `.region-label` / `.region-heading` chrome: an upper-cased
  `EditorialMonoclePalette.muted` Cinzel display label (12 px, `w600`) preceded by a
  3 dp `accentDim` **left** bar with `6 × 3` dp inner padding. The civilian panel
  keeps the default bottom-border `CtSectionLabel` chrome.
- **`LocationSectionHeader`** restyled to the mockup `.province-label` /
  `.location-label` chrome — indented body-font line, `FontWeight.w600`,
  `EditorialMonoclePalette.fg` at `0.8` opacity. The displayed `name — region`
  content is unchanged (behavior preserved per the markdown spec authority).
- Military and naval panels now request the `leftBar` variant for region headings.

## SPEC

- `SPEC/ui/military-units-panel.md` — new § Region / location header chrome + two ACs.
- `SPEC/ui/naval-units-panel.md` — new § Region / location header chrome + two ACs.

## Tests

- `app/test/units_panel_shared_widgets_test.dart`: positive `leftBar` variant test
  (left accent-dim bar, no `CtSectionLabel`, upper-cased label) and a restyled
  `LocationSectionHeader` chrome test (semi-bold, fg @ 0.8 opacity).
- Verified green locally: `units_panel_shared_widgets_test`,
  `naval_units_panel_test_part1..3`, `naval_units_panel_mockup_fidelity_test`,
  `military_units_panel_test_part1/5/6`, `unit_panels_320dp_min_viewport_test`,
  `panels_320dp_min_viewport_test`. `flutter analyze` clean on touched files.

## Deferred for #3514 (not in this PR)

- Civilian (`UNIT10001`) region-heading bottom-border `--border` restyle.
- Catalog `Ct-*` additions and panel widget goldens for all three unit panels.

## Notes

- Issue #3514 also has open PR #3533 (naval fleet-card chrome, automerge armed).
  This slice is independent (headers) and scoped to its own focused PR for clean
  review.

Refs #3514

Made with [Cursor](https://cursor.com)