### PR TITLE
refactor: extract shared TrainDialogBase for train dialogs (#3594)

### DIFF
--- a/app/lib/features/game/widgets/train_civilians_dialog.dart
+++ b/app/lib/features/game/widgets/train_civilians_dialog.dart
@@ -9,81 +9,53 @@ import '../../../config/editorial_monocle_palette.dart';
 import '../../../config/ui_screen_ids.dart';
 import '../../../core/utils/currency_format.dart';
 import '../../../l10n/l10n.dart';
-import '../../../widgets/ct_dialog_shell.dart';
 import '../../../widgets/ct_gap.dart';
 import '../../../widgets/ct_nine_patch_button.dart';
-import '../../../widgets/ct_spacing.dart';
 import '../../../widgets/strict_asset_icon.dart';
+import 'train_dialog_base.dart';
 import 'train_dialog_chrome.dart';
-import 'train_unit_dialog_helper.dart';
 
-class TrainCiviliansDialog extends StatefulWidget {
+class TrainCiviliansDialog extends TrainDialogBase {
   const TrainCiviliansDialog({
     super.key,
-    required this.game,
-    required this.humanPlayerId,
-    required this.currentOrders,
-    required this.bus,
+    required super.game,
+    required super.humanPlayerId,
+    required super.currentOrders,
+    required super.bus,
   });
 
   /// SPEC/ui/train-civilians-dialog.md — [UiScreenIds.trainCiviliansDialog].
   static const screenId = UiScreenIds.trainCiviliansDialog;
 
-  final Game game;
-  final String humanPlayerId;
-  final Orders currentOrders;
-  final AppEventBus bus;
-
   @override
   State<TrainCiviliansDialog> createState() => _TrainCiviliansDialogState();
 }
 
-class _TrainCiviliansDialogState extends State<TrainCiviliansDialog> {
-  late Map<String, int> _counts;
+class _TrainCiviliansDialogState
+    extends TrainDialogBaseState<TrainCiviliansDialog> {
+  @override
+  Iterable<String> get unitTypeIds => CivilianEconomyCatalog.byId.keys;
 
   @override
-  void initState() {
-    super.initState();
-    _counts = _initialCountsFromOrders();
+  bool get ordersAreMilitary => false;
+
+  @override
+  Map<String, String> get unlockingTechByUnitType => unlockingTechByCivilianId;
+
+  @override
+  String dialogTitle(AppLocalizations l10n) => l10n.trainCivilians_title;
+
+  @override
+  void emitCommittedOrders(List<BuildUnitOrder> orders) {
+    widget.bus.emit(TrainCivilianBuildOrdersCommittedEvent(orders: orders));
   }
 
-  /// Counts pending train-at-capital civilian builds from [widget.currentOrders].
-  Map<String, int> _initialCountsFromOrders() {
-    return initialTrainDialogCountsFromOrders(
-      unitTypeIds: CivilianEconomyCatalog.byId.keys,
-      currentOrders: widget.currentOrders,
-      humanPlayerId: widget.humanPlayerId,
-      capitalProvinceId: _player?.capitalProvinceId,
-      isMilitary: false,
-    );
-  }
-
-  Player? get _player {
-    return trainDialogPlayerById(
-      players: widget.game.players,
-      playerId: widget.humanPlayerId,
-    );
-  }
-
-  bool get _hasCapital => trainDialogHasCapital(_player);
-
-  int get _treasury => trainDialogTreasury(_player);
-  int get _paperStockpile => _player?.stockpile.quantityOf('paper') ?? 0;
-
-  Map<String, bool> get _techUnlocked => trainDialogTechUnlocked(_player);
-
-  bool _isLocked(String unitType) {
-    return trainDialogIsLocked(
-      unitType: unitType,
-      unlockingTechByUnitType: unlockingTechByCivilianId,
-      techUnlocked: _techUnlocked,
-    );
-  }
+  int get _paperStockpile => stockpileQty(CommodityCatalog.paper.id);
 
   int _totalTreasuryCost() {
     int total = 0;
     for (final e in CivilianEconomyCatalog.all) {
-      total += _counts[e.id]! * e.buildTreasuryCost;
+      total += (counts[e.id] ?? 0) * e.buildTreasuryCost;
     }
     return total;
   }
@@ -92,28 +64,29 @@ class _TrainCiviliansDialogState extends State<TrainCiviliansDialog> {
     int total = 0;
     for (final e in CivilianEconomyCatalog.all) {
       final paperQty = e.buildInputs[CommodityCatalog.paper.id] ?? 0;
-      total += _counts[e.id]! * paperQty;
+      total += (counts[e.id] ?? 0) * paperQty;
     }
     return total;
   }
 
-  bool _canAffordIncrement(String unitType) {
+  @override
+  bool canAffordIncrement(String unitType) {
     final econ = CivilianEconomyCatalog.byId[unitType];
     if (econ == null) return false;
     final newTreasuryCost = _totalTreasuryCost() + econ.buildTreasuryCost;
     final newPaperCost =
         _totalPaperCost() + (econ.buildInputs[CommodityCatalog.paper.id] ?? 0);
-    return newTreasuryCost <= _treasury && newPaperCost <= _paperStockpile;
+    return newTreasuryCost <= treasury && newPaperCost <= _paperStockpile;
   }
 
   /// Treasury left after subtracting all currently committed unit costs.
-  int _remainingTreasury() => _treasury - _totalTreasuryCost();
+  int _remainingTreasury() => treasury - _totalTreasuryCost();
 
   /// Paper left after subtracting all currently committed unit costs.
   int _remainingPaper() => _paperStockpile - _totalPaperCost();
 
   String? get _deficitHint {
-    final treasuryDeficit = _totalTreasuryCost() > _treasury;
+    final treasuryDeficit = _totalTreasuryCost() > treasury;
     final paperDeficit = _totalPaperCost() > _paperStockpile;
     if (treasuryDeficit && paperDeficit) {
       return 'Treasury low and Paper low';
@@ -123,95 +96,8 @@ class _TrainCiviliansDialogState extends State<TrainCiviliansDialog> {
     return null;
   }
 
-  void _increment(String unitType) {
-    if (_isLocked(unitType)) return;
-    if (!_canAffordIncrement(unitType)) return;
-    setState(() {
-      _counts = incrementTrainDialogCount(_counts, unitType);
-    });
-  }
-
-  void _decrement(String unitType) {
-    if (_counts[unitType] == null || _counts[unitType]! <= 0) return;
-    setState(() {
-      _counts = decrementTrainDialogCount(_counts, unitType);
-    });
-  }
-
-  void _reset() {
-    setState(() {
-      _counts = resetTrainDialogCounts(_counts);
-    });
-  }
-
-  void _applyOrders() {
-    final capital = _player?.capitalProvinceId;
-    if (capital == null) return;
-    final orders = materializeTrainDialogOrdersFromCounts(
-      orderedUnitTypeIds: CivilianEconomyCatalog.byId.keys,
-      counts: _counts,
-      capitalProvinceId: capital,
-      isMilitary: false,
-    );
-    widget.bus.emit(TrainCivilianBuildOrdersCommittedEvent(orders: orders));
-  }
-
-  String _techRequiredLabel(String unitType) {
-    final techId = unlockingTechByCivilianId[unitType];
-    if (techId == null) return '';
-    return 'Requires: ${techDisplayName(techId)}';
-  }
-
   @override
-  Widget build(BuildContext context) {
-    final l10n = appL10n(context);
-    return PopScope(
-      canPop: true,
-      onPopInvokedWithResult: (didPop, _) {
-        if (didPop) {
-          _applyOrders();
-        }
-      },
-      child: CtDialogShell(
-        padding: const EdgeInsets.fromLTRB(
-          CtSpacing.l,
-          CtSpacing.ml,
-          CtSpacing.l,
-          CtSpacing.l,
-        ),
-        child: _buildDialogContent(context, l10n),
-      ),
-    );
-  }
-
-  Widget _buildDialogContent(BuildContext context, AppLocalizations l10n) {
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        TrainDialogHeader(
-          title: l10n.trainCivilians_title,
-          onClose: () => Navigator.of(context).pop(),
-        ),
-        if (!_hasCapital) ...[
-          const TrainDialogSectionDivider(),
-          _buildNoCapitalMessage(context, l10n),
-        ] else
-          ..._buildBody(l10n),
-      ],
-    );
-  }
-
-  Widget _buildNoCapitalMessage(BuildContext context, AppLocalizations l10n) {
-    return Text(
-      l10n.trainUnits_noCapital,
-      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-        color: EditorialMonoclePalette.danger,
-      ),
-    );
-  }
-
-  List<Widget> _buildBody(AppLocalizations l10n) {
+  List<Widget> buildBody(AppLocalizations l10n) {
     return [
       const TrainDialogSectionDivider(),
       TrainDialogResourceBar(
@@ -220,7 +106,7 @@ class _TrainCiviliansDialogState extends State<TrainCiviliansDialog> {
             label: l10n.trainUnits_treasuryLabel,
             value:
                 '${formatTreasuryCurrency(_remainingTreasury())} / '
-                '${formatTreasuryCurrency(_treasury)}',
+                '${formatTreasuryCurrency(treasury)}',
           ),
           TrainDialogResourceEntry(
             label: l10n.trainUnits_paperLabel,
@@ -236,20 +122,20 @@ class _TrainCiviliansDialogState extends State<TrainCiviliansDialog> {
           for (final econ in CivilianEconomyCatalog.all)
             _UnitTypeRow(
               econ: econ,
-              count: _counts[econ.id] ?? 0,
-              isLocked: _isLocked(econ.id),
-              techRequiredLabel: _techRequiredLabel(econ.id),
-              canIncrement: _canAffordIncrement(econ.id),
-              canDecrement: (_counts[econ.id] ?? 0) > 0,
+              count: counts[econ.id] ?? 0,
+              isLocked: isLocked(econ.id),
+              techRequiredLabel: techRequiredLabel(econ.id),
+              canIncrement: canAffordIncrement(econ.id),
+              canDecrement: (counts[econ.id] ?? 0) > 0,
               treasuryInsufficient:
-                  !_isLocked(econ.id) &&
+                  !isLocked(econ.id) &&
                   _remainingTreasury() < econ.buildTreasuryCost,
               paperInsufficient:
-                  !_isLocked(econ.id) &&
+                  !isLocked(econ.id) &&
                   _remainingPaper() <
                       (econ.buildInputs[CommodityCatalog.paper.id] ?? 0),
-              onIncrement: () => _increment(econ.id),
-              onDecrement: () => _decrement(econ.id),
+              onIncrement: () => increment(econ.id),
+              onDecrement: () => decrement(econ.id),
             ),
         ],
       ),
@@ -258,7 +144,7 @@ class _TrainCiviliansDialogState extends State<TrainCiviliansDialog> {
         mainAxisAlignment: MainAxisAlignment.end,
         children: [
           CtNinePatchButton(
-            onPressed: _reset,
+            onPressed: reset,
             child: Text(l10n.common_reset),
           ),
         ],

--- a/app/lib/features/game/widgets/train_dialog_base.dart
+++ b/app/lib/features/game/widgets/train_dialog_base.dart
@@ -1,0 +1,208 @@
+// Shared base for the train-at-capital dialogs (civilian, military, naval).
+// SPEC/ui/train-civilians-dialog.md, SPEC/ui/train-military-dialog.md,
+// SPEC/ui/train-naval-dialog.md, SPEC/ui/components/train-dialog-chrome.md.
+
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:flutter/material.dart';
+
+import '../../../config/editorial_monocle_palette.dart';
+import '../../../l10n/l10n.dart';
+import '../../../widgets/ct_dialog_shell.dart';
+import '../../../widgets/ct_spacing.dart';
+import 'train_dialog_chrome.dart';
+import 'train_unit_dialog_helper.dart';
+
+/// Common widget contract for the train-at-capital dialogs. Each concrete
+/// dialog (civilian / military / naval) carries the same inputs: the active
+/// [game], the [humanPlayerId] whose capital the units train at, the
+/// [currentOrders] used to seed stepper counts, and the [bus] that the
+/// committed [BuildUnitOrder] list is emitted on when the dialog closes.
+abstract class TrainDialogBase extends StatefulWidget {
+  const TrainDialogBase({
+    super.key,
+    required this.game,
+    required this.humanPlayerId,
+    required this.currentOrders,
+    required this.bus,
+  });
+
+  final Game game;
+  final String humanPlayerId;
+  final Orders currentOrders;
+  final AppEventBus bus;
+}
+
+/// Shared [State] for [TrainDialogBase] subclasses.
+///
+/// Owns the structural scaffolding called out in `SPEC/ui/.../train-*` and
+/// `colonizethis-component-structure.mdc` (reuse at 2+ call sites): the
+/// `PopScope` + [CtDialogShell] wrapper, the no-capital message, the header +
+/// body composition, the stepper count state, count mutation, tech-lock
+/// resolution, and order materialization on close. Unit-type-specific cost
+/// modelling (treasury / peasants / commodities, deficit hint, resource bar,
+/// and per-row rendering) stays in each subclass via [buildBody] and
+/// [canAffordIncrement].
+abstract class TrainDialogBaseState<T extends TrainDialogBase>
+    extends State<T> {
+  late Map<String, int> counts;
+
+  @override
+  void initState() {
+    super.initState();
+    counts = initialTrainDialogCountsFromOrders(
+      unitTypeIds: unitTypeIds,
+      currentOrders: widget.currentOrders,
+      humanPlayerId: widget.humanPlayerId,
+      capitalProvinceId: player?.capitalProvinceId,
+      isMilitary: ordersAreMilitary,
+    );
+  }
+
+  // --- Subclass contract ---------------------------------------------------
+
+  /// Ordered trainable unit-type ids for this dialog (catalog key order).
+  Iterable<String> get unitTypeIds;
+
+  /// `isMilitary` flag stamped on materialized [BuildUnitOrder]s and used to
+  /// match this dialog's managed orders when seeding counts.
+  bool get ordersAreMilitary;
+
+  /// Map of unit-type id to the tech id that unlocks it (absent ⇒ always
+  /// available). Drives [isLocked] and [techRequiredLabel].
+  Map<String, String> get unlockingTechByUnitType;
+
+  /// Whether one more of [unitTypeId] remains affordable given currently
+  /// committed counts. Subclass-specific because the cost model differs
+  /// (civilian: treasury + paper; military/naval: treasury + peasants +
+  /// commodities).
+  bool canAffordIncrement(String unitTypeId);
+
+  /// Localized dialog title shown in the [TrainDialogHeader].
+  String dialogTitle(AppLocalizations l10n);
+
+  /// Emits this dialog's committed-orders event on [widget.bus].
+  void emitCommittedOrders(List<BuildUnitOrder> orders);
+
+  /// Builds the dialog body (resource bar, unit rows, reset action) shown when
+  /// the player has a capital.
+  List<Widget> buildBody(AppLocalizations l10n);
+
+  // --- Shared state / derived data -----------------------------------------
+
+  Player? get player => trainDialogPlayerById(
+    players: widget.game.players,
+    playerId: widget.humanPlayerId,
+  );
+
+  bool get hasCapital => trainDialogHasCapital(player);
+
+  int get treasury => trainDialogTreasury(player);
+
+  int get peasants => player?.workerPool.peasants ?? 0;
+
+  Map<String, bool> get techUnlocked => trainDialogTechUnlocked(player);
+
+  int stockpileQty(String commodityId) =>
+      player?.stockpile.quantityOf(commodityId) ?? 0;
+
+  bool isLocked(String unitType) {
+    return trainDialogIsLocked(
+      unitType: unitType,
+      unlockingTechByUnitType: unlockingTechByUnitType,
+      techUnlocked: techUnlocked,
+    );
+  }
+
+  String techRequiredLabel(String unitType) {
+    final techId = unlockingTechByUnitType[unitType];
+    if (techId == null) return '';
+    return 'Requires: ${techDisplayName(techId)}';
+  }
+
+  // --- Stepper / order mutation --------------------------------------------
+
+  void increment(String unitType) {
+    if (isLocked(unitType)) return;
+    if (!canAffordIncrement(unitType)) return;
+    setState(() {
+      counts = incrementTrainDialogCount(counts, unitType);
+    });
+  }
+
+  void decrement(String unitType) {
+    if ((counts[unitType] ?? 0) <= 0) return;
+    setState(() {
+      counts = decrementTrainDialogCount(counts, unitType);
+    });
+  }
+
+  void reset() {
+    setState(() {
+      counts = resetTrainDialogCounts(counts);
+    });
+  }
+
+  void applyOrders() {
+    final capital = player?.capitalProvinceId;
+    if (capital == null) return;
+    final orders = materializeTrainDialogOrdersFromCounts(
+      orderedUnitTypeIds: unitTypeIds,
+      counts: counts,
+      capitalProvinceId: capital,
+      isMilitary: ordersAreMilitary,
+    );
+    emitCommittedOrders(orders);
+  }
+
+  // --- Shared chrome --------------------------------------------------------
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = appL10n(context);
+    return PopScope(
+      canPop: true,
+      onPopInvokedWithResult: (didPop, _) {
+        if (didPop) {
+          applyOrders();
+        }
+      },
+      child: CtDialogShell(
+        padding: const EdgeInsets.fromLTRB(
+          CtSpacing.l,
+          CtSpacing.ml,
+          CtSpacing.l,
+          CtSpacing.l,
+        ),
+        child: _buildDialogContent(context, l10n),
+      ),
+    );
+  }
+
+  Widget _buildDialogContent(BuildContext context, AppLocalizations l10n) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        TrainDialogHeader(
+          title: dialogTitle(l10n),
+          onClose: () => Navigator.of(context).pop(),
+        ),
+        if (!hasCapital) ...[
+          const TrainDialogSectionDivider(),
+          _buildNoCapitalMessage(context, l10n),
+        ] else
+          ...buildBody(l10n),
+      ],
+    );
+  }
+
+  Widget _buildNoCapitalMessage(BuildContext context, AppLocalizations l10n) {
+    return Text(
+      l10n.trainUnits_noCapital,
+      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+        color: EditorialMonoclePalette.danger,
+      ),
+    );
+  }
+}

--- a/app/lib/features/game/widgets/train_military_dialog.dart
+++ b/app/lib/features/game/widgets/train_military_dialog.dart
@@ -7,84 +7,53 @@ import '../../../config/ui_screen_ids.dart';
 import '../../../core/utils/currency_format.dart';
 import '../../../l10n/l10n.dart';
 import '../../../config/app_assets.dart';
-import '../../../widgets/ct_dialog_shell.dart';
 import '../../../widgets/ct_gap.dart';
 import '../../../widgets/ct_nine_patch_button.dart';
-import '../../../widgets/ct_spacing.dart';
 import '../../../widgets/resource_icon.dart';
 import '../../../widgets/strict_asset_icon.dart';
 import '../utils/commodity_ui_helpers.dart';
+import 'train_dialog_base.dart';
 import 'train_dialog_chrome.dart';
-import 'train_unit_dialog_helper.dart';
 
-class TrainMilitaryDialog extends StatefulWidget {
+class TrainMilitaryDialog extends TrainDialogBase {
   const TrainMilitaryDialog({
     super.key,
-    required this.game,
-    required this.humanPlayerId,
-    required this.currentOrders,
-    required this.bus,
+    required super.game,
+    required super.humanPlayerId,
+    required super.currentOrders,
+    required super.bus,
   });
 
   /// SPEC/ui/train-military-dialog.md — [UiScreenIds.trainMilitaryDialog].
   static const screenId = UiScreenIds.trainMilitaryDialog;
 
-  final Game game;
-  final String humanPlayerId;
-  final Orders currentOrders;
-  final AppEventBus bus;
-
   @override
   State<TrainMilitaryDialog> createState() => _TrainMilitaryDialogState();
 }
 
-class _TrainMilitaryDialogState extends State<TrainMilitaryDialog> {
-  late Map<String, int> _counts;
+class _TrainMilitaryDialogState
+    extends TrainDialogBaseState<TrainMilitaryDialog> {
+  @override
+  Iterable<String> get unitTypeIds => RegimentEconomyCatalog.byId.keys;
 
   @override
-  void initState() {
-    super.initState();
-    _counts = _initialCountsFromOrders();
-  }
+  bool get ordersAreMilitary => true;
 
-  Map<String, int> _initialCountsFromOrders() {
-    return initialTrainDialogCountsFromOrders(
-      unitTypeIds: RegimentEconomyCatalog.byId.keys,
-      currentOrders: widget.currentOrders,
-      humanPlayerId: widget.humanPlayerId,
-      capitalProvinceId: _player?.capitalProvinceId,
-      isMilitary: true,
-    );
-  }
+  @override
+  Map<String, String> get unlockingTechByUnitType => unlockingTechByRegimentId;
 
-  Player? get _player {
-    return trainDialogPlayerById(
-      players: widget.game.players,
-      playerId: widget.humanPlayerId,
-    );
-  }
+  @override
+  String dialogTitle(AppLocalizations l10n) => l10n.trainMilitary_title;
 
-  bool get _hasCapital => trainDialogHasCapital(_player);
-
-  int get _treasury => trainDialogTreasury(_player);
-  int get _peasants => _player?.workerPool.peasants ?? 0;
-  Map<String, bool> get _techUnlocked => trainDialogTechUnlocked(_player);
-
-  int _stockpileQty(String commodityId) =>
-      _player?.stockpile.quantityOf(commodityId) ?? 0;
-
-  bool _isLocked(String unitType) {
-    return trainDialogIsLocked(
-      unitType: unitType,
-      unlockingTechByUnitType: unlockingTechByRegimentId,
-      techUnlocked: _techUnlocked,
-    );
+  @override
+  void emitCommittedOrders(List<BuildUnitOrder> orders) {
+    widget.bus.emit(TrainMilitaryBuildOrdersCommittedEvent(orders: orders));
   }
 
   int _totalTreasuryCost() {
     var total = 0;
     for (final e in RegimentEconomyCatalog.all) {
-      total += (_counts[e.id] ?? 0) * e.buildTreasuryCost;
+      total += (counts[e.id] ?? 0) * e.buildTreasuryCost;
     }
     return total;
   }
@@ -92,7 +61,7 @@ class _TrainMilitaryDialogState extends State<TrainMilitaryDialog> {
   int _totalPeasantCost() {
     var total = 0;
     for (final e in RegimentEconomyCatalog.all) {
-      total += (_counts[e.id] ?? 0);
+      total += (counts[e.id] ?? 0);
     }
     return total;
   }
@@ -100,7 +69,7 @@ class _TrainMilitaryDialogState extends State<TrainMilitaryDialog> {
   Map<String, int> _totalCommodityCosts() {
     final totals = <String, int>{};
     for (final e in RegimentEconomyCatalog.all) {
-      final count = _counts[e.id] ?? 0;
+      final count = counts[e.id] ?? 0;
       if (count <= 0) continue;
       for (final input in e.buildInputs.entries) {
         totals[input.key] = (totals[input.key] ?? 0) + (input.value * count);
@@ -109,43 +78,44 @@ class _TrainMilitaryDialogState extends State<TrainMilitaryDialog> {
     return totals;
   }
 
-  bool _canAffordIncrement(String unitType) {
+  @override
+  bool canAffordIncrement(String unitType) {
     final econ = RegimentEconomyCatalog.byId[unitType];
     if (econ == null) return false;
-    if (_isLocked(unitType)) return false;
+    if (isLocked(unitType)) return false;
 
     final newTreasury = _totalTreasuryCost() + econ.buildTreasuryCost;
     final newPeasants = _totalPeasantCost() + 1;
-    if (newTreasury > _treasury) return false;
-    if (newPeasants > _peasants) return false;
+    if (newTreasury > treasury) return false;
+    if (newPeasants > peasants) return false;
 
     final totals = _totalCommodityCosts();
     for (final input in econ.buildInputs.entries) {
       totals[input.key] = (totals[input.key] ?? 0) + input.value;
     }
     for (final e in totals.entries) {
-      if (e.value > _stockpileQty(e.key)) return false;
+      if (e.value > stockpileQty(e.key)) return false;
     }
     return true;
   }
 
   /// Treasury left after subtracting all currently committed regiment costs.
-  int _remainingTreasury() => _treasury - _totalTreasuryCost();
+  int _remainingTreasury() => treasury - _totalTreasuryCost();
 
   /// Peasants left after subtracting all currently committed regiment costs.
-  int _remainingPeasants() => _peasants - _totalPeasantCost();
+  int _remainingPeasants() => peasants - _totalPeasantCost();
 
   /// Stockpile of [commodityId] left after subtracting committed costs.
   int _remainingCommodity(String commodityId, Map<String, int> committed) =>
-      _stockpileQty(commodityId) - (committed[commodityId] ?? 0);
+      stockpileQty(commodityId) - (committed[commodityId] ?? 0);
 
   String? get _deficitHint {
     final deficits = <String>[];
-    if (_totalTreasuryCost() > _treasury) deficits.add('Treasury');
-    if (_totalPeasantCost() > _peasants) deficits.add('Peasants');
+    if (_totalTreasuryCost() > treasury) deficits.add('Treasury');
+    if (_totalPeasantCost() > peasants) deficits.add('Peasants');
     final totalComms = _totalCommodityCosts();
     for (final e in totalComms.entries) {
-      if (e.value > _stockpileQty(e.key)) {
+      if (e.value > stockpileQty(e.key)) {
         deficits.add(commodityDisplayName(e.key));
       }
     }
@@ -156,102 +126,16 @@ class _TrainMilitaryDialogState extends State<TrainMilitaryDialog> {
     return '$head and ${deficits.last} low';
   }
 
-  void _increment(String unitType) {
-    if (!_canAffordIncrement(unitType)) return;
-    setState(() {
-      _counts = incrementTrainDialogCount(_counts, unitType);
-    });
-  }
-
-  void _decrement(String unitType) {
-    if ((_counts[unitType] ?? 0) <= 0) return;
-    setState(() {
-      _counts = decrementTrainDialogCount(_counts, unitType);
-    });
-  }
-
-  void _reset() {
-    setState(() {
-      _counts = resetTrainDialogCounts(_counts);
-    });
-  }
-
-  void _applyOrders() {
-    final capital = _player?.capitalProvinceId;
-    if (capital == null) return;
-    final orders = materializeTrainDialogOrdersFromCounts(
-      orderedUnitTypeIds: RegimentEconomyCatalog.byId.keys,
-      counts: _counts,
-      capitalProvinceId: capital,
-      isMilitary: true,
-    );
-    widget.bus.emit(TrainMilitaryBuildOrdersCommittedEvent(orders: orders));
-  }
-
-  String _techRequiredLabel(String unitType) {
-    final techId = unlockingTechByRegimentId[unitType];
-    if (techId == null) return '';
-    return 'Requires: ${techDisplayName(techId)}';
-  }
-
   @override
-  Widget build(BuildContext context) {
-    final l10n = appL10n(context);
-    return PopScope(
-      canPop: true,
-      onPopInvokedWithResult: (didPop, _) {
-        if (didPop) {
-          _applyOrders();
-        }
-      },
-      child: CtDialogShell(
-        padding: const EdgeInsets.fromLTRB(
-          CtSpacing.l,
-          CtSpacing.ml,
-          CtSpacing.l,
-          CtSpacing.l,
-        ),
-        child: _buildDialogContent(context, l10n),
-      ),
-    );
-  }
-
-  Widget _buildDialogContent(BuildContext context, AppLocalizations l10n) {
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        TrainDialogHeader(
-          title: l10n.trainMilitary_title,
-          onClose: () => Navigator.of(context).pop(),
-        ),
-        if (!_hasCapital) ...[
-          const TrainDialogSectionDivider(),
-          _buildNoCapitalMessage(context, l10n),
-        ] else
-          ..._buildBody(l10n),
-      ],
-    );
-  }
-
-  Widget _buildNoCapitalMessage(BuildContext context, AppLocalizations l10n) {
-    return Text(
-      l10n.trainUnits_noCapital,
-      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-        color: EditorialMonoclePalette.danger,
-      ),
-    );
-  }
-
-  List<Widget> _buildBody(AppLocalizations l10n) {
+  List<Widget> buildBody(AppLocalizations l10n) {
     return [
       const TrainDialogSectionDivider(),
       _MilitaryResourceBar(
-        treasury: _treasury,
+        treasury: treasury,
         remainingTreasury: _remainingTreasury(),
-        peasants: _peasants,
+        peasants: peasants,
         remainingPeasants: _remainingPeasants(),
-        stockpile: _player?.stockpile ?? const Stockpile(),
+        stockpile: player?.stockpile ?? const Stockpile(),
         committedCommodities: _totalCommodityCosts(),
         deficitHint: _deficitHint,
         l10n: l10n,
@@ -269,7 +153,7 @@ class _TrainMilitaryDialogState extends State<TrainMilitaryDialog> {
         mainAxisAlignment: MainAxisAlignment.end,
         children: [
           CtNinePatchButton(
-            onPressed: _reset,
+            onPressed: reset,
             child: Text(l10n.common_reset),
           ),
         ],
@@ -278,7 +162,7 @@ class _TrainMilitaryDialogState extends State<TrainMilitaryDialog> {
   }
 
   Widget _buildRegimentRow(RegimentEconomy econ) {
-    final locked = _isLocked(econ.id);
+    final locked = isLocked(econ.id);
     final committed = _totalCommodityCosts();
     final insufficientCommodityIds = <String>{
       for (final input in econ.buildInputs.entries)
@@ -287,17 +171,17 @@ class _TrainMilitaryDialogState extends State<TrainMilitaryDialog> {
     };
     return _RegimentRow(
       econ: econ,
-      count: _counts[econ.id] ?? 0,
+      count: counts[econ.id] ?? 0,
       isLocked: locked,
-      techRequiredLabel: _techRequiredLabel(econ.id),
-      canIncrement: _canAffordIncrement(econ.id),
-      canDecrement: (_counts[econ.id] ?? 0) > 0,
+      techRequiredLabel: techRequiredLabel(econ.id),
+      canIncrement: canAffordIncrement(econ.id),
+      canDecrement: (counts[econ.id] ?? 0) > 0,
       treasuryInsufficient:
           !locked && _remainingTreasury() < econ.buildTreasuryCost,
       peasantInsufficient: !locked && _remainingPeasants() < 1,
       insufficientCommodityIds: insufficientCommodityIds,
-      onIncrement: () => _increment(econ.id),
-      onDecrement: () => _decrement(econ.id),
+      onIncrement: () => increment(econ.id),
+      onDecrement: () => decrement(econ.id),
     );
   }
 }

--- a/app/lib/features/game/widgets/train_naval_dialog.dart
+++ b/app/lib/features/game/widgets/train_naval_dialog.dart
@@ -6,16 +6,14 @@ import '../../../config/editorial_monocle_palette.dart';
 import '../../../config/ui_screen_ids.dart';
 import '../../../core/utils/currency_format.dart';
 import '../../../l10n/l10n.dart';
-import '../../../widgets/ct_dialog_shell.dart';
 import '../../../widgets/ct_gap.dart';
 import '../../../widgets/ct_nine_patch_button.dart';
-import '../../../widgets/ct_spacing.dart';
 import '../../../widgets/resource_icon.dart';
 import '../../../widgets/strict_asset_icon.dart';
 import '../../../config/app_assets.dart';
 import '../utils/commodity_ui_helpers.dart';
+import 'train_dialog_base.dart';
 import 'train_dialog_chrome.dart';
-import 'train_unit_dialog_helper.dart';
 
 /// Train-at-capital dialog for naval (ship) units. Mirrors the civilian and
 /// military train dialogs: a `remaining / total` resource bar, per-row cost
@@ -23,74 +21,44 @@ import 'train_unit_dialog_helper.dart';
 /// danger-styled disabled `[+]` stepper for unaffordable rows. Ships are built
 /// with `isMilitary: false` (their own unit category) and spawn into the
 /// player's home fleet at the capital. SPEC/ui/train-naval-dialog.md.
-class TrainNavalDialog extends StatefulWidget {
+class TrainNavalDialog extends TrainDialogBase {
   const TrainNavalDialog({
     super.key,
-    required this.game,
-    required this.humanPlayerId,
-    required this.currentOrders,
-    required this.bus,
+    required super.game,
+    required super.humanPlayerId,
+    required super.currentOrders,
+    required super.bus,
   });
 
   /// SPEC/ui/train-naval-dialog.md — [UiScreenIds.trainNavalDialog].
   static const screenId = UiScreenIds.trainNavalDialog;
 
-  final Game game;
-  final String humanPlayerId;
-  final Orders currentOrders;
-  final AppEventBus bus;
-
   @override
   State<TrainNavalDialog> createState() => _TrainNavalDialogState();
 }
 
-class _TrainNavalDialogState extends State<TrainNavalDialog> {
-  late Map<String, int> _counts;
+class _TrainNavalDialogState extends TrainDialogBaseState<TrainNavalDialog> {
+  @override
+  Iterable<String> get unitTypeIds => ShipEconomyCatalog.byId.keys;
 
   @override
-  void initState() {
-    super.initState();
-    _counts = _initialCountsFromOrders();
-  }
+  bool get ordersAreMilitary => false;
 
-  Map<String, int> _initialCountsFromOrders() {
-    return initialTrainDialogCountsFromOrders(
-      unitTypeIds: ShipEconomyCatalog.byId.keys,
-      currentOrders: widget.currentOrders,
-      humanPlayerId: widget.humanPlayerId,
-      capitalProvinceId: _player?.capitalProvinceId,
-      isMilitary: false,
-    );
-  }
+  @override
+  Map<String, String> get unlockingTechByUnitType => unlockingTechByShipId;
 
-  Player? get _player {
-    return trainDialogPlayerById(
-      players: widget.game.players,
-      playerId: widget.humanPlayerId,
-    );
-  }
+  @override
+  String dialogTitle(AppLocalizations l10n) => l10n.trainNaval_title;
 
-  bool get _hasCapital => trainDialogHasCapital(_player);
-
-  int get _treasury => trainDialogTreasury(_player);
-  int get _peasants => _player?.workerPool.peasants ?? 0;
-  Map<String, bool> get _techUnlocked => trainDialogTechUnlocked(_player);
-
-  int _stockpileQty(String commodityId) =>
-      _player?.stockpile.quantityOf(commodityId) ?? 0;
-
-  bool _isLocked(String shipType) {
-    return trainDialogIsLocked(
-      unitType: shipType,
-      unlockingTechByUnitType: unlockingTechByShipId,
-      techUnlocked: _techUnlocked,
-    );
+  @override
+  void emitCommittedOrders(List<BuildUnitOrder> orders) {
+    widget.bus.emit(TrainNavalBuildOrdersCommittedEvent(orders: orders));
   }
 
   int _totalTreasuryCost() {
     var total = 0;
     for (final e in ShipEconomyCatalog.all) {
-      total += (_counts[e.shipTypeId] ?? 0) * e.buildTreasuryCost;
+      total += (counts[e.shipTypeId] ?? 0) * e.buildTreasuryCost;
     }
     return total;
   }
@@ -98,7 +66,7 @@ class _TrainNavalDialogState extends State<TrainNavalDialog> {
   int _totalPeasantCost() {
     var total = 0;
     for (final e in ShipEconomyCatalog.all) {
-      total += (_counts[e.shipTypeId] ?? 0);
+      total += (counts[e.shipTypeId] ?? 0);
     }
     return total;
   }
@@ -106,7 +74,7 @@ class _TrainNavalDialogState extends State<TrainNavalDialog> {
   Map<String, int> _totalCommodityCosts() {
     final totals = <String, int>{};
     for (final e in ShipEconomyCatalog.all) {
-      final count = _counts[e.shipTypeId] ?? 0;
+      final count = counts[e.shipTypeId] ?? 0;
       if (count <= 0) continue;
       for (final input in e.buildInputs.entries) {
         totals[input.key] = (totals[input.key] ?? 0) + (input.value * count);
@@ -115,43 +83,44 @@ class _TrainNavalDialogState extends State<TrainNavalDialog> {
     return totals;
   }
 
-  bool _canAffordIncrement(String shipType) {
+  @override
+  bool canAffordIncrement(String shipType) {
     final econ = ShipEconomyCatalog.byId[shipType];
     if (econ == null) return false;
-    if (_isLocked(shipType)) return false;
+    if (isLocked(shipType)) return false;
 
     final newTreasury = _totalTreasuryCost() + econ.buildTreasuryCost;
     final newPeasants = _totalPeasantCost() + 1;
-    if (newTreasury > _treasury) return false;
-    if (newPeasants > _peasants) return false;
+    if (newTreasury > treasury) return false;
+    if (newPeasants > peasants) return false;
 
     final totals = _totalCommodityCosts();
     for (final input in econ.buildInputs.entries) {
       totals[input.key] = (totals[input.key] ?? 0) + input.value;
     }
     for (final e in totals.entries) {
-      if (e.value > _stockpileQty(e.key)) return false;
+      if (e.value > stockpileQty(e.key)) return false;
     }
     return true;
   }
 
   /// Treasury left after subtracting all currently committed ship costs.
-  int _remainingTreasury() => _treasury - _totalTreasuryCost();
+  int _remainingTreasury() => treasury - _totalTreasuryCost();
 
   /// Peasants left after subtracting all currently committed ship costs.
-  int _remainingPeasants() => _peasants - _totalPeasantCost();
+  int _remainingPeasants() => peasants - _totalPeasantCost();
 
   /// Stockpile of [commodityId] left after subtracting committed costs.
   int _remainingCommodity(String commodityId, Map<String, int> committed) =>
-      _stockpileQty(commodityId) - (committed[commodityId] ?? 0);
+      stockpileQty(commodityId) - (committed[commodityId] ?? 0);
 
   String? get _deficitHint {
     final deficits = <String>[];
-    if (_totalTreasuryCost() > _treasury) deficits.add('Treasury');
-    if (_totalPeasantCost() > _peasants) deficits.add('Peasants');
+    if (_totalTreasuryCost() > treasury) deficits.add('Treasury');
+    if (_totalPeasantCost() > peasants) deficits.add('Peasants');
     final totalComms = _totalCommodityCosts();
     for (final e in totalComms.entries) {
-      if (e.value > _stockpileQty(e.key)) {
+      if (e.value > stockpileQty(e.key)) {
         deficits.add(commodityDisplayName(e.key));
       }
     }
@@ -162,102 +131,16 @@ class _TrainNavalDialogState extends State<TrainNavalDialog> {
     return '$head and ${deficits.last} low';
   }
 
-  void _increment(String shipType) {
-    if (!_canAffordIncrement(shipType)) return;
-    setState(() {
-      _counts = incrementTrainDialogCount(_counts, shipType);
-    });
-  }
-
-  void _decrement(String shipType) {
-    if ((_counts[shipType] ?? 0) <= 0) return;
-    setState(() {
-      _counts = decrementTrainDialogCount(_counts, shipType);
-    });
-  }
-
-  void _reset() {
-    setState(() {
-      _counts = resetTrainDialogCounts(_counts);
-    });
-  }
-
-  void _applyOrders() {
-    final capital = _player?.capitalProvinceId;
-    if (capital == null) return;
-    final orders = materializeTrainDialogOrdersFromCounts(
-      orderedUnitTypeIds: ShipEconomyCatalog.byId.keys,
-      counts: _counts,
-      capitalProvinceId: capital,
-      isMilitary: false,
-    );
-    widget.bus.emit(TrainNavalBuildOrdersCommittedEvent(orders: orders));
-  }
-
-  String _techRequiredLabel(String shipType) {
-    final techId = unlockingTechByShipId[shipType];
-    if (techId == null) return '';
-    return 'Requires: ${techDisplayName(techId)}';
-  }
-
   @override
-  Widget build(BuildContext context) {
-    final l10n = appL10n(context);
-    return PopScope(
-      canPop: true,
-      onPopInvokedWithResult: (didPop, _) {
-        if (didPop) {
-          _applyOrders();
-        }
-      },
-      child: CtDialogShell(
-        padding: const EdgeInsets.fromLTRB(
-          CtSpacing.l,
-          CtSpacing.ml,
-          CtSpacing.l,
-          CtSpacing.l,
-        ),
-        child: _buildDialogContent(context, l10n),
-      ),
-    );
-  }
-
-  Widget _buildDialogContent(BuildContext context, AppLocalizations l10n) {
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        TrainDialogHeader(
-          title: l10n.trainNaval_title,
-          onClose: () => Navigator.of(context).pop(),
-        ),
-        if (!_hasCapital) ...[
-          const TrainDialogSectionDivider(),
-          _buildNoCapitalMessage(context, l10n),
-        ] else
-          ..._buildBody(l10n),
-      ],
-    );
-  }
-
-  Widget _buildNoCapitalMessage(BuildContext context, AppLocalizations l10n) {
-    return Text(
-      l10n.trainUnits_noCapital,
-      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-        color: EditorialMonoclePalette.danger,
-      ),
-    );
-  }
-
-  List<Widget> _buildBody(AppLocalizations l10n) {
+  List<Widget> buildBody(AppLocalizations l10n) {
     return [
       const TrainDialogSectionDivider(),
       _NavalResourceBar(
-        treasury: _treasury,
+        treasury: treasury,
         remainingTreasury: _remainingTreasury(),
-        peasants: _peasants,
+        peasants: peasants,
         remainingPeasants: _remainingPeasants(),
-        stockpile: _player?.stockpile ?? const Stockpile(),
+        stockpile: player?.stockpile ?? const Stockpile(),
         committedCommodities: _totalCommodityCosts(),
         deficitHint: _deficitHint,
         l10n: l10n,
@@ -274,7 +157,7 @@ class _TrainNavalDialogState extends State<TrainNavalDialog> {
         mainAxisAlignment: MainAxisAlignment.end,
         children: [
           CtNinePatchButton(
-            onPressed: _reset,
+            onPressed: reset,
             child: Text(l10n.common_reset),
           ),
         ],
@@ -283,7 +166,7 @@ class _TrainNavalDialogState extends State<TrainNavalDialog> {
   }
 
   Widget _buildShipRow(ShipEconomyEntry econ) {
-    final locked = _isLocked(econ.shipTypeId);
+    final locked = isLocked(econ.shipTypeId);
     final committed = _totalCommodityCosts();
     final insufficientCommodityIds = <String>{
       for (final input in econ.buildInputs.entries)
@@ -292,17 +175,17 @@ class _TrainNavalDialogState extends State<TrainNavalDialog> {
     };
     return _ShipTypeRow(
       econ: econ,
-      count: _counts[econ.shipTypeId] ?? 0,
+      count: counts[econ.shipTypeId] ?? 0,
       isLocked: locked,
-      techRequiredLabel: _techRequiredLabel(econ.shipTypeId),
-      canIncrement: _canAffordIncrement(econ.shipTypeId),
-      canDecrement: (_counts[econ.shipTypeId] ?? 0) > 0,
+      techRequiredLabel: techRequiredLabel(econ.shipTypeId),
+      canIncrement: canAffordIncrement(econ.shipTypeId),
+      canDecrement: (counts[econ.shipTypeId] ?? 0) > 0,
       treasuryInsufficient:
           !locked && _remainingTreasury() < econ.buildTreasuryCost,
       peasantInsufficient: !locked && _remainingPeasants() < 1,
       insufficientCommodityIds: insufficientCommodityIds,
-      onIncrement: () => _increment(econ.shipTypeId),
-      onDecrement: () => _decrement(econ.shipTypeId),
+      onIncrement: () => increment(econ.shipTypeId),
+      onDecrement: () => decrement(econ.shipTypeId),
     );
   }
 }

--- a/app/test/ct_spacing_features_adoption_test.dart
+++ b/app/test/ct_spacing_features_adoption_test.dart
@@ -417,9 +417,16 @@ const List<String> _migratedFeatureFiles = <String>[
   'lib/features/game/widgets/tech_tree_widget.dart',
   'lib/features/game/widgets/technology_panel.dart',
   'lib/features/game/widgets/technology_panel_orders.dart',
-  'lib/features/game/widgets/train_civilians_dialog.dart',
+  // train_civilians_dialog.dart / train_military_dialog.dart dropped from the
+  // adoption list: #3594 extracted the shared TrainDialogBase state, which now
+  // owns the `EdgeInsets.fromLTRB(CtSpacing.l, CtSpacing.ml, ...)`
+  // PopScope/CtDialogShell scaffold. Both dialogs (and the sibling
+  // train_naval_dialog.dart, which was never token-eligible) delegate that
+  // wrapper to the base and no longer contain token-eligible
+  // `EdgeInsets`/`CtSpacing` spacing, so the import and token-reference
+  // invariants moved to train_dialog_base.dart below.
+  'lib/features/game/widgets/train_dialog_base.dart',
   'lib/features/game/widgets/train_dialog_chrome.dart',
-  'lib/features/game/widgets/train_military_dialog.dart',
   'lib/features/game/widgets/transfer_to_home_fleet_dialog.dart',
   'lib/features/game/widgets/turn_news_dialog.dart',
   'lib/features/game/widgets/units/shared/location_section_header.dart',

--- a/app/test/train_dialog_base_test.dart
+++ b/app/test/train_dialog_base_test.dart
@@ -1,0 +1,168 @@
+// Pins the shared TrainDialogBase / TrainDialogBaseState abstraction extracted
+// for issue #3594 (AC: train_military_dialog.dart, train_civilians_dialog.dart,
+// and train_naval_dialog.dart share a TrainDialogBase abstract State class).
+//
+// These structural assertions guard against regression where a train dialog is
+// re-implemented as a bare StatefulWidget/State and silently re-duplicates the
+// PopScope/CtDialogShell wrapper, capital-check state, count scaffolding, and
+// order materialization that now live in the shared base.
+
+import 'package:colonizethis_app/features/game/widgets/train_civilians_dialog.dart';
+import 'package:colonizethis_app/features/game/widgets/train_dialog_base.dart';
+import 'package:colonizethis_app/features/game/widgets/train_military_dialog.dart';
+import 'package:colonizethis_app/features/game/widgets/train_naval_dialog.dart';
+import 'package:colonizethis_app/widgets/debug_init_game.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  suppressLogsForTests();
+
+  late Game game;
+  late String humanPlayerId;
+
+  setUpAll(() {
+    game = getDebugInitGameResult().game;
+    humanPlayerId = game.players.firstWhere((p) => p.isHuman).id;
+  });
+
+  Player getPlayer(String pid) => game.players.firstWhere((p) => p.id == pid);
+
+  Game richGame() {
+    final player = getPlayer(humanPlayerId);
+    final techUnlocked = Map<String, bool>.from(player.techUnlocked ?? {});
+    for (final techId in unlockingTechByRegimentId.values) {
+      techUnlocked[techId] = true;
+    }
+    return game.copyWith(
+      players: [
+        player.copyWith(
+          treasury: 10000,
+          workerPool: player.workerPool.copyWith(peasants: 20),
+          techUnlocked: techUnlocked,
+          stockpile: player.stockpile.merge(
+            const Stockpile(
+              quantities: {
+                'fabric': 100,
+                'castIron': 100,
+                'lumber': 100,
+                'horses': 100,
+                'steel': 100,
+                'bronze': 100,
+                'coal': 100,
+                'paper': 100,
+              },
+            ),
+          ),
+          capitalProvinceId:
+              player.capitalProvinceId ?? player.capitalTile?.provinceId,
+        ),
+        ...game.players.where((p) => p.id != humanPlayerId),
+      ],
+    );
+  }
+
+  Widget host(Widget child) =>
+      MaterialApp(home: Scaffold(body: child));
+
+  group('TrainDialogBase shared abstraction (#3594)', () {
+    testWidgets('TrainCiviliansDialog extends the shared base', (tester) async {
+      await tester.pumpWidget(
+        host(
+          TrainCiviliansDialog(
+            game: richGame(),
+            humanPlayerId: humanPlayerId,
+            currentOrders: const Orders(),
+            bus: AppEventBus.create(),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        tester.widget(find.byType(TrainCiviliansDialog)),
+        isA<TrainDialogBase>(),
+      );
+      expect(
+        tester.state(find.byType(TrainCiviliansDialog)),
+        isA<TrainDialogBaseState>(),
+      );
+    });
+
+    testWidgets('TrainMilitaryDialog extends the shared base', (tester) async {
+      await tester.pumpWidget(
+        host(
+          TrainMilitaryDialog(
+            game: richGame(),
+            humanPlayerId: humanPlayerId,
+            currentOrders: const Orders(),
+            bus: AppEventBus.create(),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        tester.widget(find.byType(TrainMilitaryDialog)),
+        isA<TrainDialogBase>(),
+      );
+      expect(
+        tester.state(find.byType(TrainMilitaryDialog)),
+        isA<TrainDialogBaseState>(),
+      );
+    });
+
+    testWidgets('TrainNavalDialog extends the shared base', (tester) async {
+      await tester.pumpWidget(
+        host(
+          TrainNavalDialog(
+            game: richGame(),
+            humanPlayerId: humanPlayerId,
+            currentOrders: const Orders(),
+            bus: AppEventBus.create(),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        tester.widget(find.byType(TrainNavalDialog)),
+        isA<TrainDialogBase>(),
+      );
+      expect(
+        tester.state(find.byType(TrainNavalDialog)),
+        isA<TrainDialogBaseState>(),
+      );
+    });
+
+    testWidgets(
+      'shared base renders the no-capital message when the player has no '
+      'capital (negative path is centralized, not re-duplicated)',
+      (tester) async {
+        // An unknown player id resolves to a null Player, exercising the
+        // shared base's hasCapital == false branch without mutating fixtures.
+        await tester.pumpWidget(
+          host(
+            TrainCiviliansDialog(
+              game: game,
+              humanPlayerId: 'no_such_player',
+              currentOrders: const Orders(),
+              bus: AppEventBus.create(),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final state =
+            tester.state(find.byType(TrainCiviliansDialog))
+                as TrainDialogBaseState;
+        expect(state.hasCapital, isFalse);
+        // No stepper steppers render in the no-capital branch.
+        expect(find.text('+'), findsNothing);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Implements issue #3594 AC4: the civilian, military, and naval train-at-capital dialogs now share a `TrainDialogBase` abstract `State` class instead of each re-implementing identical scaffolding.

`Refs #3594`

### Done in this push (AC4)

- New `app/lib/features/game/widgets/train_dialog_base.dart`:
  - `TrainDialogBase` widget base (shared `game` / `humanPlayerId` / `currentOrders` / `bus` contract).
  - `TrainDialogBaseState<T>` owns the `PopScope` + `CtDialogShell` wrapper, no-capital message, header/body composition, stepper count state + `initState` seeding, `increment`/`decrement`/`reset`, tech-lock resolution (`isLocked`/`techRequiredLabel`), and order materialization on close.
- `train_civilians_dialog.dart`, `train_military_dialog.dart`, `train_naval_dialog.dart` extend the base and now provide only their unit-type-specific cost modelling (`buildBody`, `canAffordIncrement`, catalog/title/event hooks). ~470 lines of duplicated scaffolding removed.
- **Behaviour-preserving:** identical widget trees (existing goldens unchanged) and the same public dialog constructors.

### Tests

- New `app/test/train_dialog_base_test.dart` — positive: all three dialogs are `TrainDialogBase` / `TrainDialogBaseState`; negative: the shared base centralizes the no-capital branch (no steppers render when the player has no capital).
- `ct_spacing_features_adoption_test.dart` — moved the `CtSpacing` import / token-reference invariant from the two dialogs to `train_dialog_base.dart` (the `EdgeInsets.fromLTRB(CtSpacing.l, ...)` scaffold now lives there), mirroring the PR #3600 `SplitEntityDialog` precedent.
- Ran green locally: `train_civilians_dialog_test`, `train_military_dialog_test`, `train_naval_dialog_test`, `train_dialog_chrome_test`, `train_dialogs_goldens_test`, `train_dialogs_320dp_min_viewport_test`, `train_unit_dialog_helper_test`, `train_dialog_base_test`, `ct_spacing_features_adoption_test`, `ct_radius_adoption_test`, `ui_screen_id_bindings_test`, `game_map_empire_left_rail_test`, `unit_panels_widgetbook_dark_chrome_test`, `spec_components_train_dialog_chrome_test`. `dart analyze` reports 0 errors/warnings for the change.

### Deferred (remaining #3594 scope, separate slices)

Other #3594 ACs already landed on `dev` (CtGap, CtHoverButton, SplitEntityDialog, chrome source-of-truth move, trade_screen/main_menu splits, province-overlay event routing). Still open: the proposed `check_chrome_button_base.dart` CI regression gate. Not addressed here to keep this PR a single, behaviour-preserving slice.

### SPEC

None — behaviour unchanged and implementation file paths are unchanged, per the issue's "SPEC follow-up: None".

## Test plan

- [ ] CI `quality` + `quality_app_coverage` green
- [ ] No golden diffs

Made with [Cursor](https://cursor.com)