### PR TITLE
perf(app): migrate technology widgetbook test off getDebugInitGameResult (#3656)

### DIFF
--- a/app/lib/widgetbook/catalog_panels.dart
+++ b/app/lib/widgetbook/catalog_panels.dart
@@ -57,13 +57,31 @@ List<WidgetbookNode> get productionPanelDirectories => [
 
 /// Mid-game [TechnologyScreen] fixture (Slots tab default) for Widgetbook.
 /// SPEC/ui/technology-panel.md § Widgetbook; Refs #2870 R22 / S9.
+///
+/// Refs #3656: built from a lightweight hand-constructed [Game] instead of the
+/// ~7-11s procedural `getDebugInitGameResult()` map generator. The Technology
+/// screen reads only `game.players` plus the static `techCatalog`, so the
+/// slots/tree chrome renders identically without any generated map/topology
+/// data. The single human ([_kMidGameTechPlayerId]) carries the same id the
+/// lightweight panel test fixtures use (`kPanelTestHumanPlayerId`), so the
+/// `CtGameFeatureScreenShell` `displayGame.playerById(...)` lookup resolves
+/// whether the shell falls back to this game or to a test-provided
+/// `currentGameProvider` override of the same shape.
 Widget _midGameTechnologyScreenStory(BuildContext context) {
-  final result = getDebugInitGameResult();
-  final game = result.game;
-  if (game.players.isEmpty) {
-    return Center(child: Text(appL10n(context).widgetbook_noPlayers));
-  }
-  final basePlayer = game.players.first;
+  const basePlayer = Player(
+    id: _kMidGameTechPlayerId,
+    displayName: 'Test Human',
+    isHuman: true,
+  );
+  const baseGame = Game(
+    id: kWidgetbookTechnologyStoryGameId,
+    worldState: WorldState(
+      turnState: TurnState(phase: TurnPhase.orders, turnNumber: 1),
+      oldWorld: RegionData(),
+      newWorld: RegionData(),
+    ),
+    players: [basePlayer],
+  );
   // Unlock roughly half of all techs (first 22 from catalog order).
   final allIds = techCatalog.keys.toList()..sort();
   final half = (allIds.length / 2).floor();
@@ -80,11 +98,24 @@ Widget _midGameTechnologyScreenStory(BuildContext context) {
     techUnlocked: techUnlocked,
     researchProgressByTechId: researchProgressByTechId,
   );
-  final midGame = game.copyWith(
-    players: [midGamePlayer, ...game.players.skip(1)],
-  );
+  final midGame = baseGame.copyWith(players: [midGamePlayer]);
   return TechnologyScreen(game: midGame, player: midGamePlayer);
 }
+
+/// Human player id for the lightweight mid-game Technology story. Matches the
+/// lightweight panel test fixtures' `kPanelTestHumanPlayerId` so a
+/// test-provided `currentGameProvider` of the same shape resolves the same
+/// player. Refs #3656.
+const String _kMidGameTechPlayerId = 'gp1';
+
+/// Stable game id for the lightweight mid-game Technology Widgetbook story.
+///
+/// Exposed so widget tests can build a `currentGameProvider` game of the same
+/// id and player shape: `CtGameFeatureScreenShell` renders the live
+/// `currentGameProvider` game when its id matches the screen's `game.id`
+/// (otherwise it falls back to the screen's own game), so tests pinning this
+/// story drive the rendered player deterministically. Refs #3656.
+const String kWidgetbookTechnologyStoryGameId = 'wb_technology_midgame';
 
 /// Tech Tree Widget stories. SPEC/ui/tech-tree-widget.md.
 List<WidgetbookNode> get techTreeDirectories => [

--- a/app/test/widgetbook_technology_screen_mobile_viewport_test.dart
+++ b/app/test/widgetbook_technology_screen_mobile_viewport_test.dart
@@ -16,7 +16,6 @@ import 'package:colonizethis_app/features/game/screens/technology_screen.dart';
 import 'package:colonizethis_app/features/game/widgets/technology_panel.dart';
 import 'package:colonizethis_app/providers/app_event_bus_provider.dart';
 import 'package:colonizethis_app/providers/games_provider.dart';
-import 'package:colonizethis_app/widgets/debug_init_game.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
@@ -25,6 +24,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:widgetbook/widgetbook.dart';
 
 import 'package:colonizethis_app/widgetbook/catalog.dart';
+
+import 'support/panel_test_fixtures.dart';
 
 WidgetbookUseCase _useCase(
   List<WidgetbookNode> directories, {
@@ -54,7 +55,23 @@ void main() {
   late Game baseGame;
 
   setUpAll(() {
-    baseGame = getDebugInitGameResult().game;
+    // Refs #3656: lightweight hand-built fixture replaces the ~11s procedural
+    // map generation of getDebugInitGameResult(). The Technology screen reads
+    // only game.players + the static techCatalog, so the Slots tab renders its
+    // three active slot cards plus the locked University slot without any
+    // generated map/topology data.
+    //
+    // The game id and human player id match the Widgetbook mid-game story
+    // (kWidgetbookTechnologyStoryGameId / kPanelTestHumanPlayerId): because
+    // CtGameFeatureScreenShell renders the live currentGameProvider game when
+    // its id matches the screen's game.id, this fixture's fresh player (no
+    // researched techs) is the one rendered — mirroring the previous debug-init
+    // first-player render and keeping the Slots tab free of the wide
+    // researched-tech chips that overflow a 360 dp viewport.
+    baseGame = buildPanelTestGame(
+      id: kWidgetbookTechnologyStoryGameId,
+      players: [panelTestHumanPlayer()],
+    );
     expect(baseGame.players, isNotEmpty);
   });
 
@@ -122,7 +139,8 @@ void main() {
           );
           expect(find.byType(TechnologyScreen), findsOneWidget);
           expect(find.byType(SingleChildScrollView), findsOneWidget);
-          // Debug-init player: three active slots + locked slot 4 (University).
+          // Lightweight fixture player (researchSlots null -> default 3):
+          // three active slots + locked slot 4 (University).
           expect(find.byType(ResearchSlotCard), findsNWidgets(3));
           expect(find.byType(LockedResearchSlotCard), findsOneWidget);
         },

--- a/tool/check_app_test_no_debug_init.dart
+++ b/tool/check_app_test_no_debug_init.dart
@@ -47,7 +47,6 @@ const Set<String> _kDebugInitAllowlist = <String>{
   'app/test/province_sea_zone_overlay_detail_paths_test.dart',
   'app/test/train_dialogs_goldens_test.dart',
   'app/test/unit_panels_goldens_test.dart',
-  'app/test/widgetbook_technology_screen_mobile_viewport_test.dart',
 };
 
 /// Symbol whose invocation is gated.


### PR DESCRIPTION
## Summary

`Refs #3656`. Removes another `app/test/**` file from the per-isolate
`getDebugInitGameResult()` (~7-11s procedural map generator) backlog: the
`widgetbook_technology_screen_mobile_viewport_test` only needed a `Game` with a
player to render the Technology screen (which reads `game.players` + the static
`techCatalog`, no generated map/topology data).

### Done in this push

- **Lightweight Widgetbook story:** `_midGameTechnologyScreenStory`
  (`app/lib/widgetbook/catalog_panels.dart`) now builds a small hand-constructed
  `Game` instead of `getDebugInitGameResult()`. The Slots/Tree chrome renders
  identically; only the data source changes (no behavior/contract change, screen
  ID and use-case wiring unchanged).
- **Deterministic test render:** exposed `kWidgetbookTechnologyStoryGameId` so
  the test builds a `currentGameProvider` game of the same id/player shape.
  `CtGameFeatureScreenShell` renders the live game when its id matches the
  screen's `game.id`, so the fresh player (no researched techs) is the one
  rendered — mirroring the previous debug-init first-player render and keeping
  the Slots tab free of the wide researched-tech chips that overflow a 360 dp
  viewport.
- **Test migration:** the test uses the shared lightweight panel fixtures
  (`app/test/support/panel_test_fixtures.dart`) and is removed from the
  `check_app_test_no_debug_init` allowlist (which may only ever shrink).

### Coverage of ACs (#3656)

- Advances the "allowlist only shrinks as families migrate to lightweight
  fixtures" AC (one fewer entry; the gate + its wrapper test stay green).
- The CI gate trio (`tool/check_app_test_no_debug_init.dart`,
  `test/check_app_test_no_debug_init_test.dart`, `repo.app_test_no_debug_init`)
  is unchanged and still enforced.

### Deferred (remaining for #3656)

- The remaining allowlist entries are genuinely map/topology/production-data
  dependent (game-map area suites, province overlays, production delta-colour
  pins, goldens) or require the committed seed-42 serialized-fixture path; not
  in this slice.

## Test plan

- [x] `flutter test test/widgetbook_technology_screen_mobile_viewport_test.dart` — passes (~2s vs ~11s+ previously)
- [x] `dart run tool/check_app_test_no_debug_init.dart` — no disallowed usage, no stale entries
- [x] `dart test test/check_app_test_no_debug_init_test.dart` — all gate cases pass
- [x] `flutter analyze` clean on touched files; `dart analyze` clean on the tool

Made with [Cursor](https://cursor.com)