### PR TITLE
refactor: dedup colonizethis_setup tile scans/BFS, canonical keys, naming, tests (#3712)

### DIFF
--- a/packages/colonizethis_setup/lib/src/setup/capital_choice.dart
+++ b/packages/colonizethis_setup/lib/src/setup/capital_choice.dart
@@ -1,10 +1,9 @@
-import 'dart:collection';
-
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'package:colonizethis_world/colonizethis_world.dart';
 import 'package:colonizethis_world/src/world/capital_reassignment.dart';
+import 'grid_bfs.dart';
 import 'setup_exceptions.dart';
 
 export 'package:colonizethis_world/src/world/capital_reassignment.dart'
@@ -119,6 +118,7 @@ WorldState applyCapitalPortAndRoad(
   var ports = Map<String, String>.from(worldState.portsByProvinceSeaboard);
 
   final capitalKey = tile.toTileKey();
+  final provinceIds = _provinceNodeIds(topology);
   final seaZoneIds = _seaZonesAdjacentToProvince(
     topology,
     localProvinceId,
@@ -138,6 +138,7 @@ WorldState applyCapitalPortAndRoad(
       map,
       topology,
       seaZoneId,
+      provinceIds: provinceIds,
     );
     if (capitalTouchesSeaZone) {
       tileState = _setRoadLevelMax(tileState, capitalKey, 4);
@@ -152,6 +153,7 @@ WorldState applyCapitalPortAndRoad(
       tile.y,
       topology,
       seaZoneId,
+      provinceIds: provinceIds,
     );
     if (coastal == null) {
       throw SetupTopologyDataException(
@@ -328,13 +330,14 @@ CapitalTileClass classifyCapitalTile({
   required String localProvinceId,
   Set<String>? provinceIds,
 }) {
-  final knownProvinceIds =
-      provinceIds ??
-      topology.nodes
-          .where((n) => n.type == TopologyNodeType.province)
-          .map((n) => n.id)
-          .toSet();
-  final coastal = _isTileAdjacentToSea(x, y, tileMap, topology);
+  final knownProvinceIds = provinceIds ?? _provinceNodeIds(topology);
+  final coastal = _isTileAdjacentToSea(
+    x,
+    y,
+    tileMap,
+    topology,
+    provinceIds: knownProvinceIds,
+  );
   final adjacentOtherProvince = _isTileAdjacentToOtherProvince(
     x,
     y,

--- a/packages/colonizethis_setup/lib/src/setup/capital_choice_capital_tile_scan.dart
+++ b/packages/colonizethis_setup/lib/src/setup/capital_choice_capital_tile_scan.dart
@@ -10,12 +10,24 @@ final class _CapitalTileCandidateScan {
   int? classCCoastalX;
   int? classCCoastalY;
 
-  void mergeClassC(int x, int y, TileMapResult tileMap, MapTopology topology) {
+  void mergeClassC(
+    int x,
+    int y,
+    TileMapResult tileMap,
+    MapTopology topology,
+    Set<String> provinceIds,
+  ) {
     if (classCx == null) {
       classCx = x;
       classCy = y;
     }
-    if (_isTileAdjacentToSea(x, y, tileMap, topology) &&
+    if (_isTileAdjacentToSea(
+          x,
+          y,
+          tileMap,
+          topology,
+          provinceIds: provinceIds,
+        ) &&
         classCCoastalX == null) {
       classCCoastalX = x;
       classCCoastalY = y;
@@ -28,6 +40,7 @@ final class _CapitalTileCandidateScan {
     int y,
     TileMapResult tileMap,
     MapTopology topology,
+    Set<String> provinceIds,
   ) {
     if (tileClass == CapitalTileClass.a) {
       if (classAx == null) {
@@ -43,7 +56,7 @@ final class _CapitalTileCandidateScan {
       }
       return;
     }
-    mergeClassC(x, y, tileMap, topology);
+    mergeClassC(x, y, tileMap, topology, provinceIds);
   }
 }
 
@@ -75,7 +88,7 @@ _scanCapitalTileCandidates({
         localProvinceId: localProvinceId,
         provinceIds: provinceIds,
       );
-      acc.accept(tileClass, x, y, tileMap, topology);
+      acc.accept(tileClass, x, y, tileMap, topology, provinceIds);
     }
   }
   return (

--- a/packages/colonizethis_setup/lib/src/setup/capital_choice_port_road_geometry.dart
+++ b/packages/colonizethis_setup/lib/src/setup/capital_choice_port_road_geometry.dart
@@ -21,26 +21,49 @@ Set<String> _seaZonesAdjacentToProvince(
   return out;
 }
 
-bool _isTileAdjacentToSea(
+/// Province node ids in [topology]. Single source of truth for the
+/// `topology.nodes.where(province).map(id).toSet()` construction the adjacency
+/// scans previously recomputed independently per call; callers compute it once
+/// per scan and thread it into the `_isTileAdjacentTo*` helpers.
+Set<String> _provinceNodeIds(MapTopology topology) => topology.nodes
+    .where((n) => n.type == TopologyNodeType.province)
+    .map((n) => n.id)
+    .toSet();
+
+/// Visits the in-bounds 4-neighbor cell ids of ([x], [y]) in
+/// [kGridNeighborsCardinal4] order, returning `true` as soon as [test] does.
+/// Single neighbor-iteration skeleton shared by the adjacency scans.
+bool _anyCardinalNeighborCell(
   int x,
   int y,
   TileMapResult map,
-  MapTopology topology,
+  bool Function(String cellId) test,
 ) {
-  final provinceIds = topology.nodes
-      .where((n) => n.type == TopologyNodeType.province)
-      .map((n) => n.id)
-      .toSet();
   final w = map.width;
   final h = map.height;
   for (final d in kGridNeighborsCardinal4) {
     final nx = x + d.$1;
     final ny = y + d.$2;
     if (nx < 0 || nx >= w || ny < 0 || ny >= h) continue;
-    final cellId = map.cell(nx, ny);
-    if (!provinceIds.contains(cellId)) return true;
+    if (test(map.cell(nx, ny))) return true;
   }
   return false;
+}
+
+bool _isTileAdjacentToSea(
+  int x,
+  int y,
+  TileMapResult map,
+  MapTopology topology, {
+  Set<String>? provinceIds,
+}) {
+  final ids = provinceIds ?? _provinceNodeIds(topology);
+  return _anyCardinalNeighborCell(
+    x,
+    y,
+    map,
+    (cellId) => !ids.contains(cellId),
+  );
 }
 
 bool _isTileAdjacentToOtherProvince(
@@ -50,17 +73,12 @@ bool _isTileAdjacentToOtherProvince(
   Set<String> provinceIds,
   String provinceId,
 ) {
-  final w = map.width;
-  final h = map.height;
-  for (final d in kGridNeighborsCardinal4) {
-    final nx = x + d.$1;
-    final ny = y + d.$2;
-    if (nx < 0 || nx >= w || ny < 0 || ny >= h) continue;
-    final cellId = map.cell(nx, ny);
-    if (!provinceIds.contains(cellId)) continue;
-    if (cellId != provinceId) return true;
-  }
-  return false;
+  return _anyCardinalNeighborCell(
+    x,
+    y,
+    map,
+    (cellId) => provinceIds.contains(cellId) && cellId != provinceId,
+  );
 }
 
 (int, int)? _nearestCoastalTileInProvinceForSeaZone(
@@ -69,15 +87,26 @@ bool _isTileAdjacentToOtherProvince(
   int fromX,
   int fromY,
   MapTopology topology,
-  String seaZoneId,
-) {
+  String seaZoneId, {
+  Set<String>? provinceIds,
+}) {
+  final ids = provinceIds ?? _provinceNodeIds(topology);
   int? bestDist;
   int? bestX;
   int? bestY;
   for (var y = 0; y < map.height; y++) {
     for (var x = 0; x < map.width; x++) {
       if (map.cell(x, y) != provinceId) continue;
-      if (!_isTileAdjacentToSeaZone(x, y, map, topology, seaZoneId)) continue;
+      if (!_isTileAdjacentToSeaZone(
+        x,
+        y,
+        map,
+        topology,
+        seaZoneId,
+        provinceIds: ids,
+      )) {
+        continue;
+      }
       final dist = (x - fromX).abs() + (y - fromY).abs();
       if (bestDist == null || dist < bestDist) {
         bestDist = dist;
@@ -95,26 +124,17 @@ bool _isTileAdjacentToSeaZone(
   int y,
   TileMapResult map,
   MapTopology topology,
-  String seaZoneId,
-) {
-  final provinceIds = topology.nodes
-      .where((n) => n.type == TopologyNodeType.province)
-      .map((n) => n.id)
-      .toSet();
+  String seaZoneId, {
+  Set<String>? provinceIds,
+}) {
+  final ids = provinceIds ?? _provinceNodeIds(topology);
   final seaZoneLocal = seaZoneId.contains('|')
       ? seaZoneId.split('|').last
       : seaZoneId;
-  final w = map.width;
-  final h = map.height;
-  for (final d in kGridNeighborsCardinal4) {
-    final nx = x + d.$1;
-    final ny = y + d.$2;
-    if (nx < 0 || nx >= w || ny < 0 || ny >= h) continue;
-    final cellId = map.cell(nx, ny);
-    if (provinceIds.contains(cellId)) continue;
-    if (cellId == seaZoneId || cellId == seaZoneLocal) return true;
-  }
-  return false;
+  return _anyCardinalNeighborCell(x, y, map, (cellId) {
+    if (ids.contains(cellId)) return false;
+    return cellId == seaZoneId || cellId == seaZoneLocal;
+  });
 }
 
 /// Shortest path on province tiles only (BFS). Returns ordered list (start .. end) inclusive.
@@ -128,39 +148,13 @@ List<(int, int)> _shortestPathOnProvinceTiles(
   int toY,
 ) {
   if (fromX == toX && fromY == toY) return [(fromX, fromY)];
-  final w = map.width;
-  final h = map.height;
-  final visited = <String>{};
-  final parent = <String, (int, int)>{};
-  final startKey = '$fromX|$fromY';
-  visited.add(startKey);
-  final queue = Queue<(int, int)>()..add((fromX, fromY));
-  while (queue.isNotEmpty) {
-    final (cx, cy) = queue.removeFirst();
-    if (cx == toX && cy == toY) {
-      final path = <(int, int)>[];
-      var (px, py) = (toX, toY);
-      while (true) {
-        path.insert(0, (px, py));
-        final key = '$px|$py';
-        final p = parent[key];
-        if (p == null) break;
-        px = p.$1;
-        py = p.$2;
-      }
-      return path;
-    }
-    for (final d in kGridNeighborsCardinal4) {
-      final nx = cx + d.$1;
-      final ny = cy + d.$2;
-      if (nx < 0 || nx >= w || ny < 0 || ny >= h) continue;
-      if (map.cell(nx, ny) != localProvinceId) continue;
-      final nkey = '$nx|$ny';
-      if (visited.contains(nkey)) continue;
-      visited.add(nkey);
-      parent[nkey] = (cx, cy);
-      queue.add((nx, ny));
-    }
-  }
-  return [(fromX, fromY)];
+  final parents = bfsGridParents(
+    startX: fromX,
+    startY: fromY,
+    width: map.width,
+    height: map.height,
+    passable: (x, y) => map.cell(x, y) == localProvinceId,
+  );
+  return reconstructGridPath(parents: parents, toX: toX, toY: toY) ??
+      [(fromX, fromY)];
 }

--- a/packages/colonizethis_setup/lib/src/setup/game_setup_helpers_naming.dart
+++ b/packages/colonizethis_setup/lib/src/setup/game_setup_helpers_naming.dart
@@ -71,18 +71,6 @@ void _applyGreatPowerProvinceNaming({
   required Map<String, Province> oldWorldById,
   required Set<String> usedOldWorldProvinceNames,
   required int namingSeed,
-  required void Function({
-    required List<Province> ownedProvinces,
-    required String? capitalProvinceId,
-    required String capitalName,
-    required List<String> pool,
-    required String fallbackPrefix,
-    required int rngSeed,
-    required Map<String, Province> outById,
-    required Set<String> usedInRegion,
-    required String Function(int seedOffset) generateFallback,
-  })
-  applyNamingToFaction,
   required String Function(int seedOffset) fallbackOldWorld,
 }) {
   for (var i = 0; i < game.players.length; i++) {
@@ -97,7 +85,7 @@ void _applyGreatPowerProvinceNaming({
     final variant = gpNaming.variantById(variantId);
     final capitalProvId = player.capitalProvinceId;
     if (capitalProvId == null) continue;
-    applyNamingToFaction(
+    _namingApplyNamingToFaction(
       ownedProvinces: ownedProvincesForFaction(
         oldWorldProvinces,
         player.id,
@@ -115,103 +103,103 @@ void _applyGreatPowerProvinceNaming({
   }
 }
 
-void _applyMinorNationProvinceNaming({
-  required Game game,
-  required ResolvedNamingConfig naming,
-  required List<Province> oldWorldProvinces,
-  required Map<String, Province> oldWorldById,
-  required Set<String> usedOldWorldProvinceNames,
+/// One minor/tribe faction's resolved naming inputs for the shared
+/// non-Great-Power naming pass. [empty] mirrors the prior `namingX.id.isEmpty`
+/// branch (no naming entry matched), selecting the procedural-fallback path for
+/// the capital name and the `'Territory'` fallback prefix.
+typedef _MinorOrTribeNamingEntry = ({
+  String factionId,
+  String? capitalProvinceId,
+  bool empty,
+  String displayName,
+  List<String> provinceNamePool,
+  String fallbackPrefix,
+});
+
+/// Shared naming pass for the structurally identical Minor Nation and Tribe
+/// province naming. Both previously threaded the always-constant
+/// `_namingApplyNamingToFaction` callback and duplicated the
+/// `firstWhere(..., orElse: empty)` / capital-name fallback / skip-when-empty
+/// shape, differing only in region, faction list, and `fallbackPrefix`.
+void _applyMinorOrTribeProvinceNaming({
+  required List<_MinorOrTribeNamingEntry> factions,
+  required List<Province> regionProvinces,
+  required Map<String, Province> regionById,
+  required Set<String> usedRegionProvinceNames,
   required int namingSeed,
-  required void Function({
-    required List<Province> ownedProvinces,
-    required String? capitalProvinceId,
-    required String capitalName,
-    required List<String> pool,
-    required String fallbackPrefix,
-    required int rngSeed,
-    required Map<String, Province> outById,
-    required Set<String> usedInRegion,
-    required String Function(int seedOffset) generateFallback,
-  })
-  applyNamingToFaction,
-  required String Function(int seedOffset) fallbackOldWorld,
+  required String Function(int seedOffset) fallback,
 }) {
-  for (final minor in game.minorNations) {
-    final namingMinor = naming.minorNations.firstWhere(
-      (n) => n.id == minor.id,
-      orElse: () => const MinorNationNaming(id: '', displayName: ''),
-    );
-    final owned = ownedProvincesForFaction(oldWorldProvinces, minor.id);
+  for (final faction in factions) {
+    final owned = ownedProvincesForFaction(regionProvinces, faction.factionId);
     if (owned.isEmpty) continue;
-    final capitalName = namingMinor.id.isEmpty
-        ? fallbackOldWorld(namingSeed + minor.id.hashCode)
-        : (namingMinor.provinceNamePool.isNotEmpty
-              ? namingMinor.provinceNamePool.first
-              : namingMinor.displayName);
-    applyNamingToFaction(
+    final capitalName = faction.empty
+        ? fallback(namingSeed + faction.factionId.hashCode)
+        : (faction.provinceNamePool.isNotEmpty
+              ? faction.provinceNamePool.first
+              : faction.displayName);
+    _namingApplyNamingToFaction(
       ownedProvinces: owned,
-      capitalProvinceId: minor.capitalProvinceId,
+      capitalProvinceId: faction.capitalProvinceId,
       capitalName: capitalName,
-      pool: namingMinor.provinceNamePool,
-      fallbackPrefix: namingMinor.id.isEmpty
-          ? 'Territory'
-          : namingMinor.displayName,
-      rngSeed: namingSeed + minor.id.hashCode,
-      outById: oldWorldById,
-      usedInRegion: usedOldWorldProvinceNames,
-      generateFallback: fallbackOldWorld,
+      pool: faction.provinceNamePool,
+      fallbackPrefix: faction.fallbackPrefix,
+      rngSeed: namingSeed + faction.factionId.hashCode,
+      outById: regionById,
+      usedInRegion: usedRegionProvinceNames,
+      generateFallback: fallback,
     );
   }
 }
 
-void _applyTribeProvinceNaming({
-  required Game game,
-  required ResolvedNamingConfig naming,
-  required List<Province> newWorldProvinces,
-  required Map<String, Province> newWorldById,
-  required Set<String> usedNewWorldProvinceNames,
-  required int namingSeed,
-  required void Function({
-    required List<Province> ownedProvinces,
-    required String? capitalProvinceId,
-    required String capitalName,
-    required List<String> pool,
-    required String fallbackPrefix,
-    required int rngSeed,
-    required Map<String, Province> outById,
-    required Set<String> usedInRegion,
-    required String Function(int seedOffset) generateFallback,
-  })
-  applyNamingToFaction,
-  required String Function(int seedOffset) fallbackNewWorld,
-}) {
-  for (final tribe in game.tribes) {
-    final namingTribe = naming.tribes.firstWhere(
-      (n) => n.id == tribe.id,
-      orElse: () =>
-          const TribeNaming(id: '', displayName: '', provinceNamePool: []),
-    );
-    final owned = ownedProvincesForFaction(newWorldProvinces, tribe.id);
-    if (owned.isEmpty) continue;
-    final capitalName = namingTribe.id.isEmpty
-        ? fallbackNewWorld(namingSeed + tribe.id.hashCode)
-        : (namingTribe.provinceNamePool.isNotEmpty
-              ? namingTribe.provinceNamePool.first
-              : namingTribe.displayName);
-    applyNamingToFaction(
-      ownedProvinces: owned,
-      capitalProvinceId: tribe.capitalProvinceId,
-      capitalName: capitalName,
-      pool: namingTribe.provinceNamePool,
-      fallbackPrefix: namingTribe.id.isEmpty
-          ? 'Territory'
-          : '${namingTribe.displayName} Territory',
-      rngSeed: namingSeed + tribe.id.hashCode,
-      outById: newWorldById,
-      usedInRegion: usedNewWorldProvinceNames,
-      generateFallback: fallbackNewWorld,
-    );
-  }
+List<_MinorOrTribeNamingEntry> _minorNationNamingEntries(
+  Game game,
+  ResolvedNamingConfig naming,
+) {
+  return [
+    for (final minor in game.minorNations)
+      () {
+        final namingMinor = naming.minorNations.firstWhere(
+          (n) => n.id == minor.id,
+          orElse: () => const MinorNationNaming(id: '', displayName: ''),
+        );
+        return (
+          factionId: minor.id,
+          capitalProvinceId: minor.capitalProvinceId,
+          empty: namingMinor.id.isEmpty,
+          displayName: namingMinor.displayName,
+          provinceNamePool: namingMinor.provinceNamePool,
+          fallbackPrefix: namingMinor.id.isEmpty
+              ? 'Territory'
+              : namingMinor.displayName,
+        );
+      }(),
+  ];
+}
+
+List<_MinorOrTribeNamingEntry> _tribeNamingEntries(
+  Game game,
+  ResolvedNamingConfig naming,
+) {
+  return [
+    for (final tribe in game.tribes)
+      () {
+        final namingTribe = naming.tribes.firstWhere(
+          (n) => n.id == tribe.id,
+          orElse: () =>
+              const TribeNaming(id: '', displayName: '', provinceNamePool: []),
+        );
+        return (
+          factionId: tribe.id,
+          capitalProvinceId: tribe.capitalProvinceId,
+          empty: namingTribe.id.isEmpty,
+          displayName: namingTribe.displayName,
+          provinceNamePool: namingTribe.provinceNamePool,
+          fallbackPrefix: namingTribe.id.isEmpty
+              ? 'Territory'
+              : '${namingTribe.displayName} Territory',
+        );
+      }(),
+  ];
 }
 
 List<Player> _updatedPlayersWithNaming({
@@ -366,28 +354,23 @@ Game applyNaming({
     oldWorldById: owById,
     usedOldWorldProvinceNames: usedOwProvinceDisplayNames,
     namingSeed: namingSeed,
-    applyNamingToFaction: _namingApplyNamingToFaction,
     fallbackOldWorld: fallbackOw,
   );
-  _applyMinorNationProvinceNaming(
-    game: game,
-    naming: naming,
-    oldWorldProvinces: owProvinces,
-    oldWorldById: owById,
-    usedOldWorldProvinceNames: usedOwProvinceDisplayNames,
+  _applyMinorOrTribeProvinceNaming(
+    factions: _minorNationNamingEntries(game, naming),
+    regionProvinces: owProvinces,
+    regionById: owById,
+    usedRegionProvinceNames: usedOwProvinceDisplayNames,
     namingSeed: namingSeed,
-    applyNamingToFaction: _namingApplyNamingToFaction,
-    fallbackOldWorld: fallbackOw,
+    fallback: fallbackOw,
   );
-  _applyTribeProvinceNaming(
-    game: game,
-    naming: naming,
-    newWorldProvinces: nwProvinces,
-    newWorldById: nwById,
-    usedNewWorldProvinceNames: usedNwProvinceDisplayNames,
+  _applyMinorOrTribeProvinceNaming(
+    factions: _tribeNamingEntries(game, naming),
+    regionProvinces: nwProvinces,
+    regionById: nwById,
+    usedRegionProvinceNames: usedNwProvinceDisplayNames,
     namingSeed: namingSeed,
-    applyNamingToFaction: _namingApplyNamingToFaction,
-    fallbackNewWorld: fallbackNw,
+    fallback: fallbackNw,
   );
 
   final updatedPlayers = _updatedPlayersWithNaming(

--- a/packages/colonizethis_setup/lib/src/setup/gp_starting_grain.dart
+++ b/packages/colonizethis_setup/lib/src/setup/gp_starting_grain.dart
@@ -5,6 +5,7 @@ import 'setup_logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'package:colonizethis_world/colonizethis_world.dart';
+import 'province_tile_ranking.dart';
 import 'town_capital_occupancy.dart';
 
 /// Thrown when the capital province cannot host four bootstrap grain farms on land tiles.
@@ -24,28 +25,12 @@ List<String> selectGreatPowerBootstrapGrainTileKeysLandOnly({
   required CapitalTile capital,
   Set<String> forbiddenTileKeys = const {},
 }) {
-  final regionId = capital.regionId;
-  final localId = ProvinceId.isPrefixed(capital.provinceId)
-      ? ProvinceId.localIdFrom(capital.provinceId)
-      : capital.provinceId;
-  final ranked = <(int dist, int y, int x, String key)>[];
-  for (var y = 0; y < map.height; y++) {
-    for (var x = 0; x < map.width; x++) {
-      if (map.cell(x, y) != localId) continue;
-      final dist = (x - capital.x).abs() + (y - capital.y).abs();
-      final key = CapitalTile.tileKey(regionId, capital.provinceId, x, y);
-      if (forbiddenTileKeys.contains(key)) continue;
-      ranked.add((dist, y, x, key));
-    }
-  }
-  ranked.sort((a, b) {
-    final c = a.$1.compareTo(b.$1);
-    if (c != 0) return c;
-    final cy = a.$2.compareTo(b.$2);
-    if (cy != 0) return cy;
-    return a.$3.compareTo(b.$3);
-  });
-  return ranked.take(4).map((e) => e.$4).toList();
+  return rankProvinceTileKeysByDistance(
+    map: map,
+    capital: capital,
+    accept: (x, y, key) => !forbiddenTileKeys.contains(key),
+    maxTiles: 4,
+  );
 }
 
 /// After capitals and §7d town assignment: place four `grain` / improvement 1 for each

--- a/packages/colonizethis_setup/lib/src/setup/grid_bfs.dart
+++ b/packages/colonizethis_setup/lib/src/setup/grid_bfs.dart
@@ -1,0 +1,80 @@
+// SPEC/game/capital-and-connectivity.md § Init town roads / Capital Setup;
+// SPEC/program/game-setup-pipeline.md.
+//
+// Package-internal source of truth for 4-neighbor grid BFS over setup tile
+// grids. Both road-geometry sites previously carried near-identical breadth
+// first searches with inline `'$x|$y'` coord-key strings, bounds checks, and
+// parent-map path reconstruction:
+//   - init_town_roads.dart `_bfsParentsFromCapital` / `_addPathTilesToSet`
+//   - capital_choice_port_road_geometry.dart `_shortestPathOnProvinceTiles`
+// init_town_roads.dart even documented that its neighbor ordering was kept
+// aligned with `_shortestPathOnProvinceTiles`. Centralising the skeleton here
+// keeps the deterministic [kGridNeighborsCardinal4] visit order and parent-map
+// shape byte-identical across both consumers.
+
+import 'dart:collection';
+
+import 'package:colonizethis_world/colonizethis_world.dart';
+
+/// Canonical 2D coordinate key `'$x|$y'` used by the shared grid BFS. Single
+/// source of truth for the previously inlined coord-key interpolations.
+String gridCoordKey(int x, int y) => '$x|$y';
+
+/// Whether the grid cell at ([x], [y]) may be entered during a BFS expansion.
+typedef GridTilePassable = bool Function(int x, int y);
+
+/// Breadth-first search over a 2D grid in [kGridNeighborsCardinal4] neighbor
+/// order from ([startX], [startY]). The start cell is always enqueued (its
+/// passability is never tested); every other cell is entered only when
+/// [passable] returns `true`.
+///
+/// Returns a parent map keyed by [gridCoordKey] where the start maps to itself
+/// (identity). Unreachable cells are absent (except the start). Reconstruct an
+/// ordered path with [reconstructGridPath].
+Map<String, (int, int)> bfsGridParents({
+  required int startX,
+  required int startY,
+  required int width,
+  required int height,
+  required GridTilePassable passable,
+}) {
+  final start = (startX, startY);
+  final parent = <String, (int, int)>{gridCoordKey(startX, startY): start};
+  final queue = Queue<(int, int)>()..add(start);
+  while (queue.isNotEmpty) {
+    final (cx, cy) = queue.removeFirst();
+    for (final d in kGridNeighborsCardinal4) {
+      final nx = cx + d.$1;
+      final ny = cy + d.$2;
+      if (nx < 0 || nx >= width || ny < 0 || ny >= height) continue;
+      if (!passable(nx, ny)) continue;
+      final nkey = gridCoordKey(nx, ny);
+      if (parent.containsKey(nkey)) continue;
+      parent[nkey] = (cx, cy);
+      queue.add((nx, ny));
+    }
+  }
+  return parent;
+}
+
+/// Reconstructs the coordinate path from ([toX], [toY]) back to the BFS start
+/// using [parents] (from [bfsGridParents]), returned start..end inclusive.
+///
+/// Returns `null` when ([toX], [toY]) was never reached (absent from
+/// [parents]). The start cell terminates the walk because it maps to itself.
+List<(int, int)>? reconstructGridPath({
+  required Map<String, (int, int)> parents,
+  required int toX,
+  required int toY,
+}) {
+  if (!parents.containsKey(gridCoordKey(toX, toY))) return null;
+  final path = <(int, int)>[];
+  var cur = (toX, toY);
+  while (true) {
+    path.insert(0, cur);
+    final pr = parents[gridCoordKey(cur.$1, cur.$2)];
+    if (pr == null || (pr.$1 == cur.$1 && pr.$2 == cur.$2)) break;
+    cur = pr;
+  }
+  return path;
+}

--- a/packages/colonizethis_setup/lib/src/setup/init_town_roads.dart
+++ b/packages/colonizethis_setup/lib/src/setup/init_town_roads.dart
@@ -1,17 +1,17 @@
 // SPEC/game/capital-and-connectivity.md § Init town roads; SPEC/program/game-setup-pipeline.md.
 
-import 'dart:collection';
-
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'setup_logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'package:colonizethis_world/colonizethis_world.dart';
+import 'grid_bfs.dart';
 
 const int _initTownRoadLevel = 1;
 
-/// Neighbor iteration uses [kGridNeighborsCardinal4] ordering so shortest-path
-/// scans align with [_shortestPathOnProvinceTiles] in capital_choice.dart (Refs #2391).
+/// Road BFS shares the [bfsGridParents] skeleton (grid_bfs.dart) so its
+/// [kGridNeighborsCardinal4] neighbor ordering stays aligned with the capital
+/// port-road `_shortestPathOnProvinceTiles` site (Refs #2391).
 
 /// After town assignment: for each faction whose capital lies in a region listed in
 /// [GameSetupConfig.initTownRoadWiringRegionIds], raise road level to at least
@@ -139,7 +139,7 @@ Map<String, String> _coordToTileKey(WorldState ws, String regionId) {
     for (final tk in list) {
       final coords = parseTileKeyCoordinates(tk);
       if (coords == null || coords.regionId != regionId) continue;
-      m['${coords.x}|${coords.y}'] = tk;
+      m[gridCoordKey(coords.x, coords.y)] = tk;
     }
   }
   return m;
@@ -164,6 +164,10 @@ Set<String> _allowedTileKeysForFaction(
 
 /// Returns map tileKey -> predecessor tileKey toward [capitalKey]. [capitalKey] maps to
 /// itself (identity). Unreachable tiles are absent except the capital.
+///
+/// Delegates the 4-neighbor breadth-first walk to the shared [bfsGridParents]
+/// skeleton (grid_bfs.dart) over coordinates, then maps the coord-keyed parent
+/// map back onto canonical tile keys via [coordToKey].
 Map<String, String> _bfsParentsFromCapital({
   required String capitalKey,
   required Set<String> allowed,
@@ -171,28 +175,29 @@ Map<String, String> _bfsParentsFromCapital({
   required int mapWidth,
   required int mapHeight,
 }) {
-  final parent = <String, String>{capitalKey: capitalKey};
-  final queue = Queue<String>()..add(capitalKey);
+  final capitalXY = _parseTileKeyXY(capitalKey);
+  if (capitalXY == null) return <String, String>{capitalKey: capitalKey};
+  final (capX, capY) = capitalXY;
 
-  while (queue.isNotEmpty) {
-    final cur = queue.removeFirst();
-    final xy = _parseTileKeyXY(cur);
-    if (xy == null) continue;
-    final (cx, cy) = xy;
-    for (final d in kGridNeighborsCardinal4) {
-      final nx = cx + d.$1;
-      final ny = cy + d.$2;
-      if (nx < 0 || nx >= mapWidth || ny < 0 || ny >= mapHeight) {
-        continue;
-      }
-      final nk = '$nx|$ny';
-      final nTile = coordToKey[nk];
-      if (nTile == null) continue;
-      if (!allowed.contains(nTile)) continue;
-      if (parent.containsKey(nTile)) continue;
-      parent[nTile] = cur;
-      queue.add(nTile);
-    }
+  final coordParents = bfsGridParents(
+    startX: capX,
+    startY: capY,
+    width: mapWidth,
+    height: mapHeight,
+    passable: (x, y) {
+      final tile = coordToKey[gridCoordKey(x, y)];
+      return tile != null && allowed.contains(tile);
+    },
+  );
+
+  final parent = <String, String>{capitalKey: capitalKey};
+  for (final entry in coordParents.entries) {
+    final tile = coordToKey[entry.key];
+    if (tile == null) continue;
+    final pc = entry.value;
+    final parentTile = coordToKey[gridCoordKey(pc.$1, pc.$2)];
+    if (parentTile == null) continue;
+    parent[tile] = parentTile;
   }
   return parent;
 }

--- a/packages/colonizethis_setup/lib/src/setup/initial_visibility.dart
+++ b/packages/colonizethis_setup/lib/src/setup/initial_visibility.dart
@@ -17,7 +17,7 @@ void _indexTileMapIntoProvinceBuckets({
       final localId = map.cell(x, y);
       final fullId = ProvinceId.full(regionId, localId);
       final provinceKey = fullId;
-      final tileKey = '$regionId|$localId|$x|$y';
+      final tileKey = CapitalTile.tileKey(regionId, localId, x, y);
       bucket.putIfAbsent(provinceKey, () => <String>[]).add(tileKey);
       final res = map.resourceAt(x, y);
       if (res != null) resourceByTileKey[tileKey] = res.name;
@@ -38,7 +38,7 @@ Map<String, String> _buildOldWorldVisibilityForPlayer({
       final fullId = ProvinceId.full(kRegionOldWorld, localId);
       final isSea = owSeaZoneIds.contains(localId);
       final ownerId = ownerById[fullId];
-      final tileKey = '$kRegionOldWorld|$localId|$x|$y';
+      final tileKey = CapitalTile.tileKey(kRegionOldWorld, localId, x, y);
       if (isSea) {
         visibility[tileKey] = VisibilityLevel.fogged.name;
         continue;
@@ -60,7 +60,7 @@ void _fillNewWorldUnknownVisibility({
   for (var y = 0; y < nwMap.height; y++) {
     for (var x = 0; x < nwMap.width; x++) {
       final localId = nwMap.cell(x, y);
-      final tileKey = '$kRegionNewWorld|$localId|$x|$y';
+      final tileKey = CapitalTile.tileKey(kRegionNewWorld, localId, x, y);
       visibility[tileKey] = VisibilityLevel.unknown.name;
     }
   }

--- a/packages/colonizethis_setup/lib/src/setup/minor_tribe_starting_development.dart
+++ b/packages/colonizethis_setup/lib/src/setup/minor_tribe_starting_development.dart
@@ -6,6 +6,7 @@ import 'setup_logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'package:colonizethis_world/colonizethis_world.dart';
+import 'province_tile_ranking.dart';
 import 'setup_exceptions.dart';
 import 'town_capital_occupancy.dart';
 
@@ -52,31 +53,18 @@ List<String> selectMinorTribeStartingDevelopmentTileKeys({
   if (terrainGrid == null || resGrid == null) {
     return const <String>[];
   }
-  final regionId = capital.regionId;
-  final localId = ProvinceId.isPrefixed(capital.provinceId)
-      ? ProvinceId.localIdFrom(capital.provinceId)
-      : capital.provinceId;
-  final ranked = <(int dist, int y, int x, String key)>[];
-  for (var y = 0; y < map.height; y++) {
-    for (var x = 0; x < map.width; x++) {
-      if (map.cell(x, y) != localId) continue;
-      if (map.terrainAt(x, y) == null) continue;
-      if (map.resourceAt(x, y) == null) continue;
-      final key = CapitalTile.tileKey(regionId, capital.provinceId, x, y);
-      if (forbiddenTileKeys.contains(key)) continue;
-      if (tileState.improvementLevel(key) != 0) continue;
-      final dist = (x - capital.x).abs() + (y - capital.y).abs();
-      ranked.add((dist, y, x, key));
-    }
-  }
-  ranked.sort((a, b) {
-    final c = a.$1.compareTo(b.$1);
-    if (c != 0) return c;
-    final cy = a.$2.compareTo(b.$2);
-    if (cy != 0) return cy;
-    return a.$3.compareTo(b.$3);
-  });
-  return ranked.take(maxTiles).map((e) => e.$4).toList();
+  return rankProvinceTileKeysByDistance(
+    map: map,
+    capital: capital,
+    accept: (x, y, key) {
+      if (map.terrainAt(x, y) == null) return false;
+      if (map.resourceAt(x, y) == null) return false;
+      if (forbiddenTileKeys.contains(key)) return false;
+      if (tileState.improvementLevel(key) != 0) return false;
+      return true;
+    },
+    maxTiles: maxTiles,
+  );
 }
 
 /// Applies SPEC/game/factions.md § Starting developed resources rule for every

--- a/packages/colonizethis_setup/lib/src/setup/province_tile_ranking.dart
+++ b/packages/colonizethis_setup/lib/src/setup/province_tile_ranking.dart
@@ -1,0 +1,60 @@
+// SPEC/game/tile-map-and-generation.md § Great Power starting grain;
+// SPEC/game/factions.md § Starting developed resources;
+// SPEC/program/game-setup-pipeline.md.
+//
+// Package-internal source of truth for ranking the tiles of a single capital
+// province by Manhattan distance from the capital. Both the Great Power
+// starting-grain selection (gp_starting_grain.dart) and the Minor Nation /
+// Tribe starting-development selection (minor_tribe_starting_development.dart)
+// previously carried a byte-identical `for (y) for (x)` walk that filtered to
+// one local province, built `(int dist, int y, int x, String key)` tuples, and
+// sorted with the same `dist → y → x` comparator before `take(n)`. Only the
+// per-tile eligibility predicate differed. Centralising the walk and sort here
+// keeps the deterministic selection order identical across both consumers.
+
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+/// Decides whether the cell at ([x], [y]) — whose canonical tile key is
+/// [tileKey] — is eligible for selection. The shared ranking helper computes
+/// the distance and ordering; callers supply only this predicate.
+typedef ProvinceTileEligibility =
+    bool Function(int x, int y, String tileKey);
+
+/// Returns the tile keys of [capital]'s province in [map] ranked by Manhattan
+/// distance from the capital ascending, then `y` ascending, then `x`
+/// ascending. Only cells in the capital's local province for which [accept]
+/// returns `true` are included.
+///
+/// Returns at most [maxTiles] keys when [maxTiles] is non-null; otherwise all
+/// eligible tiles in ranked order.
+List<String> rankProvinceTileKeysByDistance({
+  required TileMapResult map,
+  required CapitalTile capital,
+  required ProvinceTileEligibility accept,
+  int? maxTiles,
+}) {
+  final regionId = capital.regionId;
+  final localId = ProvinceId.isPrefixed(capital.provinceId)
+      ? ProvinceId.localIdFrom(capital.provinceId)
+      : capital.provinceId;
+  final ranked = <(int dist, int y, int x, String key)>[];
+  for (var y = 0; y < map.height; y++) {
+    for (var x = 0; x < map.width; x++) {
+      if (map.cell(x, y) != localId) continue;
+      final key = CapitalTile.tileKey(regionId, capital.provinceId, x, y);
+      if (!accept(x, y, key)) continue;
+      final dist = (x - capital.x).abs() + (y - capital.y).abs();
+      ranked.add((dist, y, x, key));
+    }
+  }
+  ranked.sort((a, b) {
+    final c = a.$1.compareTo(b.$1);
+    if (c != 0) return c;
+    final cy = a.$2.compareTo(b.$2);
+    if (cy != 0) return cy;
+    return a.$3.compareTo(b.$3);
+  });
+  final keys = ranked.map((e) => e.$4);
+  return (maxTiles == null ? keys : keys.take(maxTiles)).toList();
+}

--- a/packages/colonizethis_setup/test/setup/grid_bfs_test.dart
+++ b/packages/colonizethis_setup/test/setup/grid_bfs_test.dart
@@ -1,0 +1,105 @@
+// SPEC/game/capital-and-connectivity.md § Init town roads / Capital Setup.
+// Direct unit tests for the shared 4-neighbor grid BFS (grid_bfs.dart) that now
+// backs both road-geometry sites (Refs #3712).
+
+import 'package:colonizethis_setup/src/setup/grid_bfs.dart';
+import 'package:colonizethis_test/test.dart';
+
+void main() {
+  group('gridCoordKey', () {
+    test('formats x|y', () {
+      expect(gridCoordKey(3, 7), '3|7');
+    });
+  });
+
+  group('bfsGridParents', () {
+    test('start maps to itself', () {
+      final parents = bfsGridParents(
+        startX: 1,
+        startY: 1,
+        width: 3,
+        height: 3,
+        passable: (_, __) => true,
+      );
+      expect(parents[gridCoordKey(1, 1)], (1, 1));
+    });
+
+    test('expands neighbors in kGridNeighborsCardinal4 order (up,right,down,left)', () {
+      // 2x2 fully-passable grid from (0,0). (1,1) must be reached via (1,0)
+      // because the right neighbor is processed before the down neighbor.
+      final parents = bfsGridParents(
+        startX: 0,
+        startY: 0,
+        width: 2,
+        height: 2,
+        passable: (_, __) => true,
+      );
+      expect(parents[gridCoordKey(1, 0)], (0, 0));
+      expect(parents[gridCoordKey(0, 1)], (0, 0));
+      expect(parents[gridCoordKey(1, 1)], (1, 0));
+    });
+
+    test('does not enter impassable cells', () {
+      // Column x==1 is a wall; (2,0) is unreachable from (0,0).
+      final parents = bfsGridParents(
+        startX: 0,
+        startY: 0,
+        width: 3,
+        height: 1,
+        passable: (x, _) => x != 1,
+      );
+      expect(parents.containsKey(gridCoordKey(0, 0)), isTrue);
+      expect(parents.containsKey(gridCoordKey(1, 0)), isFalse);
+      expect(parents.containsKey(gridCoordKey(2, 0)), isFalse);
+    });
+
+    test('start passability is never tested', () {
+      final parents = bfsGridParents(
+        startX: 0,
+        startY: 0,
+        width: 1,
+        height: 1,
+        passable: (_, __) => false,
+      );
+      expect(parents[gridCoordKey(0, 0)], (0, 0));
+    });
+  });
+
+  group('reconstructGridPath', () {
+    test('returns shortest deterministic path start..end inclusive', () {
+      final parents = bfsGridParents(
+        startX: 0,
+        startY: 0,
+        width: 2,
+        height: 2,
+        passable: (_, __) => true,
+      );
+      expect(
+        reconstructGridPath(parents: parents, toX: 1, toY: 1),
+        [(0, 0), (1, 0), (1, 1)],
+      );
+    });
+
+    test('returns single-element path when end equals start', () {
+      final parents = bfsGridParents(
+        startX: 2,
+        startY: 2,
+        width: 4,
+        height: 4,
+        passable: (_, __) => true,
+      );
+      expect(reconstructGridPath(parents: parents, toX: 2, toY: 2), [(2, 2)]);
+    });
+
+    test('returns null when the target was unreachable', () {
+      final parents = bfsGridParents(
+        startX: 0,
+        startY: 0,
+        width: 3,
+        height: 1,
+        passable: (x, _) => x != 1,
+      );
+      expect(reconstructGridPath(parents: parents, toX: 2, toY: 0), isNull);
+    });
+  });
+}

--- a/packages/colonizethis_setup/test/setup/init_game_orchestrator_part1_test.dart
+++ b/packages/colonizethis_setup/test/setup/init_game_orchestrator_part1_test.dart
@@ -4,8 +4,9 @@ import 'package:colonizethis_test/test.dart';
 
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
-import 'package:colonizethis_map/colonizethis_map.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
+
+import 'init_game_orchestrator_test_support.dart';
 
 void main() {
   group('runInitGame', () {
@@ -16,7 +17,7 @@ void main() {
 
         final result = runInitGame(
           config: config,
-          options: const InitGameOptions(cellSize: 8, renderPng: false),
+          options: defaultInitOptions,
         );
 
         expect(result.game, isNotNull);
@@ -75,7 +76,7 @@ void main() {
       final config = GameSetupConfig.defaultConfig;
       final result = runInitGame(
         config: config,
-        options: const InitGameOptions(cellSize: 8, renderPng: false),
+        options: defaultInitOptions,
       );
       expect(result.markdown, contains('## Faction Setup'));
       expect(result.markdown, contains('## Faction Starting State'));
@@ -109,7 +110,7 @@ void main() {
         final config = GameSetupConfig.defaultConfig;
         final result = runInitGame(
           config: config,
-          options: const InitGameOptions(cellSize: 8, renderPng: false),
+          options: defaultInitOptions,
         );
         expect(result.warpLinks, isA<List<WarpLink>>());
         final combined = result.combinedTopology;
@@ -136,18 +137,10 @@ void main() {
     );
 
     test('seed=0 uses time-based effective seed', () {
-      final config = GameSetupConfig(
-        selectedGreatPowerIds:
-            GameSetupConfig.defaultConfig.selectedGreatPowerIds,
-        numProvincesOldWorld:
-            GameSetupConfig.defaultConfig.numProvincesOldWorld,
-        numProvincesNewWorld:
-            GameSetupConfig.defaultConfig.numProvincesNewWorld,
-        seed: 0,
-      );
+      final config = configWithOverrides(seed: 0);
       final result = runInitGame(
         config: config,
-        options: const InitGameOptions(cellSize: 8, renderPng: false),
+        options: defaultInitOptions,
       );
       expect(result.game, isNotNull);
       expect(result.game.globalGameSeed, isNonZero);
@@ -155,22 +148,10 @@ void main() {
 
     test('non-zero seed: globalGameSeed matches config.seed', () {
       const k = 900_001;
-      final base = GameSetupConfig.defaultConfig;
-      final config = GameSetupConfig(
-        selectedGreatPowerIds: base.selectedGreatPowerIds,
-        leaderVariantByGpId: base.leaderVariantByGpId,
-        continentCount: base.continentCount,
-        minorNationCount: base.minorNationCount,
-        tribeCount: base.tribeCount,
-        numProvincesOldWorld: base.numProvincesOldWorld,
-        numProvincesNewWorld: base.numProvincesNewWorld,
-        minProvincesPerMinor: base.minProvincesPerMinor,
-        seed: k,
-        startingResources: base.startingResources,
-      );
+      final config = configWithOverrides(seed: k);
       final result = runInitGame(
         config: config,
-        options: const InitGameOptions(cellSize: 8, renderPng: false),
+        options: defaultInitOptions,
       );
       expect(result.game.globalGameSeed, k);
     });
@@ -183,22 +164,9 @@ void main() {
         // Pairwise distinct sea-zone strings on one map are not required; stability
         // of (regionId|localSeaZoneId) → displayName for a fixed seed is.
         const k = 900_002;
-        final base = GameSetupConfig.defaultConfig;
-        final config = GameSetupConfig(
-          selectedGreatPowerIds: base.selectedGreatPowerIds,
-          leaderVariantByGpId: base.leaderVariantByGpId,
-          continentCount: base.continentCount,
-          minorNationCount: base.minorNationCount,
-          tribeCount: base.tribeCount,
-          numProvincesOldWorld: base.numProvincesOldWorld,
-          numProvincesNewWorld: base.numProvincesNewWorld,
-          minProvincesPerMinor: base.minProvincesPerMinor,
-          seed: k,
-          startingResources: base.startingResources,
-        );
-        const options = InitGameOptions(cellSize: 8, renderPng: false);
-        final first = runInitGame(config: config, options: options);
-        final second = runInitGame(config: config, options: options);
+        final config = configWithOverrides(seed: k);
+        final first = runInitGame(config: config, options: defaultInitOptions);
+        final second = runInitGame(config: config, options: defaultInitOptions);
         expect(
           first.game.worldState.seaZoneDisplayNameById,
           second.game.worldState.seaZoneDisplayNameById,
@@ -208,56 +176,16 @@ void main() {
 
     test('NW tile map uses effectiveSeed + 1 (OW uses effective seed)', () {
       final seedsByRegion = <String, int>{};
-      (TileMapResult, MapTopology) captureSeeds({
-        required TileMapParams params,
-        required int numProvinces,
-        required int numContinents,
-        required String regionId,
-        String seaZoneId = 's1',
-        ResourceRules? resourceRules,
-        void Function(String)? onLog,
-        void Function(
-          List<(int x, int y)> landSeeds,
-          List<int> continentIndices,
-        )?
-        onLandSeedsPlaced,
-        void Function(List<(int x, int y)> continentSeeds)?
-        onContinentSeedsPlaced,
-        List<int>? continentProvinceSizes,
-      }) {
-        seedsByRegion[regionId] = params.seed;
-        return defaultTileMapRegionGenerator(
-          params: params,
-          numProvinces: numProvinces,
-          numContinents: numContinents,
-          regionId: regionId,
-          seaZoneId: seaZoneId,
-          resourceRules: resourceRules,
-          onLog: onLog,
-          onLandSeedsPlaced: onLandSeedsPlaced,
-          onContinentSeedsPlaced: onContinentSeedsPlaced,
-          continentProvinceSizes: continentProvinceSizes,
-        );
-      }
+      final captureSeeds = wrapRegionGenerator(
+        onParams: (regionId, params) => seedsByRegion[regionId] = params.seed,
+      );
 
       const k = 77_777;
-      final base = GameSetupConfig.defaultConfig;
-      final config = GameSetupConfig(
-        selectedGreatPowerIds: base.selectedGreatPowerIds,
-        leaderVariantByGpId: base.leaderVariantByGpId,
-        continentCount: base.continentCount,
-        minorNationCount: base.minorNationCount,
-        tribeCount: base.tribeCount,
-        numProvincesOldWorld: base.numProvincesOldWorld,
-        numProvincesNewWorld: base.numProvincesNewWorld,
-        minProvincesPerMinor: base.minProvincesPerMinor,
-        seed: k,
-        startingResources: base.startingResources,
-      );
+      final config = configWithOverrides(seed: k);
 
       runInitGame(
         config: config,
-        options: const InitGameOptions(cellSize: 8, renderPng: false),
+        options: defaultInitOptions,
         generateRegion: captureSeeds,
       );
 
@@ -272,7 +200,7 @@ void main() {
     test('after runInitGame worldState.turnState is orders at turn 0', () {
       final result = runInitGame(
         config: GameSetupConfig.defaultConfig,
-        options: const InitGameOptions(cellSize: 8, renderPng: false),
+        options: defaultInitOptions,
       );
       expect(result.game.worldState.turnState.phase, TurnPhase.orders);
       expect(result.game.worldState.turnState.turnNumber, 0);
@@ -290,53 +218,32 @@ void main() {
 
     test('generateRegion injection is used for OW and NW map generation', () {
       var callCount = 0;
-      (TileMapResult, MapTopology) countingGen({
-        required TileMapParams params,
-        required int numProvinces,
-        required int numContinents,
-        required String regionId,
-        String seaZoneId = 's1',
-        ResourceRules? resourceRules,
-        void Function(String)? onLog,
-        void Function(
-          List<(int x, int y)> landSeeds,
-          List<int> continentIndices,
-        )?
-        onLandSeedsPlaced,
-        void Function(List<(int x, int y)> continentSeeds)?
-        onContinentSeedsPlaced,
-        List<int>? continentProvinceSizes,
-      }) {
-        callCount++;
-        final forcedSizes =
-            continentProvinceSizes ??
-            (numContinents == 4 &&
-                    numProvinces == 60 &&
-                    regionId == kRegionOldWorld
-                ? const [13, 13, 17, 17]
-                : numContinents == 4 &&
-                      numProvinces == 30 &&
-                      regionId == kRegionNewWorld
-                ? const [6, 6, 9, 9]
-                : null);
-        return defaultTileMapRegionGenerator(
-          params: params,
-          numProvinces: numProvinces,
-          numContinents: numContinents,
-          regionId: regionId,
-          seaZoneId: seaZoneId,
-          resourceRules: resourceRules,
-          onLog: onLog,
-          onLandSeedsPlaced: onLandSeedsPlaced,
-          onContinentSeedsPlaced: onContinentSeedsPlaced,
-          continentProvinceSizes: forcedSizes,
-        );
-      }
+      final countingGen = wrapRegionGenerator(
+        onParams: (_, __) => callCount++,
+        resolveContinentProvinceSizes:
+            ({
+              required regionId,
+              required numProvinces,
+              required numContinents,
+              required continentProvinceSizes,
+            }) {
+              return continentProvinceSizes ??
+                  (numContinents == 4 &&
+                          numProvinces == 60 &&
+                          regionId == kRegionOldWorld
+                      ? const [13, 13, 17, 17]
+                      : numContinents == 4 &&
+                            numProvinces == 30 &&
+                            regionId == kRegionNewWorld
+                      ? const [6, 6, 9, 9]
+                      : null);
+            },
+      );
 
       final config = GameSetupConfig.defaultConfig;
       final result = runInitGame(
         config: config,
-        options: const InitGameOptions(cellSize: 8, renderPng: false),
+        options: defaultInitOptions,
         generateRegion: countingGen,
       );
 

--- a/packages/colonizethis_setup/test/setup/init_game_orchestrator_part2_test.dart
+++ b/packages/colonizethis_setup/test/setup/init_game_orchestrator_part2_test.dart
@@ -11,24 +11,11 @@ void main() {
     test(
       'locked full-init profile: 60 OW / 30 NW, 6 GPs, 6 minors; init succeeds and GPs are P–P connected',
       () {
-        final base = GameSetupConfig.defaultConfig;
-        final config = GameSetupConfig(
-          selectedGreatPowerIds: base.selectedGreatPowerIds,
-          leaderVariantByGpId: base.leaderVariantByGpId,
-          continentCount: 4,
-          minorNationCount: 6,
-          tribeCount: 10,
-          numProvincesOldWorld: 60,
-          numProvincesNewWorld: 30,
-          minProvincesPerMinor: 3,
-          seed: base.seed,
-          startingResources: base.startingResources,
+        final config = lockedFullInitConfig(
+          seed: GameSetupConfig.defaultConfig.seed,
         );
 
-        final result = runInitGame(
-          config: config,
-          options: const InitGameOptions(cellSize: 8, renderPng: false),
-        );
+        final result = runInitGame(config: config, options: defaultInitOptions);
         final game = result.game;
         expect(game.worldState.oldWorld.provinces.length, 60);
         expect(game.players.length, 6);
@@ -42,23 +29,8 @@ void main() {
       'seed 42 full init: land province display names unique per region; '
       'Poland minor4 has at most one Greater Poland when locked partitions match',
       () {
-        final base = GameSetupConfig.defaultConfig;
-        final config = GameSetupConfig(
-          selectedGreatPowerIds: base.selectedGreatPowerIds,
-          leaderVariantByGpId: base.leaderVariantByGpId,
-          continentCount: 4,
-          minorNationCount: 6,
-          tribeCount: 10,
-          numProvincesOldWorld: 60,
-          numProvincesNewWorld: 30,
-          minProvincesPerMinor: 3,
-          seed: 42,
-          startingResources: base.startingResources,
-        );
-        final result = runInitGame(
-          config: config,
-          options: const InitGameOptions(cellSize: 8, renderPng: false),
-        );
+        final config = lockedFullInitConfig(seed: 42);
+        final result = runInitGame(config: config, options: defaultInitOptions);
         final game = result.game;
         void assertDistinct(Iterable<String?> names, String label) {
           final strings = names
@@ -132,22 +104,6 @@ void main() {
       },
     );
 
-    GameSetupConfig lockedFullInitConfig({required int seed}) {
-      final base = GameSetupConfig.defaultConfig;
-      return GameSetupConfig(
-        selectedGreatPowerIds: base.selectedGreatPowerIds,
-        leaderVariantByGpId: base.leaderVariantByGpId,
-        continentCount: 4,
-        minorNationCount: 6,
-        tribeCount: 10,
-        numProvincesOldWorld: 60,
-        numProvincesNewWorld: 30,
-        minProvincesPerMinor: 3,
-        seed: seed,
-        startingResources: base.startingResources,
-      );
-    }
-
     test(
       'AC-11 locked full-init profile: twenty fixed seeds complete setup',
       () {
@@ -178,10 +134,7 @@ void main() {
 
         for (final s in seeds) {
           final config = lockedFullInitConfig(seed: s);
-          final result = runInitGame(
-            config: config,
-            options: const InitGameOptions(cellSize: 8, renderPng: false),
-          );
+          final result = runInitGame(config: config, options: defaultInitOptions);
           final game = result.game;
           expect(
             game.worldState.oldWorld.provinces.length,
@@ -224,9 +177,8 @@ void main() {
         // Must match one of the AC-11 regression seeds (#1861 / #1822).
         const s = 17011;
         final config = lockedFullInitConfig(seed: s);
-        const options = InitGameOptions(cellSize: 8, renderPng: false);
-        final a = runInitGame(config: config, options: options);
-        final b = runInitGame(config: config, options: options);
+        final a = runInitGame(config: config, options: defaultInitOptions);
+        final b = runInitGame(config: config, options: defaultInitOptions);
 
         String ownerKey(Game g) {
           final parts = <String>[];

--- a/packages/colonizethis_setup/test/setup/init_game_orchestrator_test_support.dart
+++ b/packages/colonizethis_setup/test/setup/init_game_orchestrator_test_support.dart
@@ -1,7 +1,103 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_map/colonizethis_map.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart';
+
+/// Shared init options for orchestrator tests (no PNG render, 8px cells).
+/// Replaces the `const InitGameOptions(cellSize: 8, renderPng: false)` literal
+/// repeated across nearly every orchestrator test (Refs #3712).
+const defaultInitOptions = InitGameOptions(cellSize: 8, renderPng: false);
+
+/// Builds a [GameSetupConfig] from [GameSetupConfig.defaultConfig], overriding
+/// only the provided fields. Removes the verbose full-config rebuild blocks
+/// tests used to vary a single field — the config has no `copyWith` (#3712).
+GameSetupConfig configWithOverrides({
+  int? seed,
+  int? continentCount,
+  int? minorNationCount,
+  int? tribeCount,
+  int? numProvincesOldWorld,
+  int? numProvincesNewWorld,
+  int? minProvincesPerMinor,
+}) {
+  final base = GameSetupConfig.defaultConfig;
+  return GameSetupConfig(
+    selectedGreatPowerIds: base.selectedGreatPowerIds,
+    leaderVariantByGpId: base.leaderVariantByGpId,
+    continentCount: continentCount ?? base.continentCount,
+    minorNationCount: minorNationCount ?? base.minorNationCount,
+    tribeCount: tribeCount ?? base.tribeCount,
+    numProvincesOldWorld: numProvincesOldWorld ?? base.numProvincesOldWorld,
+    numProvincesNewWorld: numProvincesNewWorld ?? base.numProvincesNewWorld,
+    minProvincesPerMinor: minProvincesPerMinor ?? base.minProvincesPerMinor,
+    seed: seed ?? base.seed,
+    startingResources: base.startingResources,
+  );
+}
+
+/// The locked full-init profile config (#1830 AC-10..AC-12): default GP ids and
+/// starting resources with the locked partition counts and the given [seed].
+GameSetupConfig lockedFullInitConfig({required int seed}) => configWithOverrides(
+  seed: seed,
+  continentCount: 4,
+  minorNationCount: 6,
+  tribeCount: 10,
+  numProvincesOldWorld: 60,
+  numProvincesNewWorld: 30,
+  minProvincesPerMinor: 3,
+);
+
+/// Wraps [defaultTileMapRegionGenerator] for tests, exposing the per-region
+/// [TileMapParams] via [onParams] and allowing a [continentProvinceSizes]
+/// override via [resolveContinentProvinceSizes]. Removes the copy-pasted full
+/// generator signature from orchestrator tests (Refs #3712).
+TileMapRegionGenerator wrapRegionGenerator({
+  void Function(String regionId, TileMapParams params)? onParams,
+  List<int>? Function({
+    required String regionId,
+    required int numProvinces,
+    required int numContinents,
+    required List<int>? continentProvinceSizes,
+  })?
+  resolveContinentProvinceSizes,
+}) {
+  return ({
+    required TileMapParams params,
+    required int numProvinces,
+    required int numContinents,
+    required String regionId,
+    String seaZoneId = 's1',
+    ResourceRules? resourceRules,
+    void Function(String)? onLog,
+    void Function(List<(int x, int y)> landSeeds, List<int> continentIndices)?
+    onLandSeedsPlaced,
+    void Function(List<(int x, int y)> continentSeeds)? onContinentSeedsPlaced,
+    List<int>? continentProvinceSizes,
+  }) {
+    onParams?.call(regionId, params);
+    final sizes =
+        resolveContinentProvinceSizes?.call(
+          regionId: regionId,
+          numProvinces: numProvinces,
+          numContinents: numContinents,
+          continentProvinceSizes: continentProvinceSizes,
+        ) ??
+        continentProvinceSizes;
+    return defaultTileMapRegionGenerator(
+      params: params,
+      numProvinces: numProvinces,
+      numContinents: numContinents,
+      regionId: regionId,
+      seaZoneId: seaZoneId,
+      resourceRules: resourceRules,
+      onLog: onLog,
+      onLandSeedsPlaced: onLandSeedsPlaced,
+      onContinentSeedsPlaced: onContinentSeedsPlaced,
+      continentProvinceSizes: sizes,
+    );
+  };
+}
 
 /// When OW and NW topologies both match locked multisets, assert GitHub #1830
 /// AC-1–AC-9 (subset exercised here; procedural maps often miss multisets).

--- a/packages/colonizethis_setup/test/setup/province_tile_ranking_test.dart
+++ b/packages/colonizethis_setup/test/setup/province_tile_ranking_test.dart
@@ -1,0 +1,94 @@
+// SPEC/game/tile-map-and-generation.md § Great Power starting grain;
+// SPEC/game/factions.md § Starting developed resources.
+// Direct unit tests for the shared province tile ranker (province_tile_ranking.dart)
+// that now backs grain and minor/tribe development selection (Refs #3712).
+
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_setup/src/setup/province_tile_ranking.dart';
+import 'package:colonizethis_test/test.dart';
+
+TileMapResult _province4x3() => TileMapResult(
+  width: 4,
+  height: 3,
+  grid: const [
+    ['p1', 'p1', 'p1', 'p1'],
+    ['p1', 'p1', 'p1', 'p1'],
+    ['p1', 'p1', 'p1', 'p1'],
+  ],
+);
+
+CapitalTile _capitalAt(int x, int y) =>
+    CapitalTile(regionId: 'oldWorld', provinceId: 'oldWorld|p1', x: x, y: y);
+
+void main() {
+  group('rankProvinceTileKeysByDistance', () {
+    test('orders by Manhattan distance, then y asc, then x asc', () {
+      final picks = rankProvinceTileKeysByDistance(
+        map: _province4x3(),
+        capital: _capitalAt(2, 1),
+        accept: (_, __, ___) => true,
+        maxTiles: 5,
+      );
+      // (2,1) d=0 first, then the four distance-1 tiles sorted y asc, x asc.
+      expect(picks, [
+        'oldWorld|p1|2|1',
+        'oldWorld|p1|2|0',
+        'oldWorld|p1|1|1',
+        'oldWorld|p1|3|1',
+        'oldWorld|p1|2|2',
+      ]);
+    });
+
+    test('caps output at maxTiles', () {
+      final picks = rankProvinceTileKeysByDistance(
+        map: _province4x3(),
+        capital: _capitalAt(0, 0),
+        accept: (_, __, ___) => true,
+        maxTiles: 2,
+      );
+      expect(picks, ['oldWorld|p1|0|0', 'oldWorld|p1|1|0']);
+    });
+
+    test('returns all eligible tiles in order when maxTiles is null', () {
+      final picks = rankProvinceTileKeysByDistance(
+        map: _province4x3(),
+        capital: _capitalAt(0, 0),
+        accept: (_, __, ___) => true,
+      );
+      expect(picks, hasLength(12));
+      expect(picks.first, 'oldWorld|p1|0|0');
+    });
+
+    test('applies the eligibility predicate and excludes other provinces', () {
+      final map = TileMapResult(
+        width: 2,
+        height: 2,
+        grid: const [
+          ['p1', 'p2'],
+          ['p2', 'p1'],
+        ],
+      );
+      final picks = rankProvinceTileKeysByDistance(
+        map: map,
+        capital: _capitalAt(0, 0),
+        // Reject the capital tile itself; only the other p1 tile (1,1) remains.
+        accept: (x, y, key) => key != 'oldWorld|p1|0|0',
+      );
+      expect(picks, ['oldWorld|p1|1|1']);
+    });
+
+    test('builds keys via the canonical CapitalTile.tileKey shape', () {
+      final picks = rankProvinceTileKeysByDistance(
+        map: _province4x3(),
+        capital: _capitalAt(0, 0),
+        accept: (_, __, ___) => true,
+        maxTiles: 1,
+      );
+      expect(
+        picks.single,
+        CapitalTile.tileKey('oldWorld', 'oldWorld|p1', 0, 0),
+      );
+    });
+  });
+}

--- a/test/check_setup_lib_tile_key_interpolation_test.dart
+++ b/test/check_setup_lib_tile_key_interpolation_test.dart
@@ -1,0 +1,98 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+import '../tool/check_setup_lib_tile_key_interpolation.dart';
+
+void main() {
+  group('findSetupLibTileKeyInterpolationViolations', () {
+    const setupPath =
+        'packages/colonizethis_setup/lib/src/setup/initial_visibility.dart';
+
+    test('flags raw region|local|x|y tile-key interpolation', () {
+      const src = r'''
+String build(String regionId, String localId, int x, int y) {
+  return '$regionId|$localId|$x|$y';
+}
+''';
+      final violations = findSetupLibTileKeyInterpolationViolations(
+        relativePath: setupPath,
+        source: src,
+      );
+      expect(violations, hasLength(1));
+      expect(violations.single.message, contains('CapitalTile.tileKey'));
+    });
+
+    test('flags interpolation with braced segments', () {
+      const src = r'''
+String build(int x, int y) {
+  return '${kRegionOldWorld}|${localId}|${x}|${y}';
+}
+''';
+      final violations = findSetupLibTileKeyInterpolationViolations(
+        relativePath: setupPath,
+        source: src,
+      );
+      expect(violations, hasLength(1));
+    });
+
+    test('accepts the canonical CapitalTile.tileKey helper call', () {
+      const src = r'''
+final tileKey = CapitalTile.tileKey(regionId, localId, x, y);
+''';
+      final violations = findSetupLibTileKeyInterpolationViolations(
+        relativePath: setupPath,
+        source: src,
+      );
+      expect(violations, isEmpty);
+    });
+
+    test('does not flag two-segment coord keys', () {
+      const src = r'''
+String coord(int x, int y) => '$x|$y';
+''';
+      final violations = findSetupLibTileKeyInterpolationViolations(
+        relativePath: setupPath,
+        source: src,
+      );
+      expect(violations, isEmpty);
+    });
+
+    test('does not flag descriptive log strings with non-pipe literals', () {
+      const src = r'''
+final line = 'i=$i|sz=${lm.size}|sea=$sea|min=${lm.minProvinceId}';
+''';
+      final violations = findSetupLibTileKeyInterpolationViolations(
+        relativePath: setupPath,
+        source: src,
+      );
+      expect(violations, isEmpty);
+    });
+
+    test('passes on the live setup lib source tree', () {
+      final repoRoot = _repoRoot();
+      final code = runCheckSetupLibTileKeyInterpolation(
+        repoRoot,
+        info: (_) {},
+        err: (_) {},
+      );
+      expect(code, 0);
+    });
+  });
+}
+
+String _repoRoot() {
+  var dir = Directory.current;
+  while (true) {
+    final manifest = File(
+      p.join(dir.path, 'tool', 'ct_repo_lint_manifest.yaml'),
+    );
+    if (manifest.existsSync()) return dir.path;
+    final parent = dir.parent;
+    if (parent.path == dir.path) {
+      return Directory.current.path;
+    }
+    dir = parent;
+  }
+}

--- a/tool/check_setup_lib_tile_key_interpolation.dart
+++ b/tool/check_setup_lib_tile_key_interpolation.dart
@@ -1,0 +1,165 @@
+import 'dart:io';
+
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:path/path.dart' as p;
+
+/// Setup-package tile keys must be built through the canonical helpers
+/// (`CapitalTile.tileKey`, `gpOwTileKey`) rather than raw
+/// `'$regionId|$localId|$x|$y'` string interpolation. This mirrors the
+/// `colonizethis_map` gates (`repo.colonizethis_map_lib_pipe_split` /
+/// `repo.canonical_province_tile_keys`, GitHub #2087) for
+/// `packages/colonizethis_setup/lib/` so setup stays decoupled from the raw
+/// pipe-string tile-key shape (Refs #3712).
+const _setupLibRoot = 'packages/colonizethis_setup/lib';
+
+/// The canonical tile-key shape `region|province|x|y` is a pure-interpolation
+/// join with this many `|` separators. Two-segment coord keys (`'$x|$y'`) and
+/// port keys (`'$provinceId|$seaZoneId'`) carry fewer separators and are not
+/// flagged; descriptive log strings (`'i=$i|sz=$s|sea=$x'`) carry non-pipe
+/// literal text between segments and are likewise not flagged.
+const _tileKeySeparatorThreshold = 3;
+
+/// Canonical tile-key builders are allowed to construct the raw shape. The
+/// setup package routes all keys through `CapitalTile.tileKey` (in
+/// `colonizethis_models`) and the shared `gp_old_world_tile_scan.dart` /
+/// `province_tile_ranking.dart` helpers, none of which interpolate the raw
+/// string, so no setup source is exempt today; the allow-list documents intent
+/// and keeps a single editable place should a canonical builder ever move here.
+const _allowedRawTileKeyPaths = <String>{};
+
+/// Used by `ct_repo_lint` in-process; [info] / [err] default to stdout/stderr.
+int runCheckSetupLibTileKeyInterpolation(
+  String repoRoot, {
+  void Function(String line)? info,
+  void Function(String line)? err,
+}) {
+  final logI = info ?? stdout.writeln;
+  final logE = err ?? stderr.writeln;
+  final root = p.normalize(repoRoot);
+  final libDir = Directory(p.join(root, _setupLibRoot));
+  if (!libDir.existsSync()) {
+    logI('Setup lib tile-key interpolation check skipped (lib dir absent).');
+    return 0;
+  }
+
+  final violations = <SetupLibTileKeyInterpolationViolation>[];
+  for (final file in libDir.listSync(recursive: true, followLinks: false)) {
+    if (file is! File || !file.path.endsWith('.dart')) continue;
+    if (file.path.endsWith('.g.dart')) continue;
+    final relPath = p.normalize(p.relative(file.path, from: root));
+    if (_allowedRawTileKeyPaths.contains(relPath)) continue;
+    violations.addAll(
+      findSetupLibTileKeyInterpolationViolations(
+        relativePath: relPath,
+        source: file.readAsStringSync(),
+      ),
+    );
+  }
+
+  if (violations.isEmpty) {
+    logI('Setup lib tile-key interpolation check passed.');
+    return 0;
+  }
+
+  logE(
+    'ERROR: Build setup tile keys via CapitalTile.tileKey / gpOwTileKey '
+    'instead of raw "\$regionId|\$localId|\$x|\$y" interpolation.',
+  );
+  for (final v in violations) {
+    logE('${v.path}:${v.line}:${v.column} ${v.message}');
+  }
+  return 1;
+}
+
+void main() {
+  exit(runCheckSetupLibTileKeyInterpolation(Directory.current.path));
+}
+
+/// Scans [source] for raw canonical-shape tile-key string interpolations.
+List<SetupLibTileKeyInterpolationViolation>
+findSetupLibTileKeyInterpolationViolations({
+  required String relativePath,
+  required String source,
+}) {
+  final parsed = parseString(
+    content: source,
+    path: relativePath,
+    throwIfDiagnostics: false,
+  );
+  final visitor = _RawTileKeyInterpolationVisitor(
+    path: relativePath,
+    unit: parsed.unit,
+  );
+  parsed.unit.accept(visitor);
+  return visitor.violations;
+}
+
+class _RawTileKeyInterpolationVisitor extends RecursiveAstVisitor<void> {
+  _RawTileKeyInterpolationVisitor({required this.path, required this.unit});
+
+  final String path;
+  final CompilationUnit unit;
+  final List<SetupLibTileKeyInterpolationViolation> violations =
+      <SetupLibTileKeyInterpolationViolation>[];
+
+  @override
+  void visitStringInterpolation(StringInterpolation node) {
+    if (_isRawTileKeyShape(node)) {
+      final loc = unit.lineInfo.getLocation(node.offset);
+      violations.add(
+        SetupLibTileKeyInterpolationViolation(
+          path: path,
+          line: loc.lineNumber,
+          column: loc.columnNumber,
+          message:
+              'Raw tile-key interpolation; use CapitalTile.tileKey / gpOwTileKey.',
+        ),
+      );
+    }
+    super.visitStringInterpolation(node);
+  }
+
+  /// True when [node] is a pure-interpolation join of 4+ segments separated by
+  /// lone `|` literals — i.e. the canonical `region|province|x|y` tile-key
+  /// shape. The analyzer always emits leading/trailing [InterpolationString]
+  /// elements (possibly empty); a pure pipe-join has empty endpoints, `|`
+  /// separators, and [InterpolationExpression] segments in between.
+  bool _isRawTileKeyShape(StringInterpolation node) {
+    final elements = node.elements;
+    if (elements.length < 2) return false;
+    var separators = 0;
+    for (var i = 0; i < elements.length; i++) {
+      final element = elements[i];
+      if (i.isEven) {
+        if (element is! InterpolationString) return false;
+        final value = element.value;
+        final isEndpoint = i == 0 || i == elements.length - 1;
+        if (isEndpoint) {
+          if (value.isNotEmpty) return false;
+        } else {
+          if (value != '|') return false;
+          separators++;
+        }
+      } else {
+        if (element is! InterpolationExpression) return false;
+      }
+    }
+    return separators >= _tileKeySeparatorThreshold;
+  }
+}
+
+class SetupLibTileKeyInterpolationViolation {
+  const SetupLibTileKeyInterpolationViolation({
+    required this.path,
+    required this.line,
+    required this.column,
+    required this.message,
+  });
+
+  final String path;
+  final int line;
+  final int column;
+  final String message;
+}

--- a/tool/ct_repo_lint_lib.dart
+++ b/tool/ct_repo_lint_lib.dart
@@ -57,6 +57,7 @@ import 'check_orders_dedup_diplomatic_helpers.dart';
 import 'check_orders_dedup_map_clones.dart';
 import 'check_setup_dedup_gp_ids_from_players.dart';
 import 'check_setup_dedup_gp_ow_tile_scans.dart';
+import 'check_setup_lib_tile_key_interpolation.dart';
 import 'check_setup_dedup_init_pipeline_retry.dart';
 import 'check_logic_diplomatic_sub_validator_size.dart';
 import 'check_logic_work_target_switch.dart';
@@ -877,6 +878,8 @@ int? _tryRunDartRuleInProcess({
       return runCheckSetupDedupGpOwTileScans(repoRoot);
     case 'repo.setup_dedup_gp_ids_from_players':
       return runCheckSetupDedupGpIdsFromPlayers(repoRoot);
+    case 'repo.setup_lib_tile_key_interpolation':
+      return runCheckSetupLibTileKeyInterpolation(repoRoot);
     case 'repo.domain_package_logger_dedup':
       return runCheckDomainPackageLoggerDedup(repoRoot);
     case 'repo.ai_api_narrow_surface':

--- a/tool/ct_repo_lint_manifest.yaml
+++ b/tool/ct_repo_lint_manifest.yaml
@@ -784,6 +784,13 @@ rules:
     runner: dart
     script: tool/check_setup_dedup_gp_ow_tile_scans.dart
 
+  - rule_id: repo.setup_lib_tile_key_interpolation
+    group: structure
+    title: colonizethis_setup lib builds tile keys via CapitalTile.tileKey / gpOwTileKey (no raw pipe interpolation) (Refs #3712)
+    spec: SPEC/game/world-model-identity.md
+    runner: dart
+    script: tool/check_setup_lib_tile_key_interpolation.dart
+
   - rule_id: repo.setup_dedup_gp_ids_from_players
     group: architecture
     title: setup GP id list/set must use gpIdsSortedFromPlayers instead of re-inlining game.players.map((p) => p.id) (Refs #3449)


### PR DESCRIPTION
## Summary

Reduces duplication and tightens abstractions in `packages/colonizethis_setup` per #3712. Behavior-preserving: no setup-pipeline semantics, deterministic ordering, RNG seeding, or accepted-order/turn-resolution contracts change.

`Refs #3712`

## Done in this push

- **Province tile ranker** — new `province_tile_ranking.dart` (`rankProvinceTileKeysByDistance`) backs both `selectGreatPowerBootstrapGrainTileKeysLandOnly` and `selectMinorTribeStartingDevelopmentTileKeys`; callers supply only their eligibility predicate. Same `dist → y → x` order.
- **Grid BFS** — new `grid_bfs.dart` (`bfsGridParents` + `reconstructGridPath`) backs both road-geometry sites: `init_town_roads` `_bfsParentsFromCapital` and capital port-road `_shortestPathOnProvinceTiles`. Single `kGridNeighborsCardinal4` neighbor order / coord-key shape.
- **Adjacency scans** — shared cardinal-neighbor iterator + `_provinceNodeIds`; province-id set computed once and threaded into the three `_isTileAdjacentTo*` helpers.
- **Canonical tile keys** — `initial_visibility.dart` now builds keys via `CapitalTile.tileKey` (no raw `'$regionId|$localId|$x|$y'` interpolation).
- **Naming** — dropped the always-constant `applyNamingToFaction` callback parameter (call `_namingApplyNamingToFaction` directly); folded minor + tribe province naming into one parameterized pass. Output byte-identical for fixed seeds.
- **CI enforcement** — new `repo.setup_lib_tile_key_interpolation` `ct_repo_lint` rule (AST, setup-scoped) flags raw 4-segment pipe tile-key interpolation; mirrors the `colonizethis_map` pipe-split / canonical-key gates (#2087). Coord keys (`'$x|$y'`), port keys, and descriptive log strings are not flagged.
- **Test support** — `defaultInitOptions`, `configWithOverrides`, `lockedFullInitConfig`, `wrapRegionGenerator` added to `init_game_orchestrator_test_support.dart`; orchestrator part1/part2 tests migrated off verbose full-config rebuilds and copy-pasted `generateRegion` stubs.

## Acceptance criteria coverage

- [x] Shared ranking helper for grain + minor/tribe; outputs unchanged.
- [x] Shared 4-neighbor grid-BFS for both road-geometry sites.
- [x] Shared neighbor-iteration helper + province-id set computed once.
- [x] No raw tile-key interpolation in setup `lib/`; `ct_repo_lint` rule enforces it.
- [x] Naming no longer threads the constant callback; minor/tribe share one helper; fixed-seed naming identical.
- [x] Orchestrator tests use shared config/options/`generateRegion` support helpers.
- [x] `dart analyze` clean; package `dart test` green.
- [x] Locked full-init AC-1..AC-12 seed regressions pass unchanged.

## Tests

- New direct unit tests: `grid_bfs_test.dart` (neighbor ordering, reachability, path reconstruction incl. null), `province_tile_ranking_test.dart` (ordering, maxTiles, predicate, canonical key shape).
- New tool test: `test/check_setup_lib_tile_key_interpolation_test.dart` (positive raw-key flag, braced segments; negatives: canonical call, coord keys, log strings; live-tree pass).
- Verified green: full `colonizethis_setup` suite incl. `init_game_orchestrator_part1/part2` (AC-11 twenty-seed + AC-12 determinism), logic grain/minor-tribe selection regressions, `ct_repo_lint` manifest tests, and the new + setup-dedup lint rules.

## Out of scope / deferred

- Optional `GameSetupConfig.copyWith` in `colonizethis_data` (issue notes it as a separate follow-up).

Made with [Cursor](https://cursor.com)