### PR TITLE
test: align CtSpacing adoption list with extracted SplitEntityDialog base (Refs #3594)

### DIFF
--- a/app/test/ct_spacing_features_adoption_test.dart
+++ b/app/test/ct_spacing_features_adoption_test.dart
@@ -407,8 +407,13 @@ const List<String> _migratedFeatureFiles = <String>[
   'lib/features/game/widgets/production_commodity_breakdown_dialog.dart',
   'lib/features/game/widgets/production_panel.dart',
   'lib/features/game/widgets/province_sea_zone_detail_overlay.dart',
-  'lib/features/game/widgets/split_army_dialog.dart',
-  'lib/features/game/widgets/split_fleet_dialog.dart',
+  // split_army_dialog.dart / split_fleet_dialog.dart dropped from the adoption
+  // list: #3594 (PR #3600) extracted the shared SplitEntityDialog base, which
+  // now owns the `Padding(EdgeInsets.all(CtSpacing.l))` body. Both dialogs
+  // delegate their scaffold to that base and no longer contain any
+  // token-eligible `EdgeInsets`/`SizedBox` spacing, so the import and
+  // token-reference invariants moved to split_entity_dialog.dart below.
+  'lib/features/game/widgets/split_entity_dialog.dart',
   'lib/features/game/widgets/tech_tree_widget.dart',
   'lib/features/game/widgets/technology_panel.dart',
   'lib/features/game/widgets/technology_panel_orders.dart',


### PR DESCRIPTION
## Summary

Fixes a `dev`-wide red check (`App tests (shard 0/2)`) caused by an earlier slice of this issue.

PR #3600 (a merged slice of #3594) extracted the shared `SplitEntityDialog` base and moved the `Padding(EdgeInsets.all(CtSpacing.l))` body plus `CtGap.l` gap **out of** `split_army_dialog.dart` / `split_fleet_dialog.dart` and **into** `split_entity_dialog.dart`. The `ct_spacing_features_adoption_test.dart` pinning test was not updated: it still listed the two leaf dialogs in `_migratedFeatureFiles`, so it asserted a `widgets/ct_spacing.dart` import and a `CtSpacing.<token>` reference that no longer exist in those files. That turned the shard-0 app-test check red on `dev` and on every branch cut from it (e.g. #3599, #3602).

## Done in this push

- `app/test/ct_spacing_features_adoption_test.dart`: drop `split_army_dialog.dart` and `split_fleet_dialog.dart` from `_migratedFeatureFiles` (they now delegate all token-eligible spacing to the base) and add `split_entity_dialog.dart`, which owns the migrated `EdgeInsets.all(CtSpacing.l)` callsite and `CtGap.l`. Added an inline comment explaining the relocation (mirrors the existing `naval_units_panel.dart` drop note).

## Verification

- `cd app && flutter test test/ct_spacing_features_adoption_test.dart` → all 191 tests pass (was 4 failing).
- `flutter analyze test/ct_spacing_features_adoption_test.dart` → No issues found.

## Scope / SPEC

- Test-only change; no production behavior or SPEC change. The adoption invariants and the SPEC-pinned token scale (`SPEC/ui/pixel-art-ui-catalog.md` § Spacing tokens) are unchanged — only the file list tracking where the migrated callsites live is corrected to match the merged base extraction.

## Deferred

- Remaining #3594 refactor items (chrome button base, train dialog base, file-size splits) are out of scope for this fix and tracked separately under the issue.

Refs #3594

Made with [Cursor](https://cursor.com)