### PR TITLE
refactor: route build/declare-war suggestion tails through shared emitter (#3714)

### DIFF
--- a/packages/colonizethis_orders/lib/src/orders/order_suggestion_build.dart
+++ b/packages/colonizethis_orders/lib/src/orders/order_suggestion_build.dart
@@ -40,34 +40,38 @@ List<BuildUnitOrder> suggestBuildOrders(
     return suggestions;
   }
 
-  // Military (regiment) builds.
-  for (final entry in RegimentEconomyCatalog.byId.entries) {
-    final unitType = entry.key;
-    final candidate = BuildUnitOrder(
-      unitType: unitType,
-      isMilitary:
-          buildUnitCategoryForUnitType(unitType) == BuildUnitCategory.military,
-      spawnProvinceId: capitalId,
-    );
+  bool accept(BuildUnitOrder candidate) =>
+      isBuildOrderAcceptedWithValidator(candidateValidator, candidate);
 
-    if (isBuildOrderAcceptedWithValidator(candidateValidator, candidate)) {
-      suggestions.add(candidate);
-    }
-  }
-
-  // Naval (ship) builds. SPEC/program/order-suggestions.md.
-  for (final entry in ShipEconomyCatalog.byId.entries) {
-    final unitType = entry.key;
-    final candidate = BuildUnitOrder(
-      unitType: unitType,
-      isMilitary: false,
-      spawnProvinceId: capitalId,
-    );
-
-    if (isBuildOrderAcceptedWithValidator(candidateValidator, candidate)) {
-      suggestions.add(candidate);
-    }
-  }
+  // Military (regiment) builds, then naval (ship) builds. The shared emitter
+  // preserves catalog iteration order; the final sort yields the observable
+  // order. SPEC/program/order-suggestions.md.
+  emitAcceptedCandidates<BuildUnitOrder>(
+    candidates: [
+      for (final entry in RegimentEconomyCatalog.byId.entries)
+        BuildUnitOrder(
+          unitType: entry.key,
+          isMilitary:
+              buildUnitCategoryForUnitType(entry.key) ==
+              BuildUnitCategory.military,
+          spawnProvinceId: capitalId,
+        ),
+    ],
+    accept: accept,
+    into: suggestions,
+  );
+  emitAcceptedCandidates<BuildUnitOrder>(
+    candidates: [
+      for (final entry in ShipEconomyCatalog.byId.entries)
+        BuildUnitOrder(
+          unitType: entry.key,
+          isMilitary: false,
+          spawnProvinceId: capitalId,
+        ),
+    ],
+    accept: accept,
+    into: suggestions,
+  );
 
   suggestions.sort((a, b) => a.unitType.compareTo(b.unitType));
 

--- a/packages/colonizethis_orders/lib/src/orders/order_suggestion_diplomatic.dart
+++ b/packages/colonizethis_orders/lib/src/orders/order_suggestion_diplomatic.dart
@@ -359,20 +359,23 @@ List<DiplomaticOrder> suggestDeclareWarOrders(
           factionMembership: factionMembership,
         );
 
-  for (final targetId in sortedTargetIds) {
-    if (targetId == playerId) continue;
-    final rel = getRelation(game, playerId, targetId);
-    final atPeace = rel == null || rel.atPeace;
-    if (!atPeace) continue;
-
-    final candidate = DiplomaticOrder(
-      type: DiplomaticOrderType.declareWar,
-      targetFactionId: targetId,
-    );
-    if (isDiplomaticOrderAcceptedWithValidator(passValidator, candidate)) {
-      suggestions.add(candidate);
-    }
-  }
+  // Candidate enumeration expresses the at-peace + non-self filter; the shared
+  // emitter probes each against the fixed pass validator and collects in target
+  // order before the final sort (Refs #3714).
+  emitAcceptedCandidates<DiplomaticOrder>(
+    candidates: [
+      for (final targetId in sortedTargetIds)
+        if (targetId != playerId &&
+            (getRelation(game, playerId, targetId)?.atPeace ?? true))
+          DiplomaticOrder(
+            type: DiplomaticOrderType.declareWar,
+            targetFactionId: targetId,
+          ),
+    ],
+    accept: (candidate) =>
+        isDiplomaticOrderAcceptedWithValidator(passValidator, candidate),
+    into: suggestions,
+  );
 
   suggestions.sort((a, b) => a.targetFactionId.compareTo(b.targetFactionId));
   orderSuggestionLog.d(


### PR DESCRIPTION
## Summary

Continues the `colonizethis_orders` suggestion-boilerplate refactor (step 4 of #3714) by migrating two more suggestion families onto the shared `emitAcceptedCandidates` helper introduced for naval/recruit in #3725.

## Done in this push

- `suggestBuildOrders` (build-unit family): the two probe/collect loops (regiment + ship catalogs) now route through `emitAcceptedCandidates`, expressing only candidate enumeration + accept predicate. Catalog iteration order is preserved; the existing `unitType` sort yields the observable order.
- `suggestDeclareWarOrders` (declare-war family): the per-target probe/collect loop now routes through `emitAcceptedCandidates`, with the at-peace + non-self filter expressed as candidate enumeration against the fixed pass validator. Existing `targetFactionId` sort preserved.

This brings the number of suggestion families routed through the shared candidate-emitter to **four** (naval, recruit, build, declare-war), exceeding the issue AC's "ideally >=3 families" target.

## Behavior / determinism

- No semantics change: identical candidate sets, accept predicates, dedup behavior (none here), and final sort comparators. Preserves deterministic ordering and the 15s turn-resolution budget (`colonizethis-turn-resolution-budget.mdc`).
- Shared-validator and default-path parity remain guarded by the existing equivalence tests.

## Tests run

- `order_suggestion_shared_validator_equivalence_test.dart`, `incremental_candidate_validator_equivalence_test.dart`, `incremental_candidate_validator_equivalence_army_naval_test.dart` — pass (safety net for shared-validator parity).
- `order_suggestion_pass_context_test.dart` (emitter unit tests) — pass.
- `order_suggestion_api_impl_declare_war_test.dart`, `order_suggestion_declare_war_colonial_discovery_test.dart`, `order_suggestion_declare_war_intervention_risk_test.dart`, `order_suggestion_core_part1_work_targets_and_build_test.dart`, `order_suggestion_build_lock_recovery_affordability_guard_test.dart`, `order_suggestion_build_pending_riches_test.dart` — pass.
- `dart analyze` + `dart format` clean on both edited files.

## Deferred for #3714

- Step 3 test-support scaffolding consolidation (8 `*_test_support.dart` helpers) and removal of any local `Game`/`Player`/`Unit` builders that duplicate `TestFixtures` factories.
- Migrating remaining suggestion families (move/army-move use the separate capped-probe loop; diplomatic main pass is stateful trial-prefix accumulation and intentionally left as-is).

Refs #3714

Made with [Cursor](https://cursor.com)