### PR TITLE
refactor: dedup AI seed42 test-support helpers (#3749)

### DIFF
--- a/packages/colonizethis_ai/test/seed42_s7d_feedstock_helpers_test.dart
+++ b/packages/colonizethis_ai/test/seed42_s7d_feedstock_helpers_test.dart
@@ -31,6 +31,7 @@ Game _game({
       const {},
   Map<String, String> resourceByTileKey = const {},
   List<Province> oldWorldProvinces = const [],
+  Map<String, int> improvementByTile = const {},
 }) {
   return Game(
     id: 'g',
@@ -40,7 +41,7 @@ Game _game({
       newWorld: const RegionData(),
       tileKeysByRegionAndProvince: tileKeysByRegionAndProvince,
       resourceByTileKey: resourceByTileKey,
-      tileState: TileMapState(),
+      tileState: TileMapState(improvementByTile: improvementByTile),
     ),
     players: [
       Player(
@@ -332,6 +333,94 @@ void main() {
       );
       expect(
         ownsFeedstockResourceTileAnyLevel(game, _playerId, const {}),
+        isFalse,
+      );
+    });
+  });
+
+  group('owns(Un)improvedFeedstockResourceTile improvement-level split', () {
+    final castIronFeedstock = {timberId, ironId};
+    const provinceId = 'oldWorld|p0';
+    const tileKey = 'oldWorld|p0|2|0';
+
+    Game gameWithImprovement(int level) => _game(
+      oldWorldProvinces: const [
+        Province(id: provinceId, regionId: 'oldWorld', ownerId: _playerId),
+      ],
+      tileKeysByRegionAndProvince: const {
+        'oldWorld': {
+          provinceId: [tileKey],
+        },
+      },
+      resourceByTileKey: const {tileKey: 'timber'},
+      improvementByTile: {tileKey: level},
+    );
+
+    test('unimproved (level 0): unimproved probe true, improved probe false', () {
+      final game = gameWithImprovement(0);
+      expect(
+        ownsUnimprovedFeedstockResourceTile(game, _playerId, castIronFeedstock),
+        isTrue,
+      );
+      expect(
+        ownsImprovedFeedstockResourceTile(game, _playerId, castIronFeedstock),
+        isFalse,
+      );
+      // Any-level probe ignores the improvement split entirely.
+      expect(
+        ownsFeedstockResourceTileAnyLevel(game, _playerId, castIronFeedstock),
+        isTrue,
+      );
+    });
+
+    test('improved (level 1): improved probe true, unimproved probe false', () {
+      final game = gameWithImprovement(1);
+      expect(
+        ownsImprovedFeedstockResourceTile(game, _playerId, castIronFeedstock),
+        isTrue,
+      );
+      expect(
+        ownsUnimprovedFeedstockResourceTile(game, _playerId, castIronFeedstock),
+        isFalse,
+      );
+      expect(
+        ownsFeedstockResourceTileAnyLevel(game, _playerId, castIronFeedstock),
+        isTrue,
+      );
+    });
+
+    test('empty feedstock set: every probe is false', () {
+      final game = gameWithImprovement(0);
+      expect(
+        ownsUnimprovedFeedstockResourceTile(game, _playerId, const {}),
+        isFalse,
+      );
+      expect(
+        ownsImprovedFeedstockResourceTile(game, _playerId, const {}),
+        isFalse,
+      );
+    });
+
+    test('scanOwnedFeedstockTiles: custom predicate drives the match', () {
+      final game = gameWithImprovement(2);
+      // Predicate matching exactly level 2 succeeds; a never-true predicate
+      // short-circuits to false even though the owned feedstock tile exists.
+      expect(
+        scanOwnedFeedstockTiles(
+          game,
+          _playerId,
+          castIronFeedstock,
+          (level) => level == 2,
+        ),
+        isTrue,
+      );
+      expect(
+        scanOwnedFeedstockTiles(
+          game,
+          _playerId,
+          castIronFeedstock,
+          (_) => false,
+        ),
         isFalse,
       );
     });
@@ -737,5 +826,63 @@ void main() {
       expect(present['gp5'], 0);
       expect(absent['gp5'], 0);
     });
+  });
+
+  group('recordSeed42S7dOtherFactionOfferCounters (shared, Refs #3749)', () {
+    final timberCommodityId = CommodityCatalog.timber.id;
+
+    TradeOrder offer(String id) => TradeOrder(
+      commodityId: id,
+      type: TradeOrderType.offer,
+      quantity: 1,
+      priority: 1,
+    );
+    TradeOrder bid(String id) => TradeOrder(
+      commodityId: id,
+      type: TradeOrderType.bid,
+      quantity: 1,
+      priority: 1,
+    );
+
+    test(
+      'positive: another faction offers the commodity => present bumped',
+      () {
+        final present = <String, int>{'gp3': 0};
+        final absent = <String, int>{'gp3': 0};
+        recordSeed42S7dOtherFactionOfferCounters(
+          activeThisTurn: {'gp3'},
+          tradeOrdersByPlayerId: {
+            'gp1': [offer(timberCommodityId)],
+            'gp3': [bid(timberCommodityId)],
+          },
+          commodityId: timberCommodityId,
+          presentTurns: present,
+          absentTurns: absent,
+        );
+        expect(present['gp3'], 1);
+        expect(absent['gp3'], 0);
+      },
+    );
+
+    test(
+      'negative: own offer + others\' bids/unrelated offers => absent bumped',
+      () {
+        final present = <String, int>{'gp3': 0};
+        final absent = <String, int>{'gp3': 0};
+        recordSeed42S7dOtherFactionOfferCounters(
+          activeThisTurn: {'gp3'},
+          tradeOrdersByPlayerId: {
+            'gp3': [offer(timberCommodityId)],
+            'gp1': [bid(timberCommodityId)],
+            'gp2': [offer(ironId)],
+          },
+          commodityId: timberCommodityId,
+          presentTurns: present,
+          absentTurns: absent,
+        );
+        expect(present['gp3'], 0);
+        expect(absent['gp3'], 1);
+      },
+    );
   });
 }

--- a/packages/colonizethis_ai/test/support/growth_stage_planner_test_support.dart
+++ b/packages/colonizethis_ai/test/support/growth_stage_planner_test_support.dart
@@ -8,13 +8,14 @@ import 'package:colonizethis_logic/order_suggestion_api.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'domain_planner_test_fake_api.dart';
+import 'planner_test_helpers.dart' show kTestAiConfig;
 
 const kTestTopology = MapTopology(nodes: [], edges: []);
-const kTestConfig = AIConfig(
-  leaderId: 'victoria',
-  personalityId: 'victoria',
-  hiddenAgendaId: 'peacemaker',
-);
+
+/// Alias to the single shared default AI config (`kTestAiConfig`,
+/// `planner_test_helpers.dart`) so the growth-stage suites reuse one constant
+/// rather than duplicating the literal `AIConfig` (Refs #3749).
+const kTestConfig = kTestAiConfig;
 final kTestSeeds = AISeedBundle.fromTurnSeed(3371);
 
 Game gameWithPlayer(Player player) => Game(

--- a/packages/colonizethis_ai/test/support/seed42_s7d_feedstock_helpers.dart
+++ b/packages/colonizethis_ai/test/support/seed42_s7d_feedstock_helpers.dart
@@ -27,14 +27,16 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart';
 
 /// True iff [playerId] owns at least one province tile that hosts a fabric
-/// feedstock resource (a member of [feedstockIds]) and is still unimproved
-/// (improvement level < 1) — i.e. a Builder target a lock-recovery seller could
-/// extract to feed the `fabricFrom*` recipes. Read-only scan over owned
-/// provinces; Refs #2847 H8-supply feedstock-stage diagnostic.
-bool ownsUnimprovedFeedstockResourceTile(
+/// feedstock resource (a member of [feedstockIds]) whose improvement level
+/// satisfies [improvementMatches]. Shared owned-province tile scan backing the
+/// three `ownsFeedstock*` probes so the loop lives in one place; an empty
+/// [feedstockIds] never matches. Read-only over `(game, playerId)`; no
+/// game-state mutation.
+bool scanOwnedFeedstockTiles(
   Game game,
   String playerId,
   Set<String> feedstockIds,
+  bool Function(int improvementLevel) improvementMatches,
 ) {
   if (feedstockIds.isEmpty) return false;
   final ws = game.worldState;
@@ -47,12 +49,30 @@ bool ownsUnimprovedFeedstockResourceTile(
         if (resourceId == null || !feedstockIds.contains(resourceId)) {
           continue;
         }
-        if (ws.tileState.improvementLevel(tileKey) < 1) return true;
+        if (improvementMatches(ws.tileState.improvementLevel(tileKey))) {
+          return true;
+        }
       }
     }
   }
   return false;
 }
+
+/// True iff [playerId] owns at least one province tile that hosts a fabric
+/// feedstock resource (a member of [feedstockIds]) and is still unimproved
+/// (improvement level < 1) — i.e. a Builder target a lock-recovery seller could
+/// extract to feed the `fabricFrom*` recipes. Read-only scan over owned
+/// provinces; Refs #2847 H8-supply feedstock-stage diagnostic.
+bool ownsUnimprovedFeedstockResourceTile(
+  Game game,
+  String playerId,
+  Set<String> feedstockIds,
+) => scanOwnedFeedstockTiles(
+  game,
+  playerId,
+  feedstockIds,
+  (improvementLevel) => improvementLevel < 1,
+);
 
 /// True iff [playerId] owns at least one province tile that hosts a fabric
 /// feedstock resource (a member of [feedstockIds]) that is already improved
@@ -71,24 +91,12 @@ bool ownsImprovedFeedstockResourceTile(
   Game game,
   String playerId,
   Set<String> feedstockIds,
-) {
-  if (feedstockIds.isEmpty) return false;
-  final ws = game.worldState;
-  for (final byProvince in ws.tileKeysByRegionAndProvince.values) {
-    for (final entry in byProvince.entries) {
-      final province = ws.tryGetProvince(entry.key);
-      if (province == null || province.ownerId != playerId) continue;
-      for (final tileKey in entry.value) {
-        final resourceId = ws.resourceByTileKey[tileKey];
-        if (resourceId == null || !feedstockIds.contains(resourceId)) {
-          continue;
-        }
-        if (ws.tileState.improvementLevel(tileKey) >= 1) return true;
-      }
-    }
-  }
-  return false;
-}
+) => scanOwnedFeedstockTiles(
+  game,
+  playerId,
+  feedstockIds,
+  (improvementLevel) => improvementLevel >= 1,
+);
 
 /// True iff [playerId] owns at least one Builder unit that currently has no
 /// work assigned (`currentWork == null`) — i.e. a Builder the Full-AI civilian
@@ -606,23 +614,12 @@ bool ownsFeedstockResourceTileAnyLevel(
   Game game,
   String playerId,
   Set<String> feedstockIds,
-) {
-  if (feedstockIds.isEmpty) return false;
-  final ws = game.worldState;
-  for (final byProvince in ws.tileKeysByRegionAndProvince.values) {
-    for (final entry in byProvince.entries) {
-      final province = ws.tryGetProvince(entry.key);
-      if (province == null || province.ownerId != playerId) continue;
-      for (final tileKey in entry.value) {
-        final resourceId = ws.resourceByTileKey[tileKey];
-        if (resourceId != null && feedstockIds.contains(resourceId)) {
-          return true;
-        }
-      }
-    }
-  }
-  return false;
-}
+) => scanOwnedFeedstockTiles(
+  game,
+  playerId,
+  feedstockIds,
+  (_) => true,
+);
 
 /// Structural-invariant assertions over the S7-D diagnostic per-GP counter
 /// maps (Refs #2847). Extracted from
@@ -1063,17 +1060,39 @@ void recordSeed42S7dCastIronMarketOfferCounters({
   required String castIronCommodityId,
   required Map<String, int> presentTurns,
   required Map<String, int> absentTurns,
+}) => recordSeed42S7dOtherFactionOfferCounters(
+  activeThisTurn: feedstockGateActiveThisTurn,
+  tradeOrdersByPlayerId: tradeOrdersByPlayerId,
+  commodityId: castIronCommodityId,
+  presentTurns: presentTurns,
+  absentTurns: absentTurns,
+);
+
+/// Shared other-faction sell-offer present/absent tally backing the castIron
+/// and `fabric` market-offer recorders (Refs #2847). For each gp in
+/// [activeThisTurn], scans [tradeOrdersByPlayerId] for any *other* faction
+/// emitting a [commodityId] sell offer this turn and bumps [presentTurns] when
+/// one exists, else [absentTurns]. The gp's own offer never counts as supply,
+/// and bids (demand) are ignored. Read-only over the supplied maps except the
+/// counter bumps; extracted so the two single-commodity recorders share one
+/// scan loop.
+void recordSeed42S7dOtherFactionOfferCounters({
+  required Set<String> activeThisTurn,
+  required Map<String, List<TradeOrder>> tradeOrdersByPlayerId,
+  required String commodityId,
+  required Map<String, int> presentTurns,
+  required Map<String, int> absentTurns,
 }) {
-  for (final gpId in feedstockGateActiveThisTurn) {
+  for (final gpId in activeThisTurn) {
     var offeredByOther = false;
     for (final entry in tradeOrdersByPlayerId.entries) {
       if (entry.key == gpId) continue;
-      final offeredCastIron = entry.value.any(
+      final offered = entry.value.any(
         (order) =>
             order.type == TradeOrderType.offer &&
-            order.commodityId == castIronCommodityId,
+            order.commodityId == commodityId,
       );
-      if (offeredCastIron) {
+      if (offered) {
         offeredByOther = true;
         break;
       }
@@ -1107,29 +1126,13 @@ void recordSeed42S7dFabricMarketOfferCounters({
   required Map<String, List<TradeOrder>> tradeOrdersByPlayerId,
   required Map<String, int> presentTurns,
   required Map<String, int> absentTurns,
-}) {
-  const fabricCommodityId = 'fabric';
-  for (final gpId in fabricMarketPathActiveThisTurn) {
-    var offeredByOther = false;
-    for (final entry in tradeOrdersByPlayerId.entries) {
-      if (entry.key == gpId) continue;
-      final offeredFabric = entry.value.any(
-        (order) =>
-            order.type == TradeOrderType.offer &&
-            order.commodityId == fabricCommodityId,
-      );
-      if (offeredFabric) {
-        offeredByOther = true;
-        break;
-      }
-    }
-    if (offeredByOther) {
-      bumpCounter(presentTurns, gpId);
-    } else {
-      bumpCounter(absentTurns, gpId);
-    }
-  }
-}
+}) => recordSeed42S7dOtherFactionOfferCounters(
+  activeThisTurn: fabricMarketPathActiveThisTurn,
+  tradeOrdersByPlayerId: tradeOrdersByPlayerId,
+  commodityId: 'fabric',
+  presentTurns: presentTurns,
+  absentTurns: absentTurns,
+);
 
 /// True iff [playerId] owns at least one idle Builder for which the work-order
 /// engine **accepts** a `build_improvement` on an owned unimproved feedstock


### PR DESCRIPTION
## Summary

Phase-2 `colonizethis_ai` refactor (Refs #3749), first safe slice: **test-support deduplication** (proposed-work step 1). Behavior-preserving; no AI planning semantics, emitted-order, or scoring changes.

## Done in this push

- **Unify config constant (AC6).** `kTestConfig` in `growth_stage_planner_test_support.dart` was an identical copy of `kTestAiConfig` (`planner_test_helpers.dart`). It is now an alias (`const kTestConfig = kTestAiConfig;`) so the growth-stage suites reuse the single shared default `AIConfig`. The `kTestConfig` name stays stable, so existing test references are unchanged.
- **Extract `scanOwnedFeedstockTiles` (AC6 — tile-scan duplication removed).** The three `ownsFeedstock*` probes (`ownsUnimprovedFeedstockResourceTile`, `ownsImprovedFeedstockResourceTile`, `ownsFeedstockResourceTileAnyLevel`) repeated the same owned-province tile-scan loop with only the improvement-level predicate differing. They now delegate to one shared `scanOwnedFeedstockTiles(game, playerId, feedstockIds, predicate)`; the empty-set early return is preserved in the shared helper.
- **Merge market-offer recorders.** `recordSeed42S7dCastIronMarketOfferCounters` and `recordSeed42S7dFabricMarketOfferCounters` shared the same "another faction offers commodity X → bump present/absent" scan. Both now delegate to a shared `recordSeed42S7dOtherFactionOfferCounters`; public signatures are unchanged (the fabric wrapper passes `commodityId: 'fabric'`).
- **Tests.** Added a positive/negative group covering the improvement-level split (unimproved vs improved vs any-level) routed through the shared scan, a custom-predicate case for `scanOwnedFeedstockTiles`, and positive/negative coverage for the shared `recordSeed42S7dOtherFactionOfferCounters`.

## Verification

- `dart analyze` (edited files): clean.
- `dart test` for `seed42_s7d_feedstock_helpers_test.dart`, `growth_stage_planner_test.dart`, `growth_stage_planner_relocation_test.dart`: all pass (74 tests).
- `check_ai_test_mirrors_lib` and `check_ai_test_no_duplicate_scaffolding` gates: pass.

## Deferred (remaining for #3749)

This PR is one slice. The following issue steps are **not** in this PR and remain follow-up work: shared `runSeed42ObserverCampaign` harness + observer-test migration (step 2), soft-weight wiring parameterization (step 3), `phase_filter_common.dart` (step 4), expand-peace decider registry (step 5), branch-pin table-driving (step 6), orchestrator/scoring module splits (step 7), gate-probe delegation in `seed42_s7d_feedstock_helpers.dart` (step 8), and the new CI/manifest gates.

Refs #3749

Made with [Cursor](https://cursor.com)