### PR TITLE
refactor: break world province lookup/owner-cache cycle; dedup army-by-id scan (#3544)

### DIFF
--- a/packages/colonizethis_diplomacy/lib/src/diplomacy/diplomacy_relation_lookup.dart
+++ b/packages/colonizethis_diplomacy/lib/src/diplomacy/diplomacy_relation_lookup.dart
@@ -12,7 +12,7 @@ import 'package:colonizethis_world/src/utils/expando_index.dart';
 import 'package:colonizethis_world/src/world/diplomatic_relation_lookup.dart';
 
 export 'package:colonizethis_world/src/world/diplomatic_relation_lookup.dart';
-export 'package:colonizethis_world/src/world/province_lookup.dart'
+export 'package:colonizethis_world/src/world/province_owner_cache.dart'
     show oldWorldProvinceCountOwnedBy;
 
 /// Overture costs per diplomacy-resolution. Consulate £500, Embassy £1000.

--- a/packages/colonizethis_world/lib/colonizethis_world.dart
+++ b/packages/colonizethis_world/lib/colonizethis_world.dart
@@ -11,6 +11,7 @@ export 'package:colonizethis_world/src/trace/turn_trace_runtime.dart';
 export 'src/world_constants.dart';
 export 'package:colonizethis_world/src/world/army_commands.dart';
 export 'package:colonizethis_world/src/world/army_ids.dart';
+export 'package:colonizethis_world/src/world/army_lookup.dart';
 export 'package:colonizethis_world/src/world/ai_control.dart';
 export 'package:colonizethis_world/src/world/army_migration.dart';
 export 'package:colonizethis_world/src/world/army_movement.dart';

--- a/packages/colonizethis_world/lib/src/world/army_lookup.dart
+++ b/packages/colonizethis_world/lib/src/world/army_lookup.dart
@@ -1,0 +1,20 @@
+import 'package:colonizethis_models/colonizethis_models.dart' show Army;
+
+/// First [Army] in [armies] whose id equals [armyId], or `null` when none match.
+///
+/// Single-pass linear scan returning the first match (mirroring [List.indexWhere]
+/// / [Iterable.firstWhere] semantics on duplicate ids). Avoids the
+/// `.where(...).toList()` / `firstWhereOrNull` allocation on the single-lookup
+/// army-migration paths (Refs #2394; SPEC/program/turn-resolution.md).
+///
+/// This is the one canonical single-lookup army-by-id helper, replacing the
+/// per-file scan closures that previously lived in `army_migration.dart` and
+/// `army_migration_relocation.dart` (Refs #3544 C6). For repeated lookups over
+/// a stable [WorldState] snapshot prefer the map-based `armiesByIdForWorld`
+/// index in `army_movement.dart` (O(1) per lookup) instead.
+Army? firstArmyById(List<Army> armies, String armyId) {
+  for (final a in armies) {
+    if (a.id == armyId) return a;
+  }
+  return null;
+}

--- a/packages/colonizethis_world/lib/src/world/army_migration.dart
+++ b/packages/colonizethis_world/lib/src/world/army_migration.dart
@@ -3,6 +3,7 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../world_constants.dart';
 import 'army_ids.dart';
+import 'army_lookup.dart';
 import 'game_world_mutations.dart';
 import 'province_lookup.dart';
 import 'region_unit_lists.dart';
@@ -260,13 +261,6 @@ WorldState reconcileArmiesAfterUnitsChanged(WorldState worldState, Game game) {
       if (p.capitalProvinceId != null) p.id: p.capitalProvinceId!,
   };
 
-  Army? findArmy(String id) {
-    for (final a in armies) {
-      if (a.id == id) return a;
-    }
-    return null;
-  }
-
   for (final u in military) {
     if (claimed.contains(u.id)) continue;
     final cap = capitals[u.ownerId];
@@ -274,7 +268,7 @@ WorldState reconcileArmiesAfterUnitsChanged(WorldState worldState, Game game) {
     final targetId = wantsHome
         ? homeArmyIdFor(u.ownerId)
         : fieldArmyIdFor(u.ownerId, u.locationProvinceId);
-    var target = findArmy(targetId);
+    var target = firstArmyById(armies, targetId);
     if (target == null) {
       final regionId = _regionIdForUnitInWorld(worldState, u);
       target = Army(

--- a/packages/colonizethis_world/lib/src/world/army_migration_relocation.dart
+++ b/packages/colonizethis_world/lib/src/world/army_migration_relocation.dart
@@ -22,7 +22,7 @@ WorldState updateArmyStation(
     destinationProvinceId,
     regionId,
   );
-  final army = _armyById(armies, armyId);
+  final army = firstArmyById(armies, armyId);
   if (army == null) return worldState;
   final unitsByRegion = worldState.mutableUnitListsByRegion();
   final relocated = _relocateArmyRegiments(
@@ -85,15 +85,6 @@ List<Army> _retargetArmyStation(
             ),
     )
     .toList();
-
-/// First matching army by id. Single-pass scan; avoids `.where(...).toList()`
-/// allocation on migration paths (Refs #2394, SPEC/program/turn-resolution.md).
-Army? _armyById(List<Army> armies, String armyId) {
-  for (final a in armies) {
-    if (a.id == armyId) return a;
-  }
-  return null;
-}
 
 RegionUnitLists _moveRegimentToProvince({
   required List<Unit> ow,

--- a/packages/colonizethis_world/lib/src/world/province_lookup.dart
+++ b/packages/colonizethis_world/lib/src/world/province_lookup.dart
@@ -1,11 +1,10 @@
 import 'dart:collection' show UnmodifiableMapView;
 
 import 'package:colonizethis_models/colonizethis_models.dart'
-    show Game, Province, ProvinceId, RegionData, Unit, WorldState;
+    show Province, ProvinceId, RegionData, Unit, WorldState;
 
 import '../world_constants.dart';
 import 'package:colonizethis_world/src/utils/expando_index.dart';
-import 'package:colonizethis_world/src/world/province_owner_cache.dart';
 
 /// Id → first list index for one [RegionData.provinces] list instance (Refs #2394).
 /// First matching id wins, matching [List.indexWhere] semantics on duplicates.
@@ -425,15 +424,4 @@ extension WorldStateProvinceLookup on WorldState {
       kRegionNewWorld: List<Province>.from(newWorld.provinces),
     };
   }
-}
-
-/// Old World provinces owned by [factionId] (observer conquest / survival peace).
-///
-/// Pure world/province lookup with no diplomacy dependency; lives in `world/`
-/// so leaf-layer consumers (and `colonizethis_world` after extraction) do not
-/// import the diplomacy domain (Refs #3290 Phase 0 — `ai → diplomacy` edge).
-int oldWorldProvinceCountOwnedBy(Game game, String factionId) {
-  return ProvinceOwnerCache.of(
-    game.worldState,
-  ).countOwnedByInRegion(factionId, kRegionOldWorld);
 }

--- a/packages/colonizethis_world/lib/src/world/province_owner_cache.dart
+++ b/packages/colonizethis_world/lib/src/world/province_owner_cache.dart
@@ -1,11 +1,10 @@
 import 'dart:collection' show UnmodifiableListView;
 
 import 'package:colonizethis_models/colonizethis_models.dart'
-    show Province, WorldState;
+    show Game, Province, WorldState;
 
 import 'package:colonizethis_world/src/utils/expando_index.dart';
-import 'package:colonizethis_world/src/world/province_lookup.dart'
-    show WorldStateProvinceLookup;
+import 'province_lookup.dart' show WorldStateProvinceLookup;
 import 'package:colonizethis_world/src/world_constants.dart'
     show kRegionNewWorld, kRegionOldWorld;
 
@@ -146,4 +145,19 @@ class ProvinceOwnerCache {
         'provinceOwnerCacheByState',
         ProvinceOwnerCache.build,
       );
+}
+
+/// Old World provinces owned by [factionId] (observer conquest / survival peace).
+///
+/// Pure world/province lookup with no diplomacy dependency; lives in `world/`
+/// so leaf-layer consumers (and `colonizethis_world` after extraction) do not
+/// import the diplomacy domain (Refs #3290 Phase 0 — `ai → diplomacy` edge).
+///
+/// Co-located with [ProvinceOwnerCache] (its sole dependency) so that
+/// `province_lookup.dart` no longer imports this file, breaking the former
+/// `province_lookup` <-> `province_owner_cache` import cycle (Refs #3544 C1).
+int oldWorldProvinceCountOwnedBy(Game game, String factionId) {
+  return ProvinceOwnerCache.of(
+    game.worldState,
+  ).countOwnedByInRegion(factionId, kRegionOldWorld);
 }

--- a/packages/colonizethis_world/test/world/army_lookup_test.dart
+++ b/packages/colonizethis_world/test/world/army_lookup_test.dart
@@ -1,0 +1,39 @@
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_world/src/world/army_lookup.dart';
+import 'package:colonizethis_test/test.dart';
+
+/// Unit coverage for the consolidated single-lookup army-by-id helper
+/// (`lib/src/world/army_lookup.dart`, Refs #3544 C6). Replaces the per-file
+/// `findArmy` closure and `_armyById` scan that previously lived in
+/// `army_migration.dart` / `army_migration_relocation.dart`.
+Army _army(String id) => Army(
+  id: id,
+  ownerId: 'p1',
+  regionId: 'oldWorld',
+  stationedProvinceId: 'oldWorld|p1',
+  regimentUnitIds: const [],
+);
+
+void main() {
+  group('firstArmyById', () {
+    test('returns the matching army when present', () {
+      final a = _army('army_a');
+      final b = _army('army_b');
+      expect(firstArmyById([a, b], 'army_b'), same(b));
+    });
+
+    test('returns null when no army matches (negative)', () {
+      expect(firstArmyById([_army('army_a')], 'army_missing'), isNull);
+    });
+
+    test('returns null for an empty list (negative)', () {
+      expect(firstArmyById(const <Army>[], 'army_a'), isNull);
+    });
+
+    test('returns the first match on duplicate ids (indexWhere semantics)', () {
+      final first = _army('dup');
+      final second = _army('dup');
+      expect(firstArmyById([first, second], 'dup'), same(first));
+    });
+  });
+}

--- a/packages/colonizethis_world/test/world/world_internal_decoupling_test.dart
+++ b/packages/colonizethis_world/test/world/world_internal_decoupling_test.dart
@@ -1,0 +1,71 @@
+import 'dart:io';
+
+import 'package:colonizethis_test/test.dart';
+
+/// Source-level regression guard for the `province_lookup` <-> `province_owner_cache`
+/// import cycle broken in Refs #3544 C1.
+///
+/// `oldWorldProvinceCountOwnedBy` was relocated from `province_lookup.dart` into
+/// `province_owner_cache.dart` (its sole dependency), leaving a single one-way
+/// edge `province_owner_cache -> province_lookup`. These tests assert the cycle
+/// does not return and that no `src/world/` file re-introduces a
+/// `package:colonizethis_world/src/world/` self-import (the obscuring pattern
+/// that hid the original cycle; the rest of the package uses relative imports
+/// for sibling `src/world/` files).
+void main() {
+  const worldDir = 'lib/src/world';
+
+  String read(String relativePath) =>
+      File('$worldDir/$relativePath').readAsStringSync();
+
+  group('province lookup / owner cache cycle (Refs #3544 C1)', () {
+    test('province_lookup.dart does not import province_owner_cache.dart', () {
+      final source = read('province_lookup.dart');
+      expect(
+        source.contains('province_owner_cache'),
+        isFalse,
+        reason:
+            'province_lookup.dart must not depend on province_owner_cache.dart; '
+            'the cycle is broken by hosting oldWorldProvinceCountOwnedBy in '
+            'province_owner_cache.dart.',
+      );
+    });
+
+    test('province_owner_cache.dart keeps the one-way edge to province_lookup', () {
+      final source = read('province_owner_cache.dart');
+      expect(
+        source.contains("import 'province_lookup.dart'"),
+        isTrue,
+        reason:
+            'province_owner_cache may depend on province_lookup (one-way edge), '
+            'and should do so via a relative import.',
+      );
+    });
+  });
+
+  test('no src/world file uses a package: self-import for a sibling src/world '
+      'file', () {
+    final dir = Directory(worldDir);
+    final offenders = <String>[];
+    for (final entity in dir.listSync(recursive: true)) {
+      if (entity is! File || !entity.path.endsWith('.dart')) continue;
+      final lines = entity.readAsLinesSync();
+      for (var i = 0; i < lines.length; i++) {
+        final line = lines[i].trim();
+        if (!line.startsWith('import ') && !line.startsWith('export ')) continue;
+        if (line.contains('package:colonizethis_world/src/world/')) {
+          offenders.add('${entity.path}:${i + 1} -> $line');
+        }
+      }
+    }
+    expect(
+      offenders,
+      isEmpty,
+      reason:
+          'src/world/ files must reference sibling src/world/ libraries via '
+          'relative imports, not package:colonizethis_world/src/world/ URIs '
+          '(keeps intra-directory dependency edges visible). Offenders:\n'
+          '${offenders.join('\n')}',
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Two behaviour-preserving decoupling/dedup slices for `packages/colonizethis_world`, addressing items **C1** and **C6** of #3544. No semantic or API-surface changes — import routing and helper extraction only.

### Done in this push

**C1 (high) — break the `province_lookup` ⇄ `province_owner_cache` import cycle.**
- `province_lookup.dart` imported `province_owner_cache.dart` *only* to host `oldWorldProvinceCountOwnedBy`, while `province_owner_cache.dart` imports `province_lookup.dart` (for the `WorldStateProvinceLookup` extension). These were the only two `src/world/ → src/world/` `package:` self-imports in the package, and formed a bidirectional cycle.
- Relocated `oldWorldProvinceCountOwnedBy` into `province_owner_cache.dart` (its sole dependency), leaving a single one-way edge `province_owner_cache → province_lookup`.
- Converted the remaining intra-`src/world` reference to a relative import.
- The symbol stays exported via the world barrel; the diplomacy deep re-export (`diplomacy_relation_lookup.dart`) was retargeted to `province_owner_cache.dart`, so all cross-package consumers (`ai_api`, AI, orders, diplomacy) resolve unchanged.

**C6 (low-medium) — collapse duplicated single-lookup army-by-id scans.**
- Extracted one canonical, testable `firstArmyById(List<Army>, String)` helper into `army_lookup.dart` (barrel-exported), replacing the `findArmy` closure in `army_migration.dart` and the `_armyById` scan in `army_migration_relocation.dart`.
- The map-based `armiesByIdForWorld` bulk index stays as the distinct O(1)-per-lookup tool for repeated lookups (different access pattern; intentionally not merged).

### Tests
- `army_lookup_test.dart`: positive (match), negative (no match / empty list), and first-match-on-duplicate-id coverage for `firstArmyById`.
- `world_internal_decoupling_test.dart`: source-level regression guards that (a) `province_lookup.dart` no longer depends on `province_owner_cache.dart`, (b) the one-way owner-cache → lookup edge remains, and (c) no `src/world/` file re-introduces a `package:colonizethis_world/src/world/` self-import.
- Verified: `dart analyze` clean for touched files; world package targeted tests (48) and a diplomacy re-export test pass.

### Deferred for #3544 (follow-up commits on this issue, separate PRs)
- **C2** triplicated capital-reassignment loops, **C3** connectivity part-file chain, **C4** fog-resolution boilerplate, **C5** region-dispatch ternary. Not in this slice to keep the change reviewable and behaviour-preserving.

Refs #3544

Made with [Cursor](https://cursor.com)