### PR TITLE
refactor: share phase-filter colonial-pressure wrapper (#3749)

### DIFF
--- a/packages/colonizethis_ai/lib/src/planning/phase_filter_common.dart
+++ b/packages/colonizethis_ai/lib/src/planning/phase_filter_common.dart
@@ -1,0 +1,62 @@
+/// Shared phase-filter helpers and suppression-matrix contract
+/// (Refs #3749 step 4 — phase-filter family dedup).
+///
+/// Canonical home for the small pure helpers shared by the per-domain phase
+/// filters (`phase_planner_{conquest,diplomacy,economy,naval,goal,work_order}
+/// _filter.dart`). Each filter previously repeated the
+/// `{required PhasePlanOutcome phasePlan} =>
+/// resolvePhaseColonialPressureActive(phasePlan.phase)` colonial-pressure
+/// wrapper inline; the [PhasePlanOutcome] → COLONIAL-only projection now lives
+/// once here. Per-family files keep only their domain-specific resolvers and
+/// delegate the shared `phasePlan.phase` unwrap to this module so the
+/// structural contract is expressed in a single place.
+///
+/// ## Colonial-pressure suppression matrix
+///
+/// [phaseColonialPressureActiveFromPlan] is the single source of truth for the
+/// "is colonial-acquisition pressure structurally active for this phase plan?"
+/// projection consumed by the conquest, diplomacy, and economy filters. It is
+/// `true` **only** under [ObserverGoalPhase.colonial] and `false` for every
+/// other phase (mirrors `SPEC/ai/phase-planner-dispatch.md` § Adapter helpers):
+///
+/// | Phase | Colonial pressure | Rationale |
+/// |---|---|---|
+/// | [ObserverGoalPhase.expand] | `false` (structural) | EXPAND never advances NW acquisition. |
+/// | [ObserverGoalPhase.colonialLite] | `false` (structural) | COLONIAL-lite is the EXPAND safeguard, not a full-COLONIAL substitute. |
+/// | [ObserverGoalPhase.colonial] | `true` | Full COLONIAL is the only SPEC-authorized NW acquisition phase. |
+/// | [ObserverGoalPhase.develop] | `false` (structural) | DEVELOP suppresses new acquisition objectives. |
+///
+/// The active-phase signal is **structural**: callers do not re-check whether
+/// visible NW invadable is non-empty. The phase-planner dispatcher already
+/// gated entry to COLONIAL on `hasColonialAcquisitionTargets`
+/// (`observerGoalPhaseFor`); re-checking inside a filter would duplicate that
+/// gate and could drift from the phase resolver. Each per-family filter wraps
+/// this helper under its own documented name so the existing orchestrator /
+/// filter test pins stay stable.
+///
+/// Pure and deterministic — identical inputs always yield identical results
+/// (Refs #2509 Must-have #7). Performs no I/O, no logging, no order emission.
+library;
+
+import 'observer_goal_phase.dart';
+import 'phase_planner_dispatch.dart';
+import 'planning_helpers.dart' show resolvePhaseColonialPressureActive;
+
+/// Whether colonial-acquisition pressure is structurally active for
+/// [phasePlan] (`true` only under [ObserverGoalPhase.colonial]).
+///
+/// Single source of truth for the `resolvePhaseColonialPressureActive
+/// (phasePlan.phase)` filter wrapper duplicated across
+/// `phase_planner_conquest_filter.dart`,
+/// `phase_planner_diplomacy_filter.dart`, and
+/// `phase_planner_economy_filter.dart`. Unwraps [PhasePlanOutcome.phase] and
+/// delegates to the bare-phase structural predicate
+/// [resolvePhaseColonialPressureActive] in `planning_helpers.dart`, so the
+/// `PhasePlanOutcome` → `phase` projection lives once. See the library doc
+/// above for the full suppression matrix.
+///
+/// Pure and deterministic — identical inputs always yield identical results
+/// (Refs #2509 Must-have #7).
+bool phaseColonialPressureActiveFromPlan({
+  required PhasePlanOutcome phasePlan,
+}) => resolvePhaseColonialPressureActive(phasePlan.phase);

--- a/packages/colonizethis_ai/lib/src/planning/phase_planner_conquest_filter.dart
+++ b/packages/colonizethis_ai/lib/src/planning/phase_planner_conquest_filter.dart
@@ -21,13 +21,13 @@ import '../perception/perception_snapshot.dart';
 import 'colonial_phase_planner.dart' show ColonialMilitaryPlan;
 import 'expand_phase_planner.dart' show ExpandMilitaryPlan;
 import 'observer_goal_phase.dart';
+import 'phase_filter_common.dart';
 import 'phase_planner_dispatch.dart';
 import 'phase_planner_military_plans.dart';
 import 'phase_priority_weights.dart';
 import 'planning_helpers.dart'
     show
         resolveFromPhasePlan,
-        resolvePhaseColonialPressureActive,
         resolvePhaseExpandOrColonialLiteActive,
         resolvePhaseNewWorldAcquisitionWeight,
         resolvePhaseOldWorldConquestWeight,
@@ -113,7 +113,8 @@ PhaseConquestInvadableResolution resolvePhaseConquestInvadable({
             regionId: kNewWorldRegionId,
           );
 
-      final prioritizeColonialNwUnderLockRecovery = snapshot != null &&
+      final prioritizeColonialNwUnderLockRecovery =
+          snapshot != null &&
           isNwLockRecoveryPathEActive(
             snapshot: snapshot,
             expandEconomyPlan: plan.expandEconomyPlan,
@@ -156,7 +157,7 @@ PhaseConquestInvadableResolution resolvePhaseConquestInvadable({
 /// scoring (issue #2509 § phase suppressions).
 bool resolvePhaseConquestColonialPressureActive({
   required PhasePlanOutcome phasePlan,
-}) => resolvePhaseColonialPressureActive(phasePlan.phase);
+}) => phaseColonialPressureActiveFromPlan(phasePlan: phasePlan);
 
 /// When `true`, NW invadable army-move destinations score `0` in the
 /// conquest destination scorer (legacy `shouldSuppressNewWorldDeclareWar

--- a/packages/colonizethis_ai/lib/src/planning/phase_planner_diplomacy_filter.dart
+++ b/packages/colonizethis_ai/lib/src/planning/phase_planner_diplomacy_filter.dart
@@ -53,11 +53,11 @@ import 'dart:math' as math;
 import 'package:colonizethis_data/colonizethis_data.dart';
 
 import 'observer_goal_phase.dart';
+import 'phase_filter_common.dart';
 import 'phase_planner_dispatch.dart';
 import 'phase_priority_weights.dart';
 import 'planning_helpers.dart'
     show
-        resolvePhaseColonialPressureActive,
         resolvePhaseNewWorldAcquisitionWeight,
         resolvePhaseOldWorldConquestWeight,
         scaleWeightedBonus;
@@ -88,7 +88,7 @@ import 'planning_helpers.dart'
 /// no order emission.
 bool resolvePhaseDiplomacyDeclareWarColonialPressureActive({
   required PhasePlanOutcome phasePlan,
-}) => resolvePhaseColonialPressureActive(phasePlan.phase);
+}) => phaseColonialPressureActiveFromPlan(phasePlan: phasePlan);
 
 /// When `true`, `_declareWarSuppressedDevelopPhaseScore`
 /// (`diplomatic_candidate_scoring_declare_war.dart`) returns

--- a/packages/colonizethis_ai/lib/src/planning/phase_planner_economy_filter.dart
+++ b/packages/colonizethis_ai/lib/src/planning/phase_planner_economy_filter.dart
@@ -82,13 +82,13 @@ import '../perception/perception_snapshot.dart';
 import 'expand_phase_planner.dart'
     show ExpandEconomyPlan, cheapestRegimentBuildTreasuryCost;
 import 'observer_goal_phase.dart';
+import 'phase_filter_common.dart';
 import 'phase_planner_conquest_filter.dart';
 import 'phase_planner_dispatch.dart';
 import 'phase_priority_weights.dart';
 import 'planning_helpers.dart'
     show
         clampPhaseWeightUpperUnit,
-        resolvePhaseColonialPressureActive,
         resolvePhaseNewWorldAcquisitionWeight,
         resolvePhaseNewWorldCivilianWeight,
         resolvePhaseOldWorldCivilianWeight;
@@ -128,7 +128,7 @@ import 'planning_helpers.dart'
 /// no order emission.
 bool resolvePhaseEconomyColonialPressureActive({
   required PhasePlanOutcome phasePlan,
-}) => resolvePhaseColonialPressureActive(phasePlan.phase);
+}) => phaseColonialPressureActiveFromPlan(phasePlan: phasePlan);
 
 /// When `true`, `_runEconomyDomainPlanners` treats the active player as
 /// in the DEVELOP phase for the economy-pass civilian-work decisions:

--- a/packages/colonizethis_ai/test/planning/phase_filter_common_test.dart
+++ b/packages/colonizethis_ai/test/planning/phase_filter_common_test.dart
@@ -1,0 +1,79 @@
+// Pins the structural contract of the shared phase-filter colonial-pressure
+// helper [phaseColonialPressureActiveFromPlan] (Refs #3749 step 4 —
+// phase-filter family dedup).
+//
+// The helper is the single source of truth for the `PhasePlanOutcome` →
+// COLONIAL-only colonial-pressure projection that the conquest, diplomacy, and
+// economy phase filters previously each duplicated inline as
+// `resolvePhaseColonialPressureActive(phasePlan.phase)`. These tests assert:
+//   - positive: `true` only under `ObserverGoalPhase.colonial`;
+//   - negative: `false` for EXPAND / COLONIAL-lite / DEVELOP;
+//   - behaviour-preservation: each per-family filter wrapper now delegates to
+//     the shared helper and therefore agrees with it for every phase.
+import 'package:colonizethis_ai/src/planning/observer_goal_phase.dart';
+import 'package:colonizethis_ai/src/planning/phase_filter_common.dart';
+import 'package:colonizethis_ai/src/planning/phase_planner_conquest_filter.dart';
+import 'package:colonizethis_ai/src/planning/phase_planner_diplomacy_filter.dart';
+import 'package:colonizethis_ai/src/planning/phase_planner_dispatch.dart';
+import 'package:colonizethis_ai/src/planning/phase_planner_economy_filter.dart';
+import 'package:colonizethis_test/test.dart';
+
+void main() {
+  group('phaseColonialPressureActiveFromPlan', () {
+    test('is true only under ObserverGoalPhase.colonial', () {
+      expect(
+        phaseColonialPressureActiveFromPlan(
+          phasePlan: const PhasePlanOutcome(phase: ObserverGoalPhase.colonial),
+        ),
+        isTrue,
+      );
+    });
+
+    test('is false for every non-COLONIAL phase', () {
+      for (final phase in ObserverGoalPhase.values) {
+        if (phase == ObserverGoalPhase.colonial) continue;
+        expect(
+          phaseColonialPressureActiveFromPlan(
+            phasePlan: PhasePlanOutcome(phase: phase),
+          ),
+          isFalse,
+          reason: 'colonial pressure must be structurally inactive for $phase',
+        );
+      }
+    });
+
+    test('is deterministic for a fixed phase plan', () {
+      const outcome = PhasePlanOutcome(phase: ObserverGoalPhase.colonial);
+      final first = phaseColonialPressureActiveFromPlan(phasePlan: outcome);
+      final second = phaseColonialPressureActiveFromPlan(phasePlan: outcome);
+      expect(first, equals(second));
+    });
+  });
+
+  group('per-family wrappers delegate to the shared helper', () {
+    test('conquest / diplomacy / economy agree with the shared helper for '
+        'every phase', () {
+      for (final phase in ObserverGoalPhase.values) {
+        final outcome = PhasePlanOutcome(phase: phase);
+        final shared = phaseColonialPressureActiveFromPlan(phasePlan: outcome);
+        expect(
+          resolvePhaseConquestColonialPressureActive(phasePlan: outcome),
+          equals(shared),
+          reason: 'conquest wrapper must match shared helper for $phase',
+        );
+        expect(
+          resolvePhaseDiplomacyDeclareWarColonialPressureActive(
+            phasePlan: outcome,
+          ),
+          equals(shared),
+          reason: 'diplomacy wrapper must match shared helper for $phase',
+        );
+        expect(
+          resolvePhaseEconomyColonialPressureActive(phasePlan: outcome),
+          equals(shared),
+          reason: 'economy wrapper must match shared helper for $phase',
+        );
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Phase-2 `colonizethis_ai` refactor slice for **#3749 step 4** (phase-filter family dedup).

Introduces `packages/colonizethis_ai/lib/src/planning/phase_filter_common.dart` as the single source of truth for the `PhasePlanOutcome` → COLONIAL-only colonial-pressure projection that the conquest, diplomacy, and economy phase filters each duplicated inline as `resolvePhaseColonialPressureActive(phasePlan.phase)`.

## Done in this push

- New `phase_filter_common.dart` with `phaseColonialPressureActiveFromPlan({required PhasePlanOutcome phasePlan})` and a single shared colonial-pressure suppression-matrix doc.
- `resolvePhaseConquestColonialPressureActive`, `resolvePhaseDiplomacyDeclareWarColonialPressureActive`, and `resolvePhaseEconomyColonialPressureActive` now delegate to the shared helper. Exported names/signatures are unchanged so the existing orchestrator/filter test pins stay stable.
- New mirrored unit test `test/planning/phase_filter_common_test.dart`:
  - positive: `true` only under `ObserverGoalPhase.colonial`;
  - negative: `false` for EXPAND / COLONIAL-lite / DEVELOP (all non-COLONIAL phases);
  - determinism for a fixed phase plan;
  - behaviour-preservation: each per-family wrapper agrees with the shared helper for every phase.

Behaviour-preserving: no change to AI planning semantics, emitted-order sets/ordering, goal/phase selection, or scoring outcomes (per #3749 non-goals).

## Verification

- `dart analyze` (changed files) → no issues.
- `dart test` new test + `phase_planner_economy_filter_test`, `phase_planner_diplomacy_filter_test`, `phase_planner_filter_resolution_test`, `phase_planner_conquest_wiring_test` → all pass (84 tests).
- AST gates: `check_ai_test_mirrors_lib`, `check_ai_test_no_duplicate_scaffolding`, `check_ai_dedup_gp_wars_filter`, `check_ai_dedup_weight_scale_clamp` → no violations.
- `dart format` clean.

## Deferred (remaining #3749 step 4 / AC4 scope, follow-up)

- Consolidating the per-family soft-weight scaled-bonus/floor/cap factory naming (these already delegate to the shared `scaleWeightedBonus` in `planning_helpers.dart`, so no behavioural duplication remains; only naming/colocation).
- Consolidating the remaining per-filter suppression-matrix documentation tables into shared cross-references (kept verbatim here to preserve SPEC-traceability; deferred to avoid doc churn in this slice).
- New CI manifest gate forbidding new inline colonial-pressure filter wrappers outside `phase_filter_common.dart`.

Refs #3749

Made with [Cursor](https://cursor.com)