### PR TITLE
refactor(map): add uniform MapGenPass pass entry for generator families (#3574)

### DIFF
--- a/SPEC/program/tile-map-gen-algorithm.md
+++ b/SPEC/program/tile-map-gen-algorithm.md
@@ -92,6 +92,21 @@ The implementation SHOULD keep `TileMapGenerator` as an orchestration layer and 
 
 The orchestration contract remains unchanged: pass ordering, pass semantics, and observable outputs must match this spec and [tile-map-gen-resources.md](tile-map-gen-resources.md).
 
+### Uniform pass entry point
+
+Generation service families share a single pass-driving protocol so the orchestrator does not duplicate per-family setup/logging:
+
+- **`MapGenStage`** — base contract exposing shared `params`.
+- **`MapGenPass<P, R>`** (extends `MapGenStage`) — uniform entry `R run(MapGenPassContext<P> ctx)`, where `MapGenPassContext` carries `params`, the family's typed `payload` (`P`), and an optional `onLog` hook (`log(message)`).
+
+Because the families have heterogeneous input/output shapes, each supplies its own typed payload/result rather than a single concrete signature. **At least three of the four families** adopt `MapGenPass`: land-seeds (Pass 2–3), lakes/provinces (Pass 4–5 lake/moat + border noise), and terrain/resource (Pass 6–7). The **join-sea** family is **exempt** and remains `MapGenStage`-only: its three passes (continent joining, terrain jitter, sea-zone subdivision) share no single representative payload/result; the exemption is documented inline at the class. Adoption is enforced by `repo.map_gen_stage_protocol` (see [repo-lint.md](repo-lint.md)). `run` is behaviour-preserving: routing a pass through `run` produces byte-identical grids to the prior inline orchestration for the same inputs.
+
+**Acceptance criteria (uniform pass entry):**
+
+- Given a generator service family that owns a cohesive grid-in/grid-out pass, when the repository lint `repo.map_gen_stage_protocol` runs, then The System requires that family to declare `implements MapGenPass` and requires at least 3 of the 4 families to do so, otherwise the lint fails.
+- Given `TileMapGenLandSeeds.run` is invoked with a `MapGenPassContext` whose payload sets `seedBeforeAssignment = true` and an RNG seeded with value `s`, when the pass completes, then The System returns the same `grid`, `continentSeeds`, `landSeeds`, and `continentBySeedIndex` as the legacy `placeLandSeeds` + `assignLandByLandSeeds` calls made with a freshly `s`-seeded RNG.
+- Given a `MapGenPassContext` with a `null` `onLog`, when `context.log(message)` is called, then The System performs no action and does not throw.
+
 ---
 
 ## Constraints

--- a/packages/colonizethis_map/lib/src/map_gen_pass_payloads.dart
+++ b/packages/colonizethis_map/lib/src/map_gen_pass_payloads.dart
@@ -1,0 +1,114 @@
+/// Typed payloads/results for the [MapGenPass] uniform pass entry points
+/// adopted by the land-seed, lakes/province, and terrain/resource generation
+/// service families (Refs #3574, slice 4).
+///
+/// These types live in a standalone library (not a generator `part` file) so
+/// the families can name them in their public `run` signatures without tripping
+/// `repo.map_no_partfile_classes`. SPEC/program/tile-map-gen-algorithm.md.
+library map_gen_pass_payloads;
+
+import 'dart:math';
+
+import 'package:colonizethis_data/colonizethis_data.dart';
+
+/// Inputs for [TileMapGenLandSeeds] Pass 2–3 land seeding/assignment.
+class LandSeedPassPayload {
+  const LandSeedPassPayload({
+    required this.grid,
+    required this.provinceToContinent,
+    required this.seaZoneId,
+    required this.rnd,
+    required this.seedBeforeAssignment,
+  });
+
+  /// Initial all-sea grid to assign land into.
+  final List<List<String>> grid;
+
+  /// Province id → continent index partition.
+  final Map<String, int> provinceToContinent;
+
+  /// Sea zone sentinel id used for unassigned cells.
+  final String seaZoneId;
+
+  /// Deterministic RNG shared across the generation pipeline.
+  final Random rnd;
+
+  /// When `true`, use the seed-before-assignment path; otherwise organic.
+  final bool seedBeforeAssignment;
+}
+
+/// Result of the land-seed pass: assigned grid plus seed bookkeeping.
+class LandSeedPassResult {
+  const LandSeedPassResult({
+    required this.grid,
+    required this.continentSeeds,
+    required this.landSeeds,
+    required this.continentBySeedIndex,
+  });
+
+  /// Grid with land cells assigned (sentinel land vs [seaZoneId]).
+  final List<List<String>> grid;
+
+  /// One continent seed per continent.
+  final List<(int x, int y)> continentSeeds;
+
+  /// All placed land-shape seeds.
+  final List<(int x, int y)> landSeeds;
+
+  /// Parallel to [landSeeds]: continent index for each land seed.
+  final List<int> continentBySeedIndex;
+}
+
+/// Inputs for [MapGenPass] Pass 4–5 lake/moat fill and border noise.
+class LakesPassPayload {
+  const LakesPassPayload({
+    required this.grid,
+    required this.seaZoneId,
+    required this.landSeeds,
+    required this.continentBySeedIndex,
+    required this.rnd,
+  });
+
+  /// Post-Pass-3 grid (land sentinel vs [seaZoneId]).
+  final List<List<String>> grid;
+
+  /// Sea zone sentinel id.
+  final String seaZoneId;
+
+  /// Land seeds used for ocean/continent classification.
+  final List<(int x, int y)> landSeeds;
+
+  /// Parallel to [landSeeds]: continent index per land seed.
+  final List<int> continentBySeedIndex;
+
+  /// Deterministic RNG shared across the generation pipeline.
+  final Random rnd;
+}
+
+/// Inputs for Pass 6–7 terrain and resource assignment.
+class TerrainPassPayload {
+  const TerrainPassPayload({
+    required this.grid,
+    required this.regionId,
+    required this.resourceRules,
+    required this.rnd,
+  });
+
+  /// Grid with provinces/land assigned.
+  final List<List<String>> grid;
+
+  /// Map region id (`oldWorld` / `newWorld`).
+  final String regionId;
+
+  /// Resource rules; `null` skips terrain/resource assignment entirely.
+  final ResourceRules? resourceRules;
+
+  /// Deterministic RNG shared across the generation pipeline.
+  final Random rnd;
+}
+
+/// Result of the terrain/resource pass; both grids are `null` when skipped.
+typedef TerrainPassResult = (
+  List<List<TerrainType?>>? terrainGrid,
+  List<List<Resource?>>? resourceGrid,
+);

--- a/packages/colonizethis_map/lib/src/map_gen_stage.dart
+++ b/packages/colonizethis_map/lib/src/map_gen_stage.dart
@@ -13,6 +13,46 @@ abstract interface class MapGenStage {
   TileMapLandSeedParams get params;
 }
 
+/// Context handed to a [MapGenPass.run] invocation (Refs #3574, slice 4).
+///
+/// Carries the shared generation [params], the pass-specific typed [payload],
+/// and an optional [onLog] hook so each family shares the same logging
+/// boilerplate while keeping its own input shape via [P].
+class MapGenPassContext<P> {
+  const MapGenPassContext({
+    required this.params,
+    required this.payload,
+    this.onLog,
+  });
+
+  /// Shared generation parameters for the run.
+  final TileMapLandSeedParams params;
+
+  /// Pass-specific typed inputs for the family's [MapGenPass.run].
+  final P payload;
+
+  /// Optional per-pass log sink; `null` disables logging.
+  final void Function(String message)? onLog;
+
+  /// Emits [message] to [onLog] when a listener is attached.
+  void log(String message) => onLog?.call(message);
+}
+
+/// Uniform pass entry point for tile-map generation service families
+/// (Refs #3574, slice 4).
+///
+/// Families that own a cohesive grid-in/grid-out pass implement this protocol
+/// so [TileMapGenerator] can drive them through a single [run] call,
+/// parameterized over a typed [payload] ([P]) and result ([R]) while sharing
+/// orchestration/logging boilerplate. Families with heterogeneous, multi-pass
+/// shapes (for example join-sea: continent joining + terrain jitter + sea-zone
+/// subdivision are three distinct passes) remain [MapGenStage]-only and are
+/// documented as exempt; at least three of the four families adopt [MapGenPass].
+abstract interface class MapGenPass<P, R> implements MapGenStage {
+  /// Runs the family's primary generation pass for [ctx].
+  R run(MapGenPassContext<P> ctx);
+}
+
 /// Shared grid-pass helpers for [MapGenStage] service implementations.
 extension MapGenGridPass on MapGenStage {
   /// Returns an independent deep copy of [grid] before a mutating pass.

--- a/packages/colonizethis_map/lib/src/tile_map_generator.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_generator.dart
@@ -6,6 +6,7 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_map/package_logger.dart';
 
 import 'grid_voronoi.dart';
+import 'map_gen_pass_payloads.dart';
 import 'map_validation_exception.dart';
 import 'tile_map_generator_land_seeds.dart';
 import 'tile_map_land_sentinel.dart';
@@ -262,33 +263,25 @@ class TileMapGenerator extends _TileMapGeneratorShell {
     Random rnd,
     void Function(String)? onLog,
   ) {
-    if (params.seedBeforeAssignment) {
-      final placed = _landSeedService.placeLandSeeds(provinceToContinent, rnd);
-      final continentSeeds = placed.$1;
-      final landSeeds = placed.$2;
-      final continentBySeedIndex = placed.$3;
-      onLog?.call(
-        'Pass 2: Continent seeds ${continentSeeds.length}, land seeds ${landSeeds.length}',
-      );
-      final assignedGrid = _landSeedService.assignLandByLandSeeds(
-        grid,
-        landSeeds,
-        continentBySeedIndex,
-        provinceToContinent,
-        seaZoneId,
-      );
-      return (assignedGrid, continentSeeds, landSeeds, continentBySeedIndex);
-    }
-    final organic = _landSeedService.placeLandSeedsOrganic(
-      grid,
-      provinceToContinent,
-      seaZoneId,
-      rnd,
+    final result = _landSeedService.run(
+      MapGenPassContext<LandSeedPassPayload>(
+        params: params,
+        payload: LandSeedPassPayload(
+          grid: grid,
+          provinceToContinent: provinceToContinent,
+          seaZoneId: seaZoneId,
+          rnd: rnd,
+          seedBeforeAssignment: params.seedBeforeAssignment,
+        ),
+        onLog: onLog,
+      ),
     );
-    onLog?.call(
-      'Pass 2–3 (organic): Continent seeds ${organic.$1.length}, land seeds ${organic.$2.length}',
+    return (
+      result.grid,
+      result.continentSeeds,
+      result.landSeeds,
+      result.continentBySeedIndex,
     );
-    return (organic.$4, organic.$1, organic.$2, organic.$3);
   }
 
   int _countLandCells(List<List<String>> grid) {
@@ -307,32 +300,19 @@ class TileMapGenerator extends _TileMapGeneratorShell {
     Random rnd,
     void Function(String)? onLog,
   ) {
-    var nextGrid = grid;
-    if (params.skipFillLakes) {
-      onLog?.call('Pass 4: Fill lakes and moats skipped');
-    } else {
-      nextGrid = _lakeAndProvinceService.fillLakes(
-        nextGrid,
-        seaZoneId,
-        landSeeds,
-        continentBySeedIndex,
-      );
-      nextGrid = _lakeAndProvinceService.fillMoats(
-        nextGrid,
-        seaZoneId,
-        landSeeds,
-        continentBySeedIndex,
-        rnd,
-      );
-      onLog?.call('Pass 4: Fill lakes and moats done');
-    }
-    if (params.borderNoise > 0) {
-      nextGrid = _lakeAndProvinceService.borderNoise(nextGrid, seaZoneId, rnd);
-      onLog?.call('Pass 5: Border noise applied');
-    } else {
-      onLog?.call('Pass 5: Border noise skipped (0)');
-    }
-    return nextGrid;
+    return _lakeAndProvinceService.run(
+      MapGenPassContext<LakesPassPayload>(
+        params: params,
+        payload: LakesPassPayload(
+          grid: grid,
+          seaZoneId: seaZoneId,
+          landSeeds: landSeeds,
+          continentBySeedIndex: continentBySeedIndex,
+          rnd: rnd,
+        ),
+        onLog: onLog,
+      ),
+    );
   }
 
   (List<List<TerrainType?>>?, List<List<Resource?>>?)
@@ -343,27 +323,18 @@ class TileMapGenerator extends _TileMapGeneratorShell {
     Random rnd,
     void Function(String)? onLog,
   ) {
-    if (resourceRules == null) {
-      onLog?.call(
-        'Pass 6–7: Terrain/resources skipped (no rules or no provinces)',
-      );
-      return (null, null);
-    }
-    final t = _terrainResourceService.assignTerrainAndResources(
-      grid,
-      regionId,
-      resourceRules,
-      rnd,
+    return _terrainResourceService.run(
+      MapGenPassContext<TerrainPassPayload>(
+        params: params,
+        payload: TerrainPassPayload(
+          grid: grid,
+          regionId: regionId,
+          resourceRules: resourceRules,
+          rnd: rnd,
+        ),
+        onLog: onLog,
+      ),
     );
-    var terrainCount = 0;
-    var resourceCount = 0;
-    TileMapGrid.forEachIndex(params.height, params.width, (y, x) {
-      if (t.$1[y][x] != null) terrainCount++;
-      if (t.$2[y][x] != null) resourceCount++;
-    });
-    onLog?.call('Pass 6: Terrain assigned ($terrainCount land cells)');
-    onLog?.call('Pass 7: Resources placed ($resourceCount cells)');
-    return t;
   }
 
   (List<List<String>>, List<List<TerrainType?>>?, List<List<Resource?>>?)

--- a/packages/colonizethis_map/lib/src/tile_map_generator_join_sea.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_generator_join_sea.dart
@@ -2,6 +2,12 @@
 
 part of 'tile_map_generator.dart';
 
+/// Exempt from the uniform [MapGenPass] entry point (Refs #3574, slice 4):
+/// this family owns three heterogeneous passes — continent joining
+/// (grid+terrain+resource in/out), terrain jitter (in-place mutation), and
+/// sea-zone subdivision (grid in/out) — that share no single representative
+/// payload/result shape. It therefore implements [MapGenStage] only; the
+/// orchestrator drives its three passes via their dedicated methods.
 class _TileMapGenJoinSea implements MapGenStage {
   _TileMapGenJoinSea(this.params, this._log, this._graph);
 

--- a/packages/colonizethis_map/lib/src/tile_map_generator_lakes_provinces.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_generator_lakes_provinces.dart
@@ -2,13 +2,48 @@
 
 part of 'tile_map_generator.dart';
 
-class _TileMapGenLakesProvinces implements MapGenStage {
+class _TileMapGenLakesProvinces
+    implements MapGenPass<LakesPassPayload, List<List<String>>> {
   _TileMapGenLakesProvinces(this.params, this._graph, this._join);
 
   @override
   final TileMapParams params;
   final TileMapGridGraph _graph;
   final _TileMapGenJoinSea _join;
+
+  /// Uniform pass entry: Pass 4 lake/moat fill (unless `skipFillLakes`) then
+  /// Pass 5 border noise (when `borderNoise > 0`). Returns the updated grid;
+  /// behaviour matches the prior inline orchestration (Refs #3574, slice 4).
+  @override
+  List<List<String>> run(MapGenPassContext<LakesPassPayload> ctx) {
+    final payload = ctx.payload;
+    var nextGrid = payload.grid;
+    if (params.skipFillLakes) {
+      ctx.log('Pass 4: Fill lakes and moats skipped');
+    } else {
+      nextGrid = fillLakes(
+        nextGrid,
+        payload.seaZoneId,
+        payload.landSeeds,
+        payload.continentBySeedIndex,
+      );
+      nextGrid = fillMoats(
+        nextGrid,
+        payload.seaZoneId,
+        payload.landSeeds,
+        payload.continentBySeedIndex,
+        payload.rnd,
+      );
+      ctx.log('Pass 4: Fill lakes and moats done');
+    }
+    if (params.borderNoise > 0) {
+      nextGrid = borderNoise(nextGrid, payload.seaZoneId, payload.rnd);
+      ctx.log('Pass 5: Border noise applied');
+    } else {
+      ctx.log('Pass 5: Border noise skipped (0)');
+    }
+    return nextGrid;
+  }
 
   void _addCoastalLandCandidatesAroundLakeCell(
     int x,

--- a/packages/colonizethis_map/lib/src/tile_map_generator_land_seeds.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_generator_land_seeds.dart
@@ -13,6 +13,7 @@ library tile_map_generator_land_seeds;
 import 'dart:math';
 
 import 'grid_voronoi.dart';
+import 'map_gen_pass_payloads.dart';
 import 'map_gen_stage.dart';
 import 'tile_map_directions.dart';
 import 'tile_map_distance_sentinels.dart';
@@ -29,11 +30,60 @@ part 'tile_map_generator_land_seeds_organic_part.dart';
 part 'tile_map_generator_land_seeds_coast_part.dart';
 
 /// Pass 2–3: land seed placement and assignment (organic and seed-before-assignment).
-class TileMapGenLandSeeds implements MapGenStage {
+class TileMapGenLandSeeds
+    implements MapGenPass<LandSeedPassPayload, LandSeedPassResult> {
   TileMapGenLandSeeds(this.params);
 
   @override
   final TileMapLandSeedParams params;
+
+  /// Uniform pass entry: places land seeds and assigns land for Pass 2–3,
+  /// selecting the organic or seed-before-assignment path from
+  /// [LandSeedPassPayload.seedBeforeAssignment]. Behaviour matches the prior
+  /// inline orchestration (Refs #3574, slice 4).
+  @override
+  LandSeedPassResult run(MapGenPassContext<LandSeedPassPayload> ctx) {
+    final payload = ctx.payload;
+    if (payload.seedBeforeAssignment) {
+      final placed = placeLandSeeds(payload.provinceToContinent, payload.rnd);
+      final continentSeeds = placed.$1;
+      final landSeeds = placed.$2;
+      final continentBySeedIndex = placed.$3;
+      ctx.log(
+        'Pass 2: Continent seeds ${continentSeeds.length}, '
+        'land seeds ${landSeeds.length}',
+      );
+      final assignedGrid = assignLandByLandSeeds(
+        payload.grid,
+        landSeeds,
+        continentBySeedIndex,
+        payload.provinceToContinent,
+        payload.seaZoneId,
+      );
+      return LandSeedPassResult(
+        grid: assignedGrid,
+        continentSeeds: continentSeeds,
+        landSeeds: landSeeds,
+        continentBySeedIndex: continentBySeedIndex,
+      );
+    }
+    final organic = placeLandSeedsOrganic(
+      payload.grid,
+      payload.provinceToContinent,
+      payload.seaZoneId,
+      payload.rnd,
+    );
+    ctx.log(
+      'Pass 2–3 (organic): Continent seeds ${organic.$1.length}, '
+      'land seeds ${organic.$2.length}',
+    );
+    return LandSeedPassResult(
+      grid: organic.$4,
+      continentSeeds: organic.$1,
+      landSeeds: organic.$2,
+      continentBySeedIndex: organic.$3,
+    );
+  }
 
   /// One continent seed per continent; then a cluster of land-shape seeds per continent (K from province count). No province seeds yet.
   (List<(int x, int y)>, List<(int x, int y)>, List<int>) placeLandSeeds(

--- a/packages/colonizethis_map/lib/src/tile_map_generator_terrain_assign.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_generator_terrain_assign.dart
@@ -2,12 +2,41 @@
 
 part of 'tile_map_generator.dart';
 
-class _TileMapGenTerrainResource implements MapGenStage {
+class _TileMapGenTerrainResource
+    implements MapGenPass<TerrainPassPayload, TerrainPassResult> {
   _TileMapGenTerrainResource(this.params, this._graph);
 
   @override
   final TileMapParams params;
   final TileMapGridGraph _graph;
+
+  /// Uniform pass entry: Pass 6–7 terrain/resource assignment. Returns
+  /// `(null, null)` when [TerrainPassPayload.resourceRules] is null (skip),
+  /// matching the prior inline orchestration (Refs #3574, slice 4).
+  @override
+  TerrainPassResult run(MapGenPassContext<TerrainPassPayload> ctx) {
+    final payload = ctx.payload;
+    final rules = payload.resourceRules;
+    if (rules == null) {
+      ctx.log('Pass 6–7: Terrain/resources skipped (no rules or no provinces)');
+      return (null, null);
+    }
+    final t = assignTerrainAndResources(
+      payload.grid,
+      payload.regionId,
+      rules,
+      payload.rnd,
+    );
+    var terrainCount = 0;
+    var resourceCount = 0;
+    TileMapGrid.forEachIndex(params.height, params.width, (y, x) {
+      if (t.$1[y][x] != null) terrainCount++;
+      if (t.$2[y][x] != null) resourceCount++;
+    });
+    ctx.log('Pass 6: Terrain assigned ($terrainCount land cells)');
+    ctx.log('Pass 7: Resources placed ($resourceCount cells)');
+    return t;
+  }
 
   (List<List<TerrainType?>>, List<List<Resource?>>) assignTerrainAndResources(
     List<List<String>> grid,

--- a/packages/colonizethis_map/test/map_gen_pass_test.dart
+++ b/packages/colonizethis_map/test/map_gen_pass_test.dart
@@ -1,0 +1,157 @@
+import 'dart:math';
+
+import 'package:colonizethis_map/colonizethis_map.dart';
+import 'package:colonizethis_map/src/map_gen_pass_payloads.dart';
+import 'package:colonizethis_map/src/map_gen_stage.dart';
+import 'package:colonizethis_test/test.dart';
+
+void main() {
+  group('MapGenPassContext', () {
+    final params = TileMapParams(width: 4, height: 3, seed: 1);
+
+    test('log forwards the message when onLog is provided', () {
+      final lines = <String>[];
+      final ctx = MapGenPassContext<int>(
+        params: params,
+        payload: 0,
+        onLog: lines.add,
+      );
+      ctx.log('Pass 2: seeds placed');
+      expect(lines, <String>['Pass 2: seeds placed']);
+    });
+
+    test('log is a no-op when onLog is null', () {
+      final ctx = MapGenPassContext<int>(params: params, payload: 0);
+      expect(() => ctx.log('ignored'), returnsNormally);
+    });
+
+    test('exposes the typed payload and shared params', () {
+      final ctx = MapGenPassContext<String>(params: params, payload: 'hello');
+      expect(ctx.payload, 'hello');
+      expect(ctx.params.width, 4);
+      expect(ctx.params.height, 3);
+    });
+  });
+
+  group('TileMapGenLandSeeds.run (uniform pass entry)', () {
+    final provinceToContinent = <String, int>{
+      'p1': 0,
+      'p2': 0,
+      'p3': 1,
+      'p4': 1,
+    };
+
+    test('seed-before-assignment path matches direct method calls', () {
+      final params = TileMapParams(
+        width: 20,
+        height: 20,
+        seed: 11,
+        seaFraction: 0.6,
+        seedBeforeAssignment: true,
+      );
+      final pass = TileMapGenLandSeeds(params);
+
+      // Direct (legacy) call sequence with a fresh, identically-seeded RNG.
+      final (directContinentSeeds, directLandSeeds, directContinentBySeed) = pass
+          .placeLandSeeds(provinceToContinent, Random(params.seed));
+      final directGrid = pass.assignLandByLandSeeds(
+        List.generate(params.height, (_) => List.filled(params.width, 's1')),
+        directLandSeeds,
+        directContinentBySeed,
+        provinceToContinent,
+        's1',
+      );
+
+      final result = pass.run(
+        MapGenPassContext<LandSeedPassPayload>(
+          params: params,
+          payload: LandSeedPassPayload(
+            grid: List.generate(
+              params.height,
+              (_) => List.filled(params.width, 's1'),
+            ),
+            provinceToContinent: provinceToContinent,
+            seaZoneId: 's1',
+            rnd: Random(params.seed),
+            seedBeforeAssignment: true,
+          ),
+        ),
+      );
+
+      expect(result.continentSeeds, directContinentSeeds);
+      expect(result.landSeeds, directLandSeeds);
+      expect(result.continentBySeedIndex, directContinentBySeed);
+      expect(result.grid, directGrid);
+    });
+
+    test('organic path matches direct method call', () {
+      final params = TileMapParams(
+        width: 20,
+        height: 14,
+        seed: 5,
+        seaFraction: 0.6,
+      );
+      final pass = TileMapGenLandSeeds(params);
+
+      final direct = pass.placeLandSeedsOrganic(
+        List.generate(params.height, (_) => List.filled(params.width, 's1')),
+        provinceToContinent,
+        's1',
+        Random(params.seed),
+      );
+
+      final result = pass.run(
+        MapGenPassContext<LandSeedPassPayload>(
+          params: params,
+          payload: LandSeedPassPayload(
+            grid: List.generate(
+              params.height,
+              (_) => List.filled(params.width, 's1'),
+            ),
+            provinceToContinent: provinceToContinent,
+            seaZoneId: 's1',
+            rnd: Random(params.seed),
+            seedBeforeAssignment: false,
+          ),
+        ),
+      );
+
+      expect(result.continentSeeds, direct.$1);
+      expect(result.landSeeds, direct.$2);
+      expect(result.continentBySeedIndex, direct.$3);
+      expect(result.grid, direct.$4);
+    });
+
+    test('emits the seed-before-assignment pass log line', () {
+      final params = TileMapParams(
+        width: 16,
+        height: 16,
+        seed: 3,
+        seaFraction: 0.6,
+        seedBeforeAssignment: true,
+      );
+      final pass = TileMapGenLandSeeds(params);
+      final lines = <String>[];
+
+      pass.run(
+        MapGenPassContext<LandSeedPassPayload>(
+          params: params,
+          payload: LandSeedPassPayload(
+            grid: List.generate(
+              params.height,
+              (_) => List.filled(params.width, 's1'),
+            ),
+            provinceToContinent: provinceToContinent,
+            seaZoneId: 's1',
+            rnd: Random(params.seed),
+            seedBeforeAssignment: true,
+          ),
+          onLog: lines.add,
+        ),
+      );
+
+      expect(lines, hasLength(1));
+      expect(lines.single, startsWith('Pass 2: Continent seeds '));
+    });
+  });
+}

--- a/test/check_map_gen_stage_protocol_test.dart
+++ b/test/check_map_gen_stage_protocol_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:test/test.dart';
 
 import '../tool/check_map_gen_stage_protocol.dart';
@@ -43,6 +45,51 @@ class FooBar {}
         source: src,
       );
       expect(violations, isEmpty);
+    });
+
+    test('accepts a service adopting the uniform MapGenPass entry point', () {
+      const src = r'''
+class TileMapGenLandSeeds
+    implements MapGenPass<LandSeedPassPayload, LandSeedPassResult> {
+  @override
+  final TileMapLandSeedParams params;
+}
+''';
+      final violations = findMapGenStageProtocolViolations(
+        relativePath:
+            'packages/colonizethis_map/lib/src/tile_map_generator_land_seeds.dart',
+        source: src,
+      );
+      expect(violations, isEmpty);
+    });
+  });
+
+  group('sourceAdoptsMapGenPass', () {
+    test('true when the source implements MapGenPass', () {
+      expect(
+        sourceAdoptsMapGenPass('class X implements MapGenPass<A, B> {}'),
+        isTrue,
+      );
+    });
+
+    test('false when the source only implements MapGenStage', () {
+      expect(
+        sourceAdoptsMapGenPass('class X implements MapGenStage {}'),
+        isFalse,
+      );
+    });
+  });
+
+  group('runCheckMapGenStageProtocol', () {
+    test('passes on the live repository tree (>=3 families adopt MapGenPass)',
+        () {
+      final lines = <String>[];
+      final code = runCheckMapGenStageProtocol(
+        Directory.current.path,
+        info: lines.add,
+        err: lines.add,
+      );
+      expect(code, 0, reason: lines.join('\n'));
     });
   });
 }

--- a/tool/check_map_gen_stage_protocol.dart
+++ b/tool/check_map_gen_stage_protocol.dart
@@ -8,12 +8,24 @@ import 'package:path/path.dart' as p;
 /// [MapGenStage] contract in `map_gen_stage.dart` so pass orchestration
 /// shares a uniform params + grid-in/grid-out protocol across land seeds,
 /// lakes/provinces, join-sea, and terrain/resource services.
-const _mapLibRoot = 'packages/colonizethis_map/lib';
-
+///
+/// In addition (Refs #3574, slice 4) it requires the contract to declare the
+/// uniform [MapGenPass] pass entry point and at least
+/// [_requiredMapGenPassFamilyMinimum] of the four families to adopt it; the
+/// remaining family stays [MapGenStage]-only and is documented inline as exempt.
 const _stageContractFile =
     'packages/colonizethis_map/lib/src/map_gen_stage.dart';
 
 const _requiredStageContractPattern = 'abstract interface class MapGenStage';
+
+const _requiredPassContractPattern = 'abstract interface class MapGenPass';
+
+/// Marker showing a family implements either the base stage or the uniform pass.
+const _implementsStage = 'implements MapGenStage';
+const _implementsPass = 'implements MapGenPass';
+
+/// At least this many generator families must adopt the uniform [MapGenPass].
+const _requiredMapGenPassFamilyMinimum = 3;
 
 /// Each generator service family must declare `implements MapGenStage`.
 const _requiredServiceBindings = <String, String>{
@@ -57,7 +69,7 @@ List<MapGenStageProtocolViolation> findMapGenStageProtocolViolations({
     );
     return violations;
   }
-  if (!source.contains('implements MapGenStage')) {
+  if (!source.contains(_implementsStage) && !source.contains(_implementsPass)) {
     violations.add(
       MapGenStageProtocolViolation(
         relativePath,
@@ -67,6 +79,9 @@ List<MapGenStageProtocolViolation> findMapGenStageProtocolViolations({
   }
   return violations;
 }
+
+/// True when [source] adopts the uniform [MapGenPass] entry point.
+bool sourceAdoptsMapGenPass(String source) => source.contains(_implementsPass);
 
 void main() {
   exit(runCheckMapGenStageProtocol(Directory.current.path));
@@ -97,7 +112,17 @@ int runCheckMapGenStageProtocol(
       ),
     );
   }
+  if (!contractSource.contains(_requiredPassContractPattern)) {
+    violations.add(
+      MapGenStageProtocolViolation(
+        _stageContractFile,
+        'missing `$_requiredPassContractPattern` uniform pass entry '
+        'declaration (Refs #3574)',
+      ),
+    );
+  }
 
+  var mapGenPassFamilies = 0;
   for (final entry in _requiredServiceBindings.entries) {
     final file = File(p.join(root, entry.key));
     if (!file.existsSync()) {
@@ -106,10 +131,25 @@ int runCheckMapGenStageProtocol(
       );
       continue;
     }
+    final fileSource = file.readAsStringSync();
     violations.addAll(
       findMapGenStageProtocolViolations(
         relativePath: entry.key,
-        source: file.readAsStringSync(),
+        source: fileSource,
+      ),
+    );
+    if (sourceAdoptsMapGenPass(fileSource)) {
+      mapGenPassFamilies++;
+    }
+  }
+
+  if (mapGenPassFamilies < _requiredMapGenPassFamilyMinimum) {
+    violations.add(
+      MapGenStageProtocolViolation(
+        _stageContractFile,
+        'at least $_requiredMapGenPassFamilyMinimum generator families must '
+        'adopt the uniform MapGenPass entry point '
+        '(found $mapGenPassFamilies) (Refs #3574)',
       ),
     );
   }


### PR DESCRIPTION
## Summary

Slice 4 of the `colonizethis_map` wave-2 refactor (#3574): introduce a uniform pass entry point so generator service families share orchestration/logging boilerplate instead of each pass being driven by bespoke inline orchestration in `TileMapGenerator`.

`Refs #3574`

> Slice 3 (PNG cell-fill pipeline, PR #3582) has already merged into `dev`; this is the follow-up PR for the next slice, branched from current `dev` (one open PR per issue).

## Done in this push

- **New protocol** in `map_gen_stage.dart`:
  - `MapGenPassContext<P>` — carries shared `params`, a typed per-family `payload` (`P`), and an optional `onLog` hook (`log(message)`).
  - `MapGenPass<P, R> implements MapGenStage` — uniform `R run(MapGenPassContext<P> ctx)` entry point.
- **Typed payloads/results** in new internal `map_gen_pass_payloads.dart` (standalone lib, not a generator `part`, so it does not trip `repo.map_no_partfile_classes`).
- **3 of 4 families adopt the uniform entry** via `run`:
  - `TileMapGenLandSeeds` (Pass 2–3 seed placement/assignment; organic + seed-before-assignment).
  - `_TileMapGenLakesProvinces` (Pass 4–5 lake/moat fill + border noise).
  - `_TileMapGenTerrainResource` (Pass 6–7 terrain/resource assignment).
- **`_TileMapGenJoinSea` documented inline as exempt** (heterogeneous: continent joining, terrain jitter, sea-zone subdivision share no single representative payload/result) — remains `MapGenStage`-only.
- **Orchestrator** `TileMapGenerator` routes the land-seed, lakes, and terrain passes through `run`, collapsing duplicated inline setup/logging.
- **Behaviour-preserving:** `run` reuses the existing pass logic in identical order with the same RNG; determinism and locked-pair golden tests stay byte-identical.

## SPEC

- `SPEC/program/tile-map-gen-algorithm.md` — new **§ Uniform pass entry point** under Implementation Structure, plus ACs for the lint requirement, land-seed `run` parity, and the null-`onLog` no-op.

## CI / lint

- `repo.map_gen_stage_protocol` (`tool/check_map_gen_stage_protocol.dart`) strengthened to require the `MapGenPass` contract declaration **and** at least **3 of 4** families to adopt it; the 4th stays `MapGenStage`-only.

## Tests

- `tool` lint test (`test/check_map_gen_stage_protocol_test.dart`): accepts `MapGenPass` adoption (positive), `sourceAdoptsMapGenPass` positive/negative, and a live-tree `runCheckMapGenStageProtocol` pass.
- Map unit tests (`packages/colonizethis_map/test/map_gen_pass_test.dart`): `MapGenPassContext.log` forward + null no-op + typed payload; `TileMapGenLandSeeds.run` parity with legacy direct calls for both organic and seed-before-assignment paths; pass-log emission.
- Full `colonizethis_map` suite green (296 tests) incl. determinism + locked-pair golden tests; touched map lints green (`map_gen_stage_protocol`, `map_no_partfile_classes`, `map_public_barrel_surface`, `map_gen_no_image_import`, `map_grid_cell_iteration_central`).

## Covered ACs (issue #3574)

- [x] "At least 3 of the 4 generator service families … adopt the uniform `MapGenStage` pass entry point; any family that cannot adopt it … is documented inline with rationale; `repo.map_gen_stage_protocol` is updated and green."
- [x] "Each new abstraction … (the strengthened `MapGenStage` pass entry) has dedicated unit tests (positive and negative/edge cases)."
- [x] "No change to generated tile maps, topology, or observable in-game map behavior."

## Deferred (remaining for #3574)

- Slice 5: `lib/src/` gen/view/render folder reorganization (import-only diff) — moves slice 1–4 abstractions into target subfolders.
- Slice 7: collapse lowest-value part files.
- (Slice 6 — `colonizethis_logic` map dep moved to `dev_dependencies` — already present on `dev`.)

Made with [Cursor](https://cursor.com)