### PR TITLE
perf(app): migrate map-chrome + event-feed tests off getDebugInitGameResult (#3656)

### DIFF
--- a/app/test/game_map_area_event_feed_test.dart
+++ b/app/test/game_map_area_event_feed_test.dart
@@ -10,18 +10,18 @@ import 'package:colonizethis_app/providers/game_service_provider.dart';
 import 'package:colonizethis_app/providers/games_box_provider.dart';
 import 'package:colonizethis_app/providers/games_provider.dart';
 import 'package:colonizethis_app/providers/map_view_provider.dart';
-import 'package:colonizethis_app/widgets/debug_init_game.dart';
-import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_map/colonizethis_map.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_save/colonizethis_save.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
+
+import 'support/map_view_test_fixtures.dart';
+import 'support/panel_test_fixtures.dart';
 
 class _MapAreaHost extends StatefulWidget {
   const _MapAreaHost({required this.game, required this.mapViewData});
@@ -72,9 +72,8 @@ void main() {
   testWidgets('GameMapArea dispose cancels AppEventBus subscriptions', (
     WidgetTester tester,
   ) async {
-    final init = getDebugInitGameResult();
-    final game = init.game;
-    final mapViewData = init.mapViewData;
+    final game = buildMapAreaEventFeedTestGame();
+    final mapViewData = buildLightweightMapViewData();
     final bus = AppEventBus.create();
     final sampleUnitId = game.worldState.oldWorld.units.isNotEmpty
         ? game.worldState.oldWorld.units.first.id
@@ -130,9 +129,8 @@ void main() {
   testWidgets('debug console overlay toggles when feature is enabled', (
     WidgetTester tester,
   ) async {
-    final init = getDebugInitGameResult();
-    final game = init.game;
-    final mapViewData = init.mapViewData;
+    final game = buildMapAreaEventFeedTestGame();
+    final mapViewData = buildLightweightMapViewData();
     final bus = AppEventBus.create();
     addTearDown(bus.dispose);
 
@@ -175,9 +173,8 @@ void main() {
   testWidgets('Player turn event feed commits batch on turn complete', (
     WidgetTester tester,
   ) async {
-    final init = getDebugInitGameResult();
-    final game = init.game;
-    final mapViewData = init.mapViewData;
+    final game = buildMapAreaEventFeedTestGame();
+    final mapViewData = buildLightweightMapViewData();
     final humanId = game.players.firstWhere((p) => p.isHuman).id;
     final bus = AppEventBus.create();
     addTearDown(bus.dispose);
@@ -229,9 +226,8 @@ void main() {
   testWidgets(
     'Player turn event feed naval line emits LocateMapTileEvent on tap',
     (WidgetTester tester) async {
-      final init = getDebugInitGameResult();
-      final game = init.game;
-      final mapViewData = init.mapViewData;
+      final game = buildMapAreaEventFeedTestGame();
+      final mapViewData = buildLightweightMapViewData();
       final humanId = game.players.firstWhere((p) => p.isHuman).id;
       final opponentId = game.players.firstWhere((p) => p.id != humanId).id;
       final seaKey = game.worldState.portsByProvinceSeaboard.keys.first;
@@ -299,9 +295,8 @@ void main() {
   testWidgets(
     'Player turn event feed unresolved naval anchor is non-tappable',
     (WidgetTester tester) async {
-      final init = getDebugInitGameResult();
-      final game = init.game;
-      final mapViewData = init.mapViewData;
+      final game = buildMapAreaEventFeedTestGame();
+      final mapViewData = buildLightweightMapViewData();
       final humanId = game.players.firstWhere((p) => p.isHuman).id;
       final opponentId = game.players.firstWhere((p) => p.id != humanId).id;
       final bus = AppEventBus.create();
@@ -364,9 +359,8 @@ void main() {
   testWidgets('Player turn event feed uses specific diplomacy war copy', (
     WidgetTester tester,
   ) async {
-    final init = getDebugInitGameResult();
-    final game = init.game;
-    final mapViewData = init.mapViewData;
+    final game = buildMapAreaEventFeedTestGame();
+    final mapViewData = buildLightweightMapViewData();
     final humanId = game.players.firstWhere((p) => p.isHuman).id;
     final otherId = game.players.firstWhere((p) => p.id != humanId).id;
     final humanName = game.players
@@ -426,9 +420,8 @@ void main() {
   testWidgets(
     'Player turn event feed renders work completion and taps map tile',
     (WidgetTester tester) async {
-      final init = getDebugInitGameResult();
-      final game = init.game;
-      final mapViewData = init.mapViewData;
+      final game = buildMapAreaEventFeedTestGame();
+      final mapViewData = buildLightweightMapViewData();
       final humanId = game.players.firstWhere((p) => p.isHuman).id;
       final bus = AppEventBus.create();
       final locateEvents = <LocateMapTileEvent>[];
@@ -493,9 +486,8 @@ void main() {
   testWidgets('Player turn event feed includes discovery and overture lines', (
     WidgetTester tester,
   ) async {
-    final init = getDebugInitGameResult();
-    final game = init.game;
-    final mapViewData = init.mapViewData;
+    final game = buildMapAreaEventFeedTestGame();
+    final mapViewData = buildLightweightMapViewData();
     final humanId = game.players.firstWhere((p) => p.isHuman).id;
     final otherId = game.players.firstWhere((p) => p.id != humanId).id;
     final bus = AppEventBus.create();
@@ -554,9 +546,8 @@ void main() {
   testWidgets(
     'Player turn event feed is hidden by default and toggles from news button',
     (WidgetTester tester) async {
-      final init = getDebugInitGameResult();
-      final game = init.game;
-      final mapViewData = init.mapViewData;
+      final game = buildMapAreaEventFeedTestGame();
+      final mapViewData = buildLightweightMapViewData();
       final humanId = game.players.firstWhere((p) => p.isHuman).id;
       final bus = AppEventBus.create();
       addTearDown(bus.dispose);
@@ -626,9 +617,8 @@ void main() {
   testWidgets(
     'Player turn event feed replaces previous turn entries on next commit',
     (WidgetTester tester) async {
-      final init = getDebugInitGameResult();
-      final game = init.game;
-      final mapViewData = init.mapViewData;
+      final game = buildMapAreaEventFeedTestGame();
+      final mapViewData = buildLightweightMapViewData();
       final humanId = game.players.firstWhere((p) => p.isHuman).id;
       final bus = AppEventBus.create();
       addTearDown(() async {
@@ -717,9 +707,8 @@ void main() {
   testWidgets(
     'Player turn event feed shows entries in narrow layout when toggled',
     (WidgetTester tester) async {
-      final init = getDebugInitGameResult();
-      final game = init.game;
-      final mapViewData = init.mapViewData;
+      final game = buildMapAreaEventFeedTestGame();
+      final mapViewData = buildLightweightMapViewData();
       final humanId = game.players.firstWhere((p) => p.isHuman).id;
       final bus = AppEventBus.create();
       addTearDown(() async {

--- a/app/test/game_map_selection_prompt_dark_tokens_test.dart
+++ b/app/test/game_map_selection_prompt_dark_tokens_test.dart
@@ -31,7 +31,6 @@ import 'package:colonizethis_app/providers/game_service_provider.dart';
 import 'package:colonizethis_app/providers/games_box_provider.dart';
 import 'package:colonizethis_app/providers/games_provider.dart';
 import 'package:colonizethis_app/providers/map_view_provider.dart';
-import 'package:colonizethis_app/widgets/debug_init_game.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_save/colonizethis_save.dart';
@@ -40,6 +39,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
+
+import 'support/map_view_test_fixtures.dart';
+import 'support/panel_test_fixtures.dart';
 
 void main() {
   suppressLogsForTests();
@@ -56,15 +58,12 @@ void main() {
   /// banner is visible. Returns the [WidgetTester] focused on the running
   /// app so the calling test can locate sub-widgets.
   Future<void> pumpAndEnterSelectionMode(WidgetTester tester) async {
-    final init = getDebugInitGameResult();
-    final game = init.game;
-    final mapViewData = init.mapViewData;
+    final game = buildSelectionPromptTestGame();
+    final mapViewData = buildLightweightMapViewData();
     final bus = AppEventBus.create();
     addTearDown(bus.dispose);
 
-    final sampleUnitId = game.worldState.oldWorld.units.isNotEmpty
-        ? game.worldState.oldWorld.units.first.id
-        : game.worldState.newWorld.units.first.id;
+    final sampleUnitId = game.worldState.oldWorld.units.first.id;
 
     await tester.pumpWidget(
       ProviderScope(

--- a/app/test/support/panel_test_fixtures.dart
+++ b/app/test/support/panel_test_fixtures.dart
@@ -304,6 +304,115 @@ Game buildShellEntryCenterTestGame() {
   );
 }
 
+/// Lightweight game shaped for the work-target selection-prompt overlay suites
+/// that mount a full `GameMapArea` purely to assert banner chrome
+/// (`game_map_selection_prompt_dark_tokens_test`,
+/// the explore-prompt cases in `game_map_area_selection_mode_test`; Refs #3656).
+///
+/// Entering explore selection mode (`StartCivilianWorkTargetSelectionEvent`)
+/// only requires the referenced unit to exist: `_startWorkTargetSelection`
+/// (`game_map_area_part1.dart`) looks the unit up, sets a non-null
+/// `_cachedValidTileKeys` (possibly empty) via
+/// `resolveValidTileKeysForCivilianWorkSelection`, and the canvas stack mounts
+/// the "Select a tile, or click cancel" banner whenever
+/// `validTileKeysForSelection != null` (`game_map_canvas_stack.dart`
+/// `inWorkTargetSelectionMode`). The banner chrome (dark tokens, the
+/// `CtNinePatchButton` cancel control) never reads generated map/topology data,
+/// so an off-map explorer on the 1×1 lightweight map is sufficient.
+///
+/// The fixture provides a single human ([kPanelTestHumanPlayerId]) owning one
+/// Explorer civilian in the old world so
+/// `game.worldState.oldWorld.units.first.id` resolves the sample unit those
+/// suites pass to the selection event. Pair it with
+/// `buildLightweightMapViewData()` so the canvas mounts without the ~7-11s
+/// `getDebugInitGameResult()` map generation.
+Game buildSelectionPromptTestGame() {
+  const human = kPanelTestHumanPlayerId;
+  const province = 'oldWorld|p1';
+  return buildPanelTestGame(
+    id: 'selection-prompt-widget-test',
+    oldWorldProvinces: const [
+      Province(
+        id: province,
+        regionId: 'oldWorld',
+        ownerId: human,
+        displayName: 'Alpha',
+      ),
+    ],
+    oldWorldUnits: [
+      Unit(
+        id: 'civ_explorer',
+        type: kUnitTypeExplorer,
+        ownerId: human,
+        locationProvinceId: province,
+        tileKey: 'oldWorld|p1|0|0',
+      ),
+    ],
+  );
+}
+
+/// Lightweight game shaped for the `game_map_area_event_feed_test` suite, which
+/// mounts a full `GameMapArea` and asserts only on the player-turn event-feed
+/// chrome driven by `AppEventBus` events (Refs #3656).
+///
+/// Every feed line is produced from the emitted event payload, not generated
+/// map data (`game_map_area_part1b.dart`): research/diplomacy/discovery lines
+/// read only player display names, the work-completed line locates the tile key
+/// carried by the event, and the naval-battle line resolves its locate tile via
+/// `portsByProvinceSeaboard` (`tileKeyForSeaZoneLocation`) when no
+/// `gameServiceProvider` map data is registered — so a port-seaboard entry is
+/// the only map-shaped data needed.
+///
+/// The fixture provides:
+/// - the human ([kPanelTestHumanPlayerId]) plus one AI great power (`gp2`), both
+///   with display names, so `firstWhere((p) => p.isHuman)`, the opponent
+///   `firstWhere((p) => p.id != humanId)`, and the diplomacy war-copy name
+///   lookups all resolve;
+/// - one old-world Explorer civilian so the dispose test's
+///   `oldWorld.units.first.id` sample unit exists;
+/// - a single `portsByProvinceSeaboard` entry mapping the `sz0` seaboard to a
+///   port tile, so the naval feed line resolves a non-empty anchor tile key
+///   (`oldWorld|sz0` → `oldWorld|cap|0|0`) while an unknown sea zone stays
+///   unresolved (the non-tappable-anchor case).
+Game buildMapAreaEventFeedTestGame() {
+  const human = kPanelTestHumanPlayerId;
+  const capProvince = 'oldWorld|cap';
+  const seaZoneId = 'sz0';
+  return buildPanelTestGame(
+    id: 'map-area-event-feed-widget-test',
+    players: const [
+      Player(id: human, displayName: 'Test Human', isHuman: true),
+      Player(id: 'gp2', displayName: 'Rival Power', isHuman: false),
+    ],
+    // The province is intentionally left unowned: the event-feed suite mounts
+    // the players bar, whose per-player score chip renders the owned-province
+    // count. Owning exactly one province here would render a "1" chip that
+    // collides with the news-feed badge's "1" count
+    // (`find.text('1')` findsOneWidget).
+    oldWorldProvinces: const [
+      Province(
+        id: capProvince,
+        regionId: 'oldWorld',
+        displayName: 'Capital',
+        townTileKey: 'oldWorld|cap|0|0',
+      ),
+    ],
+    oldWorldUnits: [
+      Unit(
+        id: 'civ_explorer',
+        type: kUnitTypeExplorer,
+        ownerId: human,
+        locationProvinceId: capProvince,
+        tileKey: 'oldWorld|cap|0|0',
+      ),
+    ],
+    portsByProvinceSeaboard: const {
+      'oldWorld|cap|$seaZoneId': 'oldWorld|cap|0|0',
+    },
+    seaZoneDisplayNameById: const {'oldWorld|$seaZoneId': 'Northern Sea'},
+  );
+}
+
 /// Lightweight game shaped for the in-game Diplomacy *screen* family
 /// (`diplomacy_screen_test`, `diplomacy_screen_top_bar_test`,
 /// `diplomacy_screen_320dp_min_viewport_test`, `diplomacy_dialogs_test`).

--- a/app/test/support/panel_test_fixtures_test.dart
+++ b/app/test/support/panel_test_fixtures_test.dart
@@ -327,4 +327,48 @@ void main() {
       );
     });
   });
+
+  group('buildSelectionPromptTestGame', () {
+    test('human owns one old-world explorer resolvable as the sample unit', () {
+      final game = buildSelectionPromptTestGame();
+      expect(game.players, hasLength(1));
+      expect(game.players.first.id, kPanelTestHumanPlayerId);
+      // The selection-prompt suites read oldWorld.units.first.id as the unit
+      // passed to StartCivilianWorkTargetSelectionEvent; it must exist and be
+      // owned by the human so _startWorkTargetSelection resolves it.
+      final sample = game.worldState.oldWorld.units.first;
+      expect(sample.ownerId, kPanelTestHumanPlayerId);
+      expect(sample.type, kUnitTypeExplorer);
+      // No generated map/topology data is consumed by the banner chrome.
+      expect(game.worldState.newWorld.units, isEmpty);
+    });
+  });
+
+  group('buildMapAreaEventFeedTestGame', () {
+    test('exposes a human plus a named AI opponent for feed-line lookups', () {
+      final game = buildMapAreaEventFeedTestGame();
+      expect(game.players, hasLength(2));
+      final human = game.players.firstWhere((p) => p.isHuman);
+      expect(human.id, kPanelTestHumanPlayerId);
+      expect(human.displayName, isNotEmpty);
+      final opponent = game.players.firstWhere((p) => p.id != human.id);
+      expect(opponent.isHuman, isFalse);
+      expect(opponent.displayName, isNotEmpty);
+      // The dispose test reads oldWorld.units.first.id as the sample unit.
+      expect(game.worldState.oldWorld.units, isNotEmpty);
+    });
+
+    test('seaboard entry resolves a known sea zone but not an unknown one', () {
+      final game = buildMapAreaEventFeedTestGame();
+      final ports = game.worldState.portsByProvinceSeaboard;
+      expect(ports, isNotEmpty);
+      // The naval feed line derives seaZoneId as `<region>|<seaboard-suffix>`
+      // from the seaboard key and resolves it via tileKeyForSeaZoneLocation;
+      // the entry must expose a `region|province|seazone` key shape.
+      final key = ports.keys.first;
+      final parts = key.split('|');
+      expect(parts.length, greaterThanOrEqualTo(3));
+      expect(ports[key], isNotEmpty);
+    });
+  });
 }

--- a/tool/check_app_test_no_debug_init.dart
+++ b/tool/check_app_test_no_debug_init.dart
@@ -24,10 +24,8 @@ import 'package:path/path.dart' as p;
 const Set<String> _kDebugInitAllowlist = <String>{
   'app/test/ct_region_map_debug_init_test.dart',
   'app/test/ct_region_map_test_support.dart',
-  'app/test/game_map_area_event_feed_test.dart',
   'app/test/game_map_area_region_minimap_test.dart',
   'app/test/game_map_area_selection_mode_test.dart',
-  'app/test/game_map_selection_prompt_dark_tokens_test.dart',
   'app/test/human_draft_projected_region_provider_test.dart',
   'app/test/player_turn_event_feed_narrow_inset_test.dart',
   'app/test/production_commodity_breakdown_dialog_spec_test.dart',


### PR DESCRIPTION
## Summary

Migrates two more chrome-only `GameMapArea` widget suites off the expensive
`getDebugInitGameResult()` map generator (~7-11s per test isolate) onto the
shared lightweight fixtures (Refs #3656). Both suites assert only chrome that
derives from a `Game` + bus events, never generated map/topology data.

## Done in this push

- **`game_map_selection_prompt_dark_tokens_test.dart`** — pins the dark
  editorial-monocle selection-prompt banner. Entering explore selection mode
  only requires the referenced unit to exist (`_startWorkTargetSelection` sets a
  non-null `_cachedValidTileKeys`, so the canvas stack mounts the banner via
  `inWorkTargetSelectionMode`); a single off-map explorer on the 1x1 lightweight
  map is sufficient.
- **`game_map_area_event_feed_test.dart`** — every player-turn feed line is
  produced from the emitted `AppEventBus` payload (`game_map_area_part1b.dart`).
  The naval-battle line resolves its locate tile via `portsByProvinceSeaboard`
  (`tileKeyForSeaZoneLocation`) when no `gameServiceProvider` map data is
  registered, so only a single port-seaboard entry is map-shaped.
- Adds `buildSelectionPromptTestGame()` and `buildMapAreaEventFeedTestGame()` to
  `app/test/support/panel_test_fixtures.dart`, each with focused fixture tests.
- Removes both files from the `tool/check_app_test_no_debug_init.dart` allowlist
  (the allowlist may only ever shrink). Assertions in both suites are unchanged.

The event-feed fixture intentionally leaves its province **unowned**: the suite
mounts the players bar, whose score chip renders the owned-province count;
owning exactly one province would render a `1` chip that collides with the
news-feed badge's `1` (`find.text('1')` findsOneWidget).

## ACs covered (Refs #3656)

- [x] Allowlist shrinks: the two migrated files no longer call
  `getDebugInitGameResult()` and are removed from the documented allowlist.
- [x] Assertions preserved; both suites pass.
- [x] `flutter analyze` clean on touched files; the
  `check_app_test_no_debug_init` gate (incl. shrink-only / stale-entry checks)
  stays green.

## Remaining for #3656

The remaining allowlist suites that genuinely read generated map/topology data
(`ct_region_map_*`, `game_map_area_selection_mode_test` build-target/auto-switch
cases, `game_map_area_region_minimap`, province/sea-zone overlay,
production-breakdown delta/golden, train/unit goldens, etc.) are deferred to
follow-up slices.

## Verification

- `cd app && flutter test test/game_map_selection_prompt_dark_tokens_test.dart test/game_map_area_event_feed_test.dart test/support/panel_test_fixtures_test.dart` → all pass.
- `dart test test/check_app_test_no_debug_init_test.dart` → 6/6 passed.
- `dart run tool/check_app_test_no_debug_init.dart` → no disallowed usage.
- `cd app && flutter analyze <touched files>` → No issues found.

Refs #3656

Made with [Cursor](https://cursor.com)