### PR TITLE
test(economy): wall-clock perf gate to lock in test-suite speedup (#3661)

### DIFF
--- a/SPEC/program/economy-test-wall-clock.md
+++ b/SPEC/program/economy-test-wall-clock.md
@@ -1,0 +1,49 @@
+# Economy test wall-clock gate
+
+**SPEC/program** — Optional performance enforcement for the `packages/colonizethis_economy` `dart test` suite. Tracks the dedup/fixture-hoisting work in GitHub #3661 so the wall-clock gains are not silently regressed. Test logging policy: [test-logging.md](test-logging.md).
+
+---
+
+## Responsibility
+
+`tool/check_economy_test_wall_clock.sh` measures the wall-clock time of the economy package test suite and compares it against a configurable ceiling. It is a thin facade: it shells out to `dart test`, computes a median over repeated runs, and applies a deterministic comparison. It owns no game or economy logic.
+
+The gate exists because the economy suite's cost is dominated by repeated heavy fixture construction; #3661 deduplicated suites and hoisted shared fixtures to bring the wall-clock down. This tool locks in that gain.
+
+## Modes
+
+- **Advisory (default):** Measure and report; always exit `0`. A median over the ceiling prints a `WARN` line. Intended for CI runners whose absolute timing is noisy.
+- **Enforce (opt-in):** Set `ECONOMY_TEST_TIMING_ENFORCE=1`. A median strictly greater than the ceiling exits `1`; otherwise exit `0`.
+- **Skip:** Set `SKIP_ECONOMY_TEST_TIMING=1`. The tool prints a skip notice and exits `0` without measuring.
+
+## Configuration
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `ECONOMY_TEST_TIMING_CEILING_SECONDS` | `25` | Inclusive upper bound for the median measured wall-clock (seconds). |
+| `ECONOMY_TEST_TIMING_RUNS` | `3` | Number of `dart test` runs measured; the median is compared. Must be an odd integer `>= 1`. |
+| `ECONOMY_TEST_TIMING_ENFORCE` | unset | When `1`, over-ceiling is a hard failure. |
+| `SKIP_ECONOMY_TEST_TIMING` | unset | When `1`, skip measurement entirely. |
+| `ECONOMY_TEST_TIMING_MEASURED_SECONDS` | unset | Test/CI hook: bypass running `dart test` and treat this value as the median measurement. Used to exercise the deterministic comparison path. |
+
+The ceiling is a runner-relative ceiling, not the dev-class baseline from #3661 (≈2.25 s). It is set generously so the default advisory mode never produces false alarms; tighten only when enforcing on calibrated hardware.
+
+## Acceptance criteria
+
+- Given `SKIP_ECONOMY_TEST_TIMING=1`, when the tool runs, then the tool prints a skip notice and exits with code `0` without invoking `dart test`.
+- Given `ECONOMY_TEST_TIMING_MEASURED_SECONDS=10` and `ECONOMY_TEST_TIMING_CEILING_SECONDS=25` (no enforce), when the tool runs, then the tool prints a pass line and exits with code `0`.
+- Given `ECONOMY_TEST_TIMING_MEASURED_SECONDS=40` and `ECONOMY_TEST_TIMING_CEILING_SECONDS=25` and enforce unset, when the tool runs, then the tool prints a `WARN` line and exits with code `0`.
+- Given `ECONOMY_TEST_TIMING_MEASURED_SECONDS=40`, `ECONOMY_TEST_TIMING_CEILING_SECONDS=25`, and `ECONOMY_TEST_TIMING_ENFORCE=1`, when the tool runs, then the tool prints a failure line and exits with code `1`.
+- Given `ECONOMY_TEST_TIMING_MEASURED_SECONDS=25` and `ECONOMY_TEST_TIMING_CEILING_SECONDS=25` and `ECONOMY_TEST_TIMING_ENFORCE=1`, when the tool runs, then the tool treats the value as within budget (equal is allowed) and exits with code `0`.
+
+## Integration
+
+- **Owner:** `tool/check_economy_test_wall_clock.sh`; regression coverage in `tool/test_check_economy_test_wall_clock.sh`.
+- **CI:** Invoked in advisory mode from the nightly integration gate ([test-logging.md](test-logging.md), `.github/workflows/nightly.yml`) so it reports without blocking PRs.
+- **Local:** Run `bash tool/check_economy_test_wall_clock.sh` from the repo root. See [../../docs/project-tools.md](../../docs/project-tools.md).
+
+## Constraints
+
+- The tool must not leave run artifacts: it runs `dart test` **without** `--coverage`, so no `coverage/` tree is produced.
+- The comparison must be deterministic for fixed inputs (median + ceiling), independent of the measurement mechanism.
+- Operational output goes to stdout; the tool emits no application logging.

--- a/docs/project-tools.md
+++ b/docs/project-tools.md
@@ -400,6 +400,35 @@ Requires `dart` only (Melos activated by the script).
 
 ---
 
+## check_economy_test_wall_clock.sh (economy test perf gate)
+
+Measures the wall-clock time of `dart test` in `packages/colonizethis_economy` and compares the median over repeated runs against a ceiling, locking in the dedup/fixture-hoisting wall-clock gains from #3661. **Advisory by default** (always exits `0`; over-ceiling prints `WARN`); set `ECONOMY_TEST_TIMING_ENFORCE=1` to make over-ceiling a hard failure. It runs `dart test` **without** `--coverage`, so no coverage artifacts are produced. Spec: [SPEC/program/economy-test-wall-clock.md](../SPEC/program/economy-test-wall-clock.md).
+
+**Invocation**
+
+```bash
+tool/check_economy_test_wall_clock.sh
+```
+
+**Configuration (env)**
+
+- `ECONOMY_TEST_TIMING_CEILING_SECONDS` — median ceiling in seconds (default `25`).
+- `ECONOMY_TEST_TIMING_RUNS` — odd run count whose median is compared (default `3`).
+- `ECONOMY_TEST_TIMING_ENFORCE=1` — over-ceiling exits `1` instead of warning.
+- `SKIP_ECONOMY_TEST_TIMING=1` — skip measurement entirely.
+- `ECONOMY_TEST_TIMING_MEASURED_SECONDS` — test/CI hook: bypass `dart test` and treat this value as the median.
+
+Runs in advisory mode from the nightly integration gate (`tool/run_nightly_integration_gate.sh`).
+
+**Tests**
+
+```bash
+bash tool/test_check_economy_test_wall_clock.sh
+dart test test/check_economy_test_wall_clock_test.dart --reporter=compact
+```
+
+---
+
 ## scripts/nightly_dev_to_android_pr.sh (nightly APK PR)
 
 Creates a PR from `dev` → `build/app/android` for nightly APK builds. Merging that PR triggers the app Android build. The PR **source** is always `dev` (per GitHub workflow rules).

--- a/test/check_economy_test_wall_clock_test.dart
+++ b/test/check_economy_test_wall_clock_test.dart
@@ -1,0 +1,85 @@
+// Refs #3661 — guards tool/check_economy_test_wall_clock.sh comparison/mode
+// behaviour. Uses ECONOMY_TEST_TIMING_MEASURED_SECONDS to drive the
+// deterministic comparison path without running the real economy suite.
+// Spec: SPEC/program/economy-test-wall-clock.md.
+
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+void main() {
+  late String repoRoot;
+  late String script;
+
+  setUp(() {
+    repoRoot = Directory.current.path;
+    script = p.join(repoRoot, 'tool', 'check_economy_test_wall_clock.sh');
+  });
+
+  Future<ProcessResult> run(Map<String, String> env) => Process.run(
+        'bash',
+        [script],
+        environment: env,
+        runInShell: false,
+      );
+
+  test('skip path exits 0 without measuring', () async {
+    final r = await run({
+      'SKIP_ECONOMY_TEST_TIMING': '1',
+      'ECONOMY_TEST_TIMING_MEASURED_SECONDS': '999',
+    });
+    expect(r.exitCode, 0, reason: '${r.stderr}\n${r.stdout}');
+    expect(r.stdout as String, contains('skipping economy test timing'));
+  });
+
+  test('median under ceiling passes (advisory default)', () async {
+    final r = await run({
+      'ECONOMY_TEST_TIMING_MEASURED_SECONDS': '10',
+      'ECONOMY_TEST_TIMING_CEILING_SECONDS': '25',
+    });
+    expect(r.exitCode, 0, reason: '${r.stderr}\n${r.stdout}');
+    expect(r.stdout as String, contains('PASS: median 10'));
+  });
+
+  test('median equal to ceiling is within budget under enforce', () async {
+    final r = await run({
+      'ECONOMY_TEST_TIMING_MEASURED_SECONDS': '25',
+      'ECONOMY_TEST_TIMING_CEILING_SECONDS': '25',
+      'ECONOMY_TEST_TIMING_ENFORCE': '1',
+    });
+    expect(r.exitCode, 0, reason: '${r.stderr}\n${r.stdout}');
+    expect(r.stdout as String, contains('PASS: median 25'));
+  });
+
+  test('median over ceiling warns but exits 0 in advisory mode', () async {
+    final r = await run({
+      'ECONOMY_TEST_TIMING_MEASURED_SECONDS': '40',
+      'ECONOMY_TEST_TIMING_CEILING_SECONDS': '25',
+    });
+    expect(r.exitCode, 0, reason: '${r.stderr}\n${r.stdout}');
+    expect(r.stdout as String, contains('WARN: median 40'));
+  });
+
+  test('median over ceiling fails (exit 1) in enforce mode', () async {
+    final r = await run({
+      'ECONOMY_TEST_TIMING_MEASURED_SECONDS': '40',
+      'ECONOMY_TEST_TIMING_CEILING_SECONDS': '25',
+      'ECONOMY_TEST_TIMING_ENFORCE': '1',
+    });
+    expect(r.exitCode, 1, reason: '${r.stderr}\n${r.stdout}');
+    expect(
+      '${r.stdout}${r.stderr}',
+      contains('FAIL: median 40'),
+    );
+  });
+
+  test('even ECONOMY_TEST_TIMING_RUNS is rejected with exit 2', () async {
+    final r = await run({
+      'ECONOMY_TEST_TIMING_MEASURED_SECONDS': '10',
+      'ECONOMY_TEST_TIMING_RUNS': '2',
+    });
+    expect(r.exitCode, 2, reason: '${r.stderr}\n${r.stdout}');
+    expect('${r.stdout}${r.stderr}', contains('must be an odd integer'));
+  });
+}

--- a/tool/check_economy_test_wall_clock.sh
+++ b/tool/check_economy_test_wall_clock.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Economy test wall-clock gate (Refs #3661).
+#
+# Measures the wall-clock time of `dart test` in packages/colonizethis_economy
+# and compares the median of repeated runs against a configurable ceiling. The
+# economy suite was deduplicated and its fixtures hoisted in #3661; this tool
+# locks in the wall-clock gain so it is not silently regressed.
+#
+# Modes:
+#   - Advisory (default): measure, report, always exit 0 (over-ceiling => WARN).
+#   - Enforce (ECONOMY_TEST_TIMING_ENFORCE=1): over-ceiling => exit 1.
+#   - Skip (SKIP_ECONOMY_TEST_TIMING=1): print notice, exit 0, no measurement.
+#
+# Config (see SPEC/program/economy-test-wall-clock.md):
+#   ECONOMY_TEST_TIMING_CEILING_SECONDS  (default 25)
+#   ECONOMY_TEST_TIMING_RUNS             (default 3; odd integer >= 1)
+#   ECONOMY_TEST_TIMING_ENFORCE          (1 => hard fail over ceiling)
+#   SKIP_ECONOMY_TEST_TIMING             (1 => skip)
+#   ECONOMY_TEST_TIMING_MEASURED_SECONDS (test/CI hook: bypass dart test and
+#                                         use this value as the median)
+set -euo pipefail
+
+export SUPPRESS_IMAGE_VIEWER="${SUPPRESS_IMAGE_VIEWER:-1}"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+PKG_DIR="${ECONOMY_TEST_TIMING_PKG_DIR:-packages/colonizethis_economy}"
+CEILING="${ECONOMY_TEST_TIMING_CEILING_SECONDS:-25}"
+RUNS="${ECONOMY_TEST_TIMING_RUNS:-3}"
+ENFORCE="${ECONOMY_TEST_TIMING_ENFORCE:-0}"
+
+PREFIX="check_economy_test_wall_clock:"
+
+if [ "${SKIP_ECONOMY_TEST_TIMING:-0}" = "1" ]; then
+  echo "$PREFIX SKIP_ECONOMY_TEST_TIMING=1 set; skipping economy test timing."
+  exit 0
+fi
+
+# Validate RUNS is an odd positive integer so the median is well defined.
+if ! printf '%s' "$RUNS" | grep -qE '^[0-9]+$' || [ "$RUNS" -lt 1 ] \
+  || [ $((RUNS % 2)) -eq 0 ]; then
+  echo "$PREFIX ERROR: ECONOMY_TEST_TIMING_RUNS must be an odd integer >= 1 (got '$RUNS')." >&2
+  exit 2
+fi
+
+# ---- obtain median measurement ---------------------------------------------
+if [ -n "${ECONOMY_TEST_TIMING_MEASURED_SECONDS:-}" ]; then
+  # Deterministic comparison hook: skip running the suite.
+  median="$ECONOMY_TEST_TIMING_MEASURED_SECONDS"
+  echo "$PREFIX using injected median ${median}s (dart test not run)."
+else
+  if [ ! -d "$ROOT/$PKG_DIR/test" ]; then
+    echo "$PREFIX ERROR: $PKG_DIR/test not found; nothing to measure." >&2
+    exit 2
+  fi
+  echo "$PREFIX measuring 'dart test' in $PKG_DIR over $RUNS run(s)..."
+  measurements=()
+  for i in $(seq 1 "$RUNS"); do
+    start=$(date +%s.%N)
+    (cd "$ROOT/$PKG_DIR" && dart test --reporter=compact \
+      --test-randomize-ordering-seed=42 >/dev/null)
+    end=$(date +%s.%N)
+    elapsed=$(awk -v a="$start" -v b="$end" 'BEGIN { printf "%.2f", b - a }')
+    echo "$PREFIX   run $i: ${elapsed}s"
+    measurements+=("$elapsed")
+  done
+  median=$(printf '%s\n' "${measurements[@]}" | sort -g \
+    | awk -v n="$RUNS" 'NR==int(n/2)+1 { print; exit }')
+fi
+
+# ---- deterministic comparison ----------------------------------------------
+# over = 1 when median > ceiling (strictly); equal is within budget.
+over=$(awk -v m="$median" -v c="$CEILING" 'BEGIN { print (m > c) ? 1 : 0 }')
+
+if [ "$over" -eq 0 ]; then
+  echo "$PREFIX PASS: median ${median}s <= ceiling ${CEILING}s."
+  exit 0
+fi
+
+if [ "$ENFORCE" = "1" ]; then
+  echo "$PREFIX FAIL: median ${median}s > ceiling ${CEILING}s (enforce mode)." >&2
+  echo "$PREFIX The economy test suite regressed past its wall-clock budget." >&2
+  echo "$PREFIX Restore dedup/fixture hoisting (Refs #3661) or justify a new ceiling." >&2
+  exit 1
+fi
+
+echo "$PREFIX WARN: median ${median}s > ceiling ${CEILING}s (advisory mode; not failing)."
+echo "$PREFIX Set ECONOMY_TEST_TIMING_ENFORCE=1 to make this a hard failure."
+exit 0

--- a/tool/run_nightly_integration_gate.sh
+++ b/tool/run_nightly_integration_gate.sh
@@ -20,4 +20,10 @@ echo ""
 echo "=== sim_scenarios integration gate ==="
 melos run sim_scenarios
 
+echo ""
+echo "=== economy test wall-clock (advisory; Refs #3661) ==="
+# Advisory by default: reports the economy suite's median wall-clock against the
+# ceiling without failing the gate. See SPEC/program/economy-test-wall-clock.md.
+bash tool/check_economy_test_wall_clock.sh
+
 echo "Nightly integration gate passed."

--- a/tool/test_check_economy_test_wall_clock.sh
+++ b/tool/test_check_economy_test_wall_clock.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Regression tests for tool/check_economy_test_wall_clock.sh (Refs #3661).
+#
+# These exercise the deterministic comparison + mode behaviour without running
+# the real economy suite by injecting ECONOMY_TEST_TIMING_MEASURED_SECONDS (and
+# SKIP_ECONOMY_TEST_TIMING for the skip path). Run directly:
+#   bash tool/test_check_economy_test_wall_clock.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$ROOT/tool/check_economy_test_wall_clock.sh"
+
+if [ ! -f "$SCRIPT" ]; then
+  echo "FAIL: cannot find $SCRIPT" >&2
+  exit 1
+fi
+
+PASS_COUNT=0
+FAIL_COUNT=0
+FAIL_NAMES=()
+
+# run_case <name> <expected_rc> <expected_substr> <env assignments...>
+run_case() {
+  local name="$1"; shift
+  local expected_rc="$1"; shift
+  local expected_substr="$1"; shift
+
+  echo "--- $name ---"
+  local out_file
+  out_file="$(mktemp)"
+  set +e
+  env "$@" bash "$SCRIPT" >"$out_file" 2>&1
+  local actual_rc=$?
+  set -e
+
+  local ok=1
+  if [ "$actual_rc" -ne "$expected_rc" ]; then
+    echo "  expected exit $expected_rc, got $actual_rc"
+    ok=0
+  fi
+  if [ -n "$expected_substr" ] && ! grep -qF "$expected_substr" "$out_file"; then
+    echo "  expected output to contain: $expected_substr"
+    ok=0
+  fi
+
+  if [ "$ok" -eq 1 ]; then
+    PASS_COUNT=$((PASS_COUNT + 1))
+    echo "  PASS"
+  else
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    FAIL_NAMES+=("$name")
+    echo "  --- output ---"
+    sed 's/^/    /' "$out_file"
+    echo "  --------------"
+  fi
+  rm -f "$out_file"
+}
+
+# AC: skip path never measures and exits 0.
+run_case "skip path exits 0" 0 "skipping economy test timing" \
+  SKIP_ECONOMY_TEST_TIMING=1 ECONOMY_TEST_TIMING_MEASURED_SECONDS=999
+
+# AC: under ceiling => PASS, exit 0 (advisory default).
+run_case "under ceiling passes" 0 "PASS: median 10" \
+  ECONOMY_TEST_TIMING_MEASURED_SECONDS=10 ECONOMY_TEST_TIMING_CEILING_SECONDS=25
+
+# AC: equal to ceiling is within budget even when enforcing.
+run_case "equal to ceiling passes (enforce)" 0 "PASS: median 25" \
+  ECONOMY_TEST_TIMING_MEASURED_SECONDS=25 ECONOMY_TEST_TIMING_CEILING_SECONDS=25 \
+  ECONOMY_TEST_TIMING_ENFORCE=1
+
+# AC: over ceiling, advisory => WARN, exit 0.
+run_case "over ceiling advisory warns (exit 0)" 0 "WARN: median 40" \
+  ECONOMY_TEST_TIMING_MEASURED_SECONDS=40 ECONOMY_TEST_TIMING_CEILING_SECONDS=25
+
+# AC: over ceiling, enforce => FAIL, exit 1.
+run_case "over ceiling enforce fails (exit 1)" 1 "FAIL: median 40" \
+  ECONOMY_TEST_TIMING_MEASURED_SECONDS=40 ECONOMY_TEST_TIMING_CEILING_SECONDS=25 \
+  ECONOMY_TEST_TIMING_ENFORCE=1
+
+# AC: fractional median compares correctly (24.99 <= 25).
+run_case "fractional under ceiling passes" 0 "PASS: median 24.99" \
+  ECONOMY_TEST_TIMING_MEASURED_SECONDS=24.99 ECONOMY_TEST_TIMING_CEILING_SECONDS=25
+
+# AC: invalid RUNS (even) is rejected with exit 2.
+run_case "even runs rejected" 2 "must be an odd integer" \
+  ECONOMY_TEST_TIMING_MEASURED_SECONDS=10 ECONOMY_TEST_TIMING_RUNS=2
+
+# --- summary --------------------------------------------------------------
+echo ""
+echo "=========================================="
+echo " check_economy_test_wall_clock: $PASS_COUNT pass, $FAIL_COUNT fail"
+echo "=========================================="
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  for n in "${FAIL_NAMES[@]}"; do
+    echo "  FAIL: $n"
+  done
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Adds a wall-clock performance gate for the `packages/colonizethis_economy` test suite so the dedup/fixture-hoisting speedups landed by the earlier #3661 slices (#3666, #3668, #3682, and the step-6 catalog-loop move) cannot silently regress.

`Refs #3661`

## Done in this push

- **`tool/check_economy_test_wall_clock.sh`** — measures the median wall-clock of `dart test` in `packages/colonizethis_economy` over N runs and compares it to a configurable ceiling.
  - **Advisory by default** (over-ceiling prints `WARN`, exits `0`) so noisy CI runners never false-alarm; `ECONOMY_TEST_TIMING_ENFORCE=1` makes over-ceiling a hard failure. This matches the issue's "start as PR-comment-only if flaky" guidance.
  - `SKIP_ECONOMY_TEST_TIMING=1` to skip; `ECONOMY_TEST_TIMING_CEILING_SECONDS` / `ECONOMY_TEST_TIMING_RUNS` to tune; `ECONOMY_TEST_TIMING_MEASURED_SECONDS` as a deterministic comparison hook.
  - Runs `dart test` **without** `--coverage`, so no coverage artifacts are produced.
- **Tests:** `tool/test_check_economy_test_wall_clock.sh` (shell regression) and `test/check_economy_test_wall_clock_test.dart` (auto-run by the existing CI `dart test test/check_*_test.dart` checker group). Both drive the deterministic compare/mode paths via injected measurements.
- **CI:** advisory invocation added to `tool/run_nightly_integration_gate.sh` (nightly, non-blocking).
- **Docs/Spec:** `SPEC/program/economy-test-wall-clock.md` (Given–When–Then ACs on the deterministic comparison) and a `docs/project-tools.md` section.

## Why this scope

All seven dedup/hoisting steps proposed in #3661 already merged (FRR/treasury trim, consumption trim, bid-spend/resource-extractor fixture hoisting, catalog default-price relocation, logic-barrel import narrowing). The remaining unlanded "CI / enforcement" item was the wall-clock gate; this PR delivers it. No behavior tests were deleted (prior slices already mined the safe dedup with full SPEC/AC-pin context).

## Verification

- `bash tool/test_check_economy_test_wall_clock.sh` → 7/7 pass.
- `dart test test/check_economy_test_wall_clock_test.dart` → 6/6 pass.
- `dart analyze test/check_economy_test_wall_clock_test.dart` → no issues.
- Real run: `ECONOMY_TEST_TIMING_RUNS=1 tool/check_economy_test_wall_clock.sh` → `PASS: median 12.93s <= ceiling 25s`; no `coverage/` tree left behind.

## Deferred / not in scope

- Tightening the ceiling and flipping to enforce mode on calibrated hardware (the default ceiling is intentionally generous and advisory).

Made with [Cursor](https://cursor.com)