### PR TITLE
perf(app): migrate production breakdown delta-colour spec test off getDebugInitGameResult (#3656)

### DIFF
--- a/app/test/production_commodity_breakdown_dialog_spec_test.dart
+++ b/app/test/production_commodity_breakdown_dialog_spec_test.dart
@@ -1,6 +1,7 @@
 // Pins SPEC/ui/production-commodity-breakdown-dialog.md contract for the
 // read-only commodity breakdown modal opened from ProductionScreen.
 
+import 'package:colonizethis_data/colonizethis_data.dart' show MapTopology;
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
@@ -14,8 +15,9 @@ import 'package:colonizethis_app/features/game/widgets/chrome/ct_dialog_shell.da
 import 'package:colonizethis_app/features/game/widgets/production_commodity_breakdown_dialog.dart';
 import 'package:colonizethis_app/l10n/l10n.dart';
 import 'package:colonizethis_app/providers/production_allocation_provider.dart';
-import 'package:colonizethis_app/widgets/debug_init_game.dart';
 import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
+
+import 'support/panel_test_fixtures.dart';
 
 class _SeededProductionDesiredOutputNotifier
     extends ProductionDesiredOutputNotifier {
@@ -43,8 +45,13 @@ void main() {
         tester.view.physicalSize = surfaceSize;
         tester.view.devicePixelRatio = 1.0;
 
-        final result = getDebugInitGameResult();
-        final game = result.game;
+        // Lightweight fixture (no ~7-11s getDebugInitGameResult() map
+        // generation, Refs #3656). The delta-colour pins below are driven by the
+        // economy-preview pipeline's Consumption/Production phases off the
+        // player's workerPool labour + stockpile commodities, not owned tiles, so
+        // a tile-less hand-built game reproduces them (topology / tileMapByRegion
+        // contribute nothing here).
+        final game = buildProductionBreakdownDeltaTestGame();
         final humanPlayerId = game.players.firstWhere((p) => p.isHuman).id;
         final player = game.playerById(humanPlayerId) ?? game.players.first;
         await tester.pumpWidget(
@@ -70,8 +77,8 @@ void main() {
                         builder: (_) => ProductionCommodityBreakdownDialog(
                           game: game,
                           player: player,
-                          topology: result.combinedTopology,
-                          tileMapByRegion: result.tileMapByRegion,
+                          topology: const MapTopology(),
+                          tileMapByRegion: null,
                           currentOrders: const Orders(),
                         ),
                       );

--- a/app/test/support/panel_test_fixtures.dart
+++ b/app/test/support/panel_test_fixtures.dart
@@ -1108,11 +1108,51 @@ Game buildUnitPanelsTestGame() => buildTrainPanelTestGame();
 /// every commodity renders its `0` cells and the layout assertions hold without
 /// the ~7-11 s `getDebugInitGameResult()` map generation.
 ///
-/// Delta-colour pins (positive/negative/zero cell colours) and the committed
-/// wide golden stay on the `getDebugInitGameResult()` allowlist — they need a
-/// generated game with real extraction/production to exercise non-zero deltas.
+/// The committed wide golden stays on the `getDebugInitGameResult()` allowlist —
+/// its pixel baseline was captured against the generated debug-init content, so
+/// it cannot move to a hand-built game without re-baselining. The delta-colour
+/// pins (positive/negative/zero cell colours) move to
+/// [buildProductionBreakdownDeltaTestGame] instead (Refs #3656).
 Game buildProductionBreakdownPanelTestGame() =>
     buildPanelTestGame(id: 'production-breakdown-widget-test');
+
+/// Lightweight game shaped for the `production_commodity_breakdown_dialog_spec`
+/// **delta-colour** pins (PROD20001): the zero-delta `muted` cells, the
+/// positive-delta `success` cells, and the negative-delta `danger` cells.
+///
+/// The economy-preview pipeline that feeds the dialog
+/// (`previewStockpilePhaseDeltasByCommodityForPlayer`) runs its Consumption and
+/// Production phases off the player's `workerPool` labour and `stockpile`
+/// commodities — **not** owned tiles — so non-zero deltas are reproducible
+/// without the ~7-11 s `getDebugInitGameResult()` map generation:
+/// - `peasants` are fed `grain` in Consumption (a guaranteed negative `grain`
+///   delta) and become idle labour;
+/// - that idle labour runs the `lumber_from_timber` recipe when the dialog's
+///   `productionDesiredOutputProvider` override assigns it, producing a positive
+///   `lumber` delta and consuming `timber` (a negative `timber` delta);
+/// - every other commodity stays at `0`, giving the muted zero cells.
+///
+/// Tests pass `topology: const MapTopology()` and `tileMapByRegion: null`; the
+/// Extraction and Riches-to-treasury phases contribute nothing for a tile-less,
+/// riches-less game, so only the recipe/consumption deltas above appear.
+Game buildProductionBreakdownDeltaTestGame() => buildPanelTestGame(
+  id: 'production-breakdown-delta-widget-test',
+  players: const [
+    Player(
+      id: kPanelTestHumanPlayerId,
+      displayName: 'Test Human',
+      isHuman: true,
+      workerPool: WorkerPool(peasants: 20),
+      stockpile: Stockpile(
+        quantities: {
+          'grain': 100,
+          'timber': 100,
+        },
+      ),
+    ),
+    Player(id: 'gp2', displayName: 'Rival Power', isHuman: false),
+  ],
+);
 
 /// Lightweight game shaped for `grant_or_subsidy_listener_test`.
 ///

--- a/app/test/support/panel_test_fixtures_test.dart
+++ b/app/test/support/panel_test_fixtures_test.dart
@@ -404,4 +404,28 @@ void main() {
       expect(ports[key], isNotEmpty);
     });
   });
+
+  group('buildProductionBreakdownDeltaTestGame', () {
+    test(
+      'human carries fed labour + recipe-input stockpile for non-zero deltas',
+      () {
+        // The breakdown dialog's delta-colour pins need the economy-preview
+        // Consumption/Production phases to move the stockpile without owned
+        // tiles: peasants fed by grain become idle labour, and timber feeds the
+        // lumber_from_timber recipe (Refs #3656).
+        final game = buildProductionBreakdownDeltaTestGame();
+        final human = game.players.firstWhere((p) => p.isHuman);
+        expect(human.id, kPanelTestHumanPlayerId);
+        expect(human.workerPool.peasants, greaterThan(0));
+        expect(human.stockpile.quantityOf('grain'), greaterThan(0));
+        // 5 lumber runs consume 10 timber; the fixture must stock enough.
+        expect(human.stockpile.quantityOf('timber'), greaterThanOrEqualTo(10));
+      },
+    );
+
+    test('a non-owning player id resolves to no player (empty-state guard)', () {
+      final game = buildProductionBreakdownDeltaTestGame();
+      expect(game.players.where((p) => p.id == 'no-such-player'), isEmpty);
+    });
+  });
 }

--- a/tool/check_app_test_no_debug_init.dart
+++ b/tool/check_app_test_no_debug_init.dart
@@ -26,7 +26,6 @@ const Set<String> _kDebugInitAllowlist = <String>{
   'app/test/ct_region_map_test_support.dart',
   'app/test/game_map_area_region_minimap_test.dart',
   'app/test/game_map_area_selection_mode_test.dart',
-  'app/test/production_commodity_breakdown_dialog_spec_test.dart',
   'app/test/production_commodity_breakdown_dialog_wide_golden_test.dart',
   'app/test/province_sea_zone_overlay_detail_paths_test.dart',
   'app/test/train_dialogs_goldens_test.dart',


### PR DESCRIPTION
## Summary

Continues the app-test speedup for issue #3656 by migrating another genuine `getDebugInitGameResult()` caller off the ~7-11s procedural map generation. Follow-up to the now-merged #3696 (one open PR per issue; the prior PR merged, so this is the successor slice from current `dev`).

`production_commodity_breakdown_dialog_spec_test.dart` previously paid a full default `getDebugInitGameResult()` map generation per isolate purely to obtain a `Game` (plus topology/tile maps that the dialog's economy preview does not actually need for these assertions).

## Done in this push

- Added a shared lightweight `buildProductionBreakdownDeltaTestGame()` fixture (`app/test/support/panel_test_fixtures.dart`): a human player with `WorkerPool(peasants: 20)` and a `Stockpile` of `grain` + `timber`, plus a non-human opponent.
- Migrated `production_commodity_breakdown_dialog_spec_test.dart` to that fixture with `topology: const MapTopology()` and `tileMapByRegion: null`.
- The delta-colour pins are reproduced **without generated tiles**: the economy-preview Consumption phase feeds peasants `grain` (negative `grain` delta) into idle labour; that labour runs the `lumber_from_timber` recipe via the dialog's `productionDesiredOutputProvider` override, producing a positive `lumber` delta and consuming `timber` (negative `timber` delta); all other commodities stay at `0` (muted zero cells). Assertions and behavioral coverage are unchanged.
- Removed the file from the debug-init checker allowlist (`tool/check_app_test_no_debug_init.dart`) — the allowlist only ever shrinks.
- Added positive/negative fixture tests in `panel_test_fixtures_test.dart`.

## Verification

- `flutter test test/production_commodity_breakdown_dialog_spec_test.dart` -> All tests passed (no map generation).
- `flutter test test/support/panel_test_fixtures_test.dart` -> All tests passed (incl. new builder group).
- `dart run tool/check_app_test_no_debug_init.dart` -> no disallowed usage / no stale entries.
- `dart test test/check_app_test_no_debug_init_test.dart` -> All tests passed.
- `dart analyze` on changed files -> No issues found.

## Scope / deferred

- The committed wide golden (`production_commodity_breakdown_dialog_wide_golden_test`) stays on the allowlist: its pixel baseline was captured against generated debug-init content and cannot move to a hand-built game without re-baselining.
- Remaining allowlisted callers are genuine map/topology-dependent suites (`ct_region_map_*`, `game_map_area_*`, sea-zone overlays) that require the serialized seed-42 `InitGameResult` fixture path; deferred to follow-up per the issue's serialized-fixture / allowlist guidance.

Refs #3656

Made with [Cursor](https://cursor.com)