### PR TITLE
refactor: add shared seed42 observer campaign harness (#3749)

### DIFF
--- a/packages/colonizethis_ai/test/seed42_observer_conquest_regression_test.dart
+++ b/packages/colonizethis_ai/test/seed42_observer_conquest_regression_test.dart
@@ -1,13 +1,16 @@
-import 'package:colonizethis_test/test.dart';
-import 'package:colonizethis_ai/colonizethis_ai.dart';
-import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
 import 'package:logger/logger.dart';
 
-import 'support/faithful_full_ai_test_handoff.dart';
+import 'support/seed42_observer_campaign.dart';
 
 /// Observer seed-42 per-GP Old World conquest gate (Refs #2509).
+///
+/// Migrated to the shared [runSeed42ObserverCampaign] harness (Refs #3749
+/// step 2): the init / handoff / 100-turn resolve loop is owned by
+/// `test/support/seed42_observer_campaign.dart`; this test reads only the
+/// campaign start / end game to assert per-GP Old World gains.
 void main() {
   setUpAll(() {
     CtLogger.level = Level.off;
@@ -16,55 +19,21 @@ void main() {
   test(
     'seed 42 turn 100: every GP gains at least 3 Old World provinces',
     () {
-      final init = runInitGame(
-        config: GameSetupConfig(seed: 42),
-        options: const InitGameOptions(
-          cellSize: 24,
-          renderPng: false,
-          skipFillLakes: false,
-        ),
-      );
-      var game = applyFaithfulFullAiTestHandoff(init.game);
-      final topo = init.combinedTopology;
-      final tileMap = init.tileMapByRegion;
+      final campaign = runSeed42ObserverCampaign(turns: 100);
+
+      int owProvincesFor(Game game, String gpId) => game
+          .worldState.oldWorld.provinces
+          .where((p) => p.ownerId == gpId)
+          .length;
+
       final owStart = <String, int>{};
-      for (var i = 1; i <= 6; i++) {
-        final gpId = 'gp$i';
-        owStart[gpId] = game.worldState.oldWorld.provinces
-            .where((p) => p.ownerId == gpId)
-            .length;
-      }
-      for (var t = 0; t < 100; t++) {
-        final fullAi = generateOrdersForGameFullAI(
-          game,
-          topo,
-          tileMapByRegion: tileMap,
-        );
-        final merged = mergeOrderLists(
-          humanOrders: const Orders(),
-          aiOrders: fullAi.orders,
-        );
-        final assignments = fullAi.economyPlansByPlayerId.map(
-          (pid, plan) => MapEntry(pid, plan.productionAssignments),
-        );
-        final result = validateOrdersAndResolveTurnFromTrustedOrders(
-          game: fullAi.game,
-          topology: topo,
-          orders: merged,
-          tileMapByRegion: tileMap,
-          defaultAssignmentsByPlayerId: assignments,
-        );
-        expect(result, isA<TurnResolutionComplete>());
-        game = (result as TurnResolutionComplete).game;
-      }
       final gains = <String, int>{};
       for (var i = 1; i <= 6; i++) {
         final gpId = 'gp$i';
-        final end = game.worldState.oldWorld.provinces
-            .where((p) => p.ownerId == gpId)
-            .length;
-        gains[gpId] = end - owStart[gpId]!;
+        owStart[gpId] = owProvincesFor(campaign.initialGame, gpId);
+        gains[gpId] = owProvincesFor(campaign.finalGame, gpId) - owStart[gpId]!;
       }
+
       for (var i = 1; i <= 6; i++) {
         final gpId = 'gp$i';
         final gain = gains[gpId]!;

--- a/packages/colonizethis_ai/test/seed42_observer_nw_lock_recovery_declare_war_regression_test.dart
+++ b/packages/colonizethis_ai/test/seed42_observer_nw_lock_recovery_declare_war_regression_test.dart
@@ -1,11 +1,9 @@
-import 'package:colonizethis_ai/colonizethis_ai.dart';
-import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart';
 import 'package:logger/logger.dart';
 
-import 'support/faithful_full_ai_test_handoff.dart';
+import 'support/seed42_observer_campaign.dart';
 
 /// Seed-42 Path E lock-recovery declare-war acceptance regression (Refs #2924).
 ///
@@ -18,6 +16,12 @@ import 'support/faithful_full_ai_test_handoff.dart';
 /// NW-bound army moves may remain zero until naval transport / home-army
 /// mobility land (#2925 companion); this regression pins the upstream
 /// diplomatic emission the issue's secondary AC requires.
+///
+/// Migrated to the shared [runSeed42ObserverCampaign] harness (Refs #3749
+/// step 2): the init / handoff / 100-turn resolve loop is owned by
+/// `test/support/seed42_observer_campaign.dart`; this test contributes only
+/// its per-turn `onBeforeResolve` observation of the generated diplomatic
+/// orders.
 ///
 /// Skipped by default (~3 min). Re-run with `dart test --run-skipped` when
 /// the lock-recovery colonial acquisition surface changes.
@@ -32,54 +36,24 @@ void main() {
     'seed 42: gp3–gp6 each emit at least one tribal declareWar within 100 '
     'turns (Refs #2924 Path E)',
     () {
-      final init = runInitGame(
-        config: GameSetupConfig(seed: 42),
-        options: const InitGameOptions(
-          cellSize: 24,
-          renderPng: false,
-          skipFillLakes: false,
-        ),
-      );
-      var game = applyFaithfulFullAiTestHandoff(init.game);
-      final topo = init.combinedTopology;
-      final tileMap = init.tileMapByRegion;
-
       final tribalDeclareWarCount = <String, int>{
         for (final gpId in failingGpIds) gpId: 0,
       };
 
-      for (var t = 0; t < 100; t++) {
-        final fullAi = generateOrdersForGameFullAI(
-          game,
-          topo,
-          tileMapByRegion: tileMap,
-        );
-        for (final gpId in failingGpIds) {
-          for (final order
-              in fullAi.orders.diplomaticOrdersByPlayerId[gpId] ?? const []) {
-            if (order.type == DiplomaticOrderType.declareWar &&
-                !order.targetFactionId.startsWith('gp')) {
-              tribalDeclareWarCount[gpId] = tribalDeclareWarCount[gpId]! + 1;
+      runSeed42ObserverCampaign(
+        turns: 100,
+        onBeforeResolve: (turn, fullAi, game) {
+          for (final gpId in failingGpIds) {
+            for (final order
+                in fullAi.orders.diplomaticOrdersByPlayerId[gpId] ?? const []) {
+              if (order.type == DiplomaticOrderType.declareWar &&
+                  !order.targetFactionId.startsWith('gp')) {
+                tribalDeclareWarCount[gpId] = tribalDeclareWarCount[gpId]! + 1;
+              }
             }
           }
-        }
-        final merged = mergeOrderLists(
-          humanOrders: const Orders(),
-          aiOrders: fullAi.orders,
-        );
-        final assignments = fullAi.economyPlansByPlayerId.map(
-          (pid, plan) => MapEntry(pid, plan.productionAssignments),
-        );
-        final result = validateOrdersAndResolveTurnFromTrustedOrders(
-          game: fullAi.game,
-          topology: topo,
-          orders: merged,
-          tileMapByRegion: tileMap,
-          defaultAssignmentsByPlayerId: assignments,
-        );
-        expect(result, isA<TurnResolutionComplete>());
-        game = (result as TurnResolutionComplete).game;
-      }
+        },
+      );
 
       for (final gpId in failingGpIds) {
         expect(

--- a/packages/colonizethis_ai/test/seed42_observer_world_market_lock_recovery_regression_test.dart
+++ b/packages/colonizethis_ai/test/seed42_observer_world_market_lock_recovery_regression_test.dart
@@ -1,14 +1,12 @@
-import 'package:colonizethis_ai/colonizethis_ai.dart';
 import 'package:colonizethis_ai/src/planning/expand_phase_planner.dart'
     show cheapestRegimentBuildTreasuryCost;
 import 'package:colonizethis_data/colonizethis_data.dart'
     hide cheapestRegimentBuildTreasuryCost;
 import 'package:colonizethis_logic/colonizethis_logic.dart';
-import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart';
 import 'package:logger/logger.dart';
 
-import 'support/faithful_full_ai_test_handoff.dart';
+import 'support/seed42_observer_campaign.dart';
 
 /// Seed-42 Path F lock-recovery acceptance regression (Refs #2924).
 ///
@@ -25,6 +23,13 @@ import 'support/faithful_full_ai_test_handoff.dart';
 /// AI interventions instead of pausing with
 /// `TurnResolutionPendingIntervention` (which only arises for human players).
 ///
+/// Migrated to the shared [runSeed42ObserverCampaign] harness (Refs #3749
+/// step 2): the init / handoff / 100-turn resolve loop is owned by
+/// `test/support/seed42_observer_campaign.dart`; this test contributes only its
+/// per-turn `onBeforeResolve` (affordable-turn regiment-build tally) and
+/// `onAfterResolve` (world-market seller credit + treasury recovery tracking)
+/// observations.
+///
 /// Skipped by default (~4 min). Re-run with `dart test --run-skipped` when
 /// the lock-recovery surface changes.
 void main() {
@@ -38,18 +43,6 @@ void main() {
     'seed 42: gp3–gp6 each cross regiment treasury threshold within 100 turns '
     '(Refs #2924 Path F)',
     () {
-      final init = runInitGame(
-        config: GameSetupConfig(seed: 42),
-        options: const InitGameOptions(
-          cellSize: 24,
-          renderPng: false,
-          skipFillLakes: false,
-        ),
-      );
-      var game = applyFaithfulFullAiTestHandoff(init.game);
-      final topo = init.combinedTopology;
-      final tileMap = init.tileMapByRegion;
-
       final threshold = cheapestRegimentBuildTreasuryCost();
       final wasBrokeAfterStart = <String, bool>{
         for (final gpId in failingGpIds) gpId: false,
@@ -67,68 +60,48 @@ void main() {
         for (final gpId in failingGpIds) gpId: 0,
       };
 
-      for (var t = 0; t < 100; t++) {
-        final treasuryBeforeOrders = <String, int>{
-          for (final gpId in failingGpIds)
-            gpId: game.playerById(gpId)?.treasury ?? 0,
-        };
-        final fullAi = generateOrdersForGameFullAI(
-          game,
-          topo,
-          tileMapByRegion: tileMap,
-        );
-        for (final gpId in failingGpIds) {
-          if (treasuryBeforeOrders[gpId]! < threshold) continue;
-          final orders =
-              fullAi.orders.buildUnitOrdersByPlayerId[gpId] ?? const [];
-          regimentBuildsWhileAffordable[gpId] =
-              regimentBuildsWhileAffordable[gpId]! +
-              orders
-                  .where(
-                    (o) => RegimentEconomyCatalog.byId.containsKey(o.unitType),
-                  )
-                  .length;
-        }
-        final merged = mergeOrderLists(
-          humanOrders: const Orders(),
-          aiOrders: fullAi.orders,
-        );
-        final assignments = fullAi.economyPlansByPlayerId.map(
-          (pid, plan) => MapEntry(pid, plan.productionAssignments),
-        );
-        final result = validateOrdersAndResolveTurnFromTrustedOrders(
-          game: fullAi.game,
-          topology: topo,
-          orders: merged,
-          tileMapByRegion: tileMap,
-          defaultAssignmentsByPlayerId: assignments,
-        );
-        expect(result, isA<TurnResolutionComplete>());
-        game = (result as TurnResolutionComplete).game;
+      runSeed42ObserverCampaign(
+        turns: 100,
+        onBeforeResolve: (turn, fullAi, game) {
+          for (final gpId in failingGpIds) {
+            final treasuryBeforeOrders = game.playerById(gpId)?.treasury ?? 0;
+            if (treasuryBeforeOrders < threshold) continue;
+            final orders =
+                fullAi.orders.buildUnitOrdersByPlayerId[gpId] ?? const [];
+            regimentBuildsWhileAffordable[gpId] =
+                regimentBuildsWhileAffordable[gpId]! +
+                orders
+                    .where(
+                      (o) => RegimentEconomyCatalog.byId.containsKey(o.unitType),
+                    )
+                    .length;
+          }
+        },
+        onAfterResolve: (turn, game) {
+          final activity = game.worldMarketState.lastTurnActivity;
+          for (final entry in activity.entries) {
+            for (final deal in entry.value.deals) {
+              final seller = deal.sellerFactionId;
+              if (!lifetimeSellerCredit.containsKey(seller)) continue;
+              lifetimeSellerCredit[seller] = lifetimeSellerCredit[seller]! +
+                  (deal.quantity * deal.pricePerUnit).round();
+            }
+          }
 
-        final activity = game.worldMarketState.lastTurnActivity;
-        for (final entry in activity.entries) {
-          for (final deal in entry.value.deals) {
-            final seller = deal.sellerFactionId;
-            if (!lifetimeSellerCredit.containsKey(seller)) continue;
-            lifetimeSellerCredit[seller] = lifetimeSellerCredit[seller]! +
-                (deal.quantity * deal.pricePerUnit).round();
+          for (final gpId in failingGpIds) {
+            final treasury = game.playerById(gpId)?.treasury ?? 0;
+            if (treasury > maxTreasury[gpId]!) {
+              maxTreasury[gpId] = treasury;
+            }
+            if (turn > 0 && treasury < threshold) {
+              wasBrokeAfterStart[gpId] = true;
+            }
+            if (wasBrokeAfterStart[gpId]! && treasury >= threshold) {
+              recoveredAfterBroke[gpId] = true;
+            }
           }
-        }
-
-        for (final gpId in failingGpIds) {
-          final treasury = game.playerById(gpId)?.treasury ?? 0;
-          if (treasury > maxTreasury[gpId]!) {
-            maxTreasury[gpId] = treasury;
-          }
-          if (t > 0 && treasury < threshold) {
-            wasBrokeAfterStart[gpId] = true;
-          }
-          if (wasBrokeAfterStart[gpId]! && treasury >= threshold) {
-            recoveredAfterBroke[gpId] = true;
-          }
-        }
-      }
+        },
+      );
 
       for (final gpId in failingGpIds) {
         expect(

--- a/packages/colonizethis_ai/test/support/seed42_observer_campaign.dart
+++ b/packages/colonizethis_ai/test/support/seed42_observer_campaign.dart
@@ -1,0 +1,124 @@
+/// Shared seed-42 Full-AI observer campaign harness (Refs #3749 step 2).
+///
+/// Single source of truth for the `runInitGame(seed: 42)` ->
+/// [applyFaithfulFullAiTestHandoff] -> N-turn
+/// `generateOrdersForGameFullAI` -> `mergeOrderLists` ->
+/// `validateOrdersAndResolveTurnFromTrustedOrders` resolve loop duplicated
+/// across the top-level `seed42_observer_*` integration tests. Each migrated
+/// test supplies only its per-turn observation via [onBeforeResolve] /
+/// [onAfterResolve] and reads the start / end game from the returned
+/// [Seed42ObserverCampaignResult]; the init, handoff, per-turn order
+/// generation, merge, trusted-order resolution, and the
+/// `expect(result, isA<TurnResolutionComplete>())` assertion live here once.
+///
+/// Behaviour-preserving against the inline loops it replaces: the same
+/// [GameSetupConfig] seed, [InitGameOptions] (`cellSize: 24`, `renderPng:
+/// false`, `skipFillLakes: false`), handoff, per-turn call order, and
+/// trusted-order resolution path are retained verbatim so a migrated test
+/// observes byte-identical turn-by-turn state.
+library;
+
+import 'package:colonizethis_ai/colonizethis_ai.dart';
+import 'package:colonizethis_data/colonizethis_data.dart' show GameSetupConfig;
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+import 'faithful_full_ai_test_handoff.dart';
+
+/// Per-turn observation hook invoked immediately after the Full-AI orders for
+/// turn [turn] are generated and **before** turn resolution.
+///
+/// [fullAi] carries the generated orders / economy plans for the turn and
+/// [game] is the start-of-turn game state (before resolution advances it), so
+/// callbacks can read pre-resolution treasury / ownership and the emitted
+/// orders together — matching the inline tests that captured both before
+/// resolving.
+typedef Seed42ObserverBeforeResolve = void Function(
+  int turn,
+  FullAIResult fullAi,
+  Game game,
+);
+
+/// Per-turn observation hook invoked immediately **after** turn [turn] is
+/// resolved, receiving the resolved [game] for that turn.
+typedef Seed42ObserverAfterResolve = void Function(int turn, Game game);
+
+/// Result of [runSeed42ObserverCampaign].
+class Seed42ObserverCampaignResult {
+  const Seed42ObserverCampaignResult({
+    required this.finalGame,
+    required this.initialGame,
+  });
+
+  /// Game state after the final resolved turn of the campaign.
+  final Game finalGame;
+
+  /// Post-handoff game state captured before turn 0 (every player
+  /// `isHuman: false`, every Great Power AI-controlled). Use this to read
+  /// campaign-start baselines (for example per-GP Old World province counts).
+  final Game initialGame;
+}
+
+/// Runs a seed-[seed] Full-AI observer campaign for [turns] turns and returns
+/// the start / end game state.
+///
+/// Drives the canonical observer loop once: init the seed game, apply the
+/// faithful Full-AI handoff, then for each turn generate Full-AI orders, invoke
+/// [onBeforeResolve], merge with empty human orders, resolve from trusted
+/// orders, assert the turn completed, advance the game, and invoke
+/// [onAfterResolve].
+///
+/// Pure with respect to its callbacks: identical [seed] / [turns] inputs drive
+/// the same deterministic turn sequence (Refs #2509 Must-have #7); the
+/// callbacks are the only place a caller accumulates per-turn observations.
+Seed42ObserverCampaignResult runSeed42ObserverCampaign({
+  int turns = 100,
+  int seed = 42,
+  Seed42ObserverBeforeResolve? onBeforeResolve,
+  Seed42ObserverAfterResolve? onAfterResolve,
+}) {
+  final init = runInitGame(
+    config: GameSetupConfig(seed: seed),
+    options: const InitGameOptions(
+      cellSize: 24,
+      renderPng: false,
+      skipFillLakes: false,
+    ),
+  );
+  final initialGame = applyFaithfulFullAiTestHandoff(init.game);
+  final topo = init.combinedTopology;
+  final tileMap = init.tileMapByRegion;
+
+  var game = initialGame;
+  for (var t = 0; t < turns; t++) {
+    final fullAi = generateOrdersForGameFullAI(
+      game,
+      topo,
+      tileMapByRegion: tileMap,
+    );
+    onBeforeResolve?.call(t, fullAi, game);
+    final merged = mergeOrderLists(
+      humanOrders: const Orders(),
+      aiOrders: fullAi.orders,
+    );
+    final assignments = fullAi.economyPlansByPlayerId.map(
+      (pid, plan) => MapEntry(pid, plan.productionAssignments),
+    );
+    final result = validateOrdersAndResolveTurnFromTrustedOrders(
+      game: fullAi.game,
+      topology: topo,
+      orders: merged,
+      tileMapByRegion: tileMap,
+      defaultAssignmentsByPlayerId: assignments,
+    );
+    expect(result, isA<TurnResolutionComplete>());
+    game = (result as TurnResolutionComplete).game;
+    onAfterResolve?.call(t, game);
+  }
+
+  return Seed42ObserverCampaignResult(
+    finalGame: game,
+    initialGame: initialGame,
+  );
+}

--- a/packages/colonizethis_ai/test/support_test/seed42_observer_campaign_test.dart
+++ b/packages/colonizethis_ai/test/support_test/seed42_observer_campaign_test.dart
@@ -1,0 +1,53 @@
+import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_test/test.dart';
+import 'package:logger/logger.dart';
+
+import '../support/seed42_observer_campaign.dart';
+
+/// Smoke coverage for the shared seed-42 observer campaign harness (Refs #3749
+/// step 2).
+///
+/// The migrated `seed42_observer_*` regressions that consume
+/// [runSeed42ObserverCampaign] are skipped by default (multi-minute Full-AI
+/// runs), so this fast 2-turn campaign is the executing check that the harness
+/// drives the init -> handoff -> generate -> resolve loop and invokes the
+/// observation callbacks in turn order.
+void main() {
+  setUpAll(() {
+    CtLogger.level = Level.off;
+  });
+
+  test(
+    'runSeed42ObserverCampaign drives turns in order and advances the game',
+    () {
+      final beforeTurns = <int>[];
+      final afterTurns = <int>[];
+
+      final campaign = runSeed42ObserverCampaign(
+        turns: 2,
+        onBeforeResolve: (turn, fullAi, game) {
+          beforeTurns.add(turn);
+          // Orders are generated before resolution; the start-of-turn game is
+          // the same instance the harness will resolve.
+          expect(fullAi.game.players, isNotEmpty);
+        },
+        onAfterResolve: (turn, game) {
+          afterTurns.add(turn);
+        },
+      );
+
+      expect(beforeTurns, [0, 1]);
+      expect(afterTurns, [0, 1]);
+      expect(
+        campaign.finalGame.worldState.turnState.turnNumber,
+        greaterThan(campaign.initialGame.worldState.turnState.turnNumber),
+      );
+      // Faithful Full-AI handoff: every player is AI-controlled.
+      expect(
+        campaign.initialGame.players.every((p) => !p.isHuman),
+        isTrue,
+      );
+    },
+    timeout: const Timeout(Duration(minutes: 5)),
+  );
+}


### PR DESCRIPTION
## Summary
Phase-2 `colonizethis_ai` test-streamlining slice for #3749 (step 2 / AC6): extract the duplicated seed-42 Full-AI observer campaign loop into a shared harness and migrate the 3 smallest observer regressions onto it.

Follows the merged step-1 PR #3755 (test-support config/tile-scan/offer-counter dedup).

## Done in this push
- **`test/support/seed42_observer_campaign.dart`** — new `runSeed42ObserverCampaign({turns, seed, onBeforeResolve, onAfterResolve})` owning the canonical `runInitGame(seed: 42)` -> `applyFaithfulFullAiTestHandoff` -> N-turn `generateOrdersForGameFullAI` -> `mergeOrderLists` -> `validateOrdersAndResolveTurnFromTrustedOrders` loop and the `expect(result, isA<TurnResolutionComplete>())` assertion. Returns start (`initialGame`) and end (`finalGame`) state; per-turn observation flows through callbacks.
- **Migrated the 3 smallest observer tests** to the harness (behaviour-preserving, skips retained):
  - `seed42_observer_conquest_regression_test.dart` (initial/final OW gains)
  - `seed42_observer_nw_lock_recovery_declare_war_regression_test.dart` (`onBeforeResolve` diplomatic tally)
  - `seed42_observer_world_market_lock_recovery_regression_test.dart` (`onBeforeResolve` build tally + `onAfterResolve` market/treasury tracking)
- **`test/support_test/seed42_observer_campaign_test.dart`** — fast 2-turn smoke test (the migrated regressions stay skipped/multi-minute) verifying the harness loop, callback turn-ordering, handoff (`isHuman == false`), and game advancement.

## Verification
- `dart analyze` (changed files + full `colonizethis_ai` package): clean (2 pre-existing `lib/` warnings unrelated to this slice).
- `dart test test/support_test/seed42_observer_campaign_test.dart`: pass (init + 2 turns).
- `check_ai_test_mirrors_lib` and `check_ai_test_no_duplicate_scaffolding` gates: pass (harness is non-`_test.dart`; smoke test correctly placed under `test/support_test/`, not `test/support/`).

## Deferred (follow-up, per AC6 + issue CI section)
- Full migration of the remaining ~14 observer tests.
- New `tool/check_ai_test_seed42_campaign_harness.dart` gate forbidding new inline seed42 init/resolve loops (+ `quality.yml` wiring).
- Other #3749 steps (expand-peace registry, `phase_filter_common.dart`, soft-weight/branch test consolidation, orchestrator/scoring splits) remain open.

Refs #3749

Made with [Cursor](https://cursor.com)