### PR TITLE
perf(app): migrate human-draft-region provider test off getDebugInitGameResult (#3656)

### DIFF
--- a/app/test/human_draft_projected_region_provider_test.dart
+++ b/app/test/human_draft_projected_region_provider_test.dart
@@ -5,13 +5,15 @@ import 'package:colonizethis_app/providers/games_box_provider.dart';
 import 'package:colonizethis_app/providers/games_provider.dart';
 import 'package:colonizethis_app/providers/human_draft_projected_region_provider.dart';
 import 'package:colonizethis_app/providers/map_view_provider.dart';
-import 'package:colonizethis_app/widgets/debug_init_game.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_save/colonizethis_save.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
+
+import 'support/map_view_test_fixtures.dart';
+import 'support/panel_test_fixtures.dart';
 
 void main() {
   suppressLogsForTests();
@@ -24,15 +26,21 @@ void main() {
   });
 
   test('humanDraftProjectedRegionProvider returns region when game loaded', () {
-    final init = getDebugInitGameResult();
+    // Lightweight hand-built game + minimal two-region map view replace the
+    // ~7-11s getDebugInitGameResult() map generation (Refs #3656). The provider
+    // only needs a human player and a base region for the requested regionId;
+    // with no civilian/fleet draft orders the projection returns the base
+    // region unchanged, so this asserts identity (regionId == 'oldWorld').
+    final game = buildPanelTestGame();
+    final mapViewData = buildLightweightMapViewData();
     final container = ProviderContainer(
       overrides: [
-        currentGameProvider.overrideWith(() => CurrentGameNotifier(init.game)),
+        currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
         gamesBoxProvider.overrideWith((ref) => gamesBox),
         gameServiceProvider.overrideWith(
           (ref) => GameService(gamesBox, GameSaveAdapter()),
         ),
-        mapViewDataProvider.overrideWith((ref) => init.mapViewData),
+        mapViewDataProvider.overrideWith((ref) => mapViewData),
         currentOrdersProvider.overrideWith(
           () => CurrentOrdersNotifier(const Orders()),
         ),

--- a/tool/check_app_test_no_debug_init.dart
+++ b/tool/check_app_test_no_debug_init.dart
@@ -26,7 +26,6 @@ const Set<String> _kDebugInitAllowlist = <String>{
   'app/test/ct_region_map_test_support.dart',
   'app/test/game_map_area_region_minimap_test.dart',
   'app/test/game_map_area_selection_mode_test.dart',
-  'app/test/human_draft_projected_region_provider_test.dart',
   'app/test/production_commodity_breakdown_dialog_spec_test.dart',
   'app/test/production_commodity_breakdown_dialog_wide_golden_test.dart',
   'app/test/province_sea_zone_overlay_detail_paths_test.dart',


### PR DESCRIPTION
## Summary

Continues the app-test speedup for issue #3656 by migrating one more genuine `getDebugInitGameResult()` caller off the ~7-11s procedural map generation.

`human_draft_projected_region_provider_test.dart` previously paid a full default `getDebugInitGameResult()` map generation in-test purely to obtain a `Game` and an `InitGameMapViewData`, even though its single assertion only checks that `humanDraftProjectedRegionProvider('oldWorld')` returns a non-null region with `regionId == 'oldWorld'`.

## Done in this push

- Replaced `getDebugInitGameResult().game` / `.mapViewData` with the shared lightweight `buildPanelTestGame()` + `buildLightweightMapViewData()` fixtures (`app/test/support/`).
- The provider only needs a human player and a base region for the requested `regionId`. With no civilian/fleet draft orders (and `getMapData` returning null for the unpersisted game), `projectHumanDraftMarkersForRegion` returns the base region unchanged, so the existing assertion (`regionId == 'oldWorld'`) is preserved — no behavioral/coverage change.

## Verification

- `flutter test test/human_draft_projected_region_provider_test.dart` → `All tests passed!` (map generation no longer executed).
- `dart analyze test/human_draft_projected_region_provider_test.dart` → `No issues found!`

## Scope / deferred

- This is one slice of #3656. Remaining genuine callers are mostly map/topology-dependent suites (`ct_region_map_*`, `game_map_area_*`, sea-zone/production-breakdown) that require the serialized seed-42 `InitGameResult` fixture path, plus golden suites whose pixel baselines depend on exact debug-init content; those are deferred to follow-up PRs per the issue's serialized-fixture / allowlist guidance.

Refs #3656

Made with [Cursor](https://cursor.com)