### PR TITLE
test: pin DLG10001 dialog frame to mockup-authoritative 540 dp width (#3507)

### DIFF
--- a/SPEC/ui/new-game-leader-selection-dialog.md
+++ b/SPEC/ui/new-game-leader-selection-dialog.md
@@ -185,6 +185,10 @@ Implementation: `app/lib/features/shell/new_game_leader_selection_dialog.dart`. 
 
 - Given the dialog is open under any theme, when the title `Text` is inspected, then its `style.color` is NOT equal to `AppThemes.colonial.textTheme.titleMedium?.color` (regression guard: dropping the EditorialMonoclePalette override would surface the colonial titleMedium color instead of the canonical `--accent` token).
 
+### Dialog frame width (mockup-authoritative, Refs #3507 D1)
+
+- Given the dialog is open, when the `CtDialogShell` wrapping `NewGameLeaderSelectionDialog` is inspected, then its `maxWidth` equals `540` and its `maxHeight` equals `720`, matching the authoritative mockup `.dialog-shell{max-width:540px}` (refreshed by #3506). Per the issue source-of-truth precedence the mockup wins on this purely visual detail, so the stale "keep 480 px" figure in the original D1 text does not apply; the dialog frame width is pinned to the 540 dp mockup value (also the `kLeaderSelectionNarrowBreakpoint` wide/narrow threshold).
+
 ### Visual baseline goldens (Refs #3507)
 
 - Given the dialog is rendered directly under `AppThemes.editorialMonocle` at a `600 × 900` dp viewport (width `>= kLeaderSelectionNarrowBreakpoint`, 540 dp) with `baseConfig = GameSetupConfig.defaultConfig`, `naming = defaultNamingConfig`, the default per-GP leader-variant map, and `blessedProfileNames == const []`, when the framed surface keyed `ValueKey<String>('leaderSelectionDialogWideGolden')` is captured, then `WidgetTester.takeException()` returns `null` and the capture matches the committed baseline `app/test/goldens/new_game_leader_selection_dialog_wide.png` (side-by-side nation/leader pickers per the mockup `@media (min-width: 540px)` rule).

--- a/app/test/new_game_leader_selection_dialog_test.dart
+++ b/app/test/new_game_leader_selection_dialog_test.dart
@@ -152,6 +152,24 @@ void main() {
     });
 
     testWidgets(
+      'CtDialogShell frame is pinned to the mockup-authoritative 540 dp width',
+      (WidgetTester tester) async {
+        await pumpDialog(tester, onConfirmed: (_, _, _, _, _, _) {});
+
+        // SPEC/ui/new-game-leader-selection-dialog.md § Dialog frame width:
+        // the dialog frame is pinned to the refreshed mockup
+        // `.dialog-shell{max-width:540px}` (Refs #3506/#3507 D1). This guards
+        // against regressing to the stale 480 dp figure in the original
+        // D1 text — the mockup is the visual source of truth.
+        final shell = tester.widget<CtDialogShell>(
+          find.byType(CtDialogShell),
+        );
+        expect(shell.maxWidth, 540);
+        expect(shell.maxHeight, 720);
+      },
+    );
+
+    testWidgets(
       'large viewport: six slots visible; single shell vertical scroll only',
       (WidgetTester tester) async {
         await pumpDialog(


### PR DESCRIPTION
## Summary

Closes the only remaining loose end on **#3507** (DLG10001 leader-selection dialog mockup alignment): the dialog frame width was never directly pinned by a test, leaving the stale **480-vs-540** discrepancy from the issue's original D1 text unguarded.

The authoritative mockup `SPEC/ui/mockups/DLG10001-leader-selection-dialog.html` was refreshed to `.dialog-shell{max-width:540px}` (by #3506) and the implementation already renders at `maxWidth: 540` (merged via #3513). Per the issue's source-of-truth precedence the **mockup wins on this purely visual detail**, so 540 is canonical and the original "keep 480 px" D1 figure is stale.

## Done in this push

- **SPEC:** added a dedicated, test-targetable AC to `SPEC/ui/new-game-leader-selection-dialog.md` (§ Dialog frame width) pinning `CtDialogShell.maxWidth == 540` / `maxHeight == 720` to the mockup-authoritative value.
- **Test:** added a widget regression test in `app/test/new_game_leader_selection_dialog_test.dart` asserting the rendered `CtDialogShell` frame is `540 × 720`, guarding against regression to the stale 480 dp figure.

## Context

The bulk of #3507 (header order/centering, slot-row chrome, `CtToggleSwitch`, AI profile row, copy, 540 dp breakpoint, goldens, SPEC) was already implemented and merged via **#3513** and **#3530**. This PR only adds the missing explicit width pin + AC and reconciles the stale D1 text on the issue.

## Test plan

- [x] `flutter test test/new_game_leader_selection_dialog_test.dart` — 28 passing (incl. new width-pin test)
- [x] `flutter analyze` on the changed test file — no new findings (pre-existing `info`-level `unnecessary_underscores` only, already on `dev`)

Refs #3507

Made with [Cursor](https://cursor.com)