### PR TITLE
perf(app): migrate narrow event-feed inset test off getDebugInitGameResult (#3656)

### DIFF
--- a/app/test/player_turn_event_feed_narrow_inset_test.dart
+++ b/app/test/player_turn_event_feed_narrow_inset_test.dart
@@ -38,7 +38,6 @@ import 'package:colonizethis_app/providers/games_box_provider.dart';
 import 'package:colonizethis_app/providers/games_provider.dart';
 import 'package:colonizethis_app/providers/map_province_panel_provider.dart';
 import 'package:colonizethis_app/providers/map_view_provider.dart';
-import 'package:colonizethis_app/widgets/debug_init_game.dart';
 import 'package:colonizethis_map/colonizethis_map.dart'
     show InitGameMapViewData;
 import 'package:colonizethis_models/colonizethis_models.dart';
@@ -48,6 +47,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
+
+import 'support/map_view_test_fixtures.dart';
+import 'support/panel_test_fixtures.dart';
 
 /// Narrow viewport surface size — under `kNarrowBreakpoint` (600 dp) so
 /// `GameMapArea` selects its narrow branch and mounts the
@@ -86,6 +88,16 @@ Future<void> _pumpUntilFeedCardVisible(WidgetTester tester) async {
 double? _feedCardPositionedRight(WidgetTester tester) {
   final ctx = tester.element(find.byType(PlayerTurnEventFeedCard));
   return ctx.findAncestorWidgetOfExactType<Positioned>()?.right;
+}
+
+/// Lightweight feed-enabled game for the narrow-inset suite: the shared
+/// fixture with `mapViewState.showPlayerTurnEventsFeed` toggled on so the
+/// narrow `PlayerTurnEventFeedCard` mounts (Refs #3656).
+Game _feedEnabledGame() {
+  final base = buildEventFeedNarrowInsetTestGame();
+  return base.copyWith(
+    mapViewState: base.mapViewState.copyWith(showPlayerTurnEventsFeed: true),
+  );
 }
 
 String _firstOldWorldTileKey(Game game) {
@@ -167,19 +179,14 @@ void main() {
         'positive: narrow + feed visible + province panel CLOSED → '
         'Positioned.right equals kMapOverlayEdgeInset (no wide inset)',
         (WidgetTester tester) async {
-          final init = getDebugInitGameResult();
-          final game = init.game.copyWith(
-            mapViewState: init.game.mapViewState.copyWith(
-              showPlayerTurnEventsFeed: true,
-            ),
-          );
+          final game = _feedEnabledGame();
           final bus = AppEventBus.create();
           addTearDown(bus.dispose);
 
           await pumpNarrowGameMapArea(
             tester,
             game: game,
-            mapViewData: init.mapViewData,
+            mapViewData: buildLightweightMapViewData(),
             bus: bus,
           );
 
@@ -200,19 +207,14 @@ void main() {
         'Positioned.right still equals kMapOverlayEdgeInset (narrow '
         'bottom sheet covers from below, not from the right)',
         (WidgetTester tester) async {
-          final init = getDebugInitGameResult();
-          final game = init.game.copyWith(
-            mapViewState: init.game.mapViewState.copyWith(
-              showPlayerTurnEventsFeed: true,
-            ),
-          );
+          final game = _feedEnabledGame();
           final bus = AppEventBus.create();
           addTearDown(bus.dispose);
 
           await pumpNarrowGameMapArea(
             tester,
             game: game,
-            mapViewData: init.mapViewData,
+            mapViewData: buildLightweightMapViewData(),
             bus: bus,
           );
 
@@ -260,19 +262,14 @@ void main() {
         'gameMapWideOverlayRightInset(true) (regression guard against '
         'accidental reuse of the wide inset helper on the narrow path)',
         (WidgetTester tester) async {
-          final init = getDebugInitGameResult();
-          final game = init.game.copyWith(
-            mapViewState: init.game.mapViewState.copyWith(
-              showPlayerTurnEventsFeed: true,
-            ),
-          );
+          final game = _feedEnabledGame();
           final bus = AppEventBus.create();
           addTearDown(bus.dispose);
 
           await pumpNarrowGameMapArea(
             tester,
             game: game,
-            mapViewData: init.mapViewData,
+            mapViewData: buildLightweightMapViewData(),
             bus: bus,
           );
 

--- a/app/test/support/panel_test_fixtures.dart
+++ b/app/test/support/panel_test_fixtures.dart
@@ -413,6 +413,50 @@ Game buildMapAreaEventFeedTestGame() {
   );
 }
 
+/// Lightweight game shaped for the `player_turn_event_feed_narrow_inset_test`
+/// suite, which mounts a full **narrow** `GameMapArea` purely to assert the
+/// floating `PlayerTurnEventFeedCard`'s `Positioned.right` inset contract
+/// (Refs #2870 S3 / Req 11, Refs #3656).
+///
+/// The suite (a) toggles `mapViewState.showPlayerTurnEventsFeed` on via
+/// `copyWith` so the narrow feed card mounts, and (b) opens the province bottom
+/// sheet by feeding `mapProvincePanelProvider.reportMapTileTapped` a tile key
+/// pulled from `tileKeysByRegionAndProvince['oldWorld']`. The narrow inset
+/// contract is independent of generated map/topology data: the feed card sits
+/// at `kMapOverlayEdgeInset` whether the province panel is open or closed (the
+/// narrow code path never applies the wide `gameMapWideOverlayRightInset`), and
+/// `reportMapTileTapped` only stores the tapped tile key (no province geometry
+/// lookup — see `map_province_panel_provider.dart`).
+///
+/// The fixture therefore provides a single human ([kPanelTestHumanPlayerId])
+/// owning one old-world province whose `tileKeysByRegionAndProvince` entry
+/// supplies the `_firstOldWorldTileKey` the suite taps; that tile key maps back
+/// to the seeded province so the opened narrow province overlay resolves real
+/// (if minimal) province data rather than an unknown id. Pair it with
+/// `buildLightweightMapViewData()` so the canvas mounts without the ~7-11s
+/// `getDebugInitGameResult()` map generation.
+Game buildEventFeedNarrowInsetTestGame() {
+  const human = kPanelTestHumanPlayerId;
+  const capProvince = 'oldWorld|cap';
+  return buildPanelTestGame(
+    id: 'event-feed-narrow-inset-widget-test',
+    oldWorldProvinces: const [
+      Province(
+        id: capProvince,
+        regionId: 'oldWorld',
+        ownerId: human,
+        displayName: 'Capital',
+        townTileKey: 'oldWorld|cap|0|0',
+      ),
+    ],
+    tileKeysByRegionAndProvince: const {
+      'oldWorld': {
+        capProvince: ['oldWorld|cap|0|0'],
+      },
+    },
+  );
+}
+
 /// Lightweight game shaped for the in-game Diplomacy *screen* family
 /// (`diplomacy_screen_test`, `diplomacy_screen_top_bar_test`,
 /// `diplomacy_screen_320dp_min_viewport_test`, `diplomacy_dialogs_test`).

--- a/app/test/support/panel_test_fixtures_test.dart
+++ b/app/test/support/panel_test_fixtures_test.dart
@@ -344,6 +344,39 @@ void main() {
     });
   });
 
+  group('buildEventFeedNarrowInsetTestGame', () {
+    test('single human owns one old-world province for the narrow inset suite',
+        () {
+      final game = buildEventFeedNarrowInsetTestGame();
+      expect(game.players, hasLength(1));
+      expect(game.players.first.id, kPanelTestHumanPlayerId);
+      expect(game.worldState.oldWorld.provinces, hasLength(1));
+      expect(
+        game.worldState.oldWorld.provinces.single.ownerId,
+        kPanelTestHumanPlayerId,
+      );
+      // No generated map/topology cells are needed; the suite only mounts the
+      // canvas via buildLightweightMapViewData().
+      expect(game.worldState.newWorld.units, isEmpty);
+    });
+
+    test('exposes a tappable old-world tile key mapped back to its province',
+        () {
+      final game = buildEventFeedNarrowInsetTestGame();
+      final byProv = game.worldState.tileKeysByRegionAndProvince['oldWorld'];
+      expect(byProv, isNotNull);
+      // The suite taps `_firstOldWorldTileKey`; it must resolve a non-empty
+      // tile key whose province id matches a seeded province so the opened
+      // narrow overlay resolves real province data.
+      final entry = byProv!.entries.firstWhere((e) => e.value.isNotEmpty);
+      final tileKey = entry.value.first;
+      expect(tileKey, isNotEmpty);
+      final provinceIds =
+          game.worldState.oldWorld.provinces.map((p) => p.id).toSet();
+      expect(provinceIds, contains(entry.key));
+    });
+  });
+
   group('buildMapAreaEventFeedTestGame', () {
     test('exposes a human plus a named AI opponent for feed-line lookups', () {
       final game = buildMapAreaEventFeedTestGame();

--- a/tool/check_app_test_no_debug_init.dart
+++ b/tool/check_app_test_no_debug_init.dart
@@ -27,7 +27,6 @@ const Set<String> _kDebugInitAllowlist = <String>{
   'app/test/game_map_area_region_minimap_test.dart',
   'app/test/game_map_area_selection_mode_test.dart',
   'app/test/human_draft_projected_region_provider_test.dart',
-  'app/test/player_turn_event_feed_narrow_inset_test.dart',
   'app/test/production_commodity_breakdown_dialog_spec_test.dart',
   'app/test/production_commodity_breakdown_dialog_wide_golden_test.dart',
   'app/test/province_sea_zone_overlay_detail_paths_test.dart',


### PR DESCRIPTION
## Summary

Migrates `app/test/player_turn_event_feed_narrow_inset_test.dart` off the
expensive `getDebugInitGameResult()` map generator (~7-11s per test isolate)
onto the shared lightweight fixtures (Refs #3656). The suite asserts only the
floating `PlayerTurnEventFeedCard` `Positioned.right` inset contract on narrow
viewports (Refs #2870 S3 / Req 11), which derives from a narrow `GameMapArea` +
`mapViewState`, never from generated map/topology data.

## Done in this push

- **`player_turn_event_feed_narrow_inset_test.dart`** — replaces the three
  `getDebugInitGameResult()` setups with `buildEventFeedNarrowInsetTestGame()`
  (feed toggled on via `copyWith`) paired with `buildLightweightMapViewData()`.
  Opening the province bottom sheet only stores the tapped tile key
  (`mapProvincePanelProvider.reportMapTileTapped` — no province geometry
  lookup), so a single seeded old-world province whose
  `tileKeysByRegionAndProvince` entry maps back to it is sufficient. All three
  assertions (panel-closed inset, panel-open inset, wide-inset negative guard)
  are unchanged.
- Adds `buildEventFeedNarrowInsetTestGame()` to
  `app/test/support/panel_test_fixtures.dart` with focused fixture tests.
- Removes the file from the `tool/check_app_test_no_debug_init.dart` allowlist
  (the allowlist may only ever shrink).

## ACs covered (Refs #3656)

- [x] Allowlist shrinks: the migrated file no longer calls
  `getDebugInitGameResult()` and is removed from the documented allowlist.
- [x] Assertions preserved; the suite passes.
- [x] `flutter analyze` clean on touched files; the
  `check_app_test_no_debug_init` gate (incl. shrink-only / stale-entry checks)
  stays green.

## Remaining for #3656

The allowlist suites that genuinely read generated map/topology data
(`ct_region_map_*`, `game_map_area_region_minimap`, `game_map_area_selection_mode`
build-target/auto-switch cases, province/sea-zone overlay,
production-breakdown delta/golden, train/unit goldens, `human_draft_projected_region_provider`)
are deferred to follow-up slices.

## Verification

- `cd app && flutter test test/player_turn_event_feed_narrow_inset_test.dart test/support/panel_test_fixtures_test.dart` → all pass.
- `dart test test/check_app_test_no_debug_init_test.dart` → 6/6 passed.
- `dart run tool/check_app_test_no_debug_init.dart` → no disallowed usage.
- `cd app && flutter analyze <touched files>` → No issues found.

Refs #3656

Made with [Cursor](https://cursor.com)