### PR TITLE
refactor(app-test): migrate diplomacy screen tests to shared pumpAppShell harness (#3730)

### DIFF
--- a/app/test/diplomacy_detail_screen_test.dart
+++ b/app/test/diplomacy_detail_screen_test.dart
@@ -9,9 +9,9 @@ import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'support/app_shell_harness.dart';
 import 'support/widget_test_assets.dart';
 
 void main() {
@@ -111,21 +111,18 @@ void main() {
     final factionId = otherPlayer.id;
     final relation = getRelation(game, humanPlayerId, factionId);
 
-    await tester.pumpWidget(
-      ProviderScope(
-        child: MaterialApp(
-          home: DiplomacyDetailScreen(
-            game: game,
-            humanPlayerId: humanPlayerId,
-            factionId: factionId,
-            factionDisplayName: otherPlayer.displayName,
-            kind: FactionKind.greatPower,
-            relation: relation,
-          ),
-        ),
+    await pumpAppShell(
+      tester,
+      child: DiplomacyDetailScreen(
+        game: game,
+        humanPlayerId: humanPlayerId,
+        factionId: factionId,
+        factionDisplayName: otherPlayer.displayName,
+        kind: FactionKind.greatPower,
+        relation: relation,
       ),
+      settle: true,
     );
-    await tester.pumpAndSettle();
 
     expect(find.text('DIPLOMATIC HISTORY'), findsOneWidget);
     expect(find.text('DOSSIER'), findsOneWidget);
@@ -186,22 +183,18 @@ void main() {
         return FactionKind.tribe;
       }
 
-      await tester.pumpWidget(
-        ProviderScope(
-          child: MaterialApp(
-            home: DiplomacyDetailScreen(
-              game: game,
-              humanPlayerId: humanPlayerId,
-              factionId: chosenFactionId,
-              factionDisplayName: displayNameFor(chosenFactionId),
-              kind: kindFor(chosenFactionId),
-              relation: relation,
-            ),
-          ),
+      await pumpAppShell(
+        tester,
+        child: DiplomacyDetailScreen(
+          game: game,
+          humanPlayerId: humanPlayerId,
+          factionId: chosenFactionId,
+          factionDisplayName: displayNameFor(chosenFactionId),
+          kind: kindFor(chosenFactionId),
+          relation: relation,
         ),
+        settle: true,
       );
-
-      await tester.pumpAndSettle();
 
       expect(find.text('DIPLOMATIC HISTORY'), findsOneWidget);
       if (history.isEmpty) {
@@ -265,21 +258,18 @@ void main() {
         return id;
       }
 
-      await tester.pumpWidget(
-        ProviderScope(
-          child: MaterialApp(
-            home: DiplomacyDetailScreen(
-              game: game,
-              humanPlayerId: humanPlayerId,
-              factionId: factionId,
-              factionDisplayName: displayNameFor(factionId),
-              kind: FactionKind.minor,
-              relation: null,
-            ),
-          ),
+      await pumpAppShell(
+        tester,
+        child: DiplomacyDetailScreen(
+          game: game,
+          humanPlayerId: humanPlayerId,
+          factionId: factionId,
+          factionDisplayName: displayNameFor(factionId),
+          kind: FactionKind.minor,
+          relation: null,
         ),
+        settle: true,
       );
-      await tester.pumpAndSettle();
 
       expect(find.text('DIPLOMATIC HISTORY'), findsOneWidget);
       expect(find.text('DOSSIER'), findsNothing);
@@ -308,21 +298,18 @@ void main() {
       final relation = getRelation(game, humanPlayerId, otherFactionId);
       expect(relation, isNotNull);
 
-      await tester.pumpWidget(
-        ProviderScope(
-          child: MaterialApp(
-            home: DiplomacyDetailScreen(
-              game: game,
-              humanPlayerId: humanPlayerId,
-              factionId: otherFactionId,
-              factionDisplayName: 'Other GP',
-              kind: FactionKind.greatPower,
-              relation: relation,
-            ),
-          ),
+      await pumpAppShell(
+        tester,
+        child: DiplomacyDetailScreen(
+          game: game,
+          humanPlayerId: humanPlayerId,
+          factionId: otherFactionId,
+          factionDisplayName: 'Other GP',
+          kind: FactionKind.greatPower,
+          relation: relation,
         ),
+        settle: true,
       );
-      await tester.pumpAndSettle();
 
       expect(find.text('DIPLOMATIC HISTORY'), findsOneWidget);
       expect(find.text('DOSSIER'), findsOneWidget);
@@ -348,21 +335,18 @@ void main() {
       atWar: false,
     );
 
-    await tester.pumpWidget(
-      ProviderScope(
-        child: MaterialApp(
-          home: DiplomacyDetailScreen(
-            game: game,
-            humanPlayerId: humanPlayerId,
-            factionId: otherFactionId,
-            factionDisplayName: 'Other GP',
-            kind: FactionKind.greatPower,
-            relation: null,
-          ),
-        ),
+    await pumpAppShell(
+      tester,
+      child: DiplomacyDetailScreen(
+        game: game,
+        humanPlayerId: humanPlayerId,
+        factionId: otherFactionId,
+        factionDisplayName: 'Other GP',
+        kind: FactionKind.greatPower,
+        relation: null,
       ),
+      settle: true,
     );
-    await tester.pumpAndSettle();
 
     expect(find.text('DIPLOMATIC HISTORY'), findsOneWidget);
     expect(find.text('DOSSIER'), findsOneWidget);
@@ -389,21 +373,18 @@ void main() {
       expect(relation, isNotNull);
       expect(relation!.atWar, isFalse);
 
-      await tester.pumpWidget(
-        ProviderScope(
-          child: MaterialApp(
-            home: DiplomacyDetailScreen(
-              game: game,
-              humanPlayerId: humanPlayerId,
-              factionId: otherFactionId,
-              factionDisplayName: 'Other GP',
-              kind: FactionKind.minor,
-              relation: relation,
-            ),
-          ),
+      await pumpAppShell(
+        tester,
+        child: DiplomacyDetailScreen(
+          game: game,
+          humanPlayerId: humanPlayerId,
+          factionId: otherFactionId,
+          factionDisplayName: 'Other GP',
+          kind: FactionKind.minor,
+          relation: relation,
         ),
+        settle: true,
       );
-      await tester.pumpAndSettle();
 
       expect(find.text('DIPLOMATIC HISTORY'), findsOneWidget);
       expect(find.text('DOSSIER'), findsNothing);
@@ -433,21 +414,18 @@ void main() {
       final relation = getRelation(game, humanPlayerId, otherFactionId);
       expect(relation, isNotNull);
 
-      await tester.pumpWidget(
-        ProviderScope(
-          child: MaterialApp(
-            home: DiplomacyDetailScreen(
-              game: game,
-              humanPlayerId: humanPlayerId,
-              factionId: otherFactionId,
-              factionDisplayName: 'Other GP',
-              kind: FactionKind.greatPower,
-              relation: relation,
-            ),
-          ),
+      await pumpAppShell(
+        tester,
+        child: DiplomacyDetailScreen(
+          game: game,
+          humanPlayerId: humanPlayerId,
+          factionId: otherFactionId,
+          factionDisplayName: 'Other GP',
+          kind: FactionKind.greatPower,
+          relation: relation,
         ),
+        settle: true,
       );
-      await tester.pumpAndSettle();
 
       expect(find.text('DIPLOMATIC HISTORY'), findsOneWidget);
       expect(find.text('DOSSIER'), findsOneWidget);
@@ -479,21 +457,18 @@ void main() {
       expect(relation, isNotNull);
       expect(relation!.atWar, isTrue);
 
-      await tester.pumpWidget(
-        ProviderScope(
-          child: MaterialApp(
-            home: DiplomacyDetailScreen(
-              game: game,
-              humanPlayerId: humanPlayerId,
-              factionId: otherFactionId,
-              factionDisplayName: 'Other GP',
-              kind: FactionKind.greatPower,
-              relation: relation,
-            ),
-          ),
+      await pumpAppShell(
+        tester,
+        child: DiplomacyDetailScreen(
+          game: game,
+          humanPlayerId: humanPlayerId,
+          factionId: otherFactionId,
+          factionDisplayName: 'Other GP',
+          kind: FactionKind.greatPower,
+          relation: relation,
         ),
+        settle: true,
       );
-      await tester.pumpAndSettle();
 
       expect(find.text('DIPLOMATIC HISTORY'), findsOneWidget);
       expect(find.text('DOSSIER'), findsOneWidget);
@@ -539,21 +514,18 @@ void main() {
         dossierEvidenceEntries: const [],
       );
 
-      await tester.pumpWidget(
-        ProviderScope(
-          child: MaterialApp(
-            home: DiplomacyDetailScreen(
-              game: game,
-              humanPlayerId: humanPlayerId,
-              factionId: unknownFactionId,
-              factionDisplayName: 'Unknown Faction',
-              kind: FactionKind.minor,
-              relation: null,
-            ),
-          ),
+      await pumpAppShell(
+        tester,
+        child: DiplomacyDetailScreen(
+          game: game,
+          humanPlayerId: humanPlayerId,
+          factionId: unknownFactionId,
+          factionDisplayName: 'Unknown Faction',
+          kind: FactionKind.minor,
+          relation: null,
         ),
+        settle: true,
       );
-      await tester.pumpAndSettle();
 
       expect(find.text('DIPLOMATIC HISTORY'), findsOneWidget);
       expect(find.textContaining('Unknown faction'), findsOneWidget);
@@ -563,52 +535,48 @@ void main() {
 
   // ----- Refs #2863 S5: GAME30002 dark-theme chrome assertions -----
 
-  testWidgets(
-    'DiplomacyDetailScreen renders dark editorial-monocle chrome '
-    '(CtTopBar + scaffold bg) per Refs #2863 S5',
-    (WidgetTester tester) async {
-      const humanPlayerId = 'gp1';
-      const otherFactionId = 'gp2';
-      final game = minimalGame(
+  testWidgets('DiplomacyDetailScreen renders dark editorial-monocle chrome '
+      '(CtTopBar + scaffold bg) per Refs #2863 S5', (
+    WidgetTester tester,
+  ) async {
+    const humanPlayerId = 'gp1';
+    const otherFactionId = 'gp2';
+    final game = minimalGame(
+      humanPlayerId: humanPlayerId,
+      otherFactionId: otherFactionId,
+      eventType: DiplomaticEventType.peace,
+      includeHistory: false,
+      includeDossier: false,
+      atWar: false,
+    );
+
+    await pumpAppShell(
+      tester,
+      child: DiplomacyDetailScreen(
+        game: game,
         humanPlayerId: humanPlayerId,
-        otherFactionId: otherFactionId,
-        eventType: DiplomaticEventType.peace,
-        includeHistory: false,
-        includeDossier: false,
-        atWar: false,
-      );
+        factionId: otherFactionId,
+        factionDisplayName: 'Other GP',
+        kind: FactionKind.greatPower,
+        relation: getRelation(game, humanPlayerId, otherFactionId),
+      ),
+      settle: true,
+    );
 
-      await tester.pumpWidget(
-        ProviderScope(
-          child: MaterialApp(
-            home: DiplomacyDetailScreen(
-              game: game,
-              humanPlayerId: humanPlayerId,
-              factionId: otherFactionId,
-              factionDisplayName: 'Other GP',
-              kind: FactionKind.greatPower,
-              relation: getRelation(game, humanPlayerId, otherFactionId),
-            ),
-          ),
-        ),
-      );
-      await tester.pumpAndSettle();
+    expect(find.byType(CtTopBar), findsOneWidget);
+    expect(find.byType(CtBackButton), findsOneWidget);
+    expect(find.byType(AppBar), findsNothing);
 
-      expect(find.byType(CtTopBar), findsOneWidget);
-      expect(find.byType(CtBackButton), findsOneWidget);
-      expect(find.byType(AppBar), findsNothing);
+    expect(find.byType(CtGameFeatureScreenShell), findsOneWidget);
+    final CtGameFeatureScreenShell shell = tester.widget(
+      find.byType(CtGameFeatureScreenShell),
+    );
+    expect(shell.backgroundColor, EditorialMonoclePalette.bg);
+    expect(shell.attachGameToUiListener, isFalse);
 
-      expect(find.byType(CtGameFeatureScreenShell), findsOneWidget);
-      final CtGameFeatureScreenShell shell = tester.widget(
-        find.byType(CtGameFeatureScreenShell),
-      );
-      expect(shell.backgroundColor, EditorialMonoclePalette.bg);
-      expect(shell.attachGameToUiListener, isFalse);
-
-      final Scaffold scaffold = tester.widget(find.byType(Scaffold));
-      expect(scaffold.backgroundColor, EditorialMonoclePalette.bg);
-    },
-  );
+    final Scaffold scaffold = tester.widget(find.byType(Scaffold));
+    expect(scaffold.backgroundColor, EditorialMonoclePalette.bg);
+  });
 
   testWidgets(
     'DiplomacyDetailScreen emits exactly one PopNavigationEvent when the '
@@ -631,22 +599,19 @@ void main() {
       final sub = bus.on<PopNavigationEvent>().listen(popEvents.add);
       addTearDown(sub.cancel);
 
-      await tester.pumpWidget(
-        ProviderScope(
-          overrides: [appEventBusProvider.overrideWith((ref) => bus)],
-          child: MaterialApp(
-            home: DiplomacyDetailScreen(
-              game: game,
-              humanPlayerId: humanPlayerId,
-              factionId: otherFactionId,
-              factionDisplayName: 'Other GP',
-              kind: FactionKind.greatPower,
-              relation: getRelation(game, humanPlayerId, otherFactionId),
-            ),
-          ),
+      await pumpAppShell(
+        tester,
+        overrides: [appEventBusProvider.overrideWith((ref) => bus)],
+        child: DiplomacyDetailScreen(
+          game: game,
+          humanPlayerId: humanPlayerId,
+          factionId: otherFactionId,
+          factionDisplayName: 'Other GP',
+          kind: FactionKind.greatPower,
+          relation: getRelation(game, humanPlayerId, otherFactionId),
         ),
+        settle: true,
       );
-      await tester.pumpAndSettle();
 
       expect(popEvents, isEmpty);
       await tester.tap(find.byType(CtBackButton));
@@ -655,84 +620,76 @@ void main() {
     },
   );
 
-  testWidgets(
-    'DiplomacyDetailScreen Current relation card shows War label '
-    'in --danger colour per mockup GAME30002 .relation-row .war',
-    (WidgetTester tester) async {
-      const humanPlayerId = 'gp1';
-      const otherFactionId = 'gp2';
-      final game = minimalGame(
+  testWidgets('DiplomacyDetailScreen Current relation card shows War label '
+      'in --danger colour per mockup GAME30002 .relation-row .war', (
+    WidgetTester tester,
+  ) async {
+    const humanPlayerId = 'gp1';
+    const otherFactionId = 'gp2';
+    final game = minimalGame(
+      humanPlayerId: humanPlayerId,
+      otherFactionId: otherFactionId,
+      eventType: DiplomaticEventType.declareWar,
+      includeHistory: false,
+      includeDossier: false,
+      atWar: true,
+    );
+    final relation = getRelation(game, humanPlayerId, otherFactionId);
+    expect(relation, isNotNull);
+    expect(relation!.atWar, isTrue);
+
+    await pumpAppShell(
+      tester,
+      child: DiplomacyDetailScreen(
+        game: game,
         humanPlayerId: humanPlayerId,
-        otherFactionId: otherFactionId,
-        eventType: DiplomaticEventType.declareWar,
-        includeHistory: false,
-        includeDossier: false,
-        atWar: true,
-      );
-      final relation = getRelation(game, humanPlayerId, otherFactionId);
-      expect(relation, isNotNull);
-      expect(relation!.atWar, isTrue);
+        factionId: otherFactionId,
+        factionDisplayName: 'Other GP',
+        kind: FactionKind.greatPower,
+        relation: relation,
+      ),
+      settle: true,
+    );
 
-      await tester.pumpWidget(
-        ProviderScope(
-          child: MaterialApp(
-            home: DiplomacyDetailScreen(
-              game: game,
-              humanPlayerId: humanPlayerId,
-              factionId: otherFactionId,
-              factionDisplayName: 'Other GP',
-              kind: FactionKind.greatPower,
-              relation: relation,
-            ),
-          ),
-        ),
-      );
-      await tester.pumpAndSettle();
+    expect(find.text('CURRENT RELATION'), findsOneWidget);
+    final Text war = tester.widget(find.text('War'));
+    expect(war.style?.color, EditorialMonoclePalette.danger);
+  });
 
-      expect(find.text('CURRENT RELATION'), findsOneWidget);
-      final Text war = tester.widget(find.text('War'));
-      expect(war.style?.color, EditorialMonoclePalette.danger);
-    },
-  );
+  testWidgets('DiplomacyDetailScreen Current relation card shows Peace label '
+      'in --success colour per mockup GAME30002 .relation-row .state', (
+    WidgetTester tester,
+  ) async {
+    const humanPlayerId = 'gp1';
+    const otherFactionId = 'gp2';
+    final game = minimalGame(
+      humanPlayerId: humanPlayerId,
+      otherFactionId: otherFactionId,
+      eventType: DiplomaticEventType.peace,
+      includeHistory: false,
+      includeDossier: false,
+      atWar: false,
+    );
+    final relation = getRelation(game, humanPlayerId, otherFactionId);
+    expect(relation, isNotNull);
 
-  testWidgets(
-    'DiplomacyDetailScreen Current relation card shows Peace label '
-    'in --success colour per mockup GAME30002 .relation-row .state',
-    (WidgetTester tester) async {
-      const humanPlayerId = 'gp1';
-      const otherFactionId = 'gp2';
-      final game = minimalGame(
+    await pumpAppShell(
+      tester,
+      child: DiplomacyDetailScreen(
+        game: game,
         humanPlayerId: humanPlayerId,
-        otherFactionId: otherFactionId,
-        eventType: DiplomaticEventType.peace,
-        includeHistory: false,
-        includeDossier: false,
-        atWar: false,
-      );
-      final relation = getRelation(game, humanPlayerId, otherFactionId);
-      expect(relation, isNotNull);
+        factionId: otherFactionId,
+        factionDisplayName: 'Other GP',
+        kind: FactionKind.greatPower,
+        relation: relation,
+      ),
+      settle: true,
+    );
 
-      await tester.pumpWidget(
-        ProviderScope(
-          child: MaterialApp(
-            home: DiplomacyDetailScreen(
-              game: game,
-              humanPlayerId: humanPlayerId,
-              factionId: otherFactionId,
-              factionDisplayName: 'Other GP',
-              kind: FactionKind.greatPower,
-              relation: relation,
-            ),
-          ),
-        ),
-      );
-      await tester.pumpAndSettle();
-
-      expect(find.text('CURRENT RELATION'), findsOneWidget);
-      final Text peace = tester.widget(find.text('Peace'));
-      expect(peace.style?.color, EditorialMonoclePalette.success);
-    },
-  );
+    expect(find.text('CURRENT RELATION'), findsOneWidget);
+    final Text peace = tester.widget(find.text('Peace'));
+    expect(peace.style?.color, EditorialMonoclePalette.success);
+  });
 
   // ----- Refs #3625 AC4: formal-alliance treaty indicator on GAME30002 -----
 
@@ -756,21 +713,18 @@ void main() {
       expect(relation, isNotNull);
       expect(relation!.formalAlliance, isTrue);
 
-      await tester.pumpWidget(
-        ProviderScope(
-          child: MaterialApp(
-            home: DiplomacyDetailScreen(
-              game: game,
-              humanPlayerId: humanPlayerId,
-              factionId: otherFactionId,
-              factionDisplayName: 'Other GP',
-              kind: FactionKind.greatPower,
-              relation: relation,
-            ),
-          ),
+      await pumpAppShell(
+        tester,
+        child: DiplomacyDetailScreen(
+          game: game,
+          humanPlayerId: humanPlayerId,
+          factionId: otherFactionId,
+          factionDisplayName: 'Other GP',
+          kind: FactionKind.greatPower,
+          relation: relation,
         ),
+        settle: true,
       );
-      await tester.pumpAndSettle();
 
       expect(find.text('CURRENT RELATION'), findsOneWidget);
       final Finder badge = find.text(kDiplomacyAllianceBadgeLabel);
@@ -802,21 +756,18 @@ void main() {
       expect(relation, isNotNull);
       expect(relation!.formalAlliance, isFalse);
 
-      await tester.pumpWidget(
-        ProviderScope(
-          child: MaterialApp(
-            home: DiplomacyDetailScreen(
-              game: game,
-              humanPlayerId: humanPlayerId,
-              factionId: otherFactionId,
-              factionDisplayName: 'Other GP',
-              kind: FactionKind.greatPower,
-              relation: relation,
-            ),
-          ),
+      await pumpAppShell(
+        tester,
+        child: DiplomacyDetailScreen(
+          game: game,
+          humanPlayerId: humanPlayerId,
+          factionId: otherFactionId,
+          factionDisplayName: 'Other GP',
+          kind: FactionKind.greatPower,
+          relation: relation,
         ),
+        settle: true,
       );
-      await tester.pumpAndSettle();
 
       expect(find.text('CURRENT RELATION'), findsOneWidget);
       expect(find.text(kDiplomacyAllianceBadgeLabel), findsNothing);

--- a/app/test/diplomacy_screen_test.dart
+++ b/app/test/diplomacy_screen_test.dart
@@ -8,15 +8,14 @@
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:colonizethis_app/config/themes.dart';
 import 'package:colonizethis_app/features/game/screens/diplomacy_screen.dart';
 import 'package:colonizethis_app/widgets/ct_back_button.dart';
 import 'package:colonizethis_app/widgets/ct_screen_shell.dart';
 import 'package:colonizethis_app/widgets/ct_top_bar.dart';
 
+import 'support/app_shell_harness.dart';
 import 'support/panel_test_fixtures.dart';
 
 void main() {
@@ -37,17 +36,14 @@ void main() {
   });
 
   Widget buildScreen({required Game game, required String humanPlayerId}) {
-    return ProviderScope(
-      child: MaterialApp(
-        theme: AppThemes.editorialMonocle,
-        home: Navigator(
-          pages: [
-            MaterialPage(
-              child: DiplomacyScreen(game: game, humanPlayerId: humanPlayerId),
-            ),
-          ],
-          onDidRemovePage: (_) {},
-        ),
+    return buildAppShell(
+      child: Navigator(
+        pages: [
+          MaterialPage(
+            child: DiplomacyScreen(game: game, humanPlayerId: humanPlayerId),
+          ),
+        ],
+        onDidRemovePage: (_) {},
       ),
     );
   }
@@ -104,13 +100,7 @@ void main() {
     testWidgets('back button is tappable', (WidgetTester tester) async {
       final navigatorKey = GlobalKey<NavigatorState>();
       await tester.pumpWidget(
-        ProviderScope(
-          child: MaterialApp(
-            theme: AppThemes.editorialMonocle,
-            navigatorKey: navigatorKey,
-            home: const Text('Home'),
-          ),
-        ),
+        buildAppShell(navigatorKey: navigatorKey, child: const Text('Home')),
       );
 
       navigatorKey.currentState!.push<void>(


### PR DESCRIPTION
## Summary
Advances #3730 (consolidate `app` test scaffolding) by migrating the **diplomacy** family of widget/screen tests onto the shared `buildAppShell` / `pumpAppShell` harness in `app/test/support/app_shell_harness.dart`, completing the diplomacy portion of **AC2** ("at least the diplomacy/trade/dialog `_pump*` families are migrated to a shared `pumpAppShell(...)` helper").

## Done in this push
- `app/test/diplomacy_screen_test.dart`: `buildScreen(...)` and the inline back-navigation shell now build via `buildAppShell(...)`; dropped the bespoke `ProviderScope > MaterialApp(theme: AppThemes.editorialMonocle, ...)` boilerplate and the now-unused `flutter_riverpod` / `config/themes.dart` imports. Exact-equivalent (the shells already used `editorialMonocle`).
- `app/test/diplomacy_detail_screen_test.dart`: all 15 inline `pumpWidget(ProviderScope(child: MaterialApp(home: DiplomacyDetailScreen(...))))` + `pumpAndSettle()` stanzas (including the one `appEventBusProvider` override case) collapse to `pumpAppShell(tester, child: ..., settle: true)`. These previously used a bare light-theme `MaterialApp`; they now pump under the canonical editorial-monocle shell (the app's always-on default). The screen supplies its own chrome/colors, so every assertion is unchanged and still passes.

## Scope / context
- Prior merged slices for this issue: AC1 (320dp `min_viewport_harness` + dedup gate, #3732), AC3 (partN documented `<family>_part<N>_test.dart` convention + `check_app_test_no_partn_double_suffix` gate), and the trade/dialog `pumpAppShell` start (#3734). This PR is a follow-up slice on current `dev` (prior PRs already merged), keeping one PR per issue.
- No production code, screen IDs, or assertions changed — behavior-preserving test-scaffolding refactor only.

## Deferred for #3730 (with rationale)
- `diplomacy_relative_power_goldens_test.dart` left bespoke: golden hosts force precise surface sizes and are pixel-sensitive; migrating risks golden regeneration, out of scope for a behavior-preserving pass.
- `diplomacy_relative_power_line_test.dart` `_host(...)` left bespoke: it hosts an isolated `RelativePowerLine` widget in a minimal `MaterialApp`, not the full app shell.

## Tests
- `cd app && flutter test test/diplomacy_screen_test.dart test/diplomacy_detail_screen_test.dart` -> 19/19 pass.
- `cd app && flutter analyze test/diplomacy_screen_test.dart test/diplomacy_detail_screen_test.dart` -> no issues.
- `dart test test/check_app_test_no_duplicate_scaffolding_test.dart test/check_app_test_no_partn_double_suffix_test.dart` -> pass.

Refs #3730

Made with [Cursor](https://cursor.com)