### PR TITLE
refactor: route diplomacy test-support fixtures through shared TestFixtures (#3715)

### DIFF
--- a/packages/colonizethis_diplomacy/test/support/call_to_arms_fixtures.dart
+++ b/packages/colonizethis_diplomacy/test/support/call_to_arms_fixtures.dart
@@ -1,9 +1,15 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/game_test_fixtures.dart';
 
 /// Shared three-power game fixture for call-to-arms (alliance mutual defence)
 /// tests. Extracted so the call-to-arms suites stay within the split
 /// domain-package test file size cap (Refs #3625).
+///
+/// Built on [TestFixtures.minimalGame] (Refs #3715): the previous inline
+/// `Game`/`WorldState` builder matched `minimalGame` with empty New World and an
+/// orders-phase turn 1, so only the GP3-owned Old World provinces, the three
+/// players, and the diplomacy relations remain expressed here.
 Game threePowerCallToArmsGame({
   required bool gp1Human,
   required bool gp2Human,
@@ -11,21 +17,17 @@ Game threePowerCallToArmsGame({
   RelationLevel gp1gp2Level = RelationLevel.allied,
   bool gp1gp2FormalAlliance = true,
 }) {
-  return Game(
+  return TestFixtures.minimalGame(
     id: 'g1',
-    worldState: WorldState(
-      turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
-      oldWorld: RegionData(
-        provinces: [
-          for (var i = 0; i < kObserverConquestMinOwProvincesPerGp; i++)
-            Province(
-              id: 'oldWorld|gp3_$i',
-              regionId: 'oldWorld',
-              ownerId: 'gp3',
-            ),
-        ],
-      ),
-      newWorld: const RegionData(),
+    oldWorld: RegionData(
+      provinces: [
+        for (var i = 0; i < kObserverConquestMinOwProvincesPerGp; i++)
+          Province(
+            id: 'oldWorld|gp3_$i',
+            regionId: 'oldWorld',
+            ownerId: 'gp3',
+          ),
+      ],
     ),
     players: [
       Player(

--- a/packages/colonizethis_diplomacy/test/support/diplomacy_resolver_phase_test_support.dart
+++ b/packages/colonizethis_diplomacy/test/support/diplomacy_resolver_phase_test_support.dart
@@ -1,15 +1,17 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/game_test_fixtures.dart';
 
 /// Shared fixture for [diplomacy_resolver_phase_test_part*_test.dart].
+///
+/// Built on the shared [TestFixtures.minimalGame] factory (Refs #3715): the
+/// previous inline `Game`/`WorldState` builder was byte-equivalent to
+/// `minimalGame` with empty regions on an orders-phase turn 1, so the only
+/// per-fixture customisation kept here is the diplomacy-expertise GP plus the
+/// minor nation / tribe rosters these phase tests exercise.
 Game diplomacyResolverPhaseTestBaseGame() {
-  return Game(
+  return TestFixtures.minimalGame(
     id: 'g1',
-    worldState: WorldState(
-      turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
-      oldWorld: const RegionData(),
-      newWorld: const RegionData(),
-    ),
     players: [
       const Player(id: 'gp1', displayName: 'GP1', isHuman: true, treasury: 2000)
           .copyWith(techUnlocked: const {kTechIdDiplomaticExpertise: true}),

--- a/packages/colonizethis_diplomacy/test/support/event_dialogue_test_support.dart
+++ b/packages/colonizethis_diplomacy/test/support/event_dialogue_test_support.dart
@@ -1,4 +1,5 @@
 import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/game_test_fixtures.dart';
 
 /// Shared `Game` fixture for `event_dialogue_test.dart` and its split files.
 ///
@@ -6,7 +7,9 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 /// minimal-province game (orders phase) varying only by `turnNumber`,
 /// `players`, optional region provinces, and a handful of optional
 /// diplomacy / overture / minor-nation / tribe fields. This helper
-/// centralizes that boilerplate.
+/// centralizes that boilerplate on the shared [TestFixtures.minimalGame]
+/// factory (Refs #3715) — the previous inline builder was equivalent to
+/// `minimalGame` with the same orders-phase turn and empty-region defaults.
 ///
 /// Refs waigore/colonizethis#2216 (consolidate duplicated test setup).
 Game dialogueGame({
@@ -20,18 +23,14 @@ Game dialogueGame({
   List<Tribe> tribes = const [],
   List<OvertureState> overtureStates = const [],
 }) {
-  return Game(
+  return TestFixtures.minimalGame(
     id: id,
-    worldState: WorldState(
-      turnState: TurnState(phase: TurnPhase.orders, turnNumber: turnNumber),
-      oldWorld: oldWorldProvinces.isEmpty
-          ? const RegionData()
-          : RegionData(provinces: oldWorldProvinces),
-      newWorld: newWorldProvinces.isEmpty
-          ? const RegionData()
-          : RegionData(provinces: newWorldProvinces),
-    ),
+    turnNumber: turnNumber,
     players: players,
+    oldWorld:
+        oldWorldProvinces.isEmpty ? null : RegionData(provinces: oldWorldProvinces),
+    newWorld:
+        newWorldProvinces.isEmpty ? null : RegionData(provinces: newWorldProvinces),
     diplomacyRelations: diplomacyRelations,
     minorNations: minorNations,
     tribes: tribes,


### PR DESCRIPTION
## Summary

Completes the remaining AC3 slice of #3715: the three `colonizethis_diplomacy` test-support fixtures now build their `Game` via the shared `colonizethis_test` `TestFixtures.minimalGame` factory instead of hand-rolled `Game`/`WorldState` construction.

The prior PR (#3719, merged) already landed the bulk of this issue:
- AC1 — deleted the local `TestFixtures` duplicate; importers repointed to shared fixtures.
- AC2 — `test/` tree mirrored under `test/diplomacy/` and `test/dossier/` (+ `repo.diplomacy_test_mirrors_lib` gate).
- AC4 — `resolveHumanGatedDecision` template introduced in `diplomacy_shared_helpers.dart`; overture/FTP/intervention/call-to-arms resolvers route through it.
- AC5 — `phase_types` value types derive equality from the shared `ValueEquality` mixin (+ `repo.diplomacy_phase_types_value_equality` gate).
- AC5 (gates) — `repo.diplomacy_test_no_duplicate_fixtures` gate.

## Done in this push (Refs #3715)

Re-expressed via `TestFixtures.minimalGame` (behaviour-preserving — the inline builders were equivalent to `minimalGame` with empty-region, orders-phase, turn-1 defaults):
- `diplomacyResolverPhaseTestBaseGame()` (`diplomacy_resolver_phase_test_support.dart`)
- `threePowerCallToArmsGame(...)` (`call_to_arms_fixtures.dart`)
- `dialogueGame(...)` (`event_dialogue_test_support.dart`)

Only per-fixture players, provinces, diplomacy relations, and minor-nation/tribe rosters remain expressed locally.

## Tests / verification

- `dart test` (full `colonizethis_diplomacy` suite): **267 passing**.
- `dart analyze test/support/`: clean.
- Gates green: `check_diplomacy_test_no_duplicate_fixtures`, `check_diplomacy_test_mirrors_lib`, `check_domain_package_test_file_size`.

## Deferred / not in scope

No remaining AC gaps identified for #3715; all suggested ACs are now satisfied on `dev` plus this push. `repo.diplomacy_no_logic_deps` / `repo.diplomacy_no_part_of` untouched. No SPEC/behaviour changes.

Refs #3715

Made with [Cursor](https://cursor.com)