### PR TITLE
test: clean colonizethis_orders analyze warnings from #3714 migration (#3714)

### DIFF
--- a/packages/colonizethis_orders/test/orders/civilian_projected_tile_test.dart
+++ b/packages/colonizethis_orders/test/orders/civilian_projected_tile_test.dart
@@ -1,4 +1,3 @@
-import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_orders/src/orders/civilian_projected_tile.dart';
 import 'package:colonizethis_orders/src/orders/order_work_constants.dart';

--- a/packages/colonizethis_orders/test/orders/diplomatic_panel_actions_test.dart
+++ b/packages/colonizethis_orders/test/orders/diplomatic_panel_actions_test.dart
@@ -2,7 +2,6 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart';
-import 'package:colonizethis_world/colonizethis_world.dart';
 
 Game _gpMinorGame() {
   const ow = 'oldWorld';

--- a/packages/colonizethis_orders/test/orders/incremental_candidate_validator_equivalence_army_naval_test.dart
+++ b/packages/colonizethis_orders/test/orders/incremental_candidate_validator_equivalence_army_naval_test.dart
@@ -1,5 +1,3 @@
-import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart';
 

--- a/packages/colonizethis_orders/test/orders/order_engine_civilian_move_xor_work_test.dart
+++ b/packages/colonizethis_orders/test/orders/order_engine_civilian_move_xor_work_test.dart
@@ -1,6 +1,5 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
-import 'package:colonizethis_orders/src/orders/bundled_civilian_work_order.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart';
 

--- a/packages/colonizethis_orders/test/orders/order_engine_validate_build_civilian_test_support.dart
+++ b/packages/colonizethis_orders/test/orders/order_engine_validate_build_civilian_test_support.dart
@@ -1,4 +1,3 @@
-import 'package:colonizethis_test/test.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';

--- a/packages/colonizethis_orders/test/orders/order_engine_validate_diplomatic_relations_test.dart
+++ b/packages/colonizethis_orders/test/orders/order_engine_validate_diplomatic_relations_test.dart
@@ -1,5 +1,4 @@
 import 'package:colonizethis_test/test.dart';
-import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 

--- a/packages/colonizethis_orders/test/orders/order_engine_validate_diplomatic_test_support.dart
+++ b/packages/colonizethis_orders/test/orders/order_engine_validate_diplomatic_test_support.dart
@@ -1,5 +1,4 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 const emptyTopology = MapTopology(nodes: [], edges: []);

--- a/packages/colonizethis_orders/test/orders/order_suggestion_api_impl_trade_test.dart
+++ b/packages/colonizethis_orders/test/orders/order_suggestion_api_impl_trade_test.dart
@@ -169,10 +169,6 @@ void main() {
         final view = buildPlayerView(game, topology, 'gp1');
         const api = DefaultOrderSuggestionAPI();
         final result = api.suggestTradeOrders(view, game);
-        final available = <CommodityId, int>{
-          for (final entry in stockpile.quantities.entries)
-            if (!richesCommodityIds.contains(entry.key)) entry.key: entry.value,
-        };
         final all = <TradeOrder>[...result.offers, ...result.bids];
         final validatorResults = TradeOrderValidator.validate(
           context: tradeOrderValidationContextFromGame(game, 'gp1'),

--- a/packages/colonizethis_orders/test/orders/order_suggestion_diplomacy_filter_test.dart
+++ b/packages/colonizethis_orders/test/orders/order_suggestion_diplomacy_filter_test.dart
@@ -1,8 +1,6 @@
 import 'package:colonizethis_test/test.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
-import 'package:colonizethis_world/colonizethis_world.dart'
-    show ProvinceOwnerCache;
 
 void main() {
   group('getProvinceOwnerMap reads ProvinceOwnerCache (slice 6)', () {

--- a/packages/colonizethis_orders/test/orders/order_suggestion_unit_availability_test.dart
+++ b/packages/colonizethis_orders/test/orders/order_suggestion_unit_availability_test.dart
@@ -1,7 +1,6 @@
 import 'package:colonizethis_test/test.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
-import 'package:colonizethis_diplomacy/src/diplomacy/diplomacy_resolver.dart';
 import 'package:colonizethis_orders/src/orders/order_suggestion_context.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 

--- a/packages/colonizethis_orders/test/orders/order_suggestion_work_tile_prefilter_purchase_land_test.dart
+++ b/packages/colonizethis_orders/test/orders/order_suggestion_work_tile_prefilter_purchase_land_test.dart
@@ -1,4 +1,3 @@
-import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/src/constants.dart';
 import 'package:colonizethis_diplomacy/src/diplomacy/diplomacy_resolver.dart';
 import 'package:colonizethis_orders/src/orders/order_suggestion_work_tile_prefilter.dart';

--- a/packages/colonizethis_orders/test/orders/orders_application_work_order_application_part2_test.dart
+++ b/packages/colonizethis_orders/test/orders/orders_application_work_order_application_part2_test.dart
@@ -1,5 +1,4 @@
 import 'package:colonizethis_test/test.dart';
-import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 

--- a/packages/colonizethis_orders/test/orders/per_player_work_target_selection_cache_test.dart
+++ b/packages/colonizethis_orders/test/orders/per_player_work_target_selection_cache_test.dart
@@ -3,7 +3,6 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_world/src/world/player_view.dart';
 import 'package:colonizethis_orders/src/orders/incremental_candidate_validator.dart';
 import 'package:colonizethis_orders/src/orders/order_resolution_context.dart';
-import 'package:colonizethis_orders/src/orders/order_suggestion_context.dart';
 import 'package:colonizethis_orders/src/orders/order_work_constants.dart';
 import 'package:colonizethis_orders/src/orders/per_player_work_target_selection_cache.dart';
 import 'package:colonizethis_test/test.dart';

--- a/packages/colonizethis_orders/test/orders/validators/work_order_cost_calculator_feedstock_bootstrap_test.dart
+++ b/packages/colonizethis_orders/test/orders/validators/work_order_cost_calculator_feedstock_bootstrap_test.dart
@@ -4,13 +4,6 @@ import 'package:colonizethis_orders/src/orders/validators/work_order_cost_calcul
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart';
 
-import 'package:colonizethis_logic/colonizethis_logic.dart'
-    show
-        cheapestRegimentBuildTreasuryCost,
-        kObserverConquestMinOwProvincesPerGp,
-        kRegionOldWorld,
-        kWorkTargetBuildImprovement;
-
 // Refs #2847: H8 feedstock bootstrap castIron waiver on level-0 build_improvement.
 
 const _supplierId = 'gp1';

--- a/packages/colonizethis_orders/test/orders/validators/work_order_target_prechecks_test.dart
+++ b/packages/colonizethis_orders/test/orders/validators/work_order_target_prechecks_test.dart
@@ -1,5 +1,4 @@
 import 'package:colonizethis_logic/colonizethis_logic.dart';
-import 'package:colonizethis_diplomacy/src/diplomacy/diplomacy_resolver.dart';
 import 'package:colonizethis_orders/src/orders/validators/work_order_target_prechecks.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart';

--- a/packages/colonizethis_orders/test/orders/work_order_duration_preview_test.dart
+++ b/packages/colonizethis_orders/test/orders/work_order_duration_preview_test.dart
@@ -1,7 +1,5 @@
-import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_orders/colonizethis_orders.dart';
-import 'package:colonizethis_orders/src/orders/order_work_constants.dart';
 import 'package:colonizethis_test/test.dart';
 import 'package:colonizethis_test/game_test_fixtures.dart';
 


### PR DESCRIPTION
## Summary

Final analyze-cleanliness slice for #3714. The earlier merged slices (#3718 fixtures dedup, #3721 test-tree mirror + layout gate, #3725 / #3728 shared candidate-emitter for naval/recruit/build/declare-war families) delivered the bulk of the issue. This slice closes the remaining gap against the issue's **"`melos run analyze`/package tests … are clean"** acceptance criterion, mirroring the equivalent diplomacy cleanup done in #3727 for #3715.

## Done in this push

`dart analyze lib test` on `packages/colonizethis_orders` reported **20 issues**, all in migrated test sources. All removed (imports / dead-code only, no behavior change):

- **11 unused imports** — `colonizethis_data` / `colonizethis_world` / `colonizethis_logic` / `colonizethis_test` / `order_suggestion_context` barrels no longer referenced after the test-tree moves.
- **5 unnecessary imports** — symbols already provided by a broader barrel already imported in the same file (`bundled_civilian_work_order`, `colonizethis_world` show, two `diplomacy_resolver` src imports, `order_work_constants`).
- **2 `undefined_shown_name` + the redundant `colonizethis_logic` `show` block** in `work_order_cost_calculator_feedstock_bootstrap_test.dart` — `cheapestRegimentBuildTreasuryCost` / `kObserverConquestMinOwProvincesPerGp` were never exported, and the still-used `kRegionOldWorld` / `kWorkTargetBuildImprovement` are provided by the already-imported `package:colonizethis_logic/ai_api.dart`, so the whole `show` import is dropped.
- **1 `unused_local_variable`** (`available`) in `order_suggestion_api_impl_trade_test.dart`.

## Verification

- `dart analyze lib test` (colonizethis_orders) → **No issues found!** (was 20)
- 14 touched test files → **76/76 pass**
- Equivalence safety net unchanged: `order_suggestion_shared_validator_equivalence_test` + `incremental_candidate_validator_equivalence_test` → **22/22 pass**
- Both #3714 CI gates green: `repo.orders_test_no_duplicate_fixtures`, `repo.orders_test_mirrors_lib` (+ their paired `test/check_*_test.dart`).

## AC status for #3714

With this slice on top of the merged work, all acceptance criteria are satisfied on `dev`:
- Local `test_fixtures.dart` deleted; importers on shared `colonizethis_test` `TestFixtures` (#3718). ✅
- `test/` mirrors `lib/src/orders/`; no flat-root test sources (#3721). ✅
- No test redefines a local `Game`/`Player`/`Unit` fixture duplicating a `TestFixtures` factory. ✅
- Naval + recruit-worker + build + diplomatic families route their probe/emit/sort/dedup tail through the shared `emitAcceptedCandidates`; the capped `move`/`army-move` families share `runCappedSuggestionProbeLoop` (probe caps unchanged per the non-goal) (#3725, #3728). ✅
- `repo.orders_test_no_duplicate_fixtures` and `repo.orders_test_mirrors_lib` rules exist with passing paired tests. ✅
- `dart analyze` clean (this slice). ✅

No order-resolution semantics, suggestion ordering, probe/acceptance caps, or 15s turn-resolution-budget changes.

Refs #3714

Made with [Cursor](https://cursor.com)