### PR TITLE
refactor: extract BaseUnitsPanelState for combine-capable unit panels (#3546)

### DIFF
--- a/app/lib/features/game/widgets/military_units_panel.dart
+++ b/app/lib/features/game/widgets/military_units_panel.dart
@@ -16,13 +16,11 @@ import 'game_panel_contract.dart';
 import 'utils/military_tree_builder.dart';
 import 'move_army_dialog.dart';
 import 'split_army_dialog.dart';
+import 'units/shared/base_units_panel.dart';
 import 'units/shared/location_section_header.dart';
 import 'units/shared/region_section_header.dart';
-import 'units/shared/units_combine_header_actions.dart';
 import 'units/shared/units_entity_action_row.dart';
 import 'units/shared/units_entity_card.dart';
-import 'units/shared/units_multi_selection_controller.dart';
-import 'units/shared/units_panel_shell.dart';
 import '../utils/region_labels.dart';
 
 class MilitaryUnitsPanel extends StatefulWidget with GamePanelMixin {
@@ -54,31 +52,21 @@ class MilitaryUnitsPanel extends StatefulWidget with GamePanelMixin {
   State<MilitaryUnitsPanel> createState() => _MilitaryUnitsPanelState();
 }
 
-class _MilitaryUnitsPanelState extends State<MilitaryUnitsPanel> {
-  final UnitsMultiSelectionController _selection =
-      UnitsMultiSelectionController();
-
+class _MilitaryUnitsPanelState
+    extends BaseUnitsPanelState<MilitaryUnitsPanel> {
   Iterable<String> _armyIds(List<ArmyBlock> flat) =>
       flat.map((b) => b.army.id);
 
-  void _toggleArmySelection(String armyId) {
-    setState(() => _selection.toggle(armyId));
-  }
-
-  void _onHeaderSelectAllTapped(List<ArmyBlock> flat) {
-    setState(() => _selection.selectAllOrClear(_armyIds(flat)));
-  }
-
   void _performCombine(List<ArmyBlock> flat) {
-    if (!canCombineArmySelection(flat, _selection.selectedIds)) return;
-    final ids = _selection.selectedIds.toList()..sort();
+    if (!canCombineArmySelection(flat, selection.selectedIds)) return;
+    final ids = selection.selectedIds.toList()..sort();
     widget.bus.emit(
       ArmyCombineRequestedEvent(
         humanPlayerId: widget.humanPlayerId,
         armyIds: ids,
       ),
     );
-    setState(_selection.clear);
+    clearSelection();
   }
 
   void _openSplitDialog(ArmyBlock block) {
@@ -120,56 +108,35 @@ class _MilitaryUnitsPanelState extends State<MilitaryUnitsPanel> {
     final groups = buildMilitaryGroups(widget.game, widget.humanPlayerId);
     final flat = flattenMilitaryArmyBlocks(groups);
     final hasAny = groups.isNotEmpty;
-    final canCombine =
-        !widget.readOnly &&
-        canCombineArmySelection(flat, _selection.selectedIds);
-    final headerCheckbox = _selection.headerValue(_armyIds(flat));
     final readOnly = widget.readOnly;
+    final canCombine =
+        !readOnly && canCombineArmySelection(flat, selection.selectedIds);
 
-    return UnitsPanelShell(
+    // Shared select-all + Combine cluster per SPEC/ui/military-units-panel.md
+    // § Header actions and issue #3514 owner decisions #5 / #15; the trailing
+    // Train pill follows the cluster (`BaseUnitsPanelState.buildUnitsPanel`).
+    return buildUnitsPanel(
       title: l10n.military_units_title,
-      actions: _buildActions(
-        l10n: l10n,
-        hasAny: hasAny,
-        flat: flat,
-        canCombine: canCombine,
-        headerCheckbox: headerCheckbox,
-        readOnly: readOnly,
-      ),
+      showCombineCluster: hasAny && flat.isNotEmpty && !readOnly,
+      selectableIds: _armyIds(flat),
+      selectAllTooltip: l10n.military_units_selectAllArmies,
+      deselectAllTooltip: l10n.military_units_deselectAllArmies,
+      combineLabel: l10n.common_combine,
+      canCombine: canCombine,
+      onSelectAll: () => selectAllOrClear(_armyIds(flat)),
+      onCombine: () => _performCombine(flat),
+      trailingActions: [
+        CtActionTextButton(
+          primary: true,
+          onPressed: readOnly ? null : _openTrainDialog,
+          enabled: !readOnly,
+          label: l10n.common_train,
+        ),
+      ],
       hasContent: hasAny,
       listChildren: _buildListChildren(groups, l10n),
       emptyMessage: l10n.military_units_empty,
     );
-  }
-
-  List<Widget> _buildActions({
-    required AppLocalizations l10n,
-    required bool hasAny,
-    required List<ArmyBlock> flat,
-    required bool canCombine,
-    required bool? headerCheckbox,
-    required bool readOnly,
-  }) {
-    return [
-      if (hasAny && flat.isNotEmpty && !readOnly)
-        // Shared select-all + Combine cluster per SPEC/ui/military-units-panel.md
-        // § Header actions and issue #3514 owner decisions #5 / #15.
-        ...unitsCombineHeaderActions(
-          headerValue: headerCheckbox,
-          selectAllTooltip: l10n.military_units_selectAllArmies,
-          deselectAllTooltip: l10n.military_units_deselectAllArmies,
-          combineLabel: l10n.common_combine,
-          canCombine: canCombine,
-          onSelectAll: () => _onHeaderSelectAllTapped(flat),
-          onCombine: () => _performCombine(flat),
-        ),
-      CtActionTextButton(
-        primary: true,
-        onPressed: readOnly ? null : _openTrainDialog,
-        enabled: !readOnly,
-        label: l10n.common_train,
-      ),
-    ];
   }
 
   void _openTrainDialog() {
@@ -224,9 +191,9 @@ class _MilitaryUnitsPanelState extends State<MilitaryUnitsPanel> {
         armyId: block.army.id,
         draftOrders: widget.draftOrders,
       ),
-      isSelectedForCombine: _selection.contains(block.army.id),
+      isSelectedForCombine: isSelected(block.army.id),
       combineSelectionEnabled: !widget.readOnly,
-      onCombineSelectionToggle: () => _toggleArmySelection(block.army.id),
+      onCombineSelectionToggle: () => toggleSelection(block.army.id),
       onLocate: _armyLocateCallback(block),
       onSplit: widget.readOnly || block.army.regimentUnitIds.length < 2
           ? null

--- a/app/lib/features/game/widgets/naval_units_panel.dart
+++ b/app/lib/features/game/widgets/naval_units_panel.dart
@@ -20,10 +20,9 @@ import 'utils/naval_tree_builder.dart';
 import 'move_fleet_dialog.dart';
 import 'split_fleet_dialog.dart';
 import 'transfer_to_home_fleet_dialog.dart';
+import 'units/shared/base_units_panel.dart';
 import 'units/shared/location_section_header.dart';
 import 'units/shared/region_section_header.dart';
-import 'units/shared/units_combine_header_actions.dart';
-import 'units/shared/units_multi_selection_controller.dart';
 import 'units/shared/units_panel_shell.dart';
 import '../utils/region_labels.dart';
 
@@ -66,9 +65,7 @@ class NavalUnitsPanel extends StatefulWidget with GamePanelMixin {
   State<NavalUnitsPanel> createState() => _NavalUnitsPanelState();
 }
 
-class _NavalUnitsPanelState extends State<NavalUnitsPanel> {
-  final UnitsMultiSelectionController _selection =
-      UnitsMultiSelectionController();
+class _NavalUnitsPanelState extends BaseUnitsPanelState<NavalUnitsPanel> {
   final Set<String> _visibleScopedFleetIds = <String>{};
   static const double _desktopViewportThreshold = 1280;
   static const double _scaledWidthMin = 420;
@@ -82,7 +79,9 @@ class _NavalUnitsPanelState extends State<NavalUnitsPanel> {
     super.initState();
     final id = widget.initialSelectedFleetId;
     if (id != null && id.isNotEmpty) {
-      _selection.toggle(id);
+      // initState runs before the first build, so mutate the store directly
+      // rather than via the `setState`-wrapped dispatch.
+      selection.toggle(id);
     }
     _moveRequestedSub = widget.bus.on<NavalMoveFleetRequestedEvent>().listen((
       event,
@@ -111,7 +110,7 @@ class _NavalUnitsPanelState extends State<NavalUnitsPanel> {
       for (final r in flat) _selectionFleetId(r): r,
     };
     final activeIds =
-        _selection.selectedIds.where(rowsById.containsKey).toList();
+        selection.selectedIds.where(rowsById.containsKey).toList();
     if (activeIds.length < 2) return false;
     final homeTransferRows = _homeTransferRows(flat, activeIds.toSet());
     if (homeTransferRows != null) {
@@ -159,7 +158,7 @@ class _NavalUnitsPanelState extends State<NavalUnitsPanel> {
   }
 
   void _toggleFleetSelection(FleetRow row) {
-    setState(() => _selection.toggle(_selectionFleetId(row)));
+    toggleSelection(_selectionFleetId(row));
   }
 
   Iterable<String> _fleetSelectionIds(List<FleetRow> flat) =>
@@ -168,13 +167,13 @@ class _NavalUnitsPanelState extends State<NavalUnitsPanel> {
   /// Select-all header: from none or partial → select every row; from all → clear.
   /// Does not rely on [Checkbox] tristate `next` (indeterminate taps may pass false).
   void _onHeaderSelectAllTapped(List<FleetRow> flat) {
-    setState(() => _selection.selectAllOrClear(_fleetSelectionIds(flat)));
+    selectAllOrClear(_fleetSelectionIds(flat));
   }
 
   void _performCombine(List<FleetRow> flat) {
     if (!_canCombineSelection(flat)) return;
 
-    final selected = Set<String>.from(_selection.selectedIds);
+    final selected = Set<String>.from(selection.selectedIds);
     final homeTransferRows = _homeTransferRows(flat, selected);
     if (homeTransferRows != null &&
         _isEligibleHomeTransferSource(homeTransferRows.source)) {
@@ -229,7 +228,7 @@ class _NavalUnitsPanelState extends State<NavalUnitsPanel> {
       worldState: widget.game.worldState.copyWith(fleets: updated),
     );
 
-    setState(_selection.clear);
+    clearSelection();
     widget.bus.emit(NavalFleetsUpdatedEvent(game: newGame));
   }
 
@@ -372,11 +371,11 @@ class _NavalUnitsPanelState extends State<NavalUnitsPanel> {
         ),
       );
       final valid = flat.map(_selectionFleetId).toSet();
-      final prunedAny = !_selection.selectedIds.every(valid.contains);
+      final prunedAny = !selection.selectedIds.every(valid.contains);
       if (prunedAny) {
         WidgetsBinding.instance.addPostFrameCallback((_) {
           if (!mounted) return;
-          setState(() => _selection.retainOnly(valid));
+          setState(() => selection.retainOnly(valid));
         });
       }
       if (_pendingScopedAutoCloseAfterMove &&
@@ -466,17 +465,18 @@ class _NavalUnitsPanelState extends State<NavalUnitsPanel> {
       (group) => group.homeFleet != null || group.locations.isNotEmpty,
     );
     final canCombine = !widget.readOnly && _canCombineSelection(flat);
-    final headerCheckbox = _selection.headerValue(_fleetSelectionIds(flat));
     final readOnly = widget.readOnly;
 
-    final panel = UnitsPanelShell(
+    // Header actions render as compact **primary** pills
+    // (`CtActionTextButton(primary: true)`) per SPEC/ui/naval-units-panel.md
+    // § Header actions and issue #3514 owner decisions #5 / #15. The optional
+    // tile-scope pill (and its 4px spacer) leads the shared select-all +
+    // Combine cluster assembled by `BaseUnitsPanelState.buildUnitsPanel`.
+    final panel = buildUnitsPanel(
       title: tileScopeActive
           ? l10n.naval_units_title_tile
           : l10n.naval_units_title,
-      // Header actions render as compact **primary** pills
-      // (`CtActionTextButton(primary: true)`) per SPEC/ui/naval-units-panel.md
-      // § Header actions and issue #3514 owner decisions #5 / #15.
-      actions: [
+      leadingActions: [
         if (tileScopeActive)
           CtActionTextButton(
             primary: true,
@@ -492,17 +492,15 @@ class _NavalUnitsPanelState extends State<NavalUnitsPanel> {
           ),
         if (tileScopeActive && hasAny && flat.isNotEmpty)
           const SizedBox(width: 4),
-        if (hasAny && flat.isNotEmpty && !readOnly)
-          ...unitsCombineHeaderActions(
-            headerValue: headerCheckbox,
-            selectAllTooltip: l10n.naval_units_selectAllFleets,
-            deselectAllTooltip: l10n.naval_units_deselectAllFleets,
-            combineLabel: l10n.common_combine,
-            canCombine: canCombine,
-            onSelectAll: () => _onHeaderSelectAllTapped(flat),
-            onCombine: () => _performCombine(flat),
-          ),
       ],
+      showCombineCluster: hasAny && flat.isNotEmpty && !readOnly,
+      selectableIds: _fleetSelectionIds(flat),
+      selectAllTooltip: l10n.naval_units_selectAllFleets,
+      deselectAllTooltip: l10n.naval_units_deselectAllFleets,
+      combineLabel: l10n.common_combine,
+      canCombine: canCombine,
+      onSelectAll: () => _onHeaderSelectAllTapped(flat),
+      onCombine: () => _performCombine(flat),
       hasContent: hasAny,
       listChildren: [
         for (final group in tree) ...[
@@ -522,7 +520,7 @@ class _NavalUnitsPanelState extends State<NavalUnitsPanel> {
                       ),
                     )
                   : null,
-              isSelectedForCombine: _selection.contains(
+              isSelectedForCombine: isSelected(
                 _selectionFleetId(group.homeFleet!),
               ),
               combineSelectionEnabled: !readOnly,
@@ -551,7 +549,7 @@ class _NavalUnitsPanelState extends State<NavalUnitsPanel> {
                         ),
                       )
                     : null,
-                isSelectedForCombine: _selection.contains(
+                isSelectedForCombine: isSelected(
                   _selectionFleetId(row),
                 ),
                 combineSelectionEnabled: !readOnly,

--- a/app/lib/features/game/widgets/units/shared/base_units_panel.dart
+++ b/app/lib/features/game/widgets/units/shared/base_units_panel.dart
@@ -1,0 +1,122 @@
+// Shared `State` base for the combine-capable unit panels
+// (`MilitaryUnitsPanel`, `NavalUnitsPanel`). Refs #3546 target state #2 (AC4 /
+// AC5).
+//
+// PR #3557 (Refs #3546) extracted the selection *store*
+// (`UnitsMultiSelectionController`) and the combine-cluster *action widgets*
+// (`unitsCombineHeaderActions`) used by both panels. The panels still each
+// re-declared the same controller field, the same `setState`-wrapped selection
+// dispatch (`toggle` / `selectAllOrClear`), and the same `build`-time assembly
+// of the trailing select-all + Combine cluster into a `UnitsPanelShell`.
+//
+// [BaseUnitsPanelState] is the `BaseUnitsPanel<T>` abstraction the issue calls
+// for, realised as a `State` mixin-style base (the idiomatic Flutter home for
+// shared per-panel mutable selection state): it owns the controller, exposes
+// the `setState`-wrapped dispatch the panels share, and provides
+// [buildUnitsPanel] which composes the leading actions, the optional combine
+// cluster, and the trailing actions into a `UnitsPanelShell` with the exact
+// action ordering and spacing the panels rendered before.
+//
+// `CivilianUnitsPanel` deliberately does **not** extend this base (AC5): it is
+// a Riverpod `ConsumerStatefulWidget` (it reads
+// `availableWorkTargetIdsForUnitProvider`) with a single-id selection
+// (`String? _selectedUnitId`) and no combine affordance, so neither the
+// multi-id controller nor the combine-cluster builder applies. Forcing it onto
+// this base would add a multi-selection store it never reads and a combine
+// header it never shows. The two combine-capable panels are plain
+// `StatefulWidget`s, so the shared convention here is `State<W>`.
+library;
+
+import 'package:flutter/material.dart';
+
+import 'units_combine_header_actions.dart';
+import 'units_multi_selection_controller.dart';
+import 'units_panel_shell.dart';
+
+/// Shared selection-dispatch + panel-shell assembly base for the
+/// combine-capable unit panels.
+///
+/// [W] is the concrete panel widget type (`MilitaryUnitsPanel` /
+/// `NavalUnitsPanel`). Subclasses own their tree building and per-row action
+/// wiring; this base owns the multi-selection store and the trailing
+/// select-all + Combine header cluster so that dispatch and action wiring stay
+/// in one place.
+abstract class BaseUnitsPanelState<W extends StatefulWidget> extends State<W> {
+  /// Set-backed multi-selection store shared by the combine-capable panels.
+  ///
+  /// Subclasses derive the canonical selection id per row (army id, or the
+  /// home-fleet id for the Home Fleet) and pass it to [toggleSelection] /
+  /// [selectAllOrClear] and read membership via [isSelected].
+  final UnitsMultiSelectionController selection = UnitsMultiSelectionController();
+
+  /// Adds [id] when absent / removes it when present, inside [setState].
+  void toggleSelection(String id) => setState(() => selection.toggle(id));
+
+  /// Select-all header behaviour for [allIds] (select all, else clear when all
+  /// already selected), inside [setState].
+  void selectAllOrClear(Iterable<String> allIds) =>
+      setState(() => selection.selectAllOrClear(allIds));
+
+  /// Clears the entire selection inside [setState].
+  void clearSelection() => setState(selection.clear);
+
+  /// Whether [id] is currently selected.
+  bool isSelected(String id) => selection.contains(id);
+
+  /// Header checkbox tri-state for [allIds] (`true` all / `false` none /
+  /// `null` partial). See [UnitsMultiSelectionController.headerValue].
+  bool? headerValueFor(Iterable<String> allIds) =>
+      selection.headerValue(allIds);
+
+  /// Assembles the panel's [UnitsPanelShell], composing [leadingActions], the
+  /// optional select-all + Combine cluster, and [trailingActions] into the top
+  /// bar's trailing slot.
+  ///
+  /// When [showCombineCluster] is true the cluster is inserted between leading
+  /// and trailing actions with the same widgets and ordering the panels
+  /// inlined before (see [unitsCombineHeaderActions]); the header tri-state is
+  /// derived from [selectableIds]. Passing [panelConstraints] overrides the
+  /// shell's default size (naval scales on wide viewports); omit it for the
+  /// default panel constraints.
+  @protected
+  Widget buildUnitsPanel({
+    required String title,
+    List<Widget> leadingActions = const <Widget>[],
+    required bool showCombineCluster,
+    required Iterable<String> selectableIds,
+    required String selectAllTooltip,
+    required String deselectAllTooltip,
+    required String combineLabel,
+    required bool canCombine,
+    required VoidCallback onSelectAll,
+    required VoidCallback onCombine,
+    List<Widget> trailingActions = const <Widget>[],
+    required bool hasContent,
+    required List<Widget> listChildren,
+    required String emptyMessage,
+    BoxConstraints? panelConstraints,
+  }) {
+    return UnitsPanelShell(
+      title: title,
+      actions: <Widget>[
+        ...leadingActions,
+        if (showCombineCluster)
+          ...unitsCombineHeaderActions(
+            headerValue: selection.headerValue(selectableIds),
+            selectAllTooltip: selectAllTooltip,
+            deselectAllTooltip: deselectAllTooltip,
+            combineLabel: combineLabel,
+            canCombine: canCombine,
+            onSelectAll: onSelectAll,
+            onCombine: onCombine,
+          ),
+        ...trailingActions,
+      ],
+      hasContent: hasContent,
+      listChildren: listChildren,
+      emptyMessage: emptyMessage,
+      panelConstraints:
+          panelConstraints ?? UnitsPanelShell.defaultPanelConstraints,
+    );
+  }
+}

--- a/app/test/base_units_panel_test.dart
+++ b/app/test/base_units_panel_test.dart
@@ -1,0 +1,270 @@
+// Widget/unit tests for the shared `BaseUnitsPanelState` base extracted from the
+// military / naval unit panels (Refs #3546 target state #2, AC4 / AC5 / AC10).
+//
+// AC4: the base centralises selection dispatch and the combine-cluster action
+// wiring shared by the combine-capable panels.
+// AC5: `CivilianUnitsPanel` deliberately does NOT use this base (it is a
+// single-select, non-combinable `ConsumerStatefulWidget`); a structural test
+// asserts the documented divergence.
+
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:colonizethis_app/features/game/widgets/chrome/ct_action_text_button.dart';
+import 'package:colonizethis_app/features/game/widgets/civilian_units_panel.dart';
+import 'package:colonizethis_app/features/game/widgets/units/shared/base_units_panel.dart';
+
+/// Minimal panel exercising [BaseUnitsPanelState.buildUnitsPanel] and the shared
+/// selection-dispatch surface without pulling in the full military/naval trees.
+class _HarnessPanel extends StatefulWidget {
+  const _HarnessPanel({
+    required this.selectableIds,
+    this.showCombineCluster = true,
+    this.canCombine = true,
+    this.leading = const <Widget>[],
+    this.trailing = const <Widget>[],
+    this.onSelectAll,
+    this.onCombine,
+  });
+
+  final List<String> selectableIds;
+  final bool showCombineCluster;
+  final bool canCombine;
+  final List<Widget> leading;
+  final List<Widget> trailing;
+  final VoidCallback? onSelectAll;
+  final VoidCallback? onCombine;
+
+  @override
+  State<_HarnessPanel> createState() => _HarnessPanelState();
+}
+
+class _HarnessPanelState extends BaseUnitsPanelState<_HarnessPanel> {
+  @override
+  Widget build(BuildContext context) {
+    return buildUnitsPanel(
+      title: 'Test Panel',
+      leadingActions: widget.leading,
+      showCombineCluster: widget.showCombineCluster,
+      selectableIds: widget.selectableIds,
+      selectAllTooltip: 'Select all',
+      deselectAllTooltip: 'Deselect all',
+      combineLabel: 'Combine',
+      canCombine: widget.canCombine,
+      onSelectAll: () {
+        widget.onSelectAll?.call();
+        selectAllOrClear(widget.selectableIds);
+      },
+      onCombine: () => widget.onCombine?.call(),
+      trailingActions: widget.trailing,
+      hasContent: true,
+      listChildren: const [Text('row')],
+      emptyMessage: 'empty',
+    );
+  }
+}
+
+Future<_HarnessPanelState> _pumpHarness(
+  WidgetTester tester, {
+  required List<String> selectableIds,
+  bool showCombineCluster = true,
+  bool canCombine = true,
+  List<Widget> leading = const <Widget>[],
+  List<Widget> trailing = const <Widget>[],
+  VoidCallback? onSelectAll,
+  VoidCallback? onCombine,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: _HarnessPanel(
+          selectableIds: selectableIds,
+          showCombineCluster: showCombineCluster,
+          canCombine: canCombine,
+          leading: leading,
+          trailing: trailing,
+          onSelectAll: onSelectAll,
+          onCombine: onCombine,
+        ),
+      ),
+    ),
+  );
+  return tester.state<_HarnessPanelState>(find.byType(_HarnessPanel));
+}
+
+void main() {
+  suppressLogsForTests();
+
+  group('BaseUnitsPanelState selection dispatch', () {
+    testWidgets('toggleSelection adds/removes ids and rebuilds', (tester) async {
+      final state = await _pumpHarness(tester, selectableIds: ['a', 'b']);
+      expect(state.isSelected('a'), isFalse);
+
+      state.toggleSelection('a');
+      await tester.pump();
+      expect(state.isSelected('a'), isTrue);
+
+      state.toggleSelection('a');
+      await tester.pump();
+      expect(state.isSelected('a'), isFalse);
+    });
+
+    testWidgets('selectAllOrClear selects all then clears', (tester) async {
+      final state = await _pumpHarness(tester, selectableIds: ['a', 'b']);
+
+      state.selectAllOrClear(['a', 'b']);
+      await tester.pump();
+      expect(state.selection.selectedIds, {'a', 'b'});
+
+      state.selectAllOrClear(['a', 'b']);
+      await tester.pump();
+      expect(state.selection.isEmpty, isTrue);
+    });
+
+    testWidgets('clearSelection empties the store', (tester) async {
+      final state = await _pumpHarness(tester, selectableIds: ['a', 'b']);
+      state.selectAllOrClear(['a', 'b']);
+      await tester.pump();
+
+      state.clearSelection();
+      await tester.pump();
+      expect(state.selection.isEmpty, isTrue);
+    });
+
+    testWidgets('headerValueFor mirrors the controller tri-state', (
+      tester,
+    ) async {
+      final state = await _pumpHarness(tester, selectableIds: ['a', 'b']);
+      expect(state.headerValueFor(['a', 'b']), isFalse);
+
+      state.toggleSelection('a');
+      await tester.pump();
+      expect(state.headerValueFor(['a', 'b']), isNull);
+
+      state.toggleSelection('b');
+      await tester.pump();
+      expect(state.headerValueFor(['a', 'b']), isTrue);
+    });
+  });
+
+  group('BaseUnitsPanelState.buildUnitsPanel action wiring', () {
+    testWidgets('renders the select-all + Combine cluster when shown', (
+      tester,
+    ) async {
+      await _pumpHarness(tester, selectableIds: ['a', 'b']);
+
+      expect(find.byType(Checkbox), findsOneWidget);
+      final combine = tester.widget<CtActionTextButton>(
+        find.byType(CtActionTextButton),
+      );
+      expect(combine.label, 'Combine');
+      expect(combine.primary, isTrue);
+    });
+
+    testWidgets('omits the cluster when showCombineCluster is false', (
+      tester,
+    ) async {
+      await _pumpHarness(
+        tester,
+        selectableIds: ['a', 'b'],
+        showCombineCluster: false,
+      );
+
+      expect(find.byType(Checkbox), findsNothing);
+      expect(find.text('Combine'), findsNothing);
+    });
+
+    testWidgets('header checkbox value reflects current selection', (
+      tester,
+    ) async {
+      final state = await _pumpHarness(tester, selectableIds: ['a', 'b']);
+      expect(tester.widget<Checkbox>(find.byType(Checkbox)).value, isFalse);
+
+      state.selectAllOrClear(['a', 'b']);
+      await tester.pump();
+      expect(tester.widget<Checkbox>(find.byType(Checkbox)).value, isTrue);
+    });
+
+    testWidgets('tapping the checkbox invokes onSelectAll and selects all', (
+      tester,
+    ) async {
+      var selectAllTaps = 0;
+      final state = await _pumpHarness(
+        tester,
+        selectableIds: ['a', 'b'],
+        onSelectAll: () => selectAllTaps++,
+      );
+
+      await tester.tap(find.byType(Checkbox));
+      await tester.pump();
+      expect(selectAllTaps, 1);
+      expect(state.selection.selectedIds, {'a', 'b'});
+    });
+
+    testWidgets('Combine pill is disabled when canCombine is false', (
+      tester,
+    ) async {
+      await _pumpHarness(
+        tester,
+        selectableIds: ['a', 'b'],
+        canCombine: false,
+      );
+      final combine = tester.widget<CtActionTextButton>(
+        find.byType(CtActionTextButton),
+      );
+      expect(combine.enabled, isFalse);
+      expect(combine.onPressed, isNull);
+    });
+
+    testWidgets('Combine pill invokes onCombine when enabled', (tester) async {
+      var combined = 0;
+      await _pumpHarness(
+        tester,
+        selectableIds: ['a', 'b'],
+        onCombine: () => combined++,
+      );
+      await tester.tap(find.text('Combine'));
+      await tester.pump();
+      expect(combined, 1);
+    });
+
+    testWidgets('orders leading → cluster → trailing actions left to right', (
+      tester,
+    ) async {
+      await _pumpHarness(
+        tester,
+        selectableIds: ['a', 'b'],
+        leading: [const Icon(Icons.flag, key: Key('lead'))],
+        trailing: [const Icon(Icons.add, key: Key('trail'))],
+      );
+
+      final leadX = tester.getTopLeft(find.byKey(const Key('lead'))).dx;
+      final checkboxX = tester.getTopLeft(find.byType(Checkbox)).dx;
+      final combineX = tester.getTopLeft(find.byType(CtActionTextButton)).dx;
+      final trailX = tester.getTopLeft(find.byKey(const Key('trail'))).dx;
+
+      expect(leadX, lessThan(checkboxX));
+      expect(checkboxX, lessThan(combineX));
+      expect(combineX, lessThan(trailX));
+    });
+  });
+
+  group('AC5 — CivilianUnitsPanel divergence', () {
+    test('CivilianUnitsPanel keeps the Riverpod ConsumerStatefulWidget '
+        'convention (single-select, non-combinable)', () {
+      // Civilian rows are single-select and non-combinable, so the panel keeps
+      // its `ConsumerStatefulWidget` convention and does not adopt the
+      // multi-selection `BaseUnitsPanelState`. Asserted without instantiating
+      // (which would require a full Game) via Dart's covariant generics; the
+      // `Object`-typed reference keeps this a genuine runtime check.
+      final Object civilianPanels = <CivilianUnitsPanel>[];
+      expect(
+        civilianPanels is List<ConsumerStatefulWidget>,
+        isTrue,
+        reason: 'CivilianUnitsPanel must remain a ConsumerStatefulWidget',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Follow-up slice for the `app/` deduplication tracked by #3546 — target state **#2** (`BaseUnitsPanel<T>`), the highest-value remaining item after PR #3557 (selection-dispatch store + combine-header cluster) merged to `dev`.

PR #3557 already extracted the selection **store** (`UnitsMultiSelectionController`) and the combine-cluster **action widgets** (`unitsCombineHeaderActions`). The two combine-capable panels still each re-declared the controller field, the same `setState`-wrapped selection dispatch, and the same `build`-time assembly of the trailing select-all + Combine cluster into a `UnitsPanelShell`.

This introduces the `BaseUnitsPanel<T>` abstraction the issue calls for, realised as a shared `State` base.

## Done in this push (Refs #3546)

- **`BaseUnitsPanelState<W>`** (`units/shared/base_units_panel.dart`) owns:
  - the `UnitsMultiSelectionController`,
  - the `setState`-wrapped selection dispatch (`toggleSelection`, `selectAllOrClear`, `clearSelection`) and queries (`isSelected`, `headerValueFor`),
  - `buildUnitsPanel(...)` which composes leading actions + the optional select-all/Combine cluster + trailing actions into a `UnitsPanelShell`, preserving the exact prior action ordering and spacing.
- **`MilitaryUnitsPanel`** and **`NavalUnitsPanel`** states now `extend BaseUnitsPanelState<…>` and drop their duplicated controller field, dispatch wrappers, and inline cluster assembly. No behaviour change (net ~94 lines removed from the panels).
- **AC5 divergence:** `CivilianUnitsPanel` deliberately stays a single-select, non-combinable Riverpod `ConsumerStatefulWidget` and does not adopt the base; documented in code and asserted in tests.
- **Tests (AC10):** new `app/test/base_units_panel_test.dart` covers selection dispatch, the combine-cluster action wiring + left-to-right ordering, header tri-state, and the civilian divergence.

## Deferred / remaining for #3546

- Widgetbook catalog domain reorg + `repo.app_widgetbook_file_naming` CI rule (item 4 / AC7 + remaining CI AC). Untouched here.

No SPEC change required (structural refactor; convention `StatefulWidget` vs `ConsumerStatefulWidget` resolved per AC5 by documented civilian divergence).

## Test plan

- [x] `flutter analyze` clean on touched files
- [x] New base test passes (`base_units_panel_test.dart`)
- [x] Existing shared-selection tests pass (`units_multi_selection_controller_test.dart`, `units_combine_header_actions_test.dart`)
- [x] Full military panel suites pass (parts 1–6)
- [x] Full naval panel suites pass (parts 1–5 + mockup fidelity)

Refs #3546

Made with [Cursor](https://cursor.com)