### PR TITLE
test: dedup redundant economy FRR/treasury test scenarios (#3661)

### DIFF
--- a/packages/colonizethis_economy/test/world_market_deal_matcher_first_right_test.dart
+++ b/packages/colonizethis_economy/test/world_market_deal_matcher_first_right_test.dart
@@ -1,5 +1,4 @@
 import 'package:colonizethis_logic/colonizethis_logic.dart';
-import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart';
 
 import 'package:colonizethis_economy_test_support/colonizethis_economy_test_support.dart';
@@ -11,95 +10,13 @@ import 'package:colonizethis_economy_test_support/colonizethis_economy_test_supp
 /// file exercises the matcher integration only.
 void main() {
   group('DealMatcher.matchDeals — First Right of Refusal (#2992 D2)', () {
-    test('owning GP bid fills purchased-tile offer ahead of higher-priority '
-        'bid from another GP (FRR overrides priority tier)', () {
-      const tileKey = 'oldWorld|M1|0|0';
-      final result = DealMatcher.matchDeals(
-        matcherInputs(
-          offersByFactionId: {
-            'M1': [matcherOffer('timber', 10, originTileKey: tileKey)],
-          },
-          bidsByFactionId: {
-            // Owning GP only bids at the lowest precedence (priority 5).
-            'gpA': [matcherBid('timber', 10, priority: 5)],
-            // Rival GP bids at the highest precedence (priority 1).
-            'gpB': [matcherBid('timber', 10, priority: 1)],
-          },
-          tradeCapacityByFactionId: {'gpA': 100, 'gpB': 100},
-          purchasedTileIndex: frrMatcherTestIndex(),
-        ),
-      );
-
-      expect(result.filledDeals.length, 1);
-      final deal = result.filledDeals.single;
-      expect(deal.sellerFactionId, 'M1');
-      expect(deal.buyerFactionId, 'gpA');
-      expect(deal.commodityId, 'timber');
-      expect(deal.quantity, 10);
-      expect(deal.isFirstRightOfRefusalMatch, isTrue);
-      expect(deal.isFtpMatch, isFalse);
-
-      // Rival GP's bid carries forward intact (no offer remaining).
-      expect(result.unfilledBidsByFactionId['gpB'], [
-        matcherBid('timber', 10, priority: 1),
-      ]);
-      expect(result.unfilledOffersByFactionId, isEmpty);
-    });
-
-    test('FRR overrides FTP: owning GP bid fills purchased-tile offer before '
-        'an FTP-paired bid at the same priority', () {
-      const tileKey = 'oldWorld|M1|0|0';
-      final result = DealMatcher.matchDeals(
-        matcherInputs(
-          offersByFactionId: {
-            'M1': [matcherOffer('timber', 6, originTileKey: tileKey)],
-          },
-          bidsByFactionId: {
-            'gpA': [matcherBid('timber', 6, priority: 1)],
-            'gpFtp': [matcherBid('timber', 6, priority: 1)],
-          },
-          tradeCapacityByFactionId: {'gpA': 100, 'gpFtp': 100},
-          ftpPairKeys: {DealMatcher.pairKey('M1', 'gpFtp')},
-          purchasedTileIndex: frrMatcherTestIndex(),
-        ),
-      );
-
-      // Offer is consumed by FRR fill — FTP pair receives nothing.
-      expect(result.filledDeals.length, 1);
-      expect(result.filledDeals.single.buyerFactionId, 'gpA');
-      expect(result.filledDeals.single.isFirstRightOfRefusalMatch, isTrue);
-      expect(result.filledDeals.single.isFtpMatch, isFalse);
-
-      expect(result.unfilledBidsByFactionId['gpFtp'], [
-        matcherBid('timber', 6, priority: 1),
-      ]);
-    });
-
-    test('no FRR override when owning GP does not bid: purchased-tile offer '
-        'falls back to normal tier matching against other GPs', () {
-      const tileKey = 'oldWorld|M1|0|0';
-      final result = DealMatcher.matchDeals(
-        matcherInputs(
-          offersByFactionId: {
-            'M1': [matcherOffer('timber', 10, originTileKey: tileKey)],
-          },
-          bidsByFactionId: {
-            // Owning GP gpA submits NO bid — fallthrough to gpB.
-            'gpB': [matcherBid('timber', 10, priority: 1)],
-          },
-          tradeCapacityByFactionId: {'gpB': 100},
-          purchasedTileIndex: frrMatcherTestIndex(),
-        ),
-      );
-
-      expect(result.filledDeals.length, 1);
-      final deal = result.filledDeals.single;
-      expect(deal.buyerFactionId, 'gpB');
-      // FRR did not apply — the deal flows through standard tier matching.
-      expect(deal.isFirstRightOfRefusalMatch, isFalse);
-      expect(deal.isFtpMatch, isFalse);
-    });
-
+    // The three base AC #1 matcher scenarios (owning-GP priority override,
+    // FRR-overrides-FTP, and the owning-GP-does-not-bid fallback) are pinned
+    // 1:1 by the issue-AC audit file
+    // `economy/world_market/first_right_of_refusal_issue_acceptance_criteria_d5_test.dart`
+    // (group "AC #1"). This file keeps only the matcher behaviors that the
+    // d5 contract does not cover (partial fill, cargo caps, tile-key
+    // attribution edge cases, null index, multi-tile / multi-bid passes).
     test('partial FRR fill: residual offer quantity becomes available for '
         'other GPs at their normal priority tier', () {
       const tileKey = 'oldWorld|M1|0|0';

--- a/packages/colonizethis_economy/test/world_market_trade_order_validator_context_treasury_test.dart
+++ b/packages/colonizethis_economy/test/world_market_trade_order_validator_context_treasury_test.dart
@@ -24,15 +24,6 @@ void main() {
       expect(ctx.treasuryBudgetForBids, 175);
     });
 
-    test(
-      'negative treasury clamps the context budget at 0 (defensive guard)',
-      () {
-        final game = buildTreasuryBidBudgetGame(treasury: -25);
-        final ctx = tradeOrderValidationContextFromGame(game, humanPlayerId);
-        expect(ctx.treasuryBudgetForBids, 0);
-      },
-    );
-
     test('negative treasury context rejects any priced bid end-to-end '
         '(SPEC/game/world-market.md — cross-commodity bid treasury cap, '
         'clamped negative treasury AC)', () {
@@ -94,16 +85,6 @@ void main() {
       final ctx = tradeOrderValidationContextFromGame(game, 'gp_ghost');
       expect(ctx.treasuryBudgetForBids, 0);
     });
-
-    test(
-      'deterministic for identical inputs (two calls return identical budgets)',
-      () {
-        final game = buildTreasuryBidBudgetGame(treasury: 123);
-        final ctxA = tradeOrderValidationContextFromGame(game, humanPlayerId);
-        final ctxB = tradeOrderValidationContextFromGame(game, humanPlayerId);
-        expect(ctxA.treasuryBudgetForBids, ctxB.treasuryBudgetForBids);
-      },
-    );
 
     test('caller-supplied projectedTreasuryDelta reduces the budget by the '
         'projected non-bid deficit (Refs #3290 economy->orders inversion)', () {

--- a/packages/colonizethis_economy/test/world_market_trade_order_validator_treasury_test.dart
+++ b/packages/colonizethis_economy/test/world_market_trade_order_validator_treasury_test.dart
@@ -253,41 +253,6 @@ void main() {
       expect(results.single.isAccepted, isTrue);
     });
 
-    test('identical inputs produce identical result lists across two '
-        'validate() calls (Refs #3123 AC: validator determinism)', () {
-      // SPEC/program/world-market-resolution.md § Validation —
-      // determinism: pure validator with no I/O / time / random
-      // dependencies must return byte-identical results for byte-identical
-      // inputs. Pin both an accepted and a rejected order so the
-      // determinism contract covers both result branches.
-      final context = validatorCtx(
-        treasuryBudgetForBids: 100,
-        tradeCargoCapacity: 100,
-        worldMarketState: WorldMarketState(
-          prices: {
-            CommodityCatalog.timber.id: 30,
-            CommodityCatalog.iron.id: 10,
-          },
-        ),
-      );
-      final orders = [
-        validatorBid(CommodityCatalog.timber.id, 4), // 120 — rejected
-        validatorBid(CommodityCatalog.iron.id, 1), // 10 — admitted (greedy)
-      ];
-      final first = TradeOrderValidator.validate(
-        context: context,
-        proposedOrders: orders,
-      );
-      final second = TradeOrderValidator.validate(
-        context: context,
-        proposedOrders: orders,
-      );
-      expect(second, hasLength(first.length));
-      for (var i = 0; i < first.length; i++) {
-        expect(second[i].isAccepted, first[i].isAccepted);
-        expect(second[i].reason, first[i].reason);
-      }
-    });
   });
 
   group('effectiveMarketPriceForCommodityId — catalog default coverage '


### PR DESCRIPTION
## Summary

First slice of the `packages/colonizethis_economy` test dedup tracked by #3661. Removes six **genuinely redundant** tests whose production code paths remain fully covered by retained tests, with **no loss of SPEC/issue acceptance-criteria pins**.

Refs #3661

## Done in this push

| File | Removed | Why it is safe |
|------|---------|----------------|
| `world_market_trade_order_validator_context_treasury_test.dart` | "deterministic for identical inputs (two calls…)" twin-call test; standalone "negative treasury clamps the context budget at 0 (defensive guard)" test | The builder is exercised by ~8 other tests in the file; the clamp branch is still asserted by the retained end-to-end negative-treasury rejection test (`ctx.treasuryBudgetForBids == 0`). |
| `world_market_trade_order_validator_treasury_test.dart` | "identical inputs produce identical result lists across two validate() calls" twin-call determinism test | The retained greedy-continuation test pins the identical timber×4 (reject) + iron×1 (greedy admit) scenario; pure double-invocation adds no coverage. |
| `world_market_deal_matcher_first_right_test.dart` | The three base **AC #1** matcher scenarios (priority override, FRR-overrides-FTP, owning-GP-does-not-bid fallback) | Pinned 1:1 by the issue-AC audit file `first_right_of_refusal_issue_acceptance_criteria_d5_test.dart` (group "AC #1"); a pointer comment now documents the split. Unique matcher behaviors (partial fill, cargo caps, tile-key edge cases, null index, multi-tile/multi-bid) are kept. |

## Verification

- `dart test` in `packages/colonizethis_economy`: **459 → 453 tests, all passing**.
- `dart analyze` on the three touched files: **no issues**.
- Package line coverage: **92.35%** (well above the 80% gate).
- `first_right_of_refusal_issue_acceptance_criteria_d5_test.dart` AC groups untouched; no SPEC AC row loses its last pin.
- `repo.domain_package_test_file_size` (400-line cap) unaffected — changes are deletions only.

## Deferred (follow-up commits on this PR / issue)

These larger tranches from #3661 are intentionally **not** in this slice and are deferred so each step stays low-risk and individually reviewable:

- FRR credits/profit slice consolidation beyond AC #1.
- Cross-file consumption trim (`economy_consumption*` / `worker_economy`) keeping one `resolveConsumption` military smoke test.
- Bid-spend / carry-forward fixture hoisting into `colonizethis_economy_test_support`.
- Resource-extractor / non-GP shared `TileMapResult` builders.
- Narrowing/relocating the full `CommodityCatalog.all` default-price loop (keeps the invariant intact for now).
- The wall-clock CI gate + duplicate-description AST check.

As such, this PR does **not** yet claim the issue's headline ≥10% wall-clock / ≥35-removal acceptance criteria; it is a safe down-payment toward them.

Made with [Cursor](https://cursor.com)