### PR TITLE
feat: gate diplomacy panel tribe rows on first contact (#3620)

### DIFF
--- a/SPEC/ui/diplomacy-panel.md
+++ b/SPEC/ui/diplomacy-panel.md
@@ -26,13 +26,23 @@ The player can view all **discovered** factions (Great Powers, Minor Nations, Tr
 
 ## Discovered factions
 
-A faction is **discovered** for the human player when its id appears in the canonical discovery set produced by `knownDiplomaticTargetFactionIds` (`packages/colonizethis_logic/lib/order_suggestion_api.dart`, normative rules in [order-suggestions.md](../program/order-suggestions.md) § Diplomatic orders (visibility)). That helper unions three sources, so a faction is discovered when **any** of the following holds:
+A **Great Power** or **Minor Nation** is **discovered** for the human player when its id appears in the canonical discovery set produced by `knownDiplomaticTargetFactionIds` (`packages/colonizethis_logic/lib/order_suggestion_api.dart`, normative rules in [order-suggestions.md](../program/order-suggestions.md) § Diplomatic orders (visibility)). For Great Powers and Minor Nations, a faction is discovered when **either** of the following holds:
 
 1. A `DiplomacyRelation` exists between the human player and that faction.
 2. The human player has **non-`unknown` tile visibility** (fogged or fully visible) in a province owned by that faction.
-3. The faction is a **Tribe** whose New-World province is **sea-reachable** from the player's anchor provinces/units (colonial intel, Refs #2509).
 
-This decouples discovery from the relation table alone. At game start same-region (GP–GP, GP–Minor) relations are initialized, so Great Powers and Minor Nations are discovered immediately; cross-region (GP–Tribe) relations are **not** initialized, so a Tribe becomes discovered the first time the player gains tile visibility into, or sea-reachability to, that tribe's territory — **not** only after establishing a consulate.
+At game start same-region (GP–GP, GP–Minor) relations are initialized, so Great Powers and Minor Nations are discovered immediately.
+
+### Tribes require first contact (Refs #3620)
+
+A **Tribe** is **never** surfaced via sea-reachable colonial intel. A Tribe `T` appears in the Tribes section for the human GP `G` only after **first contact**, defined per `(G, T)` pair as **either** of:
+
+1. A persisted `DiplomacyRelation` exists between `G` and `T`, **or**
+2. `G` holds **non-`unknown` tile visibility** (fogged or fully visible) in at least one province owned by `T` (the canonical `discoveredTribeIdsForFirstContact` set).
+
+This supersedes the colonial-intel discovery path documented for #3341/#2509: cross-region (GP–Tribe) relations are **not** initialized at game start, and **sea-reachability alone does not surface a Tribe row** even when a tribe colony is sea-reachable from the GP's Old World anchors at turn 0. First contact is per-GP (each GP discovers each Tribe independently) and irreversible (the persisted relation keeps the Tribe row visible even if visibility later decays to fogged/unknown).
+
+> **Deferred (tracked by #3620):** the broader `knownDiplomaticTargetFactionIds` helper still includes sea-reachable tribes for **order-suggestion / AI declare-war** targeting; unifying those non-panel consumers (and persisting GP↔Tribe relations for AI GPs during turn resolution) is follow-up work on the same issue. This section governs the **diplomacy panel** surface only.
 
 **First-contact standing.** When a Tribe is discovered before a GP–Tribe relation exists, `syncGpTribeFirstContact` (`applyGpTribeFirstContactRelations` in logic) persists `AT_PEACE`, score `50`, Neutral on the same turn index, and enqueues the first-contact herald (`OVL80001`, [`tribe-first-contact-overlay.md`](tribe-first-contact-overlay.md)). Until sync runs, the panel still surfaces the same default standing for display (`RelationState.atPeace`, score `50`, `RelationLevel.neutral`).
 
@@ -301,9 +311,13 @@ Finally, an **empty-state** use case named `No factions discovered (empty state)
 
 - **Discovery via tile visibility (no prior relation):** Given the human player has non-`unknown` tile visibility in a province owned by a Tribe `T` and **no** `DiplomacyRelation` with `T`, when `buildDiplomacyRows` runs, then the returned rows include exactly one row whose `factionId == T` and `kind == FactionKind.tribe`, and that row's `relation` is non-null with `state == RelationState.atPeace`, `score == 50`, and `level == RelationLevel.neutral`. Refs #3341.
 
-- **Discovery does not depend solely on relation table (consulate fix):** Given a Tribe `T` is discovered for the human player by tile visibility or sea-reachability (per § Discovered factions) and `T` has no game-setup `DiplomacyRelation` with the player, when the Diplomacy panel renders, then the Tribe row for `T` is present under the `Tribes` section (the previously documented "tribes appear only after establishing a consulate" behavior no longer governs discovery). Refs #3341.
+- **Discovery does not depend solely on relation table (consulate fix):** Given a Tribe `T` is discovered for the human player by **tile visibility** (per § Tribes require first contact) and `T` has no game-setup `DiplomacyRelation` with the player, when the Diplomacy panel renders, then the Tribe row for `T` is present under the `Tribes` section (the previously documented "tribes appear only after establishing a consulate" behavior no longer governs discovery). Refs #3341.
 
 - **No spurious discovery (negative):** Given the human player has no `DiplomacyRelation`, no non-`unknown` tile visibility into any other faction's province, and no sea-reachable Tribe province, when `buildDiplomacyRows` runs, then it returns an empty list (no synthesized rows are added for undiscovered factions). Refs #3341.
+
+- **AC-1 (#3620) — turn-0 sea-reachable Tribe is not surfaced:** Given a new game at turn 0 where the human GP has **no** non-`unknown` tiles in any Tribe-owned province and **no** persisted `DiplomacyRelation` with that Tribe, **and** that Tribe owns a New-World province that is sea-reachable from the GP's Old-World anchor provinces/units, when `buildDiplomacyRows` runs, then the returned rows contain **no** row whose `kind == FactionKind.tribe`, even though `knownDiplomaticTargetFactionIds` still includes the tribe id. Refs #3620.
+
+- **AC-7 (#3620) — contact survives fog decay:** Given the human GP has a persisted GP↔Tribe `DiplomacyRelation` with Tribe `T` and currently holds **no** non-`unknown` tile visibility in any province owned by `T` (visibility decayed to fogged/unknown), when `buildDiplomacyRows` runs, then the returned rows include exactly one row whose `factionId == T` and `kind == FactionKind.tribe`, carrying the persisted relation. Refs #3620.
 
 - **Overture buttons shown disabled (AC-6):** Given a Minor or Tribe row at overture stage `none` and no pending diplomatic orders, when the panel renders action buttons, then `Consulate`, `Embassy`, `NAP`, and `Join Empire` buttons are all present; only `Consulate` (or the next validator-valid stage) is enabled; disabled stages expose non-empty rejection text via `Tooltip`. Refs #3341.
 

--- a/app/lib/features/game/widgets/diplomacy_panel_rows.dart
+++ b/app/lib/features/game/widgets/diplomacy_panel_rows.dart
@@ -150,11 +150,18 @@ DiplomacyRelation _defaultFirstContactRelation(
 /// Builds list of discovered factions and their available actions.
 ///
 /// Discovery follows `knownDiplomaticTargetFactionIds`
-/// (SPEC/ui/diplomacy-panel.md § Discovered factions): an existing
-/// [DiplomacyRelation], non-`unknown` tile visibility into a faction-owned
-/// province, or a sea-reachable New-World Tribe province (colonial intel).
-/// A discovered faction without a persisted relation is surfaced with the
-/// default neutral first-contact standing.
+/// (SPEC/ui/diplomacy-panel.md § Discovered factions) for Great Powers and
+/// Minor Nations: an existing [DiplomacyRelation] or non-`unknown` tile
+/// visibility into a faction-owned province. A discovered faction without a
+/// persisted relation is surfaced with the default neutral first-contact
+/// standing.
+///
+/// **Tribes require first contact (Refs #3620):** a Tribe is surfaced only
+/// after first contact — a persisted GP↔Tribe relation **or** non-`unknown`
+/// tile visibility into a province that Tribe owns
+/// ([discoveredTribeIdsForFirstContact]). Sea-reachable colonial intel alone
+/// no longer surfaces a Tribe row (SPEC/ui/diplomacy-panel.md § Tribes require
+/// first contact).
 List<DiplomacyRowData> buildDiplomacyRows(
   Game game,
   MapTopology topology,
@@ -170,6 +177,21 @@ List<DiplomacyRowData> buildDiplomacyRows(
       topology: topology,
     ),
   };
+  // First-contact gate for Tribes (Refs #3620): drop tribe ids that are only
+  // sea-reachable colonial intel (present in `knownDiplomaticTargetFactionIds`
+  // without a persisted relation or tile visibility). A tribe is contacted iff
+  // a GP↔Tribe relation is persisted or the GP holds non-`unknown` tile
+  // visibility into a province it owns.
+  final contactedTribeIds = discoveredTribeIdsForFirstContact(
+    view: view,
+    game: game,
+  );
+  discoveredIds.removeWhere((id) {
+    final isTribe = game.tribes.any((t) => t.id == id);
+    if (!isTribe) return false;
+    final hasRelation = view.diplomacyByOtherId.containsKey(id);
+    return !hasRelation && !contactedTribeIds.contains(id);
+  });
   final currentTurn = game.worldState.turnState.turnNumber;
   final factionMembership = DiplomacyFactionMembership.from(game);
   final actionsByTarget = <String, List<DiplomaticPanelAction>>{};

--- a/app/test/diplomacy_panel_rows_test.dart
+++ b/app/test/diplomacy_panel_rows_test.dart
@@ -75,6 +75,119 @@ Game _gameWithTribeDiscoveredByVisibility() {
   );
 }
 
+/// Old World coastal province sea-connected to an unrevealed New World tribe
+/// colony, with **zero** New World tile visibility (Refs #3620 AC-1). Mirrors
+/// the colonial-intel fixture used in the diplomacy package tests.
+const _seaReachableTopology = MapTopology(
+  nodes: [
+    TopologyNode(
+      id: 'oldWorld|home',
+      regionId: 'oldWorld',
+      type: TopologyNodeType.province,
+    ),
+    TopologyNode(
+      id: 'oldWorld|owSea',
+      regionId: 'oldWorld',
+      type: TopologyNodeType.seaZone,
+    ),
+    TopologyNode(
+      id: 'newWorld|nwSea',
+      regionId: 'newWorld',
+      type: TopologyNodeType.seaZone,
+    ),
+    TopologyNode(
+      id: 'newWorld|colony',
+      regionId: 'newWorld',
+      type: TopologyNodeType.province,
+    ),
+  ],
+  edges: [
+    TopologyEdge(id1: 'oldWorld|home', id2: 'oldWorld|owSea'),
+    TopologyEdge(id1: 'oldWorld|owSea', id2: 'newWorld|nwSea'),
+    TopologyEdge(id1: 'newWorld|nwSea', id2: 'newWorld|colony'),
+  ],
+);
+
+/// Turn-0 fixture where Tribe `t1` owns a New-World province that is
+/// sea-reachable from the human GP's Old-World anchor, but the GP has **no**
+/// non-`unknown` New-World tile visibility and **no** GP↔Tribe relation
+/// (Refs #3620 AC-1). The tribe must not be surfaced in the Tribes section.
+Game _gameWithSeaReachableTribeNoContact() {
+  return const Game(
+    id: 'sea-reachable-no-contact',
+    worldState: WorldState(
+      turnState: TurnState(phase: TurnPhase.orders, turnNumber: 0),
+      oldWorld: RegionData(
+        provinces: [
+          Province(id: 'oldWorld|home', regionId: 'oldWorld', ownerId: 'gp1'),
+        ],
+      ),
+      newWorld: RegionData(
+        provinces: [
+          Province(
+            id: 'newWorld|colony',
+            regionId: 'newWorld',
+            ownerId: 't1',
+          ),
+        ],
+      ),
+      playerVisibilityByTile: {
+        'gp1': {'oldWorld|home|0|0': 'fullyVisible'},
+      },
+      tileKeysByRegionAndProvince: {
+        'oldWorld': {
+          'oldWorld|home': ['oldWorld|home|0|0'],
+        },
+        'newWorld': {
+          'newWorld|colony': ['newWorld|colony|0|0'],
+        },
+      },
+    ),
+    players: [Player(id: 'gp1', displayName: 'Solo', isHuman: true)],
+    tribes: [Tribe(id: 't1', displayName: 'Tribe One')],
+    diplomacyRelations: [],
+  );
+}
+
+/// Fixture for the contact-survives-fog-decay AC (Refs #3620 AC-7): the human
+/// GP holds a persisted GP↔Tribe relation with `t1` but currently has **no**
+/// non-`unknown` tile visibility into any province `t1` owns.
+Game _gameWithTribeRelationButNoVisibility() {
+  return const Game(
+    id: 'tribe-relation-fog-decay',
+    worldState: WorldState(
+      turnState: TurnState(phase: TurnPhase.orders, turnNumber: 7),
+      oldWorld: RegionData(
+        provinces: [
+          Province(id: 'oldWorld|home', regionId: 'oldWorld', ownerId: 'gp1'),
+        ],
+      ),
+      newWorld: RegionData(
+        provinces: [
+          Province(
+            id: 'newWorld|colony',
+            regionId: 'newWorld',
+            ownerId: 't1',
+          ),
+        ],
+      ),
+      playerVisibilityByTile: {},
+    ),
+    players: [Player(id: 'gp1', displayName: 'Solo', isHuman: true)],
+    tribes: [Tribe(id: 't1', displayName: 'Tribe One')],
+    diplomacyRelations: [
+      DiplomacyRelation(
+        factionId1: 'gp1',
+        factionId2: 't1',
+        state: RelationState.atPeace,
+        score: 50,
+        sinceTurn: 4,
+        lastInteractionTurn: 4,
+      ),
+    ],
+  );
+}
+
 void main() {
   suppressLogsForTests();
 
@@ -145,6 +258,59 @@ void main() {
         expect(tribe.relation!.state, RelationState.atPeace);
         expect(tribe.relation!.score, 50);
         expect(tribe.relation!.level, RelationLevel.neutral);
+      },
+    );
+
+    test(
+      'AC-1 (#3620): turn-0 sea-reachable tribe with no contact yields no '
+      'tribe rows even though knownDiplomaticTargetFactionIds includes it',
+      () {
+        final game = _gameWithSeaReachableTribeNoContact();
+        final view = buildPlayerView(game, _seaReachableTopology, 'gp1');
+        // Precondition: the broad helper still includes the sea-reachable tribe
+        // (proves the panel-side first-contact gate is what excludes it).
+        expect(
+          knownDiplomaticTargetFactionIds(
+            view: view,
+            game: game,
+            topology: _seaReachableTopology,
+          ),
+          contains('t1'),
+        );
+
+        final rows = buildDiplomacyRows(
+          game,
+          _seaReachableTopology,
+          'gp1',
+          const Orders(),
+        );
+        expect(
+          rows.where((r) => r.kind == FactionKind.tribe),
+          isEmpty,
+          reason:
+              'Sea-reachable colonial intel alone must not surface a Tribe row '
+              '(SPEC § Tribes require first contact).',
+        );
+      },
+    );
+
+    test(
+      'AC-7 (#3620): tribe with persisted relation but no current visibility '
+      'still surfaces a tribe row (contact survives fog decay)',
+      () {
+        final rows = buildDiplomacyRows(
+          _gameWithTribeRelationButNoVisibility(),
+          const MapTopology(nodes: [], edges: []),
+          'gp1',
+          const Orders(),
+        );
+        final tribeRows = rows
+            .where((r) => r.kind == FactionKind.tribe)
+            .toList();
+        expect(tribeRows, hasLength(1));
+        expect(tribeRows.single.factionId, 't1');
+        expect(tribeRows.single.relation, isNotNull);
+        expect(tribeRows.single.relation!.state, RelationState.atPeace);
       },
     );
 

--- a/packages/colonizethis_logic/lib/order_suggestion_api.dart
+++ b/packages/colonizethis_logic/lib/order_suggestion_api.dart
@@ -21,4 +21,7 @@ export 'package:colonizethis_orders/src/orders/diplomatic_panel_actions.dart'
 export 'package:colonizethis_diplomacy/src/diplomacy/known_diplomatic_targets.dart'
     show knownDiplomaticTargetFactionIds;
 export 'package:colonizethis_diplomacy/src/diplomacy/gp_tribe_first_contact.dart'
-    show GpTribeFirstContactResult, applyGpTribeFirstContactRelations;
+    show
+        GpTribeFirstContactResult,
+        applyGpTribeFirstContactRelations,
+        discoveredTribeIdsForFirstContact;


### PR DESCRIPTION
## Summary

Fixes the reported turn-0 regression where the Diplomacy panel **Tribes**
section listed every tribe reachable via **sea-reachable colonial intel**,
even before the human GP revealed any tribe-owned tiles.

`buildDiplomacyRows` now applies the canonical **first-contact** gate to
Tribe rows: a Tribe is surfaced for the human GP only when **either**

1. a persisted `DiplomacyRelation` exists for the GP↔Tribe pair, **or**
2. the GP holds non-`unknown` tile visibility into a province that Tribe
   owns (`discoveredTribeIdsForFirstContact`).

Sea-reachable colonial intel alone no longer surfaces a Tribe row. Great
Power and Minor Nation discovery is unchanged.

## Done in this push

- **SPEC** `SPEC/ui/diplomacy-panel.md` § Discovered factions: split GP/Minor
  discovery from a new **Tribes require first contact** section; revised the
  tribe discovery ACs and added **AC-1** (turn-0 sea-reachable excluded) and
  **AC-7** (contact survives fog decay).
- **Impl** `app/lib/features/game/widgets/diplomacy_panel_rows.dart`: first-contact
  gate drops sea-reachable-only tribe ids from the discovered set.
- **Contract** `packages/colonizethis_logic/lib/order_suggestion_api.dart`:
  re-export `discoveredTribeIdsForFirstContact` through the narrow logic API.
- **Tests** `app/test/diplomacy_panel_rows_test.dart`: added AC-1 (turn-0
  sea-reachable tribe yields no tribe rows while `knownDiplomaticTargetFactionIds`
  still includes it) and AC-7 (relation-only tribe survives fog decay). Existing
  #3341 visibility-discovery and empty-state/golden tests remain green.

## ACs covered now

- **AC-1** (turn 0 empty Tribes for sea-reachable-only) ✓
- **AC-7** (contact survives fog decay) ✓
- **AC-9** (per-GP independence — relations/visibility are per-GP) ✓ (panel surface)
- Partial **AC-2 / AC-3** (visibility triggers panel surfacing; human relation
  persistence + herald already handled by `syncGpTribeFirstContact`).

## Deferred (follow-up on this same issue, not done here)

- **AC-5 (AI parity):** persist GP↔Tribe relations for **AI** GPs on visibility
  reveal during turn resolution.
- **AC-6 (order suggestions / AI helper):** remove the sea-reachable branch from
  `knownDiplomaticTargetFactionIds` so `suggestDiplomaticOrders` /
  `suggestDeclareWarOrders` stop targeting uncontacted tribes.

These two are intentionally deferred because they are coupled: removing
sea-reachable diplomatic targeting without first adding AI relation-on-reveal
parity would regress AI tribe conquest (the AI would lose its only path to a
valid declare-war target). They also carry wider blast radius across
`colonizethis_ai` tests and are better landed as a dedicated slice. The SPEC
section documents this interim split and points the remaining unification at
#3620. **AC-8** (colonial military/Explorer intel) is unaffected — those
consumers use `reachableNonOwnedProvinceIdsViaSeas` directly, not the panel.

## Test plan

- [x] `flutter test app/test/diplomacy_panel_rows_test.dart`
- [x] `flutter test app/test/diplomacy_panel_test.dart app/test/diplomacy_panel_goldens_test.dart`
- [x] `dart test` diplomacy package first-contact + known-targets suites
- [x] `flutter analyze` / `dart analyze` on touched files

Refs #3620

Made with [Cursor](https://cursor.com)