### PR TITLE
refactor: de-part-file order_suggestion_work into standalone libraries (#3543)

### DIFF
--- a/SPEC/program/dart-file-non-comment-line-size.md
+++ b/SPEC/program/dart-file-non-comment-line-size.md
@@ -10,6 +10,20 @@ files. Umbrella policy: `SPEC/program/repo-lint.md` (**no violation allowlists**
 | `tool/check_dart_file_non_comment_line_size.dart` | Walker, counter, CLI |
 | `tool/ct_repo_lint_manifest.yaml` | Registers rule `repo.dart_file_non_comment_line_size` |
 
+## Extraction shape (libraries, not part files)
+
+When a file is split to stay under this gate (or the tighter domain/models caps),
+the extracted unit MUST be a **standalone Dart library with explicit `import`
+declarations**, not a `part` / `part of` fragment that inherits the host
+library's private scope. Part fragments keep the extracted code implicitly
+coupled to the host (shared imports and private members), which defeats the
+testability and decoupling goal the size gate exists to encourage. The
+`colonizethis_turn` (`repo.turn_no_part_directives`, Refs #3416) and
+`colonizethis_diplomacy` (`repo.diplomacy_no_part_of`, Refs #3419) packages
+already forbid `part` directives in their `lib/` trees; other packages SHOULD
+prefer the same standalone-library shape when extracting for size, and MAY add an
+equivalent no-`part` gate once their `lib/` tree is part-free.
+
 ## Scan scope
 
 - The checker walks the repository tree from the repo root, skipping directory

--- a/packages/colonizethis_orders/lib/src/orders/order_suggestion_work.dart
+++ b/packages/colonizethis_orders/lib/src/orders/order_suggestion_work.dart
@@ -2,29 +2,20 @@ library order_suggestion_work;
 
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
-
-import 'feedstock_extraction_targets.dart'
-    show feedstockExtractionResourceIdsForPlayer;
-import 'order_work_constants.dart';
 import 'package:colonizethis_world/colonizethis_world.dart';
-import 'bundled_civilian_work_order.dart';
+
 import 'incremental_candidate_validator.dart';
-import 'order_resolution_context.dart';
-import 'order_suggestion_helpers.dart';
-import 'order_suggestion_work_tile_keys.dart';
-import 'order_suggestion_work_tile_prefilter.dart';
 import 'order_suggestion_context.dart';
+import 'order_suggestion_helpers.dart';
 import 'order_suggestion_pass_context.dart';
+import 'order_suggestion_work_explorer.dart';
+import 'order_suggestion_work_merchant.dart';
+import 'order_suggestion_work_spy.dart';
+import 'order_suggestion_work_worker.dart';
 import 'order_visibility.dart';
 import 'work_suggestion_pipeline.dart';
 import 'partial_province_reveal.dart';
-import 'orders_application_helpers.dart';
 import 'unit_type_helpers.dart';
-
-part 'order_suggestion_work_explorer.dart';
-part 'order_suggestion_work_worker.dart';
-part 'order_suggestion_work_spy.dart';
-part 'order_suggestion_work_merchant.dart';
 
 /// Tile keys that are merchant purchase-land suggestion candidates for [game]:
 /// tiles in provinces not owned by any [Game.players] entry that carry a
@@ -267,7 +258,7 @@ void _addWorkSuggestionsForUnit({
   final tilesInProvince = tileKeysByRegion[regionId]?[provinceId] ?? const [];
 
   if (isExplorer) {
-    _addExplorerWorkSuggestionsForUnit(
+    addExplorerWorkSuggestionsForUnit(
       view: view,
       game: game,
       topology: topology,
@@ -289,7 +280,7 @@ void _addWorkSuggestionsForUnit({
   }
 
   if (isWorker) {
-    _addWorkerSuggestionsForUnit(
+    addWorkerSuggestionsForUnit(
       view: view,
       game: game,
       topology: topology,
@@ -312,7 +303,7 @@ void _addWorkSuggestionsForUnit({
   }
 
   if (isSpy && tilesInProvince.isNotEmpty) {
-    _addSpySuggestionsForUnit(
+    addSpySuggestionsForUnit(
       game: game,
       topology: topology,
       currentOrders: currentOrders,
@@ -332,7 +323,7 @@ void _addWorkSuggestionsForUnit({
   }
 
   if (isMerchant) {
-    _addMerchantSuggestionsForUnit(
+    addMerchantSuggestionsForUnit(
       unit: unit,
       type: type,
       unitRegionId: regionId,

--- a/packages/colonizethis_orders/lib/src/orders/order_suggestion_work_explorer.dart
+++ b/packages/colonizethis_orders/lib/src/orders/order_suggestion_work_explorer.dart
@@ -1,4 +1,15 @@
-part of 'order_suggestion_work.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_world/colonizethis_world.dart';
+
+import 'bundled_civilian_work_order.dart';
+import 'incremental_candidate_validator.dart';
+import 'order_resolution_context.dart';
+import 'order_suggestion_context.dart';
+import 'order_visibility.dart';
+import 'order_work_constants.dart';
+import 'orders_application_helpers.dart';
+import 'work_suggestion_pipeline.dart';
 
 ({WorkOrder? chosen, String lastReason}) _tryExploreWorkOrderForProvince({
   required PlayerView view,
@@ -77,7 +88,7 @@ part of 'order_suggestion_work.dart';
   return (chosen: null, lastReason: 'engine_rejected');
 }
 
-void _addExplorerWorkSuggestionsForUnit({
+void addExplorerWorkSuggestionsForUnit({
   required PlayerView view,
   required Game game,
   required MapTopology topology,

--- a/packages/colonizethis_orders/lib/src/orders/order_suggestion_work_merchant.dart
+++ b/packages/colonizethis_orders/lib/src/orders/order_suggestion_work_merchant.dart
@@ -1,6 +1,12 @@
-part of 'order_suggestion_work.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
 
-void _addMerchantSuggestionsForUnit({
+import 'incremental_candidate_validator.dart';
+import 'order_suggestion_context.dart';
+import 'order_work_constants.dart';
+import 'work_suggestion_pipeline.dart';
+
+void addMerchantSuggestionsForUnit({
   required Unit unit,
   required String type,
   required String unitRegionId,

--- a/packages/colonizethis_orders/lib/src/orders/order_suggestion_work_spy.dart
+++ b/packages/colonizethis_orders/lib/src/orders/order_suggestion_work_spy.dart
@@ -1,6 +1,12 @@
-part of 'order_suggestion_work.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
 
-void _addSpySuggestionsForUnit({
+import 'incremental_candidate_validator.dart';
+import 'order_suggestion_context.dart';
+import 'order_work_constants.dart';
+import 'work_suggestion_pipeline.dart';
+
+void addSpySuggestionsForUnit({
   required Game game,
   required MapTopology topology,
   required Orders currentOrders,

--- a/packages/colonizethis_orders/lib/src/orders/order_suggestion_work_worker.dart
+++ b/packages/colonizethis_orders/lib/src/orders/order_suggestion_work_worker.dart
@@ -1,6 +1,18 @@
-part of 'order_suggestion_work.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_world/colonizethis_world.dart';
 
-void _addWorkerSuggestionsForUnit({
+import 'feedstock_extraction_targets.dart'
+    show feedstockExtractionResourceIdsForPlayer;
+import 'incremental_candidate_validator.dart';
+import 'order_suggestion_context.dart';
+import 'order_suggestion_work_tile_keys.dart';
+import 'order_suggestion_work_tile_prefilter.dart';
+import 'order_work_constants.dart';
+import 'unit_type_helpers.dart';
+import 'work_suggestion_pipeline.dart';
+
+void addWorkerSuggestionsForUnit({
   required PlayerView view,
   required Game game,
   required MapTopology topology,


### PR DESCRIPTION
## Summary

Advances **#3543** (orders package de-part-filing) by promoting the four
`order_suggestion_work` part fragments to standalone Dart libraries with
explicit imports, removing the implicit part-scope coupling described in the
issue's Current behavior §1.

This is the **Step 3** slice from the issue's ordered plan. Step 1 (sea-reachable
barrel export + `src/` import gate) already landed in #3545.

## Done in this push

- `order_suggestion_work_explorer.dart`, `_worker.dart`, `_spy.dart`,
  `_merchant.dart` are now standalone libraries (no `part of`), each declaring
  its own minimal `import` set instead of inheriting the host library's scope.
- The per-unit entry functions are renamed from private (`_addXxxSuggestionsForUnit`)
  to package-private public symbols (`addXxxSuggestionsForUnit`) so
  `order_suggestion_work.dart` imports them; internal helpers stay private.
- `order_suggestion_work.dart` drops the four `part` directives, imports the new
  libraries, and updates the four call sites. Now-unused host imports pruned.
- SPEC: clarified `SPEC/program/dart-file-non-comment-line-size.md` that
  size-driven extraction must produce standalone libraries (not `part` fragments),
  citing the existing `colonizethis_turn` / `colonizethis_diplomacy` no-`part`
  precedents (Refs #3416, #3419).

## Behavior / tests

- **No behavior change** — the moved suggestion logic is byte-for-byte identical;
  only library boundaries and the four entry-function names changed.
- `dart analyze packages/colonizethis_orders/lib` → clean.
- Full `dart test` for `colonizethis_orders` → **680 passing** (incl. all
  `order_suggestion_*` work-suggestion tests). No test referenced the old part
  fragments or private entry functions, so no test restructuring was required.

## Remaining for #3543 (follow-up, not in this PR)

- Step 4: de-part-file the remaining host libraries (`order_suggestion_move_army`,
  `order_suggestion_naval_diplomatic`, `incremental_candidate_validator`,
  `order_engine` + generated `order_engine.g`).
- Step 5: reduce `WorldState` field-drilling via focused world accessors.
- CI enforcement: add the orders-wide no-`part` gate (e.g.
  `check_orders_no_part_of_test.dart`) once the `lib/` tree is fully part-free
  (deferred until Step 4 completes — 8 part fragments still remain).

Refs #3543

Made with [Cursor](https://cursor.com)