### PR TITLE
refactor(app-test): route province shortcut-host shells through pumpAppShell (#3730)

### DIFF
--- a/app/test/province_build_improvement_shortcut_host_emit_event_test.dart
+++ b/app/test/province_build_improvement_shortcut_host_emit_event_test.dart
@@ -22,7 +22,6 @@
 //     disabled → no event).
 
 import 'package:colonizethis_app/config/constants.dart';
-import 'package:colonizethis_app/config/themes.dart';
 import 'package:colonizethis_app/core/services/game_service.dart';
 import 'package:colonizethis_app/features/game/flame/game_map_narrow_detail_overlay.dart';
 import 'package:colonizethis_app/features/game/flame/game_map_province_detail_side_panel.dart';
@@ -44,6 +43,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
+
+import 'support/app_shell_harness.dart';
 
 const String _kGameId = 'g_bi_shortcut_emit';
 const String _kHumanPlayerId = 'gp1';
@@ -270,30 +271,21 @@ void main() {
     final sub = bus.on<OpenCivilianUnitsPanelEvent>().listen(opened.add);
     addTearDown(sub.cancel);
 
-    addTearDown(() => tester.binding.setSurfaceSize(null));
-    await tester.binding.setSurfaceSize(surfaceSize);
-
-    await tester.pumpWidget(
-      ProviderScope(
-        overrides: [
-          gamesBoxProvider.overrideWith((ref) => gamesBox),
-          gameServiceProvider.overrideWith(
-            (ref) => _GameServiceBuildImprovement(gamesBox, GameSaveAdapter()),
-          ),
-          appEventBusProvider.overrideWith((ref) => bus),
-          currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
-          currentOrdersProvider.overrideWith(
-            () => CurrentOrdersNotifier(const Orders()),
-          ),
-        ],
-        child: MediaQuery(
-          data: MediaQueryData(size: surfaceSize),
-          child: MaterialApp(
-            theme: AppThemes.editorialMonocle,
-            home: Scaffold(body: host),
-          ),
+    await pumpAppShell(
+      tester,
+      viewport: surfaceSize,
+      overrides: [
+        gamesBoxProvider.overrideWith((ref) => gamesBox),
+        gameServiceProvider.overrideWith(
+          (ref) => _GameServiceBuildImprovement(gamesBox, GameSaveAdapter()),
         ),
-      ),
+        appEventBusProvider.overrideWith((ref) => bus),
+        currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
+        currentOrdersProvider.overrideWith(
+          () => CurrentOrdersNotifier(const Orders()),
+        ),
+      ],
+      child: Scaffold(body: host),
     );
 
     await _selectTileOnHost(tester, hostType);

--- a/app/test/province_explore_shortcut_host_emit_event_test.dart
+++ b/app/test/province_explore_shortcut_host_emit_event_test.dart
@@ -23,7 +23,6 @@
 //     click-time revalidation drift silent no-op.
 
 import 'package:colonizethis_app/config/constants.dart';
-import 'package:colonizethis_app/config/themes.dart';
 import 'package:colonizethis_app/core/services/game_service.dart';
 import 'package:colonizethis_app/features/game/flame/game_map_narrow_detail_overlay.dart';
 import 'package:colonizethis_app/features/game/flame/game_map_province_detail_side_panel.dart';
@@ -45,6 +44,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
+
+import 'support/app_shell_harness.dart';
 
 const String _kGameId = 'g_explore_shortcut_emit';
 const String _kHumanPlayerId = 'gp1';
@@ -310,30 +311,21 @@ void main() {
     final sub = bus.on<OpenCivilianUnitsPanelEvent>().listen(opened.add);
     addTearDown(sub.cancel);
 
-    addTearDown(() => tester.binding.setSurfaceSize(null));
-    await tester.binding.setSurfaceSize(surfaceSize);
-
-    await tester.pumpWidget(
-      ProviderScope(
-        overrides: [
-          gamesBoxProvider.overrideWith((ref) => gamesBox),
-          gameServiceProvider.overrideWith(
-            (ref) => _GameServiceExploreShortcut(gamesBox, GameSaveAdapter()),
-          ),
-          appEventBusProvider.overrideWith((ref) => bus),
-          currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
-          currentOrdersProvider.overrideWith(
-            () => CurrentOrdersNotifier(const Orders()),
-          ),
-        ],
-        child: MediaQuery(
-          data: MediaQueryData(size: surfaceSize),
-          child: MaterialApp(
-            theme: AppThemes.editorialMonocle,
-            home: Scaffold(body: host),
-          ),
+    await pumpAppShell(
+      tester,
+      viewport: surfaceSize,
+      overrides: [
+        gamesBoxProvider.overrideWith((ref) => gamesBox),
+        gameServiceProvider.overrideWith(
+          (ref) => _GameServiceExploreShortcut(gamesBox, GameSaveAdapter()),
         ),
-      ),
+        appEventBusProvider.overrideWith((ref) => bus),
+        currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
+        currentOrdersProvider.overrideWith(
+          () => CurrentOrdersNotifier(const Orders()),
+        ),
+      ],
+      child: Scaffold(body: host),
     );
 
     await _selectTileOnHost(tester, hostType);

--- a/app/test/province_prospect_shortcut_host_emit_event_test.dart
+++ b/app/test/province_prospect_shortcut_host_emit_event_test.dart
@@ -18,7 +18,6 @@
 //   - This file pins the positive path and the no-explorer negative.
 
 import 'package:colonizethis_app/config/constants.dart';
-import 'package:colonizethis_app/config/themes.dart';
 import 'package:colonizethis_app/core/services/game_service.dart';
 import 'package:colonizethis_app/features/game/flame/game_map_area_state_logic.dart';
 import 'package:colonizethis_app/features/game/flame/game_map_narrow_detail_overlay.dart';
@@ -41,6 +40,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
+
+import 'support/app_shell_harness.dart';
 
 const String _kGameId = 'g_prospect_shortcut_emit';
 const String _kHumanPlayerId = 'gp1';
@@ -276,30 +277,21 @@ void main() {
     final sub = bus.on<OpenCivilianUnitsPanelEvent>().listen(opened.add);
     addTearDown(sub.cancel);
 
-    addTearDown(() => tester.binding.setSurfaceSize(null));
-    await tester.binding.setSurfaceSize(surfaceSize);
-
-    await tester.pumpWidget(
-      ProviderScope(
-        overrides: [
-          gamesBoxProvider.overrideWith((ref) => gamesBox),
-          gameServiceProvider.overrideWith(
-            (ref) => _GameServiceProspectShortcut(gamesBox, GameSaveAdapter()),
-          ),
-          appEventBusProvider.overrideWith((ref) => bus),
-          currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
-          currentOrdersProvider.overrideWith(
-            () => CurrentOrdersNotifier(const Orders()),
-          ),
-        ],
-        child: MediaQuery(
-          data: MediaQueryData(size: surfaceSize),
-          child: MaterialApp(
-            theme: AppThemes.editorialMonocle,
-            home: Scaffold(body: host),
-          ),
+    await pumpAppShell(
+      tester,
+      viewport: surfaceSize,
+      overrides: [
+        gamesBoxProvider.overrideWith((ref) => gamesBox),
+        gameServiceProvider.overrideWith(
+          (ref) => _GameServiceProspectShortcut(gamesBox, GameSaveAdapter()),
         ),
-      ),
+        appEventBusProvider.overrideWith((ref) => bus),
+        currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
+        currentOrdersProvider.overrideWith(
+          () => CurrentOrdersNotifier(const Orders()),
+        ),
+      ],
+      child: Scaffold(body: host),
     );
 
     await _selectTileOnHost(tester, hostType);


### PR DESCRIPTION
## Summary

Follow-up slice for the app-test scaffolding dedup (#3730), opened after the prior PR (#3737) merged into `dev`.

Migrates the province **build-improvement / explore / prospect** shortcut-host emit-event tests off their identical inline `ProviderScope` + `MaterialApp(theme: AppThemes.editorialMonocle)` + `setSurfaceSize` shell to the shared `pumpAppShell(...)` harness in `app/test/support/app_shell_harness.dart`. This advances AC2 (consolidate the broader bespoke `_pump*` shell families onto the shared helper).

## Done in this push

- `app/test/province_build_improvement_shortcut_host_emit_event_test.dart`
- `app/test/province_explore_shortcut_host_emit_event_test.dart`
- `app/test/province_prospect_shortcut_host_emit_event_test.dart`

Each file's `pumpHostAndSelect` now calls `pumpAppShell(tester, viewport: surfaceSize, overrides: [...], child: Scaffold(body: host))` instead of hand-rolling the surface-size teardown + `MediaQuery` + `MaterialApp(editorialMonocle)` shell. The now-unused `config/themes.dart` import is removed from each. Net −24 lines.

Behavior-preserving: no assertions, fixtures, or screen IDs changed; only the shared shell construction is deduplicated.

## Verification

- `cd app && flutter test test/province_build_improvement_shortcut_host_emit_event_test.dart test/province_explore_shortcut_host_emit_event_test.dart test/province_prospect_shortcut_host_emit_event_test.dart` → **All 14 tests passed**.
- `flutter analyze` on the three files introduced no new issues (remaining infos/warnings are pre-existing on `dev` and out of scope for this minimal change).

## Scope / deferred

- This is one focused family slice. Other `editorialMonocle` shell builders in `app/test/` are golden/mockup/widgetbook/light-theme cases that are legitimately distinct (and exempt by the dedup gate's documented scope).

Refs #3730

Made with [Cursor](https://cursor.com)