### PR TITLE
chore(world): clean dart analyze on colonizethis_world (#3544)

### DIFF
--- a/packages/colonizethis_world/test/fog_resolution_distant_sea_zone_fog_revert_test.dart
+++ b/packages/colonizethis_world/test/fog_resolution_distant_sea_zone_fog_revert_test.dart
@@ -1,6 +1,5 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/src/constants.dart';
-import 'package:colonizethis_turn/src/turn/end_of_turn_resolver.dart';
 import 'package:colonizethis_world/src/world/fog_resolution.dart';
 import 'package:colonizethis_world/src/world/player_view.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';

--- a/packages/colonizethis_world/test/world/province_ownership_transfer_test.dart
+++ b/packages/colonizethis_world/test/world/province_ownership_transfer_test.dart
@@ -1,4 +1,3 @@
-import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/src/constants.dart';
 import 'package:colonizethis_world/src/world/province_ownership_transfer.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';


### PR DESCRIPTION
## Summary

Closes the last objective gap on the `colonizethis_world` decoupling/dedup work: `dart analyze` was reporting 2 `unused_import` warnings, so AC "`dart analyze` clean on `packages/colonizethis_world`" was not literally met.

This PR removes:
- the unused `package:colonizethis_turn/src/turn/end_of_turn_resolver.dart` import from `test/fog_resolution_distant_sea_zone_fog_revert_test.dart` (also a cross-package test-boundary smell vs. the world package), and
- the unused `package:colonizethis_data/colonizethis_data.dart` import from `test/world/province_ownership_transfer_test.dart`.

No production code or behavior changes.

## #3544 status (for verification context)

Most of #3544 already landed via merged PRs **#3547** (break province lookup ↔ owner-cache cycle; dedup army-by-id scan) and **#3549** (unify capital-reassignment loops + region unit-list dispatch). Current state of the acceptance criteria:

- [x] AC1 — acyclic import graph for `lib/src/world/`; enforced by `repo.world_no_circular_imports` (passes locally).
- [x] AC2 — single generic `_applyCapitalReassignmentForFaction` shared by GP/Minor/Tribe.
- [x] AC3 (partial) — `connectivity_propagation.dart` is a standalone library (no `part of`). The `ConnectivityHotPathMetrics` test hook was made a private, single-library-encapsulated global (reset via `tearDown`) rather than threaded as a parameter: the only consumer is a full-turn characterization test (`colonizethis_turn` `turn_characterization_test.dart`, Refs #2268 AC-10) that reads the counters after `resolveTurnForGame`, so parameter-threading would push a test-only sink across the entire cross-package turn→connectivity hot path (counter to the turn-resolution budget rule). Flagging for verifier judgment.
- [x] AC4 — both fog files delegate region/player iteration to shared `_forEachWorldRegionGpVisibility`.
- [x] AC5 — `RegionUnitListsAccess.unitListForRegion` replaces both `kRegionOldWorld ? ow : nw` ternaries.
- [x] AC6 — army-by-id lookups use shared `armiesByIdForWorld` (O(1) map) / `firstArmyById` (`army_lookup.dart`).
- [x] AC7 — `repo.world_no_circular_imports` rule present and passing.
- [x] AC9 — `dart analyze` clean (this PR).

## Verification

- `dart analyze` (packages/colonizethis_world) → No issues found.
- `dart test` on both edited files → all pass.
- `dart run tool/check_world_no_circular_imports.dart` → acyclic graph (67 files).

Refs #3544

Made with [Cursor](https://cursor.com)