### PR TITLE
perf: migrate game_map_players_bar standalone test to lightweight fixture (#3656)

### DIFF
--- a/app/test/game_map_players_bar_test.dart
+++ b/app/test/game_map_players_bar_test.dart
@@ -2,13 +2,14 @@ import 'package:colonizethis_app/config/editorial_monocle_palette.dart';
 import 'package:colonizethis_app/features/game/flame/game_screen_shared.dart'
     show kGameMapPlayerChipKeyPrefix, kGameMapPlayersBarKey;
 import 'package:colonizethis_app/features/game/widgets/game_map_players_bar.dart';
-import 'package:colonizethis_app/widgets/debug_init_game.dart';
 import 'package:colonizethis_map/colonizethis_map.dart'
     show factionOwnershipColorMapForOldWorld;
 import 'package:colonizethis_models/colonizethis_models.dart' as ct_models;
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+import 'support/panel_test_fixtures.dart';
 
 /// Tests for the in-game shell floating players bar.
 ///
@@ -25,28 +26,29 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   suppressLogsForTests();
 
-  /// Returns a debug game with a deterministic OW ownership distribution so
-  /// the score AC is testable without standing up the full setup pipeline.
+  /// Returns the lightweight players-bar fixture game with a deterministic OW
+  /// ownership distribution so the score AC is testable without standing up the
+  /// full setup pipeline (Refs #3656 — no `getDebugInitGameResult()`).
   ///
   /// First province → first GP. Second through fifth provinces → second GP.
   /// Remaining provinces remain unowned. Tribes (if any) remain untouched.
   ct_models.Game gameWithOwnership() {
-    final base = getDebugInitGameResult().game;
+    final base = buildPlayersBarTestGame();
     final greatPowers = GameMapPlayersBar.greatPowerRoster(base);
     expect(
       greatPowers.length,
       greaterThanOrEqualTo(2),
-      reason: 'Debug init game must seed at least two GPs for this test',
+      reason: 'Players-bar fixture must seed at least two GPs for this test',
     );
     final ow = base.worldState.oldWorld;
     final provinces = ow.provinces;
     expect(
       provinces.length,
       greaterThanOrEqualTo(6),
-      reason: 'Debug init game must seed at least six OW provinces',
+      reason: 'Players-bar fixture must seed at least six OW provinces',
     );
-    // Clear existing ownership first so the cached debug init game's seed
-    // distribution does not pollute the deterministic test counts below.
+    // Clear existing ownership first so the fixture's seed distribution does
+    // not pollute the deterministic test counts below.
     // `Province.copyWith` uses `??` semantics, so we reconstruct the province
     // explicitly (passing `ownerId: null`) to wipe the existing owner.
     ct_models.Province withoutOwner(ct_models.Province p) {
@@ -199,7 +201,7 @@ void main() {
   testWidgets('formats thousands separators in en_US (>= 1000 score)', (
     WidgetTester tester,
   ) async {
-    final base = getDebugInitGameResult().game;
+    final base = buildPlayersBarTestGame();
     final greatPowers = GameMapPlayersBar.greatPowerRoster(base);
     final ow = base.worldState.oldWorld;
     expect(ow.provinces.length, greaterThanOrEqualTo(1));
@@ -234,7 +236,7 @@ void main() {
   testWidgets('returns SizedBox.shrink() when the GP roster is empty', (
     WidgetTester tester,
   ) async {
-    final base = getDebugInitGameResult().game;
+    final base = buildPlayersBarTestGame();
     // Replace players with the existing tribe roster only (the widget's
     // filter must collapse to an empty chip column).
     final tribePlayers = base.tribes
@@ -256,7 +258,7 @@ void main() {
   });
 
   test('greatPowerRoster sorts by Player.id ascending and excludes tribes', () {
-    final game = getDebugInitGameResult().game;
+    final game = buildPlayersBarTestGame();
     final roster = GameMapPlayersBar.greatPowerRoster(game);
     final ids = roster.map((p) => p.id).toList();
     final sorted = List<String>.from(ids)..sort();
@@ -269,7 +271,7 @@ void main() {
 
   test('oldWorldProvinceCountFor returns ownership count for the given player',
       () {
-    final game = getDebugInitGameResult().game;
+    final game = buildPlayersBarTestGame();
     final greatPowers = GameMapPlayersBar.greatPowerRoster(game);
     final firstGpId = greatPowers.first.id;
     final ow = game.worldState.oldWorld;

--- a/app/test/support/panel_test_fixtures.dart
+++ b/app/test/support/panel_test_fixtures.dart
@@ -41,6 +41,7 @@ Game buildPanelTestGame({
   Map<String, Map<String, List<String>>> tileKeysByRegionAndProvince =
       const {},
   Map<String, String> seaZoneDisplayNameById = const {},
+  List<Tribe> tribes = const [],
   String id = 'panel-widget-test',
   TurnState turnState = const TurnState(
     phase: TurnPhase.orders,
@@ -66,6 +67,7 @@ Game buildPanelTestGame({
       seaZoneDisplayNameById: seaZoneDisplayNameById,
     ),
     players: players ?? [panelTestHumanPlayer()],
+    tribes: tribes,
   );
 }
 
@@ -178,6 +180,44 @@ Game buildVictoryPanelTestGame() {
       panelTestHumanPlayer(),
       Player(id: 'gp2', displayName: 'Rival Power', isHuman: false),
     ],
+  );
+}
+
+/// Lightweight game shaped for the `game_map_players_bar_test` standalone
+/// widget contract.
+///
+/// `GameMapPlayersBar` reads only `game.players` (via
+/// `GameMapPlayersBar.greatPowerRoster`, which excludes `game.tribes` ids and
+/// sorts by `Player.id`), `game.worldState.oldWorld.provinces[].ownerId` (the
+/// chip score), and `factionOwnershipColorMapForOldWorld(game)` (which colours
+/// every `game.players` id regardless of province ownership). None of that
+/// needs generated map/topology data.
+///
+/// The fixture provides:
+/// - **three** great powers (`gp1` human, `gp2`/`gp3` AI) so the id-sorted chip
+///   order and the "further GPs own 0 provinces" assertions are non-vacuous;
+/// - **six** unowned Old World provinces — the suite's `gameWithOwnership`
+///   helper clears ownership and reassigns province 0 → `gp1` and provinces
+///   1–4 → `gp2`, so it requires `provinces.length >= 6`;
+/// - one **tribe** (`t1`) so the tribe-exclusion and empty-roster assertions
+///   (which derive a tribe-only player list from `game.tribes`) stay meaningful.
+Game buildPlayersBarTestGame() {
+  return buildPanelTestGame(
+    id: 'players-bar-widget-test',
+    players: [
+      panelTestHumanPlayer(),
+      const Player(id: 'gp2', displayName: 'Rival Power', isHuman: false),
+      const Player(id: 'gp3', displayName: 'Third Power', isHuman: false),
+    ],
+    oldWorldProvinces: const [
+      Province(id: 'oldWorld|p0', regionId: 'oldWorld', displayName: 'Alpha'),
+      Province(id: 'oldWorld|p1', regionId: 'oldWorld', displayName: 'Beta'),
+      Province(id: 'oldWorld|p2', regionId: 'oldWorld', displayName: 'Gamma'),
+      Province(id: 'oldWorld|p3', regionId: 'oldWorld', displayName: 'Delta'),
+      Province(id: 'oldWorld|p4', regionId: 'oldWorld', displayName: 'Epsilon'),
+      Province(id: 'oldWorld|p5', regionId: 'oldWorld', displayName: 'Zeta'),
+    ],
+    tribes: const [Tribe(id: 't1', displayName: 'Tribe One')],
   );
 }
 

--- a/tool/check_app_test_no_debug_init.dart
+++ b/tool/check_app_test_no_debug_init.dart
@@ -42,7 +42,6 @@ const Set<String> _kDebugInitAllowlist = <String>{
   'app/test/game_map_empire_left_rail_narrow_test.dart',
   'app/test/game_map_empire_left_rail_test.dart',
   'app/test/game_map_players_bar_narrow_test.dart',
-  'app/test/game_map_players_bar_test.dart',
   'app/test/game_map_selection_prompt_dark_tokens_test.dart',
   'app/test/game_screen_320dp_min_viewport_test.dart',
   'app/test/game_screen_branches_test.dart',


### PR DESCRIPTION
## Summary

Next slice of the app test-speedup work tracked by #3656, after the trade /
naval / technology / victory / military / civilian families already merged
(#3672, #3671, #3667, #3662, #3660, #3659). **Test-only** change — no
production `lib/` behaviour is touched.

Migrates `app/test/game_map_players_bar_test.dart` off the ~7-11s
`getDebugInitGameResult()` procedural map generator to a new lightweight
`buildPlayersBarTestGame()` fixture.

## Done in this push

- **`app/test/support/panel_test_fixtures.dart`**: added a `tribes` parameter to
  `buildPanelTestGame` and a `buildPlayersBarTestGame()` builder (three GPs, six
  unowned Old World provinces, one tribe).
- **`app/test/game_map_players_bar_test.dart`**: all five
  `getDebugInitGameResult().game` call sites now build the lightweight fixture;
  every assertion is unchanged.
- **`tool/check_app_test_no_debug_init.dart`**: removed the migrated file from
  the allowlist (allowlist may only shrink).

## Why this is safe (no map data needed)

The standalone `GameMapPlayersBar` widget contract reads only `game.players`
(via `greatPowerRoster`, which excludes `game.tribes` and sorts by `Player.id`),
`game.worldState.oldWorld.provinces[].ownerId` (the chip score), and
`factionOwnershipColorMapForOldWorld(game)` — which colours **every**
`game.players` id regardless of province ownership. None of that needs
generated map/topology data. The suite's `gameWithOwnership` helper still
clears and reassigns ownership over the fixture's six provinces, so the score
and ordering ACs hold. Including one tribe keeps the tribe-exclusion and
empty-roster assertions non-vacuous.

The narrow-viewport companion (`game_map_players_bar_narrow_test.dart`) builds
the full `GameScreen` and feeds `debugResult.mapViewData` into
`mapViewDataProvider`, so it genuinely needs the generated map and **stays** on
the allowlist.

## Tests run

- `flutter test test/game_map_players_bar_test.dart` -> 8/8 pass (~1s test time
  vs the prior per-file ~7-11s map generation).
- `dart test test/check_app_test_no_debug_init_test.dart` -> 4/4 pass.
- `dart run tool/check_app_test_no_debug_init.dart` -> no disallowed usage.
- `flutter analyze` on the touched test/fixture files -> no issues.

## Deferred (still on #3656)

- Map-dependent suites (`ct_region_map_*`, `game_map_area_state_logic_*`,
  province/sea-zone overlays, full-`GameScreen` shells) that read
  `InitGameResult.mapViewData`/`tileMapByRegion` — still need the committed
  seed-42 serialized fixture path.
- Remaining allowlisted panel/screen families (diplomacy, other `game_map_*`).

Refs #3656

Made with [Cursor](https://cursor.com)