### PR TITLE
perf: migrate trade screen + naval part1 test families to lightweight fixtures (#3656)

### DIFF
--- a/app/test/naval_units_panel_test_part1_test.dart
+++ b/app/test/naval_units_panel_test_part1_test.dart
@@ -18,15 +18,14 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:colonizethis_app/features/game/widgets/move_fleet_dialog.dart';
 import 'package:colonizethis_app/features/game/widgets/naval_units_panel.dart';
 import 'package:colonizethis_app/features/game/widgets/chrome/ct_action_text_button.dart';
 import 'package:colonizethis_app/features/game/widgets/units/shared/units_entity_action_row.dart';
 import 'package:colonizethis_app/features/game/widgets/units/shared/units_panel_shell.dart';
 import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
 import 'package:colonizethis_app/widgets/ct_panel.dart';
-import 'package:colonizethis_app/widgets/ct_transfer_list.dart';
-import 'package:colonizethis_app/widgets/debug_init_game.dart';
+
+import 'support/panel_test_fixtures.dart';
 
 /// Mirrors shell handling of [NavalSplitFleetRequestedEvent] for widget tests.
 StreamSubscription<NavalSplitFleetRequestedEvent> wireNavalSplitForWidgetTest({
@@ -113,7 +112,21 @@ void main() {
       // still validate behavior where possible.
     }
 
-    game = getDebugInitGameResult().game;
+    // Refs #3656: lightweight hand-built fixture replaces the ~11s procedural
+    // map generation of getDebugInitGameResult(); this family asserts only on
+    // fleets/provinces/ports/sea-zone names, which the fixture provides.
+    //
+    // Like the original demo game, the human starts with a single Home Fleet so
+    // the panel renders exactly one fleet row by default (the global
+    // `find.byTooltip('Split')` assertions expect one). The tests that need a
+    // second non-home/sea/port fleet inject it themselves via `copyWith`.
+    final base = buildNavalPanelTestGame();
+    final homeFleet = base.worldState.fleets.firstWhere(
+      (f) => f.inPortAtProvinceId != null,
+    );
+    game = base.copyWith(
+      worldState: base.worldState.copyWith(fleets: [homeFleet]),
+    );
     humanPlayerIdWithFleets = game.players.isNotEmpty
         ? game.players.first.id
         : 'gp1';
@@ -1064,7 +1077,7 @@ void main() {
                       game: game,
                       humanPlayerId: humanId,
                       bus: bus,
-                      topology: getDebugInitGameResult().combinedTopology,
+                      topology: const MapTopology(),
                     ),
                   ),
                 ],

--- a/app/test/support/panel_test_fixtures.dart
+++ b/app/test/support/panel_test_fixtures.dart
@@ -206,7 +206,8 @@ Game buildTechnologyPanelTestGame() {
 }
 
 /// Lightweight game shaped for the `trade_screen_*` scaffold/viewport family
-/// (`trade_screen_scaffold_test`, `trade_screen_320dp_min_viewport_test`).
+/// (`trade_screen_scaffold_test`, `trade_screen_320dp_min_viewport_test`,
+/// `trade_screen_issue_acceptance_criteria_e8_test` route-host tests).
 ///
 /// `TradeScreen` (via `CtGameFeatureScreenShell`) reads only `game.players` for
 /// the supplied `player`, the static `CommodityCatalog` for the read-only

--- a/app/test/trade_screen_issue_acceptance_criteria_e8_test.dart
+++ b/app/test/trade_screen_issue_acceptance_criteria_e8_test.dart
@@ -68,7 +68,6 @@ import 'package:colonizethis_app/widgets/ct_back_button.dart';
 import 'package:colonizethis_app/widgets/ct_panel.dart';
 import 'package:colonizethis_app/widgets/ct_tab_strip.dart';
 import 'package:colonizethis_app/widgets/ct_top_bar.dart';
-import 'package:colonizethis_app/widgets/debug_init_game.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart'
     show homeFleetIdFor;
@@ -80,12 +79,13 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
 
+import 'support/panel_test_fixtures.dart';
 import 'widget_test_pumps.dart';
 
 // Player ids used by the isolated `_pumpTradeScreenStandalone` harness
 // (AC #2, #3, #4, #5, and observe-variant tests). The route-host
-// fixture (AC #1, #6) uses the human player baked into
-// `getDebugInitGameResult()`.
+// fixture (AC #1, #6) uses the human player from the shared lightweight
+// `buildTradePanelTestGame()` fixture (Refs #3656).
 const String _humanPlayerId = 'gp_h';
 const String _capProvinceId = 'oldWorld|cap1';
 
@@ -299,8 +299,11 @@ void main() {
   late Box<dynamic> gamesBox;
 
   setUpAll(() async {
-    final result = getDebugInitGameResult();
-    routeHostGame = result.game;
+    // Lightweight fixture (Refs #3656): the route-host + left-rail tests
+    // (AC #1, #6) only need a Game with a human player for navigation and the
+    // TradeScreen chrome — no generated map/topology data — so the ~7-11s
+    // procedural map generator is avoided.
+    routeHostGame = buildTradePanelTestGame();
     routeHostPlayer = routeHostGame.players.firstWhere(
       (p) => p.isHuman,
       orElse: () => routeHostGame.players.first,

--- a/app/test/trade_screen_scaffold_test.dart
+++ b/app/test/trade_screen_scaffold_test.dart
@@ -22,7 +22,6 @@ import 'package:colonizethis_app/providers/game_service_provider.dart';
 import 'package:colonizethis_app/widgets/ct_back_button.dart';
 import 'package:colonizethis_app/widgets/ct_tab_strip.dart';
 import 'package:colonizethis_app/widgets/ct_top_bar.dart';
-import 'package:colonizethis_app/widgets/debug_init_game.dart';
 import 'package:colonizethis_app/widgets/strict_asset_icon.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_save/colonizethis_save.dart';
@@ -32,6 +31,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
 
+import 'support/panel_test_fixtures.dart';
 import 'widget_test_pumps.dart';
 
 void main() {
@@ -42,8 +42,12 @@ void main() {
   late Box<dynamic> gamesBox;
 
   setUpAll(() async {
-    final result = getDebugInitGameResult();
-    game = result.game;
+    // Lightweight fixture (Refs #3656): the trade route host, left rail, and
+    // TradeScreen body read only `game.players` (for the supplied player), the
+    // static CommodityCatalog, and a default-empty WorldMarketState — no
+    // generated map/topology data — so the ~7-11s procedural map generator is
+    // avoided.
+    game = buildTradePanelTestGame();
     humanPlayer = game.players.firstWhere(
       (p) => p.isHuman,
       orElse: () => game.players.first,

--- a/tool/check_app_test_no_debug_init.dart
+++ b/tool/check_app_test_no_debug_init.dart
@@ -72,8 +72,6 @@ const Set<String> _kDebugInitAllowlist = <String>{
   'app/test/province_overlay_tile_section_remaining_live_data_dark_tokens_test.dart',
   'app/test/province_sea_zone_overlay_detail_paths_test.dart',
   'app/test/shell_game_screen_specs_test.dart',
-  'app/test/trade_screen_issue_acceptance_criteria_e8_test.dart',
-  'app/test/trade_screen_scaffold_test.dart',
   'app/test/train_dialogs_goldens_test.dart',
   'app/test/unit_panels_320dp_min_viewport_test.dart',
   'app/test/unit_panels_goldens_test.dart',

--- a/tool/check_app_test_no_debug_init.dart
+++ b/tool/check_app_test_no_debug_init.dart
@@ -55,7 +55,6 @@ const Set<String> _kDebugInitAllowlist = <String>{
   'app/test/grant_or_subsidy_listener_test.dart',
   'app/test/human_draft_projected_region_provider_test.dart',
   'app/test/naval_units_panel_mockup_fidelity_test.dart',
-  'app/test/naval_units_panel_test_part1_test.dart',
   'app/test/panels_320dp_min_viewport_test.dart',
   'app/test/pause_menu_side_menu_specs_test.dart',
   'app/test/player_turn_event_feed_narrow_inset_test.dart',


### PR DESCRIPTION
## Summary

Migrates the trade-screen widget-test family off the ~7-11s
`getDebugInitGameResult()` procedural map generator to the shared
`buildTradePanelTestGame()` lightweight fixture (Refs #3656). This is the next
slice of the app-test speedup work after the naval / military / civilian /
victory / technology families already merged.

## Done in this push

- `app/test/trade_screen_scaffold_test.dart` — route host, two-tab body, and
  `GameMapEmpireLeftRail` tests now build the lightweight game.
- `app/test/trade_screen_issue_acceptance_criteria_e8_test.dart` — route-host /
  left-rail tests (AC #1, #6) now use the fixture; the standalone harness tests
  (AC #2–#5) already used a hand-built `Game`.
- `tool/check_app_test_no_debug_init.dart` — removed both files from the
  allowlist so the gate keeps shrinking.
- `app/test/support/panel_test_fixtures.dart` — doc note that the E8 route-host
  tests now share `buildTradePanelTestGame()`.

## Why this is safe (no map data needed)

`TradeScreen`, the trade route host, and `GameMapEmpireLeftRail` read only
`game.players` (for the supplied player), the static `CommodityCatalog`, and a
default-empty `WorldMarketState`. The left rail's `getMapData(game.id)` lookup
falls back to an empty `MapTopology()` when no generated map is registered, so
the lightweight fixture renders identically. The sibling
`trade_screen_320dp_min_viewport_test.dart` already uses this fixture.

## ACs covered

- Migrated `trade_screen_*` files no longer call `getDebugInitGameResult()`; all
  assertions unchanged and passing.
- Gate (`check_app_test_no_debug_init`) allowlist shrinks by two; gate still
  green.

## Deferred (still on #3656)

- Map-dependent suites (`ct_region_map_*`, `game_map_area_state_logic_*`,
  province/sea-zone overlays, `production_commodity_breakdown_dialog_*` which
  read `InitGameResult.combinedTopology`/`tileMapByRegion`) need the committed
  seed-42 serialized fixture path — not addressed here.
- Remaining allowlisted panel/screen families (diplomacy, game_map_*, etc.).

## Tests run

- `flutter test test/trade_screen_scaffold_test.dart test/trade_screen_issue_acceptance_criteria_e8_test.dart` → 23 passing.
- `dart test test/check_app_test_no_debug_init_test.dart` → passing.
- `dart run tool/check_app_test_no_debug_init.dart` → no disallowed usage.
- `flutter analyze` on both files → no issues.

Refs #3656

Made with [Cursor](https://cursor.com)


---

## Update: naval units panel part1 slice (added in this push)

`naval_units_panel_test_part1_test.dart` was the last naval part still calling `getDebugInitGameResult()`. It now uses `buildNavalPanelTestGame()` (single Home Fleet by default so the global `find.byTooltip('Split')` assertions still expect one row; non-home/sea/port fleet tests inject their own fleets), and the cross-panel watcher test uses an empty `MapTopology()`. Removed the file from the `check_app_test_no_debug_init` allowlist (allowlist may only shrink) and dropped two pre-existing unused imports.

- Verified: `flutter test test/naval_units_panel_test_part1_test.dart` -> 21/21 pass; `flutter analyze` clean; `dart test test/check_app_test_no_debug_init_test.dart` + `dart run tool/check_app_test_no_debug_init.dart` green.
- This completes the naval `_part*` family migration (parts 2-5 were already migrated).
