### PR TITLE
refactor(app-test): route dark editorial-monocle shells through pumpAppShell (#3730)

### DIFF
--- a/app/test/debug_log_viewer_test.dart
+++ b/app/test/debug_log_viewer_test.dart
@@ -12,6 +12,8 @@ import 'package:colonizethis_app/features/debug_log/debug_log_viewer_screen.dart
 import 'package:colonizethis_app/widgets/ct_back_button.dart';
 import 'package:colonizethis_app/widgets/ct_choice_chip.dart';
 
+import 'support/app_shell_harness.dart';
+
 CtChoiceChip _chipWithLabel(WidgetTester tester, String label) {
   return tester.widget<CtChoiceChip>(
     find.ancestor(
@@ -304,13 +306,11 @@ void main() {
 const double _expectedRowAlpha = 0.08;
 
 Future<void> _pumpEditorialMonocleViewer(WidgetTester tester) async {
-  await tester.pumpWidget(
-    MaterialApp(
-      theme: AppThemes.editorialMonocle,
-      home: const DebugLogViewerScreen(),
-    ),
+  await pumpAppShell(
+    tester,
+    settle: true,
+    child: const DebugLogViewerScreen(),
   );
-  await tester.pumpAndSettle();
 }
 
 void _expectTintMatches(

--- a/app/test/intervention_dialogue_overlay_dark_chrome_test.dart
+++ b/app/test/intervention_dialogue_overlay_dark_chrome_test.dart
@@ -17,7 +17,6 @@
 // scrim, title key + color, and brass divider key are produced by that
 // single helper.
 import 'package:colonizethis_app/config/editorial_monocle_palette.dart';
-import 'package:colonizethis_app/config/themes.dart';
 import 'package:colonizethis_app/features/game/dialogue/intervention_dialogue_overlay.dart';
 import 'package:colonizethis_app/widgets/ct_brass_divider.dart';
 import 'package:colonizethis_app/widgets/ct_dialog_shell.dart';
@@ -26,6 +25,8 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+import 'support/app_shell_harness.dart';
 
 class _FailingAssetBundle extends Fake implements AssetBundle {
   @override
@@ -66,9 +67,8 @@ Future<void> _pumpDegradedOverlay(
   tester.view.physicalSize = surfaceSize;
   tester.view.devicePixelRatio = 1.0;
   await tester.pumpWidget(
-    MaterialApp(
-      theme: AppThemes.editorialMonocle,
-      home: InterventionDialogueOverlay(
+    buildAppShell(
+      child: InterventionDialogueOverlay(
         game: _kFixtureGame,
         prompts: _kFixturePrompts,
         skipIntroForTest: true,

--- a/app/test/widgets/ct_nine_patch_button_dark_test.dart
+++ b/app/test/widgets/ct_nine_patch_button_dark_test.dart
@@ -8,13 +8,14 @@
 //   - disabled wraps the button in 0.4 opacity and suppresses taps.
 
 import 'package:colonizethis_app/config/editorial_monocle_palette.dart';
-import 'package:colonizethis_app/config/themes.dart';
 import 'package:colonizethis_app/widgets/ct_gradients.dart';
 import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+import '../support/app_shell_harness.dart';
 
 Future<void> _pumpButton(
   WidgetTester tester, {
@@ -27,29 +28,27 @@ Future<void> _pumpButton(
   LinearGradient? pressedGradient,
   Widget child = const Text('Confirm'),
 }) async {
-  await tester.pumpWidget(
-    MaterialApp(
-      theme: AppThemes.editorialMonocle,
-      home: Scaffold(
-        body: Center(
-          child: SizedBox(
-            width: 200,
-            child: CtNinePatchButton(
-              onPressed: onPressed,
-              enabled: enabled,
-              dangerVariant: dangerVariant,
-              mutedVariant: mutedVariant,
-              disabledOpacityOverride: disabledOpacityOverride,
-              gradient: gradient,
-              pressedGradient: pressedGradient,
-              child: child,
-            ),
+  await pumpAppShell(
+    tester,
+    settle: true,
+    child: Scaffold(
+      body: Center(
+        child: SizedBox(
+          width: 200,
+          child: CtNinePatchButton(
+            onPressed: onPressed,
+            enabled: enabled,
+            dangerVariant: dangerVariant,
+            mutedVariant: mutedVariant,
+            disabledOpacityOverride: disabledOpacityOverride,
+            gradient: gradient,
+            pressedGradient: pressedGradient,
+            child: child,
           ),
         ),
       ),
     ),
   );
-  await tester.pumpAndSettle();
 }
 
 DecoratedBox _findButtonSurfaceDecoratedBox(WidgetTester tester) {


### PR DESCRIPTION
## Summary
Continues the app-test scaffolding consolidation for #3730 by routing the remaining **dark editorial-monocle** bespoke `_pump*` shell helpers through the shared `app/test/support/app_shell_harness.dart` (`pumpAppShell` / `buildAppShell`), removing per-file `MaterialApp(theme: AppThemes.editorialMonocle, …)` wrappers. Behavior-preserving: no assertion or rendering changes.

## Done in this push
- `app/test/widgets/ct_nine_patch_button_dark_test.dart` — `_pumpButton` now uses `pumpAppShell(..., settle: true, child: Scaffold(...))`; dropped the local `AppThemes` import.
- `app/test/debug_log_viewer_test.dart` — `_pumpEditorialMonocleViewer` now uses `pumpAppShell(..., settle: true, child: DebugLogViewerScreen())`. The `AppThemes.light` shells in the same file are intentionally left bespoke (the editorial harness only mounts `editorialMonocle`).
- `app/test/intervention_dialogue_overlay_dark_chrome_test.dart` — `_pumpDegradedOverlay` builds its shell via `buildAppShell(child: ...)` while keeping its `tester.view.physicalSize` viewport setup and custom two-phase `pump()` strategy (the chrome contract needs explicit pumps, not the harness's single-pump/settle).

These three were the only remaining **non-golden, non-widgetbook, non-mockup-fidelity** test files still hand-rolling an `editorialMonocle` `MaterialApp` shell. This advances AC2 (diplomacy/trade/**dialog** `_pump*` families migrated to the shared helper).

## Deferred for #3730 (documented as legitimately bespoke)
- Golden tests (`diplomacy_panel_goldens`, `diplomacy_relative_power_goldens`, `research_slot_card_goldens`, `technology_slot_occupancy_goldens`, `technology_slots_panel_parity_goldens`), `diplomacy_panel_mockup_fidelity`, and the widgetbook-story tests keep bespoke shells. These are exactly the categories the dedup gate's own scope comment (`tool/check_app_test_no_duplicate_scaffolding.dart`) carves out as legitimately distinct (golden capture, mockup-fidelity, widgetbook viewport stories), so they are not migrated.
- The `AppThemes.light` shells in `debug_log_viewer_test.dart` stay (different theme; migrating would change the tested theme).

## Tests run
- `cd app && flutter test test/widgets/ct_nine_patch_button_dark_test.dart test/debug_log_viewer_test.dart test/intervention_dialogue_overlay_dark_chrome_test.dart` → all pass (34/34).
- `dart test test/check_app_test_no_duplicate_scaffolding_test.dart` → green (gate unaffected; the migrated files are outside the `*_320dp_min_viewport_test.dart` scope).
- `dart analyze` on the three files → no issues.

Refs #3730

Made with [Cursor](https://cursor.com)