### PR TITLE
docs(ui): train-dialog mockup parity — remaining/total, danger states, naval mockup (#3568)

### DIFF
--- a/SPEC/ui/mockups/UNIT40001-train-civilians-dialog.html
+++ b/SPEC/ui/mockups/UNIT40001-train-civilians-dialog.html
@@ -28,7 +28,12 @@ html,body{min-height:100vh;min-height:100dvh;background:var(--bg);color:var(--fg
 .stepper .btn{padding:3px 10px;font-family:monospace;font-size:14px;font-weight:700;cursor:pointer;border:none;min-width:28px;transition:color 0.15s}
 .stepper .btn-minus{background:var(--bg-deep);border:1px solid var(--border);color:var(--muted)}.stepper .btn-minus:hover:not(:disabled){color:var(--fg)}.stepper .btn-minus:disabled{opacity:0.3;cursor:not-allowed}
 .stepper .btn-plus{background:var(--surface-lite);border:1px solid var(--accent-dim);color:var(--accent)}.stepper .btn-plus:hover:not(:disabled){color:var(--accent)}.stepper .btn-plus:disabled{opacity:0.3;cursor:not-allowed}
+/* Resource-blocked [+] (insufficient stockpile, not tech-locked): danger border/label at full opacity, distinct from the neutral tech-locked disabled look. */
+.stepper .btn-plus.btn-danger:disabled{opacity:1;background:var(--bg-deep);border:1px solid var(--danger);color:var(--danger)}
 .stepper .count{font-family:monospace;font-size:14px;font-weight:700;color:var(--fg);min-width:20px;text-align:center}
+/* Per-segment cost danger: a cost item turns red when the remaining stockpile cannot cover one more of this unit. */
+.unit-row .cost .danger{color:var(--danger)}
+.resource-bar .val.danger{color:var(--danger)}
 .sep{height:1px;background:var(--border);margin:2px 0 8px}
 .actions{display:flex;gap:10px;justify-content:flex-end;margin-top:8px}
 .btn-act{padding:8px 18px;font-family:var(--font-display);font-size:13px;font-weight:600;letter-spacing:0.05em;cursor:pointer;border:none;transition:color 0.15s}
@@ -39,10 +44,7 @@ html,body{min-height:100vh;min-height:100dvh;background:var(--bg);color:var(--fg
 <div class="scrim" onclick="location.reload()"></div>
 <div class="dialog">
   <h3>Train Civilians</h3>
-  <div class="resource-bar">
-    <span>Treasury: <span class="val">&#xa3;5,000</span></span>
-    <span>Paper: <span class="val">12</span></span>
-  </div>
+  <div class="resource-bar" id="resbar"></div>
   <p class="deficit" id="deficit" style="display:none"></p>
   <div id="units"></div>
   <div class="actions">
@@ -58,41 +60,60 @@ const units=[
   {id:'merchant',name:'Merchant',treasury:2000,paper:4,locked:true,tech:'Merchant Companies'},
   {id:'rail_builder',name:'Rail Builder',treasury:2000,paper:4,locked:true,tech:'Early Steam Engine'}
 ]
-let counts={} ; let treasury=5000, paper=12
-units.forEach(u=>{counts[u.id]=0})
+const treasury=5000, paper=12
+// Default deficit scenario (#3568 AC): queued explorers + spies exceed both
+// treasury and paper so the comma-joined deficit hint (`Treasury low, Paper
+// low`), per-segment danger colour, and danger [+] variant show on load.
+let counts={};units.forEach(u=>{counts[u.id]=0})
+counts.explorer=3;counts.spy=2
+function totals(){let t=0,p=0;units.forEach(u=>{t+=counts[u.id]*u.treasury;p+=counts[u.id]*u.paper});return {t,p}}
+function remaining(){const c=totals();return {t:treasury-c.t,p:paper-c.p}}
 function deficitCheck(){
-  let totalT=0,totalP=0
-  units.forEach(u=>{totalT+=counts[u.id]*u.treasury;totalP+=counts[u.id]*u.paper})
-  let msgs=[]
-  if(totalT>treasury)msgs.push('Treasury low')
-  if(totalP>paper)msgs.push('Paper low')
+  const c=totals();const msgs=[]
+  if(c.t>treasury)msgs.push('Treasury low')
+  if(c.p>paper)msgs.push('Paper low')
   const d=document.getElementById('deficit')
-  d.style.display=msgs.length?'block':'none'
-  d.textContent=msgs.join(', ')
+  d.style.display=msgs.length?'block':'none';d.textContent=msgs.join(', ')
 }
+// Affordable for one more iff remaining covers both treasury and paper.
 function canAdd(id){
   const u=units.find(x=>x.id===id);if(!u||u.locked)return false
-  let totalT=0,totalP=0
-  units.forEach(x=>{totalT+=counts[x.id]*x.treasury;totalP+=counts[x.id]*x.paper})
-  return totalT+u.treasury<=treasury && totalP+u.paper<=paper
+  const r=remaining();return r.t>=u.treasury&&r.p>=u.paper
 }
 function adjust(id,d){
   if(d<0&&counts[id]<=0)return;if(d>0&&!canAdd(id))return
-  counts[id]+=d;if(counts[id]<0)counts[id]=0;deficitCheck();render()
+  counts[id]+=d;if(counts[id]<0)counts[id]=0;render()
 }
-function resetAll(){units.forEach(u=>{counts[u.id]=0});deficitCheck();render()}
+function resetAll(){units.forEach(u=>{counts[u.id]=0});render()}
+function renderResbar(){
+  const r=remaining()
+  document.getElementById('resbar').innerHTML=
+    `<span>Treasury: <span class="val${r.t<0?' danger':''}">\u00a3${r.t.toLocaleString()} / \u00a3${treasury.toLocaleString()}</span></span>`+
+    `<span>Paper: <span class="val${r.p<0?' danger':''}">${r.p} / ${paper}</span></span>`
+}
+// Each cost segment turns danger when remaining for that resource cannot cover
+// one more of this unit (skipped for tech-locked rows, which read neutral).
+function costHtml(u,r){
+  const tDanger=!u.locked&&r.t<u.treasury,pDanger=!u.locked&&r.p<u.paper
+  return `<span class="${tDanger?'danger':''}">\u00a3${u.treasury.toLocaleString()}</span> + `+
+    `<span class="${pDanger?'danger':''}">${u.paper} paper</span>`
+}
 function render(){
-  document.getElementById('units').innerHTML=units.map(u=>`
+  renderResbar();deficitCheck()
+  const r=remaining()
+  document.getElementById('units').innerHTML=units.map(u=>{
+    const blocked=!u.locked&&!canAdd(u.id)
+    return `
     <div class="unit-row${u.locked?' locked':''}">
       <div class="info"><div class="name">${u.locked?'&#x1F512; ':''}${u.name}</div>
-      <div class="cost">\u00a3${u.treasury.toLocaleString()} + ${u.paper} paper</div>
+      <div class="cost">${costHtml(u,r)}</div>
       ${u.locked?`<div class="lock-reason">Requires: ${u.tech}</div>`:''}</div>
       <div class="stepper">
         <button class="btn btn-minus" ${u.locked?'disabled':''} onclick="adjust('${u.id}',-1)" ${counts[u.id]<=0?'disabled':''}>&#x2212;</button>
         <span class="count">${counts[u.id]}</span>
-        <button class="btn btn-plus" ${u.locked?'disabled':''} onclick="adjust('${u.id}',1)" ${!canAdd(u.id)?'disabled':''}>+</button>
+        <button class="btn btn-plus${blocked?' btn-danger':''}" ${u.locked||blocked?'disabled':''} onclick="adjust('${u.id}',1)">+</button>
       </div>
-    </div>`).join('')
+    </div>`}).join('')
 }
 render()
 </script>

--- a/SPEC/ui/mockups/UNIT60001-train-naval-dialog.html
+++ b/SPEC/ui/mockups/UNIT60001-train-naval-dialog.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>ColonizeThis — Train Military</title>
+<title>ColonizeThis — Train Naval</title>
 <style>
 :root {
   --bg: oklch(16% 0.018 50); --bg-deep: oklch(12% 0.015 45);
@@ -20,10 +20,11 @@ html,body{min-height:100vh;min-height:100dvh;background:var(--bg);color:var(--fg
 .dialog{position:relative;z-index:1;width:min(92vw,440px);max-height:88vh;overflow-y:auto;background:linear-gradient(180deg,var(--surface-lite) 0%,var(--surface) 15%,var(--bg-deep) 100%);border:2px solid var(--accent-dim);padding:16px 20px}
 .dialog h3{font-family:var(--font-display);font-size:clamp(16px,2.2vw,20px);font-weight:700;letter-spacing:0.05em;color:var(--accent);text-align:center;margin-bottom:10px}
 .resource-bar{display:flex;flex-wrap:wrap;justify-content:space-around;align-items:center;gap:6px;padding:8px;background:var(--bg-deep);border:1px solid var(--border);margin-bottom:6px;font-size:11px}.resource-bar span{color:var(--muted)}.resource-bar .val{color:var(--fg);font-family:monospace;font-weight:700;margin-left:3px}
+.resource-bar .val.danger{color:var(--danger)}
 .deficit{font-size:11px;color:var(--danger);font-style:italic;text-align:center;margin-bottom:8px}
 .unit-row{display:flex;align-items:center;gap:8px;padding:8px 10px;background:var(--surface);border:1px solid var(--border);margin-bottom:6px;flex-wrap:wrap}
 .unit-row.locked{opacity:0.5}
-.unit-row .info{flex:1;min-width:120px}.unit-row .name{font-family:var(--font-display);font-size:13px;font-weight:600;color:var(--fg);letter-spacing:0.03em;margin-bottom:3px}.unit-row .cost{font-size:11px;color:var(--muted)}.unit-row .lock-reason{font-size:10px;color:var(--muted);font-style:italic}
+.unit-row .info{flex:1;min-width:120px}.unit-row .name{font-family:var(--font-display);font-size:13px;font-weight:600;color:var(--fg);letter-spacing:0.03em;margin-bottom:3px}.unit-row .cost{font-size:11px;color:var(--muted)}.unit-row .cost .danger{color:var(--danger)}.unit-row .lock-reason{font-size:10px;color:var(--muted);font-style:italic}
 .stepper{display:flex;align-items:center;gap:6px;flex-shrink:0}
 .stepper .btn{padding:3px 10px;font-family:monospace;font-size:14px;font-weight:700;cursor:pointer;border:none;min-width:28px;transition:color 0.15s}
 .stepper .btn-minus{background:var(--bg-deep);border:1px solid var(--border);color:var(--muted)}.stepper .btn-minus:hover:not(:disabled){color:var(--fg)}.stepper .btn-minus:disabled{opacity:0.3;cursor:not-allowed}
@@ -31,9 +32,6 @@ html,body{min-height:100vh;min-height:100dvh;background:var(--bg);color:var(--fg
 /* Resource-blocked [+] (insufficient stockpile, not tech-locked): danger border/label at full opacity, distinct from the neutral tech-locked disabled look. */
 .stepper .btn-plus.btn-danger:disabled{opacity:1;background:var(--bg-deep);border:1px solid var(--danger);color:var(--danger)}
 .stepper .count{font-family:monospace;font-size:14px;font-weight:700;color:var(--fg);min-width:20px;text-align:center}
-/* Per-segment cost danger: a cost item turns red when the remaining stockpile cannot cover one more of this unit. */
-.unit-row .cost .danger{color:var(--danger)}
-.resource-bar .val.danger{color:var(--danger)}
 .actions{display:flex;gap:10px;justify-content:flex-end;margin-top:8px}
 .btn-act{padding:8px 18px;font-family:var(--font-display);font-size:13px;font-weight:600;letter-spacing:0.05em;cursor:pointer;border:none;transition:color 0.15s}
 .btn-reset{background:linear-gradient(180deg,var(--surface) 0%,var(--bg-deep) 100%);border-top:1px solid var(--border);border-bottom:1px solid var(--border);color:var(--muted)}.btn-reset:hover{color:var(--fg)}
@@ -42,7 +40,7 @@ html,body{min-height:100vh;min-height:100dvh;background:var(--bg);color:var(--fg
 <body>
 <div class="scrim" onclick="location.reload()"></div>
 <div class="dialog">
-  <h3>Train Military</h3>
+  <h3>Train Naval</h3>
   <div class="resource-bar" id="resbar"></div>
   <p class="deficit" id="deficit" style="display:none"></p>
   <div id="units"></div>
@@ -51,25 +49,37 @@ html,body{min-height:100vh;min-height:100dvh;background:var(--bg);color:var(--fg
   </div>
 </div>
 <script>
-// Resource keys consumed by military training, in display order.
-const KEYS=['treasury','peasants','fabric','castIron','horses']
-const LABEL={treasury:'Treasury',peasants:'Peasants',fabric:'Fabric',castIron:'Cast Iron',horses:'Horses'}
-// Cost-line segment labels (singular resource noun shown next to the quantity).
-const COST_LABEL={peasants:'peasant',fabric:'fabric',castIron:'cast iron',horses:'horses'}
+// Resource keys consumed by naval training, in display order: treasury,
+// peasants, and the union of all ship-input commodities (lumber, fabric,
+// cast iron, coal) per SPEC/ui/train-naval-dialog.md § Resource bar.
+const KEYS=['treasury','peasants','lumber','fabric','castIron','coal']
+const LABEL={treasury:'Treasury',peasants:'Peasants',lumber:'Lumber',fabric:'Fabric',castIron:'Cast Iron',coal:'Coal'}
+// Cost-line segment labels (resource noun shown next to the quantity).
+const COST_LABEL={peasants:'peasant',lumber:'lumber',fabric:'fabric',castIron:'cast iron',coal:'coal'}
+// Every ship costs 1 peasant. Costs mirror ShipEconomyCatalog; lock/unlock
+// state here is illustrative (a representative mid-game tech state) rather
+// than a literal tech-tree projection.
 const units=[
-  {id:'peasant_levies',name:'Peasant Levies',treasury:500,fabric:1,peasants:1,locked:false},
-  {id:'line_infantry',name:'Line Infantry',treasury:1200,fabric:2,castIron:1,peasants:1,locked:false},
-  {id:'grenadiers',name:'Grenadiers',treasury:2000,fabric:2,castIron:2,peasants:1,locked:true,tech:'Grenadier Companies'},
-  {id:'light_cavalry',name:'Light Cavalry',treasury:1500,fabric:1,horses:2,peasants:1,locked:false},
-  {id:'dragoons',name:'Dragoons',treasury:2500,fabric:2,horses:3,castIron:1,peasants:1,locked:true,tech:'Dragoon Regiments'},
-  {id:'siege_guns',name:'Siege Guns',treasury:3000,castIron:3,peasants:1,locked:true,tech:'Siege Artillery'}
+  {id:'carrack',name:'Carrack',treasury:8000,peasants:1,lumber:2,fabric:1,locked:false},
+  {id:'fluyte',name:'Fluyte',treasury:6000,peasants:1,lumber:1,fabric:1,locked:false},
+  {id:'sloop',name:'Sloop',treasury:5500,peasants:1,lumber:1,fabric:1,locked:false},
+  {id:'trader',name:'Trader',treasury:7500,peasants:1,lumber:2,fabric:2,locked:false},
+  {id:'galleon',name:'Galleon',treasury:9500,peasants:1,lumber:3,fabric:2,locked:false},
+  {id:'raider',name:'Raider',treasury:11500,peasants:1,lumber:2,fabric:1,castIron:2,locked:false},
+  {id:'indiaman',name:'Indiaman',treasury:11000,peasants:1,lumber:3,fabric:3,locked:true,tech:'Large Hulls'},
+  {id:'frigate',name:'Frigate',treasury:10500,peasants:1,lumber:2,fabric:2,locked:true,tech:'Advanced Hull Design'},
+  {id:'ship_of_the_line',name:'Ship of the Line',treasury:16500,peasants:1,lumber:5,fabric:3,locked:true,tech:'Ship of the Line'},
+  {id:'clipper',name:'Clipper',treasury:13500,peasants:1,lumber:3,fabric:3,locked:true,tech:'Clipper Ships'},
+  {id:'merchant_steamship',name:'Merchant Steamship',treasury:15500,peasants:1,lumber:2,fabric:2,coal:3,locked:true,tech:'Merchant Steamships'},
+  {id:'ironclad',name:'Ironclad',treasury:21000,peasants:1,lumber:2,fabric:2,castIron:5,locked:true,tech:'Advanced Iron Working'}
 ]
-const res={treasury:8000,peasants:24,fabric:8,castIron:6,horses:4}
-// Default deficit scenario (#3568 AC): queued line infantry + light cavalry
-// exceed treasury, fabric, and horses so the comma-joined deficit hint,
-// per-segment danger colour, and danger [+] variant are all visible on load.
+const res={treasury:50000,peasants:20,lumber:10,fabric:10,castIron:1,coal:6}
+// Default deficit scenario (#3568 AC): one queued Raider commits 2 cast iron
+// against a stockpile of 1, so the `Cast Iron low` hint, the cast-iron cost
+// segment danger colour, and the Raider's danger [+] variant show on load,
+// while the cast-iron-free hulls stay affordable (mixed state).
 let counts={};units.forEach(u=>{counts[u.id]=0})
-counts.line_infantry=3;counts.light_cavalry=3
+counts.raider=1
 function committed(){
   let tot={};KEYS.forEach(k=>tot[k]=0)
   units.forEach(u=>{KEYS.forEach(k=>{tot[k]+=counts[u.id]*(u[k]||0)})})
@@ -83,7 +93,7 @@ function deficitCheck(){
   const d=document.getElementById('deficit')
   d.style.display=msgs.length?'block':'none';d.textContent=msgs.join(', ')
 }
-// A unit is affordable for one more iff remaining covers every resource it needs.
+// Affordable for one more iff remaining covers every resource the ship needs.
 function canAdd(id){
   const u=units.find(x=>x.id===id);if(!u||u.locked)return false
   const r=remaining();return KEYS.every(k=>r[k]>=(u[k]||0))
@@ -100,7 +110,7 @@ function renderResbar(){
   ).join('')
 }
 // Each cost segment turns danger when remaining for that resource cannot cover
-// one more of this unit (skipped for tech-locked rows, which read neutral).
+// one more of this ship (skipped for tech-locked rows, which read neutral).
 function costHtml(u,r){
   const seg=k=>{const q=u[k]||0;if(!q)return null
     const danger=!u.locked&&r[k]<q;const label=k==='treasury'?fmt('treasury',u.treasury):q+' '+COST_LABEL[k]

--- a/SPEC/ui/train-naval-dialog.md
+++ b/SPEC/ui/train-naval-dialog.md
@@ -3,6 +3,7 @@
 **Screen ID:** `UNIT60001` — stable; do not reassign.
 **SPEC/ui** — Modal dialog for queuing naval (ship) training orders. Implementation: `app/lib/features/game/widgets/train_naval_dialog.dart`. Integrates with [naval-units-panel.md](naval-units-panel.md) and the shared [components/train-dialog-chrome.md](components/train-dialog-chrome.md). Game model: [ships-and-naval.md](../game/ships-and-naval.md), [tech-tree-naval.md](../game/tech-tree-naval.md), [world-model.md](../game/world-model.md). Order model: [orders.md](../program/orders.md).
 **Widgetbook:** `Train Naval Dialog` → `app/lib/widgetbook/catalog_screens_combat.dart`.
+**Mockup:** [mockups/UNIT60001-train-naval-dialog.html](mockups/UNIT60001-train-naval-dialog.html)
 
 ---
 


### PR DESCRIPTION
## Summary

Completes the deferred **mockup-parity** slice of #3568 (decisions 1 & 4) that prior PR #3637 (comma-join + chrome parity) explicitly left as follow-up. The civilian/military train-dialog HTML mockups now demonstrate the already-shipped runtime behaviour, and the net-new naval mockup is created.

`Refs #3568`

## Done in this push

- **UNIT40001 (Train Civilians) & UNIT50001 (Train Military) mockups** — added the four net-new states:
  - Resource bar values render as **`remaining / total`** (treasury with `£` + comma grouping on both sides), recomputed live on every stepper toggle; the value turns `--danger` when remaining is negative.
  - **Per-segment cost danger:** each cost item renders `--danger` independently when remaining for that resource cannot cover one more of that unit (tech-locked rows stay neutral).
  - **`[+]` danger variant:** a resource-blocked `[+]` shows a red border/label at full opacity, distinct from the neutral tech-locked disabled appearance.
  - **Default deficit scenario:** queued counts exceed resources on load so the comma-joined deficit hint (`Treasury low, Paper low` / `Treasury low, Fabric low, Horses low`) and danger styling are immediately visible; reducing counts transitions rows back to normal.
- **UNIT60001 (Train Naval) mockup — new file** mirroring the civilian/military chrome contract: centered title, no `×`, no section dividers, `0.5` locked-row opacity, `🔒` name prefix, all **12** `ShipEconomyCatalog` ship types with treasury/peasants + the `lumber/fabric/castIron/coal` commodity union, and the same `remaining/total`, per-segment danger, danger `[+]`, and deficit-scenario states (default `Cast Iron low`).
- **SPEC:** `SPEC/ui/train-naval-dialog.md` links the new mockup.

## ACs covered now

- AC1 (mockups show `remaining/total`, per-segment danger, `[+]` danger vs neutral tech-lock), AC2 (deficit scenario + hint visible), AC7 (naval mockup exists matching the civilian/military chrome contract). Chrome geometry ACs (centered title, no `×`, no dividers, `0.5` opacity, `🔒`) landed earlier in #3637 and are reflected in all three mockups.

## Verification

- Logic of all three mockup scripts validated with a stubbed-DOM Node harness (temp file, removed after): default deficit hints, `remaining / total` rendering, per-segment danger spans, and danger/neutral `[+]` variants match the runtime contract in `SPEC/ui/train-*-dialog.md`. No Dart test reads the mockup HTML, so no app test impact.

## Deferred (still on #3568)

- Net-new **Widgetbook** use cases dedicated to the `remaining/total` + danger states (the underlying runtime behaviour is already covered by the existing train-dialog widget tests from #3601/#3602/#3637); not required for mockup parity.

Tracked by #3568 (does not auto-close).

Made with [Cursor](https://cursor.com)