### PR TITLE
refactor: app province scans use allProvinces / provincesForRegion (#3658)

### DIFF
--- a/app/lib/features/game/widgets/civilian_units_sort.dart
+++ b/app/lib/features/game/widgets/civilian_units_sort.dart
@@ -7,7 +7,7 @@
 import 'package:colonizethis_data/colonizethis_data.dart'
     show UnitRole, unitRoleForType;
 import 'package:colonizethis_logic/colonizethis_logic.dart'
-    show projectedCivilianTileKey;
+    show WorldStateProvinceLookup, projectedCivilianTileKey;
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 /// Builds prefixed province id (`regionId|provinceId`) → display name from
@@ -15,10 +15,7 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 /// civilian-units-panel rendering and by sort key resolution.
 Map<String, String> provinceNamesByPrefixedId(Game game) {
   final out = <String, String>{};
-  for (final p in game.worldState.oldWorld.provinces) {
-    out['${p.regionId}|${p.id}'] = p.displayName ?? p.id;
-  }
-  for (final p in game.worldState.newWorld.provinces) {
+  for (final p in game.worldState.allProvinces()) {
     out['${p.regionId}|${p.id}'] = p.displayName ?? p.id;
   }
   return out;

--- a/app/lib/providers/map_view_provider.dart
+++ b/app/lib/providers/map_view_provider.dart
@@ -109,15 +109,13 @@ final mapViewDataProvider = Provider<InitGameMapViewData?>((ref) {
         }
         final regionId = parsed.regionId;
         final localProvinceId = parsed.provinceLocalId;
-        final ownedByHuman =
-            (regionId == kRegionOldWorld
-                    ? game.worldState.oldWorld.provinces
-                    : game.worldState.newWorld.provinces)
-                .any(
-                  (province) =>
-                      province.id == '$regionId|$localProvinceId' &&
-                      province.ownerId == mapPlayer.id,
-                );
+        final ownedByHuman = game.worldState
+            .provincesForRegion(regionId)
+            .any(
+              (province) =>
+                  province.id == '$regionId|$localProvinceId' &&
+                  province.ownerId == mapPlayer.id,
+            );
         if (!ownedByHuman) {
           continue;
         }

--- a/app/test/features/game/widgets/civilian_units_sort_test.dart
+++ b/app/test/features/game/widgets/civilian_units_sort_test.dart
@@ -81,6 +81,27 @@ void main() {
       expect(names['newWorld|newWorld|p1'], 'Cibola');
       expect(names, hasLength(3));
     });
+
+    test('iterates old-world entries before new-world (allProvinces order)', () {
+      final game = _gameWith(
+        oldProvinces: const [
+          Province(id: 'oldWorld|p1', regionId: 'oldWorld'),
+        ],
+        newProvinces: const [
+          Province(id: 'newWorld|p1', regionId: 'newWorld'),
+        ],
+      );
+
+      final keys = provinceNamesByPrefixedId(game).keys.toList();
+
+      expect(keys, ['oldWorld|oldWorld|p1', 'newWorld|newWorld|p1']);
+    });
+
+    test('returns an empty index when neither region has provinces', () {
+      final names = provinceNamesByPrefixedId(_gameWith());
+
+      expect(names, isEmpty);
+    });
   });
 
   group('isCivilianUnit', () {


### PR DESCRIPTION
## Summary
Follow-up slice for #3658 (the two prior PRs #3665 and #3669 already merged). Migrates two remaining `app/lib` data-derivation dual-region province scans off direct `worldState.oldWorld/newWorld.provinces` field access onto the sanctioned `colonizethis_world` lookup contracts.

## Done in this push
- **`civilian_units_sort.dart`** `provinceNamesByPrefixedId`: collapse the separate old-world + new-world province loops into a single `world.allProvinces()` iteration. Old-world-first ordering is preserved (the contract yields `oldWorld` then `newWorld`). Brings `WorldStateProvinceLookup` into the existing `show` clause.
- **`map_view_provider.dart`** ownership probe: replace the `regionId == kRegionOldWorld ? oldWorld.provinces : newWorld.provinces` region selection with `world.provincesForRegion(regionId)`. Behavior-preserving — `regionId` is always a canonical id parsed from a tile key, and the prefixed-id `.any()` predicate is unchanged.

Both swaps are exactly behavior-preserving; no user-visible panel/map behavior or iteration-order change.

## Tests
- Extended `app/test/features/game/widgets/civilian_units_sort_test.dart` with positive old-world-first ordering and empty-index cases for `provinceNamesByPrefixedId`.
- `flutter test test/features/game/widgets/civilian_units_sort_test.dart` → 14/14 pass.
- `flutter test test/game_map_area_region_minimap_test.dart` (exercises `map_view_provider`) → pass.
- `flutter analyze` on changed files → no issues.

## Deferred for #3658 (follow-up)
- **Dual-key fallback sites** (`naval_tree_builder.dart`, `split_fleet_dialog.dart`, `transfer_to_home_fleet_dialog.dart`): their `{p.id, regionId|p.id}` maps are load-bearing (e.g. `fleet.inPortAtProvinceId` may be prefixed or bare). `allProvincesById` keys by `Province.id` only, so a clean swap would require a new logic/world contract — out of this issue's scope.
- **Combined-unit spreads in flame/debug-spawn layers** and the **AST gate for inline index rebuilds (AC #4 second half)**: the field-access offenders aren't fully cleared yet, so gating that pattern now would need a large allowlist; deferred until more sites migrate. The string-literal gate (AC #4 first half, `repo.app_region_string_literals`) is already in place.

## ACs covered now vs follow-up
- AC #3 (flat scans → cached/region-scoped helpers): advanced for the two clean province-scan sites; remaining dual-key/flame/debug sites deferred as above.
- AC #5 (existing app tests pass unchanged; no behavior change): met for this slice.
- AC #6 (`flutter analyze` clean): met for changed files.

Refs #3658

Made with [Cursor](https://cursor.com)