### PR TITLE
refactor(app): extract shared nine-patch widget-test asset helper (#3656)

### DIFF
--- a/app/test/ct_game_feature_screen_shell_test.dart
+++ b/app/test/ct_game_feature_screen_shell_test.dart
@@ -1,20 +1,15 @@
-import 'dart:convert';
-import 'dart:io';
-import 'dart:ui' as ui;
-
 import 'package:colonizethis_app/providers/app_event_bus_provider.dart';
 import 'package:colonizethis_app/providers/games_provider.dart';
 import 'package:colonizethis_app/widgets/ct_game_feature_screen_shell.dart';
 import 'package:colonizethis_app/widgets/game_to_ui_bus_listener.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
-import 'package:flame/flame.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'support/panel_test_fixtures.dart';
+import 'support/widget_test_assets.dart';
 
 void main() {
   suppressLogsForTests();
@@ -24,8 +19,7 @@ void main() {
   late Game differentIdGame;
 
   setUpAll(() async {
-    await _mockNinePatchAssetBundle();
-    await _preWarmPanelNinePatch();
+    await setUpNinePatchAssets();
     // Lightweight fixture (Refs #3656): the shell only reads `game.id` (for the
     // current-vs-route id match) and `players.first.displayName` (rendered by
     // the test body builder); no generated map/topology data is needed.
@@ -50,11 +44,6 @@ void main() {
         ...routeGame.players.skip(1),
       ],
     );
-  });
-
-  tearDownAll(() {
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-        .setMockMessageHandler('flutter/assets', null);
   });
 
   Widget buildShell({
@@ -136,42 +125,4 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.byType(GameToUIBusListener), findsNothing);
   });
-}
-
-Future<void> _preWarmPanelNinePatch() async {
-  try {
-    final bytes = await rootBundle.load('assets/images/ui_button_nine_patch.png');
-    final codec = await ui.instantiateImageCodec(bytes.buffer.asUint8List());
-    final frame = await codec.getNextFrame();
-    Flame.images.add('ui_button_nine_patch.png', frame.image);
-    Flame.images.add('assets/images/ui_button_nine_patch.png', frame.image);
-  } catch (_) {
-    // Keep tests resilient when the asset is unavailable in CI.
-  }
-}
-
-Future<void> _mockNinePatchAssetBundle() async {
-  final fallbackBytes = base64Decode(
-    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+X2ioAAAAASUVORK5CYII=',
-  );
-  var ninePatchBytes = fallbackBytes;
-  final assetCandidates = <String>[
-    'app/assets/images/ui_button_nine_patch.png',
-    'assets/images/ui_button_nine_patch.png',
-  ];
-  for (final candidate in assetCandidates) {
-    final file = File(candidate);
-    if (await file.exists()) {
-      ninePatchBytes = await file.readAsBytes();
-      break;
-    }
-  }
-  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-      .setMockMessageHandler('flutter/assets', (message) async {
-        final key = const StringCodec().decodeMessage(message);
-        if (key == 'assets/images/ui_button_nine_patch.png') {
-          return ByteData.view(Uint8List.fromList(ninePatchBytes).buffer);
-        }
-        return null;
-      });
 }

--- a/app/test/ct_nine_patch_button_test.dart
+++ b/app/test/ct_nine_patch_button_test.dart
@@ -1,59 +1,16 @@
-import 'dart:convert';
-import 'dart:io';
-import 'dart:ui' as ui;
-
 import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
-import 'package:flame/flame.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+import 'support/widget_test_assets.dart';
 
 void main() {
   suppressLogsForTests();
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  final ninePatchFallbackPng = base64Decode(
-    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+X2ioAAAAASUVORK5CYII=',
-  );
-  Uint8List ninePatchBytes = ninePatchFallbackPng;
-
   setUpAll(() async {
-    final assetCandidates = <String>[
-      'app/assets/images/ui_button_nine_patch.png',
-      'assets/images/ui_button_nine_patch.png',
-    ];
-    for (final candidate in assetCandidates) {
-      final file = File(candidate);
-      if (await file.exists()) {
-        ninePatchBytes = await file.readAsBytes();
-        break;
-      }
-    }
-
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-        .setMockMessageHandler('flutter/assets', (message) async {
-          final key = const StringCodec().decodeMessage(message);
-          if (key == 'assets/images/ui_button_nine_patch.png') {
-            return ByteData.view(ninePatchBytes.buffer);
-          }
-          return null;
-        });
-
-    try {
-      final bytes = await rootBundle.load('assets/images/ui_button_nine_patch.png');
-      final codec = await ui.instantiateImageCodec(bytes.buffer.asUint8List());
-      final frame = await codec.getNextFrame();
-      Flame.images.add('ui_button_nine_patch.png', frame.image);
-      Flame.images.add('assets/images/ui_button_nine_patch.png', frame.image);
-    } catch (_) {
-      // Keep test resilient when prewarm cannot decode on this host.
-    }
-  });
-
-  tearDownAll(() {
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-        .setMockMessageHandler('flutter/assets', null);
+    await setUpNinePatchAssets();
   });
 
   testWidgets(

--- a/app/test/diplomacy_detail_screen_320dp_min_viewport_test.dart
+++ b/app/test/diplomacy_detail_screen_320dp_min_viewport_test.dart
@@ -42,8 +42,6 @@
 // Refs #2870 S10 (no horizontal overflow at 320 dp on every covered
 // screen).
 
-import 'dart:ui' as ui;
-
 import 'package:colonizethis_app/config/constants.dart';
 import 'package:colonizethis_app/config/themes.dart';
 import 'package:colonizethis_app/features/game/screens/diplomacy_detail_screen.dart';
@@ -53,11 +51,11 @@ import 'package:colonizethis_app/widgets/ct_top_bar.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
-import 'package:flame/flame.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+import 'support/widget_test_assets.dart';
 
 /// Minimum supported viewport dimensions for SPEC/ui/mobile-adaptation.md
 /// § 7. Width matches [kMinViewportWidth]; height (640 dp) mirrors the
@@ -76,28 +74,6 @@ const Size _kWideRegressionViewport = Size(1024, 768);
 const String _kHumanPlayerId = 'gp1';
 const String _kOtherFactionId = 'gp2';
 const String _kOtherFactionDisplayName = 'Other GP';
-
-/// Pre-warms the brass nine-patch sprite into the Flame image cache so
-/// the `CtNinePatchButton` chrome that may surface inside the
-/// `CtGameFeatureScreenShell` lays out at its true declared size during
-/// the 320 dp pin rather than falling back to a `SizedBox.shrink()`
-/// silhouette while the asset bytes resolve. Mirrors the helper used by
-/// `diplomacy_detail_screen_test.dart` and `unit_panels_320dp_min_viewport_test.dart`.
-Future<void> _ensureUiNinePatchAssetLoaded() async {
-  try {
-    final bytes = await rootBundle.load(
-      'assets/images/ui_button_nine_patch.png',
-    );
-    final codec = await ui.instantiateImageCodec(bytes.buffer.asUint8List());
-    final frame = await codec.getNextFrame();
-    Flame.images.add('ui_button_nine_patch.png', frame.image);
-  } catch (_) {
-    // Silently ignore — the pin still asserts the chrome lays out at the
-    // 320 dp viewport even when the asset cannot be resolved in the test
-    // sandbox; `CtNinePatchButton` falls back to a 0-size placeholder
-    // which still respects the surrounding `Wrap` / `Column` layout.
-  }
-}
 
 /// Minimal in-memory `Game` carrying a single human GP and one other GP
 /// (which acts as the detail-screen target). Mirrors the helper used by
@@ -207,7 +183,7 @@ void main() {
   suppressLogsForTests();
 
   setUpAll(() async {
-    await _ensureUiNinePatchAssetLoaded();
+    await preloadNinePatchImage();
   });
 
   group(

--- a/app/test/diplomacy_detail_screen_test.dart
+++ b/app/test/diplomacy_detail_screen_test.dart
@@ -8,27 +8,17 @@ import 'package:colonizethis_app/widgets/ct_top_bar.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
-import 'package:flame/flame.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'dart:ui' as ui;
+
+import 'support/widget_test_assets.dart';
 
 void main() {
   suppressLogsForTests();
 
   setUpAll(() async {
-    try {
-      final bytes = await rootBundle.load(
-        'assets/images/ui_button_nine_patch.png',
-      );
-      final codec = await ui.instantiateImageCodec(bytes.buffer.asUint8List());
-      final frame = await codec.getNextFrame();
-      Flame.images.add('ui_button_nine_patch.png', frame.image);
-    } catch (e) {
-      // Silently fail - the test might still work if the image is available later
-    }
+    await preloadNinePatchImage();
   });
 
   Game minimalGame({

--- a/app/test/diplomacy_panel_chrome_test.dart
+++ b/app/test/diplomacy_panel_chrome_test.dart
@@ -4,14 +4,11 @@
 // non-comment lines). SPEC/ui/diplomacy-panel.md § Per-faction row.
 
 import 'dart:async';
-import 'dart:ui' as ui;
 
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
-import 'package:flame/flame.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:colonizethis_app/config/editorial_monocle_palette.dart';
@@ -19,6 +16,7 @@ import 'package:colonizethis_app/features/game/widgets/diplomacy_panel.dart';
 import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
 
 import 'support/panel_test_fixtures.dart';
+import 'support/widget_test_assets.dart';
 
 /// `pumpAndSettle` hangs here: Flame nine-patch widgets can keep the ticker
 /// busy. Bounded pumps flush layout, bus handlers, and dialog routes.
@@ -115,19 +113,6 @@ class _EventHandlingWrapperState extends State<_EventHandlingWrapper> {
   Widget build(BuildContext context) => widget.child;
 }
 
-Future<void> _preWarmFlameImageCache() async {
-  try {
-    final bytes = await rootBundle.load(
-      'assets/images/ui_button_nine_patch.png',
-    );
-    final codec = await ui.instantiateImageCodec(bytes.buffer.asUint8List());
-    final frame = await codec.getNextFrame();
-    Flame.images.add('ui_button_nine_patch.png', frame.image);
-  } catch (e) {
-    // Silently fail - the test might still work if the image is available later
-  }
-}
-
 Widget _buildPanel({
   required Game game,
   required String humanPlayerId,
@@ -167,7 +152,7 @@ void main() {
   });
 
   setUpAll(() async {
-    await _preWarmFlameImageCache();
+    await preloadNinePatchImage();
     // Refs #3656: lightweight discovered-GP fixture replaces the ~7-11s
     // getDebugInitGameResult() map generation. These chrome suites only read a
     // discovered Great Power row (relation badges + action buttons), which the

--- a/app/test/diplomacy_panel_narrow_layout_test.dart
+++ b/app/test/diplomacy_panel_narrow_layout_test.dart
@@ -5,33 +5,16 @@
 // layout selected via [kDiplomacyRowNarrowMaxWidth] and surfaced through
 // the public `kDiplomacyRowBodyKeyPrefix`-tagged body key.
 
-import 'dart:ui' as ui;
-
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
-import 'package:flame/flame.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:colonizethis_app/features/game/widgets/diplomacy_panel.dart';
 
 import 'support/panel_test_fixtures.dart';
-
-Future<void> _preWarmFlameImageCache() async {
-  try {
-    final bytes = await rootBundle.load(
-      'assets/images/ui_button_nine_patch.png',
-    );
-    final codec = await ui.instantiateImageCodec(bytes.buffer.asUint8List());
-    final frame = await codec.getNextFrame();
-    Flame.images.add('ui_button_nine_patch.png', frame.image);
-  } catch (_) {
-    // Best-effort: existing diplomacy tests tolerate a missing nine-patch
-    // bundle. Layout assertions here do not require pixel-perfect chrome.
-  }
-}
+import 'support/widget_test_assets.dart';
 
 Future<void> _pumpPanelBuilt(WidgetTester tester) async {
   await tester.pump();
@@ -85,7 +68,7 @@ void main() {
   setUp(() => AppEventBus.reset());
 
   setUpAll(() async {
-    await _preWarmFlameImageCache();
+    await preloadNinePatchImage();
     // Refs #3656: lightweight discovered-GP fixture replaces the ~7-11s
     // getDebugInitGameResult() map generation. The responsive-layout pins only
     // need one discovered faction row (keyed by faction id), which the

--- a/app/test/diplomacy_panel_orders_test.dart
+++ b/app/test/diplomacy_panel_orders_test.dart
@@ -1,70 +1,24 @@
 // DiplomacyPanel order UI + bus command emission coverage.
-import 'dart:convert';
-import 'dart:io';
-import 'dart:ui' as ui;
-
 import 'package:colonizethis_app/features/game/widgets/diplomacy_panel.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
-import 'package:flame/flame.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'support/panel_test_fixtures.dart';
+import 'support/widget_test_assets.dart';
 
 void main() {
   suppressLogsForTests();
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  final ninePatchFallbackPng = base64Decode(
-    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+X2ioAAAAASUVORK5CYII=',
-  );
-  Uint8List ninePatchBytes = ninePatchFallbackPng;
-
   setUpAll(() async {
-    final assetCandidates = <String>[
-      'app/assets/images/ui_button_nine_patch.png',
-      'assets/images/ui_button_nine_patch.png',
-    ];
-    for (final candidate in assetCandidates) {
-      final file = File(candidate);
-      if (await file.exists()) {
-        ninePatchBytes = await file.readAsBytes();
-        break;
-      }
-    }
-
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-        .setMockMessageHandler('flutter/assets', (message) async {
-          final key = const StringCodec().decodeMessage(message);
-          if (key == 'assets/images/ui_button_nine_patch.png') {
-            return ByteData.view(ninePatchBytes.buffer);
-          }
-          return null;
-        });
-
-    try {
-      final bytes = await rootBundle.load(
-        'assets/images/ui_button_nine_patch.png',
-      );
-      final codec = await ui.instantiateImageCodec(bytes.buffer.asUint8List());
-      final frame = await codec.getNextFrame();
-      Flame.images.add('ui_button_nine_patch.png', frame.image);
-      Flame.images.add('assets/images/ui_button_nine_patch.png', frame.image);
-    } catch (_) {
-      // Keep test resilient if this host cannot decode during prewarm.
-    }
+    await setUpNinePatchAssets();
   });
 
   setUp(() {
     AppEventBus.reset();
-  });
-
-  tearDownAll(() {
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-        .setMockMessageHandler('flutter/assets', null);
   });
 
   testWidgets(

--- a/app/test/diplomacy_panel_test.dart
+++ b/app/test/diplomacy_panel_test.dart
@@ -1,14 +1,11 @@
 // Tests for DiplomacyPanel. SPEC/ui/diplomacy-panel.md.
 
 import 'dart:async';
-import 'dart:ui' as ui;
 
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
-import 'package:flame/flame.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:colonizethis_app/config/editorial_monocle_palette.dart';
@@ -16,6 +13,7 @@ import 'package:colonizethis_app/features/game/widgets/diplomacy_panel.dart';
 import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
 
 import 'support/panel_test_fixtures.dart';
+import 'support/widget_test_assets.dart';
 
 /// `pumpAndSettle` hangs here: Flame nine-patch widgets can keep the ticker
 /// busy. Bounded pumps flush layout, bus handlers, and dialog routes.
@@ -112,19 +110,6 @@ class _EventHandlingWrapperState extends State<_EventHandlingWrapper> {
 
   @override
   Widget build(BuildContext context) => widget.child;
-}
-
-Future<void> _preWarmFlameImageCache() async {
-  try {
-    final bytes = await rootBundle.load(
-      'assets/images/ui_button_nine_patch.png',
-    );
-    final codec = await ui.instantiateImageCodec(bytes.buffer.asUint8List());
-    final frame = await codec.getNextFrame();
-    Flame.images.add('ui_button_nine_patch.png', frame.image);
-  } catch (e) {
-    // Silently fail - the test might still work if the image is available later
-  }
 }
 
 Widget buildPanel({
@@ -255,7 +240,7 @@ void main() {
   });
 
   setUpAll(() async {
-    await _preWarmFlameImageCache();
+    await preloadNinePatchImage();
     // Refs #3656: lightweight discovered-faction fixture replaces the ~7-11s
     // getDebugInitGameResult() map generation. It seeds discovered GPs (one at
     // peace → PEACE badge, one at war → WAR badge), a Minor Nation with the

--- a/app/test/diplomacy_relative_power_goldens_test.dart
+++ b/app/test/diplomacy_relative_power_goldens_test.dart
@@ -20,8 +20,6 @@
 // criteria (AC-15); SPEC/ui/diplomacy-detail-screen.md § Acceptance Criteria
 // (relative-power golden).
 
-import 'dart:ui' as ui;
-
 import 'package:colonizethis_app/config/themes.dart';
 import 'package:colonizethis_app/features/game/screens/diplomacy_detail_screen.dart';
 import 'package:colonizethis_app/features/game/widgets/diplomacy_panel.dart';
@@ -29,11 +27,11 @@ import 'package:colonizethis_app/l10n/l10n.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
-import 'package:flame/flame.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+import 'support/widget_test_assets.dart';
 
 /// `pumpAndSettle` can hang on the detail surface (animated chrome keeps the
 /// ticker busy); bounded pumps flush layout and the deferred build instead.
@@ -118,16 +116,7 @@ void main() {
     // The detail screen chrome (CtTopBar / CtBackButton) may consume the
     // shared nine-patch image; preload it so the golden renders the framed
     // button rather than an error box (mirrors diplomacy_detail_screen_test).
-    try {
-      final bytes = await rootBundle.load(
-        'assets/images/ui_button_nine_patch.png',
-      );
-      final codec = await ui.instantiateImageCodec(bytes.buffer.asUint8List());
-      final frame = await codec.getNextFrame();
-      Flame.images.add('ui_button_nine_patch.png', frame.image);
-    } catch (_) {
-      // Best-effort: the golden still captures the relative-power line.
-    }
+    await preloadNinePatchImage();
   });
 
   setUp(AppEventBus.reset);

--- a/app/test/naval_units_panel_test_part1_test.dart
+++ b/app/test/naval_units_panel_test_part1_test.dart
@@ -1,9 +1,6 @@
 // Tests for NavalUnitsPanel. SPEC/ui/naval-units-panel.md.
 
 import 'dart:async';
-import 'dart:convert';
-import 'dart:io';
-import 'dart:ui' as ui;
 
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart'
@@ -13,9 +10,7 @@ import 'package:colonizethis_logic/colonizethis_logic.dart'
         homeFleetIdFor;
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
-import 'package:flame/flame.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:colonizethis_app/features/game/widgets/naval_units_panel.dart';
@@ -26,6 +21,7 @@ import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
 import 'package:colonizethis_app/widgets/ct_panel.dart';
 
 import 'support/panel_test_fixtures.dart';
+import 'support/widget_test_assets.dart';
 
 /// Mirrors shell handling of [NavalSplitFleetRequestedEvent] for widget tests.
 StreamSubscription<NavalSplitFleetRequestedEvent> wireNavalSplitForWidgetTest({
@@ -69,48 +65,8 @@ void main() {
   late String humanPlayerIdWithFleets;
   const String humanPlayerIdWithNoFleets = 'no-such-player';
 
-  // Fallback 1x1 transparent PNG if the real asset cannot be read.
-  final ninePatchFallbackPng = base64Decode(
-    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+X2ioAAAAASUVORK5CYII=',
-  );
-  Uint8List ninePatchBytes = ninePatchFallbackPng;
-
   setUpAll(() async {
-    final assetCandidates = <String>[
-      'app/assets/images/ui_button_nine_patch.png',
-      'assets/images/ui_button_nine_patch.png',
-    ];
-    for (final candidate in assetCandidates) {
-      final file = File(candidate);
-      if (await file.exists()) {
-        ninePatchBytes = await file.readAsBytes();
-        break;
-      }
-    }
-
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-        .setMockMessageHandler('flutter/assets', (message) async {
-          final key = const StringCodec().decodeMessage(message);
-          if (key == 'assets/images/ui_button_nine_patch.png') {
-            return ByteData.view(ninePatchBytes.buffer);
-          }
-          return null;
-        });
-
-    // Preload panel nine-patch image into Flame cache so widget tests are
-    // stable regardless of invocation directory.
-    try {
-      final bytes = await rootBundle.load(
-        'assets/images/ui_button_nine_patch.png',
-      );
-      final codec = await ui.instantiateImageCodec(bytes.buffer.asUint8List());
-      final frame = await codec.getNextFrame();
-      Flame.images.add('ui_button_nine_patch.png', frame.image);
-      Flame.images.add('assets/images/ui_button_nine_patch.png', frame.image);
-    } catch (_) {
-      // Keep tests resilient when asset prewarm fails; individual tests can
-      // still validate behavior where possible.
-    }
+    await setUpNinePatchAssets();
 
     // Refs #3656: lightweight hand-built fixture replaces the ~11s procedural
     // map generation of getDebugInitGameResult(); this family asserts only on
@@ -130,11 +86,6 @@ void main() {
     humanPlayerIdWithFleets = game.players.isNotEmpty
         ? game.players.first.id
         : 'gp1';
-  });
-
-  tearDownAll(() {
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-        .setMockMessageHandler('flutter/assets', null);
   });
 
   Widget buildPanel({

--- a/app/test/naval_units_panel_test_part2_test.dart
+++ b/app/test/naval_units_panel_test_part2_test.dart
@@ -1,9 +1,6 @@
 // Tests for NavalUnitsPanel. SPEC/ui/naval-units-panel.md.
 
 import 'dart:async';
-import 'dart:convert';
-import 'dart:io';
-import 'dart:ui' as ui;
 
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart'
@@ -13,9 +10,7 @@ import 'package:colonizethis_logic/colonizethis_logic.dart'
         homeFleetIdFor;
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
-import 'package:flame/flame.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:colonizethis_app/features/game/widgets/move_fleet_dialog.dart';
@@ -26,6 +21,8 @@ import 'package:colonizethis_app/features/game/widgets/units/shared/units_panel_
 import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
 import 'package:colonizethis_app/widgets/ct_panel.dart';
 import 'package:colonizethis_app/widgets/ct_transfer_list.dart';
+
+import 'support/widget_test_assets.dart';
 
 /// Mirrors shell handling of [NavalSplitFleetRequestedEvent] for widget tests.
 StreamSubscription<NavalSplitFleetRequestedEvent> wireNavalSplitForWidgetTest({
@@ -65,54 +62,8 @@ void main() {
   suppressLogsForTests();
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  // Fallback 1x1 transparent PNG if the real asset cannot be read.
-  final ninePatchFallbackPng = base64Decode(
-    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+X2ioAAAAASUVORK5CYII=',
-  );
-  Uint8List ninePatchBytes = ninePatchFallbackPng;
-
   setUpAll(() async {
-    final assetCandidates = <String>[
-      'app/assets/images/ui_button_nine_patch.png',
-      'assets/images/ui_button_nine_patch.png',
-    ];
-    for (final candidate in assetCandidates) {
-      final file = File(candidate);
-      if (await file.exists()) {
-        ninePatchBytes = await file.readAsBytes();
-        break;
-      }
-    }
-
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-        .setMockMessageHandler('flutter/assets', (message) async {
-          final key = const StringCodec().decodeMessage(message);
-          if (key == 'assets/images/ui_button_nine_patch.png') {
-            return ByteData.view(ninePatchBytes.buffer);
-          }
-          return null;
-        });
-
-    // Preload panel nine-patch image into Flame cache so widget tests are
-    // stable regardless of invocation directory.
-    try {
-      final bytes = await rootBundle.load(
-        'assets/images/ui_button_nine_patch.png',
-      );
-      final codec = await ui.instantiateImageCodec(bytes.buffer.asUint8List());
-      final frame = await codec.getNextFrame();
-      Flame.images.add('ui_button_nine_patch.png', frame.image);
-      Flame.images.add('assets/images/ui_button_nine_patch.png', frame.image);
-    } catch (_) {
-      // Keep tests resilient when asset prewarm fails; individual tests can
-      // still validate behavior where possible.
-    }
-
-  });
-
-  tearDownAll(() {
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-        .setMockMessageHandler('flutter/assets', null);
+    await setUpNinePatchAssets();
   });
 
   Widget buildPanel({

--- a/app/test/naval_units_panel_test_part3_test.dart
+++ b/app/test/naval_units_panel_test_part3_test.dart
@@ -1,9 +1,6 @@
 // Tests for NavalUnitsPanel. SPEC/ui/naval-units-panel.md.
 
 import 'dart:async';
-import 'dart:convert';
-import 'dart:io';
-import 'dart:ui' as ui;
 
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart'
@@ -13,9 +10,7 @@ import 'package:colonizethis_logic/colonizethis_logic.dart'
         homeFleetIdFor;
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
-import 'package:flame/flame.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:colonizethis_app/features/game/widgets/move_fleet_dialog.dart';
@@ -26,6 +21,8 @@ import 'package:colonizethis_app/features/game/widgets/units/shared/units_panel_
 import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
 import 'package:colonizethis_app/widgets/ct_panel.dart';
 import 'package:colonizethis_app/widgets/ct_transfer_list.dart';
+
+import 'support/widget_test_assets.dart';
 
 /// Mirrors shell handling of [NavalSplitFleetRequestedEvent] for widget tests.
 StreamSubscription<NavalSplitFleetRequestedEvent> wireNavalSplitForWidgetTest({
@@ -65,54 +62,8 @@ void main() {
   suppressLogsForTests();
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  // Fallback 1x1 transparent PNG if the real asset cannot be read.
-  final ninePatchFallbackPng = base64Decode(
-    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+X2ioAAAAASUVORK5CYII=',
-  );
-  Uint8List ninePatchBytes = ninePatchFallbackPng;
-
   setUpAll(() async {
-    final assetCandidates = <String>[
-      'app/assets/images/ui_button_nine_patch.png',
-      'assets/images/ui_button_nine_patch.png',
-    ];
-    for (final candidate in assetCandidates) {
-      final file = File(candidate);
-      if (await file.exists()) {
-        ninePatchBytes = await file.readAsBytes();
-        break;
-      }
-    }
-
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-        .setMockMessageHandler('flutter/assets', (message) async {
-          final key = const StringCodec().decodeMessage(message);
-          if (key == 'assets/images/ui_button_nine_patch.png') {
-            return ByteData.view(ninePatchBytes.buffer);
-          }
-          return null;
-        });
-
-    // Preload panel nine-patch image into Flame cache so widget tests are
-    // stable regardless of invocation directory.
-    try {
-      final bytes = await rootBundle.load(
-        'assets/images/ui_button_nine_patch.png',
-      );
-      final codec = await ui.instantiateImageCodec(bytes.buffer.asUint8List());
-      final frame = await codec.getNextFrame();
-      Flame.images.add('ui_button_nine_patch.png', frame.image);
-      Flame.images.add('assets/images/ui_button_nine_patch.png', frame.image);
-    } catch (_) {
-      // Keep tests resilient when asset prewarm fails; individual tests can
-      // still validate behavior where possible.
-    }
-
-  });
-
-  tearDownAll(() {
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-        .setMockMessageHandler('flutter/assets', null);
+    await setUpNinePatchAssets();
   });
 
   Widget buildPanel({

--- a/app/test/naval_units_panel_test_part4_test.dart
+++ b/app/test/naval_units_panel_test_part4_test.dart
@@ -1,9 +1,6 @@
 // Tests for NavalUnitsPanel. SPEC/ui/naval-units-panel.md.
 
 import 'dart:async';
-import 'dart:convert';
-import 'dart:io';
-import 'dart:ui' as ui;
 
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart'
@@ -13,9 +10,7 @@ import 'package:colonizethis_logic/colonizethis_logic.dart'
         homeFleetIdFor;
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
-import 'package:flame/flame.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:colonizethis_app/features/game/widgets/move_fleet_dialog.dart';
@@ -28,6 +23,7 @@ import 'package:colonizethis_app/widgets/ct_panel.dart';
 import 'package:colonizethis_app/widgets/ct_transfer_list.dart';
 
 import 'support/panel_test_fixtures.dart';
+import 'support/widget_test_assets.dart';
 
 /// Mirrors shell handling of [NavalSplitFleetRequestedEvent] for widget tests.
 StreamSubscription<NavalSplitFleetRequestedEvent> wireNavalSplitForWidgetTest({
@@ -70,56 +66,11 @@ void main() {
   late Game game;
   late String humanPlayerIdWithFleets;
 
-  // Fallback 1x1 transparent PNG if the real asset cannot be read.
-  final ninePatchFallbackPng = base64Decode(
-    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+X2ioAAAAASUVORK5CYII=',
-  );
-  Uint8List ninePatchBytes = ninePatchFallbackPng;
-
   setUpAll(() async {
-    final assetCandidates = <String>[
-      'app/assets/images/ui_button_nine_patch.png',
-      'assets/images/ui_button_nine_patch.png',
-    ];
-    for (final candidate in assetCandidates) {
-      final file = File(candidate);
-      if (await file.exists()) {
-        ninePatchBytes = await file.readAsBytes();
-        break;
-      }
-    }
-
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-        .setMockMessageHandler('flutter/assets', (message) async {
-          final key = const StringCodec().decodeMessage(message);
-          if (key == 'assets/images/ui_button_nine_patch.png') {
-            return ByteData.view(ninePatchBytes.buffer);
-          }
-          return null;
-        });
-
-    // Preload panel nine-patch image into Flame cache so widget tests are
-    // stable regardless of invocation directory.
-    try {
-      final bytes = await rootBundle.load(
-        'assets/images/ui_button_nine_patch.png',
-      );
-      final codec = await ui.instantiateImageCodec(bytes.buffer.asUint8List());
-      final frame = await codec.getNextFrame();
-      Flame.images.add('ui_button_nine_patch.png', frame.image);
-      Flame.images.add('assets/images/ui_button_nine_patch.png', frame.image);
-    } catch (_) {
-      // Keep tests resilient when asset prewarm fails; individual tests can
-      // still validate behavior where possible.
-    }
+    await setUpNinePatchAssets();
 
     game = buildNavalPanelTestGame();
     humanPlayerIdWithFleets = kPanelTestHumanPlayerId;
-  });
-
-  tearDownAll(() {
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-        .setMockMessageHandler('flutter/assets', null);
   });
 
   Widget buildPanel({

--- a/app/test/naval_units_panel_test_part5_test.dart
+++ b/app/test/naval_units_panel_test_part5_test.dart
@@ -1,9 +1,6 @@
 // Tests for NavalUnitsPanel. SPEC/ui/naval-units-panel.md.
 
 import 'dart:async';
-import 'dart:convert';
-import 'dart:io';
-import 'dart:ui' as ui;
 
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart'
@@ -13,9 +10,7 @@ import 'package:colonizethis_logic/colonizethis_logic.dart'
         homeFleetIdFor;
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
-import 'package:flame/flame.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:colonizethis_app/features/game/widgets/move_fleet_dialog.dart';
@@ -25,6 +20,8 @@ import 'package:colonizethis_app/features/game/widgets/units/shared/units_panel_
 import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
 import 'package:colonizethis_app/widgets/ct_panel.dart';
 import 'package:colonizethis_app/widgets/ct_transfer_list.dart';
+
+import 'support/widget_test_assets.dart';
 
 /// Mirrors shell handling of [NavalSplitFleetRequestedEvent] for widget tests.
 StreamSubscription<NavalSplitFleetRequestedEvent> wireNavalSplitForWidgetTest({
@@ -64,54 +61,8 @@ void main() {
   suppressLogsForTests();
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  // Fallback 1x1 transparent PNG if the real asset cannot be read.
-  final ninePatchFallbackPng = base64Decode(
-    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+X2ioAAAAASUVORK5CYII=',
-  );
-  Uint8List ninePatchBytes = ninePatchFallbackPng;
-
   setUpAll(() async {
-    final assetCandidates = <String>[
-      'app/assets/images/ui_button_nine_patch.png',
-      'assets/images/ui_button_nine_patch.png',
-    ];
-    for (final candidate in assetCandidates) {
-      final file = File(candidate);
-      if (await file.exists()) {
-        ninePatchBytes = await file.readAsBytes();
-        break;
-      }
-    }
-
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-        .setMockMessageHandler('flutter/assets', (message) async {
-          final key = const StringCodec().decodeMessage(message);
-          if (key == 'assets/images/ui_button_nine_patch.png') {
-            return ByteData.view(ninePatchBytes.buffer);
-          }
-          return null;
-        });
-
-    // Preload panel nine-patch image into Flame cache so widget tests are
-    // stable regardless of invocation directory.
-    try {
-      final bytes = await rootBundle.load(
-        'assets/images/ui_button_nine_patch.png',
-      );
-      final codec = await ui.instantiateImageCodec(bytes.buffer.asUint8List());
-      final frame = await codec.getNextFrame();
-      Flame.images.add('ui_button_nine_patch.png', frame.image);
-      Flame.images.add('assets/images/ui_button_nine_patch.png', frame.image);
-    } catch (_) {
-      // Keep tests resilient when asset prewarm fails; individual tests can
-      // still validate behavior where possible.
-    }
-
-  });
-
-  tearDownAll(() {
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-        .setMockMessageHandler('flutter/assets', null);
+    await setUpNinePatchAssets();
   });
 
   Widget buildPanel({

--- a/app/test/panels_320dp_min_viewport_test.dart
+++ b/app/test/panels_320dp_min_viewport_test.dart
@@ -25,14 +25,10 @@
 // SPEC: `SPEC/ui/mobile-adaptation.md` § 7 (Minimum-viewport pin).
 // Refs #2870 S10.
 
-import 'dart:ui' as ui;
-
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
-import 'package:flame/flame.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:colonizethis_app/config/constants.dart';
@@ -51,6 +47,7 @@ import 'package:colonizethis_app/features/game/widgets/technology_panel.dart';
 
 import 'production_panel_test_fixtures.dart';
 import 'support/panel_test_fixtures.dart';
+import 'support/widget_test_assets.dart';
 
 /// Minimum supported viewport dimensions for SPEC/ui/mobile-adaptation.md
 /// § 7. Width matches [kMinViewportWidth]; height (640 dp) mirrors the
@@ -63,25 +60,6 @@ const Size _kMinViewport = Size(kMinViewportWidth, 640);
 /// pins keeps the regression signal honest. Mirrors the same pattern in
 /// `mobile_320dp_min_viewport_test.dart`.
 const Size _kWideRegressionViewport = Size(1024, 768);
-
-/// Pre-warms the Flame image cache for the brass nine-patch button asset so
-/// DiplomacyPanel's `CtNinePatchButton` action chrome lays out at its true
-/// declared height (32 dp) instead of falling back to a `SizedBox.shrink()`
-/// silhouette. Mirrors the helper used by
-/// `diplomacy_panel_narrow_layout_test.dart`.
-Future<void> _preWarmFlameImageCache() async {
-  try {
-    final bytes = await rootBundle.load(
-      'assets/images/ui_button_nine_patch.png',
-    );
-    final codec = await ui.instantiateImageCodec(bytes.buffer.asUint8List());
-    final frame = await codec.getNextFrame();
-    Flame.images.add('ui_button_nine_patch.png', frame.image);
-  } catch (_) {
-    // Best-effort: existing diplomacy tests tolerate a missing nine-patch
-    // bundle. Layout assertions here do not require pixel-perfect chrome.
-  }
-}
 
 /// Pumps [child] at [size] under the running editorial-monocle theme.
 /// Sets the surface size (so the binding's render flex math sees the
@@ -248,7 +226,7 @@ void main() {
       setUp(() => AppEventBus.reset());
 
       setUpAll(() async {
-        await _preWarmFlameImageCache();
+        await preloadNinePatchImage();
         // Lightweight fixture (Refs #3656): a single discovered Great Power is
         // enough to exercise the narrow faction-row body; no generated
         // map/topology data is read, so an empty `MapTopology` suffices.

--- a/app/test/province_overlay_test.dart
+++ b/app/test/province_overlay_test.dart
@@ -1,11 +1,8 @@
 // Tests for ProvinceSeaZoneDetailOverlay. SPEC/ui/province-sea-zone-detail-overlay.md.
 
-import 'dart:convert';
-
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:colonizethis_map/colonizethis_map.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:colonizethis_app/features/game/widgets/province_sea_zone_detail_overlay.dart';
@@ -18,6 +15,8 @@ import 'package:colonizethis_app/features/game/widgets/province_overlay_demo_dat
         sampleSeaZoneIdForOverlay,
         sampleTileKeyForProvinceOverlay;
 import 'package:colonizethis_app/widgets/ct_region_map.dart';
+
+import 'support/widget_test_assets.dart';
 
 void main() {
   suppressLogsForTests();
@@ -142,21 +141,7 @@ void main() {
     testWidgets('sea zone overlay uses sea-zone display name field', (
       WidgetTester tester,
     ) async {
-      const tinyPngBase64 =
-          'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+X2ioAAAAASUVORK5CYII=';
-      final tinyPng = Uint8List.fromList(base64Decode(tinyPngBase64));
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMessageHandler('flutter/assets', (message) async {
-            final key = const StringCodec().decodeMessage(message);
-            if (key == 'assets/images/ui_button_nine_patch.png') {
-              return ByteData.view(tinyPng.buffer);
-            }
-            return null;
-          });
-      addTearDown(() {
-        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-            .setMockMessageHandler('flutter/assets', null);
-      });
+      await installNinePatchAssetMock();
 
       final game = demoGameForOverlay;
       final named = game.copyWith(
@@ -186,21 +171,7 @@ void main() {
     testWidgets(
       'AC: sea zone hides canonical name when all sea tiles in zone are unrevealed',
       (WidgetTester tester) async {
-        const tinyPngBase64 =
-            'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+X2ioAAAAASUVORK5CYII=';
-        final tinyPng = Uint8List.fromList(base64Decode(tinyPngBase64));
-        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-            .setMockMessageHandler('flutter/assets', (message) async {
-              final key = const StringCodec().decodeMessage(message);
-              if (key == 'assets/images/ui_button_nine_patch.png') {
-                return ByteData.view(tinyPng.buffer);
-              }
-              return null;
-            });
-        addTearDown(() {
-          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-              .setMockMessageHandler('flutter/assets', null);
-        });
+        await installNinePatchAssetMock();
 
         final baseRegion = demoRegionForOverlay;
         final cells = baseRegion.cells
@@ -268,21 +239,7 @@ void main() {
     testWidgets(
       'AC: sea zone shows display name when at least one sea tile in zone is fogged',
       (WidgetTester tester) async {
-        const tinyPngBase64 =
-            'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+X2ioAAAAASUVORK5CYII=';
-        final tinyPng = Uint8List.fromList(base64Decode(tinyPngBase64));
-        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-            .setMockMessageHandler('flutter/assets', (message) async {
-              final key = const StringCodec().decodeMessage(message);
-              if (key == 'assets/images/ui_button_nine_patch.png') {
-                return ByteData.view(tinyPng.buffer);
-              }
-              return null;
-            });
-        addTearDown(() {
-          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-              .setMockMessageHandler('flutter/assets', null);
-        });
+        await installNinePatchAssetMock();
 
         final baseRegion = demoRegionForOverlay;
         final seaPrefixed = sampleSeaZoneIdForOverlay;

--- a/app/test/support/widget_test_assets.dart
+++ b/app/test/support/widget_test_assets.dart
@@ -1,0 +1,85 @@
+// Shared widget-test asset scaffolding for the nine-patch button image
+// (Refs #3656). Many app panel/widget tests render `CtNinePatchButton`, which
+// resolves `assets/images/ui_button_nine_patch.png` via the asset bundle and a
+// preloaded Flame image cache. Before this helper, the asset-bundle mock and
+// the Flame cache preload were copy-pasted across ~20+ test files; this
+// centralizes both behaviors so call sites share one implementation
+// (`colonizethis-component-structure.mdc`: extract at 2+ uses).
+
+import 'dart:convert';
+import 'dart:ui' as ui;
+
+import 'package:flame/flame.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Logical asset key for the nine-patch button image, as resolved through the
+/// Flutter asset bundle.
+const String kNinePatchAssetKey = 'assets/images/ui_button_nine_patch.png';
+
+/// Flame image-cache key the panel widgets look up (the asset basename) plus
+/// the full asset key, both registered for resilience across invocation dirs.
+const List<String> _kNinePatchFlameCacheKeys = <String>[
+  'ui_button_nine_patch.png',
+  kNinePatchAssetKey,
+];
+
+// 1x1 transparent PNG served for the nine-patch asset key. The nine-patch
+// widgets only require decodable bytes for layout, not the production artwork,
+// so an embedded constant keeps the mock free of real `dart:io` file I/O.
+//
+// Using `Uint8List.fromList` guarantees the backing buffer length equals the
+// byte length, so `ByteData.view(...buffer)` exposes exactly the PNG bytes.
+// Real file I/O is intentionally avoided here: this helper may be invoked from
+// inside a `testWidgets` body (which runs in a fake-async zone where a real
+// filesystem future never completes), so it must stay synchronous apart from
+// microtask scheduling.
+final Uint8List _ninePatchPngBytes = Uint8List.fromList(
+  base64Decode(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+X2ioAAAAASUVORK5CYII=',
+  ),
+);
+
+/// Installs a mock `flutter/assets` message handler that serves the nine-patch
+/// button PNG bytes. Cleanup is registered via [addTearDown], so calling this
+/// from `setUpAll` removes the handler after the suite and calling it from a
+/// test body removes it after that test.
+Future<void> installNinePatchAssetMock() async {
+  final messenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+  messenger.setMockMessageHandler('flutter/assets', (message) async {
+    final key = const StringCodec().decodeMessage(message);
+    if (key == kNinePatchAssetKey) {
+      return ByteData.view(_ninePatchPngBytes.buffer);
+    }
+    return null;
+  });
+  addTearDown(() {
+    messenger.setMockMessageHandler('flutter/assets', null);
+  });
+}
+
+/// Preloads the nine-patch image into the Flame image cache so widget tests are
+/// stable regardless of the directory `flutter test` is invoked from. Failures
+/// are swallowed: tests stay resilient when the asset cannot be decoded on a
+/// given host.
+Future<void> preloadNinePatchImage() async {
+  try {
+    final bytes = await rootBundle.load(kNinePatchAssetKey);
+    final codec = await ui.instantiateImageCodec(bytes.buffer.asUint8List());
+    final frame = await codec.getNextFrame();
+    for (final key in _kNinePatchFlameCacheKeys) {
+      Flame.images.add(key, frame.image);
+    }
+  } catch (_) {
+    // Keep tests resilient when asset prewarm fails on this host.
+  }
+}
+
+/// Convenience for the common `setUpAll` pattern: installs the asset mock and
+/// then preloads the Flame cache. Equivalent to calling
+/// [installNinePatchAssetMock] followed by [preloadNinePatchImage].
+Future<void> setUpNinePatchAssets() async {
+  await installNinePatchAssetMock();
+  await preloadNinePatchImage();
+}

--- a/app/test/support/widget_test_assets_test.dart
+++ b/app/test/support/widget_test_assets_test.dart
@@ -1,0 +1,66 @@
+// Focused tests for the shared nine-patch asset scaffolding (Refs #3656). These
+// guard that the helper serves bytes through the asset bundle and warms the
+// Flame image cache, so migrated panel/widget tests can rely on it in place of
+// the previously copy-pasted blocks.
+//
+// Usage contract under test:
+//  * [installNinePatchAssetMock] is safe inside a `testWidgets` body (it does no
+//    real I/O or image decoding), mirroring the inline province-overlay usage.
+//  * [preloadNinePatchImage] / [setUpNinePatchAssets] decode an image via the
+//    engine and must run from `setUpAll` (real async), mirroring every panel
+//    family's `setUpAll` usage — never from inside a fake-async test body.
+
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'widget_test_assets.dart';
+
+void main() {
+  suppressLogsForTests();
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('installNinePatchAssetMock (in-test usage)', () {
+    testWidgets('serves decodable bytes for the nine-patch asset key', (
+      tester,
+    ) async {
+      await installNinePatchAssetMock();
+
+      final data = await rootBundle.load(kNinePatchAssetKey);
+
+      expect(data.lengthInBytes, greaterThan(0));
+    });
+
+    testWidgets('returns null for unrelated asset keys', (tester) async {
+      await installNinePatchAssetMock();
+
+      final messenger =
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+      final response = await messenger.handlePlatformMessage(
+        'flutter/assets',
+        const StringCodec().encodeMessage('assets/images/does_not_exist.png'),
+        (_) {},
+      );
+
+      expect(response, isNull);
+    });
+  });
+
+  group('setUpNinePatchAssets (setUpAll usage)', () {
+    // Exercises the combined install + best-effort Flame preload from
+    // `setUpAll` (the production usage). The Flame preload is intentionally
+    // best-effort — image decoding is environment dependent and swallowed — so
+    // the deterministic invariant asserted here is that the bundle mock is
+    // installed and still serves the nine-patch bytes afterwards.
+    setUpAll(() async {
+      await setUpNinePatchAssets();
+    });
+
+    testWidgets('installs the bundle mock so the asset key resolves', (
+      tester,
+    ) async {
+      final data = await rootBundle.load(kNinePatchAssetKey);
+      expect(data.lengthInBytes, greaterThan(0));
+    });
+  });
+}

--- a/app/test/unit_panels_320dp_min_viewport_test.dart
+++ b/app/test/unit_panels_320dp_min_viewport_test.dart
@@ -42,14 +42,10 @@
 //        `SPEC/ui/naval-units-panel.md`.
 // Refs #2870 S10.
 
-import 'dart:ui' as ui;
-
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
-import 'package:flame/flame.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -60,6 +56,7 @@ import 'package:colonizethis_app/features/game/widgets/military_units_panel.dart
 import 'package:colonizethis_app/features/game/widgets/naval_units_panel.dart';
 
 import 'support/panel_test_fixtures.dart';
+import 'support/widget_test_assets.dart';
 
 /// Minimum supported viewport dimensions for SPEC/ui/mobile-adaptation.md
 /// § 7. Width matches [kMinViewportWidth]; height (640 dp) mirrors the
@@ -142,28 +139,6 @@ Widget _buildNavalUnitsPanel({
   );
 }
 
-/// Pre-warms the Flame image cache for the brass nine-patch button asset so
-/// `NavalUnitsPanel`'s `FleetExpansionTile` action chrome lays out at its
-/// true declared height (32 dp) instead of falling back to a
-/// `SizedBox.shrink()` silhouette. Mirrors the helper used by
-/// `panels_320dp_min_viewport_test.dart` (DiplomacyPanel group) and
-/// `naval_units_panel_test_part1`.
-Future<void> _preWarmFlameImageCache() async {
-  try {
-    final bytes = await rootBundle.load(
-      'assets/images/ui_button_nine_patch.png',
-    );
-    final codec = await ui.instantiateImageCodec(bytes.buffer.asUint8List());
-    final frame = await codec.getNextFrame();
-    Flame.images.add('ui_button_nine_patch.png', frame.image);
-    Flame.images.add('assets/images/ui_button_nine_patch.png', frame.image);
-  } catch (_) {
-    // Best-effort: mirrors the resilience of the sibling pin file. The
-    // layout contract under test is overflow-free chrome, not a
-    // pixel-perfect nine-patch render.
-  }
-}
-
 void main() {
   suppressLogsForTests();
 
@@ -172,7 +147,7 @@ void main() {
   late String humanPlayerId;
 
   setUpAll(() async {
-    await _preWarmFlameImageCache();
+    await preloadNinePatchImage();
     // Refs #3656: a shared lightweight fixture (civilians + army/regiments +
     // home/non-home fleets in both regions) replaces the ~11s
     // `getDebugInitGameResult()` map generation. These pins assert chrome only

--- a/app/test/widgetbook_diplomacy_panel_empty_state_test.dart
+++ b/app/test/widgetbook_diplomacy_panel_empty_state_test.dart
@@ -16,12 +16,8 @@
 //     beneath the Tribes heading, and renders no faction-row bodies
 //     (the fixture `Game` has no discovered factions). Refs #3341.
 
-import 'dart:ui' as ui;
-
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
-import 'package:flame/flame.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:widgetbook/widgetbook.dart';
 
@@ -30,24 +26,7 @@ import 'package:colonizethis_app/features/game/widgets/diplomacy_panel.dart';
 import 'package:colonizethis_app/l10n/l10n.dart';
 import 'package:colonizethis_app/widgetbook/catalog.dart';
 
-/// Pre-warm the brass nine-patch into Flame's image cache so the mode
-/// bar button at the bottom of the empty-state panel lays out at its
-/// declared height (mirrors the helper used by the mobile-viewport
-/// test).
-Future<void> _preWarmFlameImageCache() async {
-  try {
-    final bytes = await rootBundle.load(
-      'assets/images/ui_button_nine_patch.png',
-    );
-    final codec = await ui.instantiateImageCodec(bytes.buffer.asUint8List());
-    final frame = await codec.getNextFrame();
-    Flame.images.add('ui_button_nine_patch.png', frame.image);
-  } catch (_) {
-    // Best-effort: the empty-state assertions below do not require
-    // pixel-perfect chrome, only that the empty-state copy is present
-    // and that no row body is rendered.
-  }
-}
+import 'support/widget_test_assets.dart';
 
 /// Locate the single use-case with [useCaseName] inside the
 /// [WidgetbookFolder] whose name matches [folderName], failing with a
@@ -81,7 +60,7 @@ void main() {
   suppressLogsForTests();
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  setUpAll(_preWarmFlameImageCache);
+  setUpAll(preloadNinePatchImage);
 
   group('Diplomacy Panel Widgetbook empty-state story (Refs #2863 S7)', () {
     testWidgets(

--- a/app/test/widgetbook_diplomacy_panel_mobile_viewport_test.dart
+++ b/app/test/widgetbook_diplomacy_panel_mobile_viewport_test.dart
@@ -19,35 +19,15 @@
 // (< `kDiplomacyRowNarrowMaxWidth` = 500 dp) the diplomacy faction-row
 // body builder selects the `Column` arrangement.
 
-import 'dart:ui' as ui;
-
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
-import 'package:flame/flame.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:widgetbook/widgetbook.dart';
 
 import 'package:colonizethis_app/features/game/widgets/diplomacy_panel.dart';
 import 'package:colonizethis_app/widgetbook/catalog.dart';
 
-/// Pre-warm the brass nine-patch into Flame's image cache so action
-/// buttons inside the diplomacy panel lay out at their declared height
-/// (matches the helper used by `diplomacy_panel_narrow_layout_test.dart`
-/// and `panels_320dp_min_viewport_test.dart`).
-Future<void> _preWarmFlameImageCache() async {
-  try {
-    final bytes = await rootBundle.load(
-      'assets/images/ui_button_nine_patch.png',
-    );
-    final codec = await ui.instantiateImageCodec(bytes.buffer.asUint8List());
-    final frame = await codec.getNextFrame();
-    Flame.images.add('ui_button_nine_patch.png', frame.image);
-  } catch (_) {
-    // Best-effort: the layout assertion below only requires the body
-    // widget type, not pixel-perfect chrome.
-  }
-}
+import 'support/widget_test_assets.dart';
 
 /// Locate the single use-case with [useCaseName] inside the
 /// [WidgetbookFolder] whose name matches [folderName], failing with a
@@ -81,7 +61,7 @@ void main() {
   suppressLogsForTests();
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  setUpAll(_preWarmFlameImageCache);
+  setUpAll(preloadNinePatchImage);
 
   group(
     'Diplomacy Panel Widgetbook mobile-viewport story (Refs #2870 R22 / S9)',

--- a/app/test/widgetbook_main_menu_mobile_viewport_test.dart
+++ b/app/test/widgetbook_main_menu_mobile_viewport_test.dart
@@ -21,34 +21,14 @@
 // per `SPEC/ui/mobile-adaptation.md` § 6 and the Widgetbook AC under
 // the cross-cutting `Refs #2870` mobile-adaptation issue.
 
-import 'dart:ui' as ui;
-
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
-import 'package:flame/flame.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:widgetbook/widgetbook.dart';
 
 import 'package:colonizethis_app/widgetbook/catalog.dart';
 
-/// Pre-warm the brass nine-patch into Flame's image cache so wood-panel
-/// `CtNinePatchButton` chrome inside the pixelArt main menu lays out at
-/// declared height (mirrors the helper used in
-/// `widgetbook_diplomacy_panel_mobile_viewport_test.dart`).
-Future<void> _preWarmFlameImageCache() async {
-  try {
-    final bytes = await rootBundle.load(
-      'assets/images/ui_button_nine_patch.png',
-    );
-    final codec = await ui.instantiateImageCodec(bytes.buffer.asUint8List());
-    final frame = await codec.getNextFrame();
-    Flame.images.add('ui_button_nine_patch.png', frame.image);
-  } catch (_) {
-    // Best-effort; the pump assertions below only require the use case
-    // to mount, not pixel-perfect chrome.
-  }
-}
+import 'support/widget_test_assets.dart';
 
 WidgetbookUseCase _useCase(
   List<WidgetbookNode> directories, {
@@ -99,7 +79,7 @@ void main() {
   suppressLogsForTests();
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  setUpAll(_preWarmFlameImageCache);
+  setUpAll(preloadNinePatchImage);
 
   group(
     'Main Menu Widgetbook mobile-viewport stories (Refs #2870 R22 / S9)',

--- a/app/test/widgetbook_main_menu_stories_editorial_monocle_test.dart
+++ b/app/test/widgetbook_main_menu_stories_editorial_monocle_test.dart
@@ -5,12 +5,8 @@
 // covered separately by `widgetbook_main_menu_mobile_viewport_test.dart`
 // (Refs #2870 R22 / S9).
 
-import 'dart:ui' as ui;
-
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
-import 'package:flame/flame.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:widgetbook/widgetbook.dart';
 
@@ -22,6 +18,8 @@ import 'package:colonizethis_app/widgets/ct_fleur_de_lis_ornament.dart';
 import 'package:colonizethis_app/widgets/ct_main_menu_collage.dart';
 import 'package:colonizethis_app/widgets/main_menu.dart';
 import 'package:colonizethis_app/widgetbook/catalog.dart';
+
+import 'support/widget_test_assets.dart';
 
 /// Normative inventory for issue #2860 S6 — renaming or removing a story
 /// must fail this list before reviewers lose a state × variant combination.
@@ -49,19 +47,6 @@ const List<String> kMainMenuEditorialMonocleDesktopUseCaseNames = <String>[
   'No saves (pixel)',
   'Resume game visible (pixel)',
 ];
-
-Future<void> _preWarmFlameImageCache() async {
-  try {
-    final bytes = await rootBundle.load(
-      'assets/images/ui_button_nine_patch.png',
-    );
-    final codec = await ui.instantiateImageCodec(bytes.buffer.asUint8List());
-    final frame = await codec.getNextFrame();
-    Flame.images.add('ui_button_nine_patch.png', frame.image);
-  } catch (_) {
-    // Best-effort; pump assertions only require mount, not pixel-perfect chrome.
-  }
-}
 
 WidgetbookFolder _mainMenuFolder() {
   return mainMenuDirectories.whereType<WidgetbookFolder>().firstWhere(
@@ -101,7 +86,7 @@ void main() {
   suppressLogsForTests();
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  setUpAll(_preWarmFlameImageCache);
+  setUpAll(preloadNinePatchImage);
 
   group(
     'Main Menu Widgetbook editorial-monocle stories (Refs #2860 S6)',

--- a/app/test/widgetbook_province_overlay_mobile_viewport_test.dart
+++ b/app/test/widgetbook_province_overlay_mobile_viewport_test.dart
@@ -18,33 +18,14 @@
 // overlay; the pump assertion guards the AC that the narrow story is
 // reviewable in Widgetbook without resizing the host window.
 
-import 'dart:ui' as ui;
-
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
-import 'package:flame/flame.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:widgetbook/widgetbook.dart';
 
 import 'package:colonizethis_app/widgetbook/catalog.dart';
 
-/// Pre-warm the brass nine-patch into Flame's image cache so the
-/// overlay's panel chrome (which can reference Flame-cached assets via
-/// shared Ct primitives) lays out at declared height. Best-effort; the
-/// pump assertions only require the use case to mount.
-Future<void> _preWarmFlameImageCache() async {
-  try {
-    final bytes = await rootBundle.load(
-      'assets/images/ui_button_nine_patch.png',
-    );
-    final codec = await ui.instantiateImageCodec(bytes.buffer.asUint8List());
-    final frame = await codec.getNextFrame();
-    Flame.images.add('ui_button_nine_patch.png', frame.image);
-  } catch (_) {
-    // Best-effort.
-  }
-}
+import 'support/widget_test_assets.dart';
 
 WidgetbookUseCase _useCase(
   List<WidgetbookNode> directories, {
@@ -71,7 +52,7 @@ void main() {
   suppressLogsForTests();
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  setUpAll(_preWarmFlameImageCache);
+  setUpAll(preloadNinePatchImage);
 
   group(
     'Province Overlay Widgetbook mobile-viewport story (Refs #2870 R22 / S9)',


### PR DESCRIPTION
## Summary

Implements the outstanding **AC1** gap on #3656: the shared nine-patch widget-test asset helper (`app/test/support/widget_test_assets.dart`) that issue verification repeatedly flagged as *never implemented*. Centralizes the `flutter/assets` bundle mock and the Flame nine-patch preload that were copy-pasted across many app test files.

`Refs #3656` (does not close — AC4 wall-time numbers are recorded below (see AC4 section)).

## Done in this push

- **New `app/test/support/widget_test_assets.dart`** exposing:
  - `installNinePatchAssetMock()` — installs the `flutter/assets` mock serving the nine-patch PNG bytes; auto-cleans via `addTearDown`. Safe inside `testWidgets` bodies (no real `dart:io` I/O, so it does not hang the fake-async zone).
  - `preloadNinePatchImage()` — best-effort Flame image-cache warm (engine image decode); intended for `setUpAll`.
  - `setUpNinePatchAssets()` — convenience combining both (the common `setUpAll` pattern).
- **New focused test** `app/test/support/widget_test_assets_test.dart` covering both usage contracts (in-test mock + `setUpAll` install/preload).
- **Migrated 22 app test files** off the duplicated inline blocks / local `_preWarmFlameImageCache` / `_mockNinePatchAssetBundle` helpers to the shared helper, removing now-unused `dart:io` / `dart:convert` / `dart:ui` / `flame` / `flutter/services` imports:
  - naval units panel `part1..5`, `ct_nine_patch_button_test`
  - diplomacy: `diplomacy_panel_test`, `diplomacy_panel_orders_test`, `diplomacy_panel_chrome_test`, `diplomacy_panel_narrow_layout_test`, `diplomacy_detail_screen_test`, `diplomacy_relative_power_goldens_test`
  - viewport pins: `panels_320dp_min_viewport_test`, `unit_panels_320dp_min_viewport_test`, `diplomacy_detail_screen_320dp_min_viewport_test`
  - shell + overlay: `ct_game_feature_screen_shell_test`, `province_overlay_test`
  - widgetbook: `widgetbook_diplomacy_panel_empty_state_test`, `widgetbook_diplomacy_panel_mobile_viewport_test`, `widgetbook_main_menu_mobile_viewport_test`, `widgetbook_main_menu_stories_editorial_monocle_test`, `widgetbook_province_overlay_mobile_viewport_test`

Behavior is preserved: the real asset PNG is not committed, so the prior file-read paths always fell back to the embedded 1×1 transparent PNG; the helper uses that embedded fallback directly. Net diff is ~206 insertions / ~715 deletions (de-duplication).

## Notable correctness detail

The original copy-pasted setup did real file I/O. Hoisting it into a helper that some tests call from inside `testWidgets` bodies caused a fake-async hang (a real filesystem future never completes in the test zone). The helper therefore avoids file I/O entirely for the bundle mock, and the engine image-decode preload stays in `setUpAll` only — matching how every migrated file already used it.

## Not in this push (deferred)

- **AC4** (record before/after full-suite wall-time numbers) — verification-lane measurement; not a code change. The structural elimination of map-gen call sites was completed by earlier merged PRs.

## Test plan

- [x] `flutter analyze test/support/widget_test_assets.dart test/support/widget_test_assets_test.dart` → No issues found
- [x] `flutter analyze` on all migrated files → 0 errors (remaining warnings are pre-existing dead app-widget imports in the naval split files, untouched here)
- [x] `flutter test` on the new helper test and all 22 migrated files → all pass (run in batches)
- [ ] CI `quality` / `quality_app_coverage` on `dev`

Made with [Cursor](https://cursor.com)


## AC4 — before/after app-test wall-time (recorded)

Closes the AC4 documentation gap.

**Before (baseline `dev @ 6d077b9d`):** 94 `app/test/**` files each called `getDebugInitGameResult()` in `setUpAll`, running the full `runInitGame(defaultConfig, cellSize 24, renderPng false)` map-generation pipeline. Measured execution-only cost per call (AOT `tool/init_game`, 3 runs): **10.95 / 11.02 / 11.13 s (mean ~11.0 s)**. `flutter test` isolates each file, so the per-isolate cache never amortizes across files — the suite paid this fixed cost ~94×, i.e. **~94 × 11.0 s ≈ ~1,034 s (~17 min) of map generation alone**, before any actual test execution.

**After (current `dev`):** **0** AST-level `getDebugInitGameResult()` call sites remain — verified by `dart run tool/check_app_test_no_debug_init.dart` (no disallowed usage; allowlist empty) and enforced by the `repo.app_test_no_debug_init` gate (AC5). Panel/widget suites build hand-constructed `Game` fixtures (no map gen); map/topology-dependent suites decode the committed seed-42 fixtures (`seed42_game.json`, `seed42_map_view.json`, `seed42_tile_map.json`) once per file — a cheap JSON decode in place of ~11 s of procedural generation.

**Net:** the suite no longer performs ~1,034 s of mandatory map generation. CI now runs the full app suite split across 2 shards at **~1m13s + ~1m29s** of in-shard test time; the eliminated ~1,034 s of map-gen alone is more than an order of magnitude larger than 10% of total app-test wall time. The **≥10% reduction target is satisfied by a wide margin**; consistent with the issue's AC4 note, the exact aggregate figure is non-material because the 94× ~11 s removal mechanically guarantees it.

**Measurement note:** an isolated local full-suite `flutter test` re-time was attempted but the local environment had a concurrent `flutter test` invocation contending for shared `/tmp`, producing `flutter_tools` `PathNotFoundException` finalization races (a tooling/temp-dir collision, not test-assertion failures). The figures above therefore rely on the issue's reproducible per-call baseline, the CI shard timings, and the CI-verified structural removal rather than a polluted local aggregate.
