### PR TITLE
refactor(app-test): route trade route-host shells through shared harness (#3730)

### DIFF
--- a/app/test/support/app_shell_harness.dart
+++ b/app/test/support/app_shell_harness.dart
@@ -35,6 +35,15 @@ import 'package:flutter_test/flutter_test.dart';
 /// the [MaterialApp]; their defaults match `MaterialApp`'s own so non-localized
 /// callers are unaffected. Any extra structural wrappers a screen needs (a
 /// [Scaffold] host, a [Stack], an event-handler scope, …) belong in [child].
+///
+/// [onGenerateRoute] is forwarded to the [MaterialApp] so route-host tests that
+/// drive `Navigator.pushNamed` (for example through `Routes.generate`) can use
+/// the shared shell while keeping [child] as the `'/'` home; pass
+/// [navigatorKey] when the host pushes via an app-owned key. [shellWrapper], if
+/// supplied, wraps the [MaterialApp] before it becomes the [ProviderScope]
+/// child — the composition seam for an app-level wrapper that must sit
+/// **outside** the [MaterialApp] (for example `AppEventHandlerScope`), which a
+/// `home`-hosted [child] cannot express. When null the shell is unwrapped.
 Widget buildAppShell({
   required Widget child,
   Size? viewport,
@@ -43,16 +52,20 @@ Widget buildAppShell({
   Iterable<Locale> supportedLocales = const <Locale>[Locale('en', 'US')],
   Locale? locale,
   GlobalKey<NavigatorState>? navigatorKey,
+  RouteFactory? onGenerateRoute,
+  Widget Function(Widget app)? shellWrapper,
 }) {
+  final MaterialApp app = _appShellMaterialApp(
+    home: _wrapViewport(child, viewport),
+    localizationsDelegates: localizationsDelegates,
+    supportedLocales: supportedLocales,
+    locale: locale,
+    navigatorKey: navigatorKey,
+    onGenerateRoute: onGenerateRoute,
+  );
   return ProviderScope(
     overrides: overrides,
-    child: _appShellMaterialApp(
-      home: _wrapViewport(child, viewport),
-      localizationsDelegates: localizationsDelegates,
-      supportedLocales: supportedLocales,
-      locale: locale,
-      navigatorKey: navigatorKey,
-    ),
+    child: shellWrapper == null ? app : shellWrapper(app),
   );
 }
 
@@ -75,16 +88,20 @@ Widget buildAppShellWithContainer({
   Iterable<Locale> supportedLocales = const <Locale>[Locale('en', 'US')],
   Locale? locale,
   GlobalKey<NavigatorState>? navigatorKey,
+  RouteFactory? onGenerateRoute,
+  Widget Function(Widget app)? shellWrapper,
 }) {
+  final MaterialApp app = _appShellMaterialApp(
+    home: _wrapViewport(child, viewport),
+    localizationsDelegates: localizationsDelegates,
+    supportedLocales: supportedLocales,
+    locale: locale,
+    navigatorKey: navigatorKey,
+    onGenerateRoute: onGenerateRoute,
+  );
   return UncontrolledProviderScope(
     container: container,
-    child: _appShellMaterialApp(
-      home: _wrapViewport(child, viewport),
-      localizationsDelegates: localizationsDelegates,
-      supportedLocales: supportedLocales,
-      locale: locale,
-      navigatorKey: navigatorKey,
-    ),
+    child: shellWrapper == null ? app : shellWrapper(app),
   );
 }
 
@@ -97,6 +114,7 @@ MaterialApp _appShellMaterialApp({
   Iterable<Locale> supportedLocales = const <Locale>[Locale('en', 'US')],
   Locale? locale,
   GlobalKey<NavigatorState>? navigatorKey,
+  RouteFactory? onGenerateRoute,
 }) {
   return MaterialApp(
     navigatorKey: navigatorKey,
@@ -104,6 +122,7 @@ MaterialApp _appShellMaterialApp({
     localizationsDelegates: localizationsDelegates,
     supportedLocales: supportedLocales,
     locale: locale,
+    onGenerateRoute: onGenerateRoute,
     home: home,
   );
 }
@@ -140,6 +159,8 @@ Future<void> pumpAppShell(
   Iterable<Locale> supportedLocales = const <Locale>[Locale('en', 'US')],
   Locale? locale,
   GlobalKey<NavigatorState>? navigatorKey,
+  RouteFactory? onGenerateRoute,
+  Widget Function(Widget app)? shellWrapper,
   bool settle = false,
 }) async {
   if (viewport != null) {
@@ -155,6 +176,8 @@ Future<void> pumpAppShell(
       supportedLocales: supportedLocales,
       locale: locale,
       navigatorKey: navigatorKey,
+      onGenerateRoute: onGenerateRoute,
+      shellWrapper: shellWrapper,
     ),
   );
   if (settle) {
@@ -181,6 +204,8 @@ Future<void> pumpAppShellWithContainer(
   Iterable<Locale> supportedLocales = const <Locale>[Locale('en', 'US')],
   Locale? locale,
   GlobalKey<NavigatorState>? navigatorKey,
+  RouteFactory? onGenerateRoute,
+  Widget Function(Widget app)? shellWrapper,
   bool settle = false,
 }) async {
   if (viewport != null) {
@@ -196,6 +221,8 @@ Future<void> pumpAppShellWithContainer(
       supportedLocales: supportedLocales,
       locale: locale,
       navigatorKey: navigatorKey,
+      onGenerateRoute: onGenerateRoute,
+      shellWrapper: shellWrapper,
     ),
   );
   if (settle) {

--- a/app/test/support/app_shell_harness_test.dart
+++ b/app/test/support/app_shell_harness_test.dart
@@ -11,7 +11,12 @@
 //  * `settle: true` drains pending animations;
 //  * `pumpAppShellWithContainer` binds an externally-owned `ProviderContainer`
 //    (via `UncontrolledProviderScope`) so the same container reads back state
-//    the UI mutated, under the same theme + forced-viewport contract.
+//    the UI mutated, under the same theme + forced-viewport contract;
+//  * `onGenerateRoute` is forwarded so route-host tests can `pushNamed` named
+//    routes off the shared shell while `child` stays the `'/'` home;
+//  * `shellWrapper` composes an app-level wrapper outside the `MaterialApp`
+//    (the seam used to keep `AppEventHandlerScope` above routing), and is
+//    absent from the tree when not supplied.
 
 import 'package:colonizethis_app/config/themes.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
@@ -181,6 +186,93 @@ void main() {
       expect(tester.takeException(), isNull);
     },
   );
+
+  testWidgets(
+    'buildAppShell forwards onGenerateRoute so named routes resolve off the '
+    'shared shell',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        buildAppShell(
+          onGenerateRoute: (settings) {
+            if (settings.name == '/details') {
+              return MaterialPageRoute<void>(
+                builder: (_) => const Text('details-route'),
+              );
+            }
+            return null;
+          },
+          child: Builder(
+            builder: (context) {
+              return Scaffold(
+                body: Center(
+                  child: ElevatedButton(
+                    onPressed: () =>
+                        Navigator.of(context).pushNamed('/details'),
+                    child: const Text('go'),
+                  ),
+                ),
+              );
+            },
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // The `'/'` home (child) renders first; the named route is not yet shown.
+      expect(find.text('go'), findsOneWidget);
+      expect(find.text('details-route'), findsNothing);
+
+      await tester.tap(find.text('go'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('details-route'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets(
+    'buildAppShell wraps the MaterialApp with shellWrapper when supplied',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        buildAppShell(
+          shellWrapper: (app) => _ShellMarker(child: app),
+          child: const SizedBox.shrink(),
+        ),
+      );
+
+      // The wrapper sits above the MaterialApp (outside routing), as an
+      // app-level scope such as AppEventHandlerScope would.
+      expect(
+        find.ancestor(
+          of: find.byType(MaterialApp),
+          matching: find.byType(_ShellMarker),
+        ),
+        findsOneWidget,
+      );
+    },
+  );
+
+  testWidgets(
+    'buildAppShell omits any wrapper when shellWrapper is null',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        buildAppShell(child: const SizedBox.shrink()),
+      );
+
+      expect(find.byType(_ShellMarker), findsNothing);
+      expect(find.byType(MaterialApp), findsOneWidget);
+    },
+  );
+}
+
+/// Inert wrapper used to assert `shellWrapper` composes above the MaterialApp.
+class _ShellMarker extends StatelessWidget {
+  const _ShellMarker({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) => child;
 }
 
 class _BrieflyAnimating extends StatefulWidget {

--- a/app/test/trade_screen_initial_tab_index_e7_test.dart
+++ b/app/test/trade_screen_initial_tab_index_e7_test.dart
@@ -18,7 +18,6 @@
 //    Deal Book stories in the SPEC-pinned order so reviewers can
 //    audit the live ledger chrome.
 
-import 'package:colonizethis_app/config/themes.dart';
 import 'package:colonizethis_app/features/game/screens/trade_screen.dart';
 import 'package:colonizethis_app/widgets/ct_tab_strip.dart';
 import 'package:colonizethis_app/widgetbook/catalog.dart';
@@ -154,32 +153,29 @@ void main() {
       'positive initialTabIndex foregrounds the matching tab body on '
       'first frame',
       (tester) async {
-        await tester.pumpWidget(
-          MaterialApp(
-            theme: AppThemes.editorialMonocle,
-            home: Scaffold(
-              body: CtTabStrip(
-                initialTabIndex: 1,
-                tabLabels: const <String>['First', 'Second', 'Third'],
-                tabViews: const <Widget>[
-                  Text(
-                    'first-body',
-                    key: ValueKey<String>('tab-body-first'),
-                  ),
-                  Text(
-                    'second-body',
-                    key: ValueKey<String>('tab-body-second'),
-                  ),
-                  Text(
-                    'third-body',
-                    key: ValueKey<String>('tab-body-third'),
-                  ),
-                ],
-              ),
+        await pumpAppShell(
+          tester,
+          child: Scaffold(
+            body: CtTabStrip(
+              initialTabIndex: 1,
+              tabLabels: const <String>['First', 'Second', 'Third'],
+              tabViews: const <Widget>[
+                Text(
+                  'first-body',
+                  key: ValueKey<String>('tab-body-first'),
+                ),
+                Text(
+                  'second-body',
+                  key: ValueKey<String>('tab-body-second'),
+                ),
+                Text(
+                  'third-body',
+                  key: ValueKey<String>('tab-body-third'),
+                ),
+              ],
             ),
           ),
         );
-        await tester.pump();
 
         expect(
           find.byKey(const ValueKey<String>('tab-body-second')),

--- a/app/test/trade_screen_issue_acceptance_criteria_e8_test.dart
+++ b/app/test/trade_screen_issue_acceptance_criteria_e8_test.dart
@@ -50,7 +50,6 @@ import 'package:colonizethis_app/app.dart';
 import 'package:colonizethis_app/config/constants.dart';
 import 'package:colonizethis_app/config/route_paths.dart';
 import 'package:colonizethis_app/config/routes.dart';
-import 'package:colonizethis_app/config/themes.dart';
 import 'package:colonizethis_app/core/services/app_event_handler_scope.dart';
 import 'package:colonizethis_app/core/services/game_service.dart';
 import 'package:colonizethis_app/features/game/flame/game_map_empire_left_rail.dart';
@@ -348,62 +347,57 @@ void main() {
     ];
 
   Widget buildLeftRailHost({bool globalObserve = false}) {
-    return ProviderScope(
+    return buildAppShell(
       overrides: routeHostOverrides(globalObserve: globalObserve),
-      child: AppEventHandlerScope(
-        child: MaterialApp(
-          navigatorKey: appNavigatorKey,
-          theme: AppThemes.editorialMonocle,
-          onGenerateRoute: Routes.generate,
-          home: Scaffold(
-            body: Stack(
-              children: [
-                Positioned(
-                  left: 20,
-                  top: 0,
-                  child: GameMapEmpireLeftRail(
-                    game: routeHostGame,
-                    humanPlayerId: routeHostPlayer.id,
-                  ),
-                ),
-              ],
+      navigatorKey: appNavigatorKey,
+      onGenerateRoute: Routes.generate,
+      shellWrapper: (app) => AppEventHandlerScope(child: app),
+      child: Scaffold(
+        body: Stack(
+          children: [
+            Positioned(
+              left: 20,
+              top: 0,
+              child: GameMapEmpireLeftRail(
+                game: routeHostGame,
+                humanPlayerId: routeHostPlayer.id,
+              ),
             ),
-          ),
+          ],
         ),
       ),
     );
   }
 
   Widget buildTradeRouteHost({bool globalObserve = false}) {
-    return ProviderScope(
+    // Route host: pushes RoutePaths.trade through Routes.generate, so it uses
+    // the shared shell's onGenerateRoute + appNavigatorKey seams and the
+    // shellWrapper seam to keep AppEventHandlerScope above routing (Refs #3730).
+    return buildAppShell(
       overrides: routeHostOverrides(globalObserve: globalObserve),
-      child: AppEventHandlerScope(
-        child: MaterialApp(
-          navigatorKey: appNavigatorKey,
-          theme: AppThemes.editorialMonocle,
-          onGenerateRoute: Routes.generate,
-          home: Builder(
-            builder: (context) {
-              return Scaffold(
-                body: Center(
-                  child: ElevatedButton(
-                    onPressed: () {
-                      Navigator.of(context).pushNamed(
-                        RoutePaths.trade,
-                        arguments: <String, Object?>{
-                          'game': routeHostGame,
-                          'humanPlayerId': routeHostPlayer.id,
-                        },
-                      );
+      navigatorKey: appNavigatorKey,
+      onGenerateRoute: Routes.generate,
+      shellWrapper: (app) => AppEventHandlerScope(child: app),
+      child: Builder(
+        builder: (context) {
+          return Scaffold(
+            body: Center(
+              child: ElevatedButton(
+                onPressed: () {
+                  Navigator.of(context).pushNamed(
+                    RoutePaths.trade,
+                    arguments: <String, Object?>{
+                      'game': routeHostGame,
+                      'humanPlayerId': routeHostPlayer.id,
                     },
-                    // ignore: avoid_hardcoded_strings_in_widgets
-                    child: const Text('open trade'),
-                  ),
-                ),
-              );
-            },
-          ),
-        ),
+                  );
+                },
+                // ignore: avoid_hardcoded_strings_in_widgets
+                child: const Text('open trade'),
+              ),
+            ),
+          );
+        },
       ),
     );
   }

--- a/app/test/trade_screen_scaffold_test.dart
+++ b/app/test/trade_screen_scaffold_test.dart
@@ -5,7 +5,6 @@ import 'package:colonizethis_app/app.dart';
 import 'package:colonizethis_app/config/constants.dart';
 import 'package:colonizethis_app/config/route_paths.dart';
 import 'package:colonizethis_app/config/routes.dart';
-import 'package:colonizethis_app/config/themes.dart';
 import 'package:colonizethis_app/config/ui_screen_ids.dart';
 import 'package:colonizethis_app/core/services/app_event_handler_scope.dart';
 import 'package:colonizethis_app/core/services/game_service.dart';
@@ -27,10 +26,10 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_save/colonizethis_save.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
 
+import 'support/app_shell_harness.dart';
 import 'support/panel_test_fixtures.dart';
 import 'widget_test_pumps.dart';
 
@@ -99,61 +98,57 @@ void main() {
   ];
 
   Widget buildTradeRouteHost({bool globalObserve = false}) {
-    return ProviderScope(
+    // Route host: drives `Navigator.pushNamed(RoutePaths.trade)` through
+    // `Routes.generate`, so it uses the shared shell's `onGenerateRoute` +
+    // `appNavigatorKey` seams and the `shellWrapper` seam to keep
+    // `AppEventHandlerScope` above routing (Refs #3730).
+    return buildAppShell(
       overrides: baseOverrides(globalObserve: globalObserve),
-      child: AppEventHandlerScope(
-        child: MaterialApp(
-          navigatorKey: appNavigatorKey,
-          theme: AppThemes.editorialMonocle,
-          onGenerateRoute: Routes.generate,
-          home: Builder(
-            builder: (context) {
-              return Scaffold(
-                body: Center(
-                  child: ElevatedButton(
-                    onPressed: () {
-                      Navigator.of(context).pushNamed(
-                        RoutePaths.trade,
-                        arguments: <String, Object?>{
-                          'game': game,
-                          'humanPlayerId': humanPlayer.id,
-                        },
-                      );
+      navigatorKey: appNavigatorKey,
+      onGenerateRoute: Routes.generate,
+      shellWrapper: (app) => AppEventHandlerScope(child: app),
+      child: Builder(
+        builder: (context) {
+          return Scaffold(
+            body: Center(
+              child: ElevatedButton(
+                onPressed: () {
+                  Navigator.of(context).pushNamed(
+                    RoutePaths.trade,
+                    arguments: <String, Object?>{
+                      'game': game,
+                      'humanPlayerId': humanPlayer.id,
                     },
-                    // ignore: avoid_hardcoded_strings_in_widgets
-                    child: const Text('open trade'),
-                  ),
-                ),
-              );
-            },
-          ),
-        ),
+                  );
+                },
+                // ignore: avoid_hardcoded_strings_in_widgets
+                child: const Text('open trade'),
+              ),
+            ),
+          );
+        },
       ),
     );
   }
 
   Widget buildLeftRailHost() {
-    return ProviderScope(
+    return buildAppShell(
       overrides: baseOverrides(),
-      child: AppEventHandlerScope(
-        child: MaterialApp(
-          navigatorKey: appNavigatorKey,
-          theme: AppThemes.editorialMonocle,
-          onGenerateRoute: Routes.generate,
-          home: Scaffold(
-            body: Stack(
-              children: [
-                Positioned(
-                  left: 20,
-                  top: 0,
-                  child: GameMapEmpireLeftRail(
-                    game: game,
-                    humanPlayerId: humanPlayer.id,
-                  ),
-                ),
-              ],
+      navigatorKey: appNavigatorKey,
+      onGenerateRoute: Routes.generate,
+      shellWrapper: (app) => AppEventHandlerScope(child: app),
+      child: Scaffold(
+        body: Stack(
+          children: [
+            Positioned(
+              left: 20,
+              top: 0,
+              child: GameMapEmpireLeftRail(
+                game: game,
+                humanPlayerId: humanPlayer.id,
+              ),
             ),
-          ),
+          ],
         ),
       ),
     );


### PR DESCRIPTION
## Summary
Advances #3730 (consolidate `app` test scaffolding) by extending the shared `app/test/support/app_shell_harness.dart` so **route-host** widget tests can reuse the single editorial-monocle `MaterialApp` definition instead of re-declaring a bespoke `ProviderScope > AppEventHandlerScope > MaterialApp(onGenerateRoute: Routes.generate, …)` shell. This removes the largest remaining class of duplicated trade-family shell boilerplate (AC2: "the trade … `_pump*` families are migrated to a shared `pumpAppShell(...)` helper").

## Done in this push
- **Harness extension (behavior-preserving, opt-in):** `buildAppShell` / `buildAppShellWithContainer` (and the `pumpAppShell*` helpers) gain:
  - `onGenerateRoute` — forwarded to the shared `MaterialApp` so route-host tests drive `Navigator.pushNamed` (e.g. `Routes.generate`) while `child` stays the `'/'` home;
  - `shellWrapper` — a `Widget Function(Widget app)` composition seam that wraps the `MaterialApp` from **outside** (the seam used to keep `AppEventHandlerScope` above routing, which a `home`-hosted child cannot express).
  - Both default to current behavior, so existing callers are unaffected; there remains a single editorial-monocle `MaterialApp` definition.
- **Migrations:**
  - `trade_screen_scaffold_test.dart`: `buildTradeRouteHost` + `buildLeftRailHost` now build via `buildAppShell(... onGenerateRoute: Routes.generate, shellWrapper: (app) => AppEventHandlerScope(child: app))`; dropped the bespoke shell and the now-unused `config/themes.dart` + `flutter_riverpod` imports.
  - `trade_screen_issue_acceptance_criteria_e8_test.dart`: same two route-host builders migrated; dropped the now-unused `config/themes.dart` import (the file still uses `pumpAppShellWithContainer`).
  - `trade_screen_initial_tab_index_e7_test.dart`: the editorial-monocle `CtTabStrip` shell collapses to `pumpAppShell(child: …)`; dropped the now-unused `config/themes.dart` import.
- No production code, screen IDs, or assertions changed — behavior-preserving test-scaffolding refactor only (theme was already `editorial-monocle` in every migrated shell, so zero theme drift).

## Tests
- `cd app && flutter test test/support/app_shell_harness_test.dart test/trade_screen_scaffold_test.dart test/trade_screen_issue_acceptance_criteria_e8_test.dart test/trade_screen_initial_tab_index_e7_test.dart` → 39/39 pass.
- Added harness smoke tests: `onGenerateRoute` resolves a pushed named route off the shared shell; `shellWrapper` wraps the `MaterialApp` when supplied and is absent when null.
- `cd app && flutter analyze <touched files>` → no issues.
- `dart test test/check_app_test_no_duplicate_scaffolding_test.dart test/check_app_test_no_partn_double_suffix_test.dart` → pass.

## Deferred for #3730
- Broad migration of the remaining ~40 bespoke `_pump*` / shell helpers (golden, dark-token, mockup-fidelity, and widgetbook viewport families) where bespoke surface sizing / theme assertions make the home-hosting shell a poor fit. AC2's diplomacy/trade/dialog minimum is satisfied by prior merged slices (#3732/#3734/#3735) plus this PR; these remaining families are tracked for follow-up commits.

Refs #3730

Made with [Cursor](https://cursor.com)