### PR TITLE
refactor(app): extract shared province-detail overlay host wiring (#3594)

### DIFF
--- a/app/lib/features/game/flame/game_map_narrow_detail_overlay.dart
+++ b/app/lib/features/game/flame/game_map_narrow_detail_overlay.dart
@@ -10,9 +10,9 @@ import '../../../../providers/game_service_provider.dart';
 import '../../../../providers/games_provider.dart';
 import '../../../../providers/map_province_panel_provider.dart';
 import '../../../core/services/game_service.dart' show GameMapData;
-import 'game_map_area_state_logic.dart';
 import 'per_player_work_target_selection_cache.dart';
 import 'province_action_state_calculator.dart';
+import 'province_detail_overlay_host_support.dart';
 import 'province_detail_panel_slide_transition.dart';
 import '../widgets/province_sea_zone_detail_overlay.dart';
 
@@ -53,15 +53,10 @@ class GameMapNarrowDetailOverlaySlot extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final panel = ref.watch(mapProvincePanelProvider);
     final draftOrders = ref.watch(currentOrdersProvider);
-    final tileKey = panel.selectedTileKey;
-    final displayId = tileKey == null || tileKey.isEmpty
-        ? ''
-        : (provinceDetailDisplayIdForPortHarborMapTile(
-                    region: region,
-                    tileKey: tileKey,
-                  ) ??
-                  displayProvinceOrSeaIdFromTileKey(tileKey)) ??
-              '';
+    final displayId = resolveProvinceDetailDisplayId(
+      region: region,
+      tileKey: panel.selectedTileKey,
+    );
     final showPanel = panel.overlayOpen && displayId.isNotEmpty;
     if (!showPanel) {
       return ProvinceDetailPanelSlideTransition(
@@ -77,7 +72,6 @@ class GameMapNarrowDetailOverlaySlot extends ConsumerWidget {
       // Some widget tests render this panel without initializing persistence-backed providers.
       mapData = null;
     }
-    final topology = mapData?.combinedTopology;
     final actionStates = ProvinceActionStateCalculator.compute(
       game: game,
       humanPlayerId: humanPlayerId,
@@ -91,6 +85,20 @@ class GameMapNarrowDetailOverlaySlot extends ConsumerWidget {
     final exploreState = actionStates.explore;
     final prospectState = actionStates.prospect;
     final buildImprovementState = actionStates.buildImprovement;
+    final shortcuts = buildProvinceDetailShortcutCallbacks(
+      game: game,
+      humanPlayerId: humanPlayerId,
+      region: region,
+      playerView: playerView,
+      workTargetSelectionCache: workTargetSelectionCache,
+      draftOrders: draftOrders,
+      mapData: mapData,
+      selectedTileKey: panel.selectedTileKey,
+      exploreEnabled: exploreState.enabled,
+      prospectEnabled: prospectState.enabled,
+      buildImprovementEnabled: buildImprovementState.enabled,
+      bus: ref.read(appEventBusProvider),
+    );
     final overlay = SizedBox(
       width: double.infinity,
       height: MediaQuery.sizeOf(context).height * 0.33,
@@ -116,83 +124,9 @@ class GameMapNarrowDetailOverlaySlot extends ConsumerWidget {
         buildImprovementActionEnabled:
             canMutateViaUi && buildImprovementState.enabled,
         omniscientDetail: omniscientDetail,
-        onExploreWithExplorerTap:
-            exploreState.enabled && panel.selectedTileKey != null
-            ? () {
-                final selectedTileKey = panel.selectedTileKey!;
-                final revalidatedState =
-                    GameMapAreaStateLogic.provinceExploreActionState(
-                      game: game,
-                      humanPlayerId: humanPlayerId,
-                      selectedTileKey: selectedTileKey,
-                      selectedRegion: region,
-                      workTargetSelectionCache: workTargetSelectionCache,
-                    );
-                if (!revalidatedState.enabled) {
-                  return;
-                }
-                ref
-                    .read(appEventBusProvider)
-                    .emit(
-                      ct_models.OpenCivilianUnitsPanelEvent(
-                        explorerOnly: true,
-                        exploreShortcutTargetTileKey: selectedTileKey,
-                      ),
-                    );
-              }
-            : null,
-        onProspectWithExplorerTap:
-            prospectState.enabled && panel.selectedTileKey != null
-            ? () {
-                final selectedTileKey = panel.selectedTileKey!;
-                final revalidatedState =
-                    GameMapAreaStateLogic.provinceProspectActionState(
-                      game: game,
-                      humanPlayerId: humanPlayerId,
-                      selectedTileKey: selectedTileKey,
-                      playerView: playerView,
-                      topology: topology,
-                      currentOrders: draftOrders,
-                      tileMapByRegion: mapData?.tileMapByRegion,
-                    );
-                if (!revalidatedState.enabled) {
-                  return;
-                }
-                ref
-                    .read(appEventBusProvider)
-                    .emit(
-                      ct_models.OpenCivilianUnitsPanelEvent(
-                        explorerOnly: true,
-                        prospectShortcutTargetTileKey: selectedTileKey,
-                      ),
-                    );
-              }
-            : null,
-        onBuildImprovementTap:
-            buildImprovementState.enabled && panel.selectedTileKey != null
-            ? () {
-                final selectedTileKey = panel.selectedTileKey!;
-                final revalidatedState =
-                    GameMapAreaStateLogic.provinceBuildImprovementActionState(
-                      game: game,
-                      humanPlayerId: humanPlayerId,
-                      selectedTileKey: selectedTileKey,
-                      playerView: playerView,
-                      workTargetSelectionCache: workTargetSelectionCache,
-                    );
-                if (!revalidatedState.enabled) {
-                  return;
-                }
-                ref
-                    .read(appEventBusProvider)
-                    .emit(
-                      ct_models.OpenCivilianUnitsPanelEvent(
-                        builderOnly: true,
-                        buildImprovementShortcutTargetTileKey: selectedTileKey,
-                      ),
-                    );
-              }
-            : null,
+        onExploreWithExplorerTap: shortcuts.onExploreWithExplorerTap,
+        onProspectWithExplorerTap: shortcuts.onProspectWithExplorerTap,
+        onBuildImprovementTap: shortcuts.onBuildImprovementTap,
       ),
     );
     return ProvinceDetailPanelSlideTransition(

--- a/app/lib/features/game/flame/game_map_province_detail_side_panel.dart
+++ b/app/lib/features/game/flame/game_map_province_detail_side_panel.dart
@@ -11,10 +11,10 @@ import '../../../../providers/game_service_provider.dart';
 import '../../../../providers/games_provider.dart';
 import '../../../../providers/map_province_panel_provider.dart';
 import '../../../core/services/game_service.dart' show GameMapData;
-import 'game_map_area_state_logic.dart';
 import 'game_screen_shared.dart' show kGameMapWideProvinceSidePanelWidth;
 import 'per_player_work_target_selection_cache.dart';
 import 'province_action_state_calculator.dart';
+import 'province_detail_overlay_host_support.dart';
 import 'province_detail_panel_slide_transition.dart';
 import '../widgets/province_sea_zone_detail_overlay.dart';
 
@@ -43,15 +43,10 @@ class GameMapProvinceDetailSidePanel extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final panel = ref.watch(mapProvincePanelProvider);
     final draftOrders = ref.watch(currentOrdersProvider);
-    final tileKey = panel.selectedTileKey;
-    final displayId = tileKey == null || tileKey.isEmpty
-        ? ''
-        : (provinceDetailDisplayIdForPortHarborMapTile(
-                    region: region,
-                    tileKey: tileKey,
-                  ) ??
-                  displayProvinceOrSeaIdFromTileKey(tileKey)) ??
-              '';
+    final displayId = resolveProvinceDetailDisplayId(
+      region: region,
+      tileKey: panel.selectedTileKey,
+    );
     final showPanel = panel.overlayOpen && displayId.isNotEmpty;
     if (!showPanel) {
       if (kCtE2EEnabled) {
@@ -83,7 +78,6 @@ class GameMapProvinceDetailSidePanel extends ConsumerWidget {
       // Some widget tests render this panel without initializing persistence-backed providers.
       mapData = null;
     }
-    final topology = mapData?.combinedTopology;
     final actionStates = ProvinceActionStateCalculator.compute(
       game: game,
       humanPlayerId: humanPlayerId,
@@ -97,6 +91,20 @@ class GameMapProvinceDetailSidePanel extends ConsumerWidget {
     final exploreState = actionStates.explore;
     final prospectState = actionStates.prospect;
     final buildImprovementState = actionStates.buildImprovement;
+    final shortcuts = buildProvinceDetailShortcutCallbacks(
+      game: game,
+      humanPlayerId: humanPlayerId,
+      region: region,
+      playerView: playerView,
+      workTargetSelectionCache: workTargetSelectionCache,
+      draftOrders: draftOrders,
+      mapData: mapData,
+      selectedTileKey: panel.selectedTileKey,
+      exploreEnabled: exploreState.enabled,
+      prospectEnabled: prospectState.enabled,
+      buildImprovementEnabled: buildImprovementState.enabled,
+      bus: ref.read(appEventBusProvider),
+    );
     Widget overlay = ProvinceSeaZoneDetailOverlay(
       game: game,
       region: region,
@@ -117,83 +125,9 @@ class GameMapProvinceDetailSidePanel extends ConsumerWidget {
       buildImprovementActionEnabled:
           canMutateViaUi && buildImprovementState.enabled,
       omniscientDetail: omniscientDetail,
-      onExploreWithExplorerTap:
-          exploreState.enabled && panel.selectedTileKey != null
-          ? () {
-              final selectedTileKey = panel.selectedTileKey!;
-              final revalidatedState =
-                  GameMapAreaStateLogic.provinceExploreActionState(
-                    game: game,
-                    humanPlayerId: humanPlayerId,
-                    selectedTileKey: selectedTileKey,
-                    selectedRegion: region,
-                    workTargetSelectionCache: workTargetSelectionCache,
-                  );
-              if (!revalidatedState.enabled) {
-                return;
-              }
-              ref
-                  .read(appEventBusProvider)
-                  .emit(
-                    ct_models.OpenCivilianUnitsPanelEvent(
-                      explorerOnly: true,
-                      exploreShortcutTargetTileKey: selectedTileKey,
-                    ),
-                  );
-            }
-          : null,
-      onProspectWithExplorerTap:
-          prospectState.enabled && panel.selectedTileKey != null
-          ? () {
-              final selectedTileKey = panel.selectedTileKey!;
-              final revalidatedState =
-                  GameMapAreaStateLogic.provinceProspectActionState(
-                    game: game,
-                    humanPlayerId: humanPlayerId,
-                    selectedTileKey: selectedTileKey,
-                    playerView: playerView,
-                    topology: topology,
-                    currentOrders: draftOrders,
-                    tileMapByRegion: mapData?.tileMapByRegion,
-                  );
-              if (!revalidatedState.enabled) {
-                return;
-              }
-              ref
-                  .read(appEventBusProvider)
-                  .emit(
-                    ct_models.OpenCivilianUnitsPanelEvent(
-                      explorerOnly: true,
-                      prospectShortcutTargetTileKey: selectedTileKey,
-                    ),
-                  );
-            }
-          : null,
-      onBuildImprovementTap:
-          buildImprovementState.enabled && panel.selectedTileKey != null
-          ? () {
-              final selectedTileKey = panel.selectedTileKey!;
-              final revalidatedState =
-                  GameMapAreaStateLogic.provinceBuildImprovementActionState(
-                    game: game,
-                    humanPlayerId: humanPlayerId,
-                    selectedTileKey: selectedTileKey,
-                    playerView: playerView,
-                    workTargetSelectionCache: workTargetSelectionCache,
-                  );
-              if (!revalidatedState.enabled) {
-                return;
-              }
-              ref
-                  .read(appEventBusProvider)
-                  .emit(
-                    ct_models.OpenCivilianUnitsPanelEvent(
-                      builderOnly: true,
-                      buildImprovementShortcutTargetTileKey: selectedTileKey,
-                    ),
-                  );
-            }
-          : null,
+      onExploreWithExplorerTap: shortcuts.onExploreWithExplorerTap,
+      onProspectWithExplorerTap: shortcuts.onProspectWithExplorerTap,
+      onBuildImprovementTap: shortcuts.onBuildImprovementTap,
     );
     if (kCtE2EEnabled) {
       overlay = KeyedSubtree(key: kCtE2EProvincePanelRootKey, child: overlay);

--- a/app/lib/features/game/flame/province_detail_overlay_host_support.dart
+++ b/app/lib/features/game/flame/province_detail_overlay_host_support.dart
@@ -1,0 +1,168 @@
+// Shared province-detail overlay host wiring (Refs #3594 — resolve flame-host
+// ↔ widget duplication / coupling, work item 7).
+//
+// Both province-detail overlay hosts — the wide side panel
+// (`GameMapProvinceDetailSidePanel`) and the narrow bottom-sheet slot
+// (`GameMapNarrowDetailOverlaySlot`) — previously duplicated two identical
+// blocks verbatim: the `displayId` resolution from the selected tile key and
+// the explore / prospect / build-improvement shortcut `onTap` callbacks (each
+// re-validating its action state before emitting an
+// `OpenCivilianUnitsPanelEvent`). The only differences between the two hosts
+// are the slide axis, wrapper sizing, and the wide host's e2e snapshot — not
+// this wiring. Following the precedent of `ProvinceActionStateCalculator`
+// (issue #3279 item 4), the shared logic lives here so each host instantiates
+// the overlay directly (keeping the SPEC § Architecture and wiring host→overlay
+// contract intact) without copy-pasting the wiring.
+
+import 'package:colonizethis_logic/colonizethis_logic.dart' show PlayerView;
+import 'package:colonizethis_map/colonizethis_map.dart';
+import 'package:colonizethis_models/colonizethis_models.dart' as ct_models;
+import 'package:flutter/widgets.dart';
+
+import '../../../../providers/map_province_panel_provider.dart'
+    show displayProvinceOrSeaIdFromTileKey;
+import '../../../core/services/game_service.dart' show GameMapData;
+import 'game_map_area_state_logic.dart';
+import 'per_player_work_target_selection_cache.dart';
+
+/// The three province-overlay shortcut `onTap` callbacks. Each entry is `null`
+/// when its action is disabled or no tile is selected, matching the previous
+/// inline `state.enabled && selectedTileKey != null ? ... : null` gating.
+typedef ProvinceDetailShortcutCallbacks = ({
+  VoidCallback? onExploreWithExplorerTap,
+  VoidCallback? onProspectWithExplorerTap,
+  VoidCallback? onBuildImprovementTap,
+});
+
+/// Resolves the overlay `displayId` from a selected tile key.
+///
+/// Returns the empty string when [tileKey] is `null`/empty or no province or
+/// sea id can be derived — the canonical "nothing to show" sentinel both hosts
+/// already relied on. Behavior is unchanged from the previously duplicated
+/// inline expression.
+String resolveProvinceDetailDisplayId({
+  required RegionMapViewData region,
+  required String? tileKey,
+}) {
+  if (tileKey == null || tileKey.isEmpty) {
+    return '';
+  }
+  return (provinceDetailDisplayIdForPortHarborMapTile(
+            region: region,
+            tileKey: tileKey,
+          ) ??
+          displayProvinceOrSeaIdFromTileKey(tileKey)) ??
+      '';
+}
+
+/// Builds the explore / prospect / build-improvement shortcut callbacks shared
+/// by both province-detail overlay hosts.
+///
+/// Each callback re-validates its action state via [GameMapAreaStateLogic] at
+/// tap time (guarding against stale enablement) and, only when still enabled,
+/// emits an [ct_models.OpenCivilianUnitsPanelEvent] on [bus] carrying the
+/// matching shortcut target tile key. The `*Enabled` flags mirror the hosts'
+/// previous `state.enabled` gating (not the `canMutateViaUi`-gated icon flags,
+/// which stay on the overlay's `show*`/`*ActionEnabled` props).
+///
+/// This introduces no new behavior: it forwards to the same logic entry points
+/// with the same arguments the hosts used inline.
+ProvinceDetailShortcutCallbacks buildProvinceDetailShortcutCallbacks({
+  required ct_models.Game game,
+  required String humanPlayerId,
+  required RegionMapViewData region,
+  required PlayerView playerView,
+  required PerPlayerWorkTargetSelectionCache workTargetSelectionCache,
+  required ct_models.Orders draftOrders,
+  required GameMapData? mapData,
+  required String? selectedTileKey,
+  required bool exploreEnabled,
+  required bool prospectEnabled,
+  required bool buildImprovementEnabled,
+  required ct_models.AppEventBus bus,
+}) {
+  final String? tileKey = selectedTileKey;
+  if (tileKey == null) {
+    return (
+      onExploreWithExplorerTap: null,
+      onProspectWithExplorerTap: null,
+      onBuildImprovementTap: null,
+    );
+  }
+  final topology = mapData?.combinedTopology;
+
+  VoidCallback? onExplore;
+  if (exploreEnabled) {
+    onExplore = () {
+      final revalidated = GameMapAreaStateLogic.provinceExploreActionState(
+        game: game,
+        humanPlayerId: humanPlayerId,
+        selectedTileKey: tileKey,
+        selectedRegion: region,
+        workTargetSelectionCache: workTargetSelectionCache,
+      );
+      if (!revalidated.enabled) {
+        return;
+      }
+      bus.emit(
+        ct_models.OpenCivilianUnitsPanelEvent(
+          explorerOnly: true,
+          exploreShortcutTargetTileKey: tileKey,
+        ),
+      );
+    };
+  }
+
+  VoidCallback? onProspect;
+  if (prospectEnabled) {
+    onProspect = () {
+      final revalidated = GameMapAreaStateLogic.provinceProspectActionState(
+        game: game,
+        humanPlayerId: humanPlayerId,
+        selectedTileKey: tileKey,
+        playerView: playerView,
+        topology: topology,
+        currentOrders: draftOrders,
+        tileMapByRegion: mapData?.tileMapByRegion,
+      );
+      if (!revalidated.enabled) {
+        return;
+      }
+      bus.emit(
+        ct_models.OpenCivilianUnitsPanelEvent(
+          explorerOnly: true,
+          prospectShortcutTargetTileKey: tileKey,
+        ),
+      );
+    };
+  }
+
+  VoidCallback? onBuildImprovement;
+  if (buildImprovementEnabled) {
+    onBuildImprovement = () {
+      final revalidated =
+          GameMapAreaStateLogic.provinceBuildImprovementActionState(
+            game: game,
+            humanPlayerId: humanPlayerId,
+            selectedTileKey: tileKey,
+            playerView: playerView,
+            workTargetSelectionCache: workTargetSelectionCache,
+          );
+      if (!revalidated.enabled) {
+        return;
+      }
+      bus.emit(
+        ct_models.OpenCivilianUnitsPanelEvent(
+          builderOnly: true,
+          buildImprovementShortcutTargetTileKey: tileKey,
+        ),
+      );
+    };
+  }
+
+  return (
+    onExploreWithExplorerTap: onExplore,
+    onProspectWithExplorerTap: onProspect,
+    onBuildImprovementTap: onBuildImprovement,
+  );
+}

--- a/app/test/province_detail_overlay_host_support_test.dart
+++ b/app/test/province_detail_overlay_host_support_test.dart
@@ -1,0 +1,184 @@
+// Unit pins for the shared province-detail overlay host support extracted in
+// Refs #3594 (work item 7 — resolve flame-host ↔ widget duplication/coupling).
+//
+// The wide side panel (`GameMapProvinceDetailSidePanel`) and the narrow
+// bottom-sheet slot (`GameMapNarrowDetailOverlaySlot`) previously duplicated
+// the `displayId` resolution and the explore/prospect/build-improvement
+// shortcut callback gating verbatim. These pins assert the extracted helper
+// keeps the same gating contract (null tile key → no callbacks; disabled
+// actions → null callback; enabled action → non-null callback). The full
+// runtime tap/emit behavior remains pinned by the host-level tests
+// (`province_*_shortcut_host_emit_event_test.dart`).
+
+import 'package:colonizethis_app/features/game/flame/per_player_work_target_selection_cache.dart';
+import 'package:colonizethis_app/features/game/flame/province_detail_overlay_host_support.dart';
+import 'package:colonizethis_data/colonizethis_data.dart' show MapTopology;
+import 'package:colonizethis_logic/colonizethis_logic.dart'
+    show PlayerView, buildPlayerView;
+import 'package:colonizethis_map/colonizethis_map.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter_test/flutter_test.dart';
+
+const String _kPlayerId = 'gp1';
+const String _kTileKey = 'oldWorld|p1|0|0';
+
+Game _minimalGame() => Game(
+      id: 'g_support',
+      worldState: const WorldState(
+        turnState: TurnState(phase: TurnPhase.orders, turnNumber: 1),
+        oldWorld: RegionData(provinces: [], units: []),
+        newWorld: RegionData(provinces: [], units: []),
+      ),
+      players: const [
+        Player(
+          id: _kPlayerId,
+          displayName: 'Human',
+          isHuman: true,
+          capitalProvinceId: '',
+        ),
+      ],
+      minorNations: const [],
+      tribes: const [],
+    );
+
+RegionMapViewData _emptyRegion() => const RegionMapViewData(
+      regionId: 'oldWorld',
+      width: 1,
+      height: 1,
+      cellSize: 16,
+      cells: [],
+      capitalMarkers: [],
+      portMarkers: [],
+      factionColors: {},
+      greatPowerFactionIds: {},
+      terrainColors: {},
+      provincePoliticalOwnerByPrefixedProvinceId: {},
+    );
+
+PlayerView _playerView(Game game) =>
+    buildPlayerView(game, const MapTopology(nodes: [], edges: []), _kPlayerId);
+
+ProvinceDetailShortcutCallbacks _callbacks({
+  required Game game,
+  required String? selectedTileKey,
+  required bool exploreEnabled,
+  required bool prospectEnabled,
+  required bool buildImprovementEnabled,
+  required AppEventBus bus,
+}) =>
+    buildProvinceDetailShortcutCallbacks(
+      game: game,
+      humanPlayerId: _kPlayerId,
+      region: _emptyRegion(),
+      playerView: _playerView(game),
+      workTargetSelectionCache:
+          PerPlayerWorkTargetSelectionCache(strategies: const {}),
+      draftOrders: const Orders(),
+      mapData: null,
+      selectedTileKey: selectedTileKey,
+      exploreEnabled: exploreEnabled,
+      prospectEnabled: prospectEnabled,
+      buildImprovementEnabled: buildImprovementEnabled,
+      bus: bus,
+    );
+
+void main() {
+  suppressLogsForTests();
+
+  group('resolveProvinceDetailDisplayId', () {
+    test('returns empty string for a null tile key', () {
+      expect(
+        resolveProvinceDetailDisplayId(region: _emptyRegion(), tileKey: null),
+        isEmpty,
+      );
+    });
+
+    test('returns empty string for an empty tile key', () {
+      expect(
+        resolveProvinceDetailDisplayId(region: _emptyRegion(), tileKey: ''),
+        isEmpty,
+      );
+    });
+  });
+
+  group('buildProvinceDetailShortcutCallbacks gating', () {
+    late AppEventBus bus;
+
+    setUp(() {
+      bus = AppEventBus.create();
+    });
+
+    tearDown(() {
+      bus.dispose();
+    });
+
+    test('returns all-null callbacks when no tile is selected', () {
+      final callbacks = _callbacks(
+        game: _minimalGame(),
+        selectedTileKey: null,
+        exploreEnabled: true,
+        prospectEnabled: true,
+        buildImprovementEnabled: true,
+        bus: bus,
+      );
+
+      expect(callbacks.onExploreWithExplorerTap, isNull);
+      expect(callbacks.onProspectWithExplorerTap, isNull);
+      expect(callbacks.onBuildImprovementTap, isNull);
+    });
+
+    test('returns all-null callbacks when every action is disabled', () {
+      final callbacks = _callbacks(
+        game: _minimalGame(),
+        selectedTileKey: _kTileKey,
+        exploreEnabled: false,
+        prospectEnabled: false,
+        buildImprovementEnabled: false,
+        bus: bus,
+      );
+
+      expect(callbacks.onExploreWithExplorerTap, isNull);
+      expect(callbacks.onProspectWithExplorerTap, isNull);
+      expect(callbacks.onBuildImprovementTap, isNull);
+    });
+
+    test('exposes only the enabled action callback (per-action gating)', () {
+      final exploreOnly = _callbacks(
+        game: _minimalGame(),
+        selectedTileKey: _kTileKey,
+        exploreEnabled: true,
+        prospectEnabled: false,
+        buildImprovementEnabled: false,
+        bus: bus,
+      );
+      expect(exploreOnly.onExploreWithExplorerTap, isNotNull);
+      expect(exploreOnly.onProspectWithExplorerTap, isNull);
+      expect(exploreOnly.onBuildImprovementTap, isNull);
+
+      final prospectOnly = _callbacks(
+        game: _minimalGame(),
+        selectedTileKey: _kTileKey,
+        exploreEnabled: false,
+        prospectEnabled: true,
+        buildImprovementEnabled: false,
+        bus: bus,
+      );
+      expect(prospectOnly.onExploreWithExplorerTap, isNull);
+      expect(prospectOnly.onProspectWithExplorerTap, isNotNull);
+      expect(prospectOnly.onBuildImprovementTap, isNull);
+
+      final buildOnly = _callbacks(
+        game: _minimalGame(),
+        selectedTileKey: _kTileKey,
+        exploreEnabled: false,
+        prospectEnabled: false,
+        buildImprovementEnabled: true,
+        bus: bus,
+      );
+      expect(buildOnly.onExploreWithExplorerTap, isNull);
+      expect(buildOnly.onProspectWithExplorerTap, isNull);
+      expect(buildOnly.onBuildImprovementTap, isNotNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Resolves the **work item 7** duplication/coupling in #3594 (flame-host ↔ `widgets/` province-detail overlay) by deduplicating the verbatim wiring that the two overlay hosts copy-pasted.

The wide side panel (`GameMapProvinceDetailSidePanel`) and the narrow bottom-sheet slot (`GameMapNarrowDetailOverlaySlot`) previously duplicated, byte-for-byte:
- the `displayId` resolution from the selected tile key, and
- the explore / prospect / build-improvement shortcut `onTap` callbacks (each re-validating its action state before emitting `OpenCivilianUnitsPanelEvent`).

Both blocks now live in a shared `province_detail_overlay_host_support.dart` helper, following the existing `ProvinceActionStateCalculator` precedent (issue #3279 item 4).

## Done in this push

- New `province_detail_overlay_host_support.dart`:
  - `resolveProvinceDetailDisplayId(...)`
  - `buildProvinceDetailShortcutCallbacks(...)` returning the three gated callbacks.
- Both hosts delegate to the helper; **each still instantiates the overlay directly and reads `mapProvincePanelProvider`**, preserving the `SPEC/ui/province-sea-zone-detail-overlay.md` § Architecture and wiring host→overlay contract (pinned by `province_sea_zone_overlay_architecture_test.dart`, still green).
- Net ~132 lines of duplicated wiring removed from the two hosts.

## Behavior

Behavior-preserving — no new behavior, no SPEC change. The helper forwards to the same `GameMapAreaStateLogic` entry points with identical arguments. Verified by the existing host-level emit-event tests (positive emit, disabled no-op, click-time-drift no-op) which pass unchanged.

## Tests

- New `province_detail_overlay_host_support_test.dart`: pins the helper gating contract (null tile key → no callbacks; all-disabled → no callbacks; per-action gating exposes only the enabled callback) and `displayId` empty-string sentinels.
- Re-ran impacted suite — all green:
  - `province_sea_zone_overlay_architecture_test.dart`
  - `province_explore_shortcut_host_emit_event_test.dart`
  - `province_prospect_shortcut_host_emit_event_test.dart`
  - `province_build_improvement_shortcut_host_emit_event_test.dart`
  - `province_build_improvement_shortcut_host_goldens_test.dart`
  - `game_map_narrow_detail_overlay_test.dart`
  - `panels_320dp_min_viewport_test.dart`
- `flutter analyze` clean for all changed/added files.

## Deferred for #3594

- **Item 3 (TrainDialogBase):** sequenced after the in-flight train-dialog PR #3602, which rewrites both train dialogs and adds a third (naval) dialog that the base should also cover. Extracting the base now would conflict pervasively and exclude the naval dialog.
- **Item 7 (full AppEventBus re-mounting):** the literal "route panel construction through `AppEventBus`" approach conflicts with the issue's own "no behavior change" non-goal and is not a true layering violation (these hosts are Flutter `ConsumerWidget`s composing a child widget, not cross-panel orchestration). This PR addresses the underlying duplication/coupling that item 7 targets; the bus re-mounting needs a SPEC decision before implementation.

Refs #3594

Made with [Cursor](https://cursor.com)