### PR TITLE
perf(app): migrate shell-entry auto-center test off getDebugInitGameResult (#3656)

### DIFF
--- a/app/test/game_map_area_shell_entry_center_test.dart
+++ b/app/test/game_map_area_shell_entry_center_test.dart
@@ -19,8 +19,6 @@ import 'package:colonizethis_app/providers/map_province_panel_provider.dart';
 import 'package:colonizethis_app/providers/map_view_provider.dart';
 import 'package:colonizethis_app/providers/observe_session_provider.dart';
 import 'package:colonizethis_app/providers/treasury_summary_provider.dart';
-import 'package:colonizethis_app/widgets/debug_init_game.dart';
-import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_map/colonizethis_map.dart' show InitGameMapViewData;
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_save/colonizethis_save.dart';
@@ -29,6 +27,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
+
+import 'support/map_view_test_fixtures.dart';
+import 'support/panel_test_fixtures.dart';
 
 void main() {
   suppressLogsForTests();
@@ -173,11 +174,18 @@ void main() {
   });
 
   group('GameMapArea shell-entry auto-center (widget) (Refs #3616)', () {
-    late InitGameResult debugResult;
+    // Refs #3656: this group only asserts shell-entry chrome derived from
+    // `game.players` + observe state (secondary highlight on the current
+    // player's capital tile, province overlay closed, home-to-capital gating).
+    // The lightweight game + minimal mapViewData replace the ~7-11s
+    // getDebugInitGameResult() map generation with identical behaviour — the
+    // capital-center camera move and highlight paint safely no-op for the
+    // off-map capital tile.
+    final Game lightweightGame = buildShellEntryCenterTestGame();
+    final InitGameMapViewData mapViewData = buildLightweightMapViewData();
     late Box<dynamic> gamesBox;
 
     setUpAll(() async {
-      debugResult = getDebugInitGameResult();
       Hive.init('./.dart_tool/test_hive_shell_entry_center');
       gamesBox = await Hive.openBox<dynamic>(HiveBoxNames.games);
     });
@@ -242,17 +250,17 @@ void main() {
       'AC: mount sets secondary highlight on the current player capital and '
       'does not open the province overlay',
       (tester) async {
-        final human = debugResult.game.players.firstWhere((p) => p.isHuman);
+        final human = lightweightGame.players.firstWhere((p) => p.isHuman);
         final capital = human.capitalTile;
         expect(
           capital,
           isNotNull,
-          reason: 'debug fixture human player must have a capital tile',
+          reason: 'lightweight fixture human player must have a capital tile',
         );
         final container = await pumpShell(
           tester,
-          game: debugResult.game,
-          mapViewData: debugResult.mapViewData,
+          game: lightweightGame,
+          mapViewData: mapViewData,
         );
         final panel = container.read(mapProvincePanelProvider);
         expect(panel.secondaryHighlightTileKey, capital!.toTileKey());
@@ -266,8 +274,8 @@ void main() {
       (tester) async {
         await pumpShell(
           tester,
-          game: debugResult.game,
-          mapViewData: debugResult.mapViewData,
+          game: lightweightGame,
+          mapViewData: mapViewData,
         );
         final controls = tester.widget<GameMapCornerControls>(
           find.byType(GameMapCornerControls),
@@ -282,8 +290,8 @@ void main() {
       (tester) async {
         final container = await pumpShell(
           tester,
-          game: debugResult.game,
-          mapViewData: debugResult.mapViewData,
+          game: lightweightGame,
+          mapViewData: mapViewData,
         );
         container.read(observeSessionProvider.notifier).setModeGlobal();
         await tester.pump();
@@ -300,12 +308,12 @@ void main() {
       (tester) async {
         final container = await pumpShell(
           tester,
-          game: debugResult.game,
-          mapViewData: debugResult.mapViewData,
+          game: lightweightGame,
+          mapViewData: mapViewData,
         );
         container
             .read(observeSessionProvider.notifier)
-            .setModePlayer(debugResult.game.players.first.id);
+            .setModePlayer(lightweightGame.players.first.id);
         await tester.pump();
         final controls = tester.widget<GameMapCornerControls>(
           find.byType(GameMapCornerControls),

--- a/app/test/support/panel_test_fixtures.dart
+++ b/app/test/support/panel_test_fixtures.dart
@@ -264,6 +264,46 @@ Game buildGameScreenSpecsTestGame() {
   );
 }
 
+/// Lightweight game shaped for the `GameMapArea` shell-entry auto-center widget
+/// suite (`game_map_area_shell_entry_center_test`; Refs #3656).
+///
+/// The widget group asserts only shell-entry chrome derived from `game.players`
+/// plus observe state: on mount the secondary highlight equals the current
+/// player's `capitalTile.toTileKey()`, the province overlay stays closed, and
+/// the home-to-capital corner control enables/disables purely from
+/// `shell.viewingPlayerId != null` (normal play / player observe → enabled;
+/// global observe → disabled). None of that reads generated map/topology data:
+/// `_applyCapitalCenter` (`game_map_area_part1.dart`) sets the highlight
+/// unconditionally, and both the camera move (`ct_region_map_game.dart`
+/// `centerOnTileKey`) and the highlight ring paint
+/// (`region_map_component_render_markers.dart` `_paintTileOutlineRing`) safely
+/// no-op when the capital tile falls outside the mounted region bounds.
+///
+/// The fixture provides a single human ([kPanelTestHumanPlayerId]) so
+/// `players.first`, `firstWhere((p) => p.isHuman)`, and the player-observe
+/// (`setModePlayer(players.first.id)`) lookups all resolve it. Its old-world
+/// `capitalTile` drives the highlight assertion. Pair it with
+/// `buildLightweightMapViewData()` so the canvas mounts without the ~7-11s
+/// `getDebugInitGameResult()` map generation.
+Game buildShellEntryCenterTestGame() {
+  return buildPanelTestGame(
+    id: 'shell-entry-center-widget-test',
+    players: const [
+      Player(
+        id: kPanelTestHumanPlayerId,
+        displayName: 'Test Human',
+        isHuman: true,
+        capitalTile: CapitalTile(
+          regionId: 'oldWorld',
+          provinceId: 'cap',
+          x: 2,
+          y: 3,
+        ),
+      ),
+    ],
+  );
+}
+
 /// Lightweight game shaped for the in-game Diplomacy *screen* family
 /// (`diplomacy_screen_test`, `diplomacy_screen_top_bar_test`,
 /// `diplomacy_screen_320dp_min_viewport_test`, `diplomacy_dialogs_test`).

--- a/tool/check_app_test_no_debug_init.dart
+++ b/tool/check_app_test_no_debug_init.dart
@@ -27,7 +27,6 @@ const Set<String> _kDebugInitAllowlist = <String>{
   'app/test/game_map_area_event_feed_test.dart',
   'app/test/game_map_area_region_minimap_test.dart',
   'app/test/game_map_area_selection_mode_test.dart',
-  'app/test/game_map_area_shell_entry_center_test.dart',
   'app/test/game_map_selection_prompt_dark_tokens_test.dart',
   'app/test/human_draft_projected_region_provider_test.dart',
   'app/test/player_turn_event_feed_narrow_inset_test.dart',


### PR DESCRIPTION
## Summary

Migrates the `GameMapArea` shell-entry auto-center widget suite
(`app/test/game_map_area_shell_entry_center_test.dart`) off the expensive
`getDebugInitGameResult()` map generator (~7-11s per test isolate) onto the
shared lightweight fixtures (Refs #3656).

The widget group asserts **chrome only** — on mount the province-panel secondary
highlight equals the current player's `capitalTile.toTileKey()`, the province
overlay stays closed, and the home-to-capital corner control enables/disables
purely from `shell.viewingPlayerId != null` (normal play / player observe →
enabled; global observe → disabled). None of that reads generated map/topology
data:

- `_applyCapitalCenter` (`game_map_area_part1.dart`) sets the secondary
  highlight unconditionally.
- `centerOnTileKey` (`ct_region_map_game.dart`) and the highlight ring paint
  (`region_map_component_render_markers.dart` `_paintTileOutlineRing`) both
  bounds-check and **no-op** when the capital tile falls outside the mounted
  region, so an off-map capital on the 1×1 lightweight map is safe.

## Done in this push

- Add `buildShellEntryCenterTestGame()` to `app/test/support/panel_test_fixtures.dart`
  (single human [`gp1`] with an old-world `capitalTile`).
- Rewrite the widget group to use `buildShellEntryCenterTestGame()` +
  `buildLightweightMapViewData()` instead of `getDebugInitGameResult()`;
  assertions are unchanged.
- Remove `app/test/game_map_area_shell_entry_center_test.dart` from the
  `tool/check_app_test_no_debug_init.dart` allowlist (the allowlist may only
  shrink).

The pure-logic `resolveShellEntryAutoCenter` unit-test group (which already
hand-builds games) is untouched.

## ACs covered (Refs #3656)

- [x] Allowlist shrinks: the migrated file no longer calls
  `getDebugInitGameResult()` and is removed from the documented allowlist.
- [x] Assertions preserved; the file passes.
- [x] `flutter analyze` (errors-only) clean on touched files; the
  `check_app_test_no_debug_init` gate (incl. shrink-only / stale-entry checks)
  stays green.

## Remaining for #3656

The remaining allowlist suites (`ct_region_map_*`, other
`game_map_area_*`, production-breakdown delta/golden, train/unit goldens, etc.)
that genuinely read generated map/topology data are deferred to follow-up
slices.

## Verification

- `cd app && flutter test test/game_map_area_shell_entry_center_test.dart` → 11/11 passed (~5s).
- `dart test test/check_app_test_no_debug_init_test.dart` → 6/6 passed.
- `cd app && flutter analyze test/game_map_area_shell_entry_center_test.dart test/support/panel_test_fixtures.dart` → No issues found.

Refs #3656

Made with [Cursor](https://cursor.com)