### PR TITLE
refactor(map): route view-builder & visualizer cell walks through TileMapGrid (#3574)

### DIFF
--- a/packages/colonizethis_map/lib/src/game_world_state_map_visualizer.dart
+++ b/packages/colonizethis_map/lib/src/game_world_state_map_visualizer.dart
@@ -95,26 +95,24 @@ Uint8List renderSingleRegionGameStateMapToPng({
   image.clear(white);
 
   // Fill: provinces by owner color, sea zones deep blue
-  for (var y = 0; y < result.height; y++) {
-    for (var x = 0; x < result.width; x++) {
-      final id = result.cell(x, y);
-      final isSea = seaZoneIds.contains(id);
-      final fullProvinceId = isSea ? null : ProvinceId.full(regionId, id);
-      final (r, g, b) = isSea
-          ? seaColorRgb
-          : (factionColors[ownerByProvinceId[fullProvinceId] ?? ''] ??
-                (128, 128, 128));
-      final color = image.getColor(r, g, b);
-      img.fillRect(
-        image,
-        x1: x * cellSize,
-        y1: y * cellSize,
-        x2: (x + 1) * cellSize - 1,
-        y2: (y + 1) * cellSize - 1,
-        color: color,
-      );
-    }
-  }
+  TileMapGrid.forEachIndex(result.height, result.width, (y, x) {
+    final id = result.cell(x, y);
+    final isSea = seaZoneIds.contains(id);
+    final fullProvinceId = isSea ? null : ProvinceId.full(regionId, id);
+    final (r, g, b) = isSea
+        ? seaColorRgb
+        : (factionColors[ownerByProvinceId[fullProvinceId] ?? ''] ??
+              (128, 128, 128));
+    final color = image.getColor(r, g, b);
+    img.fillRect(
+      image,
+      x1: x * cellSize,
+      y1: y * cellSize,
+      x2: (x + 1) * cellSize - 1,
+      y2: (y + 1) * cellSize - 1,
+      color: color,
+    );
+  });
 
   drawBorders(image, result, seaZoneIds, cellSize, seaZoneBorderColor);
 
@@ -200,14 +198,8 @@ Uint8List renderInitGameMapToPng({
   required Map<String, MapTopology> topologyByRegion,
   int cellSize = 24,
 }) {
-  final owInputs = regionMapRenderInputs(
-    game: game,
-    regionId: kRegionOldWorld,
-  );
-  final nwInputs = regionMapRenderInputs(
-    game: game,
-    regionId: kRegionNewWorld,
-  );
+  final owInputs = regionMapRenderInputs(game: game, regionId: kRegionOldWorld);
+  final nwInputs = regionMapRenderInputs(game: game, regionId: kRegionNewWorld);
 
   // Port tile positions from WorldState.portsByProvinceSeaboard (value = regionId|provinceId|x|y)
   final owPortTiles = <({int x, int y})>[];

--- a/packages/colonizethis_map/lib/src/init_game_map_view_builder.dart
+++ b/packages/colonizethis_map/lib/src/init_game_map_view_builder.dart
@@ -14,10 +14,10 @@ import 'port_icon_placement.dart';
 import 'province_ownership_view.dart';
 import 'region_constants.dart';
 import 'region_data_access.dart';
-import 'region_map_view_inputs.dart';
 import 'sea_zone_centroid_tile.dart';
 import 'tile_key_util.dart';
 import 'tile_map_capital_markers.dart';
+import 'tile_map_grid.dart';
 import 'tile_map_topology_helpers.dart';
 import 'tile_map_visualization_shared.dart';
 

--- a/packages/colonizethis_map/lib/src/init_game_map_view_builder_cells_markers_part.dart
+++ b/packages/colonizethis_map/lib/src/init_game_map_view_builder_cells_markers_part.dart
@@ -13,55 +13,53 @@ List<CellViewData> _buildCellViewDataList({
   required Map<String, int>? resourceExtractionBlockedUnitsByTile,
 }) {
   final cells = <CellViewData>[];
-  for (var y = 0; y < tileMap.height; y++) {
-    for (var x = 0; x < tileMap.width; x++) {
-      final localId = tileMap.cell(x, y);
-      final isSea = seaZoneIds.contains(localId);
-      final terrain = tileMap.terrainAt(x, y);
-      final resource = tileMap.resourceAt(x, y);
-      final tileKey = '$regionId|$localId|$x|$y';
-      final improvement = isSea ? null : tileState.improvementLevel(tileKey);
-      final road = isSea ? null : tileState.roadLevel(tileKey);
-      final visibility = visibilityByTile != null
-          ? (visibilityByTile[tileKey] ?? TileVisibility.visible)
-          : TileVisibility.visible;
-      final extractionUnits = isSea
-          ? null
-          : resourceExtractionUnitsByTile?[tileKey];
-      final extractionEffectiveUnits = isSea
-          ? null
-          : resourceExtractionEffectiveUnitsByTile?[tileKey];
-      final extractionBlockedUnits = isSea
-          ? null
-          : resourceExtractionBlockedUnitsByTile?[tileKey];
-      final fullProvinceId = isSea ? null : ProvinceId.full(regionId, localId);
-      cells.add(
-        CellViewData(
-          x: x,
-          y: y,
-          regionCellId: localId,
-          isSea: isSea,
-          terrainTypeId: terrain?.name,
-          terrainType: terrain,
-          resourceId: resource?.name,
-          ownerFactionId: fullProvinceId != null
-              ? ownerByProvinceId[fullProvinceId]
-              : null,
-          provinceDisplayName: isSea
-              ? null
-              : (fullProvinceId != null
-                    ? provinceDisplayNameById[fullProvinceId]
-                    : null),
-          improvementLevel: isSea ? null : improvement,
-          roadLevel: isSea ? null : road,
-          resourceExtractionUnits: extractionUnits,
-          resourceExtractionEffectiveUnits: extractionEffectiveUnits,
-          resourceExtractionBlockedUnits: extractionBlockedUnits,
-          visibility: visibility,
-        ),
-      );
-    }
-  }
+  TileMapGrid.forEachIndex(tileMap.height, tileMap.width, (y, x) {
+    final localId = tileMap.cell(x, y);
+    final isSea = seaZoneIds.contains(localId);
+    final terrain = tileMap.terrainAt(x, y);
+    final resource = tileMap.resourceAt(x, y);
+    final tileKey = '$regionId|$localId|$x|$y';
+    final improvement = isSea ? null : tileState.improvementLevel(tileKey);
+    final road = isSea ? null : tileState.roadLevel(tileKey);
+    final visibility = visibilityByTile != null
+        ? (visibilityByTile[tileKey] ?? TileVisibility.visible)
+        : TileVisibility.visible;
+    final extractionUnits = isSea
+        ? null
+        : resourceExtractionUnitsByTile?[tileKey];
+    final extractionEffectiveUnits = isSea
+        ? null
+        : resourceExtractionEffectiveUnitsByTile?[tileKey];
+    final extractionBlockedUnits = isSea
+        ? null
+        : resourceExtractionBlockedUnitsByTile?[tileKey];
+    final fullProvinceId = isSea ? null : ProvinceId.full(regionId, localId);
+    cells.add(
+      CellViewData(
+        x: x,
+        y: y,
+        regionCellId: localId,
+        isSea: isSea,
+        terrainTypeId: terrain?.name,
+        terrainType: terrain,
+        resourceId: resource?.name,
+        ownerFactionId: fullProvinceId != null
+            ? ownerByProvinceId[fullProvinceId]
+            : null,
+        provinceDisplayName: isSea
+            ? null
+            : (fullProvinceId != null
+                  ? provinceDisplayNameById[fullProvinceId]
+                  : null),
+        improvementLevel: isSea ? null : improvement,
+        roadLevel: isSea ? null : road,
+        resourceExtractionUnits: extractionUnits,
+        resourceExtractionEffectiveUnits: extractionEffectiveUnits,
+        resourceExtractionBlockedUnits: extractionBlockedUnits,
+        visibility: visibility,
+      ),
+    );
+  });
   return cells;
 }
 
@@ -71,16 +69,14 @@ Map<String, (int x, int y)> _buildProvinceToRepresentativeTile({
   required Set<String> seaZoneIds,
 }) {
   final provinceToTile = <String, (int x, int y)>{};
-  for (var y = 0; y < tileMap.height; y++) {
-    for (var x = 0; x < tileMap.width; x++) {
-      final localId = tileMap.cell(x, y);
-      if (seaZoneIds.contains(localId)) {
-        continue;
-      }
-      final fullProvinceId = ProvinceId.full(regionId, localId);
-      provinceToTile.putIfAbsent(fullProvinceId, () => (x, y));
+  TileMapGrid.forEachIndex(tileMap.height, tileMap.width, (y, x) {
+    final localId = tileMap.cell(x, y);
+    if (seaZoneIds.contains(localId)) {
+      return;
     }
-  }
+    final fullProvinceId = ProvinceId.full(regionId, localId);
+    provinceToTile.putIfAbsent(fullProvinceId, () => (x, y));
+  });
   return provinceToTile;
 }
 
@@ -137,10 +133,7 @@ _buildUnitAndCivilianMarkerData({
     );
   }
 
-  final regionUnits = regionDataForMapRegionId(
-    game.worldState,
-    regionId,
-  ).units;
+  final regionUnits = regionDataForMapRegionId(game.worldState, regionId).units;
   for (final u in regionUnits) {
     final isPlayerOwnedCivilian =
         civilianOwnerIds.contains(u.ownerId) && isCivilianUnitType(u.type);

--- a/packages/colonizethis_map/lib/src/init_game_map_view_builder_map_markers_part.dart
+++ b/packages/colonizethis_map/lib/src/init_game_map_view_builder_map_markers_part.dart
@@ -119,15 +119,13 @@ Map<String, (int x, int y)> _buildSeaZoneToRepresentativeTile({
   required Set<String> seaZoneIds,
 }) {
   final seaZoneToTile = <String, (int x, int y)>{};
-  for (var y = 0; y < tileMap.height; y++) {
-    for (var x = 0; x < tileMap.width; x++) {
-      final localId = tileMap.cell(x, y);
-      if (!seaZoneIds.contains(localId)) {
-        continue;
-      }
-      seaZoneToTile.putIfAbsent(localId, () => (x, y));
+  TileMapGrid.forEachIndex(tileMap.height, tileMap.width, (y, x) {
+    final localId = tileMap.cell(x, y);
+    if (!seaZoneIds.contains(localId)) {
+      return;
     }
-  }
+    seaZoneToTile.putIfAbsent(localId, () => (x, y));
+  });
   return seaZoneToTile;
 }
 

--- a/packages/colonizethis_map/lib/src/sea_zone_centroid_tile.dart
+++ b/packages/colonizethis_map/lib/src/sea_zone_centroid_tile.dart
@@ -4,6 +4,8 @@ library;
 
 import 'package:colonizethis_data/colonizethis_data.dart';
 
+import 'tile_map_grid.dart';
+
 /// Returns tile key `regionId|localSeaZoneId|x|y` for the cell whose coordinates
 /// are `round(average x)`, `round(average y)` over all grid cells assigned to
 /// [localSeaZoneId] on [tileMap].
@@ -17,14 +19,12 @@ String? seaZoneCentroidTileKey({
     return null;
   }
   final points = <(int, int)>[];
-  for (var y = 0; y < tileMap.height; y++) {
-    for (var x = 0; x < tileMap.width; x++) {
-      if (tileMap.cell(x, y) != localSeaZoneId) {
-        continue;
-      }
-      points.add((x, y));
+  TileMapGrid.forEachIndex(tileMap.height, tileMap.width, (y, x) {
+    if (tileMap.cell(x, y) != localSeaZoneId) {
+      return;
     }
-  }
+    points.add((x, y));
+  });
   final c = roundedCentroidIntCoords(points);
   if (c == null) {
     return null;

--- a/packages/colonizethis_map/lib/src/tile_map_visualization.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_visualization.dart
@@ -6,6 +6,7 @@ import 'dart:typed_data';
 import 'package:image/image.dart' as img;
 import 'package:colonizethis_data/colonizethis_data.dart';
 
+import 'tile_map_grid.dart';
 import 'tile_map_topology_helpers.dart';
 import 'tile_map_visualization_shared.dart'
     show
@@ -166,22 +167,20 @@ void _drawMapCells({
   required Set<String> seaZoneIds,
   required Map<String, (int, int, int)>? regionColors,
 }) {
-  for (var y = 0; y < result.height; y++) {
-    for (var x = 0; x < result.width; x++) {
-      final id = result.cell(x, y);
-      final (r, g, b) = useTerrain
-          ? _terrainOrSeaCellColor(result, seaZoneIds, x, y, id)
-          : regionColors![id]!;
-      img.fillRect(
-        image,
-        x1: x * cellSize,
-        y1: y * cellSize,
-        x2: (x + 1) * cellSize - 1,
-        y2: (y + 1) * cellSize - 1,
-        color: image.getColor(r, g, b),
-      );
-    }
-  }
+  TileMapGrid.forEachIndex(result.height, result.width, (y, x) {
+    final id = result.cell(x, y);
+    final (r, g, b) = useTerrain
+        ? _terrainOrSeaCellColor(result, seaZoneIds, x, y, id)
+        : regionColors![id]!;
+    img.fillRect(
+      image,
+      x1: x * cellSize,
+      y1: y * cellSize,
+      x2: (x + 1) * cellSize - 1,
+      y2: (y + 1) * cellSize - 1,
+      color: image.getColor(r, g, b),
+    );
+  });
 }
 
 (int, int, int) _terrainOrSeaCellColor(
@@ -256,19 +255,17 @@ void _drawRegionIdLabels({
     regionIdLabelRgb.$3,
   );
   const idInset = 2;
-  for (var y = 0; y < result.height; y++) {
-    for (var x = 0; x < result.width; x++) {
-      final id = result.cell(x, y);
-      img.drawString(
-        image,
-        id,
-        font: img.arial14,
-        x: x * cellSize + idInset,
-        y: y * cellSize + idInset,
-        color: regionIdColor,
-      );
-    }
-  }
+  TileMapGrid.forEachIndex(result.height, result.width, (y, x) {
+    final id = result.cell(x, y);
+    img.drawString(
+      image,
+      id,
+      font: img.arial14,
+      x: x * cellSize + idInset,
+      y: y * cellSize + idInset,
+      color: regionIdColor,
+    );
+  });
 }
 
 void _drawResourceLettersOnMap({

--- a/packages/colonizethis_map/lib/src/tile_map_visualization_shared.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_visualization_shared.dart
@@ -6,6 +6,7 @@ import 'package:image/image.dart' as img;
 
 import 'init_game_map_view_data.dart';
 import 'tile_map_colors.dart';
+import 'tile_map_grid.dart';
 import 'tile_map_resource_legend.dart';
 
 export 'tile_map_colors.dart';
@@ -125,36 +126,34 @@ void drawBorders(
 ) {
   final black = image.getColor(0, 0, 0);
   final borderThickness = cellSize >= 12 ? 2 : 1;
-  for (var y = 0; y < result.height; y++) {
-    for (var x = 0; x < result.width; x++) {
-      if (x + 1 < result.width) {
-        _drawVerticalCellBorderIfDifferent(
-          image,
-          result,
-          x,
-          y,
-          seaZoneIds,
-          cellSize,
-          seaZoneBorderColor,
-          black,
-          borderThickness,
-        );
-      }
-      if (y + 1 < result.height) {
-        _drawHorizontalCellBorderIfDifferent(
-          image,
-          result,
-          x,
-          y,
-          seaZoneIds,
-          cellSize,
-          seaZoneBorderColor,
-          black,
-          borderThickness,
-        );
-      }
+  TileMapGrid.forEachIndex(result.height, result.width, (y, x) {
+    if (x + 1 < result.width) {
+      _drawVerticalCellBorderIfDifferent(
+        image,
+        result,
+        x,
+        y,
+        seaZoneIds,
+        cellSize,
+        seaZoneBorderColor,
+        black,
+        borderThickness,
+      );
     }
-  }
+    if (y + 1 < result.height) {
+      _drawHorizontalCellBorderIfDifferent(
+        image,
+        result,
+        x,
+        y,
+        seaZoneIds,
+        cellSize,
+        seaZoneBorderColor,
+        black,
+        borderThickness,
+      );
+    }
+  });
 }
 
 /// Draws a color swatch in the legend at row y.

--- a/packages/colonizethis_map/lib/src/topology_inference.dart
+++ b/packages/colonizethis_map/lib/src/topology_inference.dart
@@ -3,16 +3,15 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 
 import 'map_pipe_string_util.dart';
+import 'tile_map_grid.dart';
 
 /// Infers MapTopology from a tile map result. SPEC/program/tile-map-gen-resources.md § Topology inference.
 /// Collects unique region ids from grid; classifies province vs sea zone; builds edges from adjacencies.
 MapTopology inferTopologyFromTileMap(TileMapResult result, String regionId) {
   final ids = <String>{};
-  for (var y = 0; y < result.height; y++) {
-    for (var x = 0; x < result.width; x++) {
-      ids.add(result.cell(x, y));
-    }
-  }
+  TileMapGrid.forEachIndex(result.height, result.width, (y, x) {
+    ids.add(result.cell(x, y));
+  });
 
   final nodes = <TopologyNode>[];
   for (final id in ids) {


### PR DESCRIPTION
## Summary

Continues the canonical tile-grid cell-traversal centralization for `packages/colonizethis_map` (issue #3574, Slice 1). PR #3576 added the `TileMapGrid.forEachIndex` / `forEachCell` API and migrated the **generator passes**; the issue sequences "generator passes first, then view builder cell walks, then visualizer fill loops." This PR completes that next step: the remaining hand-rolled nested `for (var y …) { for (var x …) }` tile walks in the **view-builder** and **PNG visualizer** paths now route through `TileMapGrid.forEachIndex`.

`Refs #3574`

## Done in this push

Behavior-preserving migration (row-major `y`-outer/`x`-inner order preserved, so seeded generation/render output stays bit-for-bit deterministic; `continue` → early `return` inside the visit callback):

- `init_game_map_view_builder_cells_markers_part.dart` — cell-view list build + province representative-tile map
- `init_game_map_view_builder_map_markers_part.dart` — sea-zone representative-tile map
- `game_world_state_map_visualizer.dart` — ownership fill loop
- `tile_map_visualization.dart` — `_drawMapCells`, `_drawRegionIdLabels`
- `tile_map_visualization_shared.dart` — `drawBorders`
- `topology_inference.dart` — region-id collection
- `sea_zone_centroid_tile.dart` — centroid point collection

Also removed a dead `region_map_view_inputs.dart` import in `init_game_map_view_builder.dart` (its exported symbols are used only by the game-world visualizer), pre-existing on `dev`.

## Remaining nested y/x loops (intentional exemptions)

These are not migrated because they cannot adopt a single-pass `(y, x)` callback or are graph algorithms (matches the issue's planned lint exemptions for graph code):

- `tile_map_grid.dart` — the API definition itself.
- `tile_map_grid_graph.dart` — BFS/flood-fill / neighbour graph algorithms.
- `tile_map_manhattan_distance_transform.dart` — two-pass (forward + reverse) distance transform; not forward-only row-major.
- `_regionIdsFromResult` (`tile_map_visualization.dart`) and `tileMapResourceGlyphs` (`tile_map_resource_legend.dart`) — `sync*` generators that `yield` per cell (a callback cannot yield to the enclosing generator).

## Deferred (still outstanding for #3574)

- **CI gate** `repo.map_grid_cell_iteration_central` (`tool/check_map_grid_cell_iteration_central.dart` + fixture test + manifest wiring) forbidding new nested y/x walks outside the documented exemptions — follow-up, since robust file- vs function-level exemption handling (the two `sync*` generators) warrants its own focused diff.
- Slices 2–7 (region-dispatch unification, render-pipeline abstraction, `MapGenStage` uniform pass entry, `lib/src/` gen/view/render reorg, part-file collapse) — independent follow-ups.

## Tests

- No new behavior → no new asserts; covered by existing gates. `forEachIndex`/`forEachCell` unit tests already exist (`test/tile_map_grid_test.dart`, incl. row-major order, early-return-as-continue, ragged grids, empty grids).
- `cd packages/colonizethis_map && dart test` → **278 tests, all passed** (including `tile_map_generator_determinism_test`, locked-pair init, and `tile_map_visualization_test` golden/pixel checks).
- `dart analyze lib/src` → **No issues found**.
- `dart format` applied to touched files.

## Notes on scope vs other #3574 work

Both prior #3574 PRs (#3576, #3577) are merged and there is no other open PR for this issue, so this is the single open PR for #3574 per one-PR-per-issue.

Made with [Cursor](https://cursor.com)