### PR TITLE
refactor: dedup turn-package helpers and adopt phase adapters (#3565)

### DIFF
--- a/packages/colonizethis_turn/lib/src/turn/economy_preview_pipeline.dart
+++ b/packages/colonizethis_turn/lib/src/turn/economy_preview_pipeline.dart
@@ -17,6 +17,27 @@ const List<EconomyPreviewStockpilePhase> _economyPreviewStockpilePhases =
       EconomyPreviewStockpilePhase.production,
     ];
 
+/// Builds the [EconomyPhaseStepContext] shared by the preview entry points
+/// ([economyPreviewStockpilePhaseDeltasForPlayer] and
+/// [applyEconomyPhasesForPreview]). Centralizing construction keeps the common
+/// economy-preview context fields in one place so a new field is threaded once
+/// (extract-at-2+-uses; preview context is identical across both call sites).
+EconomyPhaseStepContext _economyPreviewStepContext({
+  required MapTopology topology,
+  Map<String, TileMapResult>? tileMapByRegion,
+  Map<String, Map<CommodityId, int>> extractedByPlayerId = const {},
+  List<AssignedRecipe> defaultAssignments = const [],
+  Map<String, List<AssignedRecipe>>? defaultAssignmentsByPlayerId,
+}) {
+  return EconomyPhaseStepContext(
+    topology: topology,
+    tileMapByRegion: tileMapByRegion,
+    extractedByPlayerId: extractedByPlayerId,
+    defaultAssignments: defaultAssignments,
+    defaultAssignmentsByPlayerId: defaultAssignmentsByPlayerId,
+  );
+}
+
 Map<String, int> _stockpileCommodityDeltaMap(
   Stockpile before,
   Stockpile after,
@@ -244,7 +265,7 @@ economyPreviewStockpilePhaseDeltasForPlayer({
     stockpileForViewed(acc.game),
   );
 
-  final economyCtx = EconomyPhaseStepContext(
+  final economyCtx = _economyPreviewStepContext(
     topology: topology,
     tileMapByRegion: tileMapByRegion,
     extractedByPlayerId: extractedByPlayerId,
@@ -284,7 +305,7 @@ Game applyEconomyPhasesForPreview({
   );
   acc = runEconomyPhaseSequence(
     acc,
-    EconomyPhaseStepContext(
+    _economyPreviewStepContext(
       topology: topology,
       tileMapByRegion: tileMapByRegion,
       extractedByPlayerId: extractedByPlayerId,

--- a/packages/colonizethis_turn/lib/src/turn/economy_preview_pipeline.dart
+++ b/packages/colonizethis_turn/lib/src/turn/economy_preview_pipeline.dart
@@ -42,15 +42,39 @@ Map<String, int> _stockpileCommodityDeltaMap(
 /// preview clone. Re-uses [canAffordRecruitWorker] / [applyRecruitWorkerCostDeduction]
 /// so the projection shares the validator/resolver cost source of truth.
 /// SPEC/program/order-projections.md § Production panel stockpile preview phases.
-Game _applyPendingRecruitWorkerOrderCostsForPreview({
+/// Applies pending per-player [O] order costs onto a preview clone, sharing the
+/// `canAfford` → `applyDeduction` → `copyWith(workerPool, stockpile, treasury)`
+/// loop used by both the worker-pool (recruit) and unit-build sub-phases.
+///
+/// [canAffordOrder] gates each order; [applyDeduction] returns the next
+/// `(workers, stockpile, treasury)` snapshot. Both close over the order-type's
+/// validator/resolver so the projection shares the live cost source of truth.
+/// Per-player iteration follows [Game.mapPlayers] for deterministic order.
+Game _applyPendingOrderCostsForPreview<O>({
   required Game game,
-  required Orders currentOrders,
+  required Map<String, List<O>> ordersByPlayerId,
+  required bool Function(
+    Player player,
+    O order,
+    WorkerPool workers,
+    Stockpile stockpile,
+    int treasury,
+  )
+  canAffordOrder,
+  required ({WorkerPool workers, Stockpile stockpile, int treasury}) Function(
+    Player player,
+    O order,
+    WorkerPool workers,
+    Stockpile stockpile,
+    int treasury,
+  )
+  applyDeduction,
 }) {
-  if (currentOrders.recruitWorkerOrdersByPlayerId.isEmpty) {
+  if (ordersByPlayerId.isEmpty) {
     return game;
   }
   return game.mapPlayers((player) {
-    final orders = currentOrders.recruitWorkerOrdersByPlayerId[player.id];
+    final orders = ordersByPlayerId[player.id];
     if (orders == null || orders.isEmpty) {
       return player;
     }
@@ -58,68 +82,10 @@ Game _applyPendingRecruitWorkerOrderCostsForPreview({
     var stockpile = player.stockpile;
     var treasury = player.treasury;
     for (final order in orders) {
-      final check = canAffordRecruitWorker(
-        player,
-        order,
-        workers,
-        stockpile,
-        treasury,
-      );
-      if (!check.canAfford) {
+      if (!canAffordOrder(player, order, workers, stockpile, treasury)) {
         continue;
       }
-      final after = applyRecruitWorkerCostDeduction(
-        order,
-        workers,
-        stockpile,
-        treasury,
-      );
-      workers = after.workers;
-      stockpile = after.stockpile;
-      treasury = after.treasury;
-    }
-    return player.copyWith(
-      workerPool: workers,
-      stockpile: stockpile,
-      treasury: treasury,
-    );
-  });
-}
-
-Game _applyPendingBuildOrderCostsForPreview({
-  required Game game,
-  required Orders currentOrders,
-}) {
-  if (currentOrders.buildUnitOrdersByPlayerId.isEmpty) {
-    return game;
-  }
-  return game.mapPlayers((player) {
-    var workers = player.workerPool;
-    var stockpile = player.stockpile;
-    var treasury = player.treasury;
-    final orders =
-        currentOrders.buildUnitOrdersByPlayerId[player.id] ?? const [];
-    if (orders.isEmpty) {
-      return player;
-    }
-    for (final order in orders) {
-      final check = ProjectedCostEngine.canAffordBuildOrder(
-        player,
-        order,
-        workers,
-        stockpile,
-        treasury,
-      );
-      if (!check.canAfford) {
-        continue;
-      }
-      final after = ProjectedCostEngine.applyBuildOrderCostDeduction(
-        player,
-        order,
-        workers,
-        stockpile,
-        treasury,
-      );
+      final after = applyDeduction(player, order, workers, stockpile, treasury);
       workers = after.workers;
       stockpile = after.stockpile;
       treasury = after.treasury;
@@ -199,13 +165,39 @@ Game _applyPendingStockpileCostsForPreview({
   required Game game,
   required Orders currentOrders,
 }) {
-  final afterRecruits = _applyPendingRecruitWorkerOrderCostsForPreview(
+  final afterRecruits = _applyPendingOrderCostsForPreview<RecruitWorkerOrder>(
     game: game,
-    currentOrders: currentOrders,
+    ordersByPlayerId: currentOrders.recruitWorkerOrdersByPlayerId,
+    canAffordOrder: (player, order, workers, stockpile, treasury) =>
+        canAffordRecruitWorker(
+          player,
+          order,
+          workers,
+          stockpile,
+          treasury,
+        ).canAfford,
+    applyDeduction: (player, order, workers, stockpile, treasury) =>
+        applyRecruitWorkerCostDeduction(order, workers, stockpile, treasury),
   );
-  final afterBuilds = _applyPendingBuildOrderCostsForPreview(
+  final afterBuilds = _applyPendingOrderCostsForPreview<BuildUnitOrder>(
     game: afterRecruits,
-    currentOrders: currentOrders,
+    ordersByPlayerId: currentOrders.buildUnitOrdersByPlayerId,
+    canAffordOrder: (player, order, workers, stockpile, treasury) =>
+        ProjectedCostEngine.canAffordBuildOrder(
+          player,
+          order,
+          workers,
+          stockpile,
+          treasury,
+        ).canAfford,
+    applyDeduction: (player, order, workers, stockpile, treasury) =>
+        ProjectedCostEngine.applyBuildOrderCostDeduction(
+          player,
+          order,
+          workers,
+          stockpile,
+          treasury,
+        ),
   );
   return _applyPendingMaterialWorkOrderCostsForPreview(
     game: afterBuilds,
@@ -341,15 +333,7 @@ Map<String, int> previewStockpileNetDeltaByCommodityForPlayer({
     defaultAssignmentsByPlayerId: defaultAssignmentsByPlayerId,
   );
   final after = afterGame.playerById(playerId)?.stockpile ?? before;
-  final keys = <String>{...before.quantities.keys, ...after.quantities.keys};
-  final out = <String, int>{};
-  for (final id in keys) {
-    final delta = after.quantityOf(id) - before.quantityOf(id);
-    if (delta != 0) {
-      out[id] = delta;
-    }
-  }
-  return out;
+  return _stockpileCommodityDeltaMap(before, after);
 }
 
 /// Per-phase stockpile commodity deltas for the production panel breakdown

--- a/packages/colonizethis_turn/lib/src/turn/end_of_turn_resolver.dart
+++ b/packages/colonizethis_turn/lib/src/turn/end_of_turn_resolver.dart
@@ -113,7 +113,7 @@ void _emitEraChangeDialogue(
   final previousEra = eraFromYear(mapping.yearAtTurn(currentTurn));
   final newEra = eraFromYear(mapping.yearAtTurn(nextTurn));
   if (previousEra == newEra) return;
-  final seed = (game.globalGameSeed ?? 0) ^ (nextTurn * kTurnResolutionSeedMix);
+  final seed = mixTurnSeed(game, nextTurn);
   final events = dialogueEventsForEraChange(game, previousEra, newEra, seed);
   for (final e in events) {
     onDialogue(e);

--- a/packages/colonizethis_turn/lib/src/turn/naval_resolution.dart
+++ b/packages/colonizethis_turn/lib/src/turn/naval_resolution.dart
@@ -115,9 +115,7 @@ Game runNavalInterceptionCombatPhase(
     for (final b in battles)
       normalizeNavalBattleSidesForAttacker(b, game, movedFleetIds),
   ];
-  var seed =
-      (game.globalGameSeed ?? 0) ^
-      (game.worldState.turnState.turnNumber * kTurnResolutionSeedMix);
+  var seed = mixTurnSeed(game, game.worldState.turnState.turnNumber);
   battles = filterBattlesByInterception(game, battles, movedFleetIds, seed);
   turnLog.d('naval phase after interception battles=${battles.length}');
   seed =

--- a/packages/colonizethis_turn/lib/src/turn/phases/combat_phase.dart
+++ b/packages/colonizethis_turn/lib/src/turn/phases/combat_phase.dart
@@ -69,8 +69,7 @@ Game runCombatPhase(
   };
   Game state = game;
   final turn = state.worldState.turnState.turnNumber;
-  final preBattleDialogueSeed =
-      (game.globalGameSeed ?? 0) ^ (turn * kTurnResolutionSeedMix);
+  final preBattleDialogueSeed = mixTurnSeed(game, turn);
   state = applyUnopposedProvinceCaptures(state, orders);
   turnLog.i('combat conflict_detection start turn=$turn');
   final battles = detectConflicts(state, orders);
@@ -93,7 +92,7 @@ Game runCombatPhase(
     ledger: combatGeneralLedger,
   );
   final defaultMode = game.defaultCombatMode ?? CombatMode.autoResolve;
-  var seed = (game.globalGameSeed ?? 0) ^ (turn * kTurnResolutionSeedMix);
+  var seed = mixTurnSeed(game, turn);
   var battleIndex = 0;
   for (final ctx in boundBattles) {
     final mode = resolveCombatModeForBattle(

--- a/packages/colonizethis_turn/lib/src/turn/phases/consumption_phase.dart
+++ b/packages/colonizethis_turn/lib/src/turn/phases/consumption_phase.dart
@@ -5,6 +5,7 @@ import 'package:colonizethis_world/colonizethis_world.dart';
 import '../economy_phase_sequence.dart';
 import '../turn_phase_handler_helpers.dart';
 import '../turn_pipeline_state.dart';
+import '../turn_resolution_helpers.dart';
 import '../turn_resolver_config.dart';
 
 /// Consumption phase; returns new pipeline state with updated feeding maps.
@@ -35,24 +36,14 @@ TurnPipelineState runConsumptionPipelinePhase(TurnPipelineState acc) {
       shipCountsById: shipCounts,
     );
 
-    double landCoverage;
-    if (result.totalRegiments <= 0) {
-      landCoverage = 1.0;
-    } else {
-      landCoverage = result.fullyFedRegiments / result.totalRegiments;
-      if (landCoverage < 0) landCoverage = 0;
-      if (landCoverage > 1) landCoverage = 1;
-    }
+    final landCoverage = result.totalRegiments <= 0
+        ? 1.0
+        : clamp01(result.fullyFedRegiments / result.totalRegiments);
     landFeeding[player.id] = landCoverage;
 
-    double navalCoverage;
-    if (result.totalShips <= 0) {
-      navalCoverage = 1.0;
-    } else {
-      navalCoverage = result.fullyFedShips / result.totalShips;
-      if (navalCoverage < 0) navalCoverage = 0;
-      if (navalCoverage > 1) navalCoverage = 1;
-    }
+    final navalCoverage = result.totalShips <= 0
+        ? 1.0
+        : clamp01(result.fullyFedShips / result.totalShips);
     navalFeeding[player.id] = navalCoverage;
     idleLabour[player.id] = result.idleLabour;
     return player.copyWith(

--- a/packages/colonizethis_turn/lib/src/turn/phases/extraction_phase.dart
+++ b/packages/colonizethis_turn/lib/src/turn/phases/extraction_phase.dart
@@ -59,9 +59,10 @@ Game runExtractionPhase(
   // Not [Game.mapPlayers]: [currentState] (fleets) may change between players.
   final updatedPlayers = <Player>[];
   final fleetsByIdStartOfPhase = fleetsByIdForWorld(state.worldState);
-  var extractionSeed =
-      (state.globalGameSeed ?? 0) ^
-      (state.worldState.turnState.turnNumber * kTurnResolutionSeedMix);
+  var extractionSeed = mixTurnSeed(
+    state,
+    state.worldState.turnState.turnNumber,
+  );
   for (final player in state.players) {
     var stockpile = player.stockpile;
     final tot = extraction[player.id];

--- a/packages/colonizethis_turn/lib/src/turn/phases/movement_phase.dart
+++ b/packages/colonizethis_turn/lib/src/turn/phases/movement_phase.dart
@@ -3,6 +3,7 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'package:colonizethis_orders/colonizethis_orders.dart';
 import 'package:colonizethis_world/colonizethis_world.dart';
+import '../turn_phase_handler_helpers.dart';
 import '../turn_pipeline_state.dart';
 import '../turn_resolver_config.dart';
 import '../naval_resolution.dart';
@@ -202,17 +203,14 @@ TurnPhaseStepOutcome movementTurnPhaseHandler(
   TurnPipelineState acc,
   TurnResolverConfig config,
   int turn,
-) => TurnPhaseStepContinue(
-  acc.copyWith(
-    game: runMovementPhase(
-      acc.game,
-      config.topology,
-      config.orders,
-      onCivilianMoveOrderTrace:
-          config.turnTraceRuntime?.handleCivilianMoveOrderTrace,
-      onBundledWorkMoveTrace:
-          config.turnTraceRuntime?.handleBundledWorkMoveTrace,
-      onArmyMoveOrderTrace: config.turnTraceRuntime?.handleArmyMoveOrderTrace,
-    ),
+) => simpleGamePhase(
+  (game, config) => runMovementPhase(
+    game,
+    config.topology,
+    config.orders,
+    onCivilianMoveOrderTrace:
+        config.turnTraceRuntime?.handleCivilianMoveOrderTrace,
+    onBundledWorkMoveTrace: config.turnTraceRuntime?.handleBundledWorkMoveTrace,
+    onArmyMoveOrderTrace: config.turnTraceRuntime?.handleArmyMoveOrderTrace,
   ),
-);
+)(acc, config, turn);

--- a/packages/colonizethis_turn/lib/src/turn/phases/orders_phase.dart
+++ b/packages/colonizethis_turn/lib/src/turn/phases/orders_phase.dart
@@ -1,3 +1,4 @@
+import '../turn_phase_handler_helpers.dart';
 import '../turn_pipeline_state.dart';
 import '../turn_resolver_config.dart';
 
@@ -9,4 +10,4 @@ TurnPhaseStepOutcome ordersTurnPhaseHandler(
   TurnPipelineState acc,
   TurnResolverConfig config,
   int turn,
-) => TurnPhaseStepContinue(acc);
+) => simplePipelinePhase((pipeline) => pipeline)(acc, config, turn);

--- a/packages/colonizethis_turn/lib/src/turn/phases/world_market_phase.dart
+++ b/packages/colonizethis_turn/lib/src/turn/phases/world_market_phase.dart
@@ -168,6 +168,11 @@ TurnPhaseStepOutcome worldMarketTurnPhaseHandler(
   final fleetsByIdStartOfPhase = fleetsByIdForWorld(game.worldState);
   final tradeCapacityByFactionId = <String, int>{};
   final stockpileByFactionId = <String, Stockpile>{};
+  // Raw per-GP treasury (unclamped) fed to the deal matcher's settlement.
+  // Built in the same player pass as the maps above to avoid a second full
+  // iteration (Refs #3565). Minor/tribe sellers are intentionally absent —
+  // only GP factions carry a settlement treasury here.
+  final treasuryByFactionId = <String, int>{};
   // Per-buyer treasury budget passed to the deal matcher (Refs #3115).
   // Uses `Player.treasury` at phase 13 start clamped at `0` for negative
   // balances. Phase 13 runs after phase 12 Build/Work so this value
@@ -189,6 +194,7 @@ TurnPhaseStepOutcome worldMarketTurnPhaseHandler(
     treasuryBudgetByBuyerFactionId[player.id] = player.treasury > 0
         ? player.treasury
         : 0;
+    treasuryByFactionId[player.id] = player.treasury;
   }
   for (final minorId in lockRecoveryMinorBidsByFactionId.keys) {
     tradeCapacityByFactionId[minorId] = kLockRecoveryMinorBidCargoCapacity;
@@ -250,9 +256,6 @@ TurnPhaseStepOutcome worldMarketTurnPhaseHandler(
 
   final ftpPairKeys = ftpPairKeysFromGame(game);
   final purchasedTileIndex = PurchasedTileIndex.fromGame(game);
-  final treasuryByFactionId = <String, int>{
-    for (final player in gameForMarket.players) player.id: player.treasury,
-  };
 
   final matchInputs = (
     offersByFactionId: mergedOffersByFactionId,

--- a/packages/colonizethis_turn/lib/src/turn/turn_news_digest.dart
+++ b/packages/colonizethis_turn/lib/src/turn/turn_news_digest.dart
@@ -4,6 +4,8 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'package:colonizethis_world/colonizethis_world.dart';
 
+import 'turn_resolution_helpers.dart';
+
 /// Builds digest lines and world-state tracking updates for the completed turn.
 /// [start] is game at resolution entry (after military ensure); [end] is final
 /// state including turn increment. Returns null digest when [end.victory] is set.
@@ -87,18 +89,12 @@ List<TurnNewsProvinceCapturedLine> _provinceCaptureLines(Game start, Game end) {
     final pid = _fullProvinceId(prov);
     final before = _ownerForProvince(start, pid);
     final after = _ownerForProvince(end, pid);
-    // Same predicate as emitProvinceCapturedEvents: both owners non-empty faction
-    // ids and owner changed (no null/empty "new owner" capture). See SPEC/game/world-model.md.
-    if (before != null &&
-        before.isNotEmpty &&
-        after != null &&
-        after.isNotEmpty &&
-        before != after) {
+    if (isProvinceOwnershipCaptured(before, after)) {
       out.add(
         TurnNewsProvinceCapturedLine(
           provinceId: pid,
-          previousOwnerId: before,
-          newOwnerId: after,
+          previousOwnerId: before!,
+          newOwnerId: after!,
         ),
       );
     }

--- a/packages/colonizethis_turn/lib/src/turn/turn_resolution_events.dart
+++ b/packages/colonizethis_turn/lib/src/turn/turn_resolution_events.dart
@@ -4,8 +4,15 @@ import '../constants.dart';
 import 'package:colonizethis_world/colonizethis_world.dart';
 import 'package:colonizethis_diplomacy/colonizethis_diplomacy.dart';
 
+import 'turn_resolution_helpers.dart';
+
 /// Emits game events after turn resolution phases. SPEC/program/game-events.md.
 /// Keeps turn_resolver switch thin by moving event emission here.
+
+/// Deterministically ordered player ids for [game], sorted ascending. Used by
+/// the event emitters so per-player iteration order is stable across runs.
+List<String> _sortedPlayerIds(Game game) =>
+    game.players.map((p) => p.id).toList()..sort();
 
 Set<String> _techKeysUnlockedBefore(Game stateBefore) {
   final hadTechBefore = <String>{};
@@ -63,8 +70,7 @@ void emitResearchCompleteEvents(
 ) {
   final hadTechBefore = _techKeysUnlockedBefore(stateBefore);
   final firstDiscoveriesThisTurn = <String>{};
-  final sortedPlayerIds = stateAfter.players.map((p) => p.id).toList()
-    ..sort();
+  final sortedPlayerIds = _sortedPlayerIds(stateAfter);
   for (final playerId in sortedPlayerIds) {
     final player = stateAfter.playerById(playerId);
     if (player == null) continue;
@@ -138,15 +144,11 @@ void emitProvinceCapturedEvents(
   for (final prov in stateAfter.worldState.allProvinces()) {
     final previousOwner = previousOwnership[prov.id];
     final newOwner = prov.ownerId;
-    if (previousOwner != null &&
-        previousOwner.isNotEmpty &&
-        newOwner != null &&
-        newOwner.isNotEmpty &&
-        previousOwner != newOwner) {
+    if (isProvinceOwnershipCaptured(previousOwner, newOwner)) {
       final event = ProvinceCapturedEvent(
         provinceId: prov.id,
-        previousOwnerId: previousOwner,
-        newOwnerId: newOwner,
+        previousOwnerId: previousOwner!,
+        newOwnerId: newOwner!,
         turnNumber: turn,
       );
       deliverGameEvent(event, eventBus: eventBus, onGameEvent: onGameEvent);
@@ -273,8 +275,7 @@ void emitPlayerDiscoveryEvents(
       beforeIndex ?? buildProvinceVisibilityIndex(stateBefore);
   final resolvedAfterIndex =
       afterIndex ?? buildProvinceVisibilityIndex(stateAfter);
-  final sortedPlayerIds = stateAfter.players.map((p) => p.id).toList()
-    ..sort();
+  final sortedPlayerIds = _sortedPlayerIds(stateAfter);
   for (final playerId in sortedPlayerIds) {
     _emitPlayerProvinceDiscoveryEvents(
       stateAfter: stateAfter,

--- a/packages/colonizethis_turn/lib/src/turn/turn_resolution_helpers.dart
+++ b/packages/colonizethis_turn/lib/src/turn/turn_resolution_helpers.dart
@@ -1,0 +1,28 @@
+/// Small pure helpers shared across turn-resolution phases and post-phase
+/// emission. Kept dependency-free (no logging, no global scans) so they are
+/// safe to call on hot paths. SPEC/program/turn-resolution-phases.md.
+library;
+
+/// True when a province changed hands between two non-empty faction owners.
+///
+/// Both [before] and [after] must be non-null, non-empty faction ids and must
+/// differ. A null/empty owner is uncolonized frontier only, not a capture
+/// outcome. SPEC/game/world-model.md § Invariants. Shared by
+/// `emitProvinceCapturedEvents` and the news-digest capture lines so the
+/// predicate stays identical for both.
+bool isProvinceOwnershipCaptured(String? before, String? after) {
+  return before != null &&
+      before.isNotEmpty &&
+      after != null &&
+      after.isNotEmpty &&
+      before != after;
+}
+
+/// Clamps [value] to the inclusive `[0, 1]` range, preserving exact `0.0`/`1.0`
+/// boundary semantics (no floating-point rescaling). Used for feeding-coverage
+/// ratios in the consumption phase.
+double clamp01(double value) {
+  if (value < 0) return 0;
+  if (value > 1) return 1;
+  return value;
+}

--- a/packages/colonizethis_turn/lib/src/turn/turn_resolution_seeds.dart
+++ b/packages/colonizethis_turn/lib/src/turn/turn_resolution_seeds.dart
@@ -12,3 +12,10 @@ const int kTurnResolutionSeedMix = kDeterministicHashMixPrime32;
 const int kTurnResolutionLcgMultiplier = kDeterministicLcgMultiplierGlibc;
 const int kTurnResolutionLcgIncrement = kDeterministicLcgIncrementGlibc;
 const int kTurnResolutionLcgMask = kDeterministicLcg31Mask;
+
+/// Deterministic base sub-seed for [turn], mixing [Game.globalGameSeed] with the
+/// turn number via [kTurnResolutionSeedMix]. Used as the seed root for combat
+/// dialogue, land/naval battle resolution, and overseas interception so previews
+/// and full resolution stay aligned for identical inputs.
+int mixTurnSeed(Game game, int turn) =>
+    (game.globalGameSeed ?? 0) ^ (turn * kTurnResolutionSeedMix);

--- a/packages/colonizethis_turn/test/check_turn_structure_test.dart
+++ b/packages/colonizethis_turn/test/check_turn_structure_test.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
 
-import 'package:test/test.dart';
+import 'package:colonizethis_test/test.dart';
 
 /// Structural regression guards for the dedup refactor in `colonizethis_turn`
 /// (Refs #3565). These lock in two single-source-of-truth helpers so the

--- a/packages/colonizethis_turn/test/check_turn_structure_test.dart
+++ b/packages/colonizethis_turn/test/check_turn_structure_test.dart
@@ -1,0 +1,111 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+/// Structural regression guards for the dedup refactor in `colonizethis_turn`
+/// (Refs #3565). These lock in two single-source-of-truth helpers so the
+/// duplicated literals they replaced cannot silently creep back in:
+///
+/// * the stockpile commodity delta (`after.quantityOf(k) - before.quantityOf(k)`)
+///   must live only in `_stockpileCommodityDeltaMap`
+///   (`economy_preview_pipeline.dart`); see issue #3565 item #1.
+/// * the turn-seed root (`(game.globalGameSeed ?? 0) ^ (turn * kTurnResolutionSeedMix)`)
+///   must live only in `mixTurnSeed` (`turn_resolution_seeds.dart`); see issue
+///   #3565 item #4.
+void main() {
+  group('colonizethis_turn structure guards (Refs #3565)', () {
+    final libDir = _turnLibDir();
+
+    test('stockpile commodity delta literal lives only in its helper', () {
+      final pattern = RegExp(r'quantityOf\([^)]*\)\s*-\s*\w+\.quantityOf\(');
+      final offenders = _filesMatching(
+        libDir,
+        pattern,
+        allowed: 'economy_preview_pipeline.dart',
+      );
+      expect(
+        offenders,
+        isEmpty,
+        reason:
+            'after-before stockpile deltas must reuse _stockpileCommodityDeltaMap '
+            '(economy_preview_pipeline.dart). Inlined copies found in:\n'
+            '${offenders.join('\n')}',
+      );
+    });
+
+    test('turn-seed root literal lives only in mixTurnSeed', () {
+      final pattern = RegExp(r'globalGameSeed\s*\?\?\s*0\)\s*\^');
+      final offenders = _filesMatching(
+        libDir,
+        pattern,
+        allowed: 'turn_resolution_seeds.dart',
+      );
+      expect(
+        offenders,
+        isEmpty,
+        reason:
+            'turn-seed roots must reuse mixTurnSeed (turn_resolution_seeds.dart). '
+            'Inlined copies found in:\n${offenders.join('\n')}',
+      );
+    });
+
+    test('guard patterns still match their canonical helpers', () {
+      // Sanity: the guards are meaningful only if the canonical sources still
+      // contain the patterns. This fails loudly if a helper is renamed/moved.
+      final delta = File(
+        '${libDir.path}/src/turn/economy_preview_pipeline.dart',
+      ).readAsStringSync();
+      final seeds = File(
+        '${libDir.path}/src/turn/turn_resolution_seeds.dart',
+      ).readAsStringSync();
+      expect(
+        RegExp(r'quantityOf\([^)]*\)\s*-\s*\w+\.quantityOf\(').hasMatch(delta),
+        isTrue,
+      );
+      expect(
+        RegExp(r'globalGameSeed\s*\?\?\s*0\)\s*\^').hasMatch(seeds),
+        isTrue,
+      );
+    });
+  });
+}
+
+/// Locates the `lib` directory of the `colonizethis_turn` package, walking up
+/// from the current working directory so the test works whether run from the
+/// package root (`dart test`) or a melos-managed parent.
+Directory _turnLibDir() {
+  var dir = Directory.current;
+  for (var i = 0; i < 6; i++) {
+    final direct = Directory('${dir.path}/lib/src/turn');
+    if (direct.existsSync()) return Directory('${dir.path}/lib');
+    final nested = Directory(
+      '${dir.path}/packages/colonizethis_turn/lib/src/turn',
+    );
+    if (nested.existsSync()) {
+      return Directory('${dir.path}/packages/colonizethis_turn/lib');
+    }
+    final parent = dir.parent;
+    if (parent.path == dir.path) break;
+    dir = parent;
+  }
+  fail('Could not locate colonizethis_turn/lib from ${Directory.current.path}');
+}
+
+List<String> _filesMatching(
+  Directory libDir,
+  RegExp pattern, {
+  required String allowed,
+}) {
+  final offenders = <String>[];
+  for (final entity in libDir.listSync(recursive: true)) {
+    if (entity is! File || !entity.path.endsWith('.dart')) continue;
+    if (entity.path.endsWith(allowed)) continue;
+    final lines = entity.readAsLinesSync();
+    for (var i = 0; i < lines.length; i++) {
+      if (pattern.hasMatch(lines[i])) {
+        offenders.add('${entity.path}:${i + 1}');
+      }
+    }
+  }
+  return offenders;
+}

--- a/packages/colonizethis_turn/test/turn_resolution_helpers_test.dart
+++ b/packages/colonizethis_turn/test/turn_resolution_helpers_test.dart
@@ -1,0 +1,86 @@
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+import 'package:colonizethis_turn/src/turn/turn_resolution_helpers.dart';
+import 'package:colonizethis_turn/src/turn/turn_resolution_seeds.dart';
+
+/// Unit coverage for the shared turn-resolution helpers extracted in Refs #3565:
+/// the province-capture predicate, the `[0, 1]` clamp, and the deterministic
+/// turn sub-seed mix. These dedup previously inlined logic, so the tests pin the
+/// exact boundary/branch behavior the call sites relied on.
+void main() {
+  Game gameWithSeed(int? seed) => Game(
+    id: 'g',
+    worldState: WorldState(
+      turnState: TurnState(phase: TurnPhase.orders, turnNumber: 1),
+      oldWorld: const RegionData(),
+      newWorld: const RegionData(),
+    ),
+    players: const [Player(id: 'h1', displayName: 'Human', isHuman: true)],
+    globalGameSeed: seed,
+  );
+
+  group('isProvinceOwnershipCaptured', () {
+    test('true when ownership changes between two non-empty factions', () {
+      expect(isProvinceOwnershipCaptured('gp1', 'gp2'), isTrue);
+    });
+
+    test('false when owner is unchanged', () {
+      expect(isProvinceOwnershipCaptured('gp1', 'gp1'), isFalse);
+    });
+
+    test('false when previous owner is null (frontier colonization)', () {
+      expect(isProvinceOwnershipCaptured(null, 'gp2'), isFalse);
+    });
+
+    test('false when new owner is null (abandonment)', () {
+      expect(isProvinceOwnershipCaptured('gp1', null), isFalse);
+    });
+
+    test('false when either owner is the empty string', () {
+      expect(isProvinceOwnershipCaptured('', 'gp2'), isFalse);
+      expect(isProvinceOwnershipCaptured('gp1', ''), isFalse);
+    });
+  });
+
+  group('clamp01', () {
+    test('returns the value unchanged when already within [0, 1]', () {
+      expect(clamp01(0.4), 0.4);
+    });
+
+    test('preserves exact boundary values', () {
+      expect(clamp01(0.0), 0.0);
+      expect(clamp01(1.0), 1.0);
+    });
+
+    test('clamps values below 0 up to 0', () {
+      expect(clamp01(-0.25), 0.0);
+    });
+
+    test('clamps values above 1 down to 1', () {
+      expect(clamp01(1.75), 1.0);
+    });
+  });
+
+  group('mixTurnSeed', () {
+    test('matches the canonical seed mix for a known global seed', () {
+      final game = gameWithSeed(12345);
+      expect(mixTurnSeed(game, 7), 12345 ^ (7 * kTurnResolutionSeedMix));
+    });
+
+    test('treats a null global seed as 0', () {
+      final game = gameWithSeed(null);
+      expect(mixTurnSeed(game, 7), 0 ^ (7 * kTurnResolutionSeedMix));
+    });
+
+    test('is deterministic for identical inputs', () {
+      final game = gameWithSeed(999);
+      expect(mixTurnSeed(game, 3), mixTurnSeed(game, 3));
+    });
+
+    test('differs across turns for the same global seed', () {
+      final game = gameWithSeed(999);
+      expect(mixTurnSeed(game, 3), isNot(mixTurnSeed(game, 4)));
+    });
+  });
+}

--- a/tool/logic_all_provinces_sanctions.yaml
+++ b/tool/logic_all_provinces_sanctions.yaml
@@ -4,31 +4,31 @@
 version: 1
 sanctions:
   - path: packages/colonizethis_turn/lib/src/turn/turn_news_digest.dart
-    line: 86
+    line: 88
     rationale: Turn news digest summarizes changes across all provinces.
     spec: SPEC/program/logic-dual-region-province-access.md
     issue: https://github.com/waigore/colonizethisv3/issues/2278
 
   - path: packages/colonizethis_turn/lib/src/turn/turn_news_digest.dart
-    line: 205
+    line: 201
     rationale: Turn news digest second pass over all provinces.
     spec: SPEC/program/logic-dual-region-province-access.md
     issue: https://github.com/waigore/colonizethisv3/issues/2278
 
   - path: packages/colonizethis_turn/lib/src/turn/phases/combat_phase.dart
-    line: 152
+    line: 151
     rationale: Combat phase snapshots pre-combat ownership across all provinces (unified dual-region iteration, Refs #3416).
     spec: SPEC/program/logic-dual-region-province-access.md
     issue: https://github.com/waigore/colonizethisv3/issues/3416
 
   - path: packages/colonizethis_turn/lib/src/turn/turn_resolution_events.dart
-    line: 138
+    line: 144
     rationale: Province-captured events scan all provinces for owner handovers (unified dual-region iteration, Refs #3416).
     spec: SPEC/program/logic-dual-region-province-access.md
     issue: https://github.com/waigore/colonizethisv3/issues/3416
 
   - path: packages/colonizethis_turn/lib/src/turn/turn_resolution_events.dart
-    line: 311
+    line: 312
     rationale: Per-player province discovery events scan all provinces (unified dual-region iteration, Refs #3416).
     spec: SPEC/program/logic-dual-region-province-access.md
     issue: https://github.com/waigore/colonizethisv3/issues/3416


### PR DESCRIPTION
## Summary

Reduces structural duplication and adopts existing abstractions in `packages/colonizethis_turn`, with no change to turn-resolution semantics, phase order, determinism, or public/exported APIs. All 306 existing turn tests stay green and new unit tests cover the extracted helpers.

`Refs #3565`

## Done in this push (8 of 10 proposed refactors)

- **#1** `previewStockpileNetDeltaByCommodityForPlayer` now calls the existing `_stockpileCommodityDeltaMap` instead of reimplementing the delta loop.
- **#2** New `clamp01(double)` helper in `turn_resolution_helpers.dart`; the four inline `if (x<0)…/if (x>1)…` clamp lines in `consumption_phase.dart` are gone.
- **#3** Extracted private `_sortedPlayerIds(Game)` in `turn_resolution_events.dart`; both former duplicate sites use it.
- **#4** New `mixTurnSeed(Game, int turn)` in `turn_resolution_seeds.dart`; `combat_phase.dart` (2 sites) and `naval_resolution.dart` call it.
- **#5** Extracted `isProvinceOwnershipCaptured(before, after)` into `turn_resolution_helpers.dart`; shared by `emitProvinceCapturedEvents` and the news-digest capture lines.
- **#6** Unified the two structurally identical `_applyPending*OrderCostsForPreview` functions into one generic `_applyPendingOrderCostsForPreview<O>` with function-typed `canAfford`/`applyDeduction` parameters.
- **#9** `ordersTurnPhaseHandler` now uses `simplePipelinePhase`; `movementTurnPhaseHandler` now uses `simpleGamePhase`. The 8 ineligible handlers are untouched (6 of 14 handlers now use an adapter).
- **#10** World-market `treasuryByFactionId` is now populated in the existing single player-iteration pass (removed the separate comprehension), so per-faction maps build in one pass.

## Deferred (with reason)

- **#7 (economy preview parameter block via record/typedef)** and **#8 (collapse the four `resumeTurnResolutionWith*Decisions` wrappers)** are **not** included. Both would require changing **public/exported** function signatures that are consumed by `app/` and `tool/sim_scenarios`, which directly conflicts with this issue's stated **non-goals** ("no `tool/` or `app/` changes"). The four resume wrappers also already forward to a single private dispatch (`_resumeTurnResolutionWithDiplomacyDecisions`), and the `repo.turn_resume_param_budget` gate bounds parameter counts rather than function count. Recommend a follow-up to reconcile AC #7/#8 with the non-goals (either relax the non-goal to permit caller updates, or close these ACs as superseded).

## ACs covered now

- [x] `previewStockpileNetDeltaByCommodityForPlayer` reuses `_stockpileCommodityDeltaMap`
- [x] `consumption_phase.dart` uses shared `clamp01`, zero inline clamp blocks
- [x] single `_sortedPlayerIds` helper; no duplicate sort site
- [x] `mixTurnSeed(Game, int)` exists; combat + naval call it
- [x] capture predicate lives in one place; both call sites use it
- [x] exactly one pending-cost preview applier
- [x] orders → `simplePipelinePhase`, movement → `simpleGamePhase`; 8 ineligible handlers unchanged
- [x] world-market per-faction maps built in one pass
- [x] all existing tests pass (306) and determinism preserved
- [ ] #7 economy preview param bundling — deferred (public-API/non-goal conflict)
- [ ] #8 resume wrapper collapse — deferred (public-API/non-goal conflict)

## Tests

- New `test/turn_resolution_helpers_test.dart` (13 cases): `clamp01` boundaries/over/under, `isProvinceOwnershipCaptured` positive + null/empty/same negatives, `mixTurnSeed` formula/null-seed/determinism/turn-variance.
- `dart analyze packages/colonizethis_turn` clean (one pre-existing unrelated `info` in `movement_phase_bundled_work_test.dart`).
- `dart test` in `packages/colonizethis_turn`: **All 306 tests passed** (behavior-preserving).

Made with [Cursor](https://cursor.com)