### PR TITLE
refactor: split domain orchestrator diplomacy pass into part module (Refs #3749)

### DIFF
--- a/packages/colonizethis_ai/lib/src/planning/domain_planner_orchestrator.dart
+++ b/packages/colonizethis_ai/lib/src/planning/domain_planner_orchestrator.dart
@@ -34,6 +34,7 @@ import 'treasury_planner.dart';
 
 part 'domain_planner_orchestrator_economy.dart';
 part 'domain_planner_orchestrator_military.dart';
+part 'domain_planner_orchestrator_diplomacy.dart';
 
 final _log = packageLogger();
 
@@ -149,28 +150,21 @@ DomainPlannerOutcome runDomainPlannersWithOutcome({
   ctx = ctx.withOrders(runMovePlanner(ctx: ctx));
   emit('aiStageC');
 
-  final peaceBeforeConquestResult = runDiplomacyPlannerWithResult(
+  final preConquestDiplomacy = _runPreConquestDiplomacyPlanners(
     ctx: ctx,
     snapshot: snapshot,
-    pass: DiplomacyPlannerPass.nonDeclareWarOnly,
     phasePlan: resolvedPhasePlan,
   );
-  ctx = ctx.withOrders(peaceBeforeConquestResult.orders);
-
-  final declareWarResult = runDiplomacyPlannerWithResult(
-    ctx: ctx,
-    snapshot: snapshot,
-    pass: DiplomacyPlannerPass.declareWarOnly,
-    phasePlan: resolvedPhasePlan,
-  );
-  ctx = ctx.withOrders(declareWarResult.orders);
+  ctx = preConquestDiplomacy.ctx;
+  final declaredWarTargetFactionId =
+      preConquestDiplomacy.declaredWarTargetFactionId;
 
   final militaryResult = _runMilitaryDomainPlanners(
     ctx: ctx,
     snapshot: snapshot,
     phasePlan: resolvedPhasePlan,
     nationId: nationId,
-    declaredWarTargetFactionId: declareWarResult.declaredWarTargetFactionId,
+    declaredWarTargetFactionId: declaredWarTargetFactionId,
     emit: emit,
   );
   ctx = militaryResult.ctx;
@@ -190,13 +184,10 @@ DomainPlannerOutcome runDomainPlannersWithOutcome({
 
   // Late peace pass undoes same-turn declare-war on the OW frontier blocker
   // (observer seed-42 gp5/gp6; Refs #2509).
-  ctx = ctx.withOrders(
-    runDiplomacyPlannerWithResult(
-      ctx: ctx,
-      snapshot: snapshot,
-      pass: DiplomacyPlannerPass.nonDeclareWarOnly,
-      phasePlan: resolvedPhasePlan,
-    ).orders,
+  ctx = _runLatePeaceDiplomacyPlanner(
+    ctx: ctx,
+    snapshot: snapshot,
+    phasePlan: resolvedPhasePlan,
   );
   emit('aiStageF');
 
@@ -265,7 +256,7 @@ DomainPlannerOutcome runDomainPlannersWithOutcome({
 
   return DomainPlannerOutcome(
     orders: ctx.orders,
-    declaredWarTargetFactionId: declareWarResult.declaredWarTargetFactionId,
+    declaredWarTargetFactionId: declaredWarTargetFactionId,
     conquestArmyMoveCount: conquestArmyMoveCount,
     phasePlan: resolvedPhasePlan,
     domainGateData: domainGateData,

--- a/packages/colonizethis_ai/lib/src/planning/domain_planner_orchestrator_diplomacy.dart
+++ b/packages/colonizethis_ai/lib/src/planning/domain_planner_orchestrator_diplomacy.dart
@@ -1,0 +1,71 @@
+part of 'domain_planner_orchestrator.dart';
+
+/// Pre-conquest diplomacy slice carrying the post-pass [PlannerContext] and the
+/// declare-war target (if any) the military pass needs to thread into conquest
+/// planning (Refs #2509).
+class _PreConquestDiplomacyResult {
+  const _PreConquestDiplomacyResult({
+    required this.ctx,
+    required this.declaredWarTargetFactionId,
+  });
+
+  final PlannerContext ctx;
+  final String? declaredWarTargetFactionId;
+}
+
+/// Runs the two pre-conquest diplomacy passes — peace-before-conquest
+/// ([DiplomacyPlannerPass.nonDeclareWarOnly]) followed by declare-war
+/// ([DiplomacyPlannerPass.declareWarOnly]) — applying each pass's orders into
+/// [ctx] and surfacing the resolved declare-war target for the downstream
+/// military pass.
+///
+/// Extracted verbatim from [runDomainPlannersWithOutcome] to keep that
+/// orchestrator within the repo function-size budget and to mirror the
+/// economy/military pass modules; behaviour and pass ordering are unchanged.
+_PreConquestDiplomacyResult _runPreConquestDiplomacyPlanners({
+  required PlannerContext ctx,
+  required AIWorldSnapshot snapshot,
+  required PhasePlanOutcome phasePlan,
+}) {
+  final peaceBeforeConquestResult = runDiplomacyPlannerWithResult(
+    ctx: ctx,
+    snapshot: snapshot,
+    pass: DiplomacyPlannerPass.nonDeclareWarOnly,
+    phasePlan: phasePlan,
+  );
+  var nextCtx = ctx.withOrders(peaceBeforeConquestResult.orders);
+
+  final declareWarResult = runDiplomacyPlannerWithResult(
+    ctx: nextCtx,
+    snapshot: snapshot,
+    pass: DiplomacyPlannerPass.declareWarOnly,
+    phasePlan: phasePlan,
+  );
+  nextCtx = nextCtx.withOrders(declareWarResult.orders);
+
+  return _PreConquestDiplomacyResult(
+    ctx: nextCtx,
+    declaredWarTargetFactionId: declareWarResult.declaredWarTargetFactionId,
+  );
+}
+
+/// Runs the late peace pass ([DiplomacyPlannerPass.nonDeclareWarOnly]) that
+/// undoes a same-turn declare-war on the OW frontier blocker (observer seed-42
+/// gp5/gp6; Refs #2509), returning [ctx] with the pass orders applied.
+///
+/// Extracted verbatim from [runDomainPlannersWithOutcome]; behaviour is
+/// unchanged.
+PlannerContext _runLatePeaceDiplomacyPlanner({
+  required PlannerContext ctx,
+  required AIWorldSnapshot snapshot,
+  required PhasePlanOutcome phasePlan,
+}) {
+  return ctx.withOrders(
+    runDiplomacyPlannerWithResult(
+      ctx: ctx,
+      snapshot: snapshot,
+      pass: DiplomacyPlannerPass.nonDeclareWarOnly,
+      phasePlan: phasePlan,
+    ).orders,
+  );
+}


### PR DESCRIPTION
## Summary

Phase-2 `colonizethis_ai` refactor slice for #3749: splits the **diplomacy pass** out of `domain_planner_orchestrator.dart` into a `part` module, mirroring the already-merged economy (#3761) and military (#3770) orchestrator pass splits.

## Done in this push

- New `domain_planner_orchestrator_diplomacy.dart` (`part of` the orchestrator) hosting:
  - `_runPreConquestDiplomacyPlanners` — runs the peace-before-conquest (`nonDeclareWarOnly`) then declare-war (`declareWarOnly`) passes, applies their orders to the `PlannerContext`, and surfaces the resolved `declaredWarTargetFactionId` the military pass consumes.
  - `_runLatePeaceDiplomacyPlanner` — runs the late peace pass after naval (the same-turn OW-frontier-blocker declare-war undo).
- `runDomainPlannersWithOutcome` now delegates to these helpers; pass ordering and the `DomainPlannerOutcome` wiring are unchanged.

This is a **verbatim extraction**: no AI planning semantics, emitted-order sets/ordering, goal/phase selection, or scoring outcomes change, per the issue non-goals and `colonizethis-turn-resolution-budget.mdc`.

## Scope / deferrals

- Covers the orchestrator **diplomacy pass split** only (one AC item: "`domain_planner_orchestrator.dart` is split into ≤3 pass modules (economy, military, diplomacy)"). Economy + military landed earlier; this completes the three-pass split for the diplomacy slice.
- Other #3749 subtasks (expand-peace decider registry, `phase_filter_common.dart`, declare-war score-ladder split, further test consolidation) remain follow-up work. Does **not** close #3749.

## Test plan

- [x] `dart analyze` clean on both touched files.
- [x] All 36 `domain_planner_orchestrator_*_test.dart` wiring pins green (99 tests).
- [x] `full_ai_planner_determinism_test.dart` green (deterministic order/economy-plan output preserved across runs).

Refs #3749

Made with [Cursor](https://cursor.com)