### PR TITLE
refactor(app-test): extract shared military_units_panel partN scaffolding (#3730)

### DIFF
--- a/app/test/military_units_panel_part1_test.dart
+++ b/app/test/military_units_panel_part1_test.dart
@@ -1,98 +1,22 @@
 // Tests for MilitaryUnitsPanel. SPEC/ui/military-units-panel.md.
 
-import 'dart:async';
-
-import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_data/colonizethis_data.dart' show isMilitaryUnit;
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:colonizethis_app/features/game/utils/map_location_resolver.dart';
-import 'package:colonizethis_app/features/game/widgets/move_army_dialog.dart';
 import 'package:colonizethis_app/features/game/widgets/military_units_panel.dart';
 import 'package:colonizethis_app/features/game/widgets/chrome/ct_action_text_button.dart';
 import 'package:colonizethis_app/features/game/widgets/units/shared/units_entity_action_row.dart';
 import 'package:colonizethis_app/features/game/widgets/units/shared/units_panel_shell.dart';
-import 'package:colonizethis_app/core/services/app_event_handler_scope.dart';
+import 'package:colonizethis_app/core/services/app_event_handler_scope.dart'
+    show trainMilitaryDialogId;
 import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
 import 'package:colonizethis_app/widgets/ct_panel.dart';
-import 'package:colonizethis_app/widgets/ct_transfer_list.dart';
 
+import 'support/military_units_panel_test_support.dart';
 import 'support/panel_test_fixtures.dart';
-
-/// Applies [ArmySplitRequestedEvent] like [AppEventHandlerScope] and rebuilds
-/// the panel with updated [Game] (widget tests do not mount full shell).
-class _ArmySplitTestHarness extends StatefulWidget {
-  const _ArmySplitTestHarness({
-    required this.initialGame,
-    required this.humanPlayerId,
-    required this.bus,
-  });
-
-  final Game initialGame;
-  final String humanPlayerId;
-  final AppEventBus bus;
-
-  @override
-  State<_ArmySplitTestHarness> createState() => _ArmySplitTestHarnessState();
-}
-
-class _ArmySplitTestHarnessState extends State<_ArmySplitTestHarness> {
-  late Game _game;
-  StreamSubscription<ArmySplitRequestedEvent>? _sub;
-
-  @override
-  void initState() {
-    super.initState();
-    _game = widget.initialGame;
-    _sub = widget.bus.on<ArmySplitRequestedEvent>().listen((e) {
-      final next = applyArmySplit(
-        game: _game,
-        playerId: e.humanPlayerId,
-        sourceArmyId: e.sourceArmyId,
-        unitIdsToMove: e.unitIdsToMove,
-      );
-      setState(() => _game = next);
-    });
-  }
-
-  @override
-  void dispose() {
-    unawaited(_sub?.cancel());
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return MilitaryUnitsPanel(
-      game: _game,
-      humanPlayerId: widget.humanPlayerId,
-      bus: widget.bus,
-      topology: const MapTopology(),
-      draftOrders: const Orders(),
-    );
-  }
-}
-
-Future<void> expandFirstArmyExpansion(WidgetTester tester) async {
-  final tiles = find.byType(ExpansionTile);
-  if (tiles.evaluate().isEmpty) {
-    return;
-  }
-  await tester.tap(tiles.first);
-  await tester.pumpAndSettle();
-}
-
-Future<void> expandAllArmyExpansions(WidgetTester tester) async {
-  final finder = find.byType(ExpansionTile);
-  final n = finder.evaluate().length;
-  for (var i = 0; i < n; i++) {
-    await tester.tap(finder.at(i));
-    await tester.pumpAndSettle();
-  }
-}
 
 void main() {
   suppressLogsForTests();
@@ -106,32 +30,12 @@ void main() {
     humanPlayerIdWithUnits = game.players.first.id;
   });
 
-  Widget buildPanel({
-    required Game game,
-    required String humanPlayerId,
-    AppEventBus? bus,
-    MapTopology? topology,
-    Orders draftOrders = const Orders(),
-  }) {
-    return MaterialApp(
-      home: Scaffold(
-        body: MilitaryUnitsPanel(
-          game: game,
-          humanPlayerId: humanPlayerId,
-          bus: bus ?? AppEventBus.create(),
-          topology: topology ?? const MapTopology(),
-          draftOrders: draftOrders,
-        ),
-      ),
-    );
-  }
-
   group('MilitaryUnitsPanel', () {
     testWidgets('AC: Panel shows title Military Units', (
       WidgetTester tester,
     ) async {
       await tester.pumpWidget(
-        buildPanel(game: game, humanPlayerId: humanPlayerIdWithUnits),
+        buildMilitaryPanel(game: game, humanPlayerId: humanPlayerIdWithUnits),
       );
       await tester.pumpAndSettle();
 
@@ -142,7 +46,7 @@ void main() {
       'AC: Empty state when human player has zero regiments and no fleets',
       (WidgetTester tester) async {
         await tester.pumpWidget(
-          buildPanel(game: game, humanPlayerId: humanPlayerIdWithNoUnits),
+          buildMilitaryPanel(game: game, humanPlayerId: humanPlayerIdWithNoUnits),
         );
         await tester.pumpAndSettle();
 
@@ -158,7 +62,7 @@ void main() {
       // Empty roster isolates the header so the only button chrome is the
       // Train pill (no row Move/Split CtNinePatchButtons, no Combine).
       await tester.pumpWidget(
-        buildPanel(game: game, humanPlayerId: humanPlayerIdWithNoUnits),
+        buildMilitaryPanel(game: game, humanPlayerId: humanPlayerIdWithNoUnits),
       );
       await tester.pumpAndSettle();
 
@@ -178,7 +82,7 @@ void main() {
       'combinable roster is present — #3514 owner decisions #5/#15',
       (WidgetTester tester) async {
         await tester.pumpWidget(
-          buildPanel(game: game, humanPlayerId: humanPlayerIdWithUnits),
+          buildMilitaryPanel(game: game, humanPlayerId: humanPlayerIdWithUnits),
         );
         await tester.pumpAndSettle();
 
@@ -257,7 +161,7 @@ void main() {
         ],
       );
       await tester.pumpWidget(
-        buildPanel(game: miniGame, humanPlayerId: humanId),
+        buildMilitaryPanel(game: miniGame, humanPlayerId: humanId),
       );
       await tester.pump();
       expect(find.textContaining('Mil Named Sea'), findsWidgets);
@@ -267,7 +171,7 @@ void main() {
       'AC: When player has military units, tree shows regions and type rows',
       (WidgetTester tester) async {
         await tester.pumpWidget(
-          buildPanel(game: game, humanPlayerId: humanPlayerIdWithUnits),
+          buildMilitaryPanel(game: game, humanPlayerId: humanPlayerIdWithUnits),
         );
         await tester.pumpAndSettle();
 
@@ -370,7 +274,7 @@ void main() {
         );
 
         await tester.pumpWidget(
-          buildPanel(game: miniGame, humanPlayerId: playerId),
+          buildMilitaryPanel(game: miniGame, humanPlayerId: playerId),
         );
         await tester.pumpAndSettle();
 
@@ -385,7 +289,7 @@ void main() {
       WidgetTester tester,
     ) async {
       await tester.pumpWidget(
-        buildPanel(game: game, humanPlayerId: humanPlayerIdWithUnits),
+        buildMilitaryPanel(game: game, humanPlayerId: humanPlayerIdWithUnits),
       );
       await tester.pumpAndSettle();
 
@@ -418,7 +322,7 @@ void main() {
       'AC: When tree has content, location headers show region (name — region)',
       (WidgetTester tester) async {
         await tester.pumpWidget(
-          buildPanel(game: game, humanPlayerId: humanPlayerIdWithUnits),
+          buildMilitaryPanel(game: game, humanPlayerId: humanPlayerIdWithUnits),
         );
         await tester.pumpAndSettle();
 
@@ -435,7 +339,7 @@ void main() {
 
     testWidgets('panel is wrapped in CtPanel', (WidgetTester tester) async {
       await tester.pumpWidget(
-        buildPanel(game: game, humanPlayerId: humanPlayerIdWithUnits),
+        buildMilitaryPanel(game: game, humanPlayerId: humanPlayerIdWithUnits),
       );
       await tester.pumpAndSettle();
 
@@ -449,7 +353,7 @@ void main() {
       final bus = AppEventBus.create();
       bus.on<LocateMapTileEvent>().listen((e) => locateEvent = e);
       await tester.pumpWidget(
-        buildPanel(game: game, humanPlayerId: humanPlayerIdWithUnits, bus: bus),
+        buildMilitaryPanel(game: game, humanPlayerId: humanPlayerIdWithUnits, bus: bus),
       );
       await tester.pumpAndSettle();
 
@@ -469,7 +373,7 @@ void main() {
 
     testWidgets('builds without locate callback', (WidgetTester tester) async {
       await tester.pumpWidget(
-        buildPanel(game: game, humanPlayerId: humanPlayerIdWithUnits),
+        buildMilitaryPanel(game: game, humanPlayerId: humanPlayerIdWithUnits),
       );
       await tester.pumpAndSettle();
 
@@ -488,7 +392,7 @@ void main() {
       bus.on<OpenDialogEvent>().listen((e) => openDialogEvent = e);
 
       await tester.pumpWidget(
-        buildPanel(game: game, humanPlayerId: humanPlayerIdWithUnits, bus: bus),
+        buildMilitaryPanel(game: game, humanPlayerId: humanPlayerIdWithUnits, bus: bus),
       );
       await tester.pumpAndSettle();
 
@@ -510,7 +414,7 @@ void main() {
         bus.stream.listen((e) => sequence.add(e.runtimeType));
 
         await tester.pumpWidget(
-          buildPanel(
+          buildMilitaryPanel(
             game: game,
             humanPlayerId: humanPlayerIdWithUnits,
             bus: bus,
@@ -533,7 +437,7 @@ void main() {
 
     testWidgets('panel is scrollable', (WidgetTester tester) async {
       await tester.pumpWidget(
-        buildPanel(game: game, humanPlayerId: humanPlayerIdWithUnits),
+        buildMilitaryPanel(game: game, humanPlayerId: humanPlayerIdWithUnits),
       );
       await tester.pumpAndSettle();
 

--- a/app/test/military_units_panel_part2_test.dart
+++ b/app/test/military_units_panel_part2_test.dart
@@ -1,128 +1,23 @@
 // Tests for MilitaryUnitsPanel. SPEC/ui/military-units-panel.md.
 
-import 'dart:async';
-
-import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:colonizethis_app/features/game/utils/map_location_resolver.dart';
-import 'package:colonizethis_app/features/game/widgets/move_army_dialog.dart';
-import 'package:colonizethis_app/features/game/widgets/military_units_panel.dart';
-import 'package:colonizethis_app/features/game/widgets/units/shared/units_entity_action_row.dart';
-import 'package:colonizethis_app/core/services/app_event_handler_scope.dart';
-import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
-import 'package:colonizethis_app/widgets/ct_panel.dart';
-import 'package:colonizethis_app/widgets/ct_transfer_list.dart';
 
 import 'support/panel_test_fixtures.dart';
-
-/// Applies [ArmySplitRequestedEvent] like [AppEventHandlerScope] and rebuilds
-/// the panel with updated [Game] (widget tests do not mount full shell).
-class _ArmySplitTestHarness extends StatefulWidget {
-  const _ArmySplitTestHarness({
-    required this.initialGame,
-    required this.humanPlayerId,
-    required this.bus,
-  });
-
-  final Game initialGame;
-  final String humanPlayerId;
-  final AppEventBus bus;
-
-  @override
-  State<_ArmySplitTestHarness> createState() => _ArmySplitTestHarnessState();
-}
-
-class _ArmySplitTestHarnessState extends State<_ArmySplitTestHarness> {
-  late Game _game;
-  StreamSubscription<ArmySplitRequestedEvent>? _sub;
-
-  @override
-  void initState() {
-    super.initState();
-    _game = widget.initialGame;
-    _sub = widget.bus.on<ArmySplitRequestedEvent>().listen((e) {
-      final next = applyArmySplit(
-        game: _game,
-        playerId: e.humanPlayerId,
-        sourceArmyId: e.sourceArmyId,
-        unitIdsToMove: e.unitIdsToMove,
-      );
-      setState(() => _game = next);
-    });
-  }
-
-  @override
-  void dispose() {
-    unawaited(_sub?.cancel());
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return MilitaryUnitsPanel(
-      game: _game,
-      humanPlayerId: widget.humanPlayerId,
-      bus: widget.bus,
-      topology: const MapTopology(),
-      draftOrders: const Orders(),
-    );
-  }
-}
-
-Future<void> expandFirstArmyExpansion(WidgetTester tester) async {
-  final tiles = find.byType(ExpansionTile);
-  if (tiles.evaluate().isEmpty) {
-    return;
-  }
-  await tester.tap(tiles.first);
-  await tester.pumpAndSettle();
-}
-
-Future<void> expandAllArmyExpansions(WidgetTester tester) async {
-  final finder = find.byType(ExpansionTile);
-  final n = finder.evaluate().length;
-  for (var i = 0; i < n; i++) {
-    await tester.tap(finder.at(i));
-    await tester.pumpAndSettle();
-  }
-}
 
 void main() {
   suppressLogsForTests();
 
   late Game game;
   late String humanPlayerIdWithUnits;
-  const String humanPlayerIdWithNoUnits = 'no-such-player';
 
   setUpAll(() {
     game = buildMilitaryPanelTestGame();
     humanPlayerIdWithUnits = game.players.first.id;
   });
-
-  Widget buildPanel({
-    required Game game,
-    required String humanPlayerId,
-    AppEventBus? bus,
-    MapTopology? topology,
-    Orders draftOrders = const Orders(),
-  }) {
-    return MaterialApp(
-      home: Scaffold(
-        body: MilitaryUnitsPanel(
-          game: game,
-          humanPlayerId: humanPlayerId,
-          bus: bus ?? AppEventBus.create(),
-          topology: topology ?? const MapTopology(),
-          draftOrders: draftOrders,
-        ),
-      ),
-    );
-  }
 
   group('tileKeyForProvinceLocation', () {
     test('returns townTileKey when province has it', () {

--- a/app/test/military_units_panel_part3_test.dart
+++ b/app/test/military_units_panel_part3_test.dart
@@ -1,128 +1,22 @@
 // Tests for MilitaryUnitsPanel. SPEC/ui/military-units-panel.md.
 
-import 'dart:async';
-
-import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:colonizethis_app/features/game/utils/map_location_resolver.dart';
-import 'package:colonizethis_app/features/game/widgets/move_army_dialog.dart';
-import 'package:colonizethis_app/features/game/widgets/military_units_panel.dart';
-import 'package:colonizethis_app/features/game/widgets/units/shared/units_entity_action_row.dart';
-import 'package:colonizethis_app/core/services/app_event_handler_scope.dart';
-import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
-import 'package:colonizethis_app/widgets/ct_panel.dart';
-import 'package:colonizethis_app/widgets/ct_transfer_list.dart';
-
+import 'support/military_units_panel_test_support.dart';
 import 'support/panel_test_fixtures.dart';
-
-/// Applies [ArmySplitRequestedEvent] like [AppEventHandlerScope] and rebuilds
-/// the panel with updated [Game] (widget tests do not mount full shell).
-class _ArmySplitTestHarness extends StatefulWidget {
-  const _ArmySplitTestHarness({
-    required this.initialGame,
-    required this.humanPlayerId,
-    required this.bus,
-  });
-
-  final Game initialGame;
-  final String humanPlayerId;
-  final AppEventBus bus;
-
-  @override
-  State<_ArmySplitTestHarness> createState() => _ArmySplitTestHarnessState();
-}
-
-class _ArmySplitTestHarnessState extends State<_ArmySplitTestHarness> {
-  late Game _game;
-  StreamSubscription<ArmySplitRequestedEvent>? _sub;
-
-  @override
-  void initState() {
-    super.initState();
-    _game = widget.initialGame;
-    _sub = widget.bus.on<ArmySplitRequestedEvent>().listen((e) {
-      final next = applyArmySplit(
-        game: _game,
-        playerId: e.humanPlayerId,
-        sourceArmyId: e.sourceArmyId,
-        unitIdsToMove: e.unitIdsToMove,
-      );
-      setState(() => _game = next);
-    });
-  }
-
-  @override
-  void dispose() {
-    unawaited(_sub?.cancel());
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return MilitaryUnitsPanel(
-      game: _game,
-      humanPlayerId: widget.humanPlayerId,
-      bus: widget.bus,
-      topology: const MapTopology(),
-      draftOrders: const Orders(),
-    );
-  }
-}
-
-Future<void> expandFirstArmyExpansion(WidgetTester tester) async {
-  final tiles = find.byType(ExpansionTile);
-  if (tiles.evaluate().isEmpty) {
-    return;
-  }
-  await tester.tap(tiles.first);
-  await tester.pumpAndSettle();
-}
-
-Future<void> expandAllArmyExpansions(WidgetTester tester) async {
-  final finder = find.byType(ExpansionTile);
-  final n = finder.evaluate().length;
-  for (var i = 0; i < n; i++) {
-    await tester.tap(finder.at(i));
-    await tester.pumpAndSettle();
-  }
-}
 
 void main() {
   suppressLogsForTests();
 
   late Game game;
   late String humanPlayerIdWithUnits;
-  const String humanPlayerIdWithNoUnits = 'no-such-player';
 
   setUpAll(() {
     game = buildMilitaryPanelTestGame();
     humanPlayerIdWithUnits = game.players.first.id;
   });
-
-  Widget buildPanel({
-    required Game game,
-    required String humanPlayerId,
-    AppEventBus? bus,
-    MapTopology? topology,
-    Orders draftOrders = const Orders(),
-  }) {
-    return MaterialApp(
-      home: Scaffold(
-        body: MilitaryUnitsPanel(
-          game: game,
-          humanPlayerId: humanPlayerId,
-          bus: bus ?? AppEventBus.create(),
-          topology: topology ?? const MapTopology(),
-          draftOrders: draftOrders,
-        ),
-      ),
-    );
-  }
 
   group('Sea zone fleet display', () {
     testWidgets('shows ship rows for fleet at sea', (
@@ -164,7 +58,7 @@ void main() {
       );
 
       await tester.pumpWidget(
-        buildPanel(game: gameWithSeaFleet, humanPlayerId: playerId),
+        buildMilitaryPanel(game: gameWithSeaFleet, humanPlayerId: playerId),
       );
       await tester.pumpAndSettle();
 
@@ -207,7 +101,7 @@ void main() {
       );
 
       await tester.pumpWidget(
-        buildPanel(game: gameWithMultipleShips, humanPlayerId: playerId),
+        buildMilitaryPanel(game: gameWithMultipleShips, humanPlayerId: playerId),
       );
       await tester.pumpAndSettle();
 
@@ -248,7 +142,7 @@ void main() {
       );
 
       await tester.pumpWidget(
-        buildPanel(game: gameWithDefendFleet, humanPlayerId: playerId),
+        buildMilitaryPanel(game: gameWithDefendFleet, humanPlayerId: playerId),
       );
       await tester.pumpAndSettle();
 
@@ -323,7 +217,7 @@ void main() {
       );
 
       await tester.pumpWidget(
-        buildPanel(game: gameWithMixedMedals, humanPlayerId: playerId),
+        buildMilitaryPanel(game: gameWithMixedMedals, humanPlayerId: playerId),
       );
       await tester.pumpAndSettle();
       await tester.tap(find.text('Army army_mixed'));

--- a/app/test/military_units_panel_part4_test.dart
+++ b/app/test/military_units_panel_part4_test.dart
@@ -1,128 +1,22 @@
 // Tests for MilitaryUnitsPanel. SPEC/ui/military-units-panel.md.
 
-import 'dart:async';
-
-import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:colonizethis_app/features/game/utils/map_location_resolver.dart';
-import 'package:colonizethis_app/features/game/widgets/move_army_dialog.dart';
-import 'package:colonizethis_app/features/game/widgets/military_units_panel.dart';
-import 'package:colonizethis_app/features/game/widgets/units/shared/units_entity_action_row.dart';
-import 'package:colonizethis_app/core/services/app_event_handler_scope.dart';
-import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
-import 'package:colonizethis_app/widgets/ct_panel.dart';
-import 'package:colonizethis_app/widgets/ct_transfer_list.dart';
-
+import 'support/military_units_panel_test_support.dart';
 import 'support/panel_test_fixtures.dart';
-
-/// Applies [ArmySplitRequestedEvent] like [AppEventHandlerScope] and rebuilds
-/// the panel with updated [Game] (widget tests do not mount full shell).
-class _ArmySplitTestHarness extends StatefulWidget {
-  const _ArmySplitTestHarness({
-    required this.initialGame,
-    required this.humanPlayerId,
-    required this.bus,
-  });
-
-  final Game initialGame;
-  final String humanPlayerId;
-  final AppEventBus bus;
-
-  @override
-  State<_ArmySplitTestHarness> createState() => _ArmySplitTestHarnessState();
-}
-
-class _ArmySplitTestHarnessState extends State<_ArmySplitTestHarness> {
-  late Game _game;
-  StreamSubscription<ArmySplitRequestedEvent>? _sub;
-
-  @override
-  void initState() {
-    super.initState();
-    _game = widget.initialGame;
-    _sub = widget.bus.on<ArmySplitRequestedEvent>().listen((e) {
-      final next = applyArmySplit(
-        game: _game,
-        playerId: e.humanPlayerId,
-        sourceArmyId: e.sourceArmyId,
-        unitIdsToMove: e.unitIdsToMove,
-      );
-      setState(() => _game = next);
-    });
-  }
-
-  @override
-  void dispose() {
-    unawaited(_sub?.cancel());
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return MilitaryUnitsPanel(
-      game: _game,
-      humanPlayerId: widget.humanPlayerId,
-      bus: widget.bus,
-      topology: const MapTopology(),
-      draftOrders: const Orders(),
-    );
-  }
-}
-
-Future<void> expandFirstArmyExpansion(WidgetTester tester) async {
-  final tiles = find.byType(ExpansionTile);
-  if (tiles.evaluate().isEmpty) {
-    return;
-  }
-  await tester.tap(tiles.first);
-  await tester.pumpAndSettle();
-}
-
-Future<void> expandAllArmyExpansions(WidgetTester tester) async {
-  final finder = find.byType(ExpansionTile);
-  final n = finder.evaluate().length;
-  for (var i = 0; i < n; i++) {
-    await tester.tap(finder.at(i));
-    await tester.pumpAndSettle();
-  }
-}
 
 void main() {
   suppressLogsForTests();
 
   late Game game;
   late String humanPlayerIdWithUnits;
-  const String humanPlayerIdWithNoUnits = 'no-such-player';
 
   setUpAll(() {
     game = buildMilitaryPanelTestGame();
     humanPlayerIdWithUnits = game.players.first.id;
   });
-
-  Widget buildPanel({
-    required Game game,
-    required String humanPlayerId,
-    AppEventBus? bus,
-    MapTopology? topology,
-    Orders draftOrders = const Orders(),
-  }) {
-    return MaterialApp(
-      home: Scaffold(
-        body: MilitaryUnitsPanel(
-          game: game,
-          humanPlayerId: humanPlayerId,
-          bus: bus ?? AppEventBus.create(),
-          topology: topology ?? const MapTopology(),
-          draftOrders: draftOrders,
-        ),
-      ),
-    );
-  }
 
   group('Unit status display', () {
     testWidgets('shows Working status when any unit is working', (
@@ -183,7 +77,7 @@ void main() {
       );
 
       await tester.pumpWidget(
-        buildPanel(game: gameWithWorkingUnit, humanPlayerId: playerId),
+        buildMilitaryPanel(game: gameWithWorkingUnit, humanPlayerId: playerId),
       );
       await tester.pumpAndSettle();
       await tester.tap(find.text('Army army_w'));
@@ -242,7 +136,7 @@ void main() {
       );
 
       await tester.pumpWidget(
-        buildPanel(game: gameWithIdleUnit, humanPlayerId: playerId),
+        buildMilitaryPanel(game: gameWithIdleUnit, humanPlayerId: playerId),
       );
       await tester.pumpAndSettle();
       await tester.tap(find.text('Army army_d'));

--- a/app/test/military_units_panel_part5_test.dart
+++ b/app/test/military_units_panel_part5_test.dart
@@ -7,30 +7,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:colonizethis_app/features/game/widgets/move_army_dialog.dart';
-import 'package:colonizethis_app/features/game/widgets/military_units_panel.dart';
 import 'package:colonizethis_app/features/game/widgets/chrome/ct_action_text_button.dart';
 import 'package:colonizethis_app/features/game/widgets/chrome/ct_circular_locate_button.dart';
 import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
 
+import 'support/military_units_panel_test_support.dart';
 import 'support/panel_test_fixtures.dart';
-
-Future<void> expandFirstArmyExpansion(WidgetTester tester) async {
-  final tiles = find.byType(ExpansionTile);
-  if (tiles.evaluate().isEmpty) {
-    return;
-  }
-  await tester.tap(tiles.first);
-  await tester.pumpAndSettle();
-}
-
-Future<void> expandAllArmyExpansions(WidgetTester tester) async {
-  final finder = find.byType(ExpansionTile);
-  final n = finder.evaluate().length;
-  for (var i = 0; i < n; i++) {
-    await tester.tap(finder.at(i));
-    await tester.pumpAndSettle();
-  }
-}
 
 void main() {
   suppressLogsForTests();
@@ -43,26 +25,6 @@ void main() {
     game = buildMilitaryPanelTestGame();
     humanPlayerIdWithUnits = game.players.first.id;
   });
-
-  Widget buildPanel({
-    required Game game,
-    required String humanPlayerId,
-    AppEventBus? bus,
-    MapTopology? topology,
-    Orders draftOrders = const Orders(),
-  }) {
-    return MaterialApp(
-      home: Scaffold(
-        body: MilitaryUnitsPanel(
-          game: game,
-          humanPlayerId: humanPlayerId,
-          bus: bus ?? AppEventBus.create(),
-          topology: topology ?? const MapTopology(),
-          draftOrders: draftOrders,
-        ),
-      ),
-    );
-  }
 
   group('Army management (bus events)', () {
     testWidgets('Home Army expansion does not show Move action', (
@@ -119,7 +81,7 @@ void main() {
         ],
       );
 
-      await tester.pumpWidget(buildPanel(game: game, humanPlayerId: playerId));
+      await tester.pumpWidget(buildMilitaryPanel(game: game, humanPlayerId: playerId));
       await tester.pumpAndSettle();
 
       final homeTile = find.widgetWithText(ExpansionTile, 'Home Army');
@@ -213,7 +175,7 @@ void main() {
         );
 
         await tester.pumpWidget(
-          buildPanel(game: game, humanPlayerId: playerId, bus: bus),
+          buildMilitaryPanel(game: game, humanPlayerId: playerId, bus: bus),
         );
         await tester.pumpAndSettle();
 
@@ -314,7 +276,7 @@ void main() {
       );
 
       await tester.pumpWidget(
-        buildPanel(
+        buildMilitaryPanel(
           game: game,
           humanPlayerId: playerId,
           bus: bus,
@@ -433,7 +395,7 @@ void main() {
         );
 
         await tester.pumpWidget(
-          buildPanel(
+          buildMilitaryPanel(
             game: game,
             humanPlayerId: playerId,
             bus: bus,
@@ -581,7 +543,7 @@ void main() {
         );
 
         await tester.pumpWidget(
-          buildPanel(
+          buildMilitaryPanel(
             game: game,
             humanPlayerId: playerId,
             bus: bus,
@@ -678,7 +640,7 @@ void main() {
         },
       );
       await tester.pumpWidget(
-        buildPanel(game: game, humanPlayerId: playerId, draftOrders: draft),
+        buildMilitaryPanel(game: game, humanPlayerId: playerId, draftOrders: draft),
       );
       await tester.pumpAndSettle();
 
@@ -776,7 +738,7 @@ void main() {
       );
 
       await tester.pumpWidget(
-        buildPanel(
+        buildMilitaryPanel(
           game: game,
           humanPlayerId: playerId,
           bus: bus,

--- a/app/test/military_units_panel_part6_test.dart
+++ b/app/test/military_units_panel_part6_test.dart
@@ -1,71 +1,14 @@
 // Tests for MilitaryUnitsPanel. SPEC/ui/military-units-panel.md.
 
-import 'dart:async';
-
-import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:colonizethis_app/features/game/widgets/military_units_panel.dart';
 import 'package:colonizethis_app/features/game/widgets/chrome/ct_action_text_button.dart';
 import 'package:colonizethis_app/widgets/ct_transfer_list.dart';
 
-/// Applies [ArmySplitRequestedEvent] like [AppEventHandlerScope] and rebuilds
-/// the panel with updated [Game] (widget tests do not mount full shell).
-class _ArmySplitTestHarness extends StatefulWidget {
-  const _ArmySplitTestHarness({
-    required this.initialGame,
-    required this.humanPlayerId,
-    required this.bus,
-  });
-
-  final Game initialGame;
-  final String humanPlayerId;
-  final AppEventBus bus;
-
-  @override
-  State<_ArmySplitTestHarness> createState() => _ArmySplitTestHarnessState();
-}
-
-class _ArmySplitTestHarnessState extends State<_ArmySplitTestHarness> {
-  late Game _game;
-  StreamSubscription<ArmySplitRequestedEvent>? _sub;
-
-  @override
-  void initState() {
-    super.initState();
-    _game = widget.initialGame;
-    _sub = widget.bus.on<ArmySplitRequestedEvent>().listen((e) {
-      final next = applyArmySplit(
-        game: _game,
-        playerId: e.humanPlayerId,
-        sourceArmyId: e.sourceArmyId,
-        unitIdsToMove: e.unitIdsToMove,
-      );
-      setState(() => _game = next);
-    });
-  }
-
-  @override
-  void dispose() {
-    unawaited(_sub?.cancel());
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return MilitaryUnitsPanel(
-      game: _game,
-      humanPlayerId: widget.humanPlayerId,
-      bus: widget.bus,
-      topology: const MapTopology(),
-      draftOrders: const Orders(),
-    );
-  }
-}
+import 'support/military_units_panel_test_support.dart';
 
 void main() {
   suppressLogsForTests();
@@ -142,7 +85,7 @@ void main() {
               body: SizedBox(
                 height: 900,
                 width: 480,
-                child: _ArmySplitTestHarness(
+                child: ArmySplitTestHarness(
                   initialGame: initial,
                   humanPlayerId: playerId,
                   bus: bus,
@@ -255,7 +198,7 @@ void main() {
               body: SizedBox(
                 height: 900,
                 width: 480,
-                child: _ArmySplitTestHarness(
+                child: ArmySplitTestHarness(
                   initialGame: initial,
                   humanPlayerId: playerId,
                   bus: bus,

--- a/app/test/support/military_units_panel_test_support.dart
+++ b/app/test/support/military_units_panel_test_support.dart
@@ -1,0 +1,126 @@
+// Shared widget-test scaffolding for the `MilitaryUnitsPanel` test family.
+//
+// The six `app/test/military_units_panel_part*_test.dart` files each previously
+// re-declared an identical local `buildPanel(...)` closure (a plain
+// `MaterialApp` > `Scaffold` host for `MilitaryUnitsPanel`), identical
+// `expandFirstArmyExpansion` / `expandAllArmyExpansions` `ExpansionTile`
+// helpers, and a byte-identical `_ArmySplitTestHarness` widget that mirrors the
+// running shell's `ArmySplitRequestedEvent` handling. Consolidating them here
+// keeps each part file's per-test fixtures and assertions local while removing
+// the copy-pasted shell, tree helpers, and bus wiring.
+//
+// Refs #3730 (consolidate app test scaffolding; partN shared setup).
+// SPEC: SPEC/ui/military-units-panel.md (panel behavior under test),
+// SPEC/program/repo-lint.md (test static-analysis scope).
+
+import 'dart:async';
+
+import 'package:colonizethis_data/colonizethis_data.dart' show MapTopology;
+import 'package:colonizethis_logic/colonizethis_logic.dart' show applyArmySplit;
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:colonizethis_app/features/game/widgets/military_units_panel.dart';
+
+/// Builds the canonical [MilitaryUnitsPanel] host used across the panel's
+/// widget tests: a plain [MaterialApp] > [Scaffold] wrapping the panel. When
+/// [bus] is omitted a fresh [AppEventBus] is created so tests that do not need
+/// to drive events still get a valid bus.
+Widget buildMilitaryPanel({
+  required Game game,
+  required String humanPlayerId,
+  AppEventBus? bus,
+  MapTopology? topology,
+  Orders draftOrders = const Orders(),
+}) {
+  return MaterialApp(
+    home: Scaffold(
+      body: MilitaryUnitsPanel(
+        game: game,
+        humanPlayerId: humanPlayerId,
+        bus: bus ?? AppEventBus.create(),
+        topology: topology ?? const MapTopology(),
+        draftOrders: draftOrders,
+      ),
+    ),
+  );
+}
+
+/// Taps the first [ExpansionTile] in the tree (if any) and settles, expanding
+/// the first army/fleet group so its detail rows render.
+Future<void> expandFirstArmyExpansion(WidgetTester tester) async {
+  final tiles = find.byType(ExpansionTile);
+  if (tiles.evaluate().isEmpty) {
+    return;
+  }
+  await tester.tap(tiles.first);
+  await tester.pumpAndSettle();
+}
+
+/// Taps every [ExpansionTile] currently in the tree (settling after each) so
+/// all army/fleet groups expand and their detail rows render.
+Future<void> expandAllArmyExpansions(WidgetTester tester) async {
+  final finder = find.byType(ExpansionTile);
+  final n = finder.evaluate().length;
+  for (var i = 0; i < n; i++) {
+    await tester.tap(finder.at(i));
+    await tester.pumpAndSettle();
+  }
+}
+
+/// Applies [ArmySplitRequestedEvent] like `AppEventHandlerScope` and rebuilds
+/// the panel with the updated [Game] (widget tests do not mount the full
+/// shell). Used by the split-UI tests that drive a real split through the bus.
+class ArmySplitTestHarness extends StatefulWidget {
+  const ArmySplitTestHarness({
+    super.key,
+    required this.initialGame,
+    required this.humanPlayerId,
+    required this.bus,
+  });
+
+  final Game initialGame;
+  final String humanPlayerId;
+  final AppEventBus bus;
+
+  @override
+  State<ArmySplitTestHarness> createState() => _ArmySplitTestHarnessState();
+}
+
+class _ArmySplitTestHarnessState extends State<ArmySplitTestHarness> {
+  late Game _game;
+  StreamSubscription<ArmySplitRequestedEvent>? _sub;
+
+  @override
+  void initState() {
+    super.initState();
+    _game = widget.initialGame;
+    _sub = widget.bus.on<ArmySplitRequestedEvent>().listen((e) {
+      final next = applyArmySplit(
+        game: _game,
+        playerId: e.humanPlayerId,
+        sourceArmyId: e.sourceArmyId,
+        unitIdsToMove: e.unitIdsToMove,
+      );
+      setState(() => _game = next);
+    });
+  }
+
+  @override
+  void dispose() {
+    unawaited(_sub?.cancel());
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MilitaryUnitsPanel(
+      game: _game,
+      humanPlayerId: widget.humanPlayerId,
+      bus: widget.bus,
+      topology: const MapTopology(),
+      draftOrders: const Orders(),
+    );
+  }
+}

--- a/app/test/support/military_units_panel_test_support_test.dart
+++ b/app/test/support/military_units_panel_test_support_test.dart
@@ -1,0 +1,170 @@
+// Smoke tests for the shared `MilitaryUnitsPanel` widget-test scaffolding.
+//
+// Verifies the consolidated helpers in `military_units_panel_test_support.dart`
+// (extracted from the six `military_units_panel_part*_test.dart` files, Refs
+// #3730) build the canonical panel host, drive the `ExpansionTile` tree
+// helpers, and bridge `ArmySplitRequestedEvent` the same way the running shell
+// does, so the part files keep their behavior.
+//
+// SPEC: SPEC/ui/military-units-panel.md, SPEC/program/app-ui-wiring.md.
+
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:colonizethis_app/features/game/widgets/military_units_panel.dart';
+
+import 'military_units_panel_test_support.dart';
+import 'panel_test_fixtures.dart';
+import 'widget_test_assets.dart';
+
+/// Minimal game with one home army of two regiments, sized so the split-UI can
+/// produce a second army when one regiment is moved.
+Game _buildHomeArmyGame() {
+  const playerId = kPanelTestHumanPlayerId;
+  const cap = 'oldWorld|cap';
+  return Game(
+    id: 'g_military_support_smoke',
+    worldState: WorldState(
+      turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+      oldWorld: RegionData(
+        provinces: [
+          Province(
+            id: cap,
+            regionId: 'oldWorld',
+            ownerId: playerId,
+            displayName: 'Capital',
+            townTileKey: 'tk_cap',
+          ),
+        ],
+        units: [
+          Unit(
+            id: 'r1',
+            type: 'musketeers',
+            ownerId: playerId,
+            locationProvinceId: cap,
+          ),
+          Unit(
+            id: 'r2',
+            type: 'musketeers',
+            ownerId: playerId,
+            locationProvinceId: cap,
+          ),
+        ],
+      ),
+      newWorld: const RegionData(),
+      armies: [
+        Army(
+          id: 'home_army',
+          ownerId: playerId,
+          regionId: 'oldWorld',
+          stationedProvinceId: cap,
+          regimentUnitIds: const ['r1', 'r2'],
+          isHomeArmy: true,
+        ),
+      ],
+      nextArmySeq: 1,
+      tileKeysByRegionAndProvince: {
+        'oldWorld': {
+          cap: const ['tk_cap'],
+        },
+      },
+    ),
+    players: const [
+      Player(
+        id: playerId,
+        displayName: 'Splitter',
+        isHuman: true,
+        capitalProvinceId: cap,
+      ),
+    ],
+  );
+}
+
+void main() {
+  suppressLogsForTests();
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    await setUpNinePatchAssets();
+  });
+
+  testWidgets(
+    'buildMilitaryPanel hosts MilitaryUnitsPanel inside a MaterialApp scaffold',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        buildMilitaryPanel(
+          game: buildMilitaryPanelTestGame(),
+          humanPlayerId: kPanelTestHumanPlayerId,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(MaterialApp), findsOneWidget);
+      expect(find.byType(Scaffold), findsOneWidget);
+      expect(find.byType(MilitaryUnitsPanel), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'expandAllArmyExpansions expands every ExpansionTile without throwing',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        buildMilitaryPanel(
+          game: buildMilitaryPanelTestGame(),
+          humanPlayerId: kPanelTestHumanPlayerId,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // The military fixture renders at least one army group as an ExpansionTile.
+      expect(find.byType(ExpansionTile), findsAtLeastNWidgets(1));
+      await expandFirstArmyExpansion(tester);
+      await expandAllArmyExpansions(tester);
+      expect(find.byType(MilitaryUnitsPanel), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'ArmySplitTestHarness renders the panel and applies a bus-driven split',
+    (WidgetTester tester) async {
+      final bus = AppEventBus.create();
+      addTearDown(bus.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              height: 900,
+              width: 480,
+              child: ArmySplitTestHarness(
+                initialGame: _buildHomeArmyGame(),
+                humanPlayerId: kPanelTestHumanPlayerId,
+                bus: bus,
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(MilitaryUnitsPanel), findsOneWidget);
+
+      // Drive a split through the bus; the harness mirrors the shell handler by
+      // applying it and rebuilding, so a second army surfaces in the tree.
+      bus.emit(
+        ArmySplitRequestedEvent(
+          humanPlayerId: kPanelTestHumanPlayerId,
+          sourceArmyId: 'home_army',
+          unitIdsToMove: const ['r2'],
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Army army_1'), findsOneWidget);
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Follow-up slice for the app-test scaffolding dedup (#3730), opened after the prior naval-family PR (#3739) merged into `dev`.

Advances **AC3** (consolidate `partN`-split families / lift shared setup into `test/support/`) for the `military_units_panel_part*` family. The six files each re-declared byte-identical scaffolding; this lifts it into one shared support file.

## Done in this push

New shared helper `app/test/support/military_units_panel_test_support.dart`:

- `buildMilitaryPanel(...)` — the identical local `buildPanel` `MaterialApp` > `Scaffold` host closure (re-declared in parts 1–5).
- `expandFirstArmyExpansion(...)` / `expandAllArmyExpansions(...)` — the identical `ExpansionTile` tree helpers (re-declared in parts 1–5).
- `ArmySplitTestHarness` — the byte-identical `_ArmySplitTestHarness` widget that mirrors the shell's `ArmySplitRequestedEvent` handling (re-declared in parts 1–4 and 6; used by part6's split-UI tests).

Migrated `app/test/military_units_panel_part1..6_test.dart` to import the shared helpers, removed the duplicated definitions, switched call sites (`buildPanel` → `buildMilitaryPanel`, `_ArmySplitTestHarness` → `ArmySplitTestHarness`), and dropped now-unused imports. `part2` (pure `tileKey*` tests) carried the scaffolding as dead code and now sheds it entirely.

Added `app/test/support/military_units_panel_test_support_test.dart` — a smoke test covering the host render, the `ExpansionTile` expansion helpers, and the bus-driven split bridge.

Net: **+334 / −546** lines across 8 files (6 migrated + 2 new support files).

Behavior-preserving: no assertions, fixtures, or screen IDs changed; only shared scaffolding deduplicated.

## Verification

- `cd app && flutter test test/military_units_panel_part1..6 + test/support/military_units_panel_test_support_test.dart` → **All 38 tests passed**.
- `cd app && flutter analyze` on the touched files → no errors (only pre-existing-style unused-local warnings on dead setUp vars; CI gate is errors-only).
- `dart test test/check_app_test_no_duplicate_scaffolding_test.dart` → **green** (the gate is scoped to the `*_320dp_min_viewport` family and is unaffected).

## Scope / deferred

- One focused family slice (military). The other `partN` families (`civilian_units_panel`, `ct_region_map_widget`, `game_map_area_state_logic`) remain for subsequent slices on this issue. These large families are kept split per the issue's oversized-file risk guidance; this slice lifts their shared setup rather than merging files.

Refs #3730

Made with [Cursor](https://cursor.com)