### PR TITLE
refactor: bundle economy-preview inputs into a record (#3565)

### DIFF
--- a/app/lib/features/game/screens/production_screen.dart
+++ b/app/lib/features/game/screens/production_screen.dart
@@ -126,13 +126,15 @@ class ProductionScreen extends ConsumerWidget {
               game: displayGame,
               topology: panelTopology,
               playerId: displayPlayer.id,
-              tileMapByRegion: panelTileMaps,
-              currentOrders: currentOrders,
-              defaultAssignmentsByPlayerId: {
-                displayPlayer.id: assignedRecipesFromDesiredOutput(
-                  desiredOutputByRecipe,
-                ),
-              },
+              inputs: economyPreviewInputs(
+                tileMapByRegion: panelTileMaps,
+                currentOrders: currentOrders,
+                defaultAssignmentsByPlayerId: {
+                  displayPlayer.id: assignedRecipesFromDesiredOutput(
+                    desiredOutputByRecipe,
+                  ),
+                },
+              ),
             );
         final canEdit = shell.canMutateViaUi;
         final labourCallbacks = ProductionLabourCallbacks(

--- a/app/lib/features/game/widgets/production_commodity_breakdown_dialog.dart
+++ b/app/lib/features/game/widgets/production_commodity_breakdown_dialog.dart
@@ -232,9 +232,11 @@ class _ProductionCommodityBreakdownDialogState
       game: widget.game,
       topology: widget.topology,
       playerId: widget.player.id,
-      tileMapByRegion: widget.tileMapByRegion,
-      currentOrders: widget.currentOrders,
-      defaultAssignmentsByPlayerId: defaultAssignmentsByPlayerId,
+      inputs: economyPreviewInputs(
+        tileMapByRegion: widget.tileMapByRegion,
+        currentOrders: widget.currentOrders,
+        defaultAssignmentsByPlayerId: defaultAssignmentsByPlayerId,
+      ),
     );
 
     final inputCommodityIds = <String>{};

--- a/app/lib/widgetbook/catalog_panel_map_stories.dart
+++ b/app/lib/widgetbook/catalog_panel_map_stories.dart
@@ -163,11 +163,13 @@ class ProductionPanelStoryBody extends ConsumerWidget {
       game: game,
       topology: topology,
       playerId: player.id,
-      tileMapByRegion: tileMapByRegion,
-      currentOrders: currentOrders,
-      defaultAssignmentsByPlayerId: {
-        player.id: assignedRecipesFromDesiredOutput(desiredOutputByRecipe),
-      },
+      inputs: economyPreviewInputs(
+        tileMapByRegion: tileMapByRegion,
+        currentOrders: currentOrders,
+        defaultAssignmentsByPlayerId: {
+          player.id: assignedRecipesFromDesiredOutput(desiredOutputByRecipe),
+        },
+      ),
     );
     final labourCallbacks = ProductionLabourCallbacks(
       onAppendRecruitOrder: (tier) {

--- a/packages/colonizethis_turn/lib/src/turn/economy_preview_pipeline.dart
+++ b/packages/colonizethis_turn/lib/src/turn/economy_preview_pipeline.dart
@@ -17,6 +17,49 @@ const List<EconomyPreviewStockpilePhase> _economyPreviewStockpilePhases =
       EconomyPreviewStockpilePhase.production,
     ];
 
+/// Bundled optional inputs shared by the economy-preview entry points
+/// ([economyPreviewStockpilePhaseDeltasForPlayer], [applyEconomyPhasesForPreview],
+/// [previewStockpileNetDeltaByCommodityForPlayer] and
+/// [previewStockpilePhaseDeltasByCommodityForPlayer]). Bundling the formerly
+/// duplicated five-field block into one record means a new preview input is
+/// declared once here instead of in every public signature.
+typedef EconomyPreviewInputs = ({
+  Map<String, TileMapResult>? tileMapByRegion,
+  Map<String, Map<CommodityId, int>> extractedByPlayerId,
+  Orders currentOrders,
+  List<AssignedRecipe> defaultAssignments,
+  Map<String, List<AssignedRecipe>>? defaultAssignmentsByPlayerId,
+});
+
+/// Default [EconomyPreviewInputs] with empty/unset fields, matching the prior
+/// per-parameter defaults declared individually on each preview entry point.
+const EconomyPreviewInputs emptyEconomyPreviewInputs = (
+  tileMapByRegion: null,
+  extractedByPlayerId: <String, Map<CommodityId, int>>{},
+  currentOrders: Orders(),
+  defaultAssignments: <AssignedRecipe>[],
+  defaultAssignmentsByPlayerId: null,
+);
+
+/// Builds [EconomyPreviewInputs] with the same defaults the preview entry points
+/// previously declared individually, preserving named-argument ergonomics for
+/// callers that set only a subset of fields.
+EconomyPreviewInputs economyPreviewInputs({
+  Map<String, TileMapResult>? tileMapByRegion,
+  Map<String, Map<CommodityId, int>> extractedByPlayerId = const {},
+  Orders currentOrders = const Orders(),
+  List<AssignedRecipe> defaultAssignments = const [],
+  Map<String, List<AssignedRecipe>>? defaultAssignmentsByPlayerId,
+}) {
+  return (
+    tileMapByRegion: tileMapByRegion,
+    extractedByPlayerId: extractedByPlayerId,
+    currentOrders: currentOrders,
+    defaultAssignments: defaultAssignments,
+    defaultAssignmentsByPlayerId: defaultAssignmentsByPlayerId,
+  );
+}
+
 /// Builds the [EconomyPhaseStepContext] shared by the preview entry points
 /// ([economyPreviewStockpilePhaseDeltasForPlayer] and
 /// [applyEconomyPhasesForPreview]). Centralizing construction keeps the common
@@ -233,11 +276,7 @@ economyPreviewStockpilePhaseDeltasForPlayer({
   required Game game,
   required MapTopology topology,
   required String playerId,
-  Map<String, TileMapResult>? tileMapByRegion,
-  Map<String, Map<CommodityId, int>> extractedByPlayerId = const {},
-  Orders currentOrders = const Orders(),
-  List<AssignedRecipe> defaultAssignments = const [],
-  Map<String, List<AssignedRecipe>>? defaultAssignmentsByPlayerId,
+  EconomyPreviewInputs inputs = emptyEconomyPreviewInputs,
 }) {
   final empty = {
     for (final p in EconomyPreviewStockpilePhase.values) p: <String, int>{},
@@ -257,7 +296,7 @@ economyPreviewStockpilePhaseDeltasForPlayer({
   acc = acc.copyWith(
     game: _applyPendingStockpileCostsForPreview(
       game: acc.game,
-      currentOrders: currentOrders,
+      currentOrders: inputs.currentOrders,
     ),
   );
   final pendingBuildCosts = _stockpileCommodityDeltaMap(
@@ -267,10 +306,10 @@ economyPreviewStockpilePhaseDeltasForPlayer({
 
   final economyCtx = _economyPreviewStepContext(
     topology: topology,
-    tileMapByRegion: tileMapByRegion,
-    extractedByPlayerId: extractedByPlayerId,
-    defaultAssignments: defaultAssignments,
-    defaultAssignmentsByPlayerId: defaultAssignmentsByPlayerId,
+    tileMapByRegion: inputs.tileMapByRegion,
+    extractedByPlayerId: inputs.extractedByPlayerId,
+    defaultAssignments: inputs.defaultAssignments,
+    defaultAssignmentsByPlayerId: inputs.defaultAssignmentsByPlayerId,
   );
   final economyDeltas = <EconomyPreviewStockpilePhase, Map<String, int>>{};
   for (var i = 0; i < economyPhaseSteps.length; i++) {
@@ -290,27 +329,23 @@ economyPreviewStockpilePhaseDeltasForPlayer({
 Game applyEconomyPhasesForPreview({
   required Game game,
   required MapTopology topology,
-  Map<String, TileMapResult>? tileMapByRegion,
-  Map<String, Map<CommodityId, int>> extractedByPlayerId = const {},
-  Orders currentOrders = const Orders(),
-  List<AssignedRecipe> defaultAssignments = const [],
-  Map<String, List<AssignedRecipe>>? defaultAssignmentsByPlayerId,
+  EconomyPreviewInputs inputs = emptyEconomyPreviewInputs,
 }) {
   var acc = TurnPipelineState(game: game);
   acc = acc.copyWith(
     game: _applyPendingStockpileCostsForPreview(
       game: acc.game,
-      currentOrders: currentOrders,
+      currentOrders: inputs.currentOrders,
     ),
   );
   acc = runEconomyPhaseSequence(
     acc,
     _economyPreviewStepContext(
       topology: topology,
-      tileMapByRegion: tileMapByRegion,
-      extractedByPlayerId: extractedByPlayerId,
-      defaultAssignments: defaultAssignments,
-      defaultAssignmentsByPlayerId: defaultAssignmentsByPlayerId,
+      tileMapByRegion: inputs.tileMapByRegion,
+      extractedByPlayerId: inputs.extractedByPlayerId,
+      defaultAssignments: inputs.defaultAssignments,
+      defaultAssignmentsByPlayerId: inputs.defaultAssignmentsByPlayerId,
     ),
   );
   return acc.game;
@@ -333,11 +368,7 @@ Map<String, int> previewStockpileNetDeltaByCommodityForPlayer({
   required Game game,
   required MapTopology topology,
   required String playerId,
-  Map<String, TileMapResult>? tileMapByRegion,
-  Map<String, Map<CommodityId, int>> extractedByPlayerId = const {},
-  Orders currentOrders = const Orders(),
-  List<AssignedRecipe> defaultAssignments = const [],
-  Map<String, List<AssignedRecipe>>? defaultAssignmentsByPlayerId,
+  EconomyPreviewInputs inputs = emptyEconomyPreviewInputs,
 }) {
   final beforePlayer = game.playerById(playerId);
   if (beforePlayer == null) {
@@ -347,11 +378,7 @@ Map<String, int> previewStockpileNetDeltaByCommodityForPlayer({
   final afterGame = applyEconomyPhasesForPreview(
     game: game,
     topology: topology,
-    tileMapByRegion: tileMapByRegion,
-    extractedByPlayerId: extractedByPlayerId,
-    currentOrders: currentOrders,
-    defaultAssignments: defaultAssignments,
-    defaultAssignmentsByPlayerId: defaultAssignmentsByPlayerId,
+    inputs: inputs,
   );
   final after = afterGame.playerById(playerId)?.stockpile ?? before;
   return _stockpileCommodityDeltaMap(before, after);
@@ -368,20 +395,12 @@ previewStockpilePhaseDeltasByCommodityForPlayer({
   required Game game,
   required MapTopology topology,
   required String playerId,
-  Map<String, TileMapResult>? tileMapByRegion,
-  Map<String, Map<CommodityId, int>> extractedByPlayerId = const {},
-  Orders currentOrders = const Orders(),
-  List<AssignedRecipe> defaultAssignments = const [],
-  Map<String, List<AssignedRecipe>>? defaultAssignmentsByPlayerId,
+  EconomyPreviewInputs inputs = emptyEconomyPreviewInputs,
 }) {
   return economyPreviewStockpilePhaseDeltasForPlayer(
     game: game,
     topology: topology,
     playerId: playerId,
-    tileMapByRegion: tileMapByRegion,
-    extractedByPlayerId: extractedByPlayerId,
-    currentOrders: currentOrders,
-    defaultAssignments: defaultAssignments,
-    defaultAssignmentsByPlayerId: defaultAssignmentsByPlayerId,
+    inputs: inputs,
   );
 }

--- a/packages/colonizethis_turn/lib/src/turn/turn_resolver.dart
+++ b/packages/colonizethis_turn/lib/src/turn/turn_resolver.dart
@@ -7,8 +7,11 @@ import 'package:colonizethis_orders/colonizethis_orders.dart';
 import '../projections/order_projections.dart';
 export 'economy_preview_pipeline.dart'
     show
+        EconomyPreviewInputs,
         applyEconomyPhasesForPreview,
+        economyPreviewInputs,
         economyPreviewStockpilePhaseDeltasForPlayer,
+        emptyEconomyPreviewInputs,
         previewStockpileNetDeltaByCommodityForPlayer,
         previewStockpilePhaseDeltasByCommodityForPlayer;
 import 'turn_order_acceptance.dart';

--- a/packages/colonizethis_turn/test/economy_preview_pipeline_characterization_test.dart
+++ b/packages/colonizethis_turn/test/economy_preview_pipeline_characterization_test.dart
@@ -86,7 +86,7 @@ void main() {
         game: game,
         topology: const MapTopology(nodes: [], edges: []),
         playerId: 'p1',
-        currentOrders: currentOrders,
+        inputs: economyPreviewInputs(currentOrders: currentOrders),
       );
       expect(
         _canonicalPreviewPhaseSnapshot(phases),

--- a/packages/colonizethis_turn/test/economy_stockpile_preview_part1_test.dart
+++ b/packages/colonizethis_turn/test/economy_stockpile_preview_part1_test.dart
@@ -44,9 +44,11 @@ void main() {
         game: game,
         topology: const MapTopology(),
         playerId: 'p1',
-        extractedByPlayerId: {
-          'p1': {CommodityCatalog.grain.id: 4},
-        },
+        inputs: economyPreviewInputs(
+          extractedByPlayerId: {
+            'p1': {CommodityCatalog.grain.id: 4},
+          },
+        ),
       );
       expect(delta[CommodityCatalog.grain.id], 4);
       expect(delta.length, 1);
@@ -137,11 +139,13 @@ void main() {
         game: game,
         topology: const MapTopology(),
         playerId: 'p1',
-        defaultAssignmentsByPlayerId: {
-          'p1': const [
-            AssignedRecipe(recipeId: 'lumber_from_timber', assignedLabour: 10),
-          ],
-        },
+        inputs: economyPreviewInputs(
+          defaultAssignmentsByPlayerId: {
+            'p1': const [
+              AssignedRecipe(recipeId: 'lumber_from_timber', assignedLabour: 10),
+            ],
+          },
+        ),
       );
       expect(delta[CommodityCatalog.timber.id], -10);
       expect(delta[CommodityCatalog.lumber.id], 5);
@@ -190,13 +194,13 @@ void main() {
         game: game,
         topology: const MapTopology(),
         playerId: 'p1',
-        currentOrders: currentOrders,
+        inputs: economyPreviewInputs(currentOrders: currentOrders),
       );
       final phases = previewStockpilePhaseDeltasByCommodityForPlayer(
         game: game,
         topology: const MapTopology(),
         playerId: 'p1',
-        currentOrders: currentOrders,
+        inputs: economyPreviewInputs(currentOrders: currentOrders),
       );
       expect(delta[CommodityCatalog.paper.id], -4);
       expect(

--- a/packages/colonizethis_turn/test/economy_stockpile_preview_part2_segment1_test.dart
+++ b/packages/colonizethis_turn/test/economy_stockpile_preview_part2_segment1_test.dart
@@ -67,13 +67,13 @@ void main() {
           game: game,
           topology: const MapTopology(),
           playerId: 'p1',
-          currentOrders: currentOrders,
+          inputs: economyPreviewInputs(currentOrders: currentOrders),
         );
         final phases = previewStockpilePhaseDeltasByCommodityForPlayer(
           game: game,
           topology: const MapTopology(),
           playerId: 'p1',
-          currentOrders: currentOrders,
+          inputs: economyPreviewInputs(currentOrders: currentOrders),
         );
         expect(delta[CommodityCatalog.lumber.id], -1);
         expect(delta[CommodityCatalog.castIron.id], -1);
@@ -131,7 +131,7 @@ void main() {
           game: game,
           topology: const MapTopology(),
           playerId: 'p1',
-          currentOrders: currentOrders,
+          inputs: economyPreviewInputs(currentOrders: currentOrders),
         );
         expect(delta[CommodityCatalog.lumber.id], -4);
         expect(delta[CommodityCatalog.castIron.id], -4);
@@ -183,7 +183,7 @@ void main() {
           game: gameBusy,
           topology: const MapTopology(),
           playerId: 'p1',
-          currentOrders: ordersBusy,
+          inputs: economyPreviewInputs(currentOrders: ordersBusy),
         ),
         isEmpty,
       );
@@ -228,7 +228,7 @@ void main() {
           game: gamePoorCost,
           topology: const MapTopology(),
           playerId: 'p1',
-          currentOrders: ordersPoorCost,
+          inputs: economyPreviewInputs(currentOrders: ordersPoorCost),
         ),
         isEmpty,
       );
@@ -274,7 +274,7 @@ void main() {
           game: game,
           topology: const MapTopology(),
           playerId: 'p1',
-          currentOrders: currentOrders,
+          inputs: economyPreviewInputs(currentOrders: currentOrders),
         ),
         isEmpty,
       );

--- a/packages/colonizethis_turn/test/economy_stockpile_preview_part2_segment2_test.dart
+++ b/packages/colonizethis_turn/test/economy_stockpile_preview_part2_segment2_test.dart
@@ -98,7 +98,7 @@ void main() {
             game: game,
             topology: const MapTopology(),
             playerId: 'p1',
-            currentOrders: orders,
+            inputs: economyPreviewInputs(currentOrders: orders),
           );
           final pending =
               phases[EconomyPreviewStockpilePhase.pendingBuildCosts]!;
@@ -213,7 +213,7 @@ void main() {
             game: game,
             topology: const MapTopology(),
             playerId: 'p1',
-            currentOrders: orders,
+            inputs: economyPreviewInputs(currentOrders: orders),
           );
           final pending =
               phases[EconomyPreviewStockpilePhase.pendingBuildCosts]!;
@@ -287,7 +287,7 @@ void main() {
             game: game,
             topology: const MapTopology(),
             playerId: 'p1',
-            currentOrders: orders,
+            inputs: economyPreviewInputs(currentOrders: orders),
           );
           final pending =
               phases[EconomyPreviewStockpilePhase.pendingBuildCosts]!;

--- a/packages/colonizethis_turn/test/economy_stockpile_preview_part2_segment3_test.dart
+++ b/packages/colonizethis_turn/test/economy_stockpile_preview_part2_segment3_test.dart
@@ -96,7 +96,7 @@ void main() {
                 game: missingUnitGame,
                 topology: const MapTopology(),
                 playerId: 'p1',
-                currentOrders: missingUnitOrders,
+                inputs: economyPreviewInputs(currentOrders: missingUnitOrders),
               )[EconomyPreviewStockpilePhase.pendingBuildCosts],
               isEmpty,
               reason: 'missing unit target=${t.target}',
@@ -138,7 +138,7 @@ void main() {
                 game: busyUnitGame,
                 topology: const MapTopology(),
                 playerId: 'p1',
-                currentOrders: busyOrders,
+                inputs: economyPreviewInputs(currentOrders: busyOrders),
               )[EconomyPreviewStockpilePhase.pendingBuildCosts],
               isEmpty,
               reason: 'busy unit target=${t.target}',
@@ -173,7 +173,7 @@ void main() {
                 game: disallowedUnitGame,
                 topology: const MapTopology(),
                 playerId: 'p1',
-                currentOrders: disallowedOrders,
+                inputs: economyPreviewInputs(currentOrders: disallowedOrders),
               )[EconomyPreviewStockpilePhase.pendingBuildCosts],
               isEmpty,
               reason: 'disallowed unit target=${t.target}',
@@ -204,7 +204,7 @@ void main() {
                 game: invalidTileGame,
                 topology: const MapTopology(),
                 playerId: 'p1',
-                currentOrders: invalidTileOrders,
+                inputs: economyPreviewInputs(currentOrders: invalidTileOrders),
               )[EconomyPreviewStockpilePhase.pendingBuildCosts],
               isEmpty,
               reason: 'invalid target key target=${t.target}',
@@ -248,7 +248,9 @@ void main() {
                 game: insufficientGame,
                 topology: const MapTopology(),
                 playerId: 'p1',
-                currentOrders: insufficientOrders,
+                inputs: economyPreviewInputs(
+                  currentOrders: insufficientOrders,
+                ),
               )[EconomyPreviewStockpilePhase.pendingBuildCosts],
               isEmpty,
               reason: 'insufficient stockpile target=${t.target}',
@@ -295,14 +297,16 @@ void main() {
         game: game,
         topology: const MapTopology(),
         playerId: 'p1',
-        extractedByPlayerId: {
-          'p1': {CommodityCatalog.grain.id: 5},
-        },
-        defaultAssignmentsByPlayerId: {
-          'p1': const [
-            AssignedRecipe(recipeId: 'lumber_from_timber', assignedLabour: 4),
-          ],
-        },
+        inputs: economyPreviewInputs(
+          extractedByPlayerId: {
+            'p1': {CommodityCatalog.grain.id: 5},
+          },
+          defaultAssignmentsByPlayerId: {
+            'p1': const [
+              AssignedRecipe(recipeId: 'lumber_from_timber', assignedLabour: 4),
+            ],
+          },
+        ),
       );
       expect(delta[CommodityCatalog.gems.id], -1);
       expect(delta[CommodityCatalog.timber.id], -2);

--- a/packages/colonizethis_turn/test/economy_stockpile_preview_recruit_worker_test.dart
+++ b/packages/colonizethis_turn/test/economy_stockpile_preview_recruit_worker_test.dart
@@ -48,13 +48,13 @@ void main() {
         game: game,
         topology: const MapTopology(),
         playerId: 'p1',
-        currentOrders: currentOrders,
+        inputs: economyPreviewInputs(currentOrders: currentOrders),
       );
       final phases = previewStockpilePhaseDeltasByCommodityForPlayer(
         game: game,
         topology: const MapTopology(),
         playerId: 'p1',
-        currentOrders: currentOrders,
+        inputs: economyPreviewInputs(currentOrders: currentOrders),
       );
 
       expect(delta[CommodityCatalog.fabric.id], -2);
@@ -92,13 +92,13 @@ void main() {
         game: game,
         topology: const MapTopology(),
         playerId: 'p1',
-        currentOrders: currentOrders,
+        inputs: economyPreviewInputs(currentOrders: currentOrders),
       );
       final phases = previewStockpilePhaseDeltasByCommodityForPlayer(
         game: game,
         topology: const MapTopology(),
         playerId: 'p1',
-        currentOrders: currentOrders,
+        inputs: economyPreviewInputs(currentOrders: currentOrders),
       );
 
       expect(delta[CommodityCatalog.paper.id], -2);
@@ -111,7 +111,7 @@ void main() {
       final preview = applyEconomyPhasesForPreview(
         game: game,
         topology: const MapTopology(),
-        currentOrders: currentOrders,
+        inputs: economyPreviewInputs(currentOrders: currentOrders),
       );
       final updated = preview.playerById('p1')!;
       expect(updated.treasury, 300);
@@ -146,13 +146,13 @@ void main() {
         game: game,
         topology: const MapTopology(),
         playerId: 'p1',
-        currentOrders: currentOrders,
+        inputs: economyPreviewInputs(currentOrders: currentOrders),
       );
       final phases = previewStockpilePhaseDeltasByCommodityForPlayer(
         game: game,
         topology: const MapTopology(),
         playerId: 'p1',
-        currentOrders: currentOrders,
+        inputs: economyPreviewInputs(currentOrders: currentOrders),
       );
 
       expect(delta, isEmpty);
@@ -164,7 +164,7 @@ void main() {
       final preview = applyEconomyPhasesForPreview(
         game: game,
         topology: const MapTopology(),
-        currentOrders: currentOrders,
+        inputs: economyPreviewInputs(currentOrders: currentOrders),
       );
       final updated = preview.playerById('p1')!;
       expect(updated.treasury, 1000);
@@ -191,7 +191,7 @@ void main() {
         game: game,
         topology: const MapTopology(),
         playerId: 'p1',
-        currentOrders: currentOrders,
+        inputs: economyPreviewInputs(currentOrders: currentOrders),
       );
 
       expect(delta, isEmpty);
@@ -199,7 +199,7 @@ void main() {
       final preview = applyEconomyPhasesForPreview(
         game: game,
         topology: const MapTopology(),
-        currentOrders: currentOrders,
+        inputs: economyPreviewInputs(currentOrders: currentOrders),
       );
       final updated = preview.playerById('p1')!;
       expect(updated.treasury, 1000);
@@ -262,7 +262,7 @@ void main() {
       final preview = applyEconomyPhasesForPreview(
         game: game,
         topology: const MapTopology(),
-        currentOrders: currentOrders,
+        inputs: economyPreviewInputs(currentOrders: currentOrders),
       );
       final updated = preview.playerById('p1')!;
 
@@ -303,7 +303,7 @@ void main() {
       final preview = applyEconomyPhasesForPreview(
         game: game,
         topology: const MapTopology(),
-        currentOrders: currentOrders,
+        inputs: economyPreviewInputs(currentOrders: currentOrders),
       );
       final updated = preview.playerById('p1')!;
       expect(updated.workerPool.peasants, 0);

--- a/packages/colonizethis_turn/test/economy_stockpile_preview_test_support.dart
+++ b/packages/colonizethis_turn/test/economy_stockpile_preview_test_support.dart
@@ -13,23 +13,23 @@ void expectPhaseDeltasSumToNet({
   List<AssignedRecipe> defaultAssignments = const [],
   Map<String, List<AssignedRecipe>>? defaultAssignmentsByPlayerId,
 }) {
-  final phases = previewStockpilePhaseDeltasByCommodityForPlayer(
-    game: game,
-    topology: const MapTopology(),
-    playerId: playerId,
+  final inputs = economyPreviewInputs(
     extractedByPlayerId: extractedByPlayerId,
     currentOrders: currentOrders,
     defaultAssignments: defaultAssignments,
     defaultAssignmentsByPlayerId: defaultAssignmentsByPlayerId,
   );
+  final phases = previewStockpilePhaseDeltasByCommodityForPlayer(
+    game: game,
+    topology: const MapTopology(),
+    playerId: playerId,
+    inputs: inputs,
+  );
   final net = previewStockpileNetDeltaByCommodityForPlayer(
     game: game,
     topology: const MapTopology(),
     playerId: playerId,
-    extractedByPlayerId: extractedByPlayerId,
-    currentOrders: currentOrders,
-    defaultAssignments: defaultAssignments,
-    defaultAssignmentsByPlayerId: defaultAssignmentsByPlayerId,
+    inputs: inputs,
   );
   final keys = <String>{};
   for (final m in phases.values) {


### PR DESCRIPTION
## Summary

Follow-up PR for #3565 (prior PR #3567 already merged 8/10 refactors → ACs #1–#6, #9, #10). This PR closes **AC #7** and resolves the long-standing scope contradiction around **AC #8**.

## Done in this push (AC #7 — economy-preview parameter bundling)

The four public economy-preview entry points each re-declared the same five-field block (`tileMapByRegion`, `extractedByPlayerId`, `currentOrders`, `defaultAssignments`, `defaultAssignmentsByPlayerId`). This PR bundles that block into a single `EconomyPreviewInputs` record:

- New `EconomyPreviewInputs` typedef record + `emptyEconomyPreviewInputs` const default + an `economyPreviewInputs({...})` builder (with the prior per-parameter defaults) so callers keep named-argument ergonomics while the signature is declared once.
- `economyPreviewStockpilePhaseDeltasForPlayer`, `applyEconomyPhasesForPreview`, `previewStockpileNetDeltaByCommodityForPlayer`, and `previewStockpilePhaseDeltasByCommodityForPlayer` now take a single `EconomyPreviewInputs inputs = emptyEconomyPreviewInputs` param.
- New symbols exported from the turn package barrel.
- **Mechanical caller updates** (see scope note): `production_screen.dart`, `production_commodity_breakdown_dialog.dart`, `catalog_panel_map_stories.dart`, and the turn-package preview tests.

Behavior is unchanged — the record carries the same values to the same internal helpers.

## Scope decision (resolves the AC ↔ non-goal contradiction)

The issue's non-goal ("no `tool/` or `app/` changes") collided with ACs #7/#8. Decision taken this run:

1. **AC #7 — implemented.** The non-goal is relaxed to permit *mechanical, behavior-preserving* caller updates strictly required to consume the new turn-package signatures (3 app files + tests). No app/tool behavior changes.
2. **AC #8 — superseded (not implemented).** "Collapse the four `resumeTurnResolutionWith*Decisions` wrappers into one generic dispatch" **directly contradicts** `SPEC/program/turn-resume-config-dispatch.md`, which mandates the four named typed public wrappers as the contract and is enforced by the `repo.turn_resume_param_budget` lint gate. The underlying duplication AC #8 targeted (the ~14-param forwarding) was already removed in #3416 via the shared private `_resumeTurnResolutionWithDiplomacyDecisions` dispatch — the wrappers are already thin 4-param typed adapters. Implementing AC #8 would require contradicting SPEC and the lint gate and would lose type safety, so it is marked superseded rather than implemented.

## Tests

```
cd packages/colonizethis_turn && dart analyze lib test   # clean (1 pre-existing unrelated info)
cd packages/colonizethis_turn && dart test                # 322/322 passed
cd app && flutter test test/production_screen_integration_test.dart \
  test/production_commodity_breakdown_dialog_spec_test.dart \
  test/widgetbook_production_panel_live_breakdown_test.dart \
  test/production_screen_top_bar_test.dart                 # 23/23 passed
```

## Remaining for #3565

- AC #7: done here.
- AC #8: superseded (SPEC conflict + already achieved by #3416) — see issue comment.
- All other ACs (#1–#6, #9–#12) landed in merged #3567.

Refs #3565

Made with [Cursor](https://cursor.com)