### PR TITLE
refactor: extract shared closePanelThenEmit bus navigation helper (#3651)

### DIFF
--- a/SPEC/program/app-ui-wiring.md
+++ b/SPEC/program/app-ui-wiring.md
@@ -158,11 +158,12 @@ In **`colonizethis_app`**, widgets and services that hold **one or more** `Strea
 
 ### CI gate — `repo.app_event_bus_decoupling` (Refs #2626)
 
-`tool/check_app_event_bus_decoupling.dart` (wired through `tool/ct_repo_lint_manifest.yaml`) enforces three invariants against `app/lib/**`:
+`tool/check_app_event_bus_decoupling.dart` (wired through `tool/ct_repo_lint_manifest.yaml`) enforces four invariants against `app/lib/**`:
 
 - **No `AppEventBus()` singleton** in production code (under `app/lib/**`, excluding `app/lib/widgetbook/**`). Use `appEventBusProvider` (or an `AppEventBus.create()` instance held by the owning widget/service).
 - **`appNavigatorKey.currentContext` / `.currentState` / equivalent property access** is restricted to `app/lib/core/services/**` and `app/lib/app.dart`. Other layers must thread an explicit `GlobalKey<NavigatorState>` parameter or use the bus.
 - **`showDialog` / `showModalBottomSheet` calls under `app/lib/features/**`** are restricted to the documented "Local by design" allow-list above (plus the per-panel carve-outs for split/move fleet, move army, train at-capital). New call sites outside the allow-list must use a typed `AppEvent` instead. Adding a new local-by-design dialog requires extending **both** this SPEC section **and** the lint allow-list.
+- **No raw `addPostFrameCallback` + bus-`emit` sequencing under `app/lib/features/**`.** A `addPostFrameCallback` closure must not emit a **non-`ClosePanelEvent`** bus event (`bus.emit(...)` / `widget.bus.emit(...)`). The "close the active panel, then emit a follow-up event next frame" idiom must route through the shared **`AppEventBus.closePanelThenEmit`** helper (`app/lib/core/services/app_event_bus_panel_nav.dart`), which emits `ClosePanelEvent` synchronously and defers the single follow-up by exactly one frame so the SPEC-normative ordering (Train → `ClosePanelEvent` then `OpenDialogEvent`; locate / work-target → `ClosePanelEvent` then the follow-up) and the post-frame rationale live in one place. A bare deferred `ClosePanelEvent` emit (for example a scoped auto-close once a panel becomes empty) remains allowed.
 
 ---
 

--- a/app/lib/core/services/app_event_bus_panel_nav.dart
+++ b/app/lib/core/services/app_event_bus_panel_nav.dart
@@ -1,0 +1,30 @@
+// Shared panel-navigation helper for the AppEventBus. Lives in `app/` because
+// it depends on Flutter's `WidgetsBinding`. SPEC/program/app-ui-wiring.md
+// (ClosePanelEvent → follow-up ordering), SPEC/program/app-event-bus.md.
+
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:flutter/widgets.dart';
+
+/// Panel-navigation convenience built on top of [AppEventBus].
+///
+/// Centralizes the "close the active handler-owned panel, then emit a
+/// follow-up event after the current frame" idiom that game unit panels would
+/// otherwise re-implement inline at every call site.
+extension AppEventBusPanelNav on AppEventBus {
+  /// Closes the active handler-owned panel, then emits [next] after the
+  /// current frame completes.
+  ///
+  /// The post-frame deferral exists so the closing panel's
+  /// `Navigator.maybePop` (driven by `AppEventHandler` handling
+  /// [ClosePanelEvent]) finishes before the next surface mounts. Emitting
+  /// [next] synchronously could mount the follow-up surface before the pop
+  /// completes.
+  ///
+  /// Preserves the SPEC-normative ordering: [ClosePanelEvent] is emitted
+  /// synchronously first, then [next] is emitted exactly once on the next
+  /// frame (`SPEC/program/app-ui-wiring.md` § Acceptance Criteria).
+  void closePanelThenEmit(AppEvent next) {
+    emit(const ClosePanelEvent());
+    WidgetsBinding.instance.addPostFrameCallback((_) => emit(next));
+  }
+}

--- a/app/lib/features/game/widgets/civilian_units_panel.dart
+++ b/app/lib/features/game/widgets/civilian_units_panel.dart
@@ -11,6 +11,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../config/ct_e2e.dart';
 import '../../../config/ct_e2e_last_panel_snapshot.dart';
 import '../../../config/ui_screen_ids.dart';
+import '../../../core/services/app_event_bus_panel_nav.dart';
 import '../../../core/services/app_event_handler_scope.dart';
 import '../../../l10n/l10n.dart';
 import '../../../providers/games_provider.dart';
@@ -320,10 +321,9 @@ class _CivilianUnitsPanelState extends ConsumerState<CivilianUnitsPanel> {
               if (key == null || key.isEmpty) {
                 return;
               }
-              widget.bus.emit(const ClosePanelEvent());
-              WidgetsBinding.instance.addPostFrameCallback((_) {
-                widget.bus.emit(OpenMapTileDetailEvent(tileKey: key));
-              });
+              widget.bus.closePanelThenEmit(
+                OpenMapTileDetailEvent(tileKey: key),
+              );
             },
             label: l10n.civilian_units_tile,
           ),
@@ -333,10 +333,9 @@ class _CivilianUnitsPanelState extends ConsumerState<CivilianUnitsPanel> {
           onPressed: widget.readOnly
               ? null
               : () {
-                  widget.bus.emit(const ClosePanelEvent());
-                  WidgetsBinding.instance.addPostFrameCallback((_) {
-                    widget.bus.emit(OpenDialogEvent(trainCiviliansDialogId));
-                  });
+                  widget.bus.closePanelThenEmit(
+                    OpenDialogEvent(trainCiviliansDialogId),
+                  );
                 },
           label: l10n.common_train,
         ),

--- a/app/lib/features/game/widgets/civilian_units_panel_support.dart
+++ b/app/lib/features/game/widgets/civilian_units_panel_support.dart
@@ -288,15 +288,12 @@ class _UnitRow extends ConsumerWidget {
                 onTap: isAvailable
                     ? () {
                         Navigator.of(ctx).pop();
-                        bus.emit(const ClosePanelEvent());
-                        WidgetsBinding.instance.addPostFrameCallback((_) {
-                          bus.emit(
-                            StartCivilianWorkTargetSelectionEvent(
-                              unitId: unit.id,
-                              workTarget: target,
-                            ),
-                          );
-                        });
+                        bus.closePanelThenEmit(
+                          StartCivilianWorkTargetSelectionEvent(
+                            unitId: unit.id,
+                            workTarget: target,
+                          ),
+                        );
                       }
                     : null,
                 child: Padding(
@@ -347,19 +344,16 @@ class _UnitRow extends ConsumerWidget {
     if (!_isIdleNoPending || !availableWorkTargetIds.contains(workTarget)) {
       return;
     }
-    bus.emit(const ClosePanelEvent());
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      bus.emit(
-        UpsertPendingCivilianWorkOrderRequestedEvent(
-          playerId: humanPlayerId,
-          workOrder: WorkOrder(
-            unitId: unit.id,
-            target: workTarget,
-            targetTileKey: targetTileKey,
-          ),
+    bus.closePanelThenEmit(
+      UpsertPendingCivilianWorkOrderRequestedEvent(
+        playerId: humanPlayerId,
+        workOrder: WorkOrder(
+          unitId: unit.id,
+          target: workTarget,
+          targetTileKey: targetTileKey,
         ),
-      );
-    });
+      ),
+    );
   }
 
   Future<void> _confirmCancel(BuildContext context) async {
@@ -455,10 +449,9 @@ class _UnitRow extends ConsumerWidget {
     if (tileKey == null) return;
     final regionId = Unit.regionIdFromTileKey(tileKey);
     if (regionId == null) return;
-    bus.emit(const ClosePanelEvent());
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      bus.emit(LocateMapTileEvent(tileKey: tileKey, regionId: regionId));
-    });
+    bus.closePanelThenEmit(
+      LocateMapTileEvent(tileKey: tileKey, regionId: regionId),
+    );
   }
 
   @override

--- a/app/lib/features/game/widgets/military_units_panel.dart
+++ b/app/lib/features/game/widgets/military_units_panel.dart
@@ -7,6 +7,7 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 
 import '../../../config/ui_screen_ids.dart';
+import '../../../core/services/app_event_bus_panel_nav.dart';
 import '../../../core/services/app_event_handler_scope.dart'
     show trainMilitaryDialogId;
 import '../../../l10n/l10n.dart';
@@ -140,10 +141,7 @@ class _MilitaryUnitsPanelState
   }
 
   void _openTrainDialog() {
-    widget.bus.emit(const ClosePanelEvent());
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      widget.bus.emit(OpenDialogEvent(trainMilitaryDialogId));
-    });
+    widget.bus.closePanelThenEmit(OpenDialogEvent(trainMilitaryDialogId));
   }
 
   List<Widget> _buildListChildren(
@@ -243,10 +241,9 @@ class _MilitaryUnitsPanelState
   }
 
   void _emitLocateMapTile({required String tileKey, required String regionId}) {
-    widget.bus.emit(const ClosePanelEvent());
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      widget.bus.emit(LocateMapTileEvent(tileKey: tileKey, regionId: regionId));
-    });
+    widget.bus.closePanelThenEmit(
+      LocateMapTileEvent(tileKey: tileKey, regionId: regionId),
+    );
   }
 }
 

--- a/app/lib/features/game/widgets/naval_units_panel.dart
+++ b/app/lib/features/game/widgets/naval_units_panel.dart
@@ -12,6 +12,7 @@ import 'package:flutter/material.dart';
 import '../../../config/ct_e2e.dart';
 import '../../../config/ct_e2e_last_panel_snapshot.dart';
 import '../../../config/ui_screen_ids.dart';
+import '../../../core/services/app_event_bus_panel_nav.dart';
 import '../../../core/services/app_event_handler_scope.dart'
     show trainNavalDialogId;
 import '../../../l10n/l10n.dart';
@@ -392,10 +393,7 @@ class _NavalUnitsPanelState extends BaseUnitsPanelState<NavalUnitsPanel> {
   }
 
   void _openTrainDialog() {
-    widget.bus.emit(const ClosePanelEvent());
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      widget.bus.emit(OpenDialogEvent(trainNavalDialogId));
-    });
+    widget.bus.closePanelThenEmit(OpenDialogEvent(trainNavalDialogId));
   }
 
   void _openSplitDialog(FleetRow row) {
@@ -473,10 +471,9 @@ class _NavalUnitsPanelState extends BaseUnitsPanelState<NavalUnitsPanel> {
             enabled: widget.tileScopeTileKey!.isNotEmpty,
             onPressed: () {
               final key = widget.tileScopeTileKey!;
-              widget.bus.emit(const ClosePanelEvent());
-              WidgetsBinding.instance.addPostFrameCallback((_) {
-                widget.bus.emit(OpenMapTileDetailEvent(tileKey: key));
-              });
+              widget.bus.closePanelThenEmit(
+                OpenMapTileDetailEvent(tileKey: key),
+              );
             },
             label: l10n.civilian_units_tile,
           ),

--- a/app/test/services/app_event_bus_panel_nav_test.dart
+++ b/app/test/services/app_event_bus_panel_nav_test.dart
@@ -1,0 +1,74 @@
+// Tests for the AppEventBusPanelNav.closePanelThenEmit helper.
+// SPEC/program/app-ui-wiring.md (ClosePanelEvent -> follow-up ordering).
+
+import 'package:colonizethis_app/core/services/app_event_bus_panel_nav.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  suppressLogsForTests();
+
+  group('AppEventBusPanelNav.closePanelThenEmit', () {
+    testWidgets(
+      'emits ClosePanelEvent synchronously, then the follow-up once next frame',
+      (tester) async {
+        // A pumped widget tree ensures `tester.pump()` produces frames that
+        // flush `addPostFrameCallback` callbacks.
+        await tester.pumpWidget(const SizedBox.shrink());
+
+        final bus = AppEventBus.create();
+        addTearDown(bus.dispose);
+        final events = <AppEvent>[];
+        final sub = bus.stream.listen(events.add);
+        addTearDown(sub.cancel);
+
+        final followUp = OpenDialogEvent('train_military');
+        bus.closePanelThenEmit(followUp);
+
+        // Before a frame runs, only ClosePanelEvent has been emitted; the
+        // follow-up is deferred to the post-frame callback.
+        await tester.idle();
+        expect(events, hasLength(1));
+        expect(events.single, isA<ClosePanelEvent>());
+
+        // After the next frame, the follow-up is emitted exactly once.
+        tester.binding.scheduleFrame();
+        await tester.pump();
+        await tester.idle();
+        expect(events, hasLength(2));
+        expect(events.first, isA<ClosePanelEvent>());
+        expect(identical(events[1], followUp), isTrue);
+      },
+    );
+
+    testWidgets('does not re-emit the follow-up on subsequent frames', (
+      tester,
+    ) async {
+      await tester.pumpWidget(const SizedBox.shrink());
+
+      final bus = AppEventBus.create();
+      addTearDown(bus.dispose);
+      final events = <AppEvent>[];
+      final sub = bus.stream.listen(events.add);
+      addTearDown(sub.cancel);
+
+      bus.closePanelThenEmit(
+        const LocateMapTileEvent(
+          tileKey: 'oldWorld|p1|0|0',
+          regionId: 'oldWorld',
+        ),
+      );
+      tester.binding.scheduleFrame();
+      await tester.pump();
+      tester.binding.scheduleFrame();
+      await tester.pump();
+      await tester.idle();
+
+      expect(events, hasLength(2));
+      expect(events.first, isA<ClosePanelEvent>());
+      expect(events[1], isA<LocateMapTileEvent>());
+    });
+  });
+}

--- a/test/check_app_event_bus_decoupling_test.dart
+++ b/test/check_app_event_bus_decoupling_test.dart
@@ -279,6 +279,132 @@ Future<void> open(Wrapper w) => w.showDialog();
       expect(code, 0);
     });
   });
+
+  group('features/ post-frame bus-emit sequencing check', () {
+    test(
+      'fails when a features/ addPostFrameCallback closure emits a follow-up '
+      'bus event after ClosePanelEvent',
+      () {
+        final root = _writeAppFile(
+          'app/lib/features/game/widgets/raw_panel.dart',
+          '''
+import 'package:flutter/material.dart';
+
+void openTrain(dynamic bus) {
+  bus.emit(const ClosePanelEvent());
+  WidgetsBinding.instance.addPostFrameCallback((_) {
+    bus.emit(OpenDialogEvent('train_military'));
+  });
+}
+''',
+        );
+        final stderrLines = <String>[];
+        final code = runCheckAppEventBusDecoupling(
+          root.path,
+          err: stderrLines.add,
+        );
+        expect(code, 1);
+        expect(
+          stderrLines.join('\n'),
+          contains(
+            'addPostFrameCallback closures emitting a non-ClosePanelEvent '
+            'bus event',
+          ),
+        );
+        expect(
+          stderrLines.join('\n'),
+          contains('app/lib/features/game/widgets/raw_panel.dart:6'),
+        );
+      },
+    );
+
+    test('fails for widget.bus.emit(...) inside a post-frame closure', () {
+      final root = _writeAppFile(
+        'app/lib/features/game/widgets/raw_widget_panel.dart',
+        '''
+import 'package:flutter/material.dart';
+
+class P {
+  dynamic widget;
+  void locate(String tileKey, String regionId) {
+    widget.bus.emit(const ClosePanelEvent());
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      widget.bus.emit(LocateMapTileEvent(tileKey: tileKey, regionId: regionId));
+    });
+  }
+}
+''',
+      );
+      final code = runCheckAppEventBusDecoupling(root.path);
+      expect(code, 1);
+    });
+
+    test(
+      'allows a bare deferred ClosePanelEvent emit (scoped auto-close)',
+      () {
+        final root = _writeAppFile(
+          'app/lib/features/game/widgets/auto_close_panel.dart',
+          '''
+import 'package:flutter/material.dart';
+
+class P {
+  dynamic widget;
+  bool mounted = true;
+  void maybeAutoClose() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      widget.bus.emit(const ClosePanelEvent());
+    });
+  }
+}
+''',
+        );
+        final stdoutLines = <String>[];
+        final code = runCheckAppEventBusDecoupling(
+          root.path,
+          info: stdoutLines.add,
+        );
+        expect(code, 0);
+        expect(stdoutLines.join('\n'), contains('no violations found'));
+      },
+    );
+
+    test('allows non-bus post-frame work (setState / layout)', () {
+      final root = _writeAppFile(
+        'app/lib/features/game/widgets/layout_panel.dart',
+        '''
+import 'package:flutter/material.dart';
+
+class P {
+  bool mounted = true;
+  void onResize() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+    });
+  }
+}
+''',
+      );
+      final code = runCheckAppEventBusDecoupling(root.path);
+      expect(code, 0);
+    });
+
+    test('ignores the same idiom outside features/ (e.g. core/services)', () {
+      final root = _writeAppFile(
+        'app/lib/core/services/app_event_bus_panel_nav.dart',
+        '''
+import 'package:flutter/widgets.dart';
+
+void closePanelThenEmit(dynamic bus, dynamic next) {
+  bus.emit(const ClosePanelEvent());
+  WidgetsBinding.instance.addPostFrameCallback((_) => bus.emit(next));
+}
+''',
+      );
+      final code = runCheckAppEventBusDecoupling(root.path);
+      expect(code, 0);
+    });
+  });
 }
 
 Directory _writeAppFile(String relativePath, String content) {

--- a/tool/check_app_event_bus_decoupling.dart
+++ b/tool/check_app_event_bus_decoupling.dart
@@ -14,7 +14,7 @@ import 'package:path/path.dart' as p;
 ///   APIs; documented local-by-design dialog/sheet carve-outs).
 /// - `SPEC/program/app-event-bus.md` (bus API and `AppEventBus.create`).
 ///
-/// Three sub-checks (any violation flips the rule red):
+/// Four sub-checks (any violation flips the rule red):
 ///
 /// 1. Production code under `app/lib/**` (excluding `app/lib/widgetbook/**`)
 ///    must not call the `AppEventBus()` singleton factory — use the
@@ -37,6 +37,17 @@ import 'package:path/path.dart' as p;
 ///    carve-outs for split / move fleet, move army, train at-capital). Any
 ///    new call site outside that allow-list is a violation; emit a typed
 ///    `AppEvent` via `AppEventBus` instead.
+///
+/// 4. Inside `app/lib/features/**`, a `addPostFrameCallback` closure must not
+///    emit a non-`ClosePanelEvent` bus event (`bus.emit(...)` /
+///    `widget.bus.emit(...)`). That "close the panel, then emit a follow-up
+///    event next frame" idiom must route through the shared
+///    `AppEventBusPanelNav.closePanelThenEmit` helper
+///    (`app/lib/core/services/app_event_bus_panel_nav.dart`) so the
+///    SPEC-normative ordering and post-frame rationale live in one place
+///    (`SPEC/program/app-ui-wiring.md`). A bare deferred `ClosePanelEvent`
+///    emit (for example a scoped auto-close once a panel becomes empty) is
+///    still allowed.
 
 const _disallowedSingletonName = 'AppEventBus';
 
@@ -89,9 +100,48 @@ const Set<String> _allowedFeatureLocalDialogFiles = <String>{
   'app/lib/features/game/screens/production_screen.dart',
 };
 
+/// Files allowed to emit a non-[ClosePanelEvent] bus event from inside a
+/// `addPostFrameCallback` closure. The shared `closePanelThenEmit` helper
+/// (`app/lib/core/services/app_event_bus_panel_nav.dart`) centralizes the
+/// "close panel, then emit a follow-up next frame" idiom; feature panels must
+/// call the helper instead of re-implementing the post-frame sequencing. The
+/// helper itself lives outside `app/lib/features/**` (so it is never scanned by
+/// this sub-check), but it is listed here to document intent and stay correct
+/// if it ever moves under `features/`.
+const Set<String> _allowedPostFrameBusEmitFiles = <String>{
+  'app/lib/core/services/app_event_bus_panel_nav.dart',
+};
+
 const _scanRoot = 'app/lib';
 const _excludedRoot = 'app/lib/widgetbook';
 const _featuresRoot = 'app/lib/features';
+
+const _closePanelEventName = 'ClosePanelEvent';
+
+/// Returns true when [target] looks like an `AppEventBus` reference such as
+/// `bus`, `widget.bus`, or `self.bus` (the shapes used by the unit panels).
+bool _isBusTarget(Expression? target) {
+  if (target is SimpleIdentifier) return target.name == 'bus';
+  if (target is PrefixedIdentifier) return target.identifier.name == 'bus';
+  if (target is PropertyAccess) return target.propertyName.name == 'bus';
+  return false;
+}
+
+/// Best-effort syntactic name of the event constructed in `emit(<event>)`.
+///
+/// `parseString` does not resolve types: `const ClosePanelEvent()` parses as an
+/// [InstanceCreationExpression] while `OpenDialogEvent(...)` parses as a bare
+/// [MethodInvocation]. Returns null for anything else (for example a variable),
+/// which callers treat as non-`ClosePanelEvent` (flagged) to stay conservative.
+String? _emittedEventTypeName(Expression arg) {
+  if (arg is InstanceCreationExpression) {
+    return arg.constructorName.type.name.lexeme;
+  }
+  if (arg is MethodInvocation && arg.target == null) {
+    return arg.methodName.name;
+  }
+  return null;
+}
 
 int runCheckAppEventBusDecoupling(
   String repoRoot, {
@@ -110,6 +160,7 @@ int runCheckAppEventBusDecoupling(
   final singletonViolations = <String>[];
   final navigatorKeyViolations = <String>[];
   final dialogViolations = <String>[];
+  final postFrameBusEmitViolations = <String>[];
 
   for (final entity in libDir.listSync(recursive: true, followLinks: false)) {
     if (entity is! File || !entity.path.endsWith('.dart')) {
@@ -131,11 +182,13 @@ int runCheckAppEventBusDecoupling(
     singletonViolations.addAll(visitor.singletonViolations);
     navigatorKeyViolations.addAll(visitor.navigatorKeyViolations);
     dialogViolations.addAll(visitor.dialogViolations);
+    postFrameBusEmitViolations.addAll(visitor.postFrameBusEmitViolations);
   }
 
   final total = singletonViolations.length +
       navigatorKeyViolations.length +
-      dialogViolations.length;
+      dialogViolations.length +
+      postFrameBusEmitViolations.length;
   if (total == 0) {
     logI('check_app_event_bus_decoupling: no violations found.');
     return 0;
@@ -170,6 +223,15 @@ int runCheckAppEventBusDecoupling(
       logE(' - $v');
     }
   }
+  if (postFrameBusEmitViolations.isNotEmpty) {
+    logE(
+      ' addPostFrameCallback closures emitting a non-ClosePanelEvent bus '
+      'event in features/ (use AppEventBus.closePanelThenEmit instead):',
+    );
+    for (final v in postFrameBusEmitViolations) {
+      logE(' - $v');
+    }
+  }
   return 1;
 }
 
@@ -185,6 +247,7 @@ class _AppEventBusDecouplingVisitor extends RecursiveAstVisitor<void> {
   final List<String> singletonViolations = <String>[];
   final List<String> navigatorKeyViolations = <String>[];
   final List<String> dialogViolations = <String>[];
+  final List<String> postFrameBusEmitViolations = <String>[];
 
   bool get _appNavigatorKeyAllowed {
     for (final prefix in _appNavigatorKeyAllowedPathPrefixes) {
@@ -201,6 +264,9 @@ class _AppEventBusDecouplingVisitor extends RecursiveAstVisitor<void> {
 
   bool get _featureFileAllowed =>
       _allowedFeatureLocalDialogFiles.contains(relativePath);
+
+  bool get _postFrameBusEmitAllowed =>
+      _allowedPostFrameBusEmitFiles.contains(relativePath);
 
   @override
   void visitInstanceCreationExpression(InstanceCreationExpression node) {
@@ -262,12 +328,49 @@ class _AppEventBusDecouplingVisitor extends RecursiveAstVisitor<void> {
         }
       }
     }
+    if (_isFeatureFile &&
+        !_postFrameBusEmitAllowed &&
+        node.methodName.name == 'addPostFrameCallback') {
+      _collectPostFrameBusEmits(node);
+    }
     super.visitMethodInvocation(node);
+  }
+
+  /// Flags `bus.emit(<non-ClosePanelEvent>)` calls inside the closure passed to
+  /// `addPostFrameCallback`. A deferred bare `ClosePanelEvent` emit is allowed.
+  void _collectPostFrameBusEmits(MethodInvocation node) {
+    for (final arg in node.argumentList.arguments) {
+      if (arg is! FunctionExpression) continue;
+      final emitVisitor = _PostFrameBusEmitVisitor();
+      arg.body.accept(emitVisitor);
+      for (final offset in emitVisitor.offendingEmitOffsets) {
+        postFrameBusEmitViolations.add(_format(offset));
+      }
+    }
   }
 
   String _format(int offset) {
     final loc = lineInfo.getLocation(offset);
     return '$relativePath:${loc.lineNumber}';
+  }
+}
+
+/// Collects offsets of `bus.emit(<event>)` calls (within a post-frame closure)
+/// whose emitted event is anything other than [ClosePanelEvent].
+class _PostFrameBusEmitVisitor extends RecursiveAstVisitor<void> {
+  final List<int> offendingEmitOffsets = <int>[];
+
+  @override
+  void visitMethodInvocation(MethodInvocation node) {
+    if (node.methodName.name == 'emit' &&
+        _isBusTarget(node.target) &&
+        node.argumentList.arguments.length == 1) {
+      final typeName = _emittedEventTypeName(node.argumentList.arguments.first);
+      if (typeName != _closePanelEventName) {
+        offendingEmitOffsets.add(node.offset);
+      }
+    }
+    super.visitMethodInvocation(node);
   }
 }
 


### PR DESCRIPTION
## Summary

Centralizes the duplicated **"close the active panel, wait one frame, then emit a follow-up bus event"** orchestration idiom in `app/` game unit panels into a single shared `AppEventBus.closePanelThenEmit` helper, and gates the raw idiom with a focused extension to the existing `repo.app_event_bus_decoupling` AST check. Removes all 9 copy-pasted `addPostFrameCallback` sequencing sites across 4 panel files while preserving the SPEC-normative `ClosePanelEvent` → follow-up event ordering byte-for-byte.

`Refs #3651`

## Implemented in this PR

- **Helper:** `app/lib/core/services/app_event_bus_panel_nav.dart` — `AppEventBusPanelNav.closePanelThenEmit(AppEvent next)` extension. Emits `ClosePanelEvent` synchronously, then defers `next` by exactly one frame via `WidgetsBinding.instance.addPostFrameCallback`. The post-frame rationale (let the handler-owned sheet finish `Navigator.maybePop` before the next surface mounts) now lives once in the helper doc comment. No `BuildContext` captured (avoids use-after-dispose).
- **Call sites migrated (9 / 9):**
  - `military_units_panel.dart` → `OpenDialogEvent(trainMilitaryDialogId)`, `LocateMapTileEvent`
  - `naval_units_panel.dart` → `OpenDialogEvent(trainNavalDialogId)`, `OpenMapTileDetailEvent`
  - `civilian_units_panel.dart` → `OpenMapTileDetailEvent`, `OpenDialogEvent(trainCiviliansDialogId)`
  - `civilian_units_panel_support.dart` → `StartCivilianWorkTargetSelectionEvent`, `UpsertPendingCivilianWorkOrderRequestedEvent`, `LocateMapTileEvent`
- **CI enforcement (extended, no new job):** Added a 4th sub-check to `tool/check_app_event_bus_decoupling.dart` (`repo.app_event_bus_decoupling`). It flags any `addPostFrameCallback` closure under `app/lib/features/**` that emits a **non-`ClosePanelEvent`** bus event, allow-listing the helper file. A bare deferred `ClosePanelEvent` emit (the naval scoped auto-close once a panel becomes empty) remains allowed by design.
- **SPEC:** `SPEC/program/app-ui-wiring.md` — documents the 4th invariant and that the documented `ClosePanelEvent` → follow-up sequences are implemented via the shared helper.

## Behavior preserved

The observable bus-event sequence is unchanged: `ClosePanelEvent` first (synchronous), follow-up second (deferred one frame). No screen-ID, screen-spec, or Widgetbook changes. Documented "Local by design" `showDialog` carve-outs and the unit-panel base classes are untouched.

## Tests

- `app/test/services/app_event_bus_panel_nav_test.dart` — helper emits `ClosePanelEvent` synchronously and `next` exactly once after one frame; no re-emit on subsequent frames.
- `test/check_app_event_bus_decoupling_test.dart` — new sub-check group: flags raw `bus.emit(...)` / `widget.bus.emit(...)` follow-ups inside post-frame closures; allows deferred bare `ClosePanelEvent` auto-close, non-bus post-frame work, and the same idiom outside `features/`.
- Verified locally (all green): the decoupling gate on the real repo (`no violations found`), the 17 tool tests, the 2 helper widget tests, the existing naval/military/civilian panel widget suites (58 cases — ordering ACs unchanged), and `dart`/`flutter analyze` on all touched files.

## ACs covered

All suggested ACs in #3651: helper exists and 9 inline sites removed; Train/locate/work-target/map-tile-detail ordering preserved; helper unit test; extended `repo.app_event_bus_decoupling` gate fails on new raw sequences and passes when the helper is used; analyze + panel suites green. No material follow-up deferred.

Made with [Cursor](https://cursor.com)