### PR TITLE
refactor(app-test): shared 320dp min-viewport harness + dedup gate

### DIFF
--- a/app/test/call_to_arms_dialogue_overlay_320dp_min_viewport_test.dart
+++ b/app/test/call_to_arms_dialogue_overlay_320dp_min_viewport_test.dart
@@ -31,7 +31,6 @@
 // overflow at 320 dp on every covered surface).
 
 import 'package:colonizethis_app/config/constants.dart';
-import 'package:colonizethis_app/config/themes.dart';
 import 'package:colonizethis_app/features/game/dialogue/call_to_arms_dialogue_overlay.dart';
 import 'package:colonizethis_app/l10n/l10n.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart' show CallToArmsPending;
@@ -39,6 +38,8 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+import 'support/min_viewport_harness.dart';
 
 /// Minimum supported viewport dimensions for SPEC/ui/mobile-adaptation.md
 /// § 7. Width matches [kMinViewportWidth]; height (640 dp) mirrors the
@@ -52,8 +53,8 @@ const Size _kWideRegressionViewport = Size(1024, 768);
 
 /// Pumps [dialog] at [size] under the running editorial-monocle theme.
 ///
-/// Mirrors `_pumpDialogAtSize` in `dialogs_320dp_min_viewport_test.dart`
-/// — sets the surface size (so the binding's render flex math sees the
+/// Delegates to the shared `pumpAtMinViewport` harness
+/// — which sets the surface size (so the binding's render flex math sees the
 /// minimum viewport) and overrides MediaQuery so dialog code that reads
 /// `MediaQuery.sizeOf(context).width` resolves to the same value.
 ///
@@ -62,25 +63,19 @@ const Size _kWideRegressionViewport = Size(1024, 768);
 /// dialog's own [CtDialogShell] layout at the narrow viewport, not the
 /// barrier / overlay route plumbing (which is already covered by the
 /// overlay's own widget tests).
-Future<void> _pumpDialogAtSize(
+Future<void> _pumpDialog(
   WidgetTester tester,
   Widget dialog, {
   required Size size,
 }) async {
-  addTearDown(() => tester.binding.setSurfaceSize(null));
-  await tester.binding.setSurfaceSize(size);
-  await tester.pumpWidget(
-    MaterialApp(
-      theme: AppThemes.editorialMonocle,
-      localizationsDelegates: AppLocalizationsBinding.localizationsDelegates,
-      supportedLocales: AppLocalizations.supportedLocales,
-      home: MediaQuery(
-        data: MediaQueryData(size: size),
-        child: Scaffold(body: Center(child: dialog)),
-      ),
-    ),
+  await pumpAtMinViewport(
+    tester,
+    size: size,
+    localizationsDelegates: AppLocalizationsBinding.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    child: Scaffold(body: Center(child: dialog)),
+    settle: true,
   );
-  await tester.pumpAndSettle();
 }
 
 void main() {
@@ -134,7 +129,7 @@ void main() {
       'kMinViewportWidth (CtFullScreenDialogueShell.maxWidth 520 is '
       'dominated by Dialog.insetPadding 16 dp each side at 320 dp)',
       (WidgetTester tester) async {
-        await _pumpDialogAtSize(
+        await _pumpDialog(
           tester,
           CallToArmsDialogueOverlay(
             game: ctaGame(),
@@ -177,7 +172,7 @@ void main() {
           aggressorGpId: 'gp_portugal',
         );
 
-        await _pumpDialogAtSize(
+        await _pumpDialog(
           tester,
           CallToArmsDialogueOverlay(
             game: ctaGame(),
@@ -203,7 +198,7 @@ void main() {
       'without exception (regression sentinel for the overflow contract — '
       'keeps the 320 dp positive pins meaningful)',
       (WidgetTester tester) async {
-        await _pumpDialogAtSize(
+        await _pumpDialog(
           tester,
           CallToArmsDialogueOverlay(
             game: ctaGame(),

--- a/app/test/choose_tech_dialog_320dp_min_viewport_test.dart
+++ b/app/test/choose_tech_dialog_320dp_min_viewport_test.dart
@@ -48,7 +48,6 @@
 // overflow at 320 dp on every covered surface).
 
 import 'package:colonizethis_app/config/constants.dart';
-import 'package:colonizethis_app/config/themes.dart';
 import 'package:colonizethis_app/features/game/widgets/technology_panel_orders.dart';
 import 'package:colonizethis_app/l10n/l10n.dart';
 import 'package:colonizethis_data/colonizethis_data.dart'
@@ -56,6 +55,8 @@ import 'package:colonizethis_data/colonizethis_data.dart'
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+import 'support/min_viewport_harness.dart';
 
 /// Minimum supported viewport dimensions for `SPEC/ui/mobile-adaptation.md`
 /// § 7. Width matches [kMinViewportWidth]; height (640 dp) mirrors the
@@ -85,8 +86,8 @@ List<TechDefinition> _longestNamedTechs() {
 
 /// Pumps [dialog] at [size] under the running editorial-monocle theme.
 ///
-/// Mirrors `_pumpDialogAtSize` in
-/// `grant_or_subsidy_dialog_320dp_min_viewport_test.dart` — sets the
+/// Delegates to the shared `pumpAtMinViewport` harness
+/// — which sets the
 /// surface size (so the binding's render flex math sees the minimum
 /// viewport) and overrides MediaQuery so dialog code that reads
 /// `MediaQuery.sizeOf(context).width` resolves to the same value.
@@ -96,25 +97,19 @@ List<TechDefinition> _longestNamedTechs() {
 /// own `CtDialogShell` layout at the narrow viewport, not the barrier /
 /// overlay route plumbing (already covered by
 /// `technology_panel_choose_tech_dialog_test.dart`).
-Future<void> _pumpDialogAtSize(
+Future<void> _pumpDialog(
   WidgetTester tester,
   Widget dialog, {
   required Size size,
 }) async {
-  addTearDown(() => tester.binding.setSurfaceSize(null));
-  await tester.binding.setSurfaceSize(size);
-  await tester.pumpWidget(
-    MaterialApp(
-      theme: AppThemes.editorialMonocle,
-      localizationsDelegates: AppLocalizationsBinding.localizationsDelegates,
-      supportedLocales: AppLocalizations.supportedLocales,
-      home: MediaQuery(
-        data: MediaQueryData(size: size),
-        child: Scaffold(body: Center(child: dialog)),
-      ),
-    ),
+  await pumpAtMinViewport(
+    tester,
+    size: size,
+    localizationsDelegates: AppLocalizationsBinding.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    child: Scaffold(body: Center(child: dialog)),
+    settle: true,
   );
-  await tester.pumpAndSettle();
 }
 
 void main() {
@@ -135,7 +130,7 @@ void main() {
         (WidgetTester tester) async {
           final techs = _longestNamedTechs();
 
-          await _pumpDialogAtSize(
+          await _pumpDialog(
             tester,
             ChooseTechDialog(
               slotIndex: 0,
@@ -179,7 +174,7 @@ void main() {
         'research" line + Close render — pins the empty-state branch '
         'fitting within the ~288 dp content width.',
         (WidgetTester tester) async {
-          await _pumpDialogAtSize(
+          await _pumpDialog(
             tester,
             ChooseTechDialog(
               slotIndex: 2,
@@ -208,7 +203,7 @@ void main() {
         (WidgetTester tester) async {
           final techs = _longestNamedTechs();
 
-          await _pumpDialogAtSize(
+          await _pumpDialog(
             tester,
             ChooseTechDialog(
               slotIndex: 0,

--- a/app/test/debug_log_viewer_320dp_min_viewport_test.dart
+++ b/app/test/debug_log_viewer_320dp_min_viewport_test.dart
@@ -64,7 +64,6 @@
 // screen).
 
 import 'package:colonizethis_app/config/constants.dart';
-import 'package:colonizethis_app/config/themes.dart';
 import 'package:colonizethis_app/features/debug_log/debug_log_viewer_screen.dart';
 import 'package:colonizethis_app/widgets/ct_back_button.dart';
 import 'package:colonizethis_app/widgets/ct_choice_chip.dart';
@@ -73,6 +72,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:logger/logger.dart';
 import 'package:session_log_buffer/session_log_buffer.dart';
+
+import 'support/min_viewport_harness.dart';
 
 /// Minimum supported viewport dimensions for `SPEC/ui/mobile-adaptation.md`
 /// § 7. Width matches [kMinViewportWidth]; height (640 dp) mirrors the
@@ -100,25 +101,19 @@ const Size _kWideRegressionViewport = Size(1024, 768);
 /// pattern already used by every other `*_320dp_min_viewport_test.dart`
 /// file. The viewer is presentational (no Riverpod providers), so no
 /// provider overrides are required.
-Future<void> _pumpDebugLogViewerAtSize(
+Future<void> _pumpDebugLogViewer(
   WidgetTester tester, {
   required Size size,
 }) async {
-  addTearDown(() => tester.binding.setSurfaceSize(null));
-  await tester.binding.setSurfaceSize(size);
-  await tester.pumpWidget(
-    MaterialApp(
-      theme: AppThemes.editorialMonocle,
-      home: MediaQuery(
-        data: MediaQueryData(size: size),
-        child: const DebugLogViewerScreen(),
-      ),
-    ),
+  // `settle: true` is safe here: the screen has no indefinite ticker and
+  // the `ListView.builder` resolves synchronously against the singleton
+  // `SessionLogBuffer`.
+  await pumpAtMinViewport(
+    tester,
+    size: size,
+    child: const DebugLogViewerScreen(),
+    settle: true,
   );
-  // `pumpAndSettle` is safe here: the screen has no indefinite ticker
-  // and the `ListView.builder` resolves synchronously against the
-  // singleton `SessionLogBuffer`.
-  await tester.pumpAndSettle();
 }
 
 void main() {
@@ -144,7 +139,7 @@ void main() {
         'default-selected `info`/`warning`/`error` level chips all '
         'render',
         (WidgetTester tester) async {
-          await _pumpDebugLogViewerAtSize(tester, size: _kMinViewport);
+          await _pumpDebugLogViewer(tester, size: _kMinViewport);
 
           expect(
             tester.takeException(),
@@ -222,7 +217,7 @@ void main() {
         'also pumps without exception (regression sentinel for the '
         'overflow contract — keeps the 320 dp positive pin meaningful)',
         (WidgetTester tester) async {
-          await _pumpDebugLogViewerAtSize(
+          await _pumpDebugLogViewer(
             tester,
             size: _kWideRegressionViewport,
           );
@@ -263,7 +258,7 @@ void main() {
             LogEvent(Level.warning, 'app: narrow-viewport pin second line'),
           );
 
-          await _pumpDebugLogViewerAtSize(tester, size: _kMinViewport);
+          await _pumpDebugLogViewer(tester, size: _kMinViewport);
 
           expect(
             tester.takeException(),
@@ -316,7 +311,7 @@ void main() {
             LogEvent(Level.warning, 'app: wide regression pin line'),
           );
 
-          await _pumpDebugLogViewerAtSize(
+          await _pumpDebugLogViewer(
             tester,
             size: _kWideRegressionViewport,
           );

--- a/app/test/dialogs_320dp_min_viewport_test.dart
+++ b/app/test/dialogs_320dp_min_viewport_test.dart
@@ -78,7 +78,6 @@
 // overflow at 320 dp on every covered surface).
 
 import 'package:colonizethis_app/config/constants.dart';
-import 'package:colonizethis_app/config/themes.dart';
 import 'package:colonizethis_app/features/game/combat/combat_mode_choice_dialog.dart';
 import 'package:colonizethis_app/features/game/combat/quick_battle_result_dialog.dart';
 import 'package:colonizethis_app/features/game/flame/exit_confirm_dialog.dart';
@@ -96,6 +95,8 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+import 'support/min_viewport_harness.dart';
 
 /// Minimum supported viewport dimensions for SPEC/ui/mobile-adaptation.md
 /// § 7. Width matches [kMinViewportWidth]; height (640 dp) mirrors the
@@ -121,34 +122,24 @@ const Size _kWideRegressionViewport = Size(1024, 768);
 /// dialog's own [CtDialogShell] layout at the narrow viewport, not the
 /// barrier / overlay route plumbing (which is already covered by
 /// `exit_confirm_dialog_test.dart`).
-Future<void> _pumpDialogAtSize(
+Future<void> _pumpDialog(
   WidgetTester tester,
   Widget dialog, {
   required Size size,
   bool settle = true,
 }) async {
-  addTearDown(() => tester.binding.setSurfaceSize(null));
-  await tester.binding.setSurfaceSize(size);
-  await tester.pumpWidget(
-    MaterialApp(
-      theme: AppThemes.editorialMonocle,
-      localizationsDelegates: AppLocalizationsBinding.localizationsDelegates,
-      supportedLocales: AppLocalizations.supportedLocales,
-      home: MediaQuery(
-        data: MediaQueryData(size: size),
-        child: Scaffold(body: Center(child: dialog)),
-      ),
-    ),
+  // `settle: false` keeps the harness on a single frame for dialogs that
+  // host an indefinite ticker (e.g. CircularProgressIndicator inside
+  // CtLoadingIndicator); the layout has resolved by the first frame,
+  // which is all the 320 dp overflow contract needs.
+  await pumpAtMinViewport(
+    tester,
+    size: size,
+    localizationsDelegates: AppLocalizationsBinding.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    child: Scaffold(body: Center(child: dialog)),
+    settle: settle,
   );
-  if (settle) {
-    await tester.pumpAndSettle();
-  } else {
-    // Single frame is enough for dialogs that host an indefinite ticker
-    // (e.g. CircularProgressIndicator inside CtLoadingIndicator). The
-    // layout has resolved by the first frame, which is all the 320 dp
-    // overflow contract needs.
-    await tester.pump();
-  }
 }
 
 void main() {
@@ -160,7 +151,7 @@ void main() {
       'AC (positive) GameParametersDialog (infiniteMode off) @ 320×640: '
       'no RenderFlex overflow exception, title + close action render',
       (WidgetTester tester) async {
-        await _pumpDialogAtSize(
+        await _pumpDialog(
           tester,
           const GameParametersDialog(infiniteMode: false),
           size: _kMinViewport,
@@ -187,7 +178,7 @@ void main() {
       'AC (positive) GameParametersDialog (infiniteMode on) @ 320×640: '
       'no exception, "Infinite mode: On" body line renders',
       (WidgetTester tester) async {
-        await _pumpDialogAtSize(
+        await _pumpDialog(
           tester,
           const GameParametersDialog(infiniteMode: true),
           size: _kMinViewport,
@@ -204,7 +195,7 @@ void main() {
         'contract — keeps the 320 dp positive pins meaningful)', (
       WidgetTester tester,
     ) async {
-      await _pumpDialogAtSize(
+      await _pumpDialog(
         tester,
         const GameParametersDialog(infiniteMode: false),
         size: _kWideRegressionViewport,
@@ -222,7 +213,7 @@ void main() {
         'overflow exception, title + body + Cancel + Exit all render', (
       WidgetTester tester,
     ) async {
-      await _pumpDialogAtSize(
+      await _pumpDialog(
         tester,
         const ExitConfirmDialog(),
         size: _kMinViewport,
@@ -250,7 +241,7 @@ void main() {
     testWidgets('Negative control: ExitConfirmDialog @ 1024×768 also pumps '
         'without exception (regression sentinel for the overflow '
         'contract)', (WidgetTester tester) async {
-      await _pumpDialogAtSize(
+      await _pumpDialog(
         tester,
         const ExitConfirmDialog(),
         size: _kWideRegressionViewport,
@@ -286,7 +277,7 @@ void main() {
     testWidgets('AC (positive) TurnNewsDialog (empty digest) @ 320×640: no '
         'RenderFlex overflow exception, "Turn 2" title + empty-state '
         'copy + Close action render', (WidgetTester tester) async {
-      await _pumpDialogAtSize(
+      await _pumpDialog(
         tester,
         TurnNewsDialog(
           game: baseGame,
@@ -320,7 +311,7 @@ void main() {
         'wraps each line within the ~288 dp content width)', (
       WidgetTester tester,
     ) async {
-      await _pumpDialogAtSize(
+      await _pumpDialog(
         tester,
         TurnNewsDialog(
           game: baseGame,
@@ -370,7 +361,7 @@ void main() {
         '1024×768 also pumps without exception (regression sentinel '
         'for the overflow contract — keeps the 320 dp positive pins '
         'meaningful)', (WidgetTester tester) async {
-      await _pumpDialogAtSize(
+      await _pumpDialog(
         tester,
         TurnNewsDialog(
           game: baseGame,
@@ -414,7 +405,7 @@ void main() {
       '(all three Expanded labels + 12 dp gap + CtToggleSwitch rows must '
       'fit within the ~288 dp content width)',
       (WidgetTester tester) async {
-        await _pumpDialogAtSize(
+        await _pumpDialog(
           tester,
           GameMapOptionsDialog(
             initialState: baseState,
@@ -447,7 +438,7 @@ void main() {
         'contract — keeps the 320 dp positive pin meaningful)', (
       WidgetTester tester,
     ) async {
-      await _pumpDialogAtSize(
+      await _pumpDialog(
         tester,
         GameMapOptionsDialog(
           initialState: baseState,
@@ -473,7 +464,7 @@ void main() {
       '(the CtLoadingIndicator + 10 dp gap + Expanded phase-text row must '
       'fit within the ~288 dp CtDialogShell content column)',
       (WidgetTester tester) async {
-        await _pumpDialogAtSize(
+        await _pumpDialog(
           tester,
           const TurnResolutionProcessingDialog(phaseText: phaseText),
           size: _kMinViewport,
@@ -500,7 +491,7 @@ void main() {
         '1024×768 also pumps without exception (regression sentinel for '
         'the overflow contract — keeps the 320 dp positive pin meaningful)',
         (WidgetTester tester) async {
-      await _pumpDialogAtSize(
+      await _pumpDialog(
         tester,
         const TurnResolutionProcessingDialog(phaseText: phaseText),
         size: _kWideRegressionViewport,
@@ -523,7 +514,7 @@ void main() {
       '(the end-aligned Auto-Resolve + 8 dp gap + Quick Battle row must fit '
       'within the ~288 dp CtDialogShell content column)',
       (WidgetTester tester) async {
-        await _pumpDialogAtSize(
+        await _pumpDialog(
           tester,
           CombatModeChoiceDialog(
             bus: AppEventBus.create(),
@@ -556,7 +547,7 @@ void main() {
         'the overflow contract — keeps the 320 dp positive pin meaningful)', (
       WidgetTester tester,
     ) async {
-      await _pumpDialogAtSize(
+      await _pumpDialog(
         tester,
         CombatModeChoiceDialog(
           bus: AppEventBus.create(),
@@ -578,7 +569,7 @@ void main() {
       '(Auto-Resolve is hidden; the single end-aligned Quick Battle button '
       'must fit within the ~288 dp CtDialogShell content column)',
       (WidgetTester tester) async {
-        await _pumpDialogAtSize(
+        await _pumpDialog(
           tester,
           CombatModeChoiceDialog(
             bus: AppEventBus.create(),
@@ -610,7 +601,7 @@ void main() {
         'overflow contract — keeps the 320 dp positive pin meaningful)', (
       WidgetTester tester,
     ) async {
-      await _pumpDialogAtSize(
+      await _pumpDialog(
         tester,
         CombatModeChoiceDialog(
           bus: AppEventBus.create(),
@@ -637,7 +628,7 @@ void main() {
       '(the end-aligned No + 8 dp gap + Yes row must fit within the '
       '~288 dp CtDialogShell content column)',
       (WidgetTester tester) async {
-        await _pumpDialogAtSize(
+        await _pumpDialog(
           tester,
           const NextTurnConfirmationDialog(currentTurn: currentTurn),
           size: _kMinViewport,
@@ -666,7 +657,7 @@ void main() {
         'contract — keeps the 320 dp positive pin meaningful)', (
       WidgetTester tester,
     ) async {
-      await _pumpDialogAtSize(
+      await _pumpDialog(
         tester,
         const NextTurnConfirmationDialog(currentTurn: currentTurn),
         size: _kWideRegressionViewport,
@@ -695,7 +686,7 @@ void main() {
       'casualty bodySmall rows + trailing OK must fit within the ~288 dp '
       'CtDialogShell content column)',
       (WidgetTester tester) async {
-        await _pumpDialogAtSize(
+        await _pumpDialog(
           tester,
           const QuickBattleResultDialog(
             result: attackerWinsFlips,
@@ -728,7 +719,7 @@ void main() {
         'contract — keeps the 320 dp positive pin meaningful)', (
       WidgetTester tester,
     ) async {
-      await _pumpDialogAtSize(
+      await _pumpDialog(
         tester,
         const QuickBattleResultDialog(
           result: attackerWinsFlips,
@@ -791,7 +782,7 @@ void main() {
       'overflow exception, "Split Army" title + "Confirm Split" action + '
       'transfer-list left/right column titles render',
       (WidgetTester tester) async {
-        await _pumpDialogAtSize(
+        await _pumpDialog(
           tester,
           SplitArmyDialog(
             army: oneLevyArmy,
@@ -833,7 +824,7 @@ void main() {
         'keeps the 320 dp positive pin meaningful)', (
       WidgetTester tester,
     ) async {
-      await _pumpDialogAtSize(
+      await _pumpDialog(
         tester,
         SplitArmyDialog(
           army: oneLevyArmy,
@@ -885,7 +876,7 @@ void main() {
       'overflow exception, "Split Fleet" title + "Confirm Split" action + '
       'New Fleet right-column title render',
       (WidgetTester tester) async {
-        await _pumpDialogAtSize(
+        await _pumpDialog(
           tester,
           SplitFleetDialog(
             originalFleet: oneCarrackAtSea,
@@ -924,7 +915,7 @@ void main() {
         'keeps the 320 dp positive pin meaningful)', (
       WidgetTester tester,
     ) async {
-      await _pumpDialogAtSize(
+      await _pumpDialog(
         tester,
         SplitFleetDialog(
           originalFleet: oneCarrackAtSea,
@@ -988,7 +979,7 @@ void main() {
       'overflow exception, dialog title + "Home Fleet" right column + '
       '"Transfer" action render',
       (WidgetTester tester) async {
-        await _pumpDialogAtSize(
+        await _pumpDialog(
           tester,
           TransferToHomeFleetDialog(
             sourceFleet: sourceFleetAtSea,
@@ -1030,7 +1021,7 @@ void main() {
         'contract — keeps the 320 dp positive pin meaningful)', (
       WidgetTester tester,
     ) async {
-      await _pumpDialogAtSize(
+      await _pumpDialog(
         tester,
         TransferToHomeFleetDialog(
           sourceFleet: sourceFleetAtSea,
@@ -1077,7 +1068,7 @@ void main() {
         final bus = AppEventBus.create();
         addTearDown(bus.dispose);
 
-        await _pumpDialogAtSize(
+        await _pumpDialog(
           tester,
           PauseMenuPanel(bus: bus),
           size: _kMinViewport,
@@ -1116,7 +1107,7 @@ void main() {
         final bus = AppEventBus.create();
         addTearDown(bus.dispose);
 
-        await _pumpDialogAtSize(
+        await _pumpDialog(
           tester,
           PauseMenuPanel(bus: bus),
           size: _kMinViewport,
@@ -1160,7 +1151,7 @@ void main() {
         final bus = AppEventBus.create();
         addTearDown(bus.dispose);
 
-        await _pumpDialogAtSize(
+        await _pumpDialog(
           tester,
           PauseMenuPanel(bus: bus),
           size: _kWideRegressionViewport,

--- a/app/test/diplomacy_detail_screen_320dp_min_viewport_test.dart
+++ b/app/test/diplomacy_detail_screen_320dp_min_viewport_test.dart
@@ -43,7 +43,6 @@
 // screen).
 
 import 'package:colonizethis_app/config/constants.dart';
-import 'package:colonizethis_app/config/themes.dart';
 import 'package:colonizethis_app/features/game/screens/diplomacy_detail_screen.dart';
 import 'package:colonizethis_app/features/game/widgets/diplomacy_panel.dart';
 import 'package:colonizethis_app/widgets/ct_back_button.dart';
@@ -52,9 +51,9 @@ import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'support/min_viewport_harness.dart';
 import 'support/widget_test_assets.dart';
 
 /// Minimum supported viewport dimensions for SPEC/ui/mobile-adaptation.md
@@ -143,40 +142,28 @@ Game _minimalDetailGame({
   );
 }
 
-/// Pumps the [DiplomacyDetailScreen] at [size] under the running
-/// editorial-monocle theme. Sets the surface size (so the binding's
-/// render-flex math sees the minimum viewport) and overrides MediaQuery
-/// so widget code that reads `MediaQuery.sizeOf(context).width` resolves
-/// to the same value — the pattern already used by every other
-/// `*_320dp_min_viewport_test.dart` file.
-Future<void> _pumpDetailScreenAtSize(
+/// Pumps the [DiplomacyDetailScreen] at [size] via the shared
+/// min-viewport harness ([pumpAtMinViewport]).
+Future<void> _pumpDetailScreen(
   WidgetTester tester, {
   required Size size,
   required Game game,
   required FactionKind kind,
   required DiplomacyRelation? relation,
 }) async {
-  addTearDown(() => tester.binding.setSurfaceSize(null));
-  await tester.binding.setSurfaceSize(size);
-  await tester.pumpWidget(
-    ProviderScope(
-      child: MaterialApp(
-        theme: AppThemes.editorialMonocle,
-        home: MediaQuery(
-          data: MediaQueryData(size: size),
-          child: DiplomacyDetailScreen(
-            game: game,
-            humanPlayerId: _kHumanPlayerId,
-            factionId: _kOtherFactionId,
-            factionDisplayName: _kOtherFactionDisplayName,
-            kind: kind,
-            relation: relation,
-          ),
-        ),
-      ),
+  await pumpAtMinViewport(
+    tester,
+    size: size,
+    child: DiplomacyDetailScreen(
+      game: game,
+      humanPlayerId: _kHumanPlayerId,
+      factionId: _kOtherFactionId,
+      factionDisplayName: _kOtherFactionDisplayName,
+      kind: kind,
+      relation: relation,
     ),
+    settle: true,
   );
-  await tester.pumpAndSettle();
 }
 
 void main() {
@@ -206,7 +193,7 @@ void main() {
             _kOtherFactionId,
           );
 
-          await _pumpDetailScreenAtSize(
+          await _pumpDetailScreen(
             tester,
             size: _kMinViewport,
             game: game,
@@ -278,7 +265,7 @@ void main() {
             _kOtherFactionId,
           );
 
-          await _pumpDetailScreenAtSize(
+          await _pumpDetailScreen(
             tester,
             size: _kMinViewport,
             game: game,
@@ -321,7 +308,7 @@ void main() {
             _kOtherFactionId,
           );
 
-          await _pumpDetailScreenAtSize(
+          await _pumpDetailScreen(
             tester,
             size: _kMinViewport,
             game: game,
@@ -380,7 +367,7 @@ void main() {
             _kOtherFactionId,
           );
 
-          await _pumpDetailScreenAtSize(
+          await _pumpDetailScreen(
             tester,
             size: _kWideRegressionViewport,
             game: game,

--- a/app/test/diplomacy_screen_320dp_min_viewport_test.dart
+++ b/app/test/diplomacy_screen_320dp_min_viewport_test.dart
@@ -45,7 +45,6 @@
 // screen).
 
 import 'package:colonizethis_app/config/constants.dart';
-import 'package:colonizethis_app/config/themes.dart';
 import 'package:colonizethis_app/features/game/flame/region_map_component.dart'
     show CtMapVisibilityMode;
 import 'package:colonizethis_app/features/game/screens/diplomacy_screen.dart';
@@ -58,9 +57,9 @@ import 'package:colonizethis_app/widgets/ct_top_bar.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'support/min_viewport_harness.dart';
 import 'support/panel_test_fixtures.dart';
 
 /// Minimum supported viewport dimensions for SPEC/ui/mobile-adaptation.md
@@ -104,42 +103,32 @@ ShellPlayerContext _globalObserveShellContext() {
   );
 }
 
-/// Pumps the [DiplomacyScreen] at [size] under the running editorial-
-/// monocle theme. Sets the surface size (so the binding's render-flex
-/// math sees the minimum viewport) and overrides MediaQuery so widget
-/// code that reads `MediaQuery.sizeOf(context).width` resolves to the
-/// same value — the pattern already used by every other
-/// `*_320dp_min_viewport_test.dart` file. Overrides `currentGameProvider`
-/// (and optionally `shellPlayerContextProvider` for the global-observe
-/// branch) so the shell renders without touching Hive / GameService.
-Future<void> _pumpDiplomacyScreenAtSize(
+/// Pumps the [DiplomacyScreen] at [size] via the shared min-viewport
+/// harness ([pumpAtMinViewport]). Overrides `currentGameProvider` (and
+/// optionally `shellPlayerContextProvider` for the global-observe branch)
+/// so the shell renders without touching Hive / GameService. Settles so
+/// the panel's hover-aware chrome finishes its first-frame layout before
+/// the overflow assertion runs.
+Future<void> _pumpDiplomacyScreen(
   WidgetTester tester, {
   required Size size,
   required Game game,
   required String humanPlayerId,
   bool globalObserve = false,
 }) async {
-  addTearDown(() => tester.binding.setSurfaceSize(null));
-  await tester.binding.setSurfaceSize(size);
-  await tester.pumpWidget(
-    ProviderScope(
-      overrides: [
-        currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
-        if (globalObserve)
-          shellPlayerContextProvider.overrideWithValue(
-            _globalObserveShellContext(),
-          ),
-      ],
-      child: MaterialApp(
-        theme: AppThemes.editorialMonocle,
-        home: MediaQuery(
-          data: MediaQueryData(size: size),
-          child: DiplomacyScreen(game: game, humanPlayerId: humanPlayerId),
+  await pumpAtMinViewport(
+    tester,
+    size: size,
+    overrides: [
+      currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
+      if (globalObserve)
+        shellPlayerContextProvider.overrideWithValue(
+          _globalObserveShellContext(),
         ),
-      ),
-    ),
+    ],
+    child: DiplomacyScreen(game: game, humanPlayerId: humanPlayerId),
+    settle: true,
   );
-  await tester.pumpAndSettle();
 }
 
 void main() {
@@ -172,7 +161,7 @@ void main() {
         'label `Map`) + DiplomacyPanel body (`Great Powers` heading) '
         'both render',
         (WidgetTester tester) async {
-          await _pumpDiplomacyScreenAtSize(
+          await _pumpDiplomacyScreen(
             tester,
             size: _kMinViewport,
             game: game,
@@ -250,7 +239,7 @@ void main() {
         'pumps without exception (regression sentinel for the overflow '
         'contract — keeps the 320 dp positive pin meaningful)',
         (WidgetTester tester) async {
-          await _pumpDiplomacyScreenAtSize(
+          await _pumpDiplomacyScreen(
             tester,
             size: _kWideRegressionViewport,
             game: game,
@@ -276,7 +265,7 @@ void main() {
         'ObserveModeNotDefinedPanel sentinel renders, DiplomacyPanel '
         'body is absent',
         (WidgetTester tester) async {
-          await _pumpDiplomacyScreenAtSize(
+          await _pumpDiplomacyScreen(
             tester,
             size: _kMinViewport,
             game: game,
@@ -332,7 +321,7 @@ void main() {
         'also pumps without exception (regression sentinel for the '
         'overflow contract under the observe variant)',
         (WidgetTester tester) async {
-          await _pumpDiplomacyScreenAtSize(
+          await _pumpDiplomacyScreen(
             tester,
             size: _kWideRegressionViewport,
             game: game,

--- a/app/test/game_initializing_320dp_min_viewport_test.dart
+++ b/app/test/game_initializing_320dp_min_viewport_test.dart
@@ -37,7 +37,6 @@
 // overflow at 320 dp on every covered surface).
 
 import 'package:colonizethis_app/config/constants.dart';
-import 'package:colonizethis_app/config/themes.dart';
 import 'package:colonizethis_app/features/shell/new_game_setup_flow.dart';
 import 'package:colonizethis_app/l10n/l10n.dart';
 import 'package:colonizethis_app/widgets/ct_dialog_shell.dart';
@@ -46,6 +45,8 @@ import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+import 'support/min_viewport_harness.dart';
 
 const Size _kMinViewport = Size(kMinViewportWidth, 640);
 
@@ -82,33 +83,24 @@ const List<String> _kProgressPhaseLabels = <String>[
 /// `false` it pumps a single layout frame instead — the progress view
 /// hosts a `CircularProgressIndicator` ticker that never settles, so
 /// `pumpAndSettle` would time out without adding overflow signal.
-Future<void> _pumpSurfaceAtSize(
+Future<void> _pumpSurface(
   WidgetTester tester,
   Widget child, {
   required Size size,
   bool settle = true,
 }) async {
-  addTearDown(() => tester.binding.setSurfaceSize(null));
-  await tester.binding.setSurfaceSize(size);
-  await tester.pumpWidget(
-    MaterialApp(
-      theme: AppThemes.editorialMonocle,
-      localizationsDelegates: AppLocalizationsBinding.localizationsDelegates,
-      supportedLocales: AppLocalizations.supportedLocales,
-      home: MediaQuery(
-        data: MediaQueryData(size: size),
-        child: Scaffold(body: Center(child: child)),
-      ),
-    ),
+  // `settle: false` keeps the harness on a single layout frame — enough
+  // to surface a `RenderFlex` overflow through
+  // `WidgetTester.takeException()` without waiting on the indeterminate
+  // spinner ticker the progress view hosts.
+  await pumpAtMinViewport(
+    tester,
+    size: size,
+    localizationsDelegates: AppLocalizationsBinding.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    child: Scaffold(body: Center(child: child)),
+    settle: settle,
   );
-  if (settle) {
-    await tester.pumpAndSettle();
-  } else {
-    // A single frame is enough for the layout pass to surface a
-    // `RenderFlex` overflow through `WidgetTester.takeException()`
-    // without waiting on the indeterminate spinner ticker.
-    await tester.pump();
-  }
 }
 
 /// Renders [NewGameErrorCard] inside the same [CtDialogShell] chrome the
@@ -142,7 +134,7 @@ void main() {
           '+ "$phaseLabel" phase label + 48 dp accent spinner all render '
           'inside the CtDialogShell content column',
           (WidgetTester tester) async {
-            await _pumpSurfaceAtSize(
+            await _pumpSurface(
               tester,
               NewGameSetupProgressView(stepIndex: stepIndex),
               size: _kMinViewport,
@@ -182,7 +174,7 @@ void main() {
         'fallback per `_stepLabel` so the dialog still renders within the '
         '~288 dp CtDialogShell content column',
         (WidgetTester tester) async {
-          await _pumpSurfaceAtSize(
+          await _pumpSurface(
             tester,
             const NewGameSetupProgressView(stepIndex: 7),
             size: _kMinViewport,
@@ -203,7 +195,7 @@ void main() {
         'also pumps without exception (regression sentinel for the overflow '
         'contract — keeps the 320 dp positive pins meaningful)',
         (WidgetTester tester) async {
-          await _pumpSurfaceAtSize(
+          await _pumpSurface(
             tester,
             const NewGameSetupProgressView(stepIndex: 0),
             size: _kWideRegressionViewport,
@@ -229,7 +221,7 @@ void main() {
         'must fit within the ~288 dp CtDialogShell content column at '
         'kMinViewportWidth (320 dp)',
         (WidgetTester tester) async {
-          await _pumpSurfaceAtSize(
+          await _pumpSurface(
             tester,
             _hostedErrorCard(),
             size: _kMinViewport,
@@ -267,7 +259,7 @@ void main() {
         'exception (regression sentinel for the overflow contract — keeps '
         'the 320 dp positive pin meaningful)',
         (WidgetTester tester) async {
-          await _pumpSurfaceAtSize(
+          await _pumpSurface(
             tester,
             _hostedErrorCard(),
             size: _kWideRegressionViewport,

--- a/app/test/game_screen_320dp_min_viewport_test.dart
+++ b/app/test/game_screen_320dp_min_viewport_test.dart
@@ -50,7 +50,6 @@
 
 import 'package:colonizethis_app/app.dart';
 import 'package:colonizethis_app/config/constants.dart';
-import 'package:colonizethis_app/config/themes.dart';
 import 'package:colonizethis_app/core/services/app_event_handler_scope.dart';
 import 'package:colonizethis_app/core/services/game_service.dart';
 import 'package:colonizethis_app/features/game/flame/game_map_corner_controls.dart';
@@ -68,11 +67,11 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_save/colonizethis_save.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
 
 import 'support/map_view_test_fixtures.dart';
+import 'support/min_viewport_harness.dart';
 import 'support/panel_test_fixtures.dart';
 
 /// Minimum supported viewport dimensions for SPEC/ui/mobile-adaptation.md
@@ -151,31 +150,20 @@ void main() {
   /// keeps recurring Flame / animation tickers running indefinitely;
   /// the SPEC § 7 contract under test is the first-frame layout, which
   /// is fully resolved after a single pump.
-  Future<void> pumpGameScreenAtSize(
+  Future<void> pumpGameScreen(
     WidgetTester tester, {
     required Size size,
   }) async {
-    addTearDown(() => tester.binding.setSurfaceSize(null));
-    await tester.binding.setSurfaceSize(size);
-    await tester.pumpWidget(
-      ProviderScope(
-        overrides: gameShellOverrides(
-          game: baseGame,
-          mapViewData: lightMapViewData,
-        ),
-        child: AppEventHandlerScope(
-          child: MaterialApp(
-            navigatorKey: appNavigatorKey,
-            theme: AppThemes.editorialMonocle,
-            home: MediaQuery(
-              data: MediaQueryData(size: size),
-              child: const GameScreen(),
-            ),
-          ),
-        ),
+    await pumpAtMinViewport(
+      tester,
+      size: size,
+      overrides: gameShellOverrides(
+        game: baseGame,
+        mapViewData: lightMapViewData,
       ),
+      navigatorKey: appNavigatorKey,
+      child: AppEventHandlerScope(child: const GameScreen()),
     );
-    await tester.pump();
   }
 
   group(
@@ -187,7 +175,7 @@ void main() {
         'left-rail chrome renders end-to-end without overflow, '
         'players bar is hidden (Req 6)',
         (WidgetTester tester) async {
-          await pumpGameScreenAtSize(tester, size: _kMinViewport);
+          await pumpGameScreen(tester, size: _kMinViewport);
 
           expect(
             tester.takeException(),
@@ -272,7 +260,7 @@ void main() {
         'render at 26 × 26 dp and corner-control buttons at 24 × 24 dp '
         '(Refs #2870 Req 8 / 9, S3)',
         (WidgetTester tester) async {
-          await pumpGameScreenAtSize(tester, size: _kMinViewport);
+          await pumpGameScreen(tester, size: _kMinViewport);
 
           expect(
             tester.takeException(),
@@ -321,7 +309,7 @@ void main() {
         'exception, left-rail chrome still renders, players bar '
         'reappears at wide widths (Req 6 wide-side contrast)',
         (WidgetTester tester) async {
-          await pumpGameScreenAtSize(
+          await pumpGameScreen(
             tester,
             size: _kWideRegressionViewport,
           );

--- a/app/test/game_side_menu_320dp_min_viewport_test.dart
+++ b/app/test/game_side_menu_320dp_min_viewport_test.dart
@@ -60,7 +60,6 @@
 // screen).
 
 import 'package:colonizethis_app/config/constants.dart';
-import 'package:colonizethis_app/config/themes.dart';
 import 'package:colonizethis_app/core/services/app_event_handler_scope.dart';
 import 'package:colonizethis_app/core/services/game_service.dart';
 import 'package:colonizethis_app/features/game/flame/game_side_menu.dart';
@@ -73,10 +72,10 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_save/colonizethis_save.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
 
+import 'support/min_viewport_harness.dart';
 import 'support/panel_test_fixtures.dart';
 
 /// Minimum supported viewport dimensions for `SPEC/ui/mobile-adaptation.md`
@@ -106,49 +105,39 @@ const Size _kWideRegressionViewport = Size(1024, 768);
 /// `game_side_menu_test.dart` so the drawer's `currentGameProvider`
 /// read inside `_openGameParameters` resolves to a real `Game` and
 /// the layout exercises the live row composition.
-Future<void> _pumpGameSideMenuAtSize(
+Future<void> _pumpGameSideMenu(
   WidgetTester tester, {
   required Size size,
   required Box<dynamic> gamesBox,
   required Game game,
 }) async {
-  addTearDown(() => tester.binding.setSurfaceSize(null));
-  await tester.binding.setSurfaceSize(size);
-  await tester.pumpWidget(
-    ProviderScope(
-      overrides: [
-        gamesBoxProvider.overrideWith((ref) => gamesBox),
-        gameServiceProvider.overrideWith(
-          (ref) => GameService(gamesBox, GameSaveAdapter()),
-        ),
-        currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
-        currentOrdersProvider.overrideWith(
-          () => CurrentOrdersNotifier(const Orders()),
-        ),
-        appEventBusProvider.overrideWith((ref) {
-          final bus = AppEventBus.create();
-          ref.onDispose(bus.dispose);
-          return bus;
-        }),
-      ],
-      child: AppEventHandlerScope(
-        child: MaterialApp(
-          theme: AppThemes.editorialMonocle,
-          home: MediaQuery(
-            data: MediaQueryData(size: size),
-            child: Scaffold(
-              body: Stack(
-                children: [
-                  GameSideMenu(sideMenuOpen: true, onClose: () {}),
-                ],
-              ),
-            ),
-          ),
+  await pumpAtMinViewport(
+    tester,
+    size: size,
+    overrides: [
+      gamesBoxProvider.overrideWith((ref) => gamesBox),
+      gameServiceProvider.overrideWith(
+        (ref) => GameService(gamesBox, GameSaveAdapter()),
+      ),
+      currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
+      currentOrdersProvider.overrideWith(
+        () => CurrentOrdersNotifier(const Orders()),
+      ),
+      appEventBusProvider.overrideWith((ref) {
+        final bus = AppEventBus.create();
+        ref.onDispose(bus.dispose);
+        return bus;
+      }),
+    ],
+    child: AppEventHandlerScope(
+      child: Scaffold(
+        body: Stack(
+          children: [GameSideMenu(sideMenuOpen: true, onClose: () {})],
         ),
       ),
     ),
+    settle: true,
   );
-  await tester.pumpAndSettle();
 }
 
 void main() {
@@ -176,7 +165,7 @@ void main() {
         'render, close (`×`) glyph renders, and the drawer mounts '
         'exactly one `CtPanel` frame',
         (WidgetTester tester) async {
-          await _pumpGameSideMenuAtSize(
+          await _pumpGameSideMenu(
             tester,
             size: _kMinViewport,
             gamesBox: gamesBox,
@@ -255,7 +244,7 @@ void main() {
         'exception (regression sentinel for the overflow contract — '
         'keeps the 320 dp positive pin meaningful)',
         (WidgetTester tester) async {
-          await _pumpGameSideMenuAtSize(
+          await _pumpGameSideMenu(
             tester,
             size: _kWideRegressionViewport,
             gamesBox: gamesBox,

--- a/app/test/game_start_intro_overlay_320dp_min_viewport_test.dart
+++ b/app/test/game_start_intro_overlay_320dp_min_viewport_test.dart
@@ -54,13 +54,14 @@
 // overflow at 320 dp on every covered surface).
 
 import 'package:colonizethis_app/config/constants.dart';
-import 'package:colonizethis_app/config/themes.dart';
 import 'package:colonizethis_app/features/game/dialogue/game_start_intro_overlay.dart';
 import 'package:colonizethis_app/l10n/l10n.dart';
 import 'package:colonizethis_app/widgets/ct_brass_divider.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+import 'support/min_viewport_harness.dart';
 
 /// Minimum supported viewport dimensions for `SPEC/ui/mobile-adaptation.md`
 /// § 7. Width matches [kMinViewportWidth]; height (640 dp) mirrors the
@@ -100,8 +101,8 @@ class _FailingAssetBundle extends Fake implements AssetBundle {
 
 /// Pumps [overlay] at [size] under the running editorial-monocle theme.
 ///
-/// Mirrors `_pumpOverlayAtSize` in
-/// `intervention_dialogue_overlay_320dp_min_viewport_test.dart` — sets
+/// Delegates to the shared `pumpAtMinViewport` harness
+/// — which sets
 /// the surface size (so the binding's render flex math sees the
 /// minimum viewport) and overrides MediaQuery so widget code that
 /// reads `MediaQuery.sizeOf(context).width` resolves to the same
@@ -112,29 +113,22 @@ class _FailingAssetBundle extends Fake implements AssetBundle {
 /// overlay's own `CtFullScreenDialogueShell` + `CtDialogShell` layout
 /// at the narrow viewport, not the barrier / overlay route plumbing
 /// (which is already covered by `dialogue_acceptance_test.dart`).
-Future<void> _pumpOverlayAtSize(
+Future<void> _pumpOverlay(
   WidgetTester tester,
   Widget overlay, {
   required Size size,
 }) async {
-  addTearDown(() => tester.binding.setSurfaceSize(null));
-  await tester.binding.setSurfaceSize(size);
-  await tester.pumpWidget(
-    MaterialApp(
-      theme: AppThemes.editorialMonocle,
-      localizationsDelegates: AppLocalizationsBinding.localizationsDelegates,
-      supportedLocales: AppLocalizations.supportedLocales,
-      home: MediaQuery(
-        data: MediaQueryData(size: size),
-        child: Scaffold(body: Center(child: overlay)),
-      ),
-    ),
+  await pumpAtMinViewport(
+    tester,
+    size: size,
+    localizationsDelegates: AppLocalizationsBinding.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    child: Scaffold(body: Center(child: overlay)),
   );
-  // Two pumps mirror the existing intervention degraded-path tests:
-  // one for the failed `loadString` future, one for the post-microtask
-  // `setState(_loadError = ...)` rebuild that mounts the degraded
-  // panel.
-  await tester.pump();
+  // The harness pumps the first frame (for the failed `loadString`
+  // future); a second timed pump drives the post-microtask
+  // `setState(_loadError = ...)` rebuild that mounts the degraded panel
+  // (mirrors the existing intervention degraded-path tests).
   await tester.pump(const Duration(milliseconds: 200));
 }
 
@@ -172,7 +166,7 @@ void main() {
         'title + brass-divider header), this positive pin proves the '
         'chrome contract for every state.',
         (WidgetTester tester) async {
-          await _pumpOverlayAtSize(
+          await _pumpOverlay(
             tester,
             buildOverlay(),
             size: _kMinViewport,
@@ -211,7 +205,7 @@ void main() {
         'for the overflow contract — keeps the 320 dp positive pin '
         'meaningful).',
         (WidgetTester tester) async {
-          await _pumpOverlayAtSize(
+          await _pumpOverlay(
             tester,
             buildOverlay(),
             size: _kWideRegressionViewport,

--- a/app/test/grant_or_subsidy_dialog_320dp_min_viewport_test.dart
+++ b/app/test/grant_or_subsidy_dialog_320dp_min_viewport_test.dart
@@ -56,7 +56,6 @@
 // overflow at 320 dp on every covered surface).
 
 import 'package:colonizethis_app/config/constants.dart';
-import 'package:colonizethis_app/config/themes.dart';
 import 'package:colonizethis_app/features/game/widgets/diplomacy_dialogs.dart';
 import 'package:colonizethis_app/l10n/l10n.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart'
@@ -65,6 +64,8 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+import 'support/min_viewport_harness.dart';
 
 /// Minimum supported viewport dimensions for `SPEC/ui/mobile-adaptation.md`
 /// § 7. Width matches [kMinViewportWidth]; height (640 dp) mirrors the
@@ -108,8 +109,8 @@ Game _buildGame({required int humanTreasury}) {
 
 /// Pumps [dialog] at [size] under the running editorial-monocle theme.
 ///
-/// Mirrors `_pumpDialogAtSize` in
-/// `dialogs_320dp_min_viewport_test.dart` — sets the surface size (so
+/// Delegates to the shared `pumpAtMinViewport` harness
+/// — which sets the surface size (so
 /// the binding's render flex math sees the minimum viewport) and
 /// overrides MediaQuery so dialog code that reads
 /// `MediaQuery.sizeOf(context).width` resolves to the same value.
@@ -119,25 +120,19 @@ Game _buildGame({required int humanTreasury}) {
 /// dialog's own `CtDialogShell` layout at the narrow viewport, not the
 /// barrier / overlay route plumbing (which is already covered by
 /// `diplomacy_dialogs_test.dart`).
-Future<void> _pumpDialogAtSize(
+Future<void> _pumpDialog(
   WidgetTester tester,
   Widget dialog, {
   required Size size,
 }) async {
-  addTearDown(() => tester.binding.setSurfaceSize(null));
-  await tester.binding.setSurfaceSize(size);
-  await tester.pumpWidget(
-    MaterialApp(
-      theme: AppThemes.editorialMonocle,
-      localizationsDelegates: AppLocalizationsBinding.localizationsDelegates,
-      supportedLocales: AppLocalizations.supportedLocales,
-      home: MediaQuery(
-        data: MediaQueryData(size: size),
-        child: Scaffold(body: Center(child: dialog)),
-      ),
-    ),
+  await pumpAtMinViewport(
+    tester,
+    size: size,
+    localizationsDelegates: AppLocalizationsBinding.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    child: Scaffold(body: Center(child: dialog)),
+    settle: true,
   );
-  await tester.pumpAndSettle();
 }
 
 void main() {
@@ -164,7 +159,7 @@ void main() {
           final game = _buildGame(humanTreasury: 5 * grantAidAmountStep);
           final bus = AppEventBus.create();
 
-          await _pumpDialogAtSize(
+          await _pumpDialog(
             tester,
             GrantOrSubsidyDialog(
               game: game,
@@ -236,7 +231,7 @@ void main() {
           final game = _buildGame(humanTreasury: 5 * grantAidAmountStep);
           final bus = AppEventBus.create();
 
-          await _pumpDialogAtSize(
+          await _pumpDialog(
             tester,
             GrantOrSubsidyDialog(
               game: game,
@@ -276,7 +271,7 @@ void main() {
           final game = _buildGame(humanTreasury: grantAidAmountStep - 1);
           final bus = AppEventBus.create();
 
-          await _pumpDialogAtSize(
+          await _pumpDialog(
             tester,
             GrantOrSubsidyDialog(
               game: game,
@@ -315,7 +310,7 @@ void main() {
           final game = _buildGame(humanTreasury: 5 * grantAidAmountStep);
           final bus = AppEventBus.create();
 
-          await _pumpDialogAtSize(
+          await _pumpDialog(
             tester,
             GrantOrSubsidyDialog(
               game: game,

--- a/app/test/intervention_dialogue_overlay_320dp_min_viewport_test.dart
+++ b/app/test/intervention_dialogue_overlay_320dp_min_viewport_test.dart
@@ -58,7 +58,6 @@
 // overflow at 320 dp on every covered surface).
 
 import 'package:colonizethis_app/config/constants.dart';
-import 'package:colonizethis_app/config/themes.dart';
 import 'package:colonizethis_app/features/game/dialogue/intervention_dialogue_overlay.dart';
 import 'package:colonizethis_app/l10n/l10n.dart';
 import 'package:colonizethis_app/widgets/ct_brass_divider.dart';
@@ -68,6 +67,8 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+import 'support/min_viewport_harness.dart';
 
 /// Minimum supported viewport dimensions for `SPEC/ui/mobile-adaptation.md`
 /// § 7. Width matches [kMinViewportWidth]; height (640 dp) mirrors the
@@ -128,8 +129,8 @@ const List<InterventionPrompt> _kFixturePrompts = [
 
 /// Pumps [overlay] at [size] under the running editorial-monocle theme.
 ///
-/// Mirrors `_pumpDialogAtSize` in
-/// `overture_dialogue_overlay_320dp_min_viewport_test.dart` — sets
+/// Delegates to the shared `pumpAtMinViewport` harness
+/// — which sets
 /// the surface size (so the binding's render flex math sees the
 /// minimum viewport) and overrides MediaQuery so widget code that
 /// reads `MediaQuery.sizeOf(context).width` resolves to the same
@@ -140,29 +141,22 @@ const List<InterventionPrompt> _kFixturePrompts = [
 /// overlay's own `CtFullScreenDialogueShell` + `CtDialogShell` layout
 /// at the narrow viewport, not the barrier / overlay route plumbing
 /// (which is already covered by the overlay's own widget tests).
-Future<void> _pumpOverlayAtSize(
+Future<void> _pumpOverlay(
   WidgetTester tester,
   Widget overlay, {
   required Size size,
 }) async {
-  addTearDown(() => tester.binding.setSurfaceSize(null));
-  await tester.binding.setSurfaceSize(size);
-  await tester.pumpWidget(
-    MaterialApp(
-      theme: AppThemes.editorialMonocle,
-      localizationsDelegates: AppLocalizationsBinding.localizationsDelegates,
-      supportedLocales: AppLocalizations.supportedLocales,
-      home: MediaQuery(
-        data: MediaQueryData(size: size),
-        child: Scaffold(body: Center(child: overlay)),
-      ),
-    ),
+  await pumpAtMinViewport(
+    tester,
+    size: size,
+    localizationsDelegates: AppLocalizationsBinding.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    child: Scaffold(body: Center(child: overlay)),
   );
-  // Two pumps mirror the existing intervention degraded-path tests:
-  // one for the failed `loadString` future, one for the
-  // post-microtask `setState(_loadError = ...)` rebuild that mounts
-  // the degraded panel.
-  await tester.pump();
+  // The harness pumps the first frame (for the failed `loadString`
+  // future); a second timed pump drives the post-microtask
+  // `setState(_loadError = ...)` rebuild that mounts the degraded panel
+  // (mirrors the existing intervention degraded-path tests).
   await tester.pump(const Duration(milliseconds: 100));
 }
 
@@ -212,7 +206,7 @@ void main() {
         'routes through the same `_buildScrimmedShell` helper), this '
         'positive pin proves the chrome contract for every phase.',
         (WidgetTester tester) async {
-          await _pumpOverlayAtSize(
+          await _pumpOverlay(
             tester,
             buildOverlay(),
             size: _kMinViewport,
@@ -262,7 +256,7 @@ void main() {
         'for the overflow contract — keeps the 320 dp positive pin '
         'meaningful).',
         (WidgetTester tester) async {
-          await _pumpOverlayAtSize(
+          await _pumpOverlay(
             tester,
             buildOverlay(),
             size: _kWideRegressionViewport,

--- a/app/test/mobile_320dp_min_viewport_test.dart
+++ b/app/test/mobile_320dp_min_viewport_test.dart
@@ -32,11 +32,12 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:colonizethis_app/config/app_display_strings.dart';
 import 'package:colonizethis_app/config/constants.dart';
-import 'package:colonizethis_app/config/themes.dart';
 import 'package:colonizethis_app/features/shell/new_game_leader_selection_dialog.dart';
 import 'package:colonizethis_app/l10n/l10n.dart';
 import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
 import 'package:colonizethis_app/widgets/main_menu.dart';
+
+import 'support/min_viewport_harness.dart';
 
 /// Minimum supported viewport dimensions for SPEC/ui/mobile-adaptation.md
 /// § 7. Width matches [kMinViewportWidth]; height (640 dp) is the lower end
@@ -54,17 +55,14 @@ Widget _wrapMainMenu({
   MainMenuVariant variant = MainMenuVariant.plain,
   MainMenuState state = MainMenuState.default_,
 }) {
-  return MaterialApp(
-    theme: AppThemes.editorialMonocle,
-    home: CtMainMenu(
-      variant: variant,
-      state: state,
-      version: formatDebugAwareVersion('v1.0.0'),
-      onNewGame: () {},
-      onLoadGame: () {},
-      onSettings: () {},
-      onQuit: () {},
-    ),
+  return CtMainMenu(
+    variant: variant,
+    state: state,
+    version: formatDebugAwareVersion('v1.0.0'),
+    onNewGame: () {},
+    onLoadGame: () {},
+    onSettings: () {},
+    onQuit: () {},
   );
 }
 
@@ -81,26 +79,22 @@ Widget _wrapMainMenu({
 /// number of frames instead so screens with **continuous** animations can
 /// still be exercised against the layout overflow contract without the
 /// framework's settle-loop timing out.
-Future<void> _pumpAtSize(
+Future<void> _pumpNarrow(
   WidgetTester tester,
   Widget screen, {
   required Size size,
   bool settleAnimations = true,
 }) async {
-  addTearDown(() => tester.binding.setSurfaceSize(null));
-  await tester.binding.setSurfaceSize(size);
-  await tester.pumpWidget(
-    MediaQuery(data: MediaQueryData(size: size), child: screen),
-  );
   if (settleAnimations) {
-    await tester.pumpAndSettle();
-  } else {
-    // Two extra frames are enough for the layout pass and any one-frame
-    // post-build microtasks to surface a `RenderFlex` overflow exception
-    // through `WidgetTester.takeException()`.
-    await tester.pump();
-    await tester.pump();
+    await pumpAtMinViewport(tester, size: size, child: screen, settle: true);
+    return;
   }
+  // Two frames are enough for the layout pass and any one-frame
+  // post-build microtasks to surface a `RenderFlex` overflow exception
+  // through `WidgetTester.takeException()`: the harness pumps the first,
+  // and a second framed pump follows.
+  await pumpAtMinViewport(tester, size: size, child: screen);
+  await tester.pump();
 }
 
 /// Returns the rendered height (logical pixels) of every visible
@@ -128,7 +122,7 @@ void main() {
         'AC1 (positive) CtMainMenu plain @ 320×640: no exception, '
         'CtNinePatchButton heights ≥ kMinTouchTargetSize',
         (WidgetTester tester) async {
-          await _pumpAtSize(
+          await _pumpNarrow(
             tester,
             _wrapMainMenu(),
             size: _kMinViewport,
@@ -159,7 +153,7 @@ void main() {
         'AC1 (positive) CtMainMenu pixelArt @ 320×640: no exception, '
         'CtNinePatchButton heights ≥ kMinTouchTargetSize',
         (WidgetTester tester) async {
-          await _pumpAtSize(
+          await _pumpNarrow(
             tester,
             _wrapMainMenu(variant: MainMenuVariant.pixelArt),
             size: _kMinViewport,
@@ -177,7 +171,7 @@ void main() {
       testWidgets(
         'AC1 (positive) CtMainMenu noSaves @ 320×640: no exception',
         (WidgetTester tester) async {
-          await _pumpAtSize(
+          await _pumpNarrow(
             tester,
             _wrapMainMenu(state: MainMenuState.noSaves),
             size: _kMinViewport,
@@ -200,7 +194,7 @@ void main() {
         'AC1 (positive) CtMainMenu plain @ 320×640: menu body padding is the '
         'compact kMainMenuBodyPaddingNarrow (≤ 430 dp narrow contract)',
         (WidgetTester tester) async {
-          await _pumpAtSize(
+          await _pumpNarrow(
             tester,
             _wrapMainMenu(),
             size: _kMinViewport,
@@ -232,7 +226,7 @@ void main() {
         'AC1 (positive) CtMainMenu pixelArt @ 320×640: compact padding plus '
         'narrow button letter-spacing (≤ 430 dp narrow contract)',
         (WidgetTester tester) async {
-          await _pumpAtSize(
+          await _pumpNarrow(
             tester,
             _wrapMainMenu(variant: MainMenuVariant.pixelArt),
             size: _kMinViewport,
@@ -275,7 +269,7 @@ void main() {
         'Negative control: CtMainMenu plain @ 1024×768 also pumps without '
         'exception (regression sentinel for the overflow contract)',
         (WidgetTester tester) async {
-          await _pumpAtSize(
+          await _pumpNarrow(
             tester,
             _wrapMainMenu(),
             size: _kWideRegressionViewport,
@@ -329,37 +323,30 @@ void main() {
       // contract under test is the dialog's own [CtDialogShell] layout
       // at the narrow viewport, not the showDialog route plumbing
       // (already covered by `new_game_leader_selection_dialog_test.dart`).
-      Future<void> pumpDialogAtSize(
+      Future<void> pumpDialog(
         WidgetTester tester, {
         required Size size,
       }) async {
-        addTearDown(() => tester.binding.setSurfaceSize(null));
-        await tester.binding.setSurfaceSize(size);
-        await tester.pumpWidget(
-          MaterialApp(
-            theme: AppThemes.editorialMonocle,
-            localizationsDelegates:
-                AppLocalizationsBinding.localizationsDelegates,
-            supportedLocales: AppLocalizations.supportedLocales,
-            locale: const Locale('en'),
-            home: MediaQuery(
-              data: MediaQueryData(size: size),
-              child: Scaffold(
-                body: Center(
-                  child: NewGameLeaderSelectionDialog(
-                    baseConfig: GameSetupConfig.defaultConfig,
-                    naming: defaultNamingConfig,
-                    initialLeaderByGpId: defaultInitialLeaderByGpId(),
-                    blessedProfileNames: const [],
-                    onCancel: () {},
-                    onConfirmed: (_, _, _, _, _, __) {},
-                  ),
-                ),
+        await pumpAtMinViewport(
+          tester,
+          size: size,
+          localizationsDelegates: AppLocalizationsBinding.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          locale: const Locale('en'),
+          child: Scaffold(
+            body: Center(
+              child: NewGameLeaderSelectionDialog(
+                baseConfig: GameSetupConfig.defaultConfig,
+                naming: defaultNamingConfig,
+                initialLeaderByGpId: defaultInitialLeaderByGpId(),
+                blessedProfileNames: const [],
+                onCancel: () {},
+                onConfirmed: (_, _, _, _, _, _) {},
               ),
             ),
           ),
+          settle: true,
         );
-        await tester.pumpAndSettle();
       }
 
       testWidgets(
@@ -367,7 +354,7 @@ void main() {
         'RenderFlex overflow exception, six stacked slot bodies render, '
         'side-by-side row body is not mounted',
         (WidgetTester tester) async {
-          await pumpDialogAtSize(tester, size: _kMinViewport);
+          await pumpDialog(tester, size: _kMinViewport);
 
           expect(
             tester.takeException(),
@@ -407,7 +394,7 @@ void main() {
         'six slot labels + Cancel + Start labels render within the '
         '~288 dp content column',
         (WidgetTester tester) async {
-          await pumpDialogAtSize(tester, size: _kMinViewport);
+          await pumpDialog(tester, size: _kMinViewport);
 
           expect(tester.takeException(), isNull);
           expect(find.text('Choose nations and leaders'), findsOneWidget);
@@ -445,7 +432,7 @@ void main() {
         'rendered Cancel/Start `CtNinePatchButton` height ≥ '
         'kMinTouchTargetSize (SPEC/ui/mobile-adaptation.md § 1)',
         (WidgetTester tester) async {
-          await pumpDialogAtSize(tester, size: _kMinViewport);
+          await pumpDialog(tester, size: _kMinViewport);
 
           expect(tester.takeException(), isNull);
           final List<double> heights = _renderedNinePatchButtonHeights(
@@ -482,7 +469,7 @@ void main() {
         '(regression sentinel for the narrow-stacking branch — keeps '
         'the 320 dp positive pins meaningful)',
         (WidgetTester tester) async {
-          await pumpDialogAtSize(
+          await pumpDialog(
             tester,
             size: _kWideRegressionViewport,
           );

--- a/app/test/move_dialogs_320dp_min_viewport_test.dart
+++ b/app/test/move_dialogs_320dp_min_viewport_test.dart
@@ -39,7 +39,6 @@
 // overflow at 320 dp on every covered surface).
 
 import 'package:colonizethis_app/config/constants.dart';
-import 'package:colonizethis_app/config/themes.dart';
 import 'package:colonizethis_app/features/game/widgets/move_army_dialog.dart';
 import 'package:colonizethis_app/features/game/widgets/move_fleet_dialog.dart';
 import 'package:colonizethis_app/l10n/l10n.dart';
@@ -48,6 +47,8 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+import 'support/min_viewport_harness.dart';
 
 /// Minimum supported viewport dimensions for `SPEC/ui/mobile-adaptation.md`
 /// § 7. Width matches [kMinViewportWidth]; height (640 dp) mirrors the
@@ -82,25 +83,19 @@ const String _capitalProvince = 'oldWorld|p_320_capital';
 /// dialog's own [CtDialogShell] layout at the narrow viewport, not the
 /// barrier / overlay route plumbing (which is already covered by
 /// `move_dialogs_specs_test.dart`).
-Future<void> _pumpDialogAtSize(
+Future<void> _pumpDialog(
   WidgetTester tester,
   Widget dialog, {
   required Size size,
 }) async {
-  addTearDown(() => tester.binding.setSurfaceSize(null));
-  await tester.binding.setSurfaceSize(size);
-  await tester.pumpWidget(
-    MaterialApp(
-      theme: AppThemes.editorialMonocle,
-      localizationsDelegates: AppLocalizationsBinding.localizationsDelegates,
-      supportedLocales: AppLocalizations.supportedLocales,
-      home: MediaQuery(
-        data: MediaQueryData(size: size),
-        child: Scaffold(body: Center(child: dialog)),
-      ),
-    ),
+  await pumpAtMinViewport(
+    tester,
+    size: size,
+    localizationsDelegates: AppLocalizationsBinding.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    child: Scaffold(body: Center(child: dialog)),
+    settle: true,
   );
-  await tester.pumpAndSettle();
 }
 
 MapTopology _buildArmyTopology() {
@@ -315,7 +310,7 @@ void main() {
         'AC (positive) MoveArmyDialog @ 320×640: no RenderFlex overflow '
         'exception, title + YOUR PROVINCES + Cancel + Confirm all render',
         (WidgetTester tester) async {
-          await _pumpDialogAtSize(
+          await _pumpDialog(
             tester,
             _buildMoveArmyDialog(),
             size: _kMinViewport,
@@ -347,7 +342,7 @@ void main() {
         'exception (regression sentinel for the overflow contract — '
         'keeps the 320 dp positive pin meaningful)',
         (WidgetTester tester) async {
-          await _pumpDialogAtSize(
+          await _pumpDialog(
             tester,
             _buildMoveArmyDialog(),
             size: _kWideRegressionViewport,
@@ -371,7 +366,7 @@ void main() {
         'AC (positive) MoveFleetDialog @ 320×640: no RenderFlex overflow '
         'exception, title + SEA ZONES + Cancel + Confirm all render',
         (WidgetTester tester) async {
-          await _pumpDialogAtSize(
+          await _pumpDialog(
             tester,
             _buildMoveFleetDialog(),
             size: _kMinViewport,
@@ -404,7 +399,7 @@ void main() {
         'exception (regression sentinel for the overflow contract — '
         'keeps the 320 dp positive pin meaningful)',
         (WidgetTester tester) async {
-          await _pumpDialogAtSize(
+          await _pumpDialog(
             tester,
             _buildMoveFleetDialog(),
             size: _kWideRegressionViewport,

--- a/app/test/overture_dialogue_overlay_320dp_min_viewport_test.dart
+++ b/app/test/overture_dialogue_overlay_320dp_min_viewport_test.dart
@@ -39,7 +39,6 @@
 // overflow at 320 dp on every covered surface).
 
 import 'package:colonizethis_app/config/constants.dart';
-import 'package:colonizethis_app/config/themes.dart';
 import 'package:colonizethis_app/features/game/dialogue/overture_dialogue_overlay.dart';
 import 'package:colonizethis_app/l10n/l10n.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart' show OvertureOffer;
@@ -47,6 +46,8 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+import 'support/min_viewport_harness.dart';
 
 /// Minimum supported viewport dimensions for SPEC/ui/mobile-adaptation.md
 /// § 7. Width matches [kMinViewportWidth]; height (640 dp) mirrors the
@@ -60,8 +61,8 @@ const Size _kWideRegressionViewport = Size(1024, 768);
 
 /// Pumps [dialog] at [size] under the running editorial-monocle theme.
 ///
-/// Mirrors `_pumpDialogAtSize` in
-/// `call_to_arms_dialogue_overlay_320dp_min_viewport_test.dart` — sets
+/// Delegates to the shared `pumpAtMinViewport` harness
+/// — which sets
 /// the surface size (so the binding's render flex math sees the minimum
 /// viewport) and overrides MediaQuery so dialog code that reads
 /// `MediaQuery.sizeOf(context).width` resolves to the same value.
@@ -71,25 +72,19 @@ const Size _kWideRegressionViewport = Size(1024, 768);
 /// overlay's own [CtDialogShell] layout at the narrow viewport, not the
 /// barrier / overlay route plumbing (which is already covered by the
 /// overlay's own widget tests).
-Future<void> _pumpDialogAtSize(
+Future<void> _pumpDialog(
   WidgetTester tester,
   Widget dialog, {
   required Size size,
 }) async {
-  addTearDown(() => tester.binding.setSurfaceSize(null));
-  await tester.binding.setSurfaceSize(size);
-  await tester.pumpWidget(
-    MaterialApp(
-      theme: AppThemes.editorialMonocle,
-      localizationsDelegates: AppLocalizationsBinding.localizationsDelegates,
-      supportedLocales: AppLocalizations.supportedLocales,
-      home: MediaQuery(
-        data: MediaQueryData(size: size),
-        child: Scaffold(body: Center(child: dialog)),
-      ),
-    ),
+  await pumpAtMinViewport(
+    tester,
+    size: size,
+    localizationsDelegates: AppLocalizationsBinding.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    child: Scaffold(body: Center(child: dialog)),
+    settle: true,
   );
-  await tester.pumpAndSettle();
 }
 
 void main() {
@@ -154,7 +149,7 @@ void main() {
       'onto a second Wrap run rather than overflowing horizontally per '
       '#2867 R22).',
       (WidgetTester tester) async {
-        await _pumpDialogAtSize(
+        await _pumpDialog(
           tester,
           OvertureDialogueOverlay(
             game: overtureGame(),
@@ -193,7 +188,7 @@ void main() {
       'each per-offer Column(Row + Wrap) body at the narrow viewport '
       'without horizontal overflow).',
       (WidgetTester tester) async {
-        await _pumpDialogAtSize(
+        await _pumpDialog(
           tester,
           OvertureDialogueOverlay(
             game: overtureGame(),
@@ -221,7 +216,7 @@ void main() {
       'without exception (regression sentinel for the overflow contract '
       '— keeps the 320 dp positive pins meaningful).',
       (WidgetTester tester) async {
-        await _pumpDialogAtSize(
+        await _pumpDialog(
           tester,
           OvertureDialogueOverlay(
             game: overtureGame(),

--- a/app/test/panels_320dp_min_viewport_test.dart
+++ b/app/test/panels_320dp_min_viewport_test.dart
@@ -32,7 +32,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:colonizethis_app/config/constants.dart';
-import 'package:colonizethis_app/config/themes.dart';
 import 'package:colonizethis_app/features/game/widgets/diplomacy_panel.dart';
 import 'package:colonizethis_app/features/game/widgets/production_panel.dart';
 import 'package:colonizethis_app/features/game/widgets/province_overlay_demo_data.dart'
@@ -46,6 +45,7 @@ import 'package:colonizethis_app/features/game/widgets/province_sea_zone_detail_
 import 'package:colonizethis_app/features/game/widgets/technology_panel.dart';
 
 import 'production_panel_test_fixtures.dart';
+import 'support/min_viewport_harness.dart';
 import 'support/panel_test_fixtures.dart';
 import 'support/widget_test_assets.dart';
 
@@ -67,33 +67,27 @@ const Size _kWideRegressionViewport = Size(1024, 768);
 /// `MediaQuery.sizeOf(context).width` resolves to the same value — the
 /// pattern used by `mobile_320dp_min_viewport_test.dart` and
 /// `victory_overlay_narrow_test.dart`.
-Future<void> _pumpAtSize(
+Future<void> _pumpNarrow(
   WidgetTester tester,
   Widget child, {
   required Size size,
   bool settle = true,
 }) async {
-  addTearDown(() => tester.binding.setSurfaceSize(null));
-  await tester.binding.setSurfaceSize(size);
-  await tester.pumpWidget(
-    MaterialApp(
-      theme: AppThemes.editorialMonocle,
-      home: MediaQuery(
-        data: MediaQueryData(size: size),
-        child: Scaffold(body: child),
-      ),
-    ),
-  );
   if (settle) {
-    await tester.pumpAndSettle();
-  } else {
-    // DiplomacyPanel's hover-aware row chrome animates the border color via
-    // `AnimatedContainer`; `pumpAndSettle` would block on that animation.
-    // Two short pumps are enough to lay out the body without entering the
-    // animation steady-state loop.
-    await tester.pump();
-    await tester.pump(const Duration(milliseconds: 16));
+    await pumpAtMinViewport(
+      tester,
+      size: size,
+      child: Scaffold(body: child),
+      settle: true,
+    );
+    return;
   }
+  // DiplomacyPanel's hover-aware row chrome animates the border color via
+  // `AnimatedContainer`; `pumpAndSettle` would block on that animation.
+  // The harness pumps one frame; a second short timed pump lays out the
+  // body without entering the animation steady-state loop.
+  await pumpAtMinViewport(tester, size: size, child: Scaffold(body: child));
+  await tester.pump(const Duration(milliseconds: 16));
 }
 
 Widget _buildProductionPanel(Player player) {
@@ -155,7 +149,7 @@ void main() {
         'RenderFlex overflow exception, Available + Allocation labels both '
         'render',
         (WidgetTester tester) async {
-          await _pumpAtSize(
+          await _pumpNarrow(
             tester,
             _buildProductionPanel(fullPlayer),
             size: _kMinViewport,
@@ -183,7 +177,7 @@ void main() {
         'exception (regression guard for the partial-stockpile path the '
         'existing production_panel_test exercises at wider widths)',
         (WidgetTester tester) async {
-          await _pumpAtSize(
+          await _pumpNarrow(
             tester,
             _buildProductionPanel(partialPlayer),
             size: _kMinViewport,
@@ -200,7 +194,7 @@ void main() {
         'pumps without exception (regression sentinel for the overflow '
         'contract — keeps the 320 dp positive pins meaningful)',
         (WidgetTester tester) async {
-          await _pumpAtSize(
+          await _pumpNarrow(
             tester,
             _buildProductionPanel(fullPlayer),
             size: _kWideRegressionViewport,
@@ -254,7 +248,7 @@ void main() {
         'exception, narrow Column body selected for the first discovered '
         'faction row',
         (WidgetTester tester) async {
-          await _pumpAtSize(
+          await _pumpNarrow(
             tester,
             _buildDiplomacyPanel(
               game: game,
@@ -300,7 +294,7 @@ void main() {
         'exception (regression sentinel against future narrow-only fixes '
         'breaking the wide layout)',
         (WidgetTester tester) async {
-          await _pumpAtSize(
+          await _pumpNarrow(
             tester,
             _buildDiplomacyPanel(
               game: game,
@@ -337,7 +331,7 @@ void main() {
         'RenderFlex overflow exception, four slot cards + researched heading '
         'render',
         (WidgetTester tester) async {
-          await _pumpAtSize(
+          await _pumpNarrow(
             tester,
             _buildTechnologyPanelSlotsBody(game: game, player: player),
             size: _kMinViewport,
@@ -365,7 +359,7 @@ void main() {
         'Negative control: TechnologyPanel (Slots body host) @ 1024×768 '
         'pumps without exception',
         (WidgetTester tester) async {
-          await _pumpAtSize(
+          await _pumpNarrow(
             tester,
             _buildTechnologyPanelSlotsBody(game: game, player: player),
             size: _kWideRegressionViewport,
@@ -413,7 +407,7 @@ void main() {
         'bottom-anchored ~33 vh slot: no RenderFlex overflow exception, '
         'Province header + Tile tab label render',
         (WidgetTester tester) async {
-          await _pumpAtSize(
+          await _pumpNarrow(
             tester,
             buildOverlay(heightPx: _kMinViewport.height * 0.33),
             size: _kMinViewport,
@@ -446,7 +440,7 @@ void main() {
         (WidgetTester tester) async {
           // Wide layout: side-panel host gives the overlay full available
           // height; no bottom-sheet 33 vh clamp.
-          await _pumpAtSize(
+          await _pumpNarrow(
             tester,
             buildOverlay(),
             size: _kWideRegressionViewport,

--- a/app/test/player_turn_event_feed_320dp_min_viewport_test.dart
+++ b/app/test/player_turn_event_feed_320dp_min_viewport_test.dart
@@ -30,6 +30,8 @@ import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'support/min_viewport_harness.dart';
+
 /// Minimum supported viewport dimensions for SPEC/ui/mobile-adaptation.md
 /// § 7. Width matches [kMinViewportWidth]; height (640 dp) mirrors the
 /// sibling screen-level pin files.
@@ -53,41 +55,31 @@ const List<PlayerTurnEventFeedEntry> _kPopulatedEntries = <PlayerTurnEventFeedEn
 ];
 
 Widget _hostNarrowCard({
-  required Size viewportSize,
   required List<PlayerTurnEventFeedEntry> entries,
   required String emptyLabel,
 }) {
-  return MediaQuery(
-    data: MediaQueryData(size: viewportSize),
-    child: MaterialApp(
-      home: Scaffold(
-        body: Align(
-          alignment: Alignment.topRight,
-          child: PlayerTurnEventFeedCard(
-            entries: entries,
-            emptyLabel: emptyLabel,
-            narrow: true,
-          ),
-        ),
+  return Scaffold(
+    body: Align(
+      alignment: Alignment.topRight,
+      child: PlayerTurnEventFeedCard(
+        entries: entries,
+        emptyLabel: emptyLabel,
+        narrow: true,
       ),
     ),
   );
 }
 
-Future<void> _pumpAtSize(
+Future<void> _pumpNarrow(
   WidgetTester tester, {
   required Size size,
   required Widget child,
 }) async {
-  addTearDown(() => tester.binding.setSurfaceSize(null));
-  await tester.binding.setSurfaceSize(size);
-  await tester.pumpWidget(
-    MediaQuery(
-      data: MediaQueryData(size: size),
-      child: child,
-    ),
-  );
-  await tester.pump();
+  await pumpAtMinViewport(tester, size: size, child: child);
+  // The card's hover-aware row chrome animates the border color via an
+  // `AnimatedContainer`; a second short framed pump lays out the body
+  // without entering the animation steady-state loop (so we avoid
+  // `pumpAndSettle`).
   await tester.pump(const Duration(milliseconds: 16));
 }
 
@@ -102,11 +94,10 @@ void main() {
         'AC (positive) narrow populated @ 320×640: no RenderFlex overflow '
         'and entry lines render',
         (WidgetTester tester) async {
-          await _pumpAtSize(
+          await _pumpNarrow(
             tester,
             size: _kMinViewport,
             child: _hostNarrowCard(
-              viewportSize: _kMinViewport,
               entries: _kPopulatedEntries,
               emptyLabel: 'No events this turn.',
             ),
@@ -136,11 +127,10 @@ void main() {
         'AC (positive) narrow empty @ 320×640: no RenderFlex overflow and '
         'empty copy renders',
         (WidgetTester tester) async {
-          await _pumpAtSize(
+          await _pumpNarrow(
             tester,
             size: _kMinViewport,
             child: _hostNarrowCard(
-              viewportSize: _kMinViewport,
               entries: const <PlayerTurnEventFeedEntry>[],
               emptyLabel: 'No events this turn.',
             ),
@@ -161,11 +151,10 @@ void main() {
         'Negative control: narrow populated @ 1024×768 also pumps without '
         'exception',
         (WidgetTester tester) async {
-          await _pumpAtSize(
+          await _pumpNarrow(
             tester,
             size: _kWideRegressionViewport,
             child: _hostNarrowCard(
-              viewportSize: _kWideRegressionViewport,
               entries: _kPopulatedEntries,
               emptyLabel: 'No events this turn.',
             ),

--- a/app/test/production_commodity_breakdown_dialog_320dp_min_viewport_test.dart
+++ b/app/test/production_commodity_breakdown_dialog_320dp_min_viewport_test.dart
@@ -58,7 +58,6 @@
 // screen).
 
 import 'package:colonizethis_app/config/constants.dart';
-import 'package:colonizethis_app/config/themes.dart';
 import 'package:colonizethis_app/config/editorial_monocle_palette.dart';
 import 'package:colonizethis_app/features/game/widgets/production_commodity_breakdown_dialog.dart';
 import 'package:colonizethis_app/l10n/l10n.dart';
@@ -68,9 +67,9 @@ import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'support/min_viewport_harness.dart';
 import 'support/panel_test_fixtures.dart';
 
 /// Minimum supported viewport dimensions for SPEC/ui/mobile-adaptation.md
@@ -98,46 +97,37 @@ const Size _kWideRegressionViewport = Size(1024, 768);
 /// by the spec test). The launcher tap drives the standard `showDialog`
 /// path with the canonical `EditorialMonoclePalette.dialogScrim` barrier
 /// per SPEC § Modal barrier.
-Future<void> _pumpDialogAtSize(
+Future<void> _pumpDialog(
   WidgetTester tester, {
   required Size size,
 }) async {
-  addTearDown(() => tester.binding.setSurfaceSize(null));
-  await tester.binding.setSurfaceSize(size);
-
   final game = buildProductionBreakdownPanelTestGame();
   final player = game.players.firstWhere((p) => p.isHuman);
 
-  await tester.pumpWidget(
-    ProviderScope(
-      child: MaterialApp(
-        theme: AppThemes.editorialMonocle,
-        localizationsDelegates: AppLocalizationsBinding.localizationsDelegates,
-        supportedLocales: AppLocalizations.supportedLocales,
-        locale: const Locale('en'),
-        home: MediaQuery(
-          data: MediaQueryData(size: size),
-          child: Scaffold(
-            body: Builder(
-              builder: (context) => TextButton(
-                onPressed: () {
-                  showDialog<void>(
-                    context: context,
-                    barrierColor: EditorialMonoclePalette.dialogScrim,
-                    builder: (_) => ProductionCommodityBreakdownDialog(
-                      game: game,
-                      player: player,
-                      topology: const MapTopology(nodes: [], edges: []),
-                      tileMapByRegion: null,
-                      currentOrders: const Orders(),
-                    ),
-                  );
-                },
-                // ignore: avoid_hardcoded_strings_in_widgets
-                child: const Text('open'),
+  await pumpAtMinViewport(
+    tester,
+    size: size,
+    localizationsDelegates: AppLocalizationsBinding.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    locale: const Locale('en'),
+    child: Scaffold(
+      body: Builder(
+        builder: (context) => TextButton(
+          onPressed: () {
+            showDialog<void>(
+              context: context,
+              barrierColor: EditorialMonoclePalette.dialogScrim,
+              builder: (_) => ProductionCommodityBreakdownDialog(
+                game: game,
+                player: player,
+                topology: const MapTopology(nodes: [], edges: []),
+                tileMapByRegion: null,
+                currentOrders: const Orders(),
               ),
-            ),
-          ),
+            );
+          },
+          // ignore: avoid_hardcoded_strings_in_widgets
+          child: const Text('open'),
         ),
       ),
     ),
@@ -157,7 +147,7 @@ void main() {
         'AC (positive) ProductionCommodityBreakdownDialog @ 320×640: no '
         'RenderFlex overflow exception, title + Close action render',
         (WidgetTester tester) async {
-          await _pumpDialogAtSize(tester, size: _kMinViewport);
+          await _pumpDialog(tester, size: _kMinViewport);
 
           expect(
             tester.takeException(),
@@ -201,7 +191,7 @@ void main() {
         'is wrapped in a horizontal Scrollbar + SingleChildScrollView '
         '(the Wide-table state from SPEC § States and variants)',
         (WidgetTester tester) async {
-          await _pumpDialogAtSize(tester, size: _kMinViewport);
+          await _pumpDialog(tester, size: _kMinViewport);
 
           expect(tester.takeException(), isNull);
 
@@ -266,7 +256,7 @@ void main() {
         'renders so the body sections from SPEC § Layout / wireframe '
         'still mount at the minimum viewport',
         (WidgetTester tester) async {
-          await _pumpDialogAtSize(tester, size: _kMinViewport);
+          await _pumpDialog(tester, size: _kMinViewport);
 
           expect(tester.takeException(), isNull);
 
@@ -310,7 +300,7 @@ void main() {
         'for the overflow contract — keeps the 320 dp positive pins '
         'meaningful)',
         (WidgetTester tester) async {
-          await _pumpDialogAtSize(
+          await _pumpDialog(
             tester,
             size: _kWideRegressionViewport,
           );

--- a/app/test/production_screen_320dp_min_viewport_test.dart
+++ b/app/test/production_screen_320dp_min_viewport_test.dart
@@ -50,7 +50,6 @@
 // screen).
 
 import 'package:colonizethis_app/config/constants.dart';
-import 'package:colonizethis_app/config/themes.dart';
 import 'package:colonizethis_app/features/game/flame/region_map_component.dart'
     show CtMapVisibilityMode;
 import 'package:colonizethis_app/features/game/screens/production_screen.dart';
@@ -64,10 +63,10 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'production_panel_test_fixtures.dart';
+import 'support/min_viewport_harness.dart';
 
 /// Minimum supported viewport dimensions for SPEC/ui/mobile-adaptation.md
 /// § 7. Width matches [kMinViewportWidth]; height (640 dp) mirrors the
@@ -122,40 +121,32 @@ ShellPlayerContext _globalObserveShellContext() {
 /// for the global-observe branch) so the shell renders without
 /// touching Hive / GameService; passes an empty `panelTopologyOverride`
 /// so the panel does not attempt to look up `GameService.getMapData`.
-Future<void> _pumpProductionScreenAtSize(
+Future<void> _pumpProductionScreen(
   WidgetTester tester, {
   required Size size,
   required Game game,
   required Player player,
   bool globalObserve = false,
 }) async {
-  addTearDown(() => tester.binding.setSurfaceSize(null));
-  await tester.binding.setSurfaceSize(size);
-  await tester.pumpWidget(
-    ProviderScope(
-      overrides: [
-        currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
-        if (globalObserve)
-          shellPlayerContextProvider.overrideWithValue(
-            _globalObserveShellContext(),
-          ),
-      ],
-      child: MaterialApp(
-        theme: AppThemes.editorialMonocle,
-        home: MediaQuery(
-          data: MediaQueryData(size: size),
-          child: ProductionScreen(
-            game: game,
-            player: player,
-            attachGameToUiListener: false,
-            panelTopologyOverride: const MapTopology(),
-            panelTileMapByRegionOverride: null,
-          ),
+  await pumpAtMinViewport(
+    tester,
+    size: size,
+    overrides: [
+      currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
+      if (globalObserve)
+        shellPlayerContextProvider.overrideWithValue(
+          _globalObserveShellContext(),
         ),
-      ),
+    ],
+    child: ProductionScreen(
+      game: game,
+      player: player,
+      attachGameToUiListener: false,
+      panelTopologyOverride: const MapTopology(),
+      panelTileMapByRegionOverride: null,
     ),
+    settle: true,
   );
-  await tester.pumpAndSettle();
 }
 
 void main() {
@@ -186,7 +177,7 @@ void main() {
         'label `Map`) + ProductionPanel narrow body (both `Available` '
         'and `Allocation` labels) all render',
         (WidgetTester tester) async {
-          await _pumpProductionScreenAtSize(
+          await _pumpProductionScreen(
             tester,
             size: _kMinViewport,
             game: game,
@@ -275,7 +266,7 @@ void main() {
         'pumps without exception (regression sentinel for the overflow '
         'contract — keeps the 320 dp positive pin meaningful)',
         (WidgetTester tester) async {
-          await _pumpProductionScreenAtSize(
+          await _pumpProductionScreen(
             tester,
             size: _kWideRegressionViewport,
             game: game,
@@ -302,7 +293,7 @@ void main() {
         'ObserveModeNotDefinedPanel sentinel renders, ProductionPanel '
         'body is absent',
         (WidgetTester tester) async {
-          await _pumpProductionScreenAtSize(
+          await _pumpProductionScreen(
             tester,
             size: _kMinViewport,
             game: game,
@@ -357,7 +348,7 @@ void main() {
         'also pumps without exception (regression sentinel for the '
         'overflow contract under the observe variant)',
         (WidgetTester tester) async {
-          await _pumpProductionScreenAtSize(
+          await _pumpProductionScreen(
             tester,
             size: _kWideRegressionViewport,
             game: game,

--- a/app/test/quick_battle_screen_320dp_min_viewport_test.dart
+++ b/app/test/quick_battle_screen_320dp_min_viewport_test.dart
@@ -48,13 +48,14 @@
 // screen).
 
 import 'package:colonizethis_app/config/constants.dart';
-import 'package:colonizethis_app/config/themes.dart';
 import 'package:colonizethis_app/features/game/combat/quick_battle_screen.dart';
 import 'package:colonizethis_app/l10n/l10n.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+import 'support/min_viewport_harness.dart';
 
 /// Minimum supported viewport dimensions for SPEC/ui/mobile-adaptation.md
 /// § 7. Width matches [kMinViewportWidth]; height (640 dp) mirrors the
@@ -118,38 +119,31 @@ QuickBattleInput _input() {
 /// under test is the screen's own [CtDialogShell] layout at the narrow
 /// viewport, not the barrier / overlay route plumbing (which is already
 /// covered by other tests).
-Future<void> _pumpQuickBattleScreenAtSize(
+Future<void> _pumpQuickBattleScreen(
   WidgetTester tester, {
   required Size size,
   required bool interactive,
   ValueChanged<QuickBattleResult>? onComplete,
 }) async {
-  addTearDown(() => tester.binding.setSurfaceSize(null));
-  await tester.binding.setSurfaceSize(size);
-  await tester.pumpWidget(
-    MaterialApp(
-      theme: AppThemes.editorialMonocle,
-      localizationsDelegates: AppLocalizationsBinding.localizationsDelegates,
-      supportedLocales: AppLocalizations.supportedLocales,
-      home: MediaQuery(
-        data: MediaQueryData(size: size),
-        child: Scaffold(
-          body: Center(
-            child: QuickBattleScreen(
-              input: _input(),
-              onComplete: onComplete ?? (_) {},
-              interactive: interactive,
-            ),
-          ),
+  // The harness single pump settles the `setState` scheduled from
+  // `initState` on the non-interactive auto-resolve path; the
+  // interactive path also pumps once so the action `Wrap` lays out
+  // against the actual viewport.
+  await pumpAtMinViewport(
+    tester,
+    size: size,
+    localizationsDelegates: AppLocalizationsBinding.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    child: Scaffold(
+      body: Center(
+        child: QuickBattleScreen(
+          input: _input(),
+          onComplete: onComplete ?? (_) {},
+          interactive: interactive,
         ),
       ),
     ),
   );
-  // A single extra pump settles the `setState` scheduled from
-  // `initState` on the non-interactive auto-resolve path. The
-  // interactive path also pumps once so the action `Wrap` lays out
-  // against the actual viewport.
-  await tester.pump();
 }
 
 void main() {
@@ -164,7 +158,7 @@ void main() {
         'RenderFlex overflow exception, Battle Result winner sentence + '
         'both casualty rows + Continue render',
         (WidgetTester tester) async {
-          await _pumpQuickBattleScreenAtSize(
+          await _pumpQuickBattleScreen(
             tester,
             size: _kMinViewport,
             interactive: false,
@@ -221,7 +215,7 @@ void main() {
         (WidgetTester tester) async {
           int completeCount = 0;
           QuickBattleResult? lastResult;
-          await _pumpQuickBattleScreenAtSize(
+          await _pumpQuickBattleScreen(
             tester,
             size: _kMinViewport,
             interactive: false,
@@ -262,7 +256,7 @@ void main() {
         'QuickBattleActionSelector Command Points header + every action '
         'Wrap child render, and the Resolve (Auto) fallback is absent',
         (WidgetTester tester) async {
-          await _pumpQuickBattleScreenAtSize(
+          await _pumpQuickBattleScreen(
             tester,
             size: _kMinViewport,
             interactive: true,
@@ -329,7 +323,7 @@ void main() {
         'for the overflow contract — keeps the 320 dp positive pins '
         'meaningful)',
         (WidgetTester tester) async {
-          await _pumpQuickBattleScreenAtSize(
+          await _pumpQuickBattleScreen(
             tester,
             size: _kWideRegressionViewport,
             interactive: false,

--- a/app/test/support/min_viewport_harness.dart
+++ b/app/test/support/min_viewport_harness.dart
@@ -1,0 +1,103 @@
+// Shared minimum-viewport pump harness for the
+// `app/test/*_320dp_min_viewport_test.dart` family.
+//
+// Every 320 dp pin file previously re-declared its own private
+// `_pump<Thing>AtSize(...)` helper that repeated the identical sequence:
+// register a surface-size tear-down, force the binding surface size, pump a
+// `ProviderScope` > `MaterialApp(theme: AppThemes.editorialMonocle)` >
+// `MediaQuery(size)` shell, then pump one frame (or `pumpAndSettle`). This
+// harness consolidates that boilerplate so the only per-file variation —
+// the provider override list, the hosted widget, and the pump strategy —
+// stays local to each test.
+//
+// Refs #3730 (consolidate app test scaffolding).
+// SPEC: SPEC/program/repo-lint.md (test static-analysis scope).
+
+import 'package:colonizethis_app/config/themes.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart' show Override;
+import 'package:flutter_test/flutter_test.dart';
+
+/// Builds the canonical minimum-viewport app shell used by the 320 dp pin
+/// suite: a [ProviderScope] (scoped by [overrides]) wrapping an
+/// editorial-monocle [MaterialApp] whose [MaterialApp.home] forces [size]
+/// via [MediaQuery] so widget code that reads
+/// `MediaQuery.sizeOf(context).width` resolves to the minimum viewport.
+///
+/// [localizationsDelegates], [supportedLocales], and [locale] are forwarded
+/// to the [MaterialApp] for screens whose chrome reads `AppLocalizations`;
+/// their defaults match `MaterialApp`'s own so non-localized callers are
+/// unaffected. Any extra structural wrappers a screen needs (a [Scaffold]
+/// host, a [Stack], an event-handler scope, a launcher [Builder], …) belong
+/// in [child].
+///
+/// Callers that need a fully custom pump sequence (multiple framed pumps,
+/// explicit durations) can pump this widget directly after setting the
+/// surface size; callers with the common single-pump / settle behaviour
+/// should prefer [pumpAtMinViewport].
+Widget buildMinViewportApp({
+  required Size size,
+  required Widget child,
+  List<Override> overrides = const <Override>[],
+  Iterable<LocalizationsDelegate<dynamic>>? localizationsDelegates,
+  Iterable<Locale> supportedLocales = const <Locale>[Locale('en', 'US')],
+  Locale? locale,
+  GlobalKey<NavigatorState>? navigatorKey,
+}) {
+  return ProviderScope(
+    overrides: overrides,
+    child: MaterialApp(
+      navigatorKey: navigatorKey,
+      theme: AppThemes.editorialMonocle,
+      localizationsDelegates: localizationsDelegates,
+      supportedLocales: supportedLocales,
+      locale: locale,
+      home: MediaQuery(data: MediaQueryData(size: size), child: child),
+    ),
+  );
+}
+
+/// Pumps [child] inside [buildMinViewportApp] at the minimum viewport [size].
+///
+/// Registers a tear-down that restores the surface size, sets the binding
+/// surface to [size] (so the framework's `RenderFlex` math sees the minimum
+/// viewport), then pumps a single frame by default. When [settle] is `true`
+/// the helper drives [WidgetTester.pumpAndSettle] to completion instead —
+/// use it for screens whose first-frame chrome must settle before the
+/// overflow assertion runs, and keep the single-pump default for screens
+/// with continuous animations that would never settle.
+///
+/// For screens that need extra framed pumps with explicit durations, call
+/// this helper (which leaves the tree on its first pumped frame) and then
+/// issue the additional `tester.pump(...)` calls from the test body.
+Future<void> pumpAtMinViewport(
+  WidgetTester tester, {
+  required Size size,
+  required Widget child,
+  List<Override> overrides = const <Override>[],
+  Iterable<LocalizationsDelegate<dynamic>>? localizationsDelegates,
+  Iterable<Locale> supportedLocales = const <Locale>[Locale('en', 'US')],
+  Locale? locale,
+  GlobalKey<NavigatorState>? navigatorKey,
+  bool settle = false,
+}) async {
+  addTearDown(() => tester.binding.setSurfaceSize(null));
+  await tester.binding.setSurfaceSize(size);
+  await tester.pumpWidget(
+    buildMinViewportApp(
+      size: size,
+      overrides: overrides,
+      localizationsDelegates: localizationsDelegates,
+      supportedLocales: supportedLocales,
+      locale: locale,
+      navigatorKey: navigatorKey,
+      child: child,
+    ),
+  );
+  if (settle) {
+    await tester.pumpAndSettle();
+  } else {
+    await tester.pump();
+  }
+}

--- a/app/test/support/min_viewport_harness_test.dart
+++ b/app/test/support/min_viewport_harness_test.dart
@@ -1,0 +1,131 @@
+// Smoke tests for the shared minimum-viewport pump harness (Refs #3730).
+//
+// These pin the harness contract that every migrated
+// `*_320dp_min_viewport_test.dart` file now relies on:
+//
+//  * the surface size is forced to the requested minimum viewport so the
+//    framework's `RenderFlex` math and `MediaQuery.sizeOf` both see it;
+//  * a tear-down restores the surface size after the test;
+//  * the editorial-monocle theme drives the shell;
+//  * provider overrides are threaded into the wrapping `ProviderScope`;
+//  * `settle: true` drains pending animations.
+
+import 'package:colonizethis_app/config/themes.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'min_viewport_harness.dart';
+
+const Size _kMinViewport = Size(320, 640);
+
+final Provider<String> _labelProvider = Provider<String>((ref) => 'default');
+
+void main() {
+  suppressLogsForTests();
+
+  testWidgets(
+    'pumpAtMinViewport forces the surface size and editorial-monocle theme',
+    (WidgetTester tester) async {
+      late Size observedSize;
+      late ThemeData observedTheme;
+
+      await pumpAtMinViewport(
+        tester,
+        size: _kMinViewport,
+        child: Builder(
+          builder: (context) {
+            observedSize = MediaQuery.sizeOf(context);
+            observedTheme = Theme.of(context);
+            return const SizedBox.shrink();
+          },
+        ),
+      );
+
+      expect(observedSize, _kMinViewport);
+      expect(observedTheme.colorScheme, AppThemes.editorialMonocle.colorScheme);
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets('pumpAtMinViewport threads provider overrides into the scope', (
+    WidgetTester tester,
+  ) async {
+    late String observedLabel;
+
+    await pumpAtMinViewport(
+      tester,
+      size: _kMinViewport,
+      overrides: [_labelProvider.overrideWithValue('overridden')],
+      child: Consumer(
+        builder: (context, ref, _) {
+          observedLabel = ref.watch(_labelProvider);
+          return const SizedBox.shrink();
+        },
+      ),
+    );
+
+    expect(observedLabel, 'overridden');
+  });
+
+  testWidgets('pumpAtMinViewport constrains the child to the forced width', (
+    WidgetTester tester,
+  ) async {
+    late double maxWidth;
+
+    await pumpAtMinViewport(
+      tester,
+      size: _kMinViewport,
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          maxWidth = constraints.maxWidth;
+          return const SizedBox.shrink();
+        },
+      ),
+    );
+
+    expect(maxWidth, _kMinViewport.width);
+  });
+
+  testWidgets('pumpAtMinViewport with settle drains pending animations', (
+    WidgetTester tester,
+  ) async {
+    await pumpAtMinViewport(
+      tester,
+      size: _kMinViewport,
+      settle: true,
+      child: const _BrieflyAnimating(),
+    );
+
+    expect(find.text('done'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+}
+
+class _BrieflyAnimating extends StatefulWidget {
+  const _BrieflyAnimating();
+
+  @override
+  State<_BrieflyAnimating> createState() => _BrieflyAnimatingState();
+}
+
+class _BrieflyAnimatingState extends State<_BrieflyAnimating> {
+  String _label = 'pending';
+
+  @override
+  void initState() {
+    super.initState();
+    Future<void>.delayed(const Duration(milliseconds: 50), () {
+      if (mounted) setState(() => _label = 'done');
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Directionality(
+      textDirection: TextDirection.ltr,
+      child: Text(_label),
+    );
+  }
+}

--- a/app/test/technology_screen_320dp_min_viewport_test.dart
+++ b/app/test/technology_screen_320dp_min_viewport_test.dart
@@ -44,7 +44,6 @@
 // vertically at narrow).
 
 import 'package:colonizethis_app/config/constants.dart';
-import 'package:colonizethis_app/config/themes.dart';
 import 'package:colonizethis_app/features/game/flame/region_map_component.dart'
     show CtMapVisibilityMode;
 import 'package:colonizethis_app/features/game/screens/technology_screen.dart';
@@ -57,9 +56,9 @@ import 'package:colonizethis_app/widgets/ct_top_bar.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'support/min_viewport_harness.dart';
 import 'support/panel_test_fixtures.dart';
 
 /// Minimum supported viewport dimensions for SPEC/ui/mobile-adaptation.md
@@ -104,57 +103,43 @@ ShellPlayerContext _globalObserveShellContext() {
   );
 }
 
-/// Pumps the [TechnologyScreen] at [size] under the running editorial-monocle
-/// theme. Sets the surface size (so the binding's render flex math sees
-/// the minimum viewport) and overrides MediaQuery so widget code that
-/// reads `MediaQuery.sizeOf(context).width` resolves to the same value
-/// — the pattern already used by every other `*_320dp_min_viewport_test.dart`
-/// file. Overrides `currentGameProvider` and `currentOrdersProvider`
-/// (and optionally `shellPlayerContextProvider` for the global-observe
-/// branch) so the shell renders without touching Hive / GameService.
-Future<void> _pumpTechnologyScreenAtSize(
+/// Pumps the [TechnologyScreen] at [size] via the shared min-viewport
+/// harness ([pumpAtMinViewport]). Overrides `currentGameProvider` and
+/// `currentOrdersProvider` (and optionally `shellPlayerContextProvider`
+/// for the global-observe branch) so the shell renders without touching
+/// Hive / GameService.
+///
+/// Single pump is enough: TechnologyScreen's chrome paints synchronously
+/// and the Slots body is a `SingleChildScrollView` around a `Column` with
+/// no indefinite ticker (the harness default), so the 320 dp overflow
+/// assertion evaluates on the first frame.
+Future<void> _pumpTechnologyScreen(
   WidgetTester tester, {
   required Size size,
   required Game game,
   required Player player,
   bool globalObserve = false,
 }) async {
-  addTearDown(() => tester.binding.setSurfaceSize(null));
-  await tester.binding.setSurfaceSize(size);
-  await tester.pumpWidget(
-    ProviderScope(
-      overrides: [
-        currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
-        currentOrdersProvider.overrideWith(
-          () => CurrentOrdersNotifier(const Orders()),
-        ),
-        appEventBusProvider.overrideWith((ref) {
-          final bus = AppEventBus.create();
-          ref.onDispose(bus.dispose);
-          return bus;
-        }),
-        if (globalObserve)
-          shellPlayerContextProvider.overrideWithValue(
-            _globalObserveShellContext(),
-          ),
-      ],
-      child: MaterialApp(
-        theme: AppThemes.editorialMonocle,
-        home: MediaQuery(
-          data: MediaQueryData(size: size),
-          child: TechnologyScreen(game: game, player: player),
-        ),
+  await pumpAtMinViewport(
+    tester,
+    size: size,
+    overrides: [
+      currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
+      currentOrdersProvider.overrideWith(
+        () => CurrentOrdersNotifier(const Orders()),
       ),
-    ),
+      appEventBusProvider.overrideWith((ref) {
+        final bus = AppEventBus.create();
+        ref.onDispose(bus.dispose);
+        return bus;
+      }),
+      if (globalObserve)
+        shellPlayerContextProvider.overrideWithValue(
+          _globalObserveShellContext(),
+        ),
+    ],
+    child: TechnologyScreen(game: game, player: player),
   );
-  // Single pump is enough: TechnologyScreen's chrome paints synchronously
-  // and the Slots body is a `SingleChildScrollView` around a `Column`
-  // with no indefinite ticker. Mirrors the `await tester.pump()` branch
-  // used by `trade_screen_320dp_min_viewport_test.dart` for the same
-  // reason (`CtGameFeatureScreenShell` attaches a bus listener tied to
-  // the live `currentGameProvider`; we want the 320 dp overflow
-  // assertion to evaluate on the first frame).
-  await tester.pump();
 }
 
 void main() {
@@ -185,7 +170,7 @@ void main() {
         'back label `Map`) + Slots/Tree trailing toggles + Slots body '
         '(TechnologyPanel) all render',
         (WidgetTester tester) async {
-          await _pumpTechnologyScreenAtSize(
+          await _pumpTechnologyScreen(
             tester,
             size: _kMinViewport,
             game: game,
@@ -269,7 +254,7 @@ void main() {
         'also pumps without exception (regression sentinel for the '
         'overflow contract — keeps the 320 dp positive pin meaningful)',
         (WidgetTester tester) async {
-          await _pumpTechnologyScreenAtSize(
+          await _pumpTechnologyScreen(
             tester,
             size: _kWideRegressionViewport,
             game: game,
@@ -294,7 +279,7 @@ void main() {
         '`ObserveModeNotDefinedPanel(title: "Technology")` sentinel '
         'renders, the live TechnologyPanel body is absent',
         (WidgetTester tester) async {
-          await _pumpTechnologyScreenAtSize(
+          await _pumpTechnologyScreen(
             tester,
             size: _kMinViewport,
             game: game,
@@ -352,7 +337,7 @@ void main() {
         'also pumps without exception (regression sentinel for the '
         'overflow contract under the observe variant)',
         (WidgetTester tester) async {
-          await _pumpTechnologyScreenAtSize(
+          await _pumpTechnologyScreen(
             tester,
             size: _kWideRegressionViewport,
             game: game,

--- a/app/test/trade_screen_320dp_min_viewport_test.dart
+++ b/app/test/trade_screen_320dp_min_viewport_test.dart
@@ -42,7 +42,6 @@
 // coverage to).
 
 import 'package:colonizethis_app/config/constants.dart';
-import 'package:colonizethis_app/config/themes.dart';
 import 'package:colonizethis_app/features/game/flame/region_map_component.dart'
     show CtMapVisibilityMode;
 import 'package:colonizethis_app/features/game/screens/trade_screen.dart';
@@ -53,9 +52,9 @@ import 'package:colonizethis_app/widgets/ct_top_bar.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'support/min_viewport_harness.dart';
 import 'support/panel_test_fixtures.dart';
 
 /// Minimum supported viewport dimensions for SPEC/ui/mobile-adaptation.md
@@ -104,41 +103,31 @@ ShellPlayerContext _globalObserveShellContext() {
 /// file. Overrides `currentGameProvider` (and optionally
 /// `shellPlayerContextProvider` for the global-observe branch) so the
 /// shell renders without touching Hive / GameService.
-Future<void> _pumpTradeScreenAtSize(
+Future<void> _pumpTradeScreen(
   WidgetTester tester, {
   required Size size,
   required Game game,
   required Player player,
   bool globalObserve = false,
 }) async {
-  addTearDown(() => tester.binding.setSurfaceSize(null));
-  await tester.binding.setSurfaceSize(size);
-  await tester.pumpWidget(
-    ProviderScope(
-      overrides: [
-        currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
-        if (globalObserve)
-          shellPlayerContextProvider.overrideWithValue(
-            _globalObserveShellContext(),
-          ),
-      ],
-      child: MaterialApp(
-        theme: AppThemes.editorialMonocle,
-        home: MediaQuery(
-          data: MediaQueryData(size: size),
-          child: TradeScreen(game: game, player: player),
+  // Single pump (the harness default) is enough: TradeScreen's chrome
+  // paints synchronously and the placeholder body is a single static
+  // `CtPanel`. We avoid `pumpAndSettle` because
+  // `CtGameFeatureScreenShell`'s bus listener attaches per the live
+  // `currentGameProvider` and we want the 320 dp overflow assertion to
+  // evaluate on the first frame.
+  await pumpAtMinViewport(
+    tester,
+    size: size,
+    overrides: [
+      currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
+      if (globalObserve)
+        shellPlayerContextProvider.overrideWithValue(
+          _globalObserveShellContext(),
         ),
-      ),
-    ),
+    ],
+    child: TradeScreen(game: game, player: player),
   );
-  // Single pump is enough: TradeScreen's chrome paints synchronously
-  // and the placeholder body is a single static `CtPanel`. Mirrors the
-  // `settle: false` branch used by the dialog 320 dp pin file when a
-  // dialog hosts an indefinite ticker (here we have no ticker; we
-  // still avoid `pumpAndSettle` because `CtGameFeatureScreenShell`'s
-  // bus listener attaches per the live `currentGameProvider` and we
-  // want the 320 dp overflow assertion to evaluate on the first frame).
-  await tester.pump();
 }
 
 void main() {
@@ -168,7 +157,7 @@ void main() {
         'overflow exception, dark CtTopBar (title `Trade`, back label '
         '`Map`) + scaffold placeholder body both render',
         (WidgetTester tester) async {
-          await _pumpTradeScreenAtSize(
+          await _pumpTradeScreen(
             tester,
             size: _kMinViewport,
             game: game,
@@ -218,7 +207,7 @@ void main() {
         'without exception (regression sentinel for the overflow '
         'contract — keeps the 320 dp positive pin meaningful)',
         (WidgetTester tester) async {
-          await _pumpTradeScreenAtSize(
+          await _pumpTradeScreen(
             tester,
             size: _kWideRegressionViewport,
             game: game,
@@ -243,7 +232,7 @@ void main() {
         'ObserveModeNotDefinedPanel sentinel renders, scaffold '
         'placeholder body is absent',
         (WidgetTester tester) async {
-          await _pumpTradeScreenAtSize(
+          await _pumpTradeScreen(
             tester,
             size: _kMinViewport,
             game: game,
@@ -298,7 +287,7 @@ void main() {
         'pumps without exception (regression sentinel for the overflow '
         'contract under the observe variant)',
         (WidgetTester tester) async {
-          await _pumpTradeScreenAtSize(
+          await _pumpTradeScreen(
             tester,
             size: _kWideRegressionViewport,
             game: game,

--- a/app/test/train_dialogs_320dp_min_viewport_test.dart
+++ b/app/test/train_dialogs_320dp_min_viewport_test.dart
@@ -41,7 +41,6 @@
 // overflow at 320 dp on every covered surface).
 
 import 'package:colonizethis_app/config/constants.dart';
-import 'package:colonizethis_app/config/themes.dart';
 import 'package:colonizethis_app/features/game/widgets/train_civilians_dialog.dart';
 import 'package:colonizethis_app/features/game/widgets/train_military_dialog.dart';
 import 'package:colonizethis_app/features/game/widgets/train_naval_dialog.dart';
@@ -51,6 +50,7 @@ import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'support/min_viewport_harness.dart';
 import 'support/panel_test_fixtures.dart';
 
 /// Minimum supported viewport dimensions for SPEC/ui/mobile-adaptation.md
@@ -65,8 +65,8 @@ const Size _kWideRegressionViewport = Size(1024, 768);
 
 /// Pumps [dialog] at [size] under the running editorial-monocle theme.
 ///
-/// Mirrors `_pumpDialogAtSize` in `dialogs_320dp_min_viewport_test.dart`
-/// — sets the surface size (so the binding's render flex math sees the
+/// Delegates to the shared `pumpAtMinViewport` harness
+/// — which sets the surface size (so the binding's render flex math sees the
 /// minimum viewport) and overrides MediaQuery so dialog code that reads
 /// `MediaQuery.sizeOf(context).width` resolves to the same value.
 ///
@@ -74,25 +74,19 @@ const Size _kWideRegressionViewport = Size(1024, 768);
 /// real `showDialog` flow because the contract under test is the
 /// dialog's own [CtDialogShell] layout at the narrow viewport, not the
 /// barrier / overlay route plumbing.
-Future<void> _pumpDialogAtSize(
+Future<void> _pumpDialog(
   WidgetTester tester,
   Widget dialog, {
   required Size size,
 }) async {
-  addTearDown(() => tester.binding.setSurfaceSize(null));
-  await tester.binding.setSurfaceSize(size);
-  await tester.pumpWidget(
-    MaterialApp(
-      theme: AppThemes.editorialMonocle,
-      localizationsDelegates: AppLocalizationsBinding.localizationsDelegates,
-      supportedLocales: AppLocalizations.supportedLocales,
-      home: MediaQuery(
-        data: MediaQueryData(size: size),
-        child: Scaffold(body: Center(child: dialog)),
-      ),
-    ),
+  await pumpAtMinViewport(
+    tester,
+    size: size,
+    localizationsDelegates: AppLocalizationsBinding.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    child: Scaffold(body: Center(child: dialog)),
+    settle: true,
   );
-  await tester.pumpAndSettle();
 }
 
 /// Resolves the human player id from the lightweight train fixture.
@@ -111,7 +105,7 @@ void main() {
       (WidgetTester tester) async {
         final game = buildTrainPanelTestGame();
         final humanPlayerId = _humanPlayerId(game);
-        await _pumpDialogAtSize(
+        await _pumpDialog(
           tester,
           TrainCiviliansDialog(
             game: game,
@@ -150,7 +144,7 @@ void main() {
     ) async {
       final game = buildTrainPanelTestGame();
       final humanPlayerId = _humanPlayerId(game);
-      await _pumpDialogAtSize(
+      await _pumpDialog(
         tester,
         TrainCiviliansDialog(
           game: game,
@@ -175,7 +169,7 @@ void main() {
       (WidgetTester tester) async {
         final game = buildTrainPanelTestGame();
         final humanPlayerId = _humanPlayerId(game);
-        await _pumpDialogAtSize(
+        await _pumpDialog(
           tester,
           TrainMilitaryDialog(
             game: game,
@@ -215,7 +209,7 @@ void main() {
     ) async {
       final game = buildTrainPanelTestGame();
       final humanPlayerId = _humanPlayerId(game);
-      await _pumpDialogAtSize(
+      await _pumpDialog(
         tester,
         TrainMilitaryDialog(
           game: game,
@@ -240,7 +234,7 @@ void main() {
       (WidgetTester tester) async {
         final game = buildTrainPanelTestGame();
         final humanPlayerId = _humanPlayerId(game);
-        await _pumpDialogAtSize(
+        await _pumpDialog(
           tester,
           TrainNavalDialog(
             game: game,
@@ -277,7 +271,7 @@ void main() {
     ) async {
       final game = buildTrainPanelTestGame();
       final humanPlayerId = _humanPlayerId(game);
-      await _pumpDialogAtSize(
+      await _pumpDialog(
         tester,
         TrainNavalDialog(
           game: game,

--- a/app/test/unit_panels_320dp_min_viewport_test.dart
+++ b/app/test/unit_panels_320dp_min_viewport_test.dart
@@ -46,15 +46,14 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:colonizethis_app/config/constants.dart';
-import 'package:colonizethis_app/config/themes.dart';
 import 'package:colonizethis_app/features/game/widgets/civilian_units_panel.dart';
 import 'package:colonizethis_app/features/game/widgets/military_units_panel.dart';
 import 'package:colonizethis_app/features/game/widgets/naval_units_panel.dart';
 
+import 'support/min_viewport_harness.dart';
 import 'support/panel_test_fixtures.dart';
 import 'support/widget_test_assets.dart';
 
@@ -69,37 +68,26 @@ const Size _kMinViewport = Size(kMinViewportWidth, 640);
 /// `dialogs_320dp_min_viewport_test.dart`.
 const Size _kWideRegressionViewport = Size(1024, 768);
 
-/// Pumps [child] at [size] under the running editorial-monocle theme.
+/// Pumps [child] (hosted in a [Scaffold]) at [size] via the shared
+/// min-viewport harness ([pumpAtMinViewport]).
 ///
-/// Sets the surface size (so the binding's render flex math sees the
-/// minimum viewport) and overrides MediaQuery so widget code that reads
-/// `MediaQuery.sizeOf(context).width` resolves to the same value — the
-/// pattern already used by the sibling 320 dp pin files.
-///
-/// Wraps [child] in a [ProviderScope] so Civilian-side `Consumer*`
-/// widgets and provider reads inside the panel resolve to a deterministic
-/// (empty) default; the contract under test is the panel chrome at the
-/// narrow viewport, not the panel's full assign-work behaviour (which is
-/// already covered by the dedicated `*_units_panel_test_part*` files).
-Future<void> _pumpAtSize(
+/// The harness wraps the tree in a [ProviderScope] so Civilian-side
+/// `Consumer*` widgets and provider reads inside the panel resolve to a
+/// deterministic (empty) default; the contract under test is the panel
+/// chrome at the narrow viewport, not the panel's full assign-work
+/// behaviour (which is already covered by the dedicated
+/// `*_units_panel_test_part*` files).
+Future<void> _pumpNarrow(
   WidgetTester tester,
   Widget child, {
   required Size size,
 }) async {
-  addTearDown(() => tester.binding.setSurfaceSize(null));
-  await tester.binding.setSurfaceSize(size);
-  await tester.pumpWidget(
-    ProviderScope(
-      child: MaterialApp(
-        theme: AppThemes.editorialMonocle,
-        home: MediaQuery(
-          data: MediaQueryData(size: size),
-          child: Scaffold(body: child),
-        ),
-      ),
-    ),
+  await pumpAtMinViewport(
+    tester,
+    size: size,
+    child: Scaffold(body: child),
+    settle: true,
   );
-  await tester.pumpAndSettle();
 }
 
 Widget _buildCivilianUnitsPanel({
@@ -172,7 +160,7 @@ void main() {
         'overflow exception, "Civilian Units" title renders', (
       WidgetTester tester,
     ) async {
-      await _pumpAtSize(
+      await _pumpNarrow(
         tester,
         _buildCivilianUnitsPanel(game: game, humanPlayerId: humanPlayerId),
         size: _kMinViewport,
@@ -197,7 +185,7 @@ void main() {
         'contract — keeps the 320 dp positive pin meaningful)', (
       WidgetTester tester,
     ) async {
-      await _pumpAtSize(
+      await _pumpNarrow(
         tester,
         _buildCivilianUnitsPanel(game: game, humanPlayerId: humanPlayerId),
         size: _kWideRegressionViewport,
@@ -214,7 +202,7 @@ void main() {
         'overflow exception, "Military Units" title renders', (
       WidgetTester tester,
     ) async {
-      await _pumpAtSize(
+      await _pumpNarrow(
         tester,
         _buildMilitaryUnitsPanel(game: game, humanPlayerId: humanPlayerId),
         size: _kMinViewport,
@@ -238,7 +226,7 @@ void main() {
     testWidgets('Negative control: MilitaryUnitsPanel @ 1024×768 also pumps '
         'without exception (regression sentinel for the overflow '
         'contract)', (WidgetTester tester) async {
-      await _pumpAtSize(
+      await _pumpNarrow(
         tester,
         _buildMilitaryUnitsPanel(game: game, humanPlayerId: humanPlayerId),
         size: _kWideRegressionViewport,
@@ -255,7 +243,7 @@ void main() {
       'AC (positive) NavalUnitsPanel @ 320×640: no RenderFlex overflow '
       'exception, "Naval Units" title renders',
       (WidgetTester tester) async {
-        await _pumpAtSize(
+        await _pumpNarrow(
           tester,
           _buildNavalUnitsPanel(
             game: game,
@@ -286,7 +274,7 @@ void main() {
       'exception (regression sentinel for the overflow contract — keeps '
       'the 320 dp positive pin meaningful)',
       (WidgetTester tester) async {
-        await _pumpAtSize(
+        await _pumpNarrow(
           tester,
           _buildNavalUnitsPanel(
             game: game,

--- a/app/test/victory_overlay_320dp_min_viewport_test.dart
+++ b/app/test/victory_overlay_320dp_min_viewport_test.dart
@@ -62,7 +62,6 @@
 // overflow at 320 dp on every covered surface).
 
 import 'package:colonizethis_app/config/constants.dart';
-import 'package:colonizethis_app/config/themes.dart';
 import 'package:colonizethis_app/features/game/flame/victory_overlay.dart';
 import 'package:colonizethis_app/widgets/ct_brass_divider.dart';
 import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
@@ -71,6 +70,7 @@ import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'support/min_viewport_harness.dart';
 import 'support/panel_test_fixtures.dart';
 
 /// Minimum supported viewport dimensions for `SPEC/ui/mobile-adaptation.md`
@@ -86,32 +86,24 @@ const Size _kWideRegressionViewport = Size(1024, 768);
 
 /// Pumps [child] at [size] under the running editorial-monocle theme.
 ///
-/// Mirrors `_pumpDialogAtSize` in
-/// `grant_or_subsidy_dialog_320dp_min_viewport_test.dart` and the
-/// `_pumpAtSize` helper in `mobile_320dp_min_viewport_test.dart`:
-/// sets the surface size (so the binding's render-flex math sees the
+/// Delegates to the shared `pumpAtMinViewport` harness:
+/// which sets the surface size (so the binding's render-flex math sees the
 /// minimum viewport) and overrides `MediaQuery` so widget code that
 /// reads `MediaQuery.sizeOf(context).width` resolves to the same
 /// value. `VictoryPanel.build` switches its narrow / wide layouts off
 /// the `MediaQuery.sizeOf(context).width < kNarrowBreakpoint` predicate
 /// so both writes must agree.
-Future<void> _pumpAtSize(
+Future<void> _pumpNarrow(
   WidgetTester tester,
   Widget child, {
   required Size size,
 }) async {
-  addTearDown(() => tester.binding.setSurfaceSize(null));
-  await tester.binding.setSurfaceSize(size);
-  await tester.pumpWidget(
-    MaterialApp(
-      theme: AppThemes.editorialMonocle,
-      home: MediaQuery(
-        data: MediaQueryData(size: size),
-        child: Scaffold(body: child),
-      ),
-    ),
+  await pumpAtMinViewport(
+    tester,
+    size: size,
+    child: Scaffold(body: child),
+    settle: true,
   );
-  await tester.pumpAndSettle();
 }
 
 void main() {
@@ -154,7 +146,7 @@ void main() {
         'panel\'s 24 dp outer padding and 28 dp inner horizontal padding '
         'collapse the 320 dp viewport.',
         (WidgetTester tester) async {
-          await _pumpAtSize(
+          await _pumpNarrow(
             tester,
             Stack(
               children: <Widget>[
@@ -208,7 +200,7 @@ void main() {
         'wireframe (laurel / title / divider / body / actions column) '
         'surfaces without needing the overlay scrim plumbing.',
         (WidgetTester tester) async {
-          await _pumpAtSize(
+          await _pumpNarrow(
             tester,
             Center(
               child: VictoryPanel(
@@ -250,7 +242,7 @@ void main() {
         'row and headlineSmall title slot per '
         'SPEC/ui/victory-overlay.md § Narrow viewport).',
         (WidgetTester tester) async {
-          await _pumpAtSize(
+          await _pumpNarrow(
             tester,
             Stack(
               children: <Widget>[

--- a/test/check_app_test_no_duplicate_scaffolding_test.dart
+++ b/test/check_app_test_no_duplicate_scaffolding_test.dart
@@ -1,0 +1,179 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+import '../tool/check_app_test_no_duplicate_scaffolding.dart';
+
+const _kConsolidatedMinViewport = '''
+import 'support/min_viewport_harness.dart';
+
+const _kMinViewport = Size(320, 640);
+
+Future<void> _pumpScreen(WidgetTester tester) async {
+  await pumpAtMinViewport(
+    tester,
+    size: _kMinViewport,
+    child: const Placeholder(),
+  );
+}
+
+void main() {
+  testWidgets('renders at 320 dp', (tester) async {
+    await _pumpScreen(tester);
+  });
+}
+''';
+
+const _kReintroducedHelper = '''
+const _kMinViewport = Size(320, 640);
+
+Future<void> _pumpFooScreenAtSize(WidgetTester tester, Size size) async {
+  addTearDown(() => tester.binding.setSurfaceSize(null));
+  await tester.binding.setSurfaceSize(size);
+  await tester.pumpWidget(
+    ProviderScope(
+      child: MaterialApp(
+        theme: AppThemes.editorialMonocle,
+        home: MediaQuery(
+          data: MediaQueryData(size: size),
+          child: const Placeholder(),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+''';
+
+void _writeGovernedFile(Directory temp, String name, String contents) {
+  File('${temp.path}/app/test/$name')
+    ..createSync(recursive: true)
+    ..writeAsStringSync(contents);
+}
+
+void main() {
+  test('passes on a consolidated 320dp file that uses the shared harness', () {
+    final temp = Directory.systemTemp.createTempSync(
+      'check_app_test_no_dup_scaffolding_pass_',
+    );
+    addTearDown(() => temp.deleteSync(recursive: true));
+    _writeGovernedFile(
+      temp,
+      'technology_screen_320dp_min_viewport_test.dart',
+      _kConsolidatedMinViewport,
+    );
+
+    final logs = <String>[];
+    final code = runCheckAppTestNoDuplicateScaffolding(
+      temp.path,
+      info: logs.add,
+      err: logs.add,
+    );
+
+    expect(code, 0);
+    expect(
+      logs.join('\n'),
+      contains('no duplicated min-viewport scaffolding found'),
+    );
+  });
+
+  test('fails when a per-file _pump*AtSize helper is reintroduced', () {
+    final temp = Directory.systemTemp.createTempSync(
+      'check_app_test_no_dup_scaffolding_helper_',
+    );
+    addTearDown(() => temp.deleteSync(recursive: true));
+    _writeGovernedFile(
+      temp,
+      'foo_screen_320dp_min_viewport_test.dart',
+      _kReintroducedHelper,
+    );
+
+    final logs = <String>[];
+    final code = runCheckAppTestNoDuplicateScaffolding(
+      temp.path,
+      info: logs.add,
+      err: logs.add,
+    );
+
+    expect(code, 1);
+    final joined = logs.join('\n');
+    expect(
+      joined,
+      contains(
+        'foo_screen_320dp_min_viewport_test.dart:3: function '
+        '"_pumpFooScreenAtSize" re-declares a per-file min-viewport pump '
+        'helper',
+      ),
+    );
+    expect(joined, contains('direct "setSurfaceSize" call'));
+    expect(joined, contains('AppThemes.editorialMonocle'));
+  });
+
+  test('does not fire on the shared harness under app/test/support/', () {
+    final temp = Directory.systemTemp.createTempSync(
+      'check_app_test_no_dup_scaffolding_support_',
+    );
+    addTearDown(() => temp.deleteSync(recursive: true));
+    // The harness itself owns the viewport shell; it must never be flagged
+    // even though its file name does not match the governed family.
+    File('${temp.path}/app/test/support/min_viewport_harness.dart')
+      ..createSync(recursive: true)
+      ..writeAsStringSync('''
+Future<void> pumpAtMinViewport(WidgetTester tester, Size size) async {
+  await tester.binding.setSurfaceSize(size);
+  await tester.pumpWidget(
+    MaterialApp(theme: AppThemes.editorialMonocle),
+  );
+}
+''');
+
+    final code = runCheckAppTestNoDuplicateScaffolding(temp.path);
+    expect(code, 0);
+  });
+
+  test('ignores legitimately distinct helpers outside the 320dp family', () {
+    final temp = Directory.systemTemp.createTempSync(
+      'check_app_test_no_dup_scaffolding_distinct_',
+    );
+    addTearDown(() => temp.deleteSync(recursive: true));
+    // A goldens/mockup test that legitimately forces a surface size and uses
+    // the editorial theme, but is not part of the min-viewport pump family.
+    _writeGovernedFile(
+      temp,
+      'diplomacy_panel_goldens_test.dart',
+      _kReintroducedHelper,
+    );
+
+    final code = runCheckAppTestNoDuplicateScaffolding(temp.path);
+    expect(code, 0);
+  });
+
+  test('reports violations from multiple governed files, sorted', () {
+    final temp = Directory.systemTemp.createTempSync(
+      'check_app_test_no_dup_scaffolding_multi_',
+    );
+    addTearDown(() => temp.deleteSync(recursive: true));
+    _writeGovernedFile(
+      temp,
+      'a_screen_320dp_min_viewport_test.dart',
+      _kReintroducedHelper,
+    );
+    _writeGovernedFile(
+      temp,
+      'b_screen_320dp_min_viewport_test.dart',
+      _kReintroducedHelper,
+    );
+
+    final logs = <String>[];
+    final code = runCheckAppTestNoDuplicateScaffolding(
+      temp.path,
+      info: logs.add,
+      err: logs.add,
+    );
+
+    expect(code, 1);
+    final joined = logs.join('\n');
+    expect(joined, contains('a_screen_320dp_min_viewport_test.dart:'));
+    expect(joined, contains('b_screen_320dp_min_viewport_test.dart:'));
+  });
+}

--- a/tool/check_app_test_no_duplicate_scaffolding.dart
+++ b/tool/check_app_test_no_duplicate_scaffolding.dart
@@ -1,0 +1,178 @@
+import 'dart:io';
+
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/source/line_info.dart';
+import 'package:path/path.dart' as p;
+
+/// PR-blocking dedup gate for the `app` min-viewport test scaffolding (#3730).
+///
+/// The 25 `app/test/*_320dp_min_viewport_test.dart` files previously each
+/// re-declared an identical private `_pump<Thing>AtSize(...)` helper that
+/// repeated the same `setSurfaceSize` + `MaterialApp(theme:
+/// AppThemes.editorialMonocle, home: MediaQuery(...))` viewport shell. That
+/// boilerplate now lives once in `app/test/support/min_viewport_harness.dart`
+/// (`pumpAtMinViewport` / `buildMinViewportApp`). This gate keeps the
+/// duplication from creeping back into that family.
+///
+/// **Scope (deliberately narrow).** Only the `*_320dp_min_viewport_test.dart`
+/// family is governed, so the gate cannot fire on the many legitimately
+/// distinct helpers elsewhere in `app/test/` (golden capture, mockup-fidelity,
+/// widgetbook viewport stories, main-menu responsive `pumpAtSize`, etc.) that
+/// also force a surface size and/or use the editorial theme for unrelated
+/// reasons. The shared harness under `app/test/support/` is always exempt.
+///
+/// **Violations.** Inside a governed file, any of the following is flagged
+/// because it indicates a re-introduced bespoke viewport shell instead of the
+/// shared harness:
+///   1. a function declaration whose name ends with `AtSize` (the
+///      `_pump<Thing>AtSize` signature the harness replaced);
+///   2. a `tester.binding.setSurfaceSize(...)` invocation;
+///   3. a reference to `AppThemes.editorialMonocle`.
+///
+/// Detection is AST-based, so comments and string literals never trigger it.
+int runCheckAppTestNoDuplicateScaffolding(
+  String repoRoot, {
+  void Function(String line)? info,
+  void Function(String line)? err,
+}) {
+  final logI = info ?? stdout.writeln;
+  final logE = err ?? stderr.writeln;
+
+  final appTestDir = Directory(p.join(repoRoot, 'app', 'test'));
+  if (!appTestDir.existsSync()) {
+    logI(
+      'check_app_test_no_duplicate_scaffolding: app/test not found; nothing to '
+      'scan.',
+    );
+    return 0;
+  }
+
+  final violations = <String>[];
+
+  for (final entity in appTestDir.listSync(recursive: true, followLinks: false)) {
+    if (entity is! File) {
+      continue;
+    }
+    final relativePath = p
+        .relative(entity.path, from: repoRoot)
+        .replaceAll('\\', '/');
+    if (!_isGovernedMinViewportFile(relativePath)) {
+      continue;
+    }
+    final content = entity.readAsStringSync();
+    final parsed = parseString(content: content, path: relativePath);
+    final visitor = _ScaffoldingVisitor(
+      relativePath: relativePath,
+      lineInfo: parsed.unit.lineInfo,
+      violations: violations,
+    );
+    parsed.unit.accept(visitor);
+  }
+
+  if (violations.isEmpty) {
+    logI(
+      'check_app_test_no_duplicate_scaffolding: no duplicated min-viewport '
+      'scaffolding found.',
+    );
+    return 0;
+  }
+
+  violations.sort();
+  logE(
+    'check_app_test_no_duplicate_scaffolding: found ${violations.length} '
+    'duplicated-scaffolding violation(s):',
+  );
+  for (final v in violations) {
+    logE(' - $v');
+  }
+  logE(
+    '   Use pumpAtMinViewport / buildMinViewportApp from '
+    'app/test/support/min_viewport_harness.dart instead of re-declaring the '
+    'viewport shell.',
+  );
+  return 1;
+}
+
+/// True for `app/test/**/*_320dp_min_viewport_test.dart`, excluding the shared
+/// harness tree under `app/test/support/` and generated Dart.
+bool _isGovernedMinViewportFile(String relativePath) {
+  if (!relativePath.endsWith('_320dp_min_viewport_test.dart')) {
+    return false;
+  }
+  if (relativePath.startsWith('app/test/support/')) {
+    return false;
+  }
+  if (relativePath.endsWith('.g.dart') ||
+      relativePath.endsWith('.mocks.dart')) {
+    return false;
+  }
+  return true;
+}
+
+class _ScaffoldingVisitor extends RecursiveAstVisitor<void> {
+  _ScaffoldingVisitor({
+    required this.relativePath,
+    required this.lineInfo,
+    required this.violations,
+  });
+
+  final String relativePath;
+  final LineInfo lineInfo;
+  final List<String> violations;
+
+  void _report(int offset, String detail) {
+    final line = lineInfo.getLocation(offset).lineNumber;
+    violations.add('$relativePath:$line: $detail');
+  }
+
+  @override
+  void visitFunctionDeclaration(FunctionDeclaration node) {
+    final name = node.name.lexeme;
+    if (name.endsWith('AtSize')) {
+      _report(
+        node.name.offset,
+        'function "$name" re-declares a per-file min-viewport pump helper',
+      );
+    }
+    super.visitFunctionDeclaration(node);
+  }
+
+  @override
+  void visitMethodInvocation(MethodInvocation node) {
+    if (node.methodName.name == 'setSurfaceSize') {
+      _report(
+        node.methodName.offset,
+        'direct "setSurfaceSize" call duplicates the harness viewport setup',
+      );
+    }
+    super.visitMethodInvocation(node);
+  }
+
+  @override
+  void visitPrefixedIdentifier(PrefixedIdentifier node) {
+    if (node.identifier.name == 'editorialMonocle') {
+      _report(
+        node.offset,
+        'reference to "AppThemes.editorialMonocle" duplicates the harness shell',
+      );
+    }
+    super.visitPrefixedIdentifier(node);
+  }
+
+  @override
+  void visitPropertyAccess(PropertyAccess node) {
+    if (node.propertyName.name == 'editorialMonocle') {
+      _report(
+        node.offset,
+        'reference to "AppThemes.editorialMonocle" duplicates the harness shell',
+      );
+    }
+    super.visitPropertyAccess(node);
+  }
+}
+
+void main() {
+  exit(runCheckAppTestNoDuplicateScaffolding(Directory.current.path));
+}


### PR DESCRIPTION
## Summary
Consolidates the duplicated viewport/pump scaffolding across the `*_320dp_min_viewport_test.dart` family into one shared harness and adds an AST dedup gate so the duplication cannot return. This is the first isolatable slice of #3730 (the min-viewport family + gate); broader `pumpAppShell` consolidation and `partN` family merges are intentionally deferred to follow-up slices.

- **Shared harness** `app/test/support/min_viewport_harness.dart` exposes `pumpAtMinViewport(...)` / `buildMinViewportApp(...)` (surface-size setup, `ProviderScope` overrides, `MaterialApp(AppThemes.editorialMonocle)`, `MediaQuery`, `pump`/`pumpAndSettle` via a `settle` flag), with a small smoke test.
- **All 25** `app/test/*_320dp_min_viewport_test.dart` files migrated to delegate to the harness; every per-file `_pump*AtSize` helper removed. Per-file override lists, child wrappers, and pump/settle semantics (incl. first-frame overflow-assertion two-pump cases) preserved — assertions unchanged.
- **Dedup gate** `tool/check_app_test_no_duplicate_scaffolding.dart` + `test/check_app_test_no_duplicate_scaffolding_test.dart`, modeled on the existing `check_app_no_duplicate_helpers` paired gate. Auto-discovered by the existing `dart test test/check_*_test.dart` step in `quality.yml` (no workflow edit).

## Gate scoping decision
The gate is **scoped to the `*_320dp_min_viewport_test.dart` family only** and excludes `app/test/support/`. Within governed files it flags (AST-based): any `*AtSize` function declaration, any `setSurfaceSize` call, and any `AppThemes.editorialMonocle` reference. This honors the issue's "must not fire on legitimately distinct helpers" constraint — ~24 other `app/test` files (goldens, mockup-fidelity, widgetbook viewport stories, `screen_spec_acceptance`'s `pumpAtSize`) legitimately combine `setSurfaceSize` + the editorial theme and are untouched.

## Acceptance criteria status
- [x] AC1 — harness used by all 25 `*_320dp_min_viewport_test.dart` files; no `_pump*AtSize` remains.
- [x] AC4 — gate added; fails on a reintroduced duplicate helper, passes on the consolidated tree.
- [x] AC5 — migrated suite passes with unchanged assertions.
- [x] AC6 — new `check_*` gate test is green.
- [ ] AC2 (`pumpAppShell` broader families) — deferred follow-up slice.
- [ ] AC3 (`partN` family consolidation) — deferred follow-up slice.

## Test plan
- [x] `dart analyze` clean on all 25 files + harness + gate + gate test.
- [x] `cd app && flutter test test/support/min_viewport_harness_test.dart test/*_320dp_min_viewport_test.dart` → **137 passed**.
- [x] `dart test test/check_app_test_no_duplicate_scaffolding_test.dart` → 5 passed.
- [x] `dart run tool/check_app_test_no_duplicate_scaffolding.dart` → passes on consolidated tree.

Refs #3730

Made with [Cursor](https://cursor.com)