### PR TITLE
feat: align train dialogs and shared chrome to UNIT40001 mockup (#3568)

### DIFF
--- a/SPEC/ui/components/train-dialog-chrome.md
+++ b/SPEC/ui/components/train-dialog-chrome.md
@@ -8,7 +8,7 @@ This composite is **not** a screen and has **no** stable screen ID. It is the ca
 
 ## Purpose
 
-Consolidates the chrome (accent title + `×` dismiss, brass section divider, resource bar with optional deficit hint, compact resource chip, per-unit row surface) shared by Train Civilians and Train Military so each dialog composes only its body inside a single [`CtDialogShell`](../pixel-art-ui-catalog.md). The dark editorial-monocle contract (no Material `IconButton`, no Material `Divider`, no raw `Colors.*` literals) lives in one file. Tracking issue: [#2914](https://github.com/waigore/colonizethisv3/issues/2914) S9.
+Consolidates the chrome (accent title + `×` dismiss, brass divider, boxed resource bar with optional deficit hint, resource chip, per-unit row surface) shared by Train Civilians and Train Military so each dialog composes only its body inside a single [`CtDialogShell`](../pixel-art-ui-catalog.md). The dark editorial-monocle contract (no Material `IconButton` / `Divider`, no raw `Colors.*`) lives in one file.
 
 ---
 
@@ -18,11 +18,15 @@ Consolidates the chrome (accent title + `×` dismiss, brass section divider, res
 
 `TrainDialogSectionDivider` — no props; renders `CtBrassDivider` inside `EdgeInsets.symmetric(vertical: 8)`.
 
-`TrainDialogResourceBar` — `lines` (`List<String>`) renders one `Text` per entry inside `Wrap(spacing: 16, runSpacing: 4)`, resolved to `bodyMedium.copyWith(color: EditorialMonoclePalette.fg)`; optional `deficitHint` (`String?`) appends a row in `bodySmall.copyWith(color: EditorialMonoclePalette.danger)`.
+`TrainDialogResourceBarBox` — single `child` inside a boxed inset strip (`bgDeep` background, 1 dp `border`, `EdgeInsets.all(8)`) per mockup `.resource-bar`. Shared by both dialogs.
 
-`TrainDialogResourceChip` — single `child`, wrapped in a 4 dp-radius `BoxDecoration` (`CtGradients.rowGradient` + 1 dp `accentDim` border) with `EdgeInsets.symmetric(horizontal: 6, vertical: 4)`; content renders inside `DefaultTextStyle.merge(style: TextStyle(color: EditorialMonoclePalette.fg))`.
+`TrainDialogResourceEntry` — value object `{ label, value }` (`String`).
 
-`TrainDialogUnitRowSurface` — single `child`, wrapped in `CtGradients.rowGradient` + 1 dp `accentDim` border with `EdgeInsets.symmetric(horizontal: 12, vertical: 8)`. Optional `margin` defaults to `EdgeInsets.only(bottom: 6)`.
+`TrainDialogResourceBar` — `entries` (`List<TrainDialogResourceEntry>`) inside a `TrainDialogResourceBarBox` as `Wrap(spacing 16, runSpacing 4, spaceAround)`; each entry is a muted label (`bodyMedium`, `muted`) + a **monospace bold** value (`w700`, `fontFamilyFallback: [SF Mono, Menlo, monospace]`, `tabularFigures`, `fg`). Treasury is `£` + comma-grouped (`£5,000`). Optional `deficitHint` (`String?`) renders below the box in `bodySmall` `danger`.
+
+`TrainDialogResourceChip` — single `child` in a 4 dp-radius `BoxDecoration` (`CtGradients.rowGradient` + 1 dp `accentDim` border, padding `6 × 4`); content renders inside `DefaultTextStyle.merge(color: fg)`.
+
+`TrainDialogUnitRowSurface` — single `child` in `CtGradients.rowGradient` + 1 dp `accentDim` border (padding `12 × 8`). Optional `margin` defaults to `EdgeInsets.only(bottom: 6)`.
 
 Exported constants: `kTrainDialogLockedOpacity = 0.4` (per [#2866](https://github.com/waigore/colonizethisv3/issues/2866) AC); `kTrainDialogTitleLetterSpacing = 0.05`.
 
@@ -35,14 +39,14 @@ CtDialogShell(maxWidth: 480, maxHeight: 600)            -- canonical dialog fram
   Column(min, start)
     TrainDialogHeader(title, onClose)                   -- Row(start) [Expanded(title), CtNinePatchButton('×')]
     TrainDialogSectionDivider()                          -- Padding(8/8) CtBrassDivider
-    TrainDialogResourceBar(lines, deficitHint?)         -- Wrap(spacing 16, runSpacing 4) + optional danger hint
+    TrainDialogResourceBar(entries, deficitHint?)       -- boxed inset strip (mono bold values) + optional danger hint
     TrainDialogSectionDivider()
     ListView/Column of TrainDialogUnitRowSurface(...)   -- per unit/regiment row
       Row(...)                                          -- icon + name + cost / stepper / lock badge
     Footer (consumer-owned: Reset CtNinePatchButton)
 ```
 
-The chrome widgets are independent — consumers may skip the resource bar (e.g. when capital is missing) and still render unit rows.
+The chrome widgets are independent — consumers may skip the resource bar (e.g. no capital) and still render unit rows.
 
 ---
 
@@ -50,10 +54,10 @@ The chrome widgets are independent — consumers may skip the resource bar (e.g.
 
 1. **Stateless surfaces.** Every chrome widget is a `StatelessWidget`; affordance recomputation and stepper mutation belong to the host dialog state.
 2. **Header dismiss.** `TrainDialogHeader` mounts `CtNinePatchButton` (not Material `IconButton`) so the dark button-surface contract is preserved. Tap fires `onClose`.
-3. **Divider colour.** `TrainDialogSectionDivider` always paints `CtBrassDivider` — never Material `Divider`. Guards both dialogs against the Material ban that the `check_app_no_material_*` lints enforce.
-4. **Resource bar styling.** Each `lines` entry resolves to `EditorialMonoclePalette.fg`. `deficitHint`, when supplied, uses `EditorialMonoclePalette.danger` (warm-red) so the deficit message is unambiguous on the dark surface.
-5. **Resource chip.** `TrainDialogResourceChip` wraps inline icon + numeric content; military uses six per dialog for the commodity readout (`fabric`, `castIron`, `lumber`, `horses`, `steel`, `bronze`).
-6. **Unit row surface.** `TrainDialogUnitRowSurface` paints `CtGradients.rowGradient` inside a 1 dp `accentDim` border. The consumer owns internal layout (icon, name, cost columns, stepper, lock badge) and applies `kTrainDialogLockedOpacity` (`0.4`) via its own `Opacity` wrapper when the row is tech-locked.
+3. **Divider colour.** `TrainDialogSectionDivider` always paints `CtBrassDivider` — never Material `Divider` (guards the `check_app_no_material_*` lint ban).
+4. **Resource bar styling.** `TrainDialogResourceBar` renders entries inside a `TrainDialogResourceBarBox` (recessed `--bg-deep` strip, 1 dp `--border`) with muted labels and monospace bold `--fg` values. `deficitHint` renders below the box in `--danger`.
+5. **Resource chip.** `TrainDialogResourceChip` wraps inline icon + numeric content; military composes its treasury / peasants / six commodity chips (`fabric`, `castIron`, `lumber`, `horses`, `steel`, `bronze`) inside a `TrainDialogResourceBarBox`, sharing the boxed treatment while keeping commodity icons. Military treasury uses the same `£` + comma formatting.
+6. **Unit row surface.** `TrainDialogUnitRowSurface` paints `CtGradients.rowGradient` inside a 1 dp `accentDim` border. The consumer owns internal layout (left info column with name over cost, right stepper, lock badge) and applies `kTrainDialogLockedOpacity` (`0.4`) when tech-locked.
 7. **Letter-spacing alignment.** `kTrainDialogTitleLetterSpacing = 0.05` matches `CtTopBar` and the combat-mode choice dialog so the title rhythm aligns.
 
 ---
@@ -67,7 +71,7 @@ The chrome widgets are independent — consumers may skip the resource bar (e.g.
 | `TrainDialogUnitRowSurface` | Locked | Host wraps the row in `Opacity(opacity: kTrainDialogLockedOpacity)` | Whole surface fades to 0.4 opacity. |
 | `TrainDialogUnitRowSurface` | Custom margin | Caller overrides `margin` | Outer `Padding` adopts the caller margin (default `EdgeInsets.only(bottom: 6)`). |
 
-The chrome widgets have no theme-mode branches; the dark editorial-monocle theme is the only authorised render target.
+The chrome widgets have no theme-mode branches; editorial-monocle is the only render target.
 
 ---
 
@@ -78,7 +82,7 @@ The chrome widgets have no theme-mode branches; the dark editorial-monocle theme
 | `UNIT40001` | [`train-civilians-dialog.md`](../train-civilians-dialog.md) | Civilian list + treasury / paper resource bar; six unit-type rows with optional tech-lock variant. |
 | `UNIT50001` | [`train-military-dialog.md`](../train-military-dialog.md) | Regiment list + treasury / peasants + six commodity chips; per-regiment rows with optional tech-lock variant. |
 
-Both consumer specs link back here for the chrome contract instead of redeclaring the header / divider / resource-bar / row-surface hierarchy.
+Both consumer specs link back here instead of redeclaring the chrome hierarchy.
 
 ---
 
@@ -86,7 +90,8 @@ Both consumer specs link back here for the chrome contract instead of redeclarin
 
 - **Given** a `TrainDialogHeader` mounted with `title = 'Train Civilians'`, **When** the tree settles, **Then** exactly one `CtNinePatchButton` is mounted, zero Material `IconButton` widgets are mounted, `Text('Train Civilians')` renders, and its resolved `TextStyle.color` equals `EditorialMonoclePalette.accent`.
 - **Given** a `TrainDialogSectionDivider` mounted under any host, **When** the tree settles, **Then** exactly one `CtBrassDivider` is mounted and zero Material `Divider` widgets are mounted.
-- **Given** a `TrainDialogResourceBar` mounted with two lines and `deficitHint == null`, **When** the tree settles, **Then** two `Text` descendants render the line values and no descendant carries `EditorialMonoclePalette.danger`.
+- **Given** a `TrainDialogResourceBar` mounted with two entries and `deficitHint == null`, **When** the tree settles, **Then** exactly one `TrainDialogResourceBarBox` is mounted, both entry labels + values render, and no descendant carries `EditorialMonoclePalette.danger`.
+- **Given** a `TrainDialogResourceBar` mounted with a treasury entry of `5000`, **When** the tree settles, **Then** the rendered value reads `£5,000` (pound symbol + comma grouping).
 - **Given** a `TrainDialogResourceBar` mounted with `deficitHint = 'Treasury low'`, **When** the tree settles, **Then** a `Text('Treasury low')` mounts whose resolved `TextStyle.color` equals `EditorialMonoclePalette.danger`.
 - **Given** a `TrainDialogUnitRowSurface` mounted around any child, **When** the inner `DecoratedBox` resolves, **Then** its `BoxDecoration.border` is `Border.all(color: EditorialMonoclePalette.accentDim, width: 1)` and its `BoxDecoration.gradient` is `CtGradients.rowGradient`.
 - **Given** the source `app/lib/features/game/widgets/train_dialog_chrome.dart`, **When** read, **Then** it declares `kTrainDialogLockedOpacity = 0.4` and `kTrainDialogTitleLetterSpacing = 0.05` (canonical regression guard).
@@ -95,14 +100,13 @@ Both consumer specs link back here for the chrome contract instead of redeclarin
 
 ## Tests
 
-- `app/test/train_dialog_chrome_test.dart` — widget-level pins for `TrainDialogHeader` accent title + `CtNinePatchButton` dismiss, `TrainDialogSectionDivider` `CtBrassDivider` selection, and the `kTrainDialogLockedOpacity` constant.
-- `app/test/train_dialogs_320dp_min_viewport_test.dart` — pins `TrainCiviliansDialog` and `TrainMilitaryDialog` at `kMinViewportWidth = 320` dp with the shared chrome composed inside `CtDialogShell` (Refs [#2870](https://github.com/waigore/colonizethisv3/issues/2870) S8/S10).
-- `app/test/spec_components_train_dialog_chrome_test.dart` — spec-pinning test asserting this spec exists, declares the canonical sections, enumerates the two consumers by stable screen id, restates the chrome constants, and stays under the 1000-word ceiling.
+- `app/test/train_dialog_chrome_test.dart` — pins `TrainDialogHeader` accent title + `CtNinePatchButton` dismiss, `TrainDialogSectionDivider` selection, the resource-bar box + `£`/comma formatting, and `kTrainDialogLockedOpacity`.
+- `app/test/train_dialogs_320dp_min_viewport_test.dart` — pins both dialogs at `kMinViewportWidth = 320` dp (Refs [#2870](https://github.com/waigore/colonizethisv3/issues/2870) S8/S10).
+- `app/test/spec_components_train_dialog_chrome_test.dart` — spec-pinning test (sections, consumers, constants, ≤1000-word ceiling).
 
 ---
 
 ## Related
 
-- Catalog: [`pixel-art-ui-catalog.md`](../pixel-art-ui-catalog.md) § *CtDialogShell*, § *CtNinePatchButton*, § *CtBrassDivider*, § *CtGradients*, § *Editorial-monocle palette*.
-- Sibling chrome: [`production-allocation-row.md`](production-allocation-row.md) — same row-surface gradient + border pattern.
+- Catalog: [`pixel-art-ui-catalog.md`](../pixel-art-ui-catalog.md) § *CtDialogShell*, *CtNinePatchButton*, *CtBrassDivider*, *CtGradients*, *Editorial-monocle palette*.
 - Tracking issue: [#2914](https://github.com/waigore/colonizethisv3/issues/2914) S9.

--- a/SPEC/ui/train-civilians-dialog.md
+++ b/SPEC/ui/train-civilians-dialog.md
@@ -27,41 +27,35 @@ The Train Civilians dialog lets the player queue training orders for civilian un
 ┌─────────────────────────────────────────┐
 │  Train Civilians                    [×] │  ← CtDialogShell title bar
 ├─────────────────────────────────────────┤
-│  Treasury: 5,000  |  Paper: 12         │  ← Resource bar
-│  (can train 5 more Builders)           │  ← Dynamic deficit hint (e.g. "Treasury low")
+│ ┌─────────────────────────────────────┐ │  ← Boxed inset resource bar
+│ │  Treasury: £5,000     Paper: 12     │ │     (mono bold values)
+│ └─────────────────────────────────────┘ │
+│  Treasury low and Paper low             │  ← Dynamic deficit hint (below box)
 ├─────────────────────────────────────────┤
-│  [icon] Explorer          1,000 + 2📄   │  ← Per-unit-type row
-│                    [−] 0 [+]            │  ← Stepper
+│  [icon] Explorer            [−] 0 [+]   │  ← Per-unit-type row (single line)
+│         £1,000 + 2 paper                │     name over cost (left), stepper (right)
 │  ─────────────────────────────────────  │
-│  [icon] Builder           1,000 + 2📄   │
-│                    [−] 0 [+]            │
+│  [icon] Builder             [−] 0 [+]   │
+│         £1,000 + 2 paper                │
 │  ─────────────────────────────────────  │
-│  [icon] Engineer         1,000 + 2📄   │
-│                    [−] 0 [+]            │
-│  ─────────────────────────────────────  │
-│  [icon] Spy              2,000 + 4📄   │
-│                    [−] 0 [+]            │
-│  ─────────────────────────────────────  │
-│  [icon] Merchant 🔒      2,000 + 4📄   │  ← Locked (tech not unlocked)
-│  Requires: Merchant Companies           │  ← Lock reason
-│                    [−] 0 [+] (disabled)│
-│  ─────────────────────────────────────  │
-│  [icon] Rail Builder 🔒  2,000 + 4📄   │  ← Locked (tech not unlocked)
-│  Requires: Early Steam Engine           │  ← Lock reason
-│                    [−] 0 [+] (disabled) │
+│  [icon] Merchant 🔒         [−] 0 [+]   │  ← Locked (tech not unlocked)
+│         £2,000 + 4 paper                │
+│         Requires: Merchant Companies    │  ← Lock reason
 └─────────────────────────────────────────┘
 ```
 
 ### Resource Bar (top)
 
-Shows current player resources relevant to civilian training:
-- **Treasury:** `Player.treasury` formatted with commas
+Renders as a **boxed inset strip** (dark `--bg-deep` background, 1 dp `--border`,
+entries spaced apart) per the mockup `.resource-bar`. Each entry shows a muted
+label and a **monospace bold value** (`--fg`):
+- **Treasury:** `Player.treasury` formatted as `£` + comma thousands grouping (e.g. `£5,000`)
 - **Paper stockpile:** `Player.stockpile.quantityOf('paper')`
 
-Below the resource bar, a **dynamic deficit hint** updates on every stepper toggle:
+Below the resource bar (outside the box), a **dynamic deficit hint** updates on every stepper toggle:
 - If treasury insufficient for any queued unit: "Treasury low"
 - If paper insufficient for any queued unit: "Paper low"
-- If both insufficient: "Treasury and Paper low"
+- If both insufficient: "Treasury low and Paper low" (each clause joined with `" and "`)
 - If no deficit: hidden
 
 ### Unit Type Rows
@@ -75,10 +69,17 @@ For each `CivilianEconomyCatalog` entry:
 | Commodity inputs | `CivilianEconomy.buildInputs` (key = commodity id, value = qty) |
 | Locked state | `unlockingTechByCivilianId[unitType]` not in `Player.techUnlocked` |
 
+Each row is a **single horizontal line**: a left info `Column` (unit name stacked
+above the cost line) takes the residual width, and the stepper sits on the right
+of the same row, vertically centered (wrapping below only when the width cannot
+fit both). This matches the mockup `.unit-row` (`flex; align-items:center`) with a
+left `.info` block and a right `.stepper`.
+
 #### Unlocked Unit Row
-- Unit type icon (or pixel-art icon from catalog)
-- Treasury cost + commodity cost (e.g. `1,000 + 2📄`)
-- **Stepper:** `[−]` / count / `[+]` buttons
+- Unit type icon (or pixel-art icon from catalog) + unit name (left info column, top)
+- Treasury cost + commodity cost on the line below the name, formatted
+  `£` + comma grouping with lowercase commodity (e.g. `£1,000 + 2 paper`)
+- **Stepper:** `[−]` / count / `[+]` buttons on the right of the same row
   - Count starts at 0
   - `[+]` increases by 1; `[−]` decreases by 1 (min 0)
   - `[+]` is disabled (greyed) if insufficient resources for +1 more
@@ -198,6 +199,14 @@ pixellab_create_map_object(
 
 - **Given** the Train Civilians dialog is open, **when** the user views the resource bar, **then** the UI shows the player's current treasury and paper stockpile quantities.
 
+- **Given** the Train Civilians dialog is open with treasury `5000`, **when** the resource bar renders, **then** the treasury value reads `£5,000` (pound symbol + comma thousands grouping), not an abbreviated `5k`.
+
+- **Given** an unlocked civilian row with treasury cost `1000` and `2` paper, **when** the cost line renders, **then** it reads `£1,000 + 2 paper` (lowercase `paper`).
+
+- **Given** any unlocked unit row, **when** it renders, **then** the unit name appears stacked above the cost on the left and the stepper `[−] n [+]` appears on the right of the same row (not on a separate line below).
+
+- **Given** the resource bar, **when** it renders, **then** it appears as a boxed inset strip with monospace bold values consistent with the mockup and editorial-monocle palette.
+
 - **Given** the Train Civilians dialog is open, **when** the user increments a stepper for an unlocked unit type, **then** the deficit hint updates to reflect whether treasury/paper is now insufficient.
 
 - **Given** the Train Civilians dialog is open, **when** the user increments a stepper beyond available resources, **then** that stepper's `[+]` button is disabled and the row is visually subdued.
@@ -212,7 +221,7 @@ pixellab_create_map_object(
 
 - **Given** the Train Civilians dialog is open, **when** the user has no capital set, **then** the UI shows an error message "No capital set — cannot train units" and all steppers are disabled.
 
-- **Given** the Train Civilians dialog is open, **when** the player has insufficient resources for any unit, **then** the deficit hint shows "Treasury low", "Paper low", or both.
+- **Given** the Train Civilians dialog is open, **when** the player has insufficient resources for any unit, **then** the deficit hint shows "Treasury low", "Paper low", or — when both are insufficient — "Treasury low and Paper low".
 
 - **Given** the Train Civilians dialog is open, **when** the user taps the Reset button (if present), **then** all steppers are set to 0 and deficit hint is cleared.
 

--- a/SPEC/ui/train-military-dialog.md
+++ b/SPEC/ui/train-military-dialog.md
@@ -24,13 +24,13 @@ The Train Military dialog lets the player queue military regiment build orders i
 ## Layout
 
 - **Header:** `Train Military` title + close (`X`) button.
-- **Resource bar:** Shows available `Treasury`, `Peasants`, and regiment-input commodities (as applicable): `fabric`, `castIron`, `lumber`, `horses`, `steel`, `bronze`. Use existing resource/worker icons.
-- **Deficit hint:** Same wording style as civilian (`{Resource} low`, `{A} and {B} low`, etc.) using military resource names.
-- **Rows:** One row per `RegimentEconomyCatalog.all` entry.
+- **Resource bar:** Renders inside the shared boxed inset strip (`TrainDialogResourceBarBox`; see [components/train-dialog-chrome.md](components/train-dialog-chrome.md)). Shows `Treasury`, `Peasants`, and regiment-input commodities `fabric`, `castIron`, `lumber`, `horses`, `steel`, `bronze` as `TrainDialogResourceChip`s with existing icons. Treasury uses `£` + comma grouping (e.g. `£10,000`), matching the civilian dialog.
+- **Deficit hint:** Same wording style as civilian (`{Resource} low`, `{A} and {B} low`) below the box.
+- **Rows:** One row per `RegimentEconomyCatalog.all` entry as a single line — left info `Column` (regiment name above the icon-bearing cost summary) plus the stepper on the right (vertically centered).
   - primary label: **regiment display name** per [military-units.md](../game/military-units.md) via `regimentTypeDisplayName` in `colonizethis_data` (not the snake_case persistence id; e.g. `Peasant Levies` not `peasant_levies`). Text-only; no regiment icon requirement.
   - cost summary: treasury + commodity requirements with icons
-  - locked state + `Requires: {tech}` when regiment unlocking tech is missing
-  - `[-] count [+]` stepper
+  - locked state + `Requires: {tech}` when unlocking tech is missing
+  - `[-] count [+]` stepper on the right
 - **Footer:** `Reset` button that clears all row counts to `0`.
 
 ---
@@ -110,7 +110,11 @@ Dialog-specific affordability and tech-lock logic remains local to each dialog.
 
 - **Given** the Military Units panel is open, **when** the user taps `Train`, **then** the UI layer closes the panel and opens Train Military as a modal dialog via `OpenDialogEvent(trainMilitaryDialogId)`.
 
-- **Given** the Train Military dialog is open, **when** the user views the resource bar, **then** the UI layer shows treasury, peasants, and relevant military-input resources using existing resource/worker icon components.
+- **Given** the Train Military dialog is open, **when** the user views the resource bar, **then** the UI layer shows treasury, peasants, and military-input resources with existing icons inside the shared boxed inset strip.
+
+- **Given** treasury `10000`, **when** the resource bar renders, **then** the treasury value reads `£10,000` (pound symbol + comma grouping).
+
+- **Given** any regiment row, **when** it renders, **then** the regiment name is stacked above the cost summary on the left and the stepper `[−] n [+]` is on the right of the same row.
 
 - **Given** the Train Military dialog is open, **when** the player increments regiment steppers, **then** the UI layer enables/disables each row's `+` based on aggregate affordability across treasury, peasants, and all required commodities.
 

--- a/app/lib/core/utils/currency_format.dart
+++ b/app/lib/core/utils/currency_format.dart
@@ -1,0 +1,25 @@
+/// Number / currency formatting helpers shared by app UI.
+///
+/// SPEC: `SPEC/ui/train-civilians-dialog.md`,
+/// `SPEC/ui/train-military-dialog.md`, `SPEC/ui/components/train-dialog-chrome.md`.
+library;
+
+/// Formats [value] with comma thousands separators (e.g. `5000` -> `5,000`,
+/// `-1240` -> `-1,240`). Grouping is applied to the absolute value and the
+/// minus sign is preserved for negative inputs.
+String formatThousands(int value) {
+  final String digits = value.abs().toString();
+  final StringBuffer out = StringBuffer();
+  for (int i = 0; i < digits.length; i++) {
+    if (i > 0 && (digits.length - i) % 3 == 0) {
+      out.write(',');
+    }
+    out.write(digits[i]);
+  }
+  final String grouped = out.toString();
+  return value < 0 ? '-$grouped' : grouped;
+}
+
+/// Formats [value] as a treasury amount with the `£` symbol and comma
+/// thousands grouping (e.g. `5000` -> `£5,000`).
+String formatTreasuryCurrency(int value) => '£${formatThousands(value)}';

--- a/app/lib/features/game/widgets/train_civilians_dialog.dart
+++ b/app/lib/features/game/widgets/train_civilians_dialog.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import '../../../config/app_assets.dart';
 import '../../../config/editorial_monocle_palette.dart';
 import '../../../config/ui_screen_ids.dart';
+import '../../../core/utils/currency_format.dart';
 import '../../../l10n/l10n.dart';
 import '../../../widgets/ct_dialog_shell.dart';
 import '../../../widgets/ct_nine_patch_button.dart';
@@ -108,7 +109,7 @@ class _TrainCiviliansDialogState extends State<TrainCiviliansDialog> {
     final treasuryDeficit = _totalTreasuryCost() > _treasury;
     final paperDeficit = _totalPaperCost() > _paperStockpile;
     if (treasuryDeficit && paperDeficit) {
-      return 'Treasury and Paper low';
+      return 'Treasury low and Paper low';
     }
     if (treasuryDeficit) return 'Treasury low';
     if (paperDeficit) return 'Paper low';
@@ -207,9 +208,15 @@ class _TrainCiviliansDialogState extends State<TrainCiviliansDialog> {
     return [
       const TrainDialogSectionDivider(),
       TrainDialogResourceBar(
-        lines: [
-          l10n.trainUnits_treasury(_formatTreasury(_treasury)),
-          l10n.trainUnits_paper(_paperStockpile),
+        entries: [
+          TrainDialogResourceEntry(
+            label: l10n.trainUnits_treasuryLabel,
+            value: formatTreasuryCurrency(_treasury),
+          ),
+          TrainDialogResourceEntry(
+            label: l10n.trainUnits_paperLabel,
+            value: '$_paperStockpile',
+          ),
         ],
         deficitHint: _deficitHint,
       ),
@@ -242,13 +249,6 @@ class _TrainCiviliansDialogState extends State<TrainCiviliansDialog> {
       ),
     ];
   }
-
-  String _formatTreasury(int n) {
-    if (n >= 1000) {
-      return '${(n / 1000).toStringAsFixed(n % 1000 == 0 ? 0 : 1)}k';
-    }
-    return n.toString();
-  }
 }
 
 class _UnitTypeRow extends StatelessWidget {
@@ -280,12 +280,11 @@ class _UnitTypeRow extends StatelessWidget {
     return Opacity(
       opacity: isLocked ? kTrainDialogLockedOpacity : 1.0,
       child: TrainDialogUnitRowSurface(
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
           children: [
-            _buildHeader(context, theme, paperQty),
-            ..._buildLockedHint(theme),
-            const SizedBox(height: 4),
+            Expanded(child: _buildInfo(context, theme, paperQty)),
+            const SizedBox(width: 8),
             _buildStepper(theme),
           ],
         ),
@@ -293,31 +292,41 @@ class _UnitTypeRow extends StatelessWidget {
     );
   }
 
-  Widget _buildHeader(BuildContext context, ThemeData theme, int paperQty) {
-    return Row(
+  Widget _buildInfo(BuildContext context, ThemeData theme, int paperQty) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        if (isLocked)
-          StrictAssetIcon(
-            assetPath: '${kAppIconAssetPrefix}ui_icon_lock.png',
-            width: 20,
-            height: 20,
-          ),
-        if (isLocked) const SizedBox(width: 4),
-        Expanded(
-          child: Text(
-            econ.id,
-            style: theme.textTheme.bodyLarge?.copyWith(
-              fontWeight: FontWeight.w600,
+        Row(
+          children: [
+            if (isLocked) ...[
+              StrictAssetIcon(
+                assetPath: '${kAppIconAssetPrefix}ui_icon_lock.png',
+                width: 20,
+                height: 20,
+              ),
+              const SizedBox(width: 4),
+            ],
+            Expanded(
+              child: Text(
+                econ.id,
+                style: theme.textTheme.bodyLarge?.copyWith(
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
             ),
-          ),
+          ],
         ),
+        const SizedBox(height: 2),
         Text(
           appL10n(context).trainCivilians_costLine(
-            _formatTreasury(econ.buildTreasuryCost),
+            formatTreasuryCurrency(econ.buildTreasuryCost),
             paperQty.toString(),
           ),
-          style: theme.textTheme.bodyMedium,
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: EditorialMonoclePalette.muted,
+          ),
         ),
+        ..._buildLockedHint(theme),
       ],
     );
   }
@@ -339,7 +348,7 @@ class _UnitTypeRow extends StatelessWidget {
 
   Widget _buildStepper(ThemeData theme) {
     return Row(
-      mainAxisAlignment: MainAxisAlignment.end,
+      mainAxisSize: MainAxisSize.min,
       children: [
         CtNinePatchButton(
           onPressed: isLocked || !canDecrement ? null : onDecrement,
@@ -361,12 +370,5 @@ class _UnitTypeRow extends StatelessWidget {
         ),
       ],
     );
-  }
-
-  String _formatTreasury(int n) {
-    if (n >= 1000) {
-      return '${(n / 1000).toStringAsFixed(n % 1000 == 0 ? 0 : 1)}k';
-    }
-    return n.toString();
   }
 }

--- a/app/lib/features/game/widgets/train_dialog_chrome.dart
+++ b/app/lib/features/game/widgets/train_dialog_chrome.dart
@@ -65,32 +65,104 @@ class TrainDialogSectionDivider extends StatelessWidget {
   }
 }
 
+/// A single label + value entry in a [TrainDialogResourceBar].
+///
+/// [label] renders muted; [value] renders monospace + bold (per the mockup
+/// `.resource-bar .val`). Treasury values should be pre-formatted with the
+/// `£` symbol + comma grouping via `formatTreasuryCurrency`.
+class TrainDialogResourceEntry {
+  const TrainDialogResourceEntry({required this.label, required this.value});
+
+  final String label;
+  final String value;
+}
+
+/// Boxed inset strip wrapping a train-dialog resource readout.
+///
+/// Mirrors the mockup `.resource-bar` (recessed `--bg-deep` background, 1 dp
+/// `--border`) so both train dialogs share the same recessed treatment.
+class TrainDialogResourceBarBox extends StatelessWidget {
+  const TrainDialogResourceBarBox({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: EditorialMonoclePalette.bgDeep,
+        border: Border.all(
+          color: EditorialMonoclePalette.border,
+          width: 1,
+        ),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(CtSpacing.s),
+        child: child,
+      ),
+    );
+  }
+}
+
 /// Treasury / stockpile summary strip for train dialogs.
+///
+/// Renders [entries] inside a [TrainDialogResourceBarBox] with muted labels
+/// and monospace bold values per the mockup. An optional [deficitHint]
+/// renders below the box in the danger colour.
 class TrainDialogResourceBar extends StatelessWidget {
   const TrainDialogResourceBar({
     super.key,
-    required this.lines,
+    required this.entries,
     this.deficitHint,
   });
 
-  final List<String> lines;
+  final List<TrainDialogResourceEntry> entries;
   final String? deficitHint;
+
+  /// Monospace bold value style shared with [CtResourceCell] (`tabularFigures`
+  /// + a cross-platform monospace fallback chain). Public so widget tests can
+  /// assert the value styling.
+  static TextStyle resourceValueStyle(BuildContext context) {
+    final TextStyle base =
+        Theme.of(context).textTheme.bodyMedium ?? const TextStyle();
+    return base.copyWith(
+      color: EditorialMonoclePalette.fg,
+      fontWeight: FontWeight.w700,
+      fontFamilyFallback: const <String>['SF Mono', 'Menlo', 'monospace'],
+      fontFeatures: const <FontFeature>[FontFeature.tabularFigures()],
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
-    final TextStyle lineStyle = (theme.textTheme.bodyMedium ?? const TextStyle())
-        .copyWith(color: EditorialMonoclePalette.fg);
+    final TextStyle labelStyle = (theme.textTheme.bodyMedium ?? const TextStyle())
+        .copyWith(color: EditorialMonoclePalette.muted);
+    final TextStyle valueStyle = resourceValueStyle(context);
     final TextStyle deficitStyle = (theme.textTheme.bodySmall ??
             const TextStyle())
         .copyWith(color: EditorialMonoclePalette.danger);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Wrap(
-          spacing: 16,
-          runSpacing: 4,
-          children: [for (final line in lines) Text(line, style: lineStyle)],
+        TrainDialogResourceBarBox(
+          child: Wrap(
+            spacing: 16,
+            runSpacing: 4,
+            alignment: WrapAlignment.spaceAround,
+            children: [
+              for (final entry in entries)
+                Text.rich(
+                  TextSpan(
+                    children: [
+                      TextSpan(text: entry.label, style: labelStyle),
+                      const TextSpan(text: ' '),
+                      TextSpan(text: entry.value, style: valueStyle),
+                    ],
+                  ),
+                ),
+            ],
+          ),
         ),
         if (deficitHint != null) ...[
           const SizedBox(height: 4),

--- a/app/lib/features/game/widgets/train_military_dialog.dart
+++ b/app/lib/features/game/widgets/train_military_dialog.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 
 import '../../../config/editorial_monocle_palette.dart';
 import '../../../config/ui_screen_ids.dart';
+import '../../../core/utils/currency_format.dart';
 import '../../../l10n/l10n.dart';
 import '../../../config/app_assets.dart';
 import '../../../widgets/ct_dialog_shell.dart';
@@ -301,40 +302,44 @@ class _MilitaryResourceBar extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Wrap(
-          spacing: 10,
-          runSpacing: 6,
-          children: [
-            TrainDialogResourceChip(
-              child: Text(l10n.trainUnits_treasury('$treasury')),
-            ),
-            TrainDialogResourceChip(
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  const WorkerIcon(workerType: 'peasant', size: 14),
-                  const SizedBox(width: 4),
-                  Text(l10n.trainUnits_peasants(peasants)),
-                ],
+        TrainDialogResourceBarBox(
+          child: Wrap(
+            spacing: 10,
+            runSpacing: 6,
+            children: [
+              TrainDialogResourceChip(
+                child: Text(
+                  l10n.trainUnits_treasury(formatTreasuryCurrency(treasury)),
+                ),
               ),
-            ),
-            for (final commodityId in _militaryCommodityIds)
               TrainDialogResourceChip(
                 child: Row(
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    ResourceIcon(commodityId: commodityId, size: 14),
+                    const WorkerIcon(workerType: 'peasant', size: 14),
                     const SizedBox(width: 4),
-                    Text(
-                      l10n.trainMilitary_commodityAmount(
-                        _label(commodityId),
-                        stockpile.quantityOf(commodityId),
-                      ),
-                    ),
+                    Text(l10n.trainUnits_peasants(peasants)),
                   ],
                 ),
               ),
-          ],
+              for (final commodityId in _militaryCommodityIds)
+                TrainDialogResourceChip(
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      ResourceIcon(commodityId: commodityId, size: 14),
+                      const SizedBox(width: 4),
+                      Text(
+                        l10n.trainMilitary_commodityAmount(
+                          _label(commodityId),
+                          stockpile.quantityOf(commodityId),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+            ],
+          ),
         ),
         if (deficitHint != null) ...[
           const SizedBox(height: 4),
@@ -381,18 +386,27 @@ class _RegimentRow extends StatelessWidget {
     return Opacity(
       opacity: isLocked ? kTrainDialogLockedOpacity : 1.0,
       child: TrainDialogUnitRowSurface(
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
           children: [
-            _buildHeader(theme),
-            const SizedBox(height: 2),
-            _buildCostWrap(),
-            ..._buildLockedHint(theme),
-            const SizedBox(height: 4),
+            Expanded(child: _buildInfo(theme)),
+            const SizedBox(width: 8),
             _buildStepper(theme),
           ],
         ),
       ),
+    );
+  }
+
+  Widget _buildInfo(ThemeData theme) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _buildHeader(theme),
+        const SizedBox(height: 2),
+        _buildCostWrap(),
+        ..._buildLockedHint(theme),
+      ],
     );
   }
 
@@ -414,10 +428,6 @@ class _RegimentRow extends StatelessWidget {
               fontWeight: FontWeight.w600,
             ),
           ),
-        ),
-        Text(
-          econ.buildTreasuryCost.toString(),
-          style: theme.textTheme.bodyMedium,
         ),
       ],
     );
@@ -462,7 +472,7 @@ class _RegimentRow extends StatelessWidget {
 
   Widget _buildStepper(ThemeData theme) {
     return Row(
-      mainAxisAlignment: MainAxisAlignment.end,
+      mainAxisSize: MainAxisSize.min,
       children: [
         CtNinePatchButton(
           onPressed: isLocked || !canDecrement ? null : onDecrement,

--- a/app/lib/l10n/app_localizations_contract.dart
+++ b/app/lib/l10n/app_localizations_contract.dart
@@ -879,6 +879,12 @@ abstract class AppLocalizations {
   /// Paper summary line in civilian train dialog.
   String trainUnits_paper(int value);
 
+  /// Treasury label in the train-dialog boxed resource bar (value rendered separately in monospace).
+  String get trainUnits_treasuryLabel;
+
+  /// Paper label in the civilian train-dialog boxed resource bar (value rendered separately in monospace).
+  String get trainUnits_paperLabel;
+
   /// Peasants summary line in military train dialog.
   String trainUnits_peasants(int value);
 

--- a/app/lib/l10n/app_localizations_en_part2.dart
+++ b/app/lib/l10n/app_localizations_en_part2.dart
@@ -482,6 +482,12 @@ mixin _AppLocalizationsEnStrings2 on AppLocalizations {
   }
 
   @override
+  String get trainUnits_treasuryLabel => 'Treasury:';
+
+  @override
+  String get trainUnits_paperLabel => 'Paper:';
+
+  @override
   String trainUnits_peasants(int value) {
     return 'Peasants: $value';
   }

--- a/app/lib/l10n/app_localizations_en_part4.dart
+++ b/app/lib/l10n/app_localizations_en_part4.dart
@@ -13,7 +13,7 @@ mixin _AppLocalizationsEnStrings4 on AppLocalizations {
 
   @override
   String trainCivilians_costLine(String treasury, String paper) {
-    return '$treasury + $paper Paper';
+    return '$treasury + $paper paper';
   }
 
   @override

--- a/app/lib/l10n/arb/app_en.arb
+++ b/app/lib/l10n/arb/app_en.arb
@@ -1533,6 +1533,14 @@
       }
     }
   },
+  "trainUnits_treasuryLabel": "Treasury:",
+  "@trainUnits_treasuryLabel": {
+    "description": "Treasury label in the train-dialog boxed resource bar (value rendered separately in monospace)."
+  },
+  "trainUnits_paperLabel": "Paper:",
+  "@trainUnits_paperLabel": {
+    "description": "Paper label in the civilian train-dialog boxed resource bar (value rendered separately in monospace)."
+  },
   "trainUnits_peasants": "Peasants: {value}",
   "@trainUnits_peasants": {
     "description": "Peasants summary line in military train dialog.",
@@ -2700,7 +2708,7 @@
       }
     }
   },
-  "trainCivilians_costLine": "{treasury} + {paper} Paper",
+  "trainCivilians_costLine": "{treasury} + {paper} paper",
   "@trainCivilians_costLine": {
     "description": "Treasury cost plus paper requirement for training civilians.",
     "placeholders": {

--- a/app/test/core/utils/currency_format_test.dart
+++ b/app/test/core/utils/currency_format_test.dart
@@ -1,0 +1,33 @@
+// Tests for currency / number formatting helpers.
+// SPEC/ui/train-civilians-dialog.md, SPEC/ui/train-military-dialog.md.
+
+import 'package:colonizethis_app/core/utils/currency_format.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('formatThousands', () {
+    test('groups thousands with commas', () {
+      expect(formatThousands(0), '0');
+      expect(formatThousands(12), '12');
+      expect(formatThousands(1000), '1,000');
+      expect(formatThousands(5000), '5,000');
+      expect(formatThousands(1234567), '1,234,567');
+    });
+
+    test('preserves the minus sign for negative values', () {
+      expect(formatThousands(-1240), '-1,240');
+    });
+  });
+
+  group('formatTreasuryCurrency', () {
+    test('prepends £ and groups thousands', () {
+      expect(formatTreasuryCurrency(5000), '£5,000');
+      expect(formatTreasuryCurrency(1000), '£1,000');
+      expect(formatTreasuryCurrency(10000), '£10,000');
+    });
+
+    test('does not abbreviate with k', () {
+      expect(formatTreasuryCurrency(5000).contains('k'), isFalse);
+    });
+  });
+}

--- a/app/test/core/utils/currency_format_test.dart
+++ b/app/test/core/utils/currency_format_test.dart
@@ -2,9 +2,12 @@
 // SPEC/ui/train-civilians-dialog.md, SPEC/ui/train-military-dialog.md.
 
 import 'package:colonizethis_app/core/utils/currency_format.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  suppressLogsForTests();
+
   group('formatThousands', () {
     test('groups thousands with commas', () {
       expect(formatThousands(0), '0');

--- a/app/test/train_civilians_dialog_test.dart
+++ b/app/test/train_civilians_dialog_test.dart
@@ -97,6 +97,84 @@ void main() {
       expect(find.textContaining('Paper:'), findsOneWidget);
     });
 
+    testWidgets(
+      'AC: Treasury renders with £ + comma grouping (£5,000), not 5k',
+      (WidgetTester tester) async {
+        final richGame = gameWithResources(treasury: 5000, paper: 12);
+        await tester.pumpWidget(
+          buildDialog(game: richGame, humanPlayerId: humanPlayerId),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.textContaining('£5,000'), findsOneWidget);
+        expect(find.textContaining('5k'), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'AC: Unlocked cost line reads "£1,000 + 2 paper" (lowercase paper)',
+      (WidgetTester tester) async {
+        final richGame = gameWithResources(treasury: 10000, paper: 100);
+        await tester.pumpWidget(
+          buildDialog(game: richGame, humanPlayerId: humanPlayerId),
+        );
+        await tester.pumpAndSettle();
+
+        // Builder costs 1,000 treasury + 2 paper (mockup UNIT40001).
+        expect(find.textContaining('£1,000 + 2 paper'), findsWidgets);
+      },
+    );
+
+    testWidgets(
+      'AC: Both-resource deficit reads "Treasury low and Paper low"',
+      (WidgetTester tester) async {
+        final player = getPlayer(humanPlayerId);
+        final capital =
+            player.capitalProvinceId ?? player.capitalTile?.provinceId;
+        expect(capital, isNotNull, reason: 'debug game needs capital');
+        // Treasury 1,500 + paper 3: two queued Builders (2,000 treasury,
+        // 4 paper) exceed both resources, so both deficit clauses show.
+        final limitedPlayer = player.copyWith(
+          treasury: 1500,
+          stockpile: const Stockpile(quantities: {'paper': 3}),
+          capitalProvinceId: capital,
+        );
+        final limitedGame = game.copyWith(
+          players: [
+            limitedPlayer,
+            ...game.players.where((p) => p.id != humanPlayerId),
+          ],
+        );
+        final orders = Orders(
+          buildUnitOrdersByPlayerId: {
+            humanPlayerId: [
+              BuildUnitOrder(
+                unitType: kUnitTypeBuilder,
+                isMilitary: false,
+                spawnProvinceId: capital!,
+              ),
+              BuildUnitOrder(
+                unitType: kUnitTypeBuilder,
+                isMilitary: false,
+                spawnProvinceId: capital,
+              ),
+            ],
+          },
+        );
+
+        await tester.pumpWidget(
+          buildDialog(
+            game: limitedGame,
+            humanPlayerId: humanPlayerId,
+            currentOrders: orders,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('Treasury low and Paper low'), findsOneWidget);
+      },
+    );
+
     testWidgets('AC: All 6 civilian unit types are listed', (
       WidgetTester tester,
     ) async {

--- a/app/test/train_dialog_chrome_test.dart
+++ b/app/test/train_dialog_chrome_test.dart
@@ -45,6 +45,54 @@ void main() {
     });
   });
 
+  group('TrainDialogResourceBar', () {
+    testWidgets(
+      'renders entries inside a boxed inset strip with no danger when '
+      'deficitHint is null',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: Scaffold(
+              body: TrainDialogResourceBar(
+                entries: [
+                  TrainDialogResourceEntry(label: 'Treasury:', value: '£5,000'),
+                  TrainDialogResourceEntry(label: 'Paper:', value: '12'),
+                ],
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byType(TrainDialogResourceBarBox), findsOneWidget);
+        expect(find.textContaining('Treasury:'), findsOneWidget);
+        expect(find.textContaining('£5,000'), findsOneWidget);
+        expect(find.textContaining('Paper:'), findsOneWidget);
+        // No deficit row when deficitHint is null.
+        expect(find.textContaining('low'), findsNothing);
+      },
+    );
+
+    testWidgets('renders deficitHint below the box in the danger colour', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: TrainDialogResourceBar(
+              entries: [
+                TrainDialogResourceEntry(label: 'Treasury:', value: '£0'),
+              ],
+              deficitHint: 'Treasury low',
+            ),
+          ),
+        ),
+      );
+
+      final Text hint = tester.widget(find.text('Treasury low'));
+      expect(hint.style?.color, EditorialMonoclePalette.danger);
+    });
+  });
+
   test('kTrainDialogLockedOpacity is 0.4 per #2866 AC', () {
     expect(kTrainDialogLockedOpacity, 0.4);
   });

--- a/app/test/train_military_dialog_test.dart
+++ b/app/test/train_military_dialog_test.dart
@@ -116,6 +116,18 @@ void main() {
     expect(find.text('2'), findsWidgets);
   });
 
+  testWidgets('AC: treasury renders with £ + comma grouping (£10,000)', (
+    WidgetTester tester,
+  ) async {
+    final richGame = gameWithMilitaryResources();
+    await tester.pumpWidget(
+      buildDialog(game: richGame, humanPlayerId: humanPlayerId),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('£10,000'), findsOneWidget);
+  });
+
   testWidgets('AC: regiment rows show roster display names not type ids', (
     WidgetTester tester,
   ) async {


### PR DESCRIPTION
## Summary

Aligns the Train Civilians dialog (`UNIT40001`), the shared `TrainDialogChrome`, and the Train Military dialog (`UNIT50001`) to the canonical mockup `SPEC/ui/mockups/UNIT40001-train-civilians-dialog.html`.

`Refs #3568` (does not auto-close).

## Done in this push

- **Currency formatter:** new `app/lib/core/utils/currency_format.dart` (`formatThousands`, `formatTreasuryCurrency`) → `£` + comma thousands grouping (e.g. `£5,000`).
- **Resource bar:** restyled to a boxed inset strip with monospace bold values per the mockup. New `TrainDialogResourceBarBox` + `TrainDialogResourceEntry`; `TrainDialogResourceBar` now takes structured `entries` (muted label + mono-bold value). Military bar adopts the same boxed treatment while keeping its commodity chips/icons.
- **Row layout:** civilian `_UnitTypeRow` and military `_RegimentRow` are now a single line — left info column (name stacked above cost) with the stepper on the right of the same row.
- **Civilian cost line:** `£1,000 + 2 paper` (lowercase `paper`).
- **Civilian deficit:** both-resource case reads `Treasury low and Paper low`.
- **Military treasury:** resource bar treasury uses the same `£` + comma formatting.
- **l10n:** `trainCivilians_costLine` lowercased `paper`; added `trainUnits_treasuryLabel` / `trainUnits_paperLabel` label keys (arb + contract + en parts).
- **SPEC:** updated `train-civilians-dialog.md`, `components/train-dialog-chrome.md`, `train-military-dialog.md` (formatting, row geometry, boxed resource bar, deficit wording, new ACs). Chrome component spec kept at the ≤1000-word ceiling.

## ACs covered

All eight suggested ACs: `£`+comma treasury, `£1,000 + 2 paper` cost line, single-row name/cost/stepper layout, boxed mono-value resource bar, `Treasury low and Paper low` deficit, military `£`+comma + shared bar, 320 dp no-overflow, and updated/passing tests + SPEC.

## Tests

- Added `app/test/core/utils/currency_format_test.dart` (positive + negative formatting cases).
- Extended `train_civilians_dialog_test.dart` (`£5,000` not `5k`, `£1,000 + 2 paper`, both-low deficit wording), `train_military_dialog_test.dart` (`£10,000`), `train_dialog_chrome_test.dart` (boxed bar + `£` formatting + deficit danger colour).
- Verified green: `train_civilians_dialog_test`, `train_military_dialog_test`, `train_dialog_chrome_test`, `train_dialogs_320dp_min_viewport_test`, `spec_components_train_dialog_chrome_test`, `currency_format_test`, plus `unit_panels_widgetbook_dark_chrome_test` and `widgetbook_combat_stories_dark_chrome_test`.
- `flutter analyze` clean on all touched widget/util files.

## Deferred

None — full shared-chrome scope landed in this PR. Widgetbook stories construct the dialogs directly, so they reflect the new layout without story-code changes.

Made with [Cursor](https://cursor.com)