### PR TITLE
perf: migrate shell game-screen specs off getDebugInitGameResult (#3656)

### DIFF
--- a/app/test/shell_game_screen_specs_test.dart
+++ b/app/test/shell_game_screen_specs_test.dart
@@ -18,7 +18,6 @@ import 'package:colonizethis_app/core/utils/state_toggle_notifier.dart';
 import 'package:colonizethis_app/providers/turn_resolution_blocking_provider.dart';
 import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
 import 'package:colonizethis_app/widgets/main_menu.dart';
-import 'package:colonizethis_app/widgets/debug_init_game.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_save/colonizethis_save.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
@@ -26,6 +25,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
+
+import 'support/panel_test_fixtures.dart';
 
 class _StubBox implements Box<dynamic> {
   @override
@@ -174,7 +175,12 @@ void main() {
     late Game baseGame;
 
     setUpAll(() {
-      baseGame = getDebugInitGameResult().game;
+      // Refs #3656: lightweight hand-built fixture replaces the ~11s procedural
+      // map generation of getDebugInitGameResult(). These specs pump GameScreen
+      // with mapViewDataProvider overridden to null, so no generated
+      // map/topology data is read — only the human player (for the synthetic
+      // victory winner) and the chrome that derives from it.
+      baseGame = buildGameScreenSpecsTestGame();
     });
 
     testWidgets(

--- a/app/test/support/panel_test_fixtures.dart
+++ b/app/test/support/panel_test_fixtures.dart
@@ -243,6 +243,27 @@ Game buildSideMenuTestGame() {
   );
 }
 
+/// Lightweight game shaped for the shell/game-screen chrome specs
+/// (`shell_game_screen_specs_test`; Refs #3656).
+///
+/// The `GameScreen` group pumps the screen with `mapViewDataProvider`
+/// overridden to `null`, so the map canvas is never mounted and no generated
+/// map/topology data is read. The assertions gate only on chrome that derives
+/// from a `Game` plus provider overrides the suite supplies itself: the pause
+/// (`Icons.menu`) icon, exactly one Next-turn `CtNinePatchButton`, the
+/// `VictoryOverlay` (the victory case applies `game.copyWith(victory:)` keyed on
+/// `game.players.first.id`), the turn-resolution-blocking disable, and the
+/// game-start intro overlay.
+///
+/// A single human ([kPanelTestHumanPlayerId]) is therefore the full shape these
+/// specs need; `game.players.first` resolves the synthetic victory winner.
+Game buildGameScreenSpecsTestGame() {
+  return buildPanelTestGame(
+    id: 'game-screen-specs-widget-test',
+    players: [panelTestHumanPlayer()],
+  );
+}
+
 /// Lightweight game shaped for the in-game Diplomacy *screen* family
 /// (`diplomacy_screen_test`, `diplomacy_screen_top_bar_test`,
 /// `diplomacy_screen_320dp_min_viewport_test`, `diplomacy_dialogs_test`).

--- a/app/test/support/panel_test_fixtures_test.dart
+++ b/app/test/support/panel_test_fixtures_test.dart
@@ -165,6 +165,23 @@ void main() {
     });
   });
 
+  group('buildGameScreenSpecsTestGame', () {
+    test('exposes a single human player usable as the victory winner', () {
+      final game = buildGameScreenSpecsTestGame();
+      expect(game.players, hasLength(1));
+      final human = game.players.first;
+      expect(human.id, kPanelTestHumanPlayerId);
+      expect(human.isHuman, isTrue);
+      // The victory spec keys `VictoryState.winnerPlayerId` off players.first,
+      // so the list must be non-empty.
+      expect(game.players, isNotEmpty);
+      // No generated map/topology data is consumed (mapViewData is null).
+      expect(game.worldState.oldWorld.units, isEmpty);
+      expect(game.worldState.newWorld.units, isEmpty);
+      expect(game.victory, isNull);
+    });
+  });
+
   group('buildDiplomacyScreenTestGame', () {
     test('human first player has an affordable treasury and an AI opponent', () {
       final game = buildDiplomacyScreenTestGame();


### PR DESCRIPTION
## Summary

Continues the app-test speedup for #3656 by migrating the GameScreen specs in
`shell_game_screen_specs_test.dart` off `getDebugInitGameResult()`.

That suite pumps `GameScreen` with `mapViewDataProvider` overridden to `null`
(the map canvas is never mounted) yet still paid the ~7–11s procedural map
generation of `getDebugInitGameResult()` in `setUpAll`. The assertions only gate
on chrome derived from a `Game` plus provider overrides the suite supplies
itself (pause icon, single Next-turn `CtNinePatchButton`, `VictoryOverlay`,
turn-resolution blocking, intro overlay), so a hand-built lightweight `Game` is
sufficient.

## Done in this push

- Add `buildGameScreenSpecsTestGame()` to `app/test/support/panel_test_fixtures.dart`
  (single human player; no generated map/topology data), documented like the
  other per-family builders.
- Add a focused test for the new fixture in `panel_test_fixtures_test.dart`
  (single human, usable as the synthetic victory winner, empty regions, no victory).
- Migrate `shell_game_screen_specs_test.dart` to the new fixture; assertions unchanged.

## Verification

- `flutter test test/support/panel_test_fixtures_test.dart test/shell_game_screen_specs_test.dart` → All tests passed (31).
- `dart analyze` on the three touched files → No issues found.

## Deferred (still open on #3656)

- **Map-dependent suites** (`ct_region_map_*`, `game_map_area_*`, `province_overlay_*`,
  most `game_screen_*` that pump with a non-null `mapViewData`) → the committed
  seed-42 serialized-`InitGameResult` fixture path; not in scope here.
- **`widgetbook_technology_screen_mobile_viewport_test.dart`** is **not** a valid
  lightweight-fixture target: the Widgetbook story it pumps
  (`_midGameTechnologyScreenStory` in `catalog_panels.dart`) calls
  `getDebugInitGameResult()` internally, so the map generation lives in production
  Widgetbook code, not the test setup. It belongs on the serialized-fixture/allowlist
  path with the other map-dependent suites.
- **CI checker trio** (`repo.app_test_no_debug_init`) is intentionally not added yet:
  many genuinely map-dependent files still call `getDebugInitGameResult()` pending the
  serialized-fixture path, so a clean small allowlist is not yet possible.

Refs #3656

Made with [Cursor](https://cursor.com)