### PR TITLE
refactor: dedup economy int-map accumulators + per-GP treasury credits (#3731)

### DIFF
--- a/packages/colonizethis_economy/lib/src/economy/commodity_totals.dart
+++ b/packages/colonizethis_economy/lib/src/economy/commodity_totals.dart
@@ -1,0 +1,55 @@
+/// Library-internal integer-map accumulation and value-sum helpers (Refs
+/// #3731).
+///
+/// These tiny pure functions centralize the two arithmetic micro-idioms that
+/// were re-written inline across the economy package's extraction, production,
+/// transport, and world-market helpers:
+///
+/// - the `m[k] = (m[k] ?? 0) + v` accumulation idiom, and
+/// - the `iterable.fold<int>(0, (a, b) => a + b)` value-sum idiom (including
+///   the nested map-of-maps sum used by the extraction debug logs).
+///
+/// They preserve the exact integer arithmetic and insertion order of the
+/// original inline call sites, stay allocation-neutral, and perform no logging
+/// or `Game` access, so they remain safe inside the 15-second
+/// next-turn-resolution budget per `SPEC/program/turn-resolution-phases.md`
+/// § Determinism.
+///
+/// Intentionally **not** exported from `colonizethis_economy.dart`: this is an
+/// internal seam, consumed only by sibling `lib/src/economy/**` sources.
+library;
+
+/// Adds [delta] to the running integer total for [key] in [into], creating the
+/// entry (starting from `0`) on first use.
+///
+/// Equivalent to the inline `into[key] = (into[key] ?? 0) + delta;` idiom, with
+/// identical insertion-order semantics (a key first seen here is appended in
+/// encounter order). Callers keep their own positivity/skip guards (for example
+/// `if (delta <= 0) continue;`) — this helper does not filter.
+void addUnits<K>(Map<K, int> into, K key, int delta) {
+  into[key] = (into[key] ?? 0) + delta;
+}
+
+/// Sums [values] as integers, returning `0` for an empty iterable.
+///
+/// Equivalent to `values.fold<int>(0, (a, b) => a + b)`.
+int sumValues(Iterable<int> values) {
+  var total = 0;
+  for (final v in values) {
+    total += v;
+  }
+  return total;
+}
+
+/// Sums every integer value across the nested [maps], returning `0` when there
+/// are no entries.
+///
+/// Equivalent to `maps.fold<int>(0, (s, m) => s + sumValues(m.values))`; used by
+/// the extraction debug-log roll-ups that total a `Map<_, Map<_, int>>`.
+int sumNestedValues<K>(Iterable<Map<K, int>> maps) {
+  var total = 0;
+  for (final m in maps) {
+    total += sumValues(m.values);
+  }
+  return total;
+}

--- a/packages/colonizethis_economy/lib/src/economy/economy_extraction.dart
+++ b/packages/colonizethis_economy/lib/src/economy/economy_extraction.dart
@@ -3,6 +3,8 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'package:colonizethis_world/colonizethis_world.dart';
 
+import 'commodity_totals.dart';
+
 /// Extraction and auto-transport helpers.
 /// SPEC/game/extraction-and-improvements.md
 /// SPEC/game/stockpiles-and-production.md
@@ -25,7 +27,7 @@ void logExtractionAutoTransportLand(
   Map<CommodityId, int> land,
 ) {
   if (land.isEmpty) return;
-  final totalUnits = land.values.fold<int>(0, (a, b) => a + b);
+  final totalUnits = sumValues(land.values);
   final detail = land.entries.map((e) => '${e.key}=${e.value}').join(',');
   economyLog.d(
     'extraction auto_transport land playerId=$playerId totalUnits=$totalUnits detail=$detail',

--- a/packages/colonizethis_economy/lib/src/economy/economy_production.dart
+++ b/packages/colonizethis_economy/lib/src/economy/economy_production.dart
@@ -2,6 +2,8 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_economy/src/logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
+import 'commodity_totals.dart';
+
 /// Production resolution helpers.
 /// SPEC/game/production-recipes.md
 /// SPEC/game/workers-and-population.md
@@ -62,7 +64,7 @@ Map<CommodityId, int> productionInputConsumptionByCommodityIdForAssignments(
     for (final entry in recipe.inputQuantities.entries) {
       final consumed = entry.value * runs;
       if (consumed <= 0) continue;
-      consumption[entry.key] = (consumption[entry.key] ?? 0) + consumed;
+      addUnits(consumption, entry.key, consumed);
     }
   }
   return consumption;
@@ -151,8 +153,7 @@ ProductionResult resolveProduction({
       remainingEffectiveLabour = 0;
     }
 
-    productionByRecipe[assignment.recipeId] =
-        (productionByRecipe[assignment.recipeId] ?? 0) + runs;
+    addUnits(productionByRecipe, assignment.recipeId, runs);
 
     // Deduct inputs.
     for (final entry in recipe.inputQuantities.entries) {

--- a/packages/colonizethis_economy/lib/src/economy/non_gp_extraction.dart
+++ b/packages/colonizethis_economy/lib/src/economy/non_gp_extraction.dart
@@ -2,6 +2,7 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_world/colonizethis_world.dart';
 
+import 'commodity_totals.dart';
 import 'game_lookup_helpers.dart';
 import 'non_gp_extraction_shared.dart';
 import 'package:colonizethis_economy/src/logging.dart';
@@ -76,8 +77,7 @@ Map<String, Map<CommodityId, int>> computeNonGreatPowerExtraction({
             provincesByFullId: provincesByFullId,
             sortTileKeys: false,
             onContribution: (tileKey, contribution) {
-              totals[contribution.commodityId] =
-                  (totals[contribution.commodityId] ?? 0) + contribution.units;
+              addUnits(totals, contribution.commodityId, contribution.units);
             },
           );
           if (totals.isNotEmpty) {
@@ -86,10 +86,7 @@ Map<String, Map<CommodityId, int>> computeNonGreatPowerExtraction({
         },
   );
 
-  final totalUnits = out.values.fold<int>(
-    0,
-    (s, m) => s + m.values.fold(0, (a, b) => a + b),
-  );
+  final totalUnits = sumNestedValues(out.values);
   economyLog.d(
     'non_gp_extraction compute end factions=${out.length} totalUnits=$totalUnits',
   );

--- a/packages/colonizethis_economy/lib/src/economy/resource_extractor.dart
+++ b/packages/colonizethis_economy/lib/src/economy/resource_extractor.dart
@@ -2,6 +2,7 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_economy/src/logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
+import 'commodity_totals.dart';
 import 'economy_resource_constants.dart';
 import 'game_lookup_helpers.dart';
 import 'tile_extraction_pipeline.dart';
@@ -95,19 +96,16 @@ Map<String, ExtractionTotals> computeExtraction({
       }
 
       if (contribution.isLandRelativeToCapital) {
-        landTotals[contribution.commodityId] =
-            (landTotals[contribution.commodityId] ?? 0) + contribution.units;
+        addUnits(landTotals, contribution.commodityId, contribution.units);
       } else {
-        overseasTotals[contribution.commodityId] =
-            (overseasTotals[contribution.commodityId] ?? 0) +
-            contribution.units;
+        addUnits(overseasTotals, contribution.commodityId, contribution.units);
       }
     }
 
     final capBonus = game.capitalTileGrainBonusPerTurn;
     if (player.capitalTile != null && capBonus > 0) {
       final grainId = CommodityCatalog.grain.id;
-      landTotals[grainId] = (landTotals[grainId] ?? 0) + capBonus;
+      addUnits(landTotals, grainId, capBonus);
     }
 
     out[player.id] = ExtractionTotals(
@@ -115,14 +113,8 @@ Map<String, ExtractionTotals> computeExtraction({
       overseas: overseasTotals,
     );
   }
-  final landSum = out.values.fold<int>(
-    0,
-    (s, t) => s + t.land.values.fold(0, (a, b) => a + b),
-  );
-  final overseasSum = out.values.fold<int>(
-    0,
-    (s, t) => s + t.overseas.values.fold(0, (a, b) => a + b),
-  );
+  final landSum = sumNestedValues(out.values.map((t) => t.land));
+  final overseasSum = sumNestedValues(out.values.map((t) => t.overseas));
   economyLog.d(
     'extraction compute end players=${out.length} landTotal=$landSum overseasTotal=$overseasSum',
   );

--- a/packages/colonizethis_economy/lib/src/economy/sea_transport.dart
+++ b/packages/colonizethis_economy/lib/src/economy/sea_transport.dart
@@ -4,6 +4,8 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'package:colonizethis_world/colonizethis_world.dart';
 
+import 'commodity_totals.dart';
+
 /// Sea transport: allocate overseas extraction to stockpile by priority. SPEC/program/auto-transport.
 ///
 /// Phase 2: cargo holds derived from home fleet (with stub fallback). Fill by priority until cap; rest left behind.
@@ -47,7 +49,7 @@ Map<CommodityId, int> allocateOverseasToStockpile(
       if (available <= 0) continue;
       final take = available < spaceLeft ? available : spaceLeft;
       if (take <= 0) continue;
-      delivered[id] = (delivered[id] ?? 0) + take;
+      addUnits(delivered, id, take);
       remaining[id] = available - take;
       spaceLeft -= take;
     }
@@ -66,14 +68,8 @@ void logExtractionAutoTransportOverseasAllocation({
 }) {
   if (overseasTotals.isEmpty) return;
   if (economyDebugLogSuppressed) return;
-  final overseasTotalUnits = overseasTotals.values.fold<int>(
-    0,
-    (a, b) => a + b,
-  );
-  final allocatedUnits = allocatedToStockpile.values.fold<int>(
-    0,
-    (a, b) => a + b,
-  );
+  final overseasTotalUnits = sumValues(overseasTotals.values);
+  final allocatedUnits = sumValues(allocatedToStockpile.values);
   final detail = allocatedToStockpile.entries
       .map((e) => '${e.key}=${e.value}')
       .join(',');

--- a/packages/colonizethis_economy/lib/src/economy/trade_interception.dart
+++ b/packages/colonizethis_economy/lib/src/economy/trade_interception.dart
@@ -4,6 +4,7 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'package:colonizethis_world/colonizethis_world.dart';
 
+import 'commodity_totals.dart';
 import 'trade_interception_constants.dart';
 import 'trade_interception_scan.dart';
 
@@ -34,8 +35,8 @@ void _logExtractionAutoTransportInterception(
   Map<CommodityId, int> after,
 ) {
   if (economyDebugLogSuppressed) return;
-  final beforeUnits = before.values.fold<int>(0, (s, v) => s + v);
-  final afterUnits = after.values.fold<int>(0, (s, v) => s + v);
+  final beforeUnits = sumValues(before.values);
+  final afterUnits = sumValues(after.values);
   final ids = {...before.keys, ...after.keys};
   final deltas = <String>[];
   for (final id in ids) {

--- a/packages/colonizethis_economy/lib/src/economy/world_market/first_right_credits.dart
+++ b/packages/colonizethis_economy/lib/src/economy/world_market/first_right_credits.dart
@@ -39,6 +39,7 @@ library;
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'first_right_profit.dart';
+import 'gp_treasury_credit_accumulator.dart';
 import 'purchased_tile_index.dart';
 
 /// Per-deal credit record produced by [computeFirstRightCredits].
@@ -112,7 +113,8 @@ class FirstRightCreditsResult {
   const FirstRightCreditsResult({
     required this.creditedDeals,
     required this.treasuryCreditByGpId,
-  });
+    double? totalProfitTreasury,
+  }) : _totalProfitTreasury = totalProfitTreasury;
 
   /// Empty result. Returned when the input deal list is empty, the
   /// purchased-tile index is empty, or no deal is FRR-eligible.
@@ -120,6 +122,11 @@ class FirstRightCreditsResult {
     creditedDeals: <FirstRightDealCredit>[],
     treasuryCreditByGpId: <String, double>{},
   );
+
+  /// Precomputed grand total from the shared accumulator, when constructed via
+  /// [computeFirstRightCredits]. `null` for hand-built results (for example the
+  /// [empty] sentinel), which fall back to summing [treasuryCreditByGpId].
+  final double? _totalProfitTreasury;
 
   /// Per-deal credit records in matcher emission order (deals without
   /// a non-zero `profitTreasury` are still included so callers can
@@ -133,7 +140,13 @@ class FirstRightCreditsResult {
   /// Convenience: total overseas-profit treasury credited across every
   /// owning GP for this aggregation. Phase handlers and observer
   /// traces use this for top-line economic accounting.
+  ///
+  /// O(1) when produced by [computeFirstRightCredits] (the
+  /// [GpTreasuryCreditAccumulator] maintains the total incrementally); falls
+  /// back to re-summing [treasuryCreditByGpId] for hand-built results.
   double get totalProfitTreasury {
+    final cached = _totalProfitTreasury;
+    if (cached != null) return cached;
     var total = 0.0;
     for (final amount in treasuryCreditByGpId.values) {
       total += amount;
@@ -188,7 +201,7 @@ FirstRightCreditsResult computeFirstRightCredits({
   if (dealsList.isEmpty) return FirstRightCreditsResult.empty;
 
   final creditedDeals = <FirstRightDealCredit>[];
-  final treasuryByGp = <String, double>{};
+  final treasuryByGp = GpTreasuryCreditAccumulator<double>(0.0);
 
   for (final deal in dealsList) {
     final tileKey = deal.sellerOriginTileKey;
@@ -220,16 +233,16 @@ FirstRightCreditsResult computeFirstRightCredits({
       ),
     );
     if (profit.profitTreasury > 0.0) {
-      treasuryByGp[owningGpId] =
-          (treasuryByGp[owningGpId] ?? 0.0) + profit.profitTreasury;
+      treasuryByGp.add(owningGpId, profit.profitTreasury);
     } else {
-      treasuryByGp.putIfAbsent(owningGpId, () => 0.0);
+      treasuryByGp.ensure(owningGpId);
     }
   }
 
   if (creditedDeals.isEmpty) return FirstRightCreditsResult.empty;
   return FirstRightCreditsResult(
     creditedDeals: List.unmodifiable(creditedDeals),
-    treasuryCreditByGpId: Map.unmodifiable(treasuryByGp),
+    treasuryCreditByGpId: treasuryByGp.view,
+    totalProfitTreasury: treasuryByGp.total,
   );
 }

--- a/packages/colonizethis_economy/lib/src/economy/world_market/gp_treasury_credit_accumulator.dart
+++ b/packages/colonizethis_economy/lib/src/economy/world_market/gp_treasury_credit_accumulator.dart
@@ -1,0 +1,64 @@
+/// Shared per-owning-Great-Power treasury-credit accumulator (Refs #3731).
+///
+/// Backs the near-identical "per-GP treasury credit" roll-up previously
+/// duplicated between First-Right-of-Refusal credits
+/// ([first_right_credits.dart], `double`) and purchased-tile riches
+/// ([purchased_tile_riches.dart], `int`). It owns the insertion-ordered
+/// `byGp` map, maintains the grand total **incrementally** (O(1) read instead
+/// of re-summing the map on every access), and exposes an explicit
+/// [ensure] op so the FRR audit-trail behavior — recording a `0` entry for an
+/// FRR-eligible but zero-profit deal — is preserved exactly.
+///
+/// Determinism: entries appear in the order each GP id is first seen; the
+/// arithmetic is the same integer/double addition as the inline loops it
+/// replaces. No logging, RNG, or `Game` access — safe inside the 15-second
+/// next-turn-resolution budget per `SPEC/program/turn-resolution-phases.md`
+/// § Determinism.
+///
+/// Intentionally **not** exported from `colonizethis_economy.dart`: an internal
+/// seam consumed by the two world-market result helpers only.
+library;
+
+/// Insertion-ordered accumulator of treasury credits keyed by owning GP id.
+///
+/// [T] is the credit's numeric type (`double` for FRR overseas-profit credits,
+/// `int` for purchased-tile riches). The accumulator never introduces implicit
+/// `dynamic` and never changes precision: it adds `T` deltas and stores `T`
+/// values throughout.
+class GpTreasuryCreditAccumulator<T extends num> {
+  /// Creates an empty accumulator. [zero] is the additive identity for [T]
+  /// (`0` for `int`, `0.0` for `double`); it seeds both new map entries and
+  /// the running [total].
+  GpTreasuryCreditAccumulator(T zero) : _zero = zero, _total = zero;
+
+  final T _zero;
+  final Map<String, T> _byGp = <String, T>{};
+  T _total;
+
+  /// Adds [delta] to [gpId]'s running credit, creating the entry (from [zero])
+  /// on first use, and updates the incrementally-maintained [total].
+  void add(String gpId, T delta) {
+    _byGp[gpId] = ((_byGp[gpId] ?? _zero) + delta) as T;
+    _total = (_total + delta) as T;
+  }
+
+  /// Ensures [gpId] has an entry (value [zero]) without changing [total].
+  ///
+  /// Preserves the FRR zero-profit audit trail: an FRR-eligible deal whose
+  /// profit is `0` still records the owning GP so callers can surface every
+  /// eligible deal. A no-op when [gpId] already has an entry.
+  void ensure(String gpId) {
+    _byGp.putIfAbsent(gpId, () => _zero);
+  }
+
+  /// Unmodifiable view of the per-GP credits in first-seen insertion order.
+  Map<String, T> get view => Map<String, T>.unmodifiable(_byGp);
+
+  /// Running grand total across all GP credits, maintained incrementally so
+  /// reads are O(1). Equals the naive `view.values` re-sum, including the
+  /// zero-valued [ensure] entries (which contribute `0`).
+  T get total => _total;
+
+  /// True when no GP credit has been recorded (via [add] or [ensure]).
+  bool get isEmpty => _byGp.isEmpty;
+}

--- a/packages/colonizethis_economy/lib/src/economy/world_market/purchased_tile_riches.dart
+++ b/packages/colonizethis_economy/lib/src/economy/world_market/purchased_tile_riches.dart
@@ -38,6 +38,7 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import '../game_lookup_helpers.dart';
 import '../tile_extraction_pipeline.dart';
 import '../tile_extraction_yield.dart';
+import 'gp_treasury_credit_accumulator.dart';
 import 'purchased_tile_index.dart';
 
 /// Sentinel town-development cap passed to [computeEffectiveTileYield] from the
@@ -109,7 +110,8 @@ class PurchasedTileRichesResult {
   const PurchasedTileRichesResult({
     required this.credits,
     required this.treasuryCreditByGpId,
-  });
+    int? totalTreasuryCredit,
+  }) : _totalTreasuryCredit = totalTreasuryCredit;
 
   /// Empty result. Returned when the purchased-tile index is empty,
   /// `tileMapByRegion` is empty, or no purchased tile resolves to a
@@ -118,6 +120,12 @@ class PurchasedTileRichesResult {
     credits: <PurchasedTileRichesCredit>[],
     treasuryCreditByGpId: <String, int>{},
   );
+
+  /// Precomputed grand total from the shared accumulator, when constructed via
+  /// [computePurchasedTileRichesCredits]. `null` for hand-built results (for
+  /// example the [empty] sentinel), which fall back to summing
+  /// [treasuryCreditByGpId].
+  final int? _totalTreasuryCredit;
 
   /// Per-tile credit records (same order as
   /// [PurchasedTileIndex.attributions]).
@@ -130,7 +138,13 @@ class PurchasedTileRichesResult {
 
   /// Convenience: total treasury credited across every owning GP for
   /// this aggregation.
+  ///
+  /// O(1) when produced by [computePurchasedTileRichesCredits] (the
+  /// [GpTreasuryCreditAccumulator] maintains the total incrementally); falls
+  /// back to re-summing [treasuryCreditByGpId] for hand-built results.
   int get totalTreasuryCredit {
+    final cached = _totalTreasuryCredit;
+    if (cached != null) return cached;
     var total = 0;
     for (final amount in treasuryCreditByGpId.values) {
       total += amount;
@@ -182,7 +196,7 @@ PurchasedTileRichesResult computePurchasedTileRichesCredits({
   final tileState = game.worldState.tileState;
 
   final credits = <PurchasedTileRichesCredit>[];
-  final treasuryByGp = <String, int>{};
+  final treasuryByGp = GpTreasuryCreditAccumulator<int>(0);
 
   // Sort attributions by tileKey for deterministic emission order
   // independent of the index's underlying map iteration order.
@@ -236,13 +250,13 @@ PurchasedTileRichesResult computePurchasedTileRichesCredits({
         treasuryDelta: treasuryDelta,
       ),
     );
-    treasuryByGp[attribution.owningGpId] =
-        (treasuryByGp[attribution.owningGpId] ?? 0) + treasuryDelta;
+    treasuryByGp.add(attribution.owningGpId, treasuryDelta);
   }
 
   if (credits.isEmpty) return PurchasedTileRichesResult.empty;
   return PurchasedTileRichesResult(
     credits: List<PurchasedTileRichesCredit>.unmodifiable(credits),
-    treasuryCreditByGpId: Map<String, int>.unmodifiable(treasuryByGp),
+    treasuryCreditByGpId: treasuryByGp.view,
+    totalTreasuryCredit: treasuryByGp.total,
   );
 }

--- a/packages/colonizethis_economy/lib/src/economy/world_market/sellable_quantity.dart
+++ b/packages/colonizethis_economy/lib/src/economy/world_market/sellable_quantity.dart
@@ -16,6 +16,7 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_world/colonizethis_world.dart'
     show GamePlayerLookup;
 
+import '../commodity_totals.dart' show addUnits;
 import 'trade_order_admission.dart' show isWorldMarketTradeableCommodity;
 
 /// Per-commodity offer cap for [playerId] in [game].
@@ -95,7 +96,7 @@ Map<CommodityId, int> stagedOfferQuantitiesByCommodityId({
   for (final TradeOrder o in list) {
     if (o.type != TradeOrderType.offer) continue;
     if (o.quantity <= 0) continue;
-    byCommodity[o.commodityId] = (byCommodity[o.commodityId] ?? 0) + o.quantity;
+    addUnits(byCommodity, o.commodityId, o.quantity);
   }
   return byCommodity;
 }

--- a/packages/colonizethis_economy/test/economy/commodity_totals_test.dart
+++ b/packages/colonizethis_economy/test/economy/commodity_totals_test.dart
@@ -1,5 +1,5 @@
 import 'package:colonizethis_economy/src/economy/commodity_totals.dart';
-import 'package:test/test.dart';
+import 'package:colonizethis_test/test.dart';
 
 void main() {
   group('addUnits', () {

--- a/packages/colonizethis_economy/test/economy/commodity_totals_test.dart
+++ b/packages/colonizethis_economy/test/economy/commodity_totals_test.dart
@@ -1,0 +1,68 @@
+import 'package:colonizethis_economy/src/economy/commodity_totals.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('addUnits', () {
+    test('creates a new entry starting from zero', () {
+      final m = <String, int>{};
+      addUnits(m, 'a', 3);
+      expect(m, {'a': 3});
+    });
+
+    test('accumulates onto an existing entry', () {
+      final m = <String, int>{'a': 3};
+      addUnits(m, 'a', 4);
+      expect(m['a'], 7);
+    });
+
+    test('preserves first-seen insertion order across keys', () {
+      final m = <String, int>{};
+      addUnits(m, 'b', 1);
+      addUnits(m, 'a', 1);
+      addUnits(m, 'b', 1);
+      expect(m.keys.toList(), ['b', 'a']);
+      expect(m, {'b': 2, 'a': 1});
+    });
+
+    test('does not filter zero or negative deltas (caller guards)', () {
+      final m = <String, int>{'a': 5};
+      addUnits(m, 'a', 0);
+      addUnits(m, 'a', -2);
+      addUnits(m, 'z', -1);
+      expect(m, {'a': 3, 'z': -1});
+    });
+  });
+
+  group('sumValues', () {
+    test('returns 0 for an empty iterable', () {
+      expect(sumValues(const <int>[]), 0);
+    });
+
+    test('sums positive and negative values', () {
+      expect(sumValues(const [1, 2, 3]), 6);
+      expect(sumValues(const [5, -2, -1]), 2);
+    });
+
+    test('matches the inline fold idiom it replaces', () {
+      const values = [4, 8, 15, 16, 23, 42];
+      expect(sumValues(values), values.fold<int>(0, (a, b) => a + b));
+    });
+  });
+
+  group('sumNestedValues', () {
+    test('returns 0 for no maps and for empty maps', () {
+      expect(sumNestedValues(const <Map<String, int>>[]), 0);
+      expect(sumNestedValues(const [<String, int>{}, <String, int>{}]), 0);
+    });
+
+    test('sums every value across nested maps', () {
+      final maps = [
+        {'a': 1, 'b': 2},
+        {'a': 3},
+        <String, int>{},
+        {'c': 4},
+      ];
+      expect(sumNestedValues(maps), 10);
+    });
+  });
+}

--- a/packages/colonizethis_economy/test/economy/world_market/gp_treasury_credit_accumulator_test.dart
+++ b/packages/colonizethis_economy/test/economy/world_market/gp_treasury_credit_accumulator_test.dart
@@ -1,0 +1,75 @@
+import 'package:colonizethis_economy/src/economy/world_market/gp_treasury_credit_accumulator.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('GpTreasuryCreditAccumulator<int>', () {
+    test('starts empty with a zero total', () {
+      final acc = GpTreasuryCreditAccumulator<int>(0);
+      expect(acc.isEmpty, isTrue);
+      expect(acc.total, 0);
+      expect(acc.view, isEmpty);
+    });
+
+    test('add creates and accumulates entries, total stays incremental', () {
+      final acc = GpTreasuryCreditAccumulator<int>(0)
+        ..add('gpA', 10)
+        ..add('gpB', 5)
+        ..add('gpA', 3);
+      expect(acc.view, {'gpA': 13, 'gpB': 5});
+      expect(acc.total, 18);
+      expect(acc.isEmpty, isFalse);
+    });
+
+    test('view preserves first-seen insertion order', () {
+      final acc = GpTreasuryCreditAccumulator<int>(0)
+        ..add('gpC', 1)
+        ..add('gpA', 1)
+        ..add('gpB', 1)
+        ..add('gpA', 1);
+      expect(acc.view.keys.toList(), ['gpC', 'gpA', 'gpB']);
+    });
+
+    test('view is unmodifiable', () {
+      final acc = GpTreasuryCreditAccumulator<int>(0)..add('gpA', 1);
+      expect(() => acc.view['gpB'] = 2, throwsUnsupportedError);
+    });
+
+    test('incremental total equals the naive re-summed view total', () {
+      final acc = GpTreasuryCreditAccumulator<int>(0)
+        ..add('gpA', 7)
+        ..add('gpB', 11)
+        ..add('gpA', 2);
+      final naive = acc.view.values.fold<int>(0, (a, b) => a + b);
+      expect(acc.total, naive);
+    });
+  });
+
+  group('GpTreasuryCreditAccumulator<double> (FRR zero-profit semantics)', () {
+    test('ensure records a zero entry without changing the total', () {
+      final acc = GpTreasuryCreditAccumulator<double>(0.0)
+        ..add('gpA', 40.0)
+        ..ensure('gpB');
+      expect(acc.view, {'gpA': 40.0, 'gpB': 0.0});
+      expect(acc.total, 40.0);
+    });
+
+    test('ensure is a no-op when the key already has a credit', () {
+      final acc = GpTreasuryCreditAccumulator<double>(0.0)
+        ..add('gpA', 12.5)
+        ..ensure('gpA');
+      expect(acc.view, {'gpA': 12.5});
+      expect(acc.total, 12.5);
+    });
+
+    test('total matches naive re-sum including a zero-profit entry', () {
+      final acc = GpTreasuryCreditAccumulator<double>(0.0)
+        ..add('gpA', 4.6)
+        ..add('gpB', 40.0)
+        ..ensure('gpC')
+        ..add('gpA', 0.4);
+      final naive = acc.view.values.fold<double>(0.0, (a, b) => a + b);
+      expect(acc.total, closeTo(naive, 1e-12));
+      expect(acc.view['gpC'], 0.0);
+    });
+  });
+}

--- a/packages/colonizethis_economy/test/economy/world_market/gp_treasury_credit_accumulator_test.dart
+++ b/packages/colonizethis_economy/test/economy/world_market/gp_treasury_credit_accumulator_test.dart
@@ -1,5 +1,5 @@
 import 'package:colonizethis_economy/src/economy/world_market/gp_treasury_credit_accumulator.dart';
-import 'package:test/test.dart';
+import 'package:colonizethis_test/test.dart';
 
 void main() {
   group('GpTreasuryCreditAccumulator<int>', () {

--- a/test/check_economy_dedup_credit_aggregation_test.dart
+++ b/test/check_economy_dedup_credit_aggregation_test.dart
@@ -1,0 +1,127 @@
+// Refs #3731 — guards `repo.economy_dedup_credit_aggregation` enforcement.
+
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+import '../tool/check_economy_dedup_credit_aggregation.dart';
+
+void main() {
+  group('findEconomyDedupCreditAggregationViolations', () {
+    const frrPath =
+        'packages/colonizethis_economy/lib/src/economy/world_market/first_right_credits.dart';
+    const richesPath =
+        'packages/colonizethis_economy/lib/src/economy/world_market/purchased_tile_riches.dart';
+
+    String compliant(String body) =>
+        'final acc = GpTreasuryCreditAccumulator<int>(0);\n$body\n';
+
+    test('accepts files that delegate to the shared accumulator', () {
+      final violations = findEconomyDedupCreditAggregationViolations(
+        sourcesByPath: {
+          frrPath: compliant('acc.add(gpId, delta);'),
+          richesPath: compliant('acc.ensure(gpId);'),
+        },
+      );
+      expect(violations, isEmpty);
+    });
+
+    test('flags a re-inlined single-line per-GP accumulation (int zero)', () {
+      const src = '''
+final byGp = <String, int>{};
+byGp[gpId] = (byGp[gpId] ?? 0) + delta;
+''';
+      final violations = findEconomyDedupCreditAggregationViolations(
+        sourcesByPath: {frrPath: src},
+      );
+      // Inline loop + missing accumulator reference => two violations.
+      expect(violations, hasLength(2));
+      expect(
+        violations.map((v) => v.message).join('\n'),
+        contains('GpTreasuryCreditAccumulator'),
+      );
+    });
+
+    test('flags the two-line split accumulation (double zero) form', () {
+      final src = compliant('''
+treasuryByGp[owningGpId] =
+    (treasuryByGp[owningGpId] ?? 0.0) + profit.profitTreasury;''');
+      final violations = findEconomyDedupCreditAggregationViolations(
+        sourcesByPath: {richesPath: src},
+      );
+      expect(violations, hasLength(1));
+      expect(violations.single.message, contains('Re-inlined'));
+    });
+
+    test('flags a file that abandons the shared accumulator reference', () {
+      const src = 'final byGp = <String, int>{};\n';
+      final violations = findEconomyDedupCreditAggregationViolations(
+        sourcesByPath: {frrPath: src},
+      );
+      expect(violations, hasLength(1));
+      expect(violations.single.message, contains('Missing reference'));
+    });
+
+    test('only checks the two target files', () {
+      const otherPath =
+          'packages/colonizethis_economy/lib/src/economy/sea_transport.dart';
+      const src = 'delivered[id] = (delivered[id] ?? 0) + take;\n';
+      final violations = findEconomyDedupCreditAggregationViolations(
+        sourcesByPath: const {otherPath: src},
+      );
+      expect(violations, isEmpty);
+    });
+
+    test('passes on the live economy source tree', () {
+      final code = runCheckEconomyDedupCreditAggregation(
+        _repoRoot(),
+        info: (_) {},
+        err: (_) {},
+      );
+      expect(code, 0);
+    });
+
+    test('runCheck returns 1 on a temp tree with a reintroduced loop', () {
+      final temp = Directory.systemTemp.createTempSync('econ_credit_dedup_');
+      addTearDown(() => temp.deleteSync(recursive: true));
+      final wm = Directory(
+        p.join(
+          temp.path,
+          'packages/colonizethis_economy/lib/src/economy/world_market',
+        ),
+      )..createSync(recursive: true);
+      File(p.join(wm.path, 'first_right_credits.dart')).writeAsStringSync(
+        'final byGp = <String, double>{};\n'
+        'byGp[gpId] = (byGp[gpId] ?? 0.0) + profit;\n',
+      );
+      File(p.join(wm.path, 'purchased_tile_riches.dart')).writeAsStringSync(
+        'final acc = GpTreasuryCreditAccumulator<int>(0);\n'
+        'acc.add(gpId, delta);\n',
+      );
+      final errLogs = <String>[];
+      final code = runCheckEconomyDedupCreditAggregation(
+        temp.path,
+        info: (_) {},
+        err: errLogs.add,
+      );
+      expect(code, 1);
+      expect(errLogs.join('\n'), contains('first_right_credits.dart'));
+    });
+  });
+}
+
+String _repoRoot() {
+  var dir = Directory.current;
+  while (true) {
+    final manifest = File(
+      p.join(dir.path, 'tool', 'ct_repo_lint_manifest.yaml'),
+    );
+    if (manifest.existsSync()) return dir.path;
+    final parent = dir.parent;
+    if (parent.path == dir.path) {
+      return Directory.current.path;
+    }
+    dir = parent;
+  }
+}

--- a/tool/check_economy_dedup_credit_aggregation.dart
+++ b/tool/check_economy_dedup_credit_aggregation.dart
@@ -1,0 +1,149 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+/// SPEC: SPEC/program/repo-lint.md (Refs #3731).
+///
+/// Guards the deduplicated per-owning-Great-Power treasury-credit aggregation
+/// in the economy package. The shared
+/// `GpTreasuryCreditAccumulator<T extends num>`
+/// (`world_market/gp_treasury_credit_accumulator.dart`) is the single canonical
+/// home of the insertion-ordered `byGp` roll-up; it was extracted to remove the
+/// two independent inline `byGp[gp] = (byGp[gp] ?? 0) + delta` loops that
+/// `first_right_credits.dart` (`double` credits) and `purchased_tile_riches.dart`
+/// (`int` credits) previously re-implemented.
+///
+/// This rule fails when either of those two files:
+///   1. re-introduces the inline per-GP accumulation
+///      (`<map>[<key>] = (<map>[<key>] ?? 0) + ...`, `?? 0.0` variant included),
+///      tolerant of whitespace and a single line break so reformatting cannot
+///      defeat the gate, or
+///   2. no longer references the shared `GpTreasuryCreditAccumulator` (which
+///      would mean the helper was abandoned for a bespoke roll-up).
+///
+/// Detection is path-scoped to exactly the two files (one concern, fast). The
+/// Theme A `(map[..] ?? 0) +` micro-idiom is deliberately **not** gated here:
+/// a blanket ban is false-positive-prone and low-value, so `dart analyze`, the
+/// `commodity_totals.dart` unit tests, and code review cover it instead.
+const _economyLibDir = 'packages/colonizethis_economy/lib';
+
+/// The two world-market result helpers required to delegate to the shared
+/// accumulator, relative to the repo root.
+const _targetRelativePaths = <String>[
+  'packages/colonizethis_economy/lib/src/economy/world_market/first_right_credits.dart',
+  'packages/colonizethis_economy/lib/src/economy/world_market/purchased_tile_riches.dart',
+];
+
+/// Symbol every target file must reference (the shared accumulator type).
+const _requiredSymbol = 'GpTreasuryCreditAccumulator';
+
+/// Matches the inline per-GP accumulation `<x>[<k>] = (<x>[<k>] ?? 0) + …`,
+/// tolerant of whitespace and a single newline (`[\s\S]{0,40}?`) so the
+/// original two-line split form is still detected. The `0` / `0.0` zero literal
+/// keeps the pattern specific to a zero-seeded running-total loop.
+final RegExp _bannedInlineAccumulation = RegExp(
+  r'\[[^\]]+\]\s*=\s*\([\s\S]{0,40}?\[[^\]]+\]\s*\?\?\s*0(?:\.0)?\s*\)\s*\+',
+);
+
+void main() {
+  exit(runCheckEconomyDedupCreditAggregation(Directory.current.path));
+}
+
+/// Used by `ct_repo_lint` in-process; [info] / [err] default to stdout/stderr.
+int runCheckEconomyDedupCreditAggregation(
+  String repoRoot, {
+  void Function(String line)? info,
+  void Function(String line)? err,
+}) {
+  final logI = info ?? stdout.writeln;
+  final logE = err ?? stderr.writeln;
+  final root = p.normalize(repoRoot);
+  final dir = Directory(p.join(root, _economyLibDir));
+  if (!dir.existsSync()) {
+    logI('Economy dedup credit-aggregation check skipped (economy lib absent).');
+    return 0;
+  }
+
+  final sourcesByPath = <String, String>{};
+  for (final relative in _targetRelativePaths) {
+    final file = File(p.join(root, relative));
+    if (file.existsSync()) {
+      sourcesByPath[relative] = file.readAsStringSync();
+    }
+  }
+
+  final violations = findEconomyDedupCreditAggregationViolations(
+    sourcesByPath: sourcesByPath,
+  );
+
+  if (violations.isEmpty) {
+    logI('Economy dedup credit-aggregation check passed.');
+    return 0;
+  }
+
+  logE(
+    'ERROR: economy per-GP treasury-credit aggregation must use the shared '
+    'GpTreasuryCreditAccumulator from '
+    'world_market/gp_treasury_credit_accumulator.dart instead of an inline '
+    'byGp[gp] = (byGp[gp] ?? 0) + delta loop (Refs #3731).',
+  );
+  for (final v in violations) {
+    logE('${v.path}:${v.line} ${v.message}');
+  }
+  return 1;
+}
+
+/// Scans [sourcesByPath] (relative path -> source) for the two violation
+/// classes: a re-inlined per-GP accumulation loop, or a missing reference to
+/// the shared [_requiredSymbol]. Only the [_targetRelativePaths] entries that
+/// are present in [sourcesByPath] are checked.
+List<EconomyDedupCreditAggregationViolation>
+findEconomyDedupCreditAggregationViolations({
+  required Map<String, String> sourcesByPath,
+}) {
+  final violations = <EconomyDedupCreditAggregationViolation>[];
+  for (final relative in _targetRelativePaths) {
+    final content = sourcesByPath[relative];
+    if (content == null) continue;
+
+    final match = _bannedInlineAccumulation.firstMatch(content);
+    if (match != null) {
+      final lineNumber =
+          '\n'.allMatches(content.substring(0, match.start)).length + 1;
+      violations.add(
+        EconomyDedupCreditAggregationViolation(
+          path: relative,
+          line: lineNumber,
+          message:
+              'Re-inlined per-GP accumulation; use '
+              'GpTreasuryCreditAccumulator.add/ensure instead.',
+        ),
+      );
+    }
+
+    if (!content.contains(_requiredSymbol)) {
+      violations.add(
+        EconomyDedupCreditAggregationViolation(
+          path: relative,
+          line: 1,
+          message:
+              'Missing reference to shared $_requiredSymbol; the per-GP '
+              'treasury roll-up must delegate to it.',
+        ),
+      );
+    }
+  }
+  return violations;
+}
+
+class EconomyDedupCreditAggregationViolation {
+  const EconomyDedupCreditAggregationViolation({
+    required this.path,
+    required this.line,
+    required this.message,
+  });
+
+  final String path;
+  final int line;
+  final String message;
+}

--- a/tool/ct_repo_lint_lib.dart
+++ b/tool/ct_repo_lint_lib.dart
@@ -50,6 +50,7 @@ import 'check_flutter_action_pins.dart';
 import 'check_function_size.dart';
 import 'check_game_widgets_file_size.dart';
 import 'check_economy_cost_check_shared_helper.dart';
+import 'check_economy_dedup_credit_aggregation.dart';
 import 'check_economy_dedup_port_tile_keys.dart';
 import 'check_economy_world_market_admission_shared.dart';
 import 'check_land_province_bucket_keys.dart';
@@ -986,6 +987,8 @@ int? _tryRunLogicRuleInProcess({
       return runCheckEconomyWorldMarketAdmissionShared(repoRoot);
     case 'repo.economy_dedup_port_tile_keys':
       return runCheckEconomyDedupPortTileKeys(repoRoot);
+    case 'repo.economy_dedup_credit_aggregation':
+      return runCheckEconomyDedupCreditAggregation(repoRoot);
     default:
       return null;
   }

--- a/tool/ct_repo_lint_manifest.yaml
+++ b/tool/ct_repo_lint_manifest.yaml
@@ -104,6 +104,13 @@ rules:
     runner: dart
     script: tool/check_economy_dedup_port_tile_keys.dart
 
+  - rule_id: repo.economy_dedup_credit_aggregation
+    group: architecture
+    title: economy world-market FRR/riches credits must use the shared GpTreasuryCreditAccumulator, not inline per-GP accumulation (Refs #3731)
+    spec: SPEC/program/repo-lint.md
+    runner: dart
+    script: tool/check_economy_dedup_credit_aggregation.dart
+
   - rule_id: repo.economy_test_duplicate_descriptions
     group: testing
     title: economy test files must not share identical test()/testWidgets() descriptions across files (Refs #3661)


### PR DESCRIPTION
## Summary

Pure internal refactor of `packages/colonizethis_economy` that finishes the dedup sweep from #3731 by centralizing two duplicated patterns. No game-behavior, SPEC, or public-barrel change.

## Done in this push

**Theme A — shared int-map accumulation / value-sum helpers**
- New library-internal `lib/src/economy/commodity_totals.dart` (not barrel-exported): `addUnits<K>`, `sumValues`, `sumNestedValues`.
- Replaced the inline `m[k] = (m[k] ?? 0) + v` accumulation and `values.fold<int>(0, (a,b)=>a+b)` sum idioms at the listed call sites: `world_market/sellable_quantity.dart`, `sea_transport.dart`, `resource_extractor.dart`, `non_gp_extraction.dart`, `economy_production.dart`, `trade_interception.dart`, plus the equivalent value-sum in `economy_extraction.dart` for consistency. Each caller keeps its own positivity/skip guards; replacements are allocation-neutral (lazy `.map`, no new lists).

**Theme B — shared per-GP treasury credit accumulator**
- New `lib/src/economy/world_market/gp_treasury_credit_accumulator.dart`: `GpTreasuryCreditAccumulator<T extends num>` owning the insertion-ordered `byGp` map, `add`/`ensure`, an unmodifiable `view`, and an O(1) incrementally-maintained `total`.
- `FirstRightCreditsResult` (`double`) and `PurchasedTileRichesResult` (`int`) are backed by the accumulator. `ensure()` preserves the FRR zero-profit audit entry exactly. Public field/getter names (`treasuryCreditByGpId`, `totalProfitTreasury`, `totalTreasuryCredit`) are unchanged; getters now return the O(1) cached total when produced by the compute fns and fall back to re-summing for hand-built results (e.g. the `empty` sentinels).

**CI / enforcement**
- New focused rule `repo.economy_dedup_credit_aggregation` (manifest + `tool/check_economy_dedup_credit_aggregation.dart`, wired into `ct_repo_lint_lib.dart`) asserting `first_right_credits.dart` and `purchased_tile_riches.dart` keep delegating to the shared accumulator and do not re-inline a per-GP `(byGp[gp] ?? 0) + delta` loop.
- Deliberately **no** gate for the Theme A `(map[..] ?? 0) +` micro-idiom: a blanket ban is false-positive-prone and low-value; `dart analyze` + the new helper unit tests + review cover it instead.

## ACs covered

- [x] `commodity_totals.dart` helpers with positive + negative unit tests; all listed Theme A sites call them (verified by search).
- [x] Shared per-GP accumulator backs both result classes; public field/getter names and barrel surface unchanged.
- [x] Accumulator maintains the total incrementally; test asserts it equals the naive re-sum, incl. the FRR zero-profit entry case.
- [x] All existing `packages/colonizethis_economy/test/**` pass unchanged (457 tests green); `dart analyze` clean for the package (only the pre-existing barrel `unnecessary_library_name` info remains, untouched).
- [x] `repo.economy_dedup_credit_aggregation` rule + backing script added; passes on the refactored tree and fails on a reintroduced inline loop (negative fixture in the gate's own test).
- [x] No new global/world scans or per-iteration allocations on the touched next-turn paths.

## Tests run

- `dart test` (full economy package) → 457 passed
- `dart test test/check_economy_dedup_credit_aggregation_test.dart` → 7 passed
- `dart test test/ct_repo_lint_test.dart` → passed (manifest/dispatch consistency)
- `dart analyze` clean for new tool/test/lib files

## Deferred

None — the issue scope is fully addressed in this PR.

Refs #3731

Made with [Cursor](https://cursor.com)