### PR TITLE
perf: migrate unit-panel chrome test family to lightweight fixtures (#3656)

### DIFF
--- a/app/test/naval_units_panel_mockup_fidelity_test.dart
+++ b/app/test/naval_units_panel_mockup_fidelity_test.dart
@@ -18,7 +18,6 @@ import 'package:colonizethis_app/features/game/widgets/chrome/ct_circular_locate
 import 'package:colonizethis_app/features/game/widgets/units/shared/units_entity_action_row.dart';
 import 'package:colonizethis_app/features/game/widgets/units/shared/units_entity_card.dart';
 import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
-import 'package:colonizethis_app/widgets/debug_init_game.dart';
 
 const _humanId = 'gp_naval_fidelity';
 const _capitalLocalId = 'cap1';
@@ -134,9 +133,10 @@ void main() {
 
   late Game game;
   setUpAll(() {
-    // Warm `getDebugInitGameResult` so any internal asset/data lookups are
-    // ready, then build the deterministic fidelity scenario.
-    getDebugInitGameResult();
+    // Build the deterministic fidelity scenario directly. Refs #3656: the panel
+    // renders entirely from this hand-built fixture, so the prior ~11s
+    // `getDebugInitGameResult()` warm call (which generated a full map this
+    // suite never reads) is removed.
     game = _buildFidelityGame();
   });
 

--- a/app/test/support/panel_test_fixtures.dart
+++ b/app/test/support/panel_test_fixtures.dart
@@ -689,3 +689,18 @@ Game buildTrainPanelTestGame() {
     ],
   );
 }
+
+/// Lightweight game shaped for the in-game unit-panel chrome family
+/// (`unit_panels_320dp_min_viewport_test`,
+/// `unit_panels_widgetbook_dark_chrome_test`).
+///
+/// These suites mount the Civilian / Military / Naval `UnitsPanelShell` (and the
+/// Widgetbook Train dialogs) together and assert **chrome only** — the panel
+/// title text, the absence of banned Material chrome, no `RenderFlex` overflow,
+/// and the editorial-monocle dark theme — never reading generated
+/// map/topology data. The combined train fixture already carries a single human
+/// (with a capital, all train tech, and treasury/stockpile) plus civilians, an
+/// army with regiments, and home/non-home fleets across both regions, so it is
+/// exactly the multi-family shape these panels render. A `const MapTopology()`
+/// replaces the debug-init `combinedTopology` the assertions never inspect.
+Game buildUnitPanelsTestGame() => buildTrainPanelTestGame();

--- a/app/test/unit_panels_320dp_min_viewport_test.dart
+++ b/app/test/unit_panels_320dp_min_viewport_test.dart
@@ -58,7 +58,8 @@ import 'package:colonizethis_app/config/themes.dart';
 import 'package:colonizethis_app/features/game/widgets/civilian_units_panel.dart';
 import 'package:colonizethis_app/features/game/widgets/military_units_panel.dart';
 import 'package:colonizethis_app/features/game/widgets/naval_units_panel.dart';
-import 'package:colonizethis_app/widgets/debug_init_game.dart';
+
+import 'support/panel_test_fixtures.dart';
 
 /// Minimum supported viewport dimensions for SPEC/ui/mobile-adaptation.md
 /// § 7. Width matches [kMinViewportWidth]; height (640 dp) mirrors the
@@ -172,14 +173,17 @@ void main() {
 
   setUpAll(() async {
     await _preWarmFlameImageCache();
-    final result = getDebugInitGameResult();
-    game = result.game;
-    topology = result.combinedTopology;
+    // Refs #3656: a shared lightweight fixture (civilians + army/regiments +
+    // home/non-home fleets in both regions) replaces the ~11s
+    // `getDebugInitGameResult()` map generation. These pins assert chrome only
+    // (no overflow + title text), so an empty `MapTopology` is sufficient.
+    game = buildUnitPanelsTestGame();
+    topology = const MapTopology();
     expect(
       game.players,
       isNotEmpty,
       reason:
-          'Debug init game must seed at least one player so the panels '
+          'Fixture must seed at least one player so the panels '
           'render a meaningful unit list at 320 dp.',
     );
     humanPlayerId = game.players.first.id;

--- a/app/test/unit_panels_widgetbook_dark_chrome_test.dart
+++ b/app/test/unit_panels_widgetbook_dark_chrome_test.dart
@@ -18,13 +18,15 @@ import 'package:colonizethis_app/features/game/widgets/naval_units_panel.dart';
 import 'package:colonizethis_app/features/game/widgets/train_civilians_dialog.dart';
 import 'package:colonizethis_app/features/game/widgets/train_military_dialog.dart';
 import 'package:colonizethis_app/config/themes.dart';
-import 'package:colonizethis_app/widgets/debug_init_game.dart';
+import 'package:colonizethis_data/colonizethis_data.dart' show MapTopology;
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+import 'support/panel_test_fixtures.dart';
 
 int _argb(Color c) {
   final int a = (c.a * 255.0).round() & 0xFF;
@@ -75,16 +77,17 @@ Widget _editorialMonocleHost({required Widget child}) {
 void main() {
   suppressLogsForTests();
 
-  late InitGameResult debugInit;
   late Game game;
   late String humanPlayerId;
 
   setUpAll(() {
-    debugInit = getDebugInitGameResult();
-    game = debugInit.game;
-    humanPlayerId = game.players.isNotEmpty
-        ? game.players.firstWhere((p) => p.isHuman).id
-        : game.players.first.id;
+    // Refs #3656: a shared lightweight fixture (civilians + army/regiments +
+    // home/non-home fleets, with capital + train tech) replaces the ~11s
+    // `getDebugInitGameResult()` map generation. These stories assert chrome
+    // only (no exception, no Material chrome, editorial-monocle theme) and never
+    // read generated map/topology data.
+    game = buildUnitPanelsTestGame();
+    humanPlayerId = game.players.firstWhere((p) => p.isHuman).id;
   });
 
   group('Widgetbook unit panel / train dialog dark chrome (#2866 S6)', () {
@@ -123,7 +126,7 @@ void main() {
               game: game,
               humanPlayerId: humanPlayerId,
               bus: AppEventBus.create(),
-              topology: debugInit.combinedTopology,
+              topology: const MapTopology(),
               draftOrders: const Orders(),
             ),
           ),
@@ -147,7 +150,7 @@ void main() {
               game: game,
               humanPlayerId: humanPlayerId,
               bus: AppEventBus.create(),
-              topology: debugInit.combinedTopology,
+              topology: const MapTopology(),
             ),
           ),
         ),

--- a/tool/check_app_test_no_debug_init.dart
+++ b/tool/check_app_test_no_debug_init.dart
@@ -45,7 +45,6 @@ const Set<String> _kDebugInitAllowlist = <String>{
   'app/test/game_side_menu_test.dart',
   'app/test/grant_or_subsidy_listener_test.dart',
   'app/test/human_draft_projected_region_provider_test.dart',
-  'app/test/naval_units_panel_mockup_fidelity_test.dart',
   'app/test/panels_320dp_min_viewport_test.dart',
   'app/test/pause_menu_side_menu_specs_test.dart',
   'app/test/player_turn_event_feed_narrow_inset_test.dart',
@@ -63,9 +62,7 @@ const Set<String> _kDebugInitAllowlist = <String>{
   'app/test/province_sea_zone_overlay_detail_paths_test.dart',
   'app/test/shell_game_screen_specs_test.dart',
   'app/test/train_dialogs_goldens_test.dart',
-  'app/test/unit_panels_320dp_min_viewport_test.dart',
   'app/test/unit_panels_goldens_test.dart',
-  'app/test/unit_panels_widgetbook_dark_chrome_test.dart',
   'app/test/widgetbook_technology_screen_mobile_viewport_test.dart',
 };
 


### PR DESCRIPTION
## Summary

Continues the #3656 app-test speedup by removing the ~11s
`getDebugInitGameResult()` procedural map generation from the in-game
**unit-panel chrome** test family. Because `flutter test` isolates each file,
each of these files paid the full map-generation cost once; none of them read
generated map/topology data.

`Refs #3656`

## Done in this push

- **`app/test/support/panel_test_fixtures.dart`** — add `buildUnitPanelsTestGame()`,
  a clearly-named combined fixture (civilians + army/regiments + home/non-home
  fleets across both regions, with a capital + train tech) reusing the existing
  lightweight train shape. No map generation.
- **`naval_units_panel_mockup_fidelity_test.dart`** — drop the unused
  `getDebugInitGameResult()` warm call and import; the suite already renders
  entirely from its own hand-built `_buildFidelityGame()` fixture.
- **`unit_panels_320dp_min_viewport_test.dart`** — build from
  `buildUnitPanelsTestGame()` + `const MapTopology()`. Pins assert no `RenderFlex`
  overflow + panel title text only.
- **`unit_panels_widgetbook_dark_chrome_test.dart`** — build from
  `buildUnitPanelsTestGame()` + `const MapTopology()`. Stories assert no
  exception, no banned Material chrome, and the editorial-monocle dark theme.
- **`tool/check_app_test_no_debug_init.dart`** — remove the three migrated files
  from the allowlist (the allowlist only ever shrinks per #3656).

## Done in follow-up commit (production screen + allowlist hygiene)

- **`production_screen_320dp_min_viewport_test.dart`** — migrate off
  `getDebugInitGameResult()` to the existing hand-built `production_panel_test_fixtures`
  (`productionPanelTestFullPlayer()` / `productionPanelTestGameFor(...)`).
  `ProductionScreen` takes its `game`/`player` directly and is pumped with
  `panelTopologyOverride: const MapTopology()` + `panelTileMapByRegionOverride: null`,
  so it reads no generated map/topology data; the fixture renders the same
  default-path Available/Allocation body and global-observe sentinel the pin asserted.
  Removes one more ~11s full map generation. Verified: **4 tests pass in ~3s**
  (was ~11s+ in `setUpAll`).
- **`tool/check_app_test_no_debug_init.dart`** — remove
  `production_screen_320dp_min_viewport_test.dart` plus three **stale** entries
  (`game_side_menu_test`, `game_side_menu_320dp_min_viewport_test`,
  `pause_menu_side_menu_specs_test`) that already build from `buildSideMenuTestGame()`
  and no longer call the helper. Pruning stale entries keeps the gate honest so a
  future regression re-introducing the expensive call to those files is caught.

## ACs covered now vs follow-up

- Migrates additional highest-cost slices toward the **≥10% wall-time** AC (this PR
  now removes ~4× full map generations and prunes 3 stale gate entries); remaining
  allowlisted families (diplomacy panels with discovered factions, game-map/province
  overlays, game-screen shells, production-breakdown dialog with `tileMapByRegion`,
  goldens) genuinely need generated map/topology data and are follow-up work on #3656
  (lightweight or serialized fixtures).
- The CI gate (checker trio) already exists from prior #3656 work; this PR keeps
  it green with a smaller allowlist.

## Test plan

- [x] `flutter test` on the migrated unit-panel files — 22 tests pass; trio now runs
  in ~11s total vs ~33s+ before.
- [x] `flutter test test/production_screen_320dp_min_viewport_test.dart` — 4 tests
  pass in ~3s (was dominated by ~11s `getDebugInitGameResult()`).
- [x] `dart run tool/check_app_test_no_debug_init.dart` — no disallowed usage.
- [x] `dart test test/check_app_test_no_debug_init_test.dart` — wrapper test passes.
- [x] `dart analyze` on all touched files — no issues.

Made with [Cursor](https://cursor.com)
