### PR TITLE
refactor(map-test): share genParams() builder for generator tests (#3746)

### DIFF
--- a/packages/colonizethis_map/test/map_gen_pass_test.dart
+++ b/packages/colonizethis_map/test/map_gen_pass_test.dart
@@ -5,9 +5,11 @@ import 'package:colonizethis_map/src/gen/map_gen_pass_payloads.dart';
 import 'package:colonizethis_map/src/gen/map_gen_stage.dart';
 import 'package:colonizethis_test/test.dart';
 
+import 'support/tile_map_gen_fixtures.dart';
+
 void main() {
   group('MapGenPassContext', () {
-    final params = TileMapParams(width: 4, height: 3, seed: 1);
+    final params = genParams(width: 4, height: 3, seed: 1);
 
     test('log forwards the message when onLog is provided', () {
       final lines = <String>[];
@@ -42,11 +44,10 @@ void main() {
     };
 
     test('seed-before-assignment path matches direct method calls', () {
-      final params = TileMapParams(
+      final params = genParams(
         width: 20,
         height: 20,
         seed: 11,
-        seaFraction: 0.6,
         seedBeforeAssignment: true,
       );
       final pass = TileMapGenLandSeeds(params);
@@ -85,11 +86,10 @@ void main() {
     });
 
     test('organic path matches direct method call', () {
-      final params = TileMapParams(
+      final params = genParams(
         width: 20,
         height: 14,
         seed: 5,
-        seaFraction: 0.6,
       );
       final pass = TileMapGenLandSeeds(params);
 
@@ -123,11 +123,10 @@ void main() {
     });
 
     test('emits the seed-before-assignment pass log line', () {
-      final params = TileMapParams(
+      final params = genParams(
         width: 16,
         height: 16,
         seed: 3,
-        seaFraction: 0.6,
         seedBeforeAssignment: true,
       );
       final pass = TileMapGenLandSeeds(params);

--- a/packages/colonizethis_map/test/support/tile_map_gen_fixtures.dart
+++ b/packages/colonizethis_map/test/support/tile_map_gen_fixtures.dart
@@ -1,0 +1,59 @@
+import 'package:colonizethis_map/colonizethis_map.dart';
+
+/// Shared scaffolding for the tile-map *generator* test suite
+/// (`tile_map_generator_*_test.dart`, `tile_map_gen_*_test.dart`,
+/// `tile_map_grid_graph_test.dart`, …).
+///
+/// The generator suite constructs [TileMapParams] dozens of times with the same
+/// width/height/seed/seaFraction shape repeated inline. [genParams] is the
+/// single source of truth for those params: every named argument keeps the
+/// exact production [TileMapParams] default, so a bare `genParams()` and any
+/// `genParams(width: …, height: …, seed: …)` call are byte-for-byte equivalent
+/// to the inline `TileMapParams(...)` they replace (behavior-preserving). The
+/// common `seaFraction: 0.6` argument matches both the [TileMapParams] default
+/// and the value almost every generator test used, so call sites can drop it.
+///
+/// Only the parameters generator tests actually vary are exposed; the remaining
+/// pass-tuning knobs (mountain/terrain-seed/pattern factors, `clusterShape`,
+/// `voronoiNoiseScale`, `multiRegionResourceCapFraction`) keep their
+/// [TileMapParams] defaults. A test that needs one of those rare knobs can still
+/// construct [TileMapParams] directly. Refs #3746.
+TileMapParams genParams({
+  int width = 100,
+  int height = 100,
+  int seed = 42,
+  double seaFraction = 0.6,
+  double borderNoise = 0.0,
+  int maxEnforceIterations = 10,
+  int continentBufferTiles = 2,
+  bool skipFillLakes = false,
+  bool joinContinents = true,
+  bool seedBeforeAssignment = false,
+  double maxSeaZoneFraction = 0.05,
+  double terrainVariation = 0.5,
+  double jitterHomogeneityThreshold = 0.85,
+  double jitterMaxFraction = 0.1,
+  double jitterProbability = 0.25,
+  int jitterMinProvinceSize = 10,
+  int jitterNeighborSupportThreshold = 2,
+}) {
+  return TileMapParams(
+    width: width,
+    height: height,
+    seed: seed,
+    seaFraction: seaFraction,
+    borderNoise: borderNoise,
+    maxEnforceIterations: maxEnforceIterations,
+    continentBufferTiles: continentBufferTiles,
+    skipFillLakes: skipFillLakes,
+    joinContinents: joinContinents,
+    seedBeforeAssignment: seedBeforeAssignment,
+    maxSeaZoneFraction: maxSeaZoneFraction,
+    terrainVariation: terrainVariation,
+    jitterHomogeneityThreshold: jitterHomogeneityThreshold,
+    jitterMaxFraction: jitterMaxFraction,
+    jitterProbability: jitterProbability,
+    jitterMinProvinceSize: jitterMinProvinceSize,
+    jitterNeighborSupportThreshold: jitterNeighborSupportThreshold,
+  );
+}

--- a/packages/colonizethis_map/test/tile_map_forest_split_test.dart
+++ b/packages/colonizethis_map/test/tile_map_forest_split_test.dart
@@ -2,6 +2,8 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_map/colonizethis_map.dart';
 import 'package:colonizethis_test/test.dart';
 
+import 'support/tile_map_gen_fixtures.dart';
+
 /// Map-generation integration tests for the forest split (issue #3573):
 /// guaranteed forest resource spawn (R3 / AC3) and hardwood clustering
 /// (R7 / AC7). SPEC/program/tile-map-gen-resources.md,
@@ -10,7 +12,7 @@ void main() {
   suppressLogsForTests();
 
   TileMapResult generate(String regionId, {int seed = 42}) {
-    final params = TileMapParams(
+    final params = genParams(
       width: 80,
       height: 80,
       seed: seed,

--- a/packages/colonizethis_map/test/tile_map_gen_join_passes_test.dart
+++ b/packages/colonizethis_map/test/tile_map_gen_join_passes_test.dart
@@ -11,6 +11,8 @@ import 'package:colonizethis_map/src/gen/tile_map_gen_terrain_jitter_pass.dart';
 import 'package:colonizethis_map/src/gen/tile_map_grid_graph.dart';
 import 'package:colonizethis_test/test.dart';
 
+import 'support/tile_map_gen_fixtures.dart';
+
 /// Per-pass unit tests for the standalone JoinSea passes extracted from the
 /// former `_TileMapGenJoinSea` family (Refs #3588). Each pass is exercised in
 /// isolation, which the prior `part of` coupling prevented.
@@ -22,7 +24,7 @@ void main() {
         ContinentJoinPass(params, packageLogger(), TileMapGridGraph(params));
 
     test('joinContinents bridges two land components of one continent', () {
-      final params = TileMapParams(width: 5, height: 1);
+      final params = genParams(width: 5, height: 1);
       final pass = passFor(params);
       final grid = <List<String>>[
         ['p1', sea, sea, sea, 'p1'],
@@ -59,7 +61,7 @@ void main() {
     });
 
     test('joinContinents leaves a single-component continent unchanged', () {
-      final params = TileMapParams(width: 3, height: 1);
+      final params = genParams(width: 3, height: 1);
       final pass = passFor(params);
       final grid = <List<String>>[
         ['p1', 'p1', sea],
@@ -81,7 +83,7 @@ void main() {
     });
 
     test('run returns inputs unchanged when joinContinents is disabled', () {
-      final params = TileMapParams(width: 5, height: 1, joinContinents: false);
+      final params = genParams(width: 5, height: 1, joinContinents: false);
       final pass = passFor(params);
       final grid = <List<String>>[
         ['p1', sea, sea, sea, 'p1'],
@@ -113,7 +115,7 @@ void main() {
     test(
       'preserveSeaFraction restores coastal land to sea (count-bounded)',
       () {
-        final params = TileMapParams(width: 3, height: 3);
+        final params = genParams(width: 3, height: 3);
         final pass = passFor(params);
         final grid = <List<String>>[
           [sea, 'p1', sea],
@@ -144,7 +146,7 @@ void main() {
         SeaZoneSubdividePass(params, TileMapGridGraph(params));
 
     test('countSeaCells counts only sea-id cells', () {
-      final params = TileMapParams(width: 2, height: 2);
+      final params = genParams(width: 2, height: 2);
       final pass = passFor(params);
       final grid = <List<String>>[
         [sea, 'p1'],
@@ -154,7 +156,7 @@ void main() {
     });
 
     test('subdivideSeaZonesWithCap splits one component into capped zones', () {
-      final params = TileMapParams(
+      final params = genParams(
         width: 10,
         height: 1,
         maxSeaZoneFraction: 0.3,
@@ -171,7 +173,7 @@ void main() {
     test(
       'subdivideSeaZonesWithCap keeps a small component as a single zone',
       () {
-        final params = TileMapParams(width: 3, height: 1);
+        final params = genParams(width: 3, height: 1);
         final pass = passFor(params);
         final grid = <List<String>>[
           [sea, sea, sea],
@@ -183,7 +185,7 @@ void main() {
     );
 
     test('run is a no-op (no log) when there is no sea', () {
-      final params = TileMapParams(width: 2, height: 1);
+      final params = genParams(width: 2, height: 1);
       final pass = passFor(params);
       final grid = <List<String>>[
         ['p1', 'p1'],
@@ -215,7 +217,7 @@ void main() {
     test(
       'jitter reassigns dominant edge cells toward supported neighbours',
       () {
-        final params = TileMapParams(
+        final params = genParams(
           width: 5,
           height: 5,
           jitterMinProvinceSize: 4,
@@ -261,7 +263,7 @@ void main() {
     );
 
     test('jitter leaves provinces below the min size untouched', () {
-      final params = TileMapParams(
+      final params = genParams(
         width: 5,
         height: 5,
         jitterMinProvinceSize: 1000,

--- a/packages/colonizethis_map/test/tile_map_gen_lakes_provinces_test.dart
+++ b/packages/colonizethis_map/test/tile_map_gen_lakes_provinces_test.dart
@@ -9,6 +9,8 @@ import 'package:colonizethis_map/src/gen/tile_map_generator_lakes_provinces.dart
 import 'package:colonizethis_map/src/gen/tile_map_grid_graph.dart';
 import 'package:colonizethis_test/test.dart';
 
+import 'support/tile_map_gen_fixtures.dart';
+
 // Direct unit tests for the standalone `TileMapGenLakesProvinces` class
 // (extracted from a `part of 'tile_map_generator.dart'` fragment, Refs #3588).
 // These construct the pass directly — no `TileMapGenerator` orchestration — to
@@ -25,7 +27,7 @@ void main() {
 
   group('TileMapGenLakesProvinces (standalone, direct construction)', () {
     test('run with skipFillLakes leaves the grid unchanged and logs skips', () {
-      final params = TileMapParams(
+      final params = genParams(
         width: 4,
         height: 3,
         skipFillLakes: true,
@@ -63,7 +65,7 @@ void main() {
     });
 
     test('fillLakes converts an enclosed single-continent lake to land', () {
-      final params = TileMapParams(width: 5, height: 3);
+      final params = genParams(width: 5, height: 3);
       final pass = buildPass(params);
       final grid = <List<String>>[
         [land, sea, sea, sea, land],
@@ -78,7 +80,7 @@ void main() {
     });
 
     test('fillLakes preserves a two-continent strait as sea', () {
-      final params = TileMapParams(width: 4, height: 3);
+      final params = genParams(width: 4, height: 3);
       final pass = buildPass(params);
       final grid = <List<String>>[
         [land, sea, sea, land],
@@ -101,7 +103,7 @@ void main() {
     });
 
     test('assignProvincesFromSeeds replaces land sentinels with seed ids', () {
-      final params = TileMapParams(width: 3, height: 3);
+      final params = genParams(width: 3, height: 3);
       final pass = buildPass(params);
       final grid = <List<String>>[
         [land, land, sea],
@@ -121,7 +123,7 @@ void main() {
     });
 
     test('assignProvincesFromSeeds returns grid unchanged with no seeds', () {
-      final params = TileMapParams(width: 2, height: 2);
+      final params = genParams(width: 2, height: 2);
       final pass = buildPass(params);
       final grid = <List<String>>[
         [land, land],

--- a/packages/colonizethis_map/test/tile_map_gen_land_seeds_test.dart
+++ b/packages/colonizethis_map/test/tile_map_gen_land_seeds_test.dart
@@ -3,10 +3,12 @@ import 'dart:math';
 import 'package:colonizethis_map/colonizethis_map.dart';
 import 'package:colonizethis_test/test.dart';
 
+import 'support/tile_map_gen_fixtures.dart';
+
 void main() {
   group('TileMapGenLandSeeds', () {
     test('placeLandSeeds returns continent and land seed metadata', () {
-      final params = TileMapParams(width: 20, height: 12, seed: 7);
+      final params = genParams(width: 20, height: 12, seed: 7);
       final pass = TileMapGenLandSeeds(params);
       final provinceToContinent = <String, int>{
         'p1': 0,
@@ -25,11 +27,10 @@ void main() {
     });
 
     test('assignLandByLandSeeds respects the expected land budget', () {
-      final params = TileMapParams(
+      final params = genParams(
         width: 20,
         height: 20,
         seed: 11,
-        seaFraction: 0.6,
       );
       final pass = TileMapGenLandSeeds(params);
       final provinceToContinent = <String, int>{

--- a/packages/colonizethis_map/test/tile_map_gen_terrain_resource_test.dart
+++ b/packages/colonizethis_map/test/tile_map_gen_terrain_resource_test.dart
@@ -13,6 +13,8 @@ import 'package:colonizethis_map/src/gen/tile_map_grid_graph.dart';
 import 'package:colonizethis_map/src/gen/tile_map_land_sentinel.dart';
 import 'package:colonizethis_test/test.dart';
 
+import 'support/tile_map_gen_fixtures.dart';
+
 // Direct unit tests for the standalone terrain-resource family extracted from
 // the former `part of 'tile_map_generator.dart'` fragment (Refs #3588). Each
 // class is constructed directly — no `TileMapGenerator` orchestration — to
@@ -149,7 +151,7 @@ void main() {
 
     test('returns empty when there is no land (negative)', () {
       final placer = MountainRidgePlacer(
-        const TileMapParams(width: 4, height: 4),
+        genParams(width: 4, height: 4),
       );
       final terrainGrid = <List<TerrainType?>>[
         for (var y = 0; y < 4; y++) [for (var x = 0; x < 4; x++) null],
@@ -165,7 +167,7 @@ void main() {
     });
 
     test('places mountains and returns mountain-free remaining land (positive)', () {
-      const params = TileMapParams(width: 12, height: 12, seed: 42);
+      final params = genParams(width: 12, height: 12, seed: 42);
       final placer = MountainRidgePlacer(params);
       final grid = allLandGrid(12, 12);
       final terrainGrid = <List<TerrainType?>>[
@@ -203,7 +205,7 @@ void main() {
         TileMapGenTerrainResource(params, TileMapGridGraph(params));
 
     test('run returns (null, null) and logs skip when resourceRules is null', () {
-      const params = TileMapParams(width: 4, height: 4);
+      final params = genParams(width: 4, height: 4);
       final pass = build(params);
       final lines = <String>[];
       final result = pass.run(
@@ -227,7 +229,7 @@ void main() {
     });
 
     test('assignTerrainAndResources assigns terrain to every land cell', () {
-      const params = TileMapParams(width: 10, height: 10, seed: 42);
+      final params = genParams(width: 10, height: 10, seed: 42);
       final pass = build(params);
       final grid = <List<String>>[
         for (var y = 0; y < 10; y++)
@@ -247,7 +249,7 @@ void main() {
     });
 
     test('assignTerrainAndResources is deterministic for a fixed seed', () {
-      const params = TileMapParams(width: 10, height: 10, seed: 42);
+      final params = genParams(width: 10, height: 10, seed: 42);
       List<List<TerrainType?>> run() {
         final grid = <List<String>>[
           for (var y = 0; y < 10; y++)
@@ -272,7 +274,7 @@ void main() {
     });
 
     test('assignTerrainAndResources on a no-land grid yields empty terrain', () {
-      const params = TileMapParams(width: 4, height: 4, seed: 42);
+      final params = genParams(width: 4, height: 4, seed: 42);
       final pass = build(params);
       final grid = <List<String>>[
         for (var y = 0; y < 4; y++) [for (var x = 0; x < 4; x++) 's1'],

--- a/packages/colonizethis_map/test/tile_map_generation_determinism_test.dart
+++ b/packages/colonizethis_map/test/tile_map_generation_determinism_test.dart
@@ -2,6 +2,8 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_map/colonizethis_map.dart';
 import 'package:colonizethis_test/test.dart';
 
+import 'support/tile_map_gen_fixtures.dart';
+
 /// Stable fingerprint of province, terrain, and resource grids for regression
 /// guards after map-package refactors (Refs #2489).
 String tileMapGenerationDigest(TileMapResult result) {
@@ -25,11 +27,10 @@ void main() {
     test(
       'seed 42 oldWorld 24x20 digest unchanged (Refs #2489)',
       () {
-        const params = TileMapParams(
+        final params = genParams(
           width: 24,
           height: 20,
           seed: 42,
-          seaFraction: 0.6,
         );
         final (result, _) = TileMapGenerator(params: params).generate(
           numProvinces: 8,
@@ -47,11 +48,10 @@ void main() {
     );
 
     test('same seed and params yield identical digest', () {
-      const params = TileMapParams(
+      final params = genParams(
         width: 24,
         height: 20,
         seed: 42,
-        seaFraction: 0.6,
       );
       final gen = TileMapGenerator(params: params);
       final (a, _) = gen.generate(

--- a/packages/colonizethis_map/test/tile_map_generation_fn_test.dart
+++ b/packages/colonizethis_map/test/tile_map_generation_fn_test.dart
@@ -1,6 +1,8 @@
 import 'package:colonizethis_map/colonizethis_map.dart';
 import 'package:colonizethis_test/test.dart';
 
+import 'support/tile_map_gen_fixtures.dart';
+
 void main() {
   group('defaultTileMapRegionGenerator', () {
     test('delegates to TileMapGenerator and emits callbacks', () {
@@ -9,11 +11,10 @@ void main() {
       var continentSeedCallbackCalled = false;
 
       final (result, topology) = defaultTileMapRegionGenerator(
-        params: const TileMapParams(
+        params: genParams(
           width: 20,
           height: 14,
           seed: 3,
-          seaFraction: 0.6,
         ),
         numProvinces: 4,
         numContinents: 2,

--- a/packages/colonizethis_map/test/tile_map_generator_core_test.dart
+++ b/packages/colonizethis_map/test/tile_map_generator_core_test.dart
@@ -3,14 +3,15 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_map/colonizethis_map.dart';
 import 'package:logger/logger.dart';
 
+import 'support/tile_map_gen_fixtures.dart';
+
 void main() {
   group('TileMapGenerator core', () {
     test('generates grid with correct dimensions', () {
-      final params = TileMapParams(
+      final params = genParams(
         width: 20,
         height: 15,
         seed: 1,
-        seaFraction: 0.6,
       );
       final (result, topology) = TileMapGenerator(
         params: params,
@@ -37,11 +38,10 @@ void main() {
         Logger.level = Level.info;
 
         try {
-          final params = TileMapParams(
+          final params = genParams(
             width: 20,
             height: 15,
             seed: 1,
-            seaFraction: 0.6,
           );
           final gen = TileMapGenerator(params: params);
 
@@ -75,12 +75,11 @@ void main() {
     );
 
     test('two adjacent regions touch in grid', () {
-      final params = TileMapParams(
+      final params = genParams(
         width: 30,
         height: 30,
         seed: 42,
         maxEnforceIterations: 5,
-        seaFraction: 0.6,
       );
       final (result, _) = TileMapGenerator(
         params: params,
@@ -91,7 +90,7 @@ void main() {
 
     test('numProvinces 0 throws', () {
       final gen = TileMapGenerator(
-        params: TileMapParams(width: 10, height: 10),
+        params: genParams(width: 10, height: 10),
       );
       expect(
         () => gen.generate(numProvinces: 0, numContinents: 1, regionId: 'r1'),
@@ -101,7 +100,7 @@ void main() {
 
     test('numContinents 0 throws', () {
       final gen = TileMapGenerator(
-        params: TileMapParams(width: 10, height: 10),
+        params: genParams(width: 10, height: 10),
       );
       expect(
         () => gen.generate(numProvinces: 1, numContinents: 0, regionId: 'r1'),
@@ -115,7 +114,7 @@ void main() {
         const w = 20;
         const h = 20;
         const seaFraction = 0.6;
-        final params = TileMapParams(
+        final params = genParams(
           width: w,
           height: h,
           seed: 12345,
@@ -138,7 +137,7 @@ void main() {
     test('onLog receives a line per pass', () {
       final logLines = <String>[];
       TileMapGenerator(
-        params: TileMapParams(width: 10, height: 10, seed: 1, seaFraction: 0.6),
+        params: genParams(width: 10, height: 10, seed: 1),
       ).generate(
         numProvinces: 1,
         numContinents: 1,
@@ -164,7 +163,7 @@ void main() {
         Logger.addLogListener(listener);
         addTearDown(() => Logger.removeLogListener(listener));
 
-        final params = TileMapParams(
+        final params = genParams(
           width: 12,
           height: 9,
           seed: 77,
@@ -197,11 +196,10 @@ void main() {
       'final grid has only province and sea zone ids (no land sentinel)',
       () {
         final (result, topology) = TileMapGenerator(
-          params: TileMapParams(
+          params: genParams(
             width: 24,
             height: 24,
             seed: 7,
-            seaFraction: 0.6,
           ),
         ).generate(numProvinces: 2, numContinents: 1, regionId: 'r1');
         final validIds = topology.nodes.map((n) => n.id).toSet();
@@ -219,11 +217,10 @@ void main() {
 
     test('inferred topology matches grid adjacencies', () {
       final (result, topology) = TileMapGenerator(
-        params: TileMapParams(
+        params: genParams(
           width: 30,
           height: 30,
           seed: 42,
-          seaFraction: 0.6,
         ),
       ).generate(numProvinces: 2, numContinents: 1, regionId: 'r1');
       final validation = validateTileMapTopology(topology, result);
@@ -242,7 +239,7 @@ void main() {
           skipFillLakes: false,
         );
         final size = computeGridSizeFromParams(60, mapGenParams);
-        final params = TileMapParams(
+        final params = genParams(
           width: size.width,
           height: size.height,
           seed: mapGenParams.seed,
@@ -268,11 +265,10 @@ void main() {
       'joinContinents completes for small multi-continent grids (regression: no hang)',
       () {
         for (final seed in [0, 7, 42, 99, 777]) {
-          final params = TileMapParams(
+          final params = genParams(
             width: 20,
             height: 18,
             seed: seed,
-            seaFraction: 0.6,
           );
           TileMapGenerator(
             params: params,

--- a/packages/colonizethis_map/test/tile_map_generator_determinism_test.dart
+++ b/packages/colonizethis_map/test/tile_map_generator_determinism_test.dart
@@ -2,11 +2,13 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_map/colonizethis_map.dart';
 import 'package:colonizethis_test/test.dart';
 
+import 'support/tile_map_gen_fixtures.dart';
+
 void main() {
   group('TileMapGenerator determinism (Refs #2489)', () {
     test('fixed seed yields identical grid and topology on repeat', () {
       const seed = 248_901;
-      final params = TileMapParams(
+      final params = genParams(
         width: 48,
         height: 36,
         seed: seed,

--- a/packages/colonizethis_map/test/tile_map_generator_resource_rules_test.dart
+++ b/packages/colonizethis_map/test/tile_map_generator_resource_rules_test.dart
@@ -2,16 +2,17 @@ import 'package:colonizethis_test/test.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_map/colonizethis_map.dart';
 
+import 'support/tile_map_gen_fixtures.dart';
+
 void main() {
   group('TileMapGenerator resource rules', () {
     test(
       'with resourceRules produces terrain and resource grids of same dimensions',
       () {
-        final params = TileMapParams(
+        final params = genParams(
           width: 20,
           height: 15,
           seed: 2,
-          seaFraction: 0.6,
         );
         final (result, _) = TileMapGenerator(params: params).generate(
           numProvinces: 1,
@@ -31,11 +32,10 @@ void main() {
     );
 
     test('terrain and resource respect region and terrain rules', () {
-      final params = TileMapParams(
+      final params = genParams(
         width: 25,
         height: 25,
         seed: 3,
-        seaFraction: 0.6,
       );
       final (result, _) = TileMapGenerator(params: params).generate(
         numProvinces: 1,
@@ -57,11 +57,10 @@ void main() {
     });
 
     test('newWorld resources respect region and terrain rules', () {
-      final params = TileMapParams(
+      final params = genParams(
         width: 30,
         height: 30,
         seed: 17,
-        seaFraction: 0.6,
       );
       final (result, _) = TileMapGenerator(params: params).generate(
         numProvinces: 2,
@@ -85,7 +84,7 @@ void main() {
     test(
       'multi-region resource cap: newWorld keeps both resources at or below cap',
       () {
-        final params = TileMapParams(
+        final params = genParams(
           width: 24,
           height: 24,
           seed: 42,
@@ -129,7 +128,7 @@ void main() {
     test(
       'multi-region resource cap: oldWorld respects region and terrain rules',
       () {
-        final params = TileMapParams(
+        final params = genParams(
           width: 24,
           height: 24,
           seed: 99,
@@ -178,7 +177,7 @@ void main() {
 
     test('without resourceRules leaves terrain and resource grids null', () {
       final (result, _) = TileMapGenerator(
-        params: TileMapParams(width: 10, height: 10, seed: 1, seaFraction: 0.6),
+        params: genParams(width: 10, height: 10, seed: 1),
       ).generate(numProvinces: 1, numContinents: 1, regionId: 'r1');
       expect(result.terrainGrid, isNull);
       expect(result.resourceGrid, isNull);
@@ -189,7 +188,7 @@ void main() {
         result,
         _,
       ) = TileMapGenerator(
-        params: TileMapParams(width: 25, height: 25, seed: 4, seaFraction: 0.6),
+        params: genParams(width: 25, height: 25, seed: 4),
       ).generate(
         numProvinces: 1,
         numContinents: 1,
@@ -209,11 +208,10 @@ void main() {
     test('jitter params produce terrain and resource grids', () {
       final (result, _) =
           TileMapGenerator(
-            params: TileMapParams(
+            params: genParams(
               width: 24,
               height: 24,
               seed: 3,
-              seaFraction: 0.6,
               jitterHomogeneityThreshold: 0.5,
               jitterProbability: 0.5,
               jitterMaxFraction: 0.2,

--- a/packages/colonizethis_map/test/tile_map_generator_sea_lakes_test.dart
+++ b/packages/colonizethis_map/test/tile_map_generator_sea_lakes_test.dart
@@ -4,17 +4,18 @@ import 'package:colonizethis_map/colonizethis_map.dart';
 import 'package:colonizethis_map/src/tile_map_directions.dart';
 import 'package:colonizethis_map/src/tile_map_topology_helpers.dart';
 
+import 'support/tile_map_gen_fixtures.dart';
+
 void main() {
   group('TileMapGenerator sea and lakes', () {
     test(
       'no enclosed sea after fill-lakes: all sea connected to grid edge',
       () {
         final (result, _) = TileMapGenerator(
-          params: TileMapParams(
+          params: genParams(
             width: 30,
             height: 30,
             seed: 11,
-            seaFraction: 0.6,
           ),
         ).generate(numProvinces: 1, numContinents: 1, regionId: 'r1');
         final seaCells = <(int, int)>{};
@@ -64,11 +65,10 @@ void main() {
       () {
         // SPEC/game/map-topology.md § Warp zones: placement uses sea zones on the map edge.
         final (result, topology) = TileMapGenerator(
-          params: TileMapParams(
+          params: genParams(
             width: 24,
             height: 24,
             seed: 7,
-            seaFraction: 0.6,
           ),
         ).generate(numProvinces: 2, numContinents: 1, regionId: 'r1');
         final seaZoneIds = seaZoneIdsFromTopology(topology);
@@ -96,7 +96,7 @@ void main() {
 
     test('Pass 11 subdivides sea: result has sea zone ids s1, s2, ...', () {
       final (result, topology) = TileMapGenerator(
-        params: TileMapParams(width: 24, height: 24, seed: 7, seaFraction: 0.6),
+        params: genParams(width: 24, height: 24, seed: 7),
       ).generate(numProvinces: 2, numContinents: 1, regionId: 'r1');
       final seaNodes = seaZoneIdsFromTopology(topology);
       expect(seaNodes, isNotEmpty);
@@ -117,7 +117,7 @@ void main() {
       'Pass 11 sea zone size cap: subdivision produces many zones when sea is large',
       () {
         final (result, topology) = TileMapGenerator(
-          params: TileMapParams(
+          params: genParams(
             width: 40,
             height: 40,
             seed: 99,
@@ -146,7 +146,7 @@ void main() {
     test('Pass 11 log mentions sea zones and cap', () {
       final logLines = <String>[];
       TileMapGenerator(
-        params: TileMapParams(width: 24, height: 24, seed: 7, seaFraction: 0.6),
+        params: genParams(width: 24, height: 24, seed: 7),
       ).generate(
         numProvinces: 2,
         numContinents: 1,
@@ -162,7 +162,7 @@ void main() {
     test('Pass 4 log mentions lakes and moats', () {
       final logLines = <String>[];
       TileMapGenerator(
-        params: TileMapParams(width: 10, height: 10, seed: 1, seaFraction: 0.6),
+        params: genParams(width: 10, height: 10, seed: 1),
       ).generate(
         numProvinces: 1,
         numContinents: 1,
@@ -184,11 +184,10 @@ void main() {
     test('skipFillLakes true logs Fill lakes skipped', () {
       final logLines = <String>[];
       TileMapGenerator(
-        params: TileMapParams(
+        params: genParams(
           width: 10,
           height: 10,
           seed: 1,
-          seaFraction: 0.6,
           skipFillLakes: true,
         ),
       ).generate(
@@ -207,11 +206,10 @@ void main() {
       final logLines = <String>[];
       final (result, _) =
           TileMapGenerator(
-            params: TileMapParams(
+            params: genParams(
               width: 20,
               height: 20,
               seed: 2,
-              seaFraction: 0.6,
               borderNoise: 0.5,
             ),
           ).generate(

--- a/packages/colonizethis_map/test/tile_map_generator_seeding_test.dart
+++ b/packages/colonizethis_map/test/tile_map_generator_seeding_test.dart
@@ -1,6 +1,8 @@
 import 'package:colonizethis_test/test.dart';
 import 'package:colonizethis_map/colonizethis_map.dart';
 
+import 'support/tile_map_gen_fixtures.dart';
+
 void main() {
   group('TileMapGenerator land seeding', () {
     test(
@@ -8,11 +10,10 @@ void main() {
       () {
         final logLines = <String>[];
         TileMapGenerator(
-          params: TileMapParams(
+          params: genParams(
             width: 24,
             height: 24,
             seed: 5,
-            seaFraction: 0.6,
           ),
         ).generate(
           numProvinces: 2,
@@ -33,11 +34,10 @@ void main() {
         List<(int x, int y)>? capturedPositions;
         List<int>? capturedIndices;
         TileMapGenerator(
-          params: TileMapParams(
+          params: genParams(
             width: 20,
             height: 15,
             seed: 1,
-            seaFraction: 0.6,
           ),
         ).generate(
           numProvinces: 1,
@@ -65,7 +65,7 @@ void main() {
     test('onContinentSeedsPlaced is invoked with one seed per continent', () {
       List<(int x, int y)>? continentSeeds;
       TileMapGenerator(
-        params: TileMapParams(width: 24, height: 24, seed: 7, seaFraction: 0.6),
+        params: genParams(width: 24, height: 24, seed: 7),
       ).generate(
         numProvinces: 2,
         numContinents: 1,
@@ -82,7 +82,7 @@ void main() {
         const w = 20;
         const h = 20;
         const seaFraction = 0.6;
-        final params = TileMapParams(
+        final params = genParams(
           width: w,
           height: h,
           seed: 1,
@@ -106,11 +106,10 @@ void main() {
     test(
       'seedBeforeAssignment: false (organic default) produces valid tile map with land',
       () {
-        final params = TileMapParams(
+        final params = genParams(
           width: 30,
           height: 30,
           seed: 42,
-          seaFraction: 0.6,
           seedBeforeAssignment: false,
         );
         final (result, _) = TileMapGenerator(
@@ -130,11 +129,10 @@ void main() {
     test('organic mode logs Pass 2–3 (organic)', () {
       final logLines = <String>[];
       TileMapGenerator(
-        params: TileMapParams(
+        params: genParams(
           width: 10,
           height: 10,
           seed: 1,
-          seaFraction: 0.6,
           seedBeforeAssignment: false,
         ),
       ).generate(

--- a/packages/colonizethis_map/test/tile_map_generator_terrain_distribution_test.dart
+++ b/packages/colonizethis_map/test/tile_map_generator_terrain_distribution_test.dart
@@ -2,6 +2,8 @@ import 'package:colonizethis_test/test.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_map/colonizethis_map.dart';
 
+import 'support/tile_map_gen_fixtures.dart';
+
 void main() {
   group('TileMapGenerator terrain distribution', () {
     test(
@@ -9,11 +11,10 @@ void main() {
       () {
         const w = 40;
         const h = 30;
-        final params = TileMapParams(
+        final params = genParams(
           width: w,
           height: h,
           seed: 10,
-          seaFraction: 0.6,
         );
         final (result, _) = TileMapGenerator(params: params).generate(
           numProvinces: 4,
@@ -104,11 +105,10 @@ void main() {
     test('non-mountain terrain quotas roughly follow distribution', () {
       const w = 40;
       const h = 30;
-      final params = TileMapParams(
+      final params = genParams(
         width: w,
         height: h,
         seed: 20,
-        seaFraction: 0.6,
       );
       final (result, _) = TileMapGenerator(params: params).generate(
         numProvinces: 4,

--- a/packages/colonizethis_map/test/tile_map_grid_graph_test.dart
+++ b/packages/colonizethis_map/test/tile_map_grid_graph_test.dart
@@ -1,11 +1,12 @@
 import 'package:colonizethis_test/test.dart';
-import 'package:colonizethis_map/colonizethis_map.dart';
 import 'package:colonizethis_map/src/gen/tile_map_grid_graph.dart';
+
+import 'support/tile_map_gen_fixtures.dart';
 
 void main() {
   group('TileMapGridGraph', () {
     test('connectedComponentsOfLand splits two 4-connected blobs', () {
-      final params = TileMapParams(width: 4, height: 2);
+      final params = genParams(width: 4, height: 2);
       final g = TileMapGridGraph(params);
       final a = <(int, int)>{(0, 0), (1, 0)};
       final b = <(int, int)>{(3, 0), (3, 1)};
@@ -19,7 +20,7 @@ void main() {
       'oceanCells: all-sea grid is ocean only (no fillable single-continent S)',
       () {
         const sea = 's1';
-        final params = TileMapParams(width: 3, height: 3);
+        final params = genParams(width: 3, height: 3);
         final g = TileMapGridGraph(params);
         final grid = List.generate(3, (_) => List.filled(3, sea));
         final ocean = g.oceanCells(grid, sea, [], []);
@@ -30,7 +31,7 @@ void main() {
     test('oceanCells: map-border bay sea is not ocean when |S| = 1', () {
       const sea = 's1';
       const land = 'p1';
-      final params = TileMapParams(width: 5, height: 3);
+      final params = genParams(width: 5, height: 3);
       final g = TileMapGridGraph(params);
       final grid = <List<String>>[
         [land, sea, sea, sea, land],
@@ -45,7 +46,7 @@ void main() {
 
     test('oceanCells: border strait sea remains ocean when |S| >= 2', () {
       const sea = 's1';
-      final params = TileMapParams(width: 4, height: 3);
+      final params = genParams(width: 4, height: 3);
       final g = TileMapGridGraph(params);
       final grid = <List<String>>[
         ['p1', sea, sea, 'p2'],
@@ -60,7 +61,7 @@ void main() {
     });
 
     test('nearestLandSeedIndexForCell picks closest seed by squared distance', () {
-      final params = TileMapParams(width: 10, height: 10);
+      final params = genParams(width: 10, height: 10);
       final g = TileMapGridGraph(params);
       final seeds = <(int, int)>[(0, 0), (9, 9), (5, 5)];
       expect(g.nearestLandSeedIndexForCell(1, 1, seeds), 0);
@@ -69,12 +70,12 @@ void main() {
     });
 
     test('nearestLandSeedIndexForCell returns 0 when seeds empty', () {
-      final g = TileMapGridGraph(TileMapParams(width: 3, height: 3));
+      final g = TileMapGridGraph(genParams(width: 3, height: 3));
       expect(g.nearestLandSeedIndexForCell(1, 1, []), 0);
     });
 
     test('continentForLandCell maps nearest seed to continent id', () {
-      final g = TileMapGridGraph(TileMapParams(width: 10, height: 10));
+      final g = TileMapGridGraph(genParams(width: 10, height: 10));
       final seeds = <(int, int)>[(0, 0), (9, 9)];
       final continentBySeed = <int>[2, 7];
       expect(g.continentForLandCell(1, 1, seeds, continentBySeed), 2);
@@ -84,7 +85,7 @@ void main() {
 
     test('countSeaCells matches sea id cells', () {
       const sea = 's1';
-      final params = TileMapParams(width: 2, height: 2);
+      final params = genParams(width: 2, height: 2);
       final g = TileMapGridGraph(params);
       final grid = [
         [sea, 'p1'],

--- a/packages/colonizethis_map/test/tile_map_pass4_lakes_test.dart
+++ b/packages/colonizethis_map/test/tile_map_pass4_lakes_test.dart
@@ -2,6 +2,8 @@ import 'package:colonizethis_test/test.dart';
 import 'package:colonizethis_map/colonizethis_map.dart';
 import 'package:colonizethis_map/src/tile_map_directions.dart';
 
+import 'support/tile_map_gen_fixtures.dart';
+
 void main() {
   group('Pass 4 lake fill (issue 1864)', () {
     test(
@@ -9,7 +11,7 @@ void main() {
       () {
         const sea = 's1';
         const land = '_land';
-        final params = TileMapParams(width: 5, height: 3);
+        final params = genParams(width: 5, height: 3);
         final grid = <List<String>>[
           [land, sea, sea, sea, land],
           [land, sea, sea, sea, land],
@@ -30,7 +32,7 @@ void main() {
     test('fillLakesPass4ForTest preserves two-continent border strait sea', () {
       const sea = 's1';
       const land = '_land';
-      final params = TileMapParams(width: 4, height: 3);
+      final params = genParams(width: 4, height: 3);
       final grid = <List<String>>[
         [land, sea, sea, land],
         [land, sea, sea, land],
@@ -53,7 +55,7 @@ void main() {
       'full generate seed-before-assignment still has edge-reachable sea',
       () {
         final (result, _) = TileMapGenerator(
-          params: TileMapParams(
+          params: genParams(
             width: 28,
             height: 22,
             seed: 901,

--- a/packages/colonizethis_map/test/tile_map_terrain_noise_perturbation_test.dart
+++ b/packages/colonizethis_map/test/tile_map_terrain_noise_perturbation_test.dart
@@ -3,6 +3,7 @@ import 'package:colonizethis_map/colonizethis_map.dart';
 import 'package:colonizethis_test/test.dart';
 
 import 'tile_map_generation_determinism_test.dart' show tileMapGenerationDigest;
+import 'support/tile_map_gen_fixtures.dart';
 
 /// Tests for Pass 6b.5 noise perturbation
 /// (SPEC/program/tile-map-gen-algorithm.md § Pass 6b.5).
@@ -18,7 +19,7 @@ void main() {
     const baseSize = 64;
 
     TileMapResult generate({required double terrainVariation, int seed = 42}) {
-      final params = TileMapParams(
+      final params = genParams(
         width: baseSize,
         height: baseSize,
         seed: seed,


### PR DESCRIPTION
## Summary

Follow-up slice for the `colonizethis_map` test-dedup work. The first PR (#3747, now merged) shared the `init_game_map_view_builder_*` view-data scaffolding and added the `repo.map_test_no_duplicate_view_fixtures` gate, but **deferred** the generator-parameter helper. This PR completes that deferred slice.

Behavior-preserving test scaffolding only: no `lib/` changes, no changed assertions.

Tracked by #3746.

## Done in this push

- **New shared support file** `packages/colonizethis_map/test/support/tile_map_gen_fixtures.dart` exposing `genParams(...)` — a single source of truth for tile-map generator test parameters. Every named argument keeps the **exact production `TileMapParams` default**, so a bare `genParams()` / `genParams(width:, height:, seed:)` is byte-for-byte equivalent to the inline `TileMapParams(...)` it replaces. Only the params generator tests actually vary are exposed; the rarely-used pass-tuning knobs keep their defaults (a test needing one can still construct `TileMapParams` directly).
- **Routed all 81 generator-suite `TileMapParams(...)` construction sites** across **17 test files** through `genParams(...)` and dropped the redundant `seaFraction: 0.6` argument (now the builder default), collapsing the repeated `width/height/seed/seaFraction` shape the issue called out (~70+ sites).
- `tile_map_generator_support_test.dart` intentionally keeps the direct `TileMapParams` constructor — it tests `TileMapParams.copyWith` itself.

## ACs covered (from #3746 proposed work, step 4)

- [x] Generator `genParams(...)` helper with defaults added under `test/support/`.
- [x] The ~70+ `TileMapParams(...)` generator sites route through it where the shape is the shared default.
- [x] Full `colonizethis_map` suite passes (340 tests); deterministic generation digests unchanged (behavior-preserving); `dart analyze test/ lib/` clean.
- [x] Existing `repo.map_test_no_duplicate_view_fixtures` gate still green (generator helper is out of its view-builder scope by design).

## Not in scope / notes

- No new `ct_repo_lint` gate for generator params: #3746's gate requirement is view-builder-scoped and already shipped in #3747; a generator-params gate would risk false positives on bespoke-param tests. Consistent with #3747's deferral note.

## Test plan

- [x] `dart analyze test/ lib/` in `packages/colonizethis_map` — clean
- [x] `dart test` in `packages/colonizethis_map` — 340 passing (incl. determinism digests)
- [x] `dart run tool/ct_repo_lint.dart --rule repo.map_test_no_duplicate_view_fixtures` — passes

Refs #3746

Made with [Cursor](https://cursor.com)