### PR TITLE
refactor(app-test): extract shared naval_units_panel partN scaffolding (#3730)

### DIFF
--- a/app/test/naval_units_panel_part1_test.dart
+++ b/app/test/naval_units_panel_part1_test.dart
@@ -1,13 +1,7 @@
 // Tests for NavalUnitsPanel. SPEC/ui/naval-units-panel.md.
 
-import 'dart:async';
-
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/colonizethis_logic.dart'
-    show
-        applyNavalSplitFleet,
-        applyNavalTransferShipsBetweenFleets,
-        homeFleetIdFor;
+import 'package:colonizethis_logic/colonizethis_logic.dart' show homeFleetIdFor;
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
@@ -20,42 +14,9 @@ import 'package:colonizethis_app/features/game/widgets/units/shared/units_panel_
 import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
 import 'package:colonizethis_app/widgets/ct_panel.dart';
 
+import 'support/naval_units_panel_test_support.dart';
 import 'support/panel_test_fixtures.dart';
 import 'support/widget_test_assets.dart';
-
-/// Mirrors shell handling of [NavalSplitFleetRequestedEvent] for widget tests.
-StreamSubscription<NavalSplitFleetRequestedEvent> wireNavalSplitForWidgetTest({
-  required AppEventBus bus,
-  required Game Function() gameSnapshot,
-}) {
-  return bus.on<NavalSplitFleetRequestedEvent>().listen((e) {
-    final next = applyNavalSplitFleet(
-      game: gameSnapshot(),
-      humanPlayerId: e.humanPlayerId,
-      originalFleetId: e.originalFleetId,
-      shipInstanceIdsToNewFleet: e.shipInstanceIdsToNewFleet,
-    );
-    bus.emit(NavalFleetsUpdatedEvent(game: next));
-  });
-}
-
-/// Mirrors shell handling of [NavalTransferShipsRequestedEvent] for widget tests.
-StreamSubscription<NavalTransferShipsRequestedEvent>
-wireNavalTransferForWidgetTest({
-  required AppEventBus bus,
-  required Game Function() gameSnapshot,
-}) {
-  return bus.on<NavalTransferShipsRequestedEvent>().listen((e) {
-    final next = applyNavalTransferShipsBetweenFleets(
-      game: gameSnapshot(),
-      humanPlayerId: e.humanPlayerId,
-      sourceFleetId: e.sourceFleetId,
-      targetFleetId: e.targetFleetId,
-      shipInstanceIdsToTransfer: e.shipInstanceIdsToTransfer,
-    );
-    bus.emit(NavalFleetsUpdatedEvent(game: next));
-  });
-}
 
 void main() {
   suppressLogsForTests();
@@ -88,35 +49,12 @@ void main() {
         : 'gp1';
   });
 
-  Widget buildPanel({
-    required Game game,
-    required String humanPlayerId,
-    AppEventBus? bus,
-    MapTopology topology = const MapTopology(),
-    Orders draftOrders = const Orders(),
-    String? locationScopeKey,
-  }) {
-    final resolvedBus = bus ?? AppEventBus.create();
-    return MaterialApp(
-      home: Scaffold(
-        body: NavalUnitsPanel(
-          game: game,
-          humanPlayerId: humanPlayerId,
-          bus: resolvedBus,
-          topology: topology,
-          draftOrders: draftOrders,
-          locationScopeKey: locationScopeKey,
-        ),
-      ),
-    );
-  }
-
   group('NavalUnitsPanel', () {
     testWidgets('AC: Panel shows title Naval Units', (
       WidgetTester tester,
     ) async {
       await tester.pumpWidget(
-        buildPanel(game: game, humanPlayerId: humanPlayerIdWithFleets),
+        buildNavalPanel(game: game, humanPlayerId: humanPlayerIdWithFleets),
       );
       await tester.pumpAndSettle();
 
@@ -131,7 +69,7 @@ void main() {
       WidgetTester tester,
     ) async {
       await tester.pumpWidget(
-        buildPanel(game: game, humanPlayerId: humanPlayerIdWithFleets),
+        buildNavalPanel(game: game, humanPlayerId: humanPlayerIdWithFleets),
       );
       await tester.pumpAndSettle();
 
@@ -154,7 +92,7 @@ void main() {
       'AC: When human player has no fleets, panel does not crash and shows either empty or Home Fleet only',
       (WidgetTester tester) async {
         await tester.pumpWidget(
-          buildPanel(game: game, humanPlayerId: humanPlayerIdWithNoFleets),
+          buildNavalPanel(game: game, humanPlayerId: humanPlayerIdWithNoFleets),
         );
         await tester.pumpAndSettle();
 
@@ -169,7 +107,7 @@ void main() {
       'AC: When player has fleets, panel shows at least one fleet row',
       (WidgetTester tester) async {
         await tester.pumpWidget(
-          buildPanel(game: game, humanPlayerId: humanPlayerIdWithFleets),
+          buildNavalPanel(game: game, humanPlayerId: humanPlayerIdWithFleets),
         );
         await tester.pumpAndSettle();
 
@@ -193,7 +131,7 @@ void main() {
 
     testWidgets('AC: Panel is wrapped in CtPanel', (WidgetTester tester) async {
       await tester.pumpWidget(
-        buildPanel(game: game, humanPlayerId: humanPlayerIdWithFleets),
+        buildNavalPanel(game: game, humanPlayerId: humanPlayerIdWithFleets),
       );
       await tester.pumpAndSettle();
 
@@ -233,7 +171,7 @@ void main() {
       final bus = AppEventBus.create();
       bus.on<LocateMapTileEvent>().listen((e) => locateEvent = e);
       await tester.pumpWidget(
-        buildPanel(
+        buildNavalPanel(
           game: game,
           humanPlayerId: humanPlayerIdWithFleets,
           bus: bus,
@@ -258,7 +196,7 @@ void main() {
       WidgetTester tester,
     ) async {
       await tester.pumpWidget(
-        buildPanel(game: game, humanPlayerId: humanPlayerIdWithFleets),
+        buildNavalPanel(game: game, humanPlayerId: humanPlayerIdWithFleets),
       );
       await tester.pumpAndSettle();
 
@@ -333,7 +271,7 @@ void main() {
         ],
       );
       await tester.pumpWidget(
-        buildPanel(game: namedSeaGame, humanPlayerId: humanId),
+        buildNavalPanel(game: namedSeaGame, humanPlayerId: humanId),
       );
       await tester.pumpAndSettle();
       expect(find.textContaining('Caribbean Sea'), findsWidgets);
@@ -392,7 +330,7 @@ void main() {
         );
 
         await tester.pumpWidget(
-          buildPanel(game: shipLabelGame, humanPlayerId: humanId),
+          buildNavalPanel(game: shipLabelGame, humanPlayerId: humanId),
         );
         await tester.pumpAndSettle();
 
@@ -465,7 +403,7 @@ void main() {
         });
 
         await tester.pumpWidget(
-          buildPanel(
+          buildNavalPanel(
             game: gameWithExtraFleets,
             humanPlayerId: humanId,
             bus: bus,
@@ -553,7 +491,7 @@ void main() {
         );
 
         await tester.pumpWidget(
-          buildPanel(
+          buildNavalPanel(
             game: gameWithoutHomeFleets,
             humanPlayerId: humanPlayerIdWithFleets,
             bus: bus,
@@ -613,7 +551,7 @@ void main() {
           locatedRegionId = e.regionId;
         });
         await tester.pumpWidget(
-          buildPanel(
+          buildNavalPanel(
             game: gameWithExtraFleets,
             humanPlayerId: humanId,
             bus: bus,
@@ -721,7 +659,7 @@ void main() {
       });
 
       await tester.pumpWidget(
-        buildPanel(game: gameWithExtraFleets, humanPlayerId: humanId, bus: bus),
+        buildNavalPanel(game: gameWithExtraFleets, humanPlayerId: humanId, bus: bus),
       );
       await tester.pumpAndSettle();
 
@@ -749,7 +687,7 @@ void main() {
     ) async {
       final humanId = humanPlayerIdWithFleets;
 
-      await tester.pumpWidget(buildPanel(game: game, humanPlayerId: humanId));
+      await tester.pumpWidget(buildNavalPanel(game: game, humanPlayerId: humanId));
       await tester.pumpAndSettle();
 
       final homeFleetFinder = find.widgetWithText(ExpansionTile, 'Home Fleet');
@@ -776,7 +714,7 @@ void main() {
       (WidgetTester tester) async {
         final humanId = humanPlayerIdWithFleets;
 
-        await tester.pumpWidget(buildPanel(game: game, humanPlayerId: humanId));
+        await tester.pumpWidget(buildNavalPanel(game: game, humanPlayerId: humanId));
         await tester.pumpAndSettle();
 
         final homeFleetFinder = find.widgetWithText(
@@ -829,7 +767,7 @@ void main() {
 
       final baseFleet = playerFleets.first;
 
-      await tester.pumpWidget(buildPanel(game: game, humanPlayerId: humanId));
+      await tester.pumpWidget(buildNavalPanel(game: game, humanPlayerId: humanId));
       await tester.pumpAndSettle();
 
       final fleetFinder = find.widgetWithText(
@@ -849,7 +787,7 @@ void main() {
       'AC: Expanding home/non-home fleet and tapping Split opens Split Fleet dialog',
       (WidgetTester tester) async {
         final humanId = humanPlayerIdWithFleets;
-        await tester.pumpWidget(buildPanel(game: game, humanPlayerId: humanId));
+        await tester.pumpWidget(buildNavalPanel(game: game, humanPlayerId: humanId));
         await tester.pumpAndSettle();
 
         final homeFleetFinder = find.widgetWithText(
@@ -910,7 +848,7 @@ void main() {
             .toList();
         if (playerFleets.isEmpty) return;
 
-        await tester.pumpWidget(buildPanel(game: game, humanPlayerId: humanId));
+        await tester.pumpWidget(buildNavalPanel(game: game, humanPlayerId: humanId));
         await tester.pumpAndSettle();
 
         expect(
@@ -948,7 +886,7 @@ void main() {
             : 'Fleet ${targetFleet.id}';
 
         await tester.pumpWidget(
-          buildPanel(bus: bus, game: game, humanPlayerId: humanId),
+          buildNavalPanel(bus: bus, game: game, humanPlayerId: humanId),
         );
         await tester.pumpAndSettle();
 

--- a/app/test/naval_units_panel_part2_test.dart
+++ b/app/test/naval_units_panel_part2_test.dart
@@ -1,62 +1,19 @@
 // Tests for NavalUnitsPanel. SPEC/ui/naval-units-panel.md.
 
-import 'dart:async';
-
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/colonizethis_logic.dart'
-    show
-        applyNavalSplitFleet,
-        applyNavalTransferShipsBetweenFleets,
-        homeFleetIdFor;
+import 'package:colonizethis_logic/colonizethis_logic.dart' show homeFleetIdFor;
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:colonizethis_app/features/game/widgets/move_fleet_dialog.dart';
 import 'package:colonizethis_app/features/game/widgets/naval_units_panel.dart';
 import 'package:colonizethis_app/features/game/widgets/chrome/ct_action_text_button.dart';
-import 'package:colonizethis_app/features/game/widgets/units/shared/units_entity_action_row.dart';
-import 'package:colonizethis_app/features/game/widgets/units/shared/units_panel_shell.dart';
 import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
-import 'package:colonizethis_app/widgets/ct_panel.dart';
 import 'package:colonizethis_app/widgets/ct_transfer_list.dart';
 
+import 'support/naval_units_panel_test_support.dart';
 import 'support/widget_test_assets.dart';
-
-/// Mirrors shell handling of [NavalSplitFleetRequestedEvent] for widget tests.
-StreamSubscription<NavalSplitFleetRequestedEvent> wireNavalSplitForWidgetTest({
-  required AppEventBus bus,
-  required Game Function() gameSnapshot,
-}) {
-  return bus.on<NavalSplitFleetRequestedEvent>().listen((e) {
-    final next = applyNavalSplitFleet(
-      game: gameSnapshot(),
-      humanPlayerId: e.humanPlayerId,
-      originalFleetId: e.originalFleetId,
-      shipInstanceIdsToNewFleet: e.shipInstanceIdsToNewFleet,
-    );
-    bus.emit(NavalFleetsUpdatedEvent(game: next));
-  });
-}
-
-/// Mirrors shell handling of [NavalTransferShipsRequestedEvent] for widget tests.
-StreamSubscription<NavalTransferShipsRequestedEvent>
-wireNavalTransferForWidgetTest({
-  required AppEventBus bus,
-  required Game Function() gameSnapshot,
-}) {
-  return bus.on<NavalTransferShipsRequestedEvent>().listen((e) {
-    final next = applyNavalTransferShipsBetweenFleets(
-      game: gameSnapshot(),
-      humanPlayerId: e.humanPlayerId,
-      sourceFleetId: e.sourceFleetId,
-      targetFleetId: e.targetFleetId,
-      shipInstanceIdsToTransfer: e.shipInstanceIdsToTransfer,
-    );
-    bus.emit(NavalFleetsUpdatedEvent(game: next));
-  });
-}
 
 void main() {
   suppressLogsForTests();
@@ -65,29 +22,6 @@ void main() {
   setUpAll(() async {
     await setUpNinePatchAssets();
   });
-
-  Widget buildPanel({
-    required Game game,
-    required String humanPlayerId,
-    AppEventBus? bus,
-    MapTopology topology = const MapTopology(),
-    Orders draftOrders = const Orders(),
-    String? locationScopeKey,
-  }) {
-    final resolvedBus = bus ?? AppEventBus.create();
-    return MaterialApp(
-      home: Scaffold(
-        body: NavalUnitsPanel(
-          game: game,
-          humanPlayerId: humanPlayerId,
-          bus: resolvedBus,
-          topology: topology,
-          draftOrders: draftOrders,
-          locationScopeKey: locationScopeKey,
-        ),
-      ),
-    );
-  }
 
   group('NavalUnitsPanel', () {
     testWidgets(
@@ -158,7 +92,7 @@ void main() {
         );
 
         await tester.pumpWidget(
-          buildPanel(game: selectAllGame, humanPlayerId: humanId),
+          buildNavalPanel(game: selectAllGame, humanPlayerId: humanId),
         );
         await tester.pumpAndSettle();
 
@@ -267,7 +201,7 @@ void main() {
       addTearDown(sub.cancel);
 
       await tester.pumpWidget(
-        buildPanel(game: combineGame, humanPlayerId: humanId, bus: bus),
+        buildNavalPanel(game: combineGame, humanPlayerId: humanId, bus: bus),
       );
       await tester.pumpAndSettle();
 
@@ -386,7 +320,7 @@ void main() {
         );
 
         await tester.pumpWidget(
-          buildPanel(game: diffLocGame, humanPlayerId: humanId),
+          buildNavalPanel(game: diffLocGame, humanPlayerId: humanId),
         );
         await tester.pumpAndSettle();
 
@@ -486,7 +420,7 @@ void main() {
         addTearDown(subTransfer.cancel);
 
         await tester.pumpWidget(
-          buildPanel(game: homeCombineGame, humanPlayerId: humanId, bus: bus),
+          buildNavalPanel(game: homeCombineGame, humanPlayerId: humanId, bus: bus),
         );
         await tester.pumpAndSettle();
 
@@ -621,7 +555,7 @@ void main() {
         addTearDown(sub.cancel);
 
         await tester.pumpWidget(
-          buildPanel(game: threeGame, humanPlayerId: humanId, bus: bus),
+          buildNavalPanel(game: threeGame, humanPlayerId: humanId, bus: bus),
         );
         await tester.pumpAndSettle();
 
@@ -730,7 +664,7 @@ void main() {
         );
 
         await tester.pumpWidget(
-          buildPanel(game: twoSeaGame, humanPlayerId: humanId),
+          buildNavalPanel(game: twoSeaGame, humanPlayerId: humanId),
         );
         await tester.pumpAndSettle();
 
@@ -834,7 +768,7 @@ void main() {
         );
 
         await tester.pumpWidget(
-          buildPanel(game: seaPortGame, humanPlayerId: humanId),
+          buildNavalPanel(game: seaPortGame, humanPlayerId: humanId),
         );
         await tester.pumpAndSettle();
 
@@ -933,7 +867,7 @@ void main() {
         );
 
         await tester.pumpWidget(
-          buildPanel(game: gameAdj, humanPlayerId: humanId, topology: topology),
+          buildNavalPanel(game: gameAdj, humanPlayerId: humanId, topology: topology),
         );
         await tester.pumpAndSettle();
 

--- a/app/test/naval_units_panel_part3_test.dart
+++ b/app/test/naval_units_panel_part3_test.dart
@@ -1,62 +1,19 @@
 // Tests for NavalUnitsPanel. SPEC/ui/naval-units-panel.md.
 
-import 'dart:async';
-
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/colonizethis_logic.dart'
-    show
-        applyNavalSplitFleet,
-        applyNavalTransferShipsBetweenFleets,
-        homeFleetIdFor;
+import 'package:colonizethis_logic/colonizethis_logic.dart' show homeFleetIdFor;
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:colonizethis_app/features/game/widgets/move_fleet_dialog.dart';
 import 'package:colonizethis_app/features/game/widgets/naval_units_panel.dart';
 import 'package:colonizethis_app/features/game/widgets/chrome/ct_action_text_button.dart';
-import 'package:colonizethis_app/features/game/widgets/units/shared/units_entity_action_row.dart';
-import 'package:colonizethis_app/features/game/widgets/units/shared/units_panel_shell.dart';
 import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
-import 'package:colonizethis_app/widgets/ct_panel.dart';
 import 'package:colonizethis_app/widgets/ct_transfer_list.dart';
 
+import 'support/naval_units_panel_test_support.dart';
 import 'support/widget_test_assets.dart';
-
-/// Mirrors shell handling of [NavalSplitFleetRequestedEvent] for widget tests.
-StreamSubscription<NavalSplitFleetRequestedEvent> wireNavalSplitForWidgetTest({
-  required AppEventBus bus,
-  required Game Function() gameSnapshot,
-}) {
-  return bus.on<NavalSplitFleetRequestedEvent>().listen((e) {
-    final next = applyNavalSplitFleet(
-      game: gameSnapshot(),
-      humanPlayerId: e.humanPlayerId,
-      originalFleetId: e.originalFleetId,
-      shipInstanceIdsToNewFleet: e.shipInstanceIdsToNewFleet,
-    );
-    bus.emit(NavalFleetsUpdatedEvent(game: next));
-  });
-}
-
-/// Mirrors shell handling of [NavalTransferShipsRequestedEvent] for widget tests.
-StreamSubscription<NavalTransferShipsRequestedEvent>
-wireNavalTransferForWidgetTest({
-  required AppEventBus bus,
-  required Game Function() gameSnapshot,
-}) {
-  return bus.on<NavalTransferShipsRequestedEvent>().listen((e) {
-    final next = applyNavalTransferShipsBetweenFleets(
-      game: gameSnapshot(),
-      humanPlayerId: e.humanPlayerId,
-      sourceFleetId: e.sourceFleetId,
-      targetFleetId: e.targetFleetId,
-      shipInstanceIdsToTransfer: e.shipInstanceIdsToTransfer,
-    );
-    bus.emit(NavalFleetsUpdatedEvent(game: next));
-  });
-}
 
 void main() {
   suppressLogsForTests();
@@ -65,29 +22,6 @@ void main() {
   setUpAll(() async {
     await setUpNinePatchAssets();
   });
-
-  Widget buildPanel({
-    required Game game,
-    required String humanPlayerId,
-    AppEventBus? bus,
-    MapTopology topology = const MapTopology(),
-    Orders draftOrders = const Orders(),
-    String? locationScopeKey,
-  }) {
-    final resolvedBus = bus ?? AppEventBus.create();
-    return MaterialApp(
-      home: Scaffold(
-        body: NavalUnitsPanel(
-          game: game,
-          humanPlayerId: humanPlayerId,
-          bus: resolvedBus,
-          topology: topology,
-          draftOrders: draftOrders,
-          locationScopeKey: locationScopeKey,
-        ),
-      ),
-    );
-  }
 
   group('NavalUnitsPanel', () {
     testWidgets(
@@ -174,7 +108,7 @@ void main() {
         addTearDown(subUpdated.cancel);
 
         await tester.pumpWidget(
-          buildPanel(
+          buildNavalPanel(
             game: gameState,
             humanPlayerId: humanId,
             topology: topology,
@@ -307,7 +241,7 @@ void main() {
         );
 
         await tester.pumpWidget(
-          buildPanel(
+          buildNavalPanel(
             game: gameNonAdjacent,
             humanPlayerId: humanId,
             topology: topology,
@@ -417,7 +351,7 @@ void main() {
         addTearDown(sub.cancel);
 
         await tester.pumpWidget(
-          buildPanel(game: sameSeaGame, humanPlayerId: humanId, bus: bus),
+          buildNavalPanel(game: sameSeaGame, humanPlayerId: humanId, bus: bus),
         );
         await tester.pumpAndSettle();
 
@@ -531,7 +465,7 @@ void main() {
         addTearDown(sub.cancel);
 
         await tester.pumpWidget(
-          buildPanel(game: missionGame, humanPlayerId: humanId, bus: bus),
+          buildNavalPanel(game: missionGame, humanPlayerId: humanId, bus: bus),
         );
         await tester.pumpAndSettle();
 
@@ -620,7 +554,7 @@ void main() {
         );
 
         await tester.pumpWidget(
-          buildPanel(game: partialGame, humanPlayerId: humanId),
+          buildNavalPanel(game: partialGame, humanPlayerId: humanId),
         );
         await tester.pumpAndSettle();
 
@@ -740,7 +674,7 @@ void main() {
         addTearDown(sub.cancel);
 
         await tester.pumpWidget(
-          buildPanel(game: revGame, humanPlayerId: humanId, bus: bus),
+          buildNavalPanel(game: revGame, humanPlayerId: humanId, bus: bus),
         );
         await tester.pumpAndSettle();
 
@@ -858,7 +792,7 @@ void main() {
         );
 
         await tester.pumpWidget(
-          buildPanel(game: gameTwo, humanPlayerId: humanId),
+          buildNavalPanel(game: gameTwo, humanPlayerId: humanId),
         );
         await tester.pumpAndSettle();
 
@@ -874,7 +808,7 @@ void main() {
         await tester.pumpAndSettle();
 
         await tester.pumpWidget(
-          buildPanel(game: gameOne, humanPlayerId: humanId),
+          buildNavalPanel(game: gameOne, humanPlayerId: humanId),
         );
         await tester.pump();
         await tester.pumpAndSettle();
@@ -972,7 +906,7 @@ void main() {
         addTearDown(sub.cancel);
 
         await tester.pumpWidget(
-          buildPanel(game: collapsedGame, humanPlayerId: humanId, bus: bus),
+          buildNavalPanel(game: collapsedGame, humanPlayerId: humanId, bus: bus),
         );
         await tester.pumpAndSettle();
 

--- a/app/test/naval_units_panel_part4_test.dart
+++ b/app/test/naval_units_panel_part4_test.dart
@@ -3,11 +3,7 @@
 import 'dart:async';
 
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/colonizethis_logic.dart'
-    show
-        applyNavalSplitFleet,
-        applyNavalTransferShipsBetweenFleets,
-        homeFleetIdFor;
+import 'package:colonizethis_logic/colonizethis_logic.dart' show homeFleetIdFor;
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
@@ -16,48 +12,12 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:colonizethis_app/features/game/widgets/move_fleet_dialog.dart';
 import 'package:colonizethis_app/features/game/widgets/naval_units_panel.dart';
 import 'package:colonizethis_app/features/game/widgets/chrome/ct_action_text_button.dart';
-import 'package:colonizethis_app/features/game/widgets/units/shared/units_entity_action_row.dart';
-import 'package:colonizethis_app/features/game/widgets/units/shared/units_panel_shell.dart';
 import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
-import 'package:colonizethis_app/widgets/ct_panel.dart';
 import 'package:colonizethis_app/widgets/ct_transfer_list.dart';
 
+import 'support/naval_units_panel_test_support.dart';
 import 'support/panel_test_fixtures.dart';
 import 'support/widget_test_assets.dart';
-
-/// Mirrors shell handling of [NavalSplitFleetRequestedEvent] for widget tests.
-StreamSubscription<NavalSplitFleetRequestedEvent> wireNavalSplitForWidgetTest({
-  required AppEventBus bus,
-  required Game Function() gameSnapshot,
-}) {
-  return bus.on<NavalSplitFleetRequestedEvent>().listen((e) {
-    final next = applyNavalSplitFleet(
-      game: gameSnapshot(),
-      humanPlayerId: e.humanPlayerId,
-      originalFleetId: e.originalFleetId,
-      shipInstanceIdsToNewFleet: e.shipInstanceIdsToNewFleet,
-    );
-    bus.emit(NavalFleetsUpdatedEvent(game: next));
-  });
-}
-
-/// Mirrors shell handling of [NavalTransferShipsRequestedEvent] for widget tests.
-StreamSubscription<NavalTransferShipsRequestedEvent>
-wireNavalTransferForWidgetTest({
-  required AppEventBus bus,
-  required Game Function() gameSnapshot,
-}) {
-  return bus.on<NavalTransferShipsRequestedEvent>().listen((e) {
-    final next = applyNavalTransferShipsBetweenFleets(
-      game: gameSnapshot(),
-      humanPlayerId: e.humanPlayerId,
-      sourceFleetId: e.sourceFleetId,
-      targetFleetId: e.targetFleetId,
-      shipInstanceIdsToTransfer: e.shipInstanceIdsToTransfer,
-    );
-    bus.emit(NavalFleetsUpdatedEvent(game: next));
-  });
-}
 
 void main() {
   suppressLogsForTests();
@@ -72,29 +32,6 @@ void main() {
     game = buildNavalPanelTestGame();
     humanPlayerIdWithFleets = kPanelTestHumanPlayerId;
   });
-
-  Widget buildPanel({
-    required Game game,
-    required String humanPlayerId,
-    AppEventBus? bus,
-    MapTopology topology = const MapTopology(),
-    Orders draftOrders = const Orders(),
-    String? locationScopeKey,
-  }) {
-    final resolvedBus = bus ?? AppEventBus.create();
-    return MaterialApp(
-      home: Scaffold(
-        body: NavalUnitsPanel(
-          game: game,
-          humanPlayerId: humanPlayerId,
-          bus: resolvedBus,
-          topology: topology,
-          draftOrders: draftOrders,
-          locationScopeKey: locationScopeKey,
-        ),
-      ),
-    );
-  }
 
   group('NavalUnitsPanel', () {
     testWidgets('AC: Beachhead mission appears in status line', (
@@ -130,7 +67,7 @@ void main() {
       );
 
       await tester.pumpWidget(
-        buildPanel(game: gameBeach, humanPlayerId: playerId),
+        buildNavalPanel(game: gameBeach, humanPlayerId: playerId),
       );
       await tester.pumpAndSettle();
 
@@ -159,7 +96,7 @@ void main() {
       );
 
       await tester.pumpWidget(
-        buildPanel(game: emptyGame, humanPlayerId: playerId),
+        buildNavalPanel(game: emptyGame, humanPlayerId: playerId),
       );
       await tester.pumpAndSettle();
 
@@ -223,7 +160,7 @@ void main() {
         );
 
         await tester.pumpWidget(
-          buildPanel(
+          buildNavalPanel(
             game: markerScopeGame,
             humanPlayerId: humanId,
             locationScopeKey: markerScope,
@@ -290,7 +227,7 @@ void main() {
         );
 
         await tester.pumpWidget(
-          buildPanel(
+          buildNavalPanel(
             game: scopedGame,
             humanPlayerId: humanId,
             topology: topology,
@@ -549,7 +486,7 @@ void main() {
       );
 
       await tester.pumpWidget(
-        buildPanel(game: moveHomeGame, humanPlayerId: humanId),
+        buildNavalPanel(game: moveHomeGame, humanPlayerId: humanId),
       );
       await tester.pumpAndSettle();
 
@@ -577,7 +514,7 @@ void main() {
         if (nonHomeFleets.isEmpty) return;
         final targetFleet = nonHomeFleets.first;
 
-        await tester.pumpWidget(buildPanel(game: game, humanPlayerId: humanId));
+        await tester.pumpWidget(buildNavalPanel(game: game, humanPlayerId: humanId));
         await tester.pumpAndSettle();
 
         final fleetTile = find.widgetWithText(
@@ -619,7 +556,7 @@ void main() {
       if (nonHomeFleets.isEmpty) return;
       final targetFleet = nonHomeFleets.first;
 
-      await tester.pumpWidget(buildPanel(game: game, humanPlayerId: humanId));
+      await tester.pumpWidget(buildNavalPanel(game: game, humanPlayerId: humanId));
       await tester.pumpAndSettle();
 
       final fleetTile = find.widgetWithText(
@@ -716,7 +653,7 @@ void main() {
         addTearDown(subTransferNeverDelete.cancel);
 
         await tester.pumpWidget(
-          buildPanel(
+          buildNavalPanel(
             game: homeNeverDeleteGame,
             humanPlayerId: humanId,
             bus: bus,
@@ -843,7 +780,7 @@ void main() {
         addTearDown(subSplit.cancel);
 
         await tester.pumpWidget(
-          buildPanel(game: nonHomeSplitGame, humanPlayerId: humanId, bus: bus),
+          buildNavalPanel(game: nonHomeSplitGame, humanPlayerId: humanId, bus: bus),
         );
         await tester.pumpAndSettle();
 

--- a/app/test/naval_units_panel_part5_test.dart
+++ b/app/test/naval_units_panel_part5_test.dart
@@ -1,61 +1,12 @@
 // Tests for NavalUnitsPanel. SPEC/ui/naval-units-panel.md.
 
-import 'dart:async';
-
-import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/colonizethis_logic.dart'
-    show
-        applyNavalSplitFleet,
-        applyNavalTransferShipsBetweenFleets,
-        homeFleetIdFor;
+import 'package:colonizethis_logic/colonizethis_logic.dart' show homeFleetIdFor;
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:colonizethis_app/features/game/widgets/move_fleet_dialog.dart';
-import 'package:colonizethis_app/features/game/widgets/naval_units_panel.dart';
-import 'package:colonizethis_app/features/game/widgets/units/shared/units_entity_action_row.dart';
-import 'package:colonizethis_app/features/game/widgets/units/shared/units_panel_shell.dart';
-import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
-import 'package:colonizethis_app/widgets/ct_panel.dart';
-import 'package:colonizethis_app/widgets/ct_transfer_list.dart';
-
+import 'support/naval_units_panel_test_support.dart';
 import 'support/widget_test_assets.dart';
-
-/// Mirrors shell handling of [NavalSplitFleetRequestedEvent] for widget tests.
-StreamSubscription<NavalSplitFleetRequestedEvent> wireNavalSplitForWidgetTest({
-  required AppEventBus bus,
-  required Game Function() gameSnapshot,
-}) {
-  return bus.on<NavalSplitFleetRequestedEvent>().listen((e) {
-    final next = applyNavalSplitFleet(
-      game: gameSnapshot(),
-      humanPlayerId: e.humanPlayerId,
-      originalFleetId: e.originalFleetId,
-      shipInstanceIdsToNewFleet: e.shipInstanceIdsToNewFleet,
-    );
-    bus.emit(NavalFleetsUpdatedEvent(game: next));
-  });
-}
-
-/// Mirrors shell handling of [NavalTransferShipsRequestedEvent] for widget tests.
-StreamSubscription<NavalTransferShipsRequestedEvent>
-wireNavalTransferForWidgetTest({
-  required AppEventBus bus,
-  required Game Function() gameSnapshot,
-}) {
-  return bus.on<NavalTransferShipsRequestedEvent>().listen((e) {
-    final next = applyNavalTransferShipsBetweenFleets(
-      game: gameSnapshot(),
-      humanPlayerId: e.humanPlayerId,
-      sourceFleetId: e.sourceFleetId,
-      targetFleetId: e.targetFleetId,
-      shipInstanceIdsToTransfer: e.shipInstanceIdsToTransfer,
-    );
-    bus.emit(NavalFleetsUpdatedEvent(game: next));
-  });
-}
 
 void main() {
   suppressLogsForTests();
@@ -65,28 +16,6 @@ void main() {
     await setUpNinePatchAssets();
   });
 
-  Widget buildPanel({
-    required Game game,
-    required String humanPlayerId,
-    AppEventBus? bus,
-    MapTopology topology = const MapTopology(),
-    Orders draftOrders = const Orders(),
-    String? locationScopeKey,
-  }) {
-    final resolvedBus = bus ?? AppEventBus.create();
-    return MaterialApp(
-      home: Scaffold(
-        body: NavalUnitsPanel(
-          game: game,
-          humanPlayerId: humanPlayerId,
-          bus: resolvedBus,
-          topology: topology,
-          draftOrders: draftOrders,
-          locationScopeKey: locationScopeKey,
-        ),
-      ),
-    );
-  }
   group('Draft naval move subtitle', () {
 
     testWidgets('shows Moving to line when draft order present', (
@@ -155,7 +84,7 @@ void main() {
       );
 
       await tester.pumpWidget(
-        buildPanel(
+        buildNavalPanel(
           game: draftGame,
           humanPlayerId: humanId,
           draftOrders: orders,

--- a/app/test/support/naval_units_panel_test_support.dart
+++ b/app/test/support/naval_units_panel_test_support.dart
@@ -1,0 +1,94 @@
+// Shared widget-test scaffolding for the `NavalUnitsPanel` test family.
+//
+// The five `app/test/naval_units_panel_part*_test.dart` files each previously
+// re-declared identical top-level `wireNavalSplitForWidgetTest` /
+// `wireNavalTransferForWidgetTest` event bridges plus an identical local
+// `buildPanel(...)` closure that wraps `NavalUnitsPanel` in a plain
+// `MaterialApp` > `Scaffold`. Consolidating them here keeps each part file's
+// per-test fixtures and assertions local while removing the copy-pasted shell
+// and bus wiring.
+//
+// Refs #3730 (consolidate app test scaffolding; partN shared setup).
+// SPEC: SPEC/ui/naval-units-panel.md (panel behavior under test),
+// SPEC/program/repo-lint.md (test static-analysis scope).
+
+import 'dart:async';
+
+import 'package:colonizethis_data/colonizethis_data.dart' show MapTopology;
+import 'package:colonizethis_logic/colonizethis_logic.dart'
+    show applyNavalSplitFleet, applyNavalTransferShipsBetweenFleets;
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:flutter/material.dart';
+
+import 'package:colonizethis_app/features/game/widgets/naval_units_panel.dart';
+
+/// Mirrors the running shell's handling of [NavalSplitFleetRequestedEvent] for
+/// widget tests: applies [applyNavalSplitFleet] to the latest game snapshot and
+/// re-emits the result as a [NavalFleetsUpdatedEvent] so the panel rebuilds.
+///
+/// [gameSnapshot] is read lazily on each event so callers can mutate their
+/// local game reference between interactions. The returned subscription should
+/// be cancelled by the test (e.g. via `addTearDown`).
+StreamSubscription<NavalSplitFleetRequestedEvent> wireNavalSplitForWidgetTest({
+  required AppEventBus bus,
+  required Game Function() gameSnapshot,
+}) {
+  return bus.on<NavalSplitFleetRequestedEvent>().listen((e) {
+    final next = applyNavalSplitFleet(
+      game: gameSnapshot(),
+      humanPlayerId: e.humanPlayerId,
+      originalFleetId: e.originalFleetId,
+      shipInstanceIdsToNewFleet: e.shipInstanceIdsToNewFleet,
+    );
+    bus.emit(NavalFleetsUpdatedEvent(game: next));
+  });
+}
+
+/// Mirrors the running shell's handling of [NavalTransferShipsRequestedEvent]
+/// for widget tests: applies [applyNavalTransferShipsBetweenFleets] to the
+/// latest game snapshot and re-emits a [NavalFleetsUpdatedEvent].
+///
+/// See [wireNavalSplitForWidgetTest] for the [gameSnapshot]/teardown contract.
+StreamSubscription<NavalTransferShipsRequestedEvent>
+wireNavalTransferForWidgetTest({
+  required AppEventBus bus,
+  required Game Function() gameSnapshot,
+}) {
+  return bus.on<NavalTransferShipsRequestedEvent>().listen((e) {
+    final next = applyNavalTransferShipsBetweenFleets(
+      game: gameSnapshot(),
+      humanPlayerId: e.humanPlayerId,
+      sourceFleetId: e.sourceFleetId,
+      targetFleetId: e.targetFleetId,
+      shipInstanceIdsToTransfer: e.shipInstanceIdsToTransfer,
+    );
+    bus.emit(NavalFleetsUpdatedEvent(game: next));
+  });
+}
+
+/// Builds the canonical [NavalUnitsPanel] host used across the panel's widget
+/// tests: a plain [MaterialApp] > [Scaffold] wrapping the panel. When [bus] is
+/// omitted a fresh [AppEventBus] is created so tests that do not need to drive
+/// events still get a valid bus.
+Widget buildNavalPanel({
+  required Game game,
+  required String humanPlayerId,
+  AppEventBus? bus,
+  MapTopology topology = const MapTopology(),
+  Orders draftOrders = const Orders(),
+  String? locationScopeKey,
+}) {
+  final resolvedBus = bus ?? AppEventBus.create();
+  return MaterialApp(
+    home: Scaffold(
+      body: NavalUnitsPanel(
+        game: game,
+        humanPlayerId: humanPlayerId,
+        bus: resolvedBus,
+        topology: topology,
+        draftOrders: draftOrders,
+        locationScopeKey: locationScopeKey,
+      ),
+    ),
+  );
+}

--- a/app/test/support/naval_units_panel_test_support_test.dart
+++ b/app/test/support/naval_units_panel_test_support_test.dart
@@ -1,0 +1,105 @@
+// Smoke tests for the shared `NavalUnitsPanel` widget-test scaffolding.
+//
+// Verifies the consolidated helpers in `naval_units_panel_test_support.dart`
+// (extracted from the five `naval_units_panel_part*_test.dart` files, Refs
+// #3730) build the canonical panel host and bridge the split/transfer events
+// the same way the running shell does, so the part files keep their behavior.
+//
+// SPEC: SPEC/ui/naval-units-panel.md, SPEC/program/app-ui-wiring.md.
+
+import 'package:colonizethis_logic/colonizethis_logic.dart' show homeFleetIdFor;
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:colonizethis_app/features/game/widgets/naval_units_panel.dart';
+
+import 'naval_units_panel_test_support.dart';
+import 'panel_test_fixtures.dart';
+import 'widget_test_assets.dart';
+
+void main() {
+  suppressLogsForTests();
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    await setUpNinePatchAssets();
+  });
+
+  testWidgets(
+    'buildNavalPanel hosts NavalUnitsPanel inside a MaterialApp scaffold',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        buildNavalPanel(
+          game: buildNavalPanelTestGame(),
+          humanPlayerId: kPanelTestHumanPlayerId,
+        ),
+      );
+      await tester.pump();
+
+      expect(find.byType(MaterialApp), findsOneWidget);
+      expect(find.byType(Scaffold), findsOneWidget);
+      expect(find.byType(NavalUnitsPanel), findsOneWidget);
+    },
+  );
+
+  test(
+    'wireNavalSplitForWidgetTest applies the split and re-emits the update',
+    () async {
+      final bus = AppEventBus.create();
+      final game = buildNavalPanelTestGame();
+      final originalFleetCount = game.worldState.fleets.length;
+      final sub = wireNavalSplitForWidgetTest(
+        bus: bus,
+        gameSnapshot: () => game,
+      );
+      addTearDown(sub.cancel);
+
+      final updated = bus.on<NavalFleetsUpdatedEvent>().first;
+      bus.emit(
+        NavalSplitFleetRequestedEvent(
+          humanPlayerId: kPanelTestHumanPlayerId,
+          originalFleetId: 'fleet_nh1',
+          shipInstanceIdsToNewFleet: const ['n2'],
+        ),
+      );
+
+      final event = await updated;
+      expect(
+        event.game.worldState.fleets.length,
+        greaterThan(originalFleetCount),
+      );
+    },
+  );
+
+  test(
+    'wireNavalTransferForWidgetTest moves the ship and re-emits the update',
+    () async {
+      final bus = AppEventBus.create();
+      final game = buildNavalPanelTestGame();
+      final homeFleetId = homeFleetIdFor(kPanelTestHumanPlayerId);
+      final sub = wireNavalTransferForWidgetTest(
+        bus: bus,
+        gameSnapshot: () => game,
+      );
+      addTearDown(sub.cancel);
+
+      final updated = bus.on<NavalFleetsUpdatedEvent>().first;
+      bus.emit(
+        NavalTransferShipsRequestedEvent(
+          humanPlayerId: kPanelTestHumanPlayerId,
+          sourceFleetId: 'fleet_nh1',
+          targetFleetId: homeFleetId,
+          shipInstanceIdsToTransfer: const ['n2'],
+        ),
+      );
+
+      final event = await updated;
+      final source = event.game.worldState.fleets.firstWhere(
+        (f) => f.id == 'fleet_nh1',
+      );
+      expect(source.ships.length, 1);
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Follow-up slice for the app-test scaffolding dedup (#3730), opened after the prior PR (#3738) merged into `dev`.

Advances **AC3** (consolidate `partN`-split families / lift shared setup into `test/support/`) for the `naval_units_panel_part*` family. The five files each re-declared byte-identical scaffolding; this lifts it into one shared support file.

## Done in this push

New shared helper `app/test/support/naval_units_panel_test_support.dart`:

- `wireNavalSplitForWidgetTest(...)` / `wireNavalTransferForWidgetTest(...)` — the identical `AppEventBus` bridges (apply split/transfer to the latest snapshot, re-emit `NavalFleetsUpdatedEvent`) that were copy-pasted into all five part files.
- `buildNavalPanel(...)` — the identical local `buildPanel` `MaterialApp` > `Scaffold` host closure.

Migrated `app/test/naval_units_panel_part1..5_test.dart` to import the shared helpers, removed the duplicated definitions, switched call sites (`buildPanel` → `buildNavalPanel`), and dropped the now-unused imports.

Added `app/test/support/naval_units_panel_test_support_test.dart` — a smoke test covering the host render plus the split/transfer event bridges.

Net: **−384 / +255** lines across 7 files (5 migrated + 2 new support files).

Behavior-preserving: no assertions, fixtures, or screen IDs changed; only shared scaffolding deduplicated.

## Verification

- `cd app && flutter test test/naval_units_panel_part1_test.dart … part5 … test/support/naval_units_panel_test_support_test.dart` → **All 53 tests passed**.
- `cd app && flutter analyze` on the 7 touched files → **No issues found**.
- `dart test test/check_app_test_no_duplicate_scaffolding_test.dart` → **green** (gate is scoped to the `*_320dp_min_viewport` family and is unaffected).

## Scope / deferred

- One focused family slice (naval). The other `partN` families (`military_units_panel`, `civilian_units_panel`, `ct_region_map_widget`, `game_map_area_state_logic`) and any `province_panel_draft_orders` follow-up remain for subsequent slices on this issue. These large families are kept split per the issue's own oversized-file risk guidance; this slice lifts their shared setup rather than merging files.

Refs #3730

Made with [Cursor](https://cursor.com)