### PR TITLE
perf: migrate 3 non-map app tests off getDebugInitGameResult (#3656)

### DIFF
--- a/app/test/ct_e2e_turn_snapshot_refresh_test.dart
+++ b/app/test/ct_e2e_turn_snapshot_refresh_test.dart
@@ -7,7 +7,6 @@ import 'package:colonizethis_app/features/game/flame/turn_resolution_result_appl
 import 'package:colonizethis_app/providers/game_service_provider.dart';
 import 'package:colonizethis_app/providers/games_box_provider.dart';
 import 'package:colonizethis_app/providers/games_provider.dart';
-import 'package:colonizethis_app/widgets/debug_init_game.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_save/colonizethis_save.dart';
@@ -15,6 +14,8 @@ import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
+
+import 'support/panel_test_fixtures.dart';
 
 void main() {
   suppressLogsForTests();
@@ -32,11 +33,13 @@ void main() {
 
   test('refreshCtE2eNavalPanelSnapshotAfterTurnIfEnabled is no-op when CT_E2E off', () {
     expect(kCtE2EEnabled, isFalse);
-    final init = getDebugInitGameResult();
+    // Lightweight fixture (Refs #3656): the refresh hook only reads the game
+    // for the CT_E2E-off no-op guard; no generated map/topology data is needed.
+    final game = buildPanelTestGame();
     final service = GameService(gamesBox, GameSaveAdapter());
 
     refreshCtE2eNavalPanelSnapshotAfterTurnIfEnabled(
-      game: init.game,
+      game: game,
       draftOrders: const Orders(),
       gameService: service,
     );
@@ -57,14 +60,17 @@ void main() {
 
   test('TurnResolutionResultApplier invokes snapshot refresh hook when CT_E2E off', () {
     expect(kCtE2EEnabled, isFalse);
-    final init = getDebugInitGameResult();
+    // Lightweight fixture (Refs #3656): the applier only needs a Game with a
+    // stable id to confirm the snapshot hook stays a no-op and the current game
+    // is preserved; no generated map/topology data is read.
+    final game = buildPanelTestGame();
     final container = ProviderContainer(
       overrides: [
         gamesBoxProvider.overrideWith((ref) => gamesBox),
         gameServiceProvider.overrideWith(
           (ref) => GameService(gamesBox, GameSaveAdapter()),
         ),
-        currentGameProvider.overrideWith(() => CurrentGameNotifier(init.game)),
+        currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
         currentOrdersProvider.overrideWith(
           () => CurrentOrdersNotifier(const Orders()),
         ),
@@ -73,9 +79,9 @@ void main() {
     addTearDown(container.dispose);
 
     container.read(turnResolutionResultApplierProvider).apply(
-          TurnResolutionComplete(init.game),
+          TurnResolutionComplete(game),
         );
     expect(ctE2eNavalPanelSnapshot, isNull);
-    expect(container.read(currentGameProvider)?.id, init.game.id);
+    expect(container.read(currentGameProvider)?.id, game.id);
   });
 }

--- a/app/test/ct_game_feature_screen_shell_test.dart
+++ b/app/test/ct_game_feature_screen_shell_test.dart
@@ -6,7 +6,6 @@ import 'package:colonizethis_app/providers/app_event_bus_provider.dart';
 import 'package:colonizethis_app/providers/games_provider.dart';
 import 'package:colonizethis_app/widgets/ct_game_feature_screen_shell.dart';
 import 'package:colonizethis_app/widgets/game_to_ui_bus_listener.dart';
-import 'package:colonizethis_app/widgets/debug_init_game.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flame/flame.dart';
@@ -14,6 +13,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+import 'support/panel_test_fixtures.dart';
 
 void main() {
   suppressLogsForTests();
@@ -25,7 +26,10 @@ void main() {
   setUpAll(() async {
     await _mockNinePatchAssetBundle();
     await _preWarmPanelNinePatch();
-    final base = getDebugInitGameResult().game;
+    // Lightweight fixture (Refs #3656): the shell only reads `game.id` (for the
+    // current-vs-route id match) and `players.first.displayName` (rendered by
+    // the test body builder); no generated map/topology data is needed.
+    final base = buildPanelTestGame();
     final first = base.players.first;
     routeGame = base.copyWith(
       players: [

--- a/app/test/panels_320dp_min_viewport_test.dart
+++ b/app/test/panels_320dp_min_viewport_test.dart
@@ -48,9 +48,9 @@ import 'package:colonizethis_app/features/game/widgets/province_overlay_demo_dat
         sampleTileKeyForProvinceOverlay;
 import 'package:colonizethis_app/features/game/widgets/province_sea_zone_detail_overlay.dart';
 import 'package:colonizethis_app/features/game/widgets/technology_panel.dart';
-import 'package:colonizethis_app/widgets/debug_init_game.dart';
 
 import 'production_panel_test_fixtures.dart';
+import 'support/panel_test_fixtures.dart';
 
 /// Minimum supported viewport dimensions for SPEC/ui/mobile-adaptation.md
 /// § 7. Width matches [kMinViewportWidth]; height (640 dp) mirrors the
@@ -249,12 +249,12 @@ void main() {
 
       setUpAll(() async {
         await _preWarmFlameImageCache();
-        final result = getDebugInitGameResult();
-        game = result.game;
-        topology = result.combinedTopology;
-        humanPlayerId = game.players.isNotEmpty
-            ? game.players.first.id
-            : 'gp1';
+        // Lightweight fixture (Refs #3656): a single discovered Great Power is
+        // enough to exercise the narrow faction-row body; no generated
+        // map/topology data is read, so an empty `MapTopology` suffices.
+        game = buildDiplomacyPanelTestGame();
+        topology = const MapTopology();
+        humanPlayerId = game.players.first.id;
         final rows = buildDiplomacyRows(
           game,
           topology,
@@ -265,8 +265,8 @@ void main() {
           rows,
           isNotEmpty,
           reason:
-              'Debug init game must seed at least one discovered faction so '
-              'a 320 dp render exercises the narrow faction-row body.',
+              'Lightweight diplomacy fixture must seed at least one discovered '
+              'faction so a 320 dp render exercises the narrow faction-row body.',
         );
         firstNonHumanFactionId = rows.first.factionId;
       });
@@ -347,9 +347,10 @@ void main() {
       late Player player;
 
       setUpAll(() {
-        final result = getDebugInitGameResult();
-        game = result.game;
-        expect(game.players, isNotEmpty);
+        // Lightweight fixture (Refs #3656): the Technology panel reads only
+        // `game.players`; the single human starts with the default research-slot
+        // count (3 active + 1 locked), matching the assertions below.
+        game = buildTechnologyPanelTestGame();
         player = game.players.first;
       });
 

--- a/tool/check_app_test_no_debug_init.dart
+++ b/tool/check_app_test_no_debug_init.dart
@@ -20,8 +20,6 @@ import 'package:path/path.dart' as p;
 /// still calls the helper. It must only ever **shrink** as families migrate to
 /// lightweight or serialized fixtures; new entries require justification.
 const Set<String> _kDebugInitAllowlist = <String>{
-  'app/test/ct_e2e_turn_snapshot_refresh_test.dart',
-  'app/test/ct_game_feature_screen_shell_test.dart',
   'app/test/ct_region_map_debug_init_test.dart',
   'app/test/ct_region_map_test_support.dart',
   'app/test/game_map_area_event_feed_test.dart',
@@ -37,7 +35,6 @@ const Set<String> _kDebugInitAllowlist = <String>{
   'app/test/game_screen_s13_mockup_fidelity_test.dart',
   'app/test/game_screen_side_menu_toggle_test.dart',
   'app/test/human_draft_projected_region_provider_test.dart',
-  'app/test/panels_320dp_min_viewport_test.dart',
   'app/test/player_turn_event_feed_narrow_inset_test.dart',
   'app/test/production_commodity_breakdown_dialog_spec_test.dart',
   'app/test/production_commodity_breakdown_dialog_wide_golden_test.dart',


### PR DESCRIPTION
## Summary

Advances **#3656** by shrinking the `getDebugInitGameResult()` migration
backlog (the `tool/check_app_test_no_debug_init.dart` allowlist, which the
gate documents as something that "must only ever shrink"). Three app test
suites that never read generated map/topology data are migrated onto the
shared lightweight `app/test/support/panel_test_fixtures.dart` builders,
removing three full procedural map generations (~7-11s each, paid once per
isolate) from the app test suite.

## Done in this push

- **`panels_320dp_min_viewport_test.dart`** — the Diplomacy and Technology
  320 dp groups now build `buildDiplomacyPanelTestGame()` /
  `buildTechnologyPanelTestGame()` with a `const MapTopology()`. (The
  Production and ProvinceSeaZoneDetailOverlay groups already used
  `production_panel_test_fixtures.dart` / `province_overlay_demo_data.dart`,
  so the file no longer touches the debug initializer at all.)
- **`ct_game_feature_screen_shell_test.dart`** — uses `buildPanelTestGame()`;
  the shell only reads `game.id` (current-vs-route match) and
  `players.first.displayName` (rendered by the test body builder).
- **`ct_e2e_turn_snapshot_refresh_test.dart`** — uses `buildPanelTestGame()`;
  only a stable `Game` id is needed to confirm the CT_E2E-off snapshot hook
  stays a no-op and the current game is preserved.
- Removes those three files from the allowlist in
  `tool/check_app_test_no_debug_init.dart`.

## Verification

- `flutter test` (app) for all three migrated files → **15/15 pass**.
- `dart run tool/check_app_test_no_debug_init.dart` → clean (allowlist still
  enforced, now three entries smaller).
- `dart test test/check_app_test_no_debug_init_test.dart` → **4/4 pass**.
- `flutter analyze` on the three test files and `dart analyze` on the tool
  file → no issues.

## Deferred (Refs #3656)

- The remaining allowlist entries are genuinely map/topology-dependent
  (`ct_region_map_*`, `game_map_area_*`, `game_screen_*` that mount
  `GameMapArea`/`GameScreen` with real `mapViewData`, `province_overlay_*`,
  `production_commodity_breakdown_dialog_spec/_wide_golden` delta-colour
  pins) or are committed goldens. A committed seed-42 serialized
  `InitGameResult`-subset fixture (the issue's larger AC for those suites)
  is not attempted here.
- Full-suite ≥10% wall-time measurement is not re-recorded in this push.

Refs #3656

Made with [Cursor](https://cursor.com)