### PR TITLE
perf: migrate technology test family to lightweight fixtures (#3656)

### DIFF
--- a/app/test/tech_tree_widget_core_test.dart
+++ b/app/test/tech_tree_widget_core_test.dart
@@ -13,7 +13,8 @@ import 'package:colonizethis_app/widgets/ct_back_button.dart';
 import 'package:colonizethis_app/widgets/ct_dialog_shell.dart';
 import 'package:colonizethis_app/providers/app_event_bus_provider.dart';
 import 'package:colonizethis_app/providers/games_provider.dart';
-import 'package:colonizethis_app/widgets/debug_init_game.dart';
+
+import 'support/panel_test_fixtures.dart';
 
 void main() {
   suppressLogsForTests();
@@ -22,8 +23,7 @@ void main() {
   late Player player;
 
   setUpAll(() {
-    final result = getDebugInitGameResult();
-    game = result.game;
+    game = buildTechnologyPanelTestGame();
     player = game.players.isNotEmpty ? game.players.first : _dummyPlayer();
   });
 

--- a/app/test/tech_tree_widget_description_batches_test.dart
+++ b/app/test/tech_tree_widget_description_batches_test.dart
@@ -1,6 +1,5 @@
 // Tests for TechTreeWidget and TechnologyScreen. SPEC/ui/tech-tree-widget.md.
 
-import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
@@ -8,7 +7,8 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:colonizethis_app/features/game/widgets/tech_tree_widget.dart';
 import 'package:colonizethis_app/widgets/ct_dialog_shell.dart';
-import 'package:colonizethis_app/widgets/debug_init_game.dart';
+
+import 'support/panel_test_fixtures.dart';
 
 void main() {
   suppressLogsForTests();
@@ -17,8 +17,7 @@ void main() {
   late Player player;
 
   setUpAll(() {
-    final result = getDebugInitGameResult();
-    game = result.game;
+    game = buildTechnologyPanelTestGame();
     player = game.players.isNotEmpty ? game.players.first : _dummyPlayer();
   });
 

--- a/app/test/tech_tree_widget_palette_test.dart
+++ b/app/test/tech_tree_widget_palette_test.dart
@@ -15,7 +15,8 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:colonizethis_app/config/editorial_monocle_palette.dart';
 import 'package:colonizethis_app/features/game/widgets/tech_tree_widget.dart';
-import 'package:colonizethis_app/widgets/debug_init_game.dart';
+
+import 'support/panel_test_fixtures.dart';
 
 void main() {
   suppressLogsForTests();
@@ -24,8 +25,7 @@ void main() {
   late Player player;
 
   setUpAll(() {
-    final result = getDebugInitGameResult();
-    game = result.game;
+    game = buildTechnologyPanelTestGame();
     player = game.players.first;
   });
 

--- a/app/test/technology_slot_occupancy_goldens_test.dart
+++ b/app/test/technology_slot_occupancy_goldens_test.dart
@@ -27,7 +27,8 @@ import 'package:colonizethis_app/config/themes.dart';
 import 'package:colonizethis_app/features/game/widgets/technology_panel.dart';
 import 'package:colonizethis_app/l10n/l10n.dart';
 import 'package:colonizethis_app/widgets/ct_confirm_dialog.dart';
-import 'package:colonizethis_app/widgets/debug_init_game.dart';
+
+import 'support/panel_test_fixtures.dart';
 
 // Three prerequisite-free tier-1 techs occupy slots 0-2, mirroring the
 // `technologyPersistedSlotFixture` Widgetbook fixture so the golden matches the
@@ -98,8 +99,7 @@ void main() {
   late Player basePlayer;
 
   setUpAll(() {
-    final result = getDebugInitGameResult();
-    baseGame = result.game;
+    baseGame = buildTechnologyPanelTestGame();
     basePlayer = baseGame.players.first;
   });
 

--- a/app/test/technology_slots_panel_parity_goldens_test.dart
+++ b/app/test/technology_slots_panel_parity_goldens_test.dart
@@ -7,8 +7,9 @@
 // placeholder are pinned by `matchesGoldenFile` baselines.
 //
 // Rendered against `AppThemes.editorialMonocle` (the running-app dark theme) at
-// device pixel ratio 1.0 from the deterministic `getDebugInitGameResult()`
-// fixture, inside a keyed `RepaintBoundary` over a viewport-sized
+// device pixel ratio 1.0 from the deterministic lightweight
+// `buildTechnologyPanelTestGame()` fixture (Refs #3656), inside a keyed
+// `RepaintBoundary` over a viewport-sized
 // `SingleChildScrollView`, matching the committed golden harness pattern
 // (`new_game_leader_selection_dialog_golden_test.dart`). The structural /
 // behavioural contracts (heading widget type, compact controls, locked-slot
@@ -23,7 +24,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:colonizethis_app/config/themes.dart';
 import 'package:colonizethis_app/features/game/widgets/technology_panel.dart';
 import 'package:colonizethis_app/l10n/l10n.dart';
-import 'package:colonizethis_app/widgets/debug_init_game.dart';
+
+import 'support/panel_test_fixtures.dart';
 
 Future<void> _pumpPanel(
   WidgetTester tester, {
@@ -73,8 +75,7 @@ void main() {
   late Player player;
 
   setUpAll(() {
-    final result = getDebugInitGameResult();
-    game = result.game;
+    game = buildTechnologyPanelTestGame();
     player = game.players.first;
   });
 

--- a/app/test/widgetbook_technology_slots_variants_test.dart
+++ b/app/test/widgetbook_technology_slots_variants_test.dart
@@ -9,9 +9,9 @@
 //     Choose-tech list collapses to the muted empty-state line.
 //
 // The test pumps the same `(Player, Game)` fixtures the Widgetbook story
-// builders use (seeded directly here from public `getDebugInitGameResult`,
-// `techCatalog`, and `Player.copyWith` APIs so the story file does not need
-// to expose private helpers). Each variant must:
+// builders use (seeded here from the lightweight `buildTechnologyPanelTestGame`
+// fixture (Refs #3656), `techCatalog`, and `Player.copyWith` APIs so the story
+// file does not need to expose private helpers). Each variant must:
 //
 //   * render under `AppThemes.editorialMonocle`,
 //   * not throw during pump + settle,
@@ -22,7 +22,6 @@ import 'package:colonizethis_app/features/game/screens/technology_screen.dart';
 import 'package:colonizethis_app/features/game/widgets/technology_panel.dart';
 import 'package:colonizethis_app/providers/app_event_bus_provider.dart';
 import 'package:colonizethis_app/providers/games_provider.dart';
-import 'package:colonizethis_app/widgets/debug_init_game.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
@@ -31,6 +30,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'support/panel_test_fixtures.dart';
 import 'widget_test_pumps.dart';
 
 void main() {
@@ -41,8 +41,7 @@ void main() {
   late List<String> allTechIds;
 
   setUpAll(() {
-    final result = getDebugInitGameResult();
-    baseGame = result.game;
+    baseGame = buildTechnologyPanelTestGame();
     basePlayer = baseGame.players.first;
     allTechIds = techCatalog.keys.toList()..sort();
   });

--- a/tool/check_app_test_no_debug_init.dart
+++ b/tool/check_app_test_no_debug_init.dart
@@ -72,11 +72,6 @@ const Set<String> _kDebugInitAllowlist = <String>{
   'app/test/province_overlay_tile_section_remaining_live_data_dark_tokens_test.dart',
   'app/test/province_sea_zone_overlay_detail_paths_test.dart',
   'app/test/shell_game_screen_specs_test.dart',
-  'app/test/technology_slot_occupancy_goldens_test.dart',
-  'app/test/technology_slots_panel_parity_goldens_test.dart',
-  'app/test/tech_tree_widget_core_test.dart',
-  'app/test/tech_tree_widget_description_batches_test.dart',
-  'app/test/tech_tree_widget_palette_test.dart',
   'app/test/trade_screen_issue_acceptance_criteria_e8_test.dart',
   'app/test/trade_screen_scaffold_test.dart',
   'app/test/train_dialogs_goldens_test.dart',
@@ -84,7 +79,6 @@ const Set<String> _kDebugInitAllowlist = <String>{
   'app/test/unit_panels_goldens_test.dart',
   'app/test/unit_panels_widgetbook_dark_chrome_test.dart',
   'app/test/widgetbook_technology_screen_mobile_viewport_test.dart',
-  'app/test/widgetbook_technology_slots_variants_test.dart',
 };
 
 /// Symbol whose invocation is gated.


### PR DESCRIPTION
## Summary

Continues the app-test performance work for #3656 by migrating the **technology** test family off the ~7-11s `getDebugInitGameResult()` procedural map generator and onto the shared lightweight `buildTechnologyPanelTestGame()` fixture in `app/test/support/panel_test_fixtures.dart`. These suites only render `TechnologyScreen` / `TechTreeWidget` / `TechnologyPanel` from a `Game` + the human `Player` (tech state set via `copyWith`); they consume no generated map/topology data, so the hand-built fixture renders identically.

## Done in this push

Migrated (now build the game once per isolate with no map generation):

- `app/test/tech_tree_widget_core_test.dart`
- `app/test/tech_tree_widget_description_batches_test.dart`
- `app/test/tech_tree_widget_palette_test.dart`
- `app/test/widgetbook_technology_slots_variants_test.dart`
- `app/test/technology_slot_occupancy_goldens_test.dart` (golden — renders byte-identical)
- `app/test/technology_slots_panel_parity_goldens_test.dart` (golden — renders byte-identical)

Each is removed from the `tool/check_app_test_no_debug_init.dart` allowlist, so the gate keeps shrinking (its documented direction). Also dropped one pre-existing unused `colonizethis_data` import and refreshed two stale fixture-source doc comments.

## Deferred for #3656

- `widgetbook_technology_screen_mobile_viewport_test.dart` stays on the allowlist. Its rendered widget is the `lib/widgetbook` `_midGameTechnologyScreenStory` builder, whose child tree reads `currentGameProvider` for live data; substituting the lightweight game as the provider override shifts the 360 dp slot-card layout (RenderFlex overflow), so a clean migration needs a separate look. No behavior/assertion change here.
- Map-dependent suites and the overall ≥10% wall-time AC remain tracked by the issue.

## Tests

- `flutter test` for all six migrated files — **37 passing** (including both golden comparisons against the committed PNGs, unchanged).
- `dart run tool/check_app_test_no_debug_init.dart` → no disallowed usage.
- `dart test test/check_app_test_no_debug_init_test.dart` → green.
- `dart analyze` on all touched files → no issues.

Refs #3656

Made with [Cursor](https://cursor.com)