### PR TITLE
refactor(map): unify PNG cell-fill render pipeline (#3574)

### DIFF
--- a/SPEC/program/map-visualization.md
+++ b/SPEC/program/map-visualization.md
@@ -10,6 +10,17 @@ Render tile maps and topology to PNG; provide view models for tools. Two visuali
 
 ---
 
+## Cell-fill render pipeline
+
+All PNG fill paths in `colonizethis_map` share a single cell-fill abstraction so the political (ownership), geographic (terrain), and base region/terrain renders differ **only by their colour strategy**, never by a copy-pasted nested fill loop (Refs #3574).
+
+- **Per-cell primitive:** `fillCellRect` owns the `cellSize`×`cellSize` pixel-block geometry for one tile cell. Every fill path uses it so block bounds are identical across renders.
+- **Grid fill:** `fillTileGridCells(image, height, width, cellSize, colorAt)` walks a 2D tile grid via the canonical row-major `TileMapGrid.forEachIndex` order and fills each cell with the RGB returned by the `colorAt(x, y)` strategy. Used by the base tile-map visualizer (terrain or region fill) and the game-world `Game`/topology ownership fill.
+- **View-data fill:** `fillRegionViewCells(image, cells, cellSize, colorAt)` is the companion for pre-flattened `RegionMapViewData` cells, filling each via `colorAt(cell)`. Used by `renderInitGameMapToPngFromViewData` for both political and geographic modes.
+- **Determinism:** Fill order is the same as the borders/markers drawn afterwards; the abstraction preserves byte-identical PNG output relative to the previous hand-rolled loops.
+
+---
+
 ## Tile map PNG export
 
 - **Fill:** Terrain present → color by terrain type. Sea = deep blue. Land = fixed color per terrain. No terrain → fallback to region-based coloring.
@@ -151,6 +162,9 @@ Implemented in colonizethis_map. Consumed by generate_map, init_game, ctdev.
 - **Ownership colours:** Faction colours per GDD 09 (GPs, minors grey, tribes vibrant); keys are runtime faction id; `greatPowerColorOverride` applied when present. Capitals: gold circle; ports: distinct marker; legend includes ownership, capitals, ports.
 - **View model:** `RegionMapViewData` and `InitGameMapViewData` provide per-cell and overlay data; `renderInitGameMapToPngFromViewData` supports geographic mode param. View modes: political (ownership fill) vs geographic (terrain, resource glyphs); same view model, UI toggle. **Geographic legend:** In geographic mode the legend and map glyphs show only the subset g (Grain), t (Timber), i (Iron); full resource legend is in the base tile map visualizer.
 - **Multi-region:** `renderMultiRegionMapToPng(oldWorld, newWorld, options)` renders OW left, NW right, shared legend below; used by init_game.
+- **Given** a tile grid of `height` rows × `width` columns and a `colorAt(x, y)` strategy returning RGB, **when** `fillTileGridCells` renders the grid, **then** the System fills each cell `(x, y)` with the block `x1 = x*cellSize, y1 = y*cellSize, x2 = (x+1)*cellSize-1, y2 = (y+1)*cellSize-1` in row-major order, producing the same pixels as a hand-rolled nested `y`/`x` fill loop.
+- **Given** a flattened list of `CellViewData` and a `colorAt(cell)` strategy returning RGB, **when** `fillRegionViewCells` renders the cells, **then** the System fills each cell at `(cell.x, cell.y)` using the shared `fillCellRect` block geometry, in list order.
+- **Given** the political (ownership) and geographic (terrain) render paths, **when** either renders a region, **then** the System routes its cell fill through the shared cell-fill pipeline (`fillTileGridCells` / `fillRegionViewCells`) and the game-world visualizer contains no standalone ownership-fill nested loop duplicating the base fill logic.
 - **Integration:** Implemented in colonizethis_map; consumed by generate_map, init_game, ctdev. Terrain palette and border/legend behaviour fixed as specified.
 - **Given** a `Game` with tile maps, topology, and a `playerView` that exposes visibility per tile key `regionId|provinceId|x|y`, **when** `buildInitGameMapViewData` is invoked with that `playerView`, **then** each `CellViewData` in the resulting `InitGameMapViewData` has `visibility` set to `TileVisibility.visible`, `TileVisibility.fogged`, or `TileVisibility.unrevealed` according to the visibility entry for its tile key, defaulting to `TileVisibility.visible` when no entry exists.
 - **Given** a `Game` with at least one player in `Game.players`, **when** a tool builds a player-constrained map view for that game using `buildInitGameMapViewData`, **then** the tool uses the first player (`game.players.first`) as the source of `playerView` and sets `CellViewData.visibility` based on that player’s view.

--- a/packages/colonizethis_map/lib/src/game_world_state_map_visualizer.dart
+++ b/packages/colonizethis_map/lib/src/game_world_state_map_visualizer.dart
@@ -96,25 +96,23 @@ Uint8List renderSingleRegionGameStateMapToPng({
   );
   image.clear(white);
 
-  // Fill: provinces by owner color, sea zones deep blue
-  TileMapGrid.forEachIndex(result.height, result.width, (y, x) {
-    final id = result.cell(x, y);
-    final isSea = seaZoneIds.contains(id);
-    final fullProvinceId = isSea ? null : ProvinceId.full(regionId, id);
-    final (r, g, b) = isSea
-        ? seaColorRgb
-        : (factionColors[ownerByProvinceId[fullProvinceId] ?? ''] ??
-              (128, 128, 128));
-    final color = image.getColor(r, g, b);
-    img.fillRect(
-      image,
-      x1: x * cellSize,
-      y1: y * cellSize,
-      x2: (x + 1) * cellSize - 1,
-      y2: (y + 1) * cellSize - 1,
-      color: color,
-    );
-  });
+  // Fill: provinces by owner color, sea zones deep blue. Shares the canonical
+  // cell-fill render pipeline (fillTileGridCells) with the base visualizer;
+  // this path differs only by its ownership colour strategy (Refs #3574).
+  fillTileGridCells(
+    image,
+    height: result.height,
+    width: result.width,
+    cellSize: cellSize,
+    colorAt: (x, y) {
+      final id = result.cell(x, y);
+      final isSea = seaZoneIds.contains(id);
+      if (isSea) return seaColorRgb;
+      final fullProvinceId = ProvinceId.full(regionId, id);
+      return factionColors[ownerByProvinceId[fullProvinceId] ?? ''] ??
+          (128, 128, 128);
+    },
+  );
 
   drawBorders(image, result, seaZoneIds, cellSize, seaZoneBorderColor);
 
@@ -277,24 +275,21 @@ Uint8List renderInitGameMapToPngFromViewData({
     );
     image.clear(white);
 
-    // Fill: by terrain (geographic) or by ownership.
-    for (final cell in region.cells) {
-      final (r, g, b) = cell.isSea
-          ? seaColorRgb
-          : (geographicMode
-                ? _terrainRgbForCell(cell, region)
-                : (region.factionColors[cell.ownerFactionId ?? ''] ??
-                      (128, 128, 128)));
-      final color = image.getColor(r, g, b);
-      img.fillRect(
-        image,
-        x1: cell.x * region.cellSize,
-        y1: cell.y * region.cellSize,
-        x2: (cell.x + 1) * region.cellSize - 1,
-        y2: (cell.y + 1) * region.cellSize - 1,
-        color: color,
-      );
-    }
+    // Fill: by terrain (geographic) or by ownership. Shares the canonical
+    // cell-fill render pipeline (fillRegionViewCells); political vs geographic
+    // differ only by this colour strategy (Refs #3574).
+    fillRegionViewCells(
+      image,
+      cells: region.cells,
+      cellSize: region.cellSize,
+      colorAt: (cell) {
+        if (cell.isSea) return seaColorRgb;
+        return geographicMode
+            ? _terrainRgbForCell(cell, region)
+            : (region.factionColors[cell.ownerFactionId ?? ''] ??
+                  (128, 128, 128));
+      },
+    );
 
     // Reconstruct a minimal TileMapResult-like structure for border drawing.
     final tmpResult = TileMapResult(

--- a/packages/colonizethis_map/lib/src/tile_map_visualization.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_visualization.dart
@@ -18,6 +18,7 @@ import 'tile_map_visualization_shared.dart'
         drawLegendLine,
         drawResourceLegendRows,
         drawResourceLetterAtCellCenter,
+        fillTileGridCells,
         landSeedMarkerRgb,
         legendLineHeight,
         legendPadding,
@@ -169,20 +170,18 @@ void _drawMapCells({
   required Set<String> seaZoneIds,
   required Map<String, (int, int, int)>? regionColors,
 }) {
-  TileMapGrid.forEachIndex(result.height, result.width, (y, x) {
-    final id = result.cell(x, y);
-    final (r, g, b) = useTerrain
-        ? _terrainOrSeaCellColor(result, seaZoneIds, x, y, id)
-        : regionColors![id]!;
-    img.fillRect(
-      image,
-      x1: x * cellSize,
-      y1: y * cellSize,
-      x2: (x + 1) * cellSize - 1,
-      y2: (y + 1) * cellSize - 1,
-      color: image.getColor(r, g, b),
-    );
-  });
+  fillTileGridCells(
+    image,
+    height: result.height,
+    width: result.width,
+    cellSize: cellSize,
+    colorAt: (x, y) {
+      final id = result.cell(x, y);
+      return useTerrain
+          ? _terrainOrSeaCellColor(result, seaZoneIds, x, y, id)
+          : regionColors![id]!;
+    },
+  );
 }
 
 (int, int, int) _terrainOrSeaCellColor(

--- a/packages/colonizethis_map/lib/src/tile_map_visualization_shared.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_visualization_shared.dart
@@ -37,6 +37,86 @@ Set<String> seaZoneLocalIdsFromRegionCells(List<CellViewData> cells) {
   return out;
 }
 
+// --- Render pipeline: shared cell-fill ---
+// SPEC/program/map-visualization.md § Cell-fill render pipeline.
+
+/// Fills the [cellSize]×[cellSize] pixel block for tile cell ([cellX],[cellY])
+/// with [color].
+///
+/// Single source of truth for the per-cell rectangle geometry shared by every
+/// PNG fill path (terrain, region, and ownership). Keeping the
+/// `x1/y1/x2/y2` math in one place guarantees the three render paths produce
+/// byte-identical fills and differ only by their colour strategy
+/// (Refs #3574 render-pipeline dedup).
+void fillCellRect(
+  img.Image image, {
+  required int cellX,
+  required int cellY,
+  required int cellSize,
+  required img.Color color,
+}) {
+  img.fillRect(
+    image,
+    x1: cellX * cellSize,
+    y1: cellY * cellSize,
+    x2: (cellX + 1) * cellSize - 1,
+    y2: (cellY + 1) * cellSize - 1,
+    color: color,
+  );
+}
+
+/// Fills every cell of a [height] rows × [width] columns tile grid using the
+/// RGB colour returned by [colorAt] for cell `(x, y)`.
+///
+/// Iteration routes through [TileMapGrid.forEachIndex] (the canonical row-major
+/// walk) so fill order matches the borders/markers drawn afterwards and stays
+/// bit-for-bit deterministic. The geographic/region/ownership PNG paths differ
+/// only by the [colorAt] **fill strategy**, not by a copy-pasted double loop
+/// (Refs #3574).
+void fillTileGridCells(
+  img.Image image, {
+  required int height,
+  required int width,
+  required int cellSize,
+  required (int r, int g, int b) Function(int x, int y) colorAt,
+}) {
+  TileMapGrid.forEachIndex(height, width, (y, x) {
+    final (r, g, b) = colorAt(x, y);
+    fillCellRect(
+      image,
+      cellX: x,
+      cellY: y,
+      cellSize: cellSize,
+      color: image.getColor(r, g, b),
+    );
+  });
+}
+
+/// Fills each cell in [cells] (flattened [CellViewData] from a
+/// [RegionMapViewData]) using the RGB colour returned by [colorAt].
+///
+/// View-data render paths walk a pre-flattened cell list rather than a 2D grid,
+/// so this companion of [fillTileGridCells] shares the same [fillCellRect]
+/// primitive and lets political vs geographic view-data fills differ only by
+/// the [colorAt] strategy (Refs #3574).
+void fillRegionViewCells(
+  img.Image image, {
+  required Iterable<CellViewData> cells,
+  required int cellSize,
+  required (int r, int g, int b) Function(CellViewData cell) colorAt,
+}) {
+  for (final cell in cells) {
+    final (r, g, b) = colorAt(cell);
+    fillCellRect(
+      image,
+      cellX: cell.x,
+      cellY: cell.y,
+      cellSize: cellSize,
+      color: image.getColor(r, g, b),
+    );
+  }
+}
+
 img.Color _borderColorForAdjacentCells(
   String id,
   String other,

--- a/packages/colonizethis_map/test/tile_map_visualization_shared_helpers_test.dart
+++ b/packages/colonizethis_map/test/tile_map_visualization_shared_helpers_test.dart
@@ -22,6 +22,132 @@ void main() {
     });
   });
 
+  group('fillCellRect', () {
+    test('fills exactly the cellSize block for the target cell', () {
+      final image = img.Image(width: 12, height: 12);
+      image.clear(image.getColor(0, 0, 0));
+      fillCellRect(
+        image,
+        cellX: 1,
+        cellY: 1,
+        cellSize: 4,
+        color: image.getColor(10, 20, 30),
+      );
+      // Inside the block (x:4..7, y:4..7) is filled.
+      final inside = image.getPixel(5, 6);
+      expect(inside.r.toInt(), 10);
+      expect(inside.g.toInt(), 20);
+      expect(inside.b.toInt(), 30);
+      // Block edges inclusive: (4,4) and (7,7) filled.
+      expect(image.getPixel(4, 4).r.toInt(), 10);
+      expect(image.getPixel(7, 7).b.toInt(), 30);
+    });
+
+    test('does not paint neighbouring cells (negative/edge)', () {
+      final image = img.Image(width: 12, height: 12);
+      image.clear(image.getColor(0, 0, 0));
+      fillCellRect(
+        image,
+        cellX: 1,
+        cellY: 1,
+        cellSize: 4,
+        color: image.getColor(10, 20, 30),
+      );
+      // One pixel past the block on each axis stays background black.
+      final pastX = image.getPixel(8, 5);
+      expect(pastX.r.toInt(), 0);
+      expect(pastX.g.toInt(), 0);
+      final pastY = image.getPixel(5, 8);
+      expect(pastY.b.toInt(), 0);
+      // Cell origin (0,0) untouched.
+      expect(image.getPixel(0, 0).r.toInt(), 0);
+    });
+  });
+
+  group('fillTileGridCells', () {
+    test('fills every cell using the colorAt strategy', () {
+      final image = img.Image(width: 6, height: 6);
+      image.clear(image.getColor(0, 0, 0));
+      fillTileGridCells(
+        image,
+        height: 3,
+        width: 3,
+        cellSize: 2,
+        // Encode the coordinate in the colour to assert per-cell strategy.
+        colorAt: (x, y) => (x * 10, y * 10, 5),
+      );
+      // Cell (2,1): block x:4..5, y:2..3.
+      final c21 = image.getPixel(4, 2);
+      expect(c21.r.toInt(), 20);
+      expect(c21.g.toInt(), 10);
+      expect(c21.b.toInt(), 5);
+    });
+
+    test('matches a hand-rolled nested fill loop byte-for-byte (parity)', () {
+      (int, int, int) colorAt(int x, int y) => ((x + y) * 7 % 256, x, y);
+      const cellSize = 3;
+      const height = 4;
+      const width = 5;
+
+      final viaHelper = img.Image(
+        width: width * cellSize,
+        height: height * cellSize,
+      );
+      viaHelper.clear(viaHelper.getColor(255, 255, 255));
+      fillTileGridCells(
+        viaHelper,
+        height: height,
+        width: width,
+        cellSize: cellSize,
+        colorAt: colorAt,
+      );
+
+      final manual = img.Image(
+        width: width * cellSize,
+        height: height * cellSize,
+      );
+      manual.clear(manual.getColor(255, 255, 255));
+      for (var y = 0; y < height; y++) {
+        for (var x = 0; x < width; x++) {
+          final (r, g, b) = colorAt(x, y);
+          img.fillRect(
+            manual,
+            x1: x * cellSize,
+            y1: y * cellSize,
+            x2: (x + 1) * cellSize - 1,
+            y2: (y + 1) * cellSize - 1,
+            color: manual.getColor(r, g, b),
+          );
+        }
+      }
+
+      expect(img.encodePng(viaHelper), equals(img.encodePng(manual)));
+    });
+  });
+
+  group('fillRegionViewCells', () {
+    test('fills each listed cell at its (x, y) via the strategy', () {
+      final image = img.Image(width: 6, height: 6);
+      image.clear(image.getColor(0, 0, 0));
+      const cells = <CellViewData>[
+        CellViewData(x: 0, y: 0, regionCellId: 'p1', isSea: false),
+        CellViewData(x: 2, y: 1, regionCellId: 's1', isSea: true),
+      ];
+      fillRegionViewCells(
+        image,
+        cells: cells,
+        cellSize: 2,
+        colorAt: (cell) => cell.isSea ? (0, 0, 200) : (200, 0, 0),
+      );
+      // Land cell (0,0): block x:0..1, y:0..1.
+      expect(image.getPixel(0, 0).r.toInt(), 200);
+      // Sea cell (2,1): block x:4..5, y:2..3.
+      expect(image.getPixel(4, 2).b.toInt(), 200);
+      // An unlisted cell stays background.
+      expect(image.getPixel(2, 4).r.toInt(), 0);
+    });
+  });
+
   group('drawResourceLegendRows', () {
     test(
       'advances by one legend line height per resource (tile-map columns)',


### PR DESCRIPTION
## Summary

Slice 3 of the `colonizethis_map` wave-2 refactor (#3574): unify the PNG cell-fill render pipeline so the base, ownership (political), and geographic render paths differ **only by their colour strategy**, not by copy-pasted nested fill loops.

`Refs #3574`

## Done in this push

- **New shared helpers** in `tile_map_visualization_shared.dart` (already on the render-layer `package:image` allowlist):
  - `fillCellRect` — single source of truth for the `cellSize`×`cellSize` per-cell block geometry.
  - `fillTileGridCells(image, height, width, cellSize, colorAt)` — row-major grid fill via the canonical `TileMapGrid.forEachIndex`, parameterized by a `(x,y) -> RGB` strategy.
  - `fillRegionViewCells(image, cells, cellSize, colorAt)` — companion for flattened `RegionMapViewData` cells with a `(cell) -> RGB` strategy.
- **Three fill paths routed through the abstraction:**
  - `tile_map_visualization.dart` `_drawMapCells` (terrain / region fill).
  - `game_world_state_map_visualizer.dart` `renderSingleRegionGameStateMapToPng` — **removed the standalone ownership-fill double loop** that duplicated the base fill logic (AC).
  - `renderInitGameMapToPngFromViewData` — political and geographic view-data fill.
- **Behavior-preserving:** identical `fillRect` geometry and iteration order keep PNG output byte-for-byte; a parity test asserts equality against a hand-rolled nested loop.

## SPEC

- `SPEC/program/map-visualization.md` — new **§ Cell-fill render pipeline** plus ACs for `fillTileGridCells` / `fillRegionViewCells` and the no-duplicate ownership-loop guarantee.

## Tests

- Positive + edge: `fillCellRect` (inclusive block bounds; no neighbour bleed; origin untouched), `fillTileGridCells` (per-cell strategy + nested-loop **byte parity**), `fillRegionViewCells` (list-order placement, unlisted cells untouched).
- Full `colonizethis_map` suite green (290 tests) incl. determinism + locked-pair golden tests.
- Lint gates pass: `repo.map_grid_cell_iteration_central`, `repo.map_gen_no_image_import`.

## Covered ACs (issue #3574)

- [x] "PNG political and geographic render paths share a documented render-pipeline abstraction; `game_world_state_map_visualizer.dart` no longer owns a standalone ownership-fill double loop duplicating `tile_map_visualization` fill logic."
- [x] "Each new abstraction … has dedicated unit tests (positive and negative/edge cases); package coverage remains ≥90%."
- [x] "No change to generated tile maps, topology, or observable in-game map behavior."

## Deferred (remaining for #3574)

- Slice 4: strengthen `MapGenStage` uniform pass entry (3 of 4 service families).
- Slice 5: `lib/src/` gen/view/render folder reorganization (import-only diff).
- Slice 7: collapse lowest-value part files.

Made with [Cursor](https://cursor.com)