### PR TITLE
refactor(diplomacy): canonical full-faction overture teardown helper (#3562)

### DIFF
--- a/packages/colonizethis_diplomacy/lib/src/diplomacy/diplomacy_relation_lookup.dart
+++ b/packages/colonizethis_diplomacy/lib/src/diplomacy/diplomacy_relation_lookup.dart
@@ -200,6 +200,13 @@ Map<String, OvertureState> _overtureStatesByLookupKey(Game game) =>
 /// Finds the relation, passes it (or null) to [updater], and replaces or
 /// appends the result.
 ///
+/// **Soft-deprecated for batched/loop use in favour of [RelationUpsertIndex]**
+/// (Refs #3562 AC5). It is not annotated `@Deprecated` because it remains the
+/// correct primitive for a genuinely *single* isolated upsert, and a hard
+/// annotation would wrongly flag those legitimate call sites; instead the
+/// acceptable single-call-vs-batched guidance is documented here and at the
+/// remaining single-call sites.
+///
 /// Each call rebuilds the `pairKey → firstIndex` map and copies the whole
 /// relations list, so it is O(relations) per call. Use it only for a **single
 /// isolated upsert** (one accepted order / one resolver event). For **repeated**

--- a/packages/colonizethis_diplomacy/lib/src/diplomacy/diplomacy_shared_helpers.dart
+++ b/packages/colonizethis_diplomacy/lib/src/diplomacy/diplomacy_shared_helpers.dart
@@ -107,6 +107,42 @@ bool isAiControlledForEvidence(Game game, String playerId) {
   return (game: game.copyWith(overtureStates: kept), removed: removed);
 }
 
+/// Removes every overture that involves [factionId] on **either** side from
+/// [game] (i.e. `o.gpId == factionId || o.targetId == factionId`).
+///
+/// Canonical full-faction-teardown counterpart to the pair-scoped
+/// [clearOverturesBetweenGpAndFaction] (Refs #3562 AC1). Use this when an entire
+/// faction is being removed — Join-Empire absorption of a Minor/Tribe or a Great
+/// Power — so its inbound and outbound overtures all disappear regardless of the
+/// counterpart. The pair-scoped helper, by contrast, clears only a single
+/// GP↔faction pairing and is the wrong tool here.
+///
+/// Minor/Tribe targets never originate overtures (overtures are GP→target), so
+/// for them the either-side filter is equivalent to the previous
+/// `targetId == factionId` block; for an absorbed Great Power the either-side
+/// filter matches the previous `gpId == factionId || targetId == factionId`
+/// block. Both prior inline blocks are therefore behaviour-preserving here.
+///
+/// Returns the (possibly unchanged) game alongside the overtures that were
+/// removed, in their original `game.overtureStates` order. When nothing matches
+/// the original [game] instance is returned with an empty `removed` list.
+({Game game, List<OvertureState> removed}) clearOverturesInvolvingFaction(
+  Game game,
+  String factionId,
+) {
+  final removed = <OvertureState>[];
+  final kept = <OvertureState>[];
+  for (final o in game.overtureStates) {
+    if (o.gpId == factionId || o.targetId == factionId) {
+      removed.add(o);
+    } else {
+      kept.add(o);
+    }
+  }
+  if (removed.isEmpty) return (game: game, removed: const <OvertureState>[]);
+  return (game: game.copyWith(overtureStates: kept), removed: removed);
+}
+
 /// Returns the first decision in [decisions] for which [matches] is true, or
 /// null when [decisions] is null or no entry matches.
 ///

--- a/packages/colonizethis_diplomacy/lib/src/diplomacy/faction_absorption_engine.dart
+++ b/packages/colonizethis_diplomacy/lib/src/diplomacy/faction_absorption_engine.dart
@@ -214,9 +214,12 @@ Game _absorbIntoGp(
       tribes = next.tribes.where((t) => t.id != absorbedFactionId).toList();
     }
 
-    final overtures = next.overtureStates
-        .where((o) => o.targetId != absorbedFactionId)
-        .toList();
+    // Canonical full-faction overture teardown (Refs #3562 AC1) replaces the
+    // prior inline `targetId == absorbedFactionId` filter. Minor/Tribe targets
+    // never originate overtures, so clearing either side is equivalent here.
+    final overtures =
+        clearOverturesInvolvingFaction(next, absorbedFactionId).game
+            .overtureStates;
 
     final relations = next.diplomacyRelations
         .where(
@@ -243,11 +246,11 @@ Game _absorbIntoGp(
   final glyphs = Map<String, String>.from(next.politicalGlyphByPlayerId)
     ..remove(absorbedFactionId);
 
-  final overtures = next.overtureStates
-      .where(
-        (o) => o.gpId != absorbedFactionId && o.targetId != absorbedFactionId,
-      )
-      .toList();
+  // Canonical full-faction overture teardown (Refs #3562 AC1) replaces the prior
+  // inline `gpId == absorbedFactionId || targetId == absorbedFactionId` filter.
+  final overtures =
+      clearOverturesInvolvingFaction(next, absorbedFactionId).game
+          .overtureStates;
 
   final relations = next.diplomacyRelations
       .where(

--- a/packages/colonizethis_diplomacy/test/diplomacy_dedup_helpers_test.dart
+++ b/packages/colonizethis_diplomacy/test/diplomacy_dedup_helpers_test.dart
@@ -9,7 +9,9 @@ import 'test_fixtures.dart';
 /// the generic [indexByKey] builder (AC2), the relocated
 /// [isAiControlledForEvidence] helper now living in the diplomacy shared
 /// helpers (AC6), the [logDiplomaticEvent] append+log helper (AC4), and the
-/// canonical [clearOverturesBetweenGpAndFaction] overture-clearing helper (AC1).
+/// canonical [clearOverturesBetweenGpAndFaction] pair-scoped and
+/// [clearOverturesInvolvingFaction] full-faction-teardown overture-clearing
+/// helpers (AC1).
 void main() {
   group('clearOverturesBetweenGpAndFaction (AC1)', () {
     Game gameWithOvertures(List<OvertureState> overtures) =>
@@ -89,6 +91,73 @@ void main() {
     test('negative: empty overtures yields no removals and same game', () {
       final game = gameWithOvertures(const []);
       final result = clearOverturesBetweenGpAndFaction(game, 'gp1', 'minor1');
+      expect(result.removed, isEmpty);
+      expect(identical(result.game, game), isTrue);
+    });
+  });
+
+  group('clearOverturesInvolvingFaction (AC1, full-faction teardown)', () {
+    Game gameWithOvertures(List<OvertureState> overtures) =>
+        TestFixtures.minimalGame(
+          players: const [Player(id: 'gp1', displayName: 'A', isHuman: false)],
+          overtureStates: overtures,
+        );
+
+    test('positive: removes overtures involving the faction on either side', () {
+      final game = gameWithOvertures(const [
+        OvertureState(gpId: 'gp1', targetId: 'minor1'),
+        OvertureState(gpId: 'gp2', targetId: 'gp1'),
+        OvertureState(gpId: 'gp2', targetId: 'minor2'),
+      ]);
+
+      final result = clearOverturesInvolvingFaction(game, 'gp1');
+
+      expect(result.removed, hasLength(2));
+      expect(result.removed.map((o) => '${o.gpId}|${o.targetId}'), [
+        'gp1|minor1',
+        'gp2|gp1',
+      ]);
+      expect(
+        result.game.overtureStates.map((o) => '${o.gpId}|${o.targetId}'),
+        ['gp2|minor2'],
+      );
+    });
+
+    test(
+      'positive: minor/tribe target equivalence (only appears as targetId)',
+      () {
+        // Overtures are GP-originated, so a Minor/Tribe never appears as gpId.
+        // Either-side removal therefore matches the prior `targetId` filter.
+        final game = gameWithOvertures(const [
+          OvertureState(gpId: 'gp1', targetId: 'minor1'),
+          OvertureState(gpId: 'gp2', targetId: 'minor1'),
+          OvertureState(gpId: 'gp1', targetId: 'minor2'),
+        ]);
+
+        final result = clearOverturesInvolvingFaction(game, 'minor1');
+
+        expect(result.removed, hasLength(2));
+        expect(
+          result.game.overtureStates.map((o) => '${o.gpId}|${o.targetId}'),
+          ['gp1|minor2'],
+        );
+      },
+    );
+
+    test('negative: no matching faction leaves the game instance unchanged', () {
+      final game = gameWithOvertures(const [
+        OvertureState(gpId: 'gp1', targetId: 'minor1'),
+      ]);
+
+      final result = clearOverturesInvolvingFaction(game, 'gp9');
+
+      expect(result.removed, isEmpty);
+      expect(identical(result.game, game), isTrue);
+    });
+
+    test('negative: empty overtures yields no removals and same game', () {
+      final game = gameWithOvertures(const []);
+      final result = clearOverturesInvolvingFaction(game, 'gp1');
       expect(result.removed, isEmpty);
       expect(identical(result.game, game), isTrue);
     });


### PR DESCRIPTION
## Summary

Follow-up PR closing the two gaps the latest verification pass flagged on #3562 (prior PR #3563 already merged). Targets `dev`.

### Done in this push

- **AC1 (overture-clearing dedup) — gap closed.** `faction_absorption_engine.dart` still carried two inline overture-clearing filter blocks (Minor/Tribe path and Great Power path). These are *full-faction teardown* (remove every overture involving the absorbed faction, either side) and are semantically distinct from the pair-scoped `clearOverturesBetweenGpAndFaction`. Extracted a canonical sibling helper **`clearOverturesInvolvingFaction(game, factionId)`** in `diplomacy_shared_helpers.dart` and routed both absorption sites through it, removing the last inline overture filter blocks.
  - **Behaviour preserved:** overtures are GP-originated, so a Minor/Tribe never appears as `gpId`; either-side removal therefore equals the prior `targetId`-only filter on the Minor/Tribe path, and matches the prior `gpId || targetId` filter on the GP path.
  - Added focused positive/negative unit tests for the new helper.
- **AC5 (`upsertRelation` deprecation) — documentation route tightened.** The three remaining standalone single-upsert call sites (`intervention_resolver_apply.dart`, `intervention_resolver_call_to_arms.dart`) already carry explicit justification comments. Strengthened the `upsertRelation` doc to state it is **soft-deprecated for batched/loop use** in favour of `RelationUpsertIndex` while remaining the correct primitive for a genuinely single isolated upsert. A hard `@Deprecated` annotation is intentionally avoided because it would wrongly flag those legitimate single-call sites (and the AC permits "annotated `@Deprecated` and/or documented").

### Design note

This introduces a second overture-clearing helper rather than overloading the pair-scoped one. The pair-scoped `clearOverturesBetweenGpAndFaction` needs a GP↔faction pair; full-faction teardown only has a single faction id, so a dedicated `clearOverturesInvolvingFaction` is the correct, behaviour-preserving deduplication (the previous verification pass already acknowledged absorption as "a distinct single-faction operation").

### Verification

- `cd packages/colonizethis_diplomacy && dart test` → **245 tests passed** (+4 new).
- `dart run tool/ct_repo_lint.dart --rule repo.diplomacy_no_duplicate_overture_clear` → passed.
- `dart analyze lib test` on changed files clean (6 remaining issues are pre-existing on `dev`, in untouched files).

### Not in scope

No SPEC changes (pure behaviour-preserving refactor). No new behavior.

Refs #3562

Made with [Cursor](https://cursor.com)