### PR TITLE
perf: migrate side/pause-menu test family to lightweight fixture (#3656)

### DIFF
--- a/app/test/game_side_menu_320dp_min_viewport_test.dart
+++ b/app/test/game_side_menu_320dp_min_viewport_test.dart
@@ -69,7 +69,6 @@ import 'package:colonizethis_app/providers/game_service_provider.dart';
 import 'package:colonizethis_app/providers/games_box_provider.dart';
 import 'package:colonizethis_app/providers/games_provider.dart';
 import 'package:colonizethis_app/widgets/ct_panel.dart';
-import 'package:colonizethis_app/widgets/debug_init_game.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_save/colonizethis_save.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
@@ -77,6 +76,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
+
+import 'support/panel_test_fixtures.dart';
 
 /// Minimum supported viewport dimensions for `SPEC/ui/mobile-adaptation.md`
 /// § 7. Width matches [kMinViewportWidth]; height (640 dp) mirrors the
@@ -157,8 +158,9 @@ void main() {
   late Box<dynamic> gamesBox;
 
   setUpAll(() async {
-    final result = getDebugInitGameResult();
-    game = result.game;
+    // Refs #3656: lightweight fixture (no procedural map generation); the
+    // drawer only reads the active Game for `currentGameProvider`.
+    game = buildSideMenuTestGame();
 
     Hive.init('./.dart_tool/test_hive_side_menu_320dp');
     gamesBox = await Hive.openBox<dynamic>(HiveBoxNames.games);

--- a/app/test/game_side_menu_test.dart
+++ b/app/test/game_side_menu_test.dart
@@ -11,7 +11,6 @@ import 'package:colonizethis_app/providers/game_service_provider.dart';
 import 'package:colonizethis_app/providers/games_box_provider.dart';
 import 'package:colonizethis_app/providers/games_provider.dart';
 import 'package:colonizethis_app/config/themes.dart';
-import 'package:colonizethis_app/widgets/debug_init_game.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_save/colonizethis_save.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
@@ -20,6 +19,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
 
+import 'support/panel_test_fixtures.dart';
+
 void main() {
   suppressLogsForTests();
 
@@ -27,8 +28,10 @@ void main() {
   late Box<dynamic> gamesBox;
 
   setUpAll(() async {
-    final result = getDebugInitGameResult();
-    game = result.game;
+    // Refs #3656: the side menu only reads the active Game (and its
+    // `infiniteMode` flag) — no generated map/topology data — so the
+    // lightweight fixture replaces the ~11s procedural map generation.
+    game = buildSideMenuTestGame();
 
     Hive.init('./.dart_tool/test_hive_side_menu');
     gamesBox = await Hive.openBox<dynamic>(HiveBoxNames.games);

--- a/app/test/pause_menu_side_menu_specs_test.dart
+++ b/app/test/pause_menu_side_menu_specs_test.dart
@@ -14,7 +14,6 @@ import 'package:colonizethis_app/providers/game_service_provider.dart';
 import 'package:colonizethis_app/providers/games_box_provider.dart';
 import 'package:colonizethis_app/providers/games_provider.dart';
 import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
-import 'package:colonizethis_app/widgets/debug_init_game.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_save/colonizethis_save.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
@@ -22,6 +21,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
+
+import 'support/panel_test_fixtures.dart';
 
 void main() {
   suppressLogsForTests();
@@ -172,8 +173,9 @@ void main() {
     late Box<dynamic> gamesBox;
 
     setUpAll(() async {
-      final result = getDebugInitGameResult();
-      game = result.game;
+      // Refs #3656: lightweight fixture replaces the ~11s procedural map
+      // generation; the side menu only reads the active Game.
+      game = buildSideMenuTestGame();
       Hive.init('./.dart_tool/test_hive_game_side_menu_specs');
       gamesBox = await Hive.openBox<dynamic>(HiveBoxNames.games);
     });

--- a/app/test/support/panel_test_fixtures.dart
+++ b/app/test/support/panel_test_fixtures.dart
@@ -221,6 +221,26 @@ Game buildPlayersBarTestGame() {
   );
 }
 
+/// Lightweight game shaped for the in-game side/pause-menu chrome family
+/// (`game_side_menu_test`, `game_side_menu_320dp_min_viewport_test`,
+/// `pause_menu_side_menu_specs_test`).
+///
+/// `GameSideMenu` reads only the active `Game` from `currentGameProvider` and,
+/// for the read-only Game Parameters dialog, `game.infiniteMode`
+/// (`GameParametersDialog` takes just that bool). The pause menu reads no game
+/// state at all. None of these surfaces touch generated map/topology data, so a
+/// single-human default game is the full shape they need.
+///
+/// Suites that assert the "Infinite mode: On" line apply
+/// `game.copyWith(infiniteMode: true)` themselves; the base fixture leaves
+/// `infiniteMode` at its default (`false`).
+Game buildSideMenuTestGame() {
+  return buildPanelTestGame(
+    id: 'side-menu-widget-test',
+    players: [panelTestHumanPlayer()],
+  );
+}
+
 /// Lightweight game shaped for the `technology_panel_*` family
 /// (`technology_panel_test`, `technology_panel_dark_chrome_test`,
 /// `technology_panel_funding_toggles_test`,

--- a/app/test/support/panel_test_fixtures_test.dart
+++ b/app/test/support/panel_test_fixtures_test.dart
@@ -150,6 +150,21 @@ void main() {
     });
   });
 
+  group('buildSideMenuTestGame', () {
+    test('exposes a single human player and defaults infiniteMode to false', () {
+      final game = buildSideMenuTestGame();
+      expect(game.players, hasLength(1));
+      expect(game.players.first.id, kPanelTestHumanPlayerId);
+      expect(game.players.first.isHuman, isTrue);
+      // The Game Parameters dialog reads `infiniteMode`; suites opt into the
+      // "Infinite mode: On" line via copyWith, so the base must be false.
+      expect(game.infiniteMode, isFalse);
+      // No generated map/topology data is consumed by the menu chrome.
+      expect(game.worldState.oldWorld.units, isEmpty);
+      expect(game.worldState.newWorld.units, isEmpty);
+    });
+  });
+
   group('buildNavalPanelTestGame', () {
     test('human owns a home fleet and a non-home fleet, both with ships', () {
       final game = buildNavalPanelTestGame();


### PR DESCRIPTION
## Summary

Continues the app test-perf migration in #3656 (prior merged slices: #3672 trade/naval, #3673 players bar) by removing `getDebugInitGameResult()` from the in-game **side-menu / pause-menu** test family. Each of these suites paid ~7–11s of procedural map generation once per test isolate purely to obtain a `Game` for `currentGameProvider` — but none of these surfaces consume generated map/topology data.

## Done in this push

- **`app/test/support/panel_test_fixtures.dart`** — add documented `buildSideMenuTestGame()` (single human player; default `infiniteMode`). `GameSideMenu` reads only the active Game, the read-only Game Parameters dialog reads just `game.infiniteMode` (`GameParametersDialog` takes that bool), and the pause menu reads no game state.
- **`app/test/support/panel_test_fixtures_test.dart`** — focused test for the new builder (single human, `infiniteMode == false`, empty regions).
- Migrated off `getDebugInitGameResult()` (assertions unchanged):
  - `app/test/game_side_menu_test.dart`
  - `app/test/game_side_menu_320dp_min_viewport_test.dart`
  - `app/test/pause_menu_side_menu_specs_test.dart`

## Measured wall-time (AC: ≥10% per migrated set)

Warm compile cache, three migrated files:

| | wall (`/usr/bin/time -p real`) |
|---|---|
| before (`getDebugInitGameResult`, `origin/dev`) | ~38.1 s |
| after (`buildSideMenuTestGame`) | ~19.1 s |

≈50% reduction (~19 s saved) for this set — well above the 10% target.

## Verification

- `flutter test` on the 3 migrated files + the fixtures test → **41/41 pass**.
- `flutter analyze` on all 5 touched files → **No issues found**.

## Scope / deferred (remaining for #3656)

- This is one isolatable slice. Still outstanding on the issue: migrating the remaining game-only families (diplomacy screen, empire left rail, etc.), the **serialized seed-42 fixture** + round-trip test for genuinely map-dependent suites (`ct_region_map_*`, `game_map_area_*`, production breakdown dialogs), and the `repo.app_test_no_debug_init` CI checker trio (deferred until the allowlist can stay small).

SPEC: none required (test-infra change; behavior unchanged).

Refs #3656

Made with [Cursor](https://cursor.com)