### PR TITLE
refactor(app-test): migrate screen/panel shells to shared harness (#3730)

### DIFF
--- a/app/test/main_menu_wood_panel_hover_test.dart
+++ b/app/test/main_menu_wood_panel_hover_test.dart
@@ -14,7 +14,6 @@
 // `CtNinePatchButton`, but exercises the wood-panel call site so the AC
 // is anchored at the screen contract level (`CtMainMenu`).
 import 'package:colonizethis_app/config/editorial_monocle_palette.dart';
-import 'package:colonizethis_app/config/themes.dart';
 import 'package:colonizethis_app/features/game/widgets/chrome/ct_nine_patch_button.dart';
 import 'package:colonizethis_app/widgets/main_menu.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
@@ -22,25 +21,25 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-/// Pumps a `CtMainMenu` configured for the `pixelArt` variant under the
-/// `editorialMonocle` theme so the wood-panel button hover state can be
+import 'support/app_shell_harness.dart';
+
+/// Pumps a `CtMainMenu` configured for the `pixelArt` variant under the shared
+/// editorial-monocle app shell so the wood-panel button hover state can be
 /// inspected through the inner `CtNinePatchButton` widget.
 Future<void> _pumpPixelArtMainMenu(WidgetTester tester) async {
-  await tester.pumpWidget(
-    MaterialApp(
-      theme: AppThemes.editorialMonocle,
-      home: CtMainMenu(
-        variant: MainMenuVariant.pixelArt,
-        state: MainMenuState.default_,
-        version: 'v1.0.0',
-        onNewGame: () {},
-        onLoadGame: () {},
-        onSettings: () {},
-        onQuit: () {},
-      ),
+  await pumpAppShell(
+    tester,
+    settle: true,
+    child: CtMainMenu(
+      variant: MainMenuVariant.pixelArt,
+      state: MainMenuState.default_,
+      version: 'v1.0.0',
+      onNewGame: () {},
+      onLoadGame: () {},
+      onSettings: () {},
+      onQuit: () {},
     ),
   );
-  await tester.pumpAndSettle();
 }
 
 /// Returns the `CtNinePatchButton` ancestor of the menu label [label].

--- a/app/test/province_overlay_terrain_display_name_test.dart
+++ b/app/test/province_overlay_terrain_display_name_test.dart
@@ -13,6 +13,8 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:colonizethis_app/features/game/widgets/province_sea_zone_detail_overlay.dart';
 
+import 'support/app_shell_harness.dart';
+
 const _regionId = 'oldWorld';
 const _localProvinceId = 'pTerrainTest';
 String get _fullProvinceId => '$_regionId|$_localProvinceId';
@@ -89,24 +91,23 @@ Future<void> _pumpOverlay(
   CellViewData cell,
   String tk,
 ) async {
-  await tester.pumpWidget(
-    MaterialApp(
-      home: Scaffold(
-        body: SizedBox(
-          width: 800,
-          child: ProvinceSeaZoneDetailOverlay(
-            game: _minimalGame(tk),
-            region: _regionWithCell(cell),
-            displayId: _fullProvinceId,
-            selectedTileKey: tk,
-            humanPlayerId: 'gp1',
-            playerView: _omniscientView(tk),
-          ),
+  await pumpAppShell(
+    tester,
+    settle: true,
+    child: Scaffold(
+      body: SizedBox(
+        width: 800,
+        child: ProvinceSeaZoneDetailOverlay(
+          game: _minimalGame(tk),
+          region: _regionWithCell(cell),
+          displayId: _fullProvinceId,
+          selectedTileKey: tk,
+          humanPlayerId: 'gp1',
+          playerView: _omniscientView(tk),
         ),
       ),
     ),
   );
-  await tester.pumpAndSettle();
 }
 
 void main() {

--- a/app/test/research_slot_turn_preview_view_test.dart
+++ b/app/test/research_slot_turn_preview_view_test.dart
@@ -13,6 +13,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:colonizethis_app/features/game/utils/research_slot_preview.dart';
 import 'package:colonizethis_app/features/game/widgets/research_slot_turn_preview_view.dart';
 
+import 'support/app_shell_harness.dart';
+
 Player _player({int treasury = 0, Map<String, bool>? techUnlocked}) {
   return Player(
     id: 'p1',
@@ -47,20 +49,19 @@ Future<void> _pumpView(
   ResearchSlotTurnPreview preview, {
   int slotIndex = 0,
 }) async {
-  await tester.pumpWidget(
-    MaterialApp(
-      home: Scaffold(
-        body: SizedBox(
-          width: 360,
-          child: ResearchSlotTurnPreviewView(
-            slotIndex: slotIndex,
-            preview: preview,
-          ),
+  await pumpAppShell(
+    tester,
+    settle: true,
+    child: Scaffold(
+      body: SizedBox(
+        width: 360,
+        child: ResearchSlotTurnPreviewView(
+          slotIndex: slotIndex,
+          preview: preview,
         ),
       ),
     ),
   );
-  await tester.pumpAndSettle();
 }
 
 void main() {


### PR DESCRIPTION
## Summary
Continues #3730 (consolidate `app` test scaffolding) by routing three more bespoke per-file `MaterialApp` shells through the shared editorial-monocle `pumpAppShell(...)` harness in `app/test/support/app_shell_harness.dart`. This trims more of the duplicated `_pump*` wrapper boilerplate the issue targets (AC2: migrate bespoke `_pump*` families to the shared `pumpAppShell(...)` helper) and standardizes the migrated shells on the canonical app theme.

## Done in this push
- **`main_menu_wood_panel_hover_test.dart`** — already used `MaterialApp(theme: AppThemes.editorialMonocle, …)`; `_pumpPixelArtMainMenu` now delegates to `pumpAppShell(settle: true)` and the now-unused `config/themes.dart` import is dropped. Pure de-duplication, zero theme drift.
- **`research_slot_turn_preview_view_test.dart`** — theme-less bespoke `MaterialApp(home: Scaffold(…))` shell routed through the single editorial-monocle shell.
- **`province_overlay_terrain_display_name_test.dart`** — same theme-less → shared editorial-monocle shell migration.

Both pumped widgets in the latter two files take all data via constructor params (no provider reads), so the harness's empty `ProviderScope` is inert; routing the theme-less shells through the canonical editorial-monocle shell aligns with the project's dark-theme/Ct-* expectations (hard-coded non-editorial themes are treated as regressions).

No production code, screen IDs, or assertions changed — behavior-preserving test-scaffolding refactor only.

## Tests
- `cd app && flutter test test/main_menu_wood_panel_hover_test.dart test/research_slot_turn_preview_view_test.dart test/province_overlay_terrain_display_name_test.dart` → 10/10 pass.
- `cd app && flutter analyze <touched files>` → No issues found.
- `dart test test/check_app_test_no_duplicate_scaffolding_test.dart test/check_app_test_no_partn_double_suffix_test.dart` → pass (consolidated tree still green; gate not tripped).

## Deferred for #3730
- The remaining ~80+ bespoke `_pump*` / shell helpers across golden, dark-token, mockup-fidelity, widgetbook-viewport, and e2e families, plus theme-specific (`AppThemes.light`) and event-wrapper/navigator-host panels (e.g. `diplomacy_panel_test.dart`) where the shared home-hosting shell is a poor fit or would change asserted theme behavior. These are tracked for follow-up under #3730's AC2 "or documented why a case must stay bespoke" allowance.

Refs #3730

Made with [Cursor](https://cursor.com)