### PR TITLE
refactor: clean diplomacy analyze warnings from #3715 migration (#3715)

### DIFF
--- a/packages/colonizethis_diplomacy/lib/src/diplomacy/overture_resolver.dart
+++ b/packages/colonizethis_diplomacy/lib/src/diplomacy/overture_resolver.dart
@@ -1,7 +1,6 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
-import 'package:colonizethis_world/colonizethis_world.dart';
 import 'diplomacy_phase_result.dart';
 import 'diplomacy_resolver.dart';
 import 'diplomacy_shared_helpers.dart';

--- a/packages/colonizethis_diplomacy/test/diplomacy/diplomacy_call_to_arms_formal_alliance_test.dart
+++ b/packages/colonizethis_diplomacy/test/diplomacy/diplomacy_call_to_arms_formal_alliance_test.dart
@@ -1,4 +1,3 @@
-import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_test/test.dart';
 import 'package:colonizethis_diplomacy/colonizethis_diplomacy.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';

--- a/packages/colonizethis_diplomacy/test/diplomacy/diplomacy_call_to_arms_test.dart
+++ b/packages/colonizethis_diplomacy/test/diplomacy/diplomacy_call_to_arms_test.dart
@@ -1,4 +1,3 @@
-import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_test/test.dart';
 import 'package:colonizethis_diplomacy/colonizethis_diplomacy.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';

--- a/packages/colonizethis_diplomacy/test/diplomacy/diplomacy_resolver_dialogue_test.dart
+++ b/packages/colonizethis_diplomacy/test/diplomacy/diplomacy_resolver_dialogue_test.dart
@@ -1,4 +1,3 @@
-import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_test/test.dart';
 import 'package:colonizethis_world/src/game_player_lookup.dart';
 import 'package:colonizethis_diplomacy/colonizethis_diplomacy.dart';

--- a/packages/colonizethis_diplomacy/test/diplomacy/diplomacy_subsidies_insufficient_funds_test.dart
+++ b/packages/colonizethis_diplomacy/test/diplomacy/diplomacy_subsidies_insufficient_funds_test.dart
@@ -1,6 +1,4 @@
 import 'package:colonizethis_diplomacy/colonizethis_diplomacy.dart';
-import 'package:colonizethis_diplomacy/src/diplomacy/diplomacy_resolver.dart';
-import 'package:colonizethis_diplomacy/src/diplomacy/diplomacy_subsidies_relations_resolver.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart';
 import 'package:colonizethis_world/src/game_player_lookup.dart';

--- a/packages/colonizethis_diplomacy/test/diplomacy/diplomacy_subsidies_relations_resolver_index_test.dart
+++ b/packages/colonizethis_diplomacy/test/diplomacy/diplomacy_subsidies_relations_resolver_index_test.dart
@@ -1,5 +1,4 @@
 import 'package:colonizethis_diplomacy/colonizethis_diplomacy.dart';
-import 'package:colonizethis_diplomacy/src/diplomacy/diplomacy_subsidies_relations_resolver.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart';
 import 'package:colonizethis_world/src/game_player_lookup.dart';

--- a/packages/colonizethis_diplomacy/test/diplomacy/diplomacy_subsidies_relations_resolver_test.dart
+++ b/packages/colonizethis_diplomacy/test/diplomacy/diplomacy_subsidies_relations_resolver_test.dart
@@ -2,7 +2,6 @@ import 'package:colonizethis_test/test.dart';
 import 'package:colonizethis_world/src/game_player_lookup.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_diplomacy/colonizethis_diplomacy.dart';
-import 'package:colonizethis_diplomacy/src/diplomacy/diplomacy_subsidies_relations_resolver.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 void main() {


### PR DESCRIPTION
## Summary

Final cleanup slice for #3715. The earlier merged slices (#3719, #3726) delivered the bulk of the issue — local `TestFixtures` deletion, test-tree mirroring under `test/{diplomacy,dossier}/`, the `ValueEquality` mixin for `phase_types`, the shared `resolveHumanGatedDecision` template routed through all four resolvers (overture / FTP / intervention / call-to-arms), and the three `repo.diplomacy_*` CI gates. This slice closes the remaining gap against the issue's "`dart analyze` clean for the package" acceptance criterion.

## Done in this push

- Remove unused `package:colonizethis_data/...` imports from three migrated tests (`diplomacy_call_to_arms_test`, `diplomacy_call_to_arms_formal_alliance_test`, `diplomacy_resolver_dialogue_test`).
- Drop redundant deep `package:colonizethis_diplomacy/src/...` imports (now provided by the package barrel) in the subsidies resolver tests.
- Remove an unnecessary `package:colonizethis_world/...` import in `overture_resolver.dart` (symbols re-exported via `diplomacy_resolver.dart`).

No behavior change: imports only.

## Verification

- `dart analyze` → **No issues found!** (was 8 issues: 3 `unused_import` warnings + 5 `unnecessary_import` infos)
- `dart run custom_lint` → **No issues found!**
- `dart test` (colonizethis_diplomacy) → **267 passed**
- Diplomacy gates green: `repo.diplomacy_test_no_duplicate_fixtures`, `repo.diplomacy_test_mirrors_lib`, `repo.diplomacy_phase_types_value_equality`.

## AC status for #3715

All acceptance criteria are now satisfied on `dev` + this slice: local `TestFixtures` deleted, test tree mirrors `lib/src`, support helpers route through shared `TestFixtures.minimalGame`, four resolvers share the human-gated template, value-equality mixin in place, CI gates present, and `dart analyze` is clean.

Refs #3715

Made with [Cursor](https://cursor.com)