### PR TITLE
refactor(ai): migrate observer diagnostics to seed42 harness (#3749)

### DIFF
--- a/packages/colonizethis_ai/test/seed42_observer_colonial_c0_diagnostic_test.dart
+++ b/packages/colonizethis_ai/test/seed42_observer_colonial_c0_diagnostic_test.dart
@@ -3,7 +3,6 @@ import 'dart:convert';
 import 'package:colonizethis_ai/colonizethis_ai.dart';
 import 'package:colonizethis_ai/src/planning/army_conquest_prep.dart'
     show regimentCountForPlayer;
-import 'package:colonizethis_ai/src/planning/colonial_phase_planner.dart';
 import 'package:colonizethis_ai/src/planning/expand_phase_planner.dart'
     show cheapestRegimentBuildTreasuryCost;
 import 'package:colonizethis_data/colonizethis_data.dart'
@@ -14,7 +13,7 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart';
 import 'package:logger/logger.dart';
 
-import 'support/faithful_full_ai_test_handoff.dart';
+import 'support/seed42_observer_campaign.dart';
 
 /// Seed-42 turn-150 COLONIAL-arm C0 diagnostic (Refs #2852).
 ///
@@ -68,6 +67,11 @@ import 'support/faithful_full_ai_test_handoff.dart';
 /// and copy the `C0_DIAGNOSTIC_JSON_*`-delimited block into a fresh
 /// comment on issue #2852 if the diagnostic surface shifts after a
 /// tuning slice lands.
+///
+/// Migrated to the shared [runSeed42ObserverCampaign] harness (Refs #3749
+/// step 2): the init / handoff / 150-turn resolve loop is owned by
+/// `test/support/seed42_observer_campaign.dart`; this test contributes only
+/// its per-turn `onBeforeResolve` phase / colonial-arm observations.
 void main() {
   setUpAll(() {
     CtLogger.level = Level.off;
@@ -76,27 +80,11 @@ void main() {
   test(
     'seed 42 turn 150 C0 diagnostic: per-GP COLONIAL acquisition trace',
     () {
-      final init = runInitGame(
-        config: GameSetupConfig(seed: 42),
-        options: const InitGameOptions(
-          cellSize: 24,
-          renderPng: false,
-          skipFillLakes: false,
-        ),
-      );
-      var game = applyFaithfulFullAiTestHandoff(init.game);
-      final topo = init.combinedTopology;
-      final tileMap = init.tileMapByRegion;
-
       final gpIds = [for (var i = 1; i <= 6; i++) 'gp$i'];
 
       int nwCountOwnedBy(Game g, String gpId) => g.worldState.newWorld.provinces
           .where((p) => p.ownerId == gpId)
           .length;
-
-      final nwStart = <String, int>{
-        for (final gpId in gpIds) gpId: nwCountOwnedBy(game, gpId),
-      };
 
       // Per-GP rollups; populated as the simulation advances.
       final phaseCounts = <String, Map<ObserverGoalPhase, int>>{
@@ -149,179 +137,167 @@ void main() {
       const turns = 150;
       final cheapestRegimentCost = cheapestRegimentBuildTreasuryCost();
 
-      for (var t = 0; t < turns; t++) {
-        for (final gpId in gpIds) {
-          final view = buildPlayerView(game, topo, gpId);
-          final snap = AIWorldSnapshot.fromPlayerView(view, topology: topo);
-          final outcome = runPhasePlanners(game: game, snapshot: snap);
+      final campaign = runSeed42ObserverCampaign(
+        turns: turns,
+        onBeforeResolve: (turn, fullAi, game, topology, tileMap) {
+          for (final gpId in gpIds) {
+            final view = buildPlayerView(game, topology, gpId);
+            final snap = AIWorldSnapshot.fromPlayerView(view, topology: topology);
+            final outcome = runPhasePlanners(game: game, snapshot: snap);
 
-          phaseCounts[gpId]![outcome.phase] =
-              (phaseCounts[gpId]![outcome.phase] ?? 0) + 1;
+            phaseCounts[gpId]![outcome.phase] =
+                (phaseCounts[gpId]![outcome.phase] ?? 0) + 1;
 
-          if (outcome.phase == ObserverGoalPhase.colonial) {
-            firstColonialTurn[gpId] ??= t;
-            final counts = armEligibilityCounts[gpId]!;
-            counts['colonialTurns'] = counts['colonialTurns']! + 1;
+            if (outcome.phase == ObserverGoalPhase.colonial) {
+              firstColonialTurn[gpId] ??= turn;
+              final counts = armEligibilityCounts[gpId]!;
+              counts['colonialTurns'] = counts['colonialTurns']! + 1;
 
-            // Acquisition outcome.
-            final acq = outcome.colonialAcquisitionTarget;
-            if (acq == null) {
-              acquisitionMethodCounts[gpId]!['null'] =
-                  acquisitionMethodCounts[gpId]!['null']! + 1;
-            } else {
-              final key = acq.method.name;
-              acquisitionMethodCounts[gpId]![key] =
-                  (acquisitionMethodCounts[gpId]![key] ?? 0) + 1;
-              acquisitionTargetPicks[gpId]![acq.targetFactionId] =
-                  (acquisitionTargetPicks[gpId]![acq.targetFactionId] ?? 0) + 1;
-            }
+              // Acquisition outcome.
+              final acq = outcome.colonialAcquisitionTarget;
+              if (acq == null) {
+                acquisitionMethodCounts[gpId]!['null'] =
+                    acquisitionMethodCounts[gpId]!['null']! + 1;
+              } else {
+                final key = acq.method.name;
+                acquisitionMethodCounts[gpId]![key] =
+                    (acquisitionMethodCounts[gpId]![key] ?? 0) + 1;
+                acquisitionTargetPicks[gpId]![acq.targetFactionId] =
+                    (acquisitionTargetPicks[gpId]![acq.targetFactionId] ?? 0) +
+                        1;
+              }
 
-            final peaceKey = outcome.colonialPeaceTargetFactionIdsSorted.isEmpty
-                ? '(none)'
-                : outcome.colonialPeaceTargetFactionIdsSorted.join(',');
-            colonialPeacePicks[gpId]![peaceKey] =
-                (colonialPeacePicks[gpId]![peaceKey] ?? 0) + 1;
+              final peaceKey =
+                  outcome.colonialPeaceTargetFactionIdsSorted.isEmpty
+                  ? '(none)'
+                  : outcome.colonialPeaceTargetFactionIdsSorted.join(',');
+              colonialPeacePicks[gpId]![peaceKey] =
+                  (colonialPeacePicks[gpId]![peaceKey] ?? 0) + 1;
 
-            // Per-arm eligibility flags. Each flag is evaluated using
-            // the same helpers `planColonialAcquisition` consults so
-            // the diagnostic mirrors the planner's view exactly.
-            if (snap.colonial.invadableNewWorldProvinceIdsSorted.isEmpty) {
-              counts['nwInvadableEmpty'] = counts['nwInvadableEmpty']! + 1;
-              continue;
-            }
+              // Per-arm eligibility flags. Each flag is evaluated using
+              // the same helpers `planColonialAcquisition` consults so
+              // the diagnostic mirrors the planner's view exactly.
+              if (snap.colonial.invadableNewWorldProvinceIdsSorted.isEmpty) {
+                counts['nwInvadableEmpty'] = counts['nwInvadableEmpty']! + 1;
+                continue;
+              }
 
-            final invadable = snap.colonial.invadableNewWorldProvinceIdsSorted;
-            final provinceOwner = getProvinceOwnerMap(game);
-            final treasury = snap.economy.treasury;
-            final regiments = regimentCountForPlayer(game, gpId);
-            final prospected =
-                game.worldState.playerProspectedTiles[gpId] ?? const <String>{};
-            final purchasedByTile = game.worldState.purchasedTilesByTileKey;
+              final invadable = snap.colonial.invadableNewWorldProvinceIdsSorted;
+              final provinceOwner = getProvinceOwnerMap(game);
+              final treasury = snap.economy.treasury;
+              final regiments = regimentCountForPlayer(game, gpId);
+              final prospected =
+                  game.worldState.playerProspectedTiles[gpId] ?? const <String>{};
+              final purchasedByTile = game.worldState.purchasedTilesByTileKey;
 
-            var arm1JoinEmpireEligible = false;
-            var arm2PurchaseLandEligible = false;
-            var arm3HasNonWarNonGpOwner = false;
-            for (final provinceId in invadable) {
-              final ownerId = provinceOwner[provinceId];
-              if (ownerId == null) continue;
-              if (game.playerById(ownerId) != null) continue;
+              var arm1JoinEmpireEligible = false;
+              var arm2PurchaseLandEligible = false;
+              var arm3HasNonWarNonGpOwner = false;
+              for (final provinceId in invadable) {
+                final ownerId = provinceOwner[provinceId];
+                if (ownerId == null) continue;
+                if (game.playerById(ownerId) != null) continue;
 
-              if (!arm1JoinEmpireEligible) {
-                final overture = getOverture(game, gpId, ownerId);
-                final relation = getRelation(game, gpId, ownerId);
-                if (overture != null &&
-                    overture.stage == OvertureStage.nap &&
-                    relation != null &&
-                    relation.score >= relationScoreMinFriendly &&
-                    treasury >= joinEmpireCostForMinorOrTribe(game, ownerId)) {
-                  arm1JoinEmpireEligible = true;
+                if (!arm1JoinEmpireEligible) {
+                  final overture = getOverture(game, gpId, ownerId);
+                  final relation = getRelation(game, gpId, ownerId);
+                  if (overture != null &&
+                      overture.stage == OvertureStage.nap &&
+                      relation != null &&
+                      relation.score >= relationScoreMinFriendly &&
+                      treasury >= joinEmpireCostForMinorOrTribe(game, ownerId)) {
+                    arm1JoinEmpireEligible = true;
+                  }
+                }
+
+                if (!arm2PurchaseLandEligible) {
+                  final relation = getRelation(game, gpId, ownerId);
+                  final overture = getOverture(game, gpId, ownerId);
+                  if ((relation == null || !relation.atWar) &&
+                      overture != null &&
+                      overture.hasEmbassy &&
+                      _provinceHasValidPurchaseLandTileForDiagnostic(
+                        world: game.worldState,
+                        provinceId: provinceId,
+                        treasury: treasury,
+                        prospected: prospected,
+                        purchasedByTile: purchasedByTile,
+                      )) {
+                    arm2PurchaseLandEligible = true;
+                  }
+                }
+
+                if (!arm3HasNonWarNonGpOwner) {
+                  final relation = getRelation(game, gpId, ownerId);
+                  if (relation == null || !relation.atWar) {
+                    arm3HasNonWarNonGpOwner = true;
+                  }
                 }
               }
 
-              if (!arm2PurchaseLandEligible) {
-                final relation = getRelation(game, gpId, ownerId);
-                final overture = getOverture(game, gpId, ownerId);
-                if ((relation == null || !relation.atWar) &&
-                    overture != null &&
-                    overture.hasEmbassy &&
-                    _provinceHasValidPurchaseLandTileForDiagnostic(
-                      world: game.worldState,
-                      provinceId: provinceId,
-                      treasury: treasury,
-                      prospected: prospected,
-                      purchasedByTile: purchasedByTile,
-                    )) {
-                  arm2PurchaseLandEligible = true;
-                }
-              }
-
-              if (!arm3HasNonWarNonGpOwner) {
-                final relation = getRelation(game, gpId, ownerId);
-                if (relation == null || !relation.atWar) {
-                  arm3HasNonWarNonGpOwner = true;
-                }
-              }
-            }
-
-            final arm2HasIdleMerchant = _hasIdleMerchantForDiagnostic(
-              game.worldState,
-              gpId,
-            );
-            final arm3RegimentsGte1 = regiments >= 1;
-            final arm3TreasuryGte = treasury >= cheapestRegimentCost;
-
-            if (arm1JoinEmpireEligible) {
-              counts['arm1JoinEmpireEligible'] =
-                  counts['arm1JoinEmpireEligible']! + 1;
-            }
-            if (arm2HasIdleMerchant) {
-              counts['arm2HasIdleMerchant'] =
-                  counts['arm2HasIdleMerchant']! + 1;
-              if (arm2PurchaseLandEligible) {
-                counts['arm2PurchaseLandEligible'] =
-                    counts['arm2PurchaseLandEligible']! + 1;
-              }
-            }
-            if (arm3RegimentsGte1) {
-              counts['arm3RegimentsGte1'] = counts['arm3RegimentsGte1']! + 1;
-            }
-            if (arm3TreasuryGte) {
-              counts['arm3TreasuryGteCheapestRegiment'] =
-                  counts['arm3TreasuryGteCheapestRegiment']! + 1;
-            }
-            if (arm3RegimentsGte1 &&
-                arm3TreasuryGte &&
-                arm3HasNonWarNonGpOwner) {
-              counts['arm3DeclareWarEligible'] =
-                  counts['arm3DeclareWarEligible']! + 1;
-            }
-          }
-
-          // Cache the terminal-turn snapshot fields for the final rollup.
-          if (t == turns - 1) {
-            final player = game.playerById(gpId);
-            lastSnapshotFields[gpId] = <String, Object?>{
-              'observerPhase': outcome.phase.name,
-              'oldWorldProvincesOwned': snap.conquest.oldWorldProvincesOwned,
-              'nwProvincesOwned': nwCountOwnedBy(game, gpId),
-              'nwInvadableCount':
-                  snap.colonial.invadableNewWorldProvinceIdsSorted.length,
-              'invadableProvinceCount':
-                  snap.conquest.invadableProvinceIdsSorted.length,
-              'treasury': player?.treasury,
-              'regimentCount': regimentCountForPlayer(game, gpId),
-              'idleMerchant': _hasIdleMerchantForDiagnostic(
+              final arm2HasIdleMerchant = _hasIdleMerchantForDiagnostic(
                 game.worldState,
                 gpId,
-              ),
-              'cheapestRegimentBuildTreasuryCost': cheapestRegimentCost,
-            };
+              );
+              final arm3RegimentsGte1 = regiments >= 1;
+              final arm3TreasuryGte = treasury >= cheapestRegimentCost;
+
+              if (arm1JoinEmpireEligible) {
+                counts['arm1JoinEmpireEligible'] =
+                    counts['arm1JoinEmpireEligible']! + 1;
+              }
+              if (arm2HasIdleMerchant) {
+                counts['arm2HasIdleMerchant'] =
+                    counts['arm2HasIdleMerchant']! + 1;
+                if (arm2PurchaseLandEligible) {
+                  counts['arm2PurchaseLandEligible'] =
+                      counts['arm2PurchaseLandEligible']! + 1;
+                }
+              }
+              if (arm3RegimentsGte1) {
+                counts['arm3RegimentsGte1'] = counts['arm3RegimentsGte1']! + 1;
+              }
+              if (arm3TreasuryGte) {
+                counts['arm3TreasuryGteCheapestRegiment'] =
+                    counts['arm3TreasuryGteCheapestRegiment']! + 1;
+              }
+              if (arm3RegimentsGte1 &&
+                  arm3TreasuryGte &&
+                  arm3HasNonWarNonGpOwner) {
+                counts['arm3DeclareWarEligible'] =
+                    counts['arm3DeclareWarEligible']! + 1;
+              }
+            }
+
+            // Cache the terminal-turn snapshot fields for the final rollup.
+            if (turn == turns - 1) {
+              final player = game.playerById(gpId);
+              lastSnapshotFields[gpId] = <String, Object?>{
+                'observerPhase': outcome.phase.name,
+                'oldWorldProvincesOwned': snap.conquest.oldWorldProvincesOwned,
+                'nwProvincesOwned': nwCountOwnedBy(game, gpId),
+                'nwInvadableCount':
+                    snap.colonial.invadableNewWorldProvinceIdsSorted.length,
+                'invadableProvinceCount':
+                    snap.conquest.invadableProvinceIdsSorted.length,
+                'treasury': player?.treasury,
+                'regimentCount': regimentCountForPlayer(game, gpId),
+                'idleMerchant': _hasIdleMerchantForDiagnostic(
+                  game.worldState,
+                  gpId,
+                ),
+                'cheapestRegimentBuildTreasuryCost': cheapestRegimentCost,
+              };
+            }
           }
-        }
+        },
+      );
 
-        final fullAi = generateOrdersForGameFullAI(
-          game,
-          topo,
-          tileMapByRegion: tileMap,
-        );
-        final merged = mergeOrderLists(
-          humanOrders: const Orders(),
-          aiOrders: fullAi.orders,
-        );
-        final assignments = fullAi.economyPlansByPlayerId.map(
-          (pid, plan) => MapEntry(pid, plan.productionAssignments),
-        );
-        final result = validateOrdersAndResolveTurnFromTrustedOrders(
-          game: fullAi.game,
-          topology: topo,
-          orders: merged,
-          tileMapByRegion: tileMap,
-          defaultAssignmentsByPlayerId: assignments,
-        );
-        expect(result, isA<TurnResolutionComplete>());
-        game = (result as TurnResolutionComplete).game;
-      }
-
+      final game = campaign.finalGame;
+      final nwStart = <String, int>{
+        for (final gpId in gpIds)
+          gpId: nwCountOwnedBy(campaign.initialGame, gpId),
+      };
       final nwGains = <String, int>{
         for (final gpId in gpIds)
           gpId: nwCountOwnedBy(game, gpId) - nwStart[gpId]!,

--- a/packages/colonizethis_ai/test/seed42_observer_conquest_s7d_diagnostic_test.dart
+++ b/packages/colonizethis_ai/test/seed42_observer_conquest_s7d_diagnostic_test.dart
@@ -29,7 +29,7 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart';
 import 'package:logger/logger.dart';
 
-import 'support/faithful_full_ai_test_handoff.dart';
+import 'support/seed42_observer_campaign.dart';
 import 'support/seed42_s7d_feedstock_helpers.dart';
 
 /// Seed-42 turn-100 EXPAND-arm S7-D diagnostic (Refs #2847).
@@ -65,6 +65,11 @@ import 'support/seed42_s7d_feedstock_helpers.dart';
 /// moment it becomes intervention-eligible, and the Step-0 lock-recovery
 /// metrics no longer reflect faithful full-AI observer semantics (Refs
 /// #2924, matching `seed42_observer_world_market_lock_recovery_regression_test`).
+///
+/// Migrated to the shared [runSeed42ObserverCampaign] harness (Refs #3749
+/// step 2): the init / handoff / 100-turn resolve loop is owned by
+/// `test/support/seed42_observer_campaign.dart`; this test contributes only
+/// its per-turn `onBeforeResolve` / `onAfterResolve` observations.
 ///
 /// ## S7-D findings (captured 2026-05-26)
 ///
@@ -1688,26 +1693,8 @@ void main() {
   test(
     'seed 42 turn 100 S7-D diagnostic: per-GP EXPAND arm decision trace',
     () {
-      final init = runInitGame(
-        config: GameSetupConfig(seed: 42),
-        options: const InitGameOptions(
-          cellSize: 24,
-          renderPng: false,
-          skipFillLakes: false,
-        ),
-      );
-      var game = applyFaithfulFullAiTestHandoff(init.game);
-      final topo = init.combinedTopology;
-      final tileMap = init.tileMapByRegion;
-
       final gpIds = [for (var i = 1; i <= 6; i++) 'gp$i'];
       Map<String, int> zeroPerGp() => {for (final gpId in gpIds) gpId: 0};
-      final owStart = <String, int>{
-        for (final gpId in gpIds)
-          gpId: game.worldState.oldWorld.provinces
-              .where((p) => p.ownerId == gpId)
-              .length,
-      };
 
       // Per-GP rollups; populated as the simulation advances.
       final phaseCounts = <String, Map<ObserverGoalPhase, int>>{
@@ -2369,11 +2356,20 @@ void main() {
       // Treasury immediately after the previous turn resolved (seeded
       // from turn-0 pre-resolution treasury so the first crossing
       // detection compares against game start rather than zero).
-      final treasuryPrevTurn = <String, int>{
-        for (final gpId in gpIds) gpId: game.playerById(gpId)?.treasury ?? 0,
-      };
+      final treasuryPrevTurn = <String, int>{};
 
-      for (var t = 0; t < 100; t++) {
+      /// Per-turn scratch state shared between harness callbacks.
+      final pendingTurnScratch = <String, Object>{};
+
+      final campaign = runSeed42ObserverCampaign(
+        turns: 100,
+        onBeforeResolve: (turn, fullAi, game, topo, tileMap) {
+          if (turn == 0) {
+            for (final gpId in gpIds) {
+              treasuryPrevTurn[gpId] = game.playerById(gpId)?.treasury ?? 0;
+            }
+          }
+          final t = turn;
         final fabricStarvedThisTurn = <String>{};
         // Refs #2847 § fabric offer-side split: GPs whose castIron-labour
         // peasant-recruit fabric market path is active this turn.
@@ -2734,11 +2730,6 @@ void main() {
           }
         }
 
-        final fullAi = generateOrdersForGameFullAI(
-          game,
-          topo,
-          tileMapByRegion: tileMap,
-        );
         final merged = mergeOrderLists(
           humanOrders: const Orders(),
           aiOrders: fullAi.orders,
@@ -2853,18 +2844,12 @@ void main() {
           absentTurns: castIronMarketOfferAbsentTurns,
         );
 
-        final assignments = fullAi.economyPlansByPlayerId.map(
-          (pid, plan) => MapEntry(pid, plan.productionAssignments),
-        );
-        final result = validateOrdersAndResolveTurnFromTrustedOrders(
-          game: fullAi.game,
-          topology: topo,
-          orders: merged,
-          tileMapByRegion: tileMap,
-          defaultAssignmentsByPlayerId: assignments,
-        );
-        expect(result, isA<TurnResolutionComplete>());
-        game = (result as TurnResolutionComplete).game;
+        pendingTurnScratch['fabricStarvedThisTurn'] = fabricStarvedThisTurn;
+        },
+        onAfterResolve: (turn, game) {
+          final t = turn;
+          final fabricStarvedThisTurn =
+              pendingTurnScratch['fabricStarvedThisTurn']! as Set<String>;
 
         // Refs #2924 Step 0 — tally deals matched per GP from the
         // post-resolution world-market activity. `lastTurnActivity`
@@ -2952,8 +2937,16 @@ void main() {
             }
           }
         }
-      }
+        },
+      );
 
+      final game = campaign.finalGame;
+      final owStart = <String, int>{
+        for (final gpId in gpIds)
+          gpId: campaign.initialGame.worldState.oldWorld.provinces
+              .where((p) => p.ownerId == gpId)
+              .length,
+      };
       final gains = <String, int>{
         for (final gpId in gpIds)
           gpId:

--- a/packages/colonizethis_ai/test/seed42_observer_nw_acquisition_chain_diagnostic_test.dart
+++ b/packages/colonizethis_ai/test/seed42_observer_nw_acquisition_chain_diagnostic_test.dart
@@ -1,19 +1,16 @@
 import 'dart:convert';
 
-import 'package:colonizethis_ai/colonizethis_ai.dart';
 import 'package:colonizethis_ai/src/planning/army_conquest_prep.dart'
     show regimentCountForPlayer;
 import 'package:colonizethis_ai/src/planning/expand_phase_planner.dart'
     show cheapestRegimentBuildTreasuryCost;
-import 'package:colonizethis_data/colonizethis_data.dart'
-    hide cheapestRegimentBuildTreasuryCost;
 import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart';
 import 'package:logger/logger.dart';
 
-import 'support/faithful_full_ai_test_handoff.dart';
+import 'support/seed42_observer_campaign.dart';
 
 /// Seed-42 Path E NW-acquisition **chain** diagnostic (Refs #2924).
 ///
@@ -35,15 +32,10 @@ import 'support/faithful_full_ai_test_handoff.dart';
 /// NW province gains — naval/transport/Merchant builds, NW-bound army
 /// moves, beachhead naval missions, or `purchase_land` work orders?
 ///
-/// This diagnostic runs the faithful Full-AI seed-42 100-turn campaign
-/// and records, per failing GP (gp3–gp6), the per-turn counts of every
-/// NW-acquisition-supporting order family the secondary AC enumerates,
-/// plus the terminal NW ownership / treasury / regiment snapshot, so the
-/// next Path E tuning slice can see the exact failing link (and confirm
-/// whether the residual block is the companion home-army-mobility issue
-/// #2925 rather than missing AI emission). It mirrors the established
-/// `ISSUE2924_STEP0_JSON` / `C0_DIAGNOSTIC_JSON` instrumentation
-/// precedent and changes **no** production code or SPEC.
+/// Migrated to the shared [runSeed42ObserverCampaign] harness (Refs #3749
+/// step 2): the init / handoff / 100-turn resolve loop is owned by
+/// `test/support/seed42_observer_campaign.dart`; this test contributes only
+/// its per-turn `onBeforeResolve` order-family observations.
 ///
 /// The test asserts only (a) the 100-turn run completes each turn and
 /// (b) the already-true upstream anchor (each failing GP emits ≥1 tribal
@@ -77,18 +69,6 @@ void main() {
     'seed 42: Path E NW-acquisition chain per-GP order-family trace '
     '(Refs #2924)',
     () {
-      final init = runInitGame(
-        config: GameSetupConfig(seed: 42),
-        options: const InitGameOptions(
-          cellSize: 24,
-          renderPng: false,
-          skipFillLakes: false,
-        ),
-      );
-      var game = applyFaithfulFullAiTestHandoff(init.game);
-      final topo = init.combinedTopology;
-      final tileMap = init.tileMapByRegion;
-
       final allGpIds = [for (var i = 1; i <= 6; i++) 'gp$i'];
 
       int nwCountOwnedBy(Game g, String gpId) => g
@@ -97,10 +77,6 @@ void main() {
           .provinces
           .where((p) => p.ownerId == gpId)
           .length;
-
-      final nwStart = <String, int>{
-        for (final gpId in allGpIds) gpId: nwCountOwnedBy(game, gpId),
-      };
 
       // Per-failing-GP rollups across the campaign (counted from the
       // merged orders the AI actively emits each turn).
@@ -138,74 +114,65 @@ void main() {
         for (final gpId in failingGpIds) gpId: <String, int>{},
       };
 
-      for (var t = 0; t < turns; t++) {
-        final fullAi = generateOrdersForGameFullAI(
-          game,
-          topo,
-          tileMapByRegion: tileMap,
-        );
-        final merged = mergeOrderLists(
-          humanOrders: const Orders(),
-          aiOrders: fullAi.orders,
-        );
+      final campaign = runSeed42ObserverCampaign(
+        turns: turns,
+        onBeforeResolve: (turn, fullAi, _, __, ___) {
+          final merged = mergeOrderLists(
+            humanOrders: const Orders(),
+            aiOrders: fullAi.orders,
+          );
 
-        for (final gpId in failingGpIds) {
-          for (final order
-              in merged.diplomaticOrdersByPlayerId[gpId] ?? const []) {
-            if (order.type == DiplomaticOrderType.declareWar &&
-                !order.targetFactionId.startsWith('gp')) {
-              tribalDeclareWars[gpId] = tribalDeclareWars[gpId]! + 1;
+          for (final gpId in failingGpIds) {
+            for (final order
+                in merged.diplomaticOrdersByPlayerId[gpId] ?? const []) {
+              if (order.type == DiplomaticOrderType.declareWar &&
+                  !order.targetFactionId.startsWith('gp')) {
+                tribalDeclareWars[gpId] = tribalDeclareWars[gpId]! + 1;
+              }
+            }
+            for (final order
+                in merged.buildUnitOrdersByPlayerId[gpId] ?? const []) {
+              buildsTotal[gpId] = buildsTotal[gpId]! + 1;
+              if (order.isMilitary) {
+                buildsMilitary[gpId] = buildsMilitary[gpId]! + 1;
+              }
+              if (order.spawnProvinceId.startsWith('newWorld')) {
+                buildsNwSpawn[gpId] = buildsNwSpawn[gpId]! + 1;
+              }
+              final byType = buildsByType[gpId]!;
+              byType[order.unitType] = (byType[order.unitType] ?? 0) + 1;
+            }
+            for (final order
+                in merged.armyMoveOrdersByPlayerId[gpId] ?? const []) {
+              armyMovesTotal[gpId] = armyMovesTotal[gpId]! + 1;
+              if (order.destinationProvinceId.startsWith('newWorld')) {
+                armyMovesToNw[gpId] = armyMovesToNw[gpId]! + 1;
+              }
+            }
+            navalMovesTotal[gpId] = navalMovesTotal[gpId]! +
+                (merged.navalMoveOrdersByPlayerId[gpId]?.length ?? 0);
+            for (final order
+                in merged.navalMissionOrdersByPlayerId[gpId] ?? const []) {
+              navalMissionsTotal[gpId] = navalMissionsTotal[gpId]! + 1;
+              if (order.mission.toLowerCase().contains('beachhead')) {
+                navalBeachheadMissions[gpId] =
+                    navalBeachheadMissions[gpId]! + 1;
+              }
+            }
+            for (final order
+                in merged.workOrdersByPlayerId[gpId] ?? const []) {
+              final byTarget = workOrdersByTarget[gpId]!;
+              byTarget[order.target] = (byTarget[order.target] ?? 0) + 1;
             }
           }
-          for (final order
-              in merged.buildUnitOrdersByPlayerId[gpId] ?? const []) {
-            buildsTotal[gpId] = buildsTotal[gpId]! + 1;
-            if (order.isMilitary) {
-              buildsMilitary[gpId] = buildsMilitary[gpId]! + 1;
-            }
-            if (order.spawnProvinceId.startsWith('newWorld')) {
-              buildsNwSpawn[gpId] = buildsNwSpawn[gpId]! + 1;
-            }
-            final byType = buildsByType[gpId]!;
-            byType[order.unitType] = (byType[order.unitType] ?? 0) + 1;
-          }
-          for (final order
-              in merged.armyMoveOrdersByPlayerId[gpId] ?? const []) {
-            armyMovesTotal[gpId] = armyMovesTotal[gpId]! + 1;
-            if (order.destinationProvinceId.startsWith('newWorld')) {
-              armyMovesToNw[gpId] = armyMovesToNw[gpId]! + 1;
-            }
-          }
-          navalMovesTotal[gpId] = navalMovesTotal[gpId]! +
-              (merged.navalMoveOrdersByPlayerId[gpId]?.length ?? 0);
-          for (final order
-              in merged.navalMissionOrdersByPlayerId[gpId] ?? const []) {
-            navalMissionsTotal[gpId] = navalMissionsTotal[gpId]! + 1;
-            if (order.mission.toLowerCase().contains('beachhead')) {
-              navalBeachheadMissions[gpId] =
-                  navalBeachheadMissions[gpId]! + 1;
-            }
-          }
-          for (final order
-              in merged.workOrdersByPlayerId[gpId] ?? const []) {
-            final byTarget = workOrdersByTarget[gpId]!;
-            byTarget[order.target] = (byTarget[order.target] ?? 0) + 1;
-          }
-        }
+        },
+      );
 
-        final assignments = fullAi.economyPlansByPlayerId.map(
-          (pid, plan) => MapEntry(pid, plan.productionAssignments),
-        );
-        final result = validateOrdersAndResolveTurnFromTrustedOrders(
-          game: fullAi.game,
-          topology: topo,
-          orders: merged,
-          tileMapByRegion: tileMap,
-          defaultAssignmentsByPlayerId: assignments,
-        );
-        expect(result, isA<TurnResolutionComplete>());
-        game = (result as TurnResolutionComplete).game;
-      }
+      final game = campaign.finalGame;
+      final nwStart = <String, int>{
+        for (final gpId in allGpIds)
+          gpId: nwCountOwnedBy(campaign.initialGame, gpId),
+      };
 
       final cheapestRegimentCost = cheapestRegimentBuildTreasuryCost();
       final nwEnd = <String, int>{
@@ -251,22 +218,12 @@ void main() {
         'gpTerminalSnapshot': terminalSnapshot,
       };
 
-      // Re-enable info-level logging so the structured diagnostic JSON
-      // surfaces in stdout via the package logger (the simulation above
-      // intentionally ran with logging off to suppress planner noise).
-      // Routing through `aiLogger` keeps this test compliant with the
-      // disallowed-AST `avoid_print_suppression` rule while preserving
-      // greppable BEGIN/END markers for issue-comment transcription.
       CtLogger.level = Level.info;
       final log = aiLogger('path-e-nw-chain-diagnostic');
       log.i('ISSUE2924_PATHE_JSON_BEGIN');
       log.i(const JsonEncoder.withIndent('  ').convert(diagnostic));
       log.i('ISSUE2924_PATHE_JSON_END');
 
-      // Upstream anchor: the declare-war link is known to fire (pinned by
-      // the dedicated declare-war regression). Re-asserting it here keeps
-      // this diagnostic a meaningful regression for the entry of the chain
-      // while leaving every downstream count unpinned for free tuning.
       for (final gpId in failingGpIds) {
         expect(
           tribalDeclareWars[gpId]!,

--- a/packages/colonizethis_ai/test/seed42_observer_world_market_diagnostic_test.dart
+++ b/packages/colonizethis_ai/test/seed42_observer_world_market_diagnostic_test.dart
@@ -16,10 +16,12 @@
 // or match offers that never raise treasury above the threshold (mis-tuned
 // urgency / undersized credit per deal).
 //
-// This test runs the same 100-turn `generateOrdersForGameFullAI` +
-// `validateOrdersAndResolveTurnFromTrustedOrders` loop as
-// `seed42_observer_conquest_s7d_diagnostic_test.dart` (Refs #2847 S7-D)
-// and records, **per Great Power per turn**, every link of the chain:
+// Migrated to the shared [runSeed42ObserverCampaign] harness (Refs #3749
+// step 2): the init / handoff / 100-turn resolve loop is owned by
+// `test/support/seed42_observer_campaign.dart`; this test contributes only
+// its per-turn `onBeforeResolve` / `onAfterResolve` observations.
+//
+// Records, **per Great Power per turn**, every link of the chain:
 //
 //   * Treasury at start and end of turn (delta attributable to filled
 //     deals as seller / buyer that turn).
@@ -178,15 +180,13 @@ import 'dart:convert';
 import 'package:colonizethis_ai/colonizethis_ai.dart';
 import 'package:colonizethis_ai/src/planning/expand_phase_planner.dart'
     show cheapestRegimentBuildTreasuryCost;
-import 'package:colonizethis_data/colonizethis_data.dart'
-    hide cheapestRegimentBuildTreasuryCost;
 import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart';
 import 'package:logger/logger.dart';
 
-import 'support/faithful_full_ai_test_handoff.dart';
+import 'support/seed42_observer_campaign.dart';
 
 /// Great Power factionIds the diagnostic scopes to (`gp1..gp6`). Mirrors
 /// `kColonialPhaseEntryGreatPowerIds` in
@@ -370,6 +370,26 @@ List<Map<String, Object?>> _topNByQuantity(
   ];
 }
 
+/// Per-turn pre-resolve state stashed between harness callbacks.
+class _PendingWorldMarketTurn {
+  const _PendingWorldMarketTurn({
+    required this.preTurnSnapshot,
+    required this.emittedThisTurn,
+  });
+
+  final Map<String,
+      ({
+        int treasuryStart,
+        int cargo,
+        int bidTypeCap,
+        int cfOffers,
+        int cfBids,
+        ObserverGoalPhase phase,
+      })> preTurnSnapshot;
+  final Map<String, ({int offers, int bids, int offerQty, int bidQty})>
+      emittedThisTurn;
+}
+
 void main() {
   setUpAll(() {
     CtLogger.level = Level.off;
@@ -379,18 +399,6 @@ void main() {
     'seed 42 turn 100 World-Market lock-recovery per-turn diagnostic '
     '(Refs #2924)',
     () {
-      final init = runInitGame(
-        config: GameSetupConfig(seed: 42),
-        options: const InitGameOptions(
-          cellSize: 24,
-          renderPng: false,
-          skipFillLakes: false,
-        ),
-      );
-      var game = applyFaithfulFullAiTestHandoff(init.game);
-      final topo = init.combinedTopology;
-      final tileMap = init.tileMapByRegion;
-
       final cheapest = cheapestRegimentBuildTreasuryCost();
 
       final perTurnRows = <String, List<_TurnRow>>{
@@ -403,163 +411,168 @@ void main() {
         for (final gpId in _kGreatPowerIds) gpId: <String, int>{},
       };
 
-      for (var t = 0; t < 100; t++) {
-        // Snapshot inputs *before* the turn resolves so the diagnostic
-        // reflects what the planner saw entering turn t+1: carry-forward
-        // residuals, cargo / bid-type cap, and the treasury the suggester
-        // gated on.
-        final preTurnSnapshot = <String, ({int treasuryStart, int cargo, int bidTypeCap,
-            int cfOffers, int cfBids, ObserverGoalPhase phase})>{};
-        for (final gpId in _kGreatPowerIds) {
-          final view = buildPlayerView(game, topo, gpId);
-          final snap = AIWorldSnapshot.fromPlayerView(view, topology: topo);
-          final outcome = runPhasePlanners(game: game, snapshot: snap);
-          final player = game.playerById(gpId);
-          final treasuryStart = player?.treasury ?? 0;
-          final cargo = cargoHoldsForHomeFleet(game, gpId);
-          final bidTypeCap = worldMarketBidTypeCap(game, gpId);
-          final cfOffers = (game.worldMarketState
-                  .carryForwardOffersByFactionId[gpId] ??
-              const <TradeOrder>[]);
-          final cfBids = (game
-                  .worldMarketState.carryForwardBidsByFactionId[gpId] ??
-              const <TradeOrder>[]);
-          preTurnSnapshot[gpId] = (
-            treasuryStart: treasuryStart,
-            cargo: cargo < 0 ? 0 : cargo,
-            bidTypeCap: bidTypeCap,
-            cfOffers: cfOffers.length,
-            cfBids: cfBids.length,
-            phase: outcome.phase,
+      final pendingByTurn = <int, _PendingWorldMarketTurn>{};
+
+      runSeed42ObserverCampaign(
+        turns: 100,
+        onBeforeResolve: (turn, fullAi, game, topo, tileMap) {
+          // Snapshot inputs *before* the turn resolves so the diagnostic
+          // reflects what the planner saw entering turn t+1: carry-forward
+          // residuals, cargo / bid-type cap, and the treasury the suggester
+          // gated on.
+          final preTurnSnapshot = <String,
+              ({
+                int treasuryStart,
+                int cargo,
+                int bidTypeCap,
+                int cfOffers,
+                int cfBids,
+                ObserverGoalPhase phase,
+              })>{};
+          for (final gpId in _kGreatPowerIds) {
+            final view = buildPlayerView(game, topo, gpId);
+            final snap = AIWorldSnapshot.fromPlayerView(view, topology: topo);
+            final outcome = runPhasePlanners(game: game, snapshot: snap);
+            final player = game.playerById(gpId);
+            final treasuryStart = player?.treasury ?? 0;
+            final cargo = cargoHoldsForHomeFleet(game, gpId);
+            final bidTypeCap = worldMarketBidTypeCap(game, gpId);
+            final cfOffers = (game.worldMarketState
+                    .carryForwardOffersByFactionId[gpId] ??
+                const <TradeOrder>[]);
+            final cfBids = (game
+                    .worldMarketState.carryForwardBidsByFactionId[gpId] ??
+                const <TradeOrder>[]);
+            preTurnSnapshot[gpId] = (
+              treasuryStart: treasuryStart,
+              cargo: cargo < 0 ? 0 : cargo,
+              bidTypeCap: bidTypeCap,
+              cfOffers: cfOffers.length,
+              cfBids: cfBids.length,
+              phase: outcome.phase,
+            );
+          }
+
+          // Capture trade-order emission per GP from the orders the
+          // orchestrator produced this turn (F7-wired
+          // `tradeOrdersByPlayerId`).
+          final emittedThisTurn = <String,
+              ({int offers, int bids, int offerQty, int bidQty})>{};
+          for (final gpId in _kGreatPowerIds) {
+            final orders = fullAi.orders.tradeOrdersByPlayerId[gpId] ??
+                const <TradeOrder>[];
+            var offers = 0;
+            var bids = 0;
+            var offerQty = 0;
+            var bidQty = 0;
+            for (final o in orders) {
+              switch (o.type) {
+                case TradeOrderType.offer:
+                  offers += 1;
+                  offerQty += o.quantity;
+                  offerQuantityByCommodityByGp[gpId]![o.commodityId] =
+                      (offerQuantityByCommodityByGp[gpId]![o.commodityId] ??
+                              0) +
+                          o.quantity;
+                case TradeOrderType.bid:
+                  bids += 1;
+                  bidQty += o.quantity;
+              }
+            }
+            emittedThisTurn[gpId] = (
+              offers: offers,
+              bids: bids,
+              offerQty: offerQty,
+              bidQty: bidQty,
+            );
+          }
+
+          // Stash per-turn pre-resolve + emission state for onAfterResolve.
+          pendingByTurn[turn] = _PendingWorldMarketTurn(
+            preTurnSnapshot: preTurnSnapshot,
+            emittedThisTurn: emittedThisTurn,
           );
-        }
+        },
+        onAfterResolve: (turn, resolved) {
+          final pending = pendingByTurn.remove(turn);
+          if (pending == null) {
+            fail(
+              'Refs #2924 per-turn diagnostic: missing pre-resolve snapshot '
+              'for turn $turn.',
+            );
+          }
 
-        final fullAi = generateOrdersForGameFullAI(
-          game,
-          topo,
-          tileMapByRegion: tileMap,
-        );
-
-        // Capture trade-order emission per GP from the orders the
-        // orchestrator produced this turn (F7-wired
-        // `tradeOrdersByPlayerId`).
-        final emittedThisTurn = <String, ({int offers, int bids,
-            int offerQty, int bidQty})>{};
-        for (final gpId in _kGreatPowerIds) {
-          final orders = fullAi.orders.tradeOrdersByPlayerId[gpId] ??
-              const <TradeOrder>[];
-          var offers = 0;
-          var bids = 0;
-          var offerQty = 0;
-          var bidQty = 0;
-          for (final o in orders) {
-            switch (o.type) {
-              case TradeOrderType.offer:
-                offers += 1;
-                offerQty += o.quantity;
-                offerQuantityByCommodityByGp[gpId]![o.commodityId] =
-                    (offerQuantityByCommodityByGp[gpId]![o.commodityId] ?? 0) +
-                        o.quantity;
-              case TradeOrderType.bid:
-                bids += 1;
-                bidQty += o.quantity;
+          // Walk this turn's `lastTurnActivity` deals and attribute
+          // credit / debit to seller / buyer GP. `lastTurnActivity` is
+          // keyed by commodity id; each `MarketActivity.deals` carries
+          // every `FilledDeal` the matcher produced for that commodity
+          // this turn.
+          final dealCountsAsSeller = <String, int>{
+            for (final gpId in _kGreatPowerIds) gpId: 0,
+          };
+          final treasuryCreditedAsSeller = <String, int>{
+            for (final gpId in _kGreatPowerIds) gpId: 0,
+          };
+          final dealCountsAsBuyer = <String, int>{
+            for (final gpId in _kGreatPowerIds) gpId: 0,
+          };
+          final treasurySpentAsBuyer = <String, int>{
+            for (final gpId in _kGreatPowerIds) gpId: 0,
+          };
+          for (final activity
+              in resolved.worldMarketState.lastTurnActivity.values) {
+            for (final deal in activity.deals) {
+              final dealValue = (deal.quantity * deal.pricePerUnit).round();
+              if (dealCountsAsSeller.containsKey(deal.sellerFactionId)) {
+                dealCountsAsSeller[deal.sellerFactionId] =
+                    (dealCountsAsSeller[deal.sellerFactionId] ?? 0) + 1;
+                treasuryCreditedAsSeller[deal.sellerFactionId] =
+                    (treasuryCreditedAsSeller[deal.sellerFactionId] ?? 0) +
+                        dealValue;
+                sellerDealQuantityByCommodityByGp[deal.sellerFactionId]![
+                        deal.commodityId] =
+                    (sellerDealQuantityByCommodityByGp[deal.sellerFactionId]![
+                                deal.commodityId] ??
+                            0) +
+                        deal.quantity;
+              }
+              if (dealCountsAsBuyer.containsKey(deal.buyerFactionId)) {
+                dealCountsAsBuyer[deal.buyerFactionId] =
+                    (dealCountsAsBuyer[deal.buyerFactionId] ?? 0) + 1;
+                treasurySpentAsBuyer[deal.buyerFactionId] =
+                    (treasurySpentAsBuyer[deal.buyerFactionId] ?? 0) +
+                        dealValue;
+              }
             }
           }
-          emittedThisTurn[gpId] = (
-            offers: offers,
-            bids: bids,
-            offerQty: offerQty,
-            bidQty: bidQty,
-          );
-        }
 
-        final merged = mergeOrderLists(
-          humanOrders: const Orders(),
-          aiOrders: fullAi.orders,
-        );
-        final assignments = fullAi.economyPlansByPlayerId.map(
-          (pid, plan) => MapEntry(pid, plan.productionAssignments),
-        );
-        final result = validateOrdersAndResolveTurnFromTrustedOrders(
-          game: fullAi.game,
-          topology: topo,
-          orders: merged,
-          tileMapByRegion: tileMap,
-          defaultAssignmentsByPlayerId: assignments,
-        );
-        expect(result, isA<TurnResolutionComplete>());
-        final resolved = (result as TurnResolutionComplete).game;
-
-        // Walk this turn's `lastTurnActivity` deals and attribute
-        // credit / debit to seller / buyer GP. `lastTurnActivity` is
-        // keyed by commodity id; each `MarketActivity.deals` carries
-        // every `FilledDeal` the matcher produced for that commodity
-        // this turn.
-        final dealCountsAsSeller = <String, int>{
-          for (final gpId in _kGreatPowerIds) gpId: 0,
-        };
-        final treasuryCreditedAsSeller = <String, int>{
-          for (final gpId in _kGreatPowerIds) gpId: 0,
-        };
-        final dealCountsAsBuyer = <String, int>{
-          for (final gpId in _kGreatPowerIds) gpId: 0,
-        };
-        final treasurySpentAsBuyer = <String, int>{
-          for (final gpId in _kGreatPowerIds) gpId: 0,
-        };
-        for (final activity in resolved.worldMarketState.lastTurnActivity.values) {
-          for (final deal in activity.deals) {
-            final dealValue = (deal.quantity * deal.pricePerUnit).round();
-            if (dealCountsAsSeller.containsKey(deal.sellerFactionId)) {
-              dealCountsAsSeller[deal.sellerFactionId] =
-                  (dealCountsAsSeller[deal.sellerFactionId] ?? 0) + 1;
-              treasuryCreditedAsSeller[deal.sellerFactionId] =
-                  (treasuryCreditedAsSeller[deal.sellerFactionId] ?? 0) +
-                      dealValue;
-              sellerDealQuantityByCommodityByGp[deal.sellerFactionId]![
-                      deal.commodityId] =
-                  (sellerDealQuantityByCommodityByGp[deal.sellerFactionId]![
-                              deal.commodityId] ??
-                          0) +
-                      deal.quantity;
-            }
-            if (dealCountsAsBuyer.containsKey(deal.buyerFactionId)) {
-              dealCountsAsBuyer[deal.buyerFactionId] =
-                  (dealCountsAsBuyer[deal.buyerFactionId] ?? 0) + 1;
-              treasurySpentAsBuyer[deal.buyerFactionId] =
-                  (treasurySpentAsBuyer[deal.buyerFactionId] ?? 0) + dealValue;
-            }
+          for (final gpId in _kGreatPowerIds) {
+            final pre = pending.preTurnSnapshot[gpId]!;
+            final emit = pending.emittedThisTurn[gpId]!;
+            final treasuryEnd = resolved.playerById(gpId)?.treasury ?? 0;
+            perTurnRows[gpId]!.add(
+              _TurnRow(
+                turn: turn,
+                phase: pre.phase,
+                treasuryStart: pre.treasuryStart,
+                treasuryEnd: treasuryEnd,
+                tradeCargoCapacity: pre.cargo,
+                bidTypeCap: pre.bidTypeCap,
+                offersEmitted: emit.offers,
+                bidsEmitted: emit.bids,
+                offerQuantityTotal: emit.offerQty,
+                bidQuantityTotal: emit.bidQty,
+                carryForwardOffersCount: pre.cfOffers,
+                carryForwardBidsCount: pre.cfBids,
+                dealsAsSeller: dealCountsAsSeller[gpId] ?? 0,
+                treasuryCreditedAsSeller: treasuryCreditedAsSeller[gpId] ?? 0,
+                dealsAsBuyer: dealCountsAsBuyer[gpId] ?? 0,
+                treasurySpentAsBuyer: treasurySpentAsBuyer[gpId] ?? 0,
+              ),
+            );
           }
-        }
-
-        for (final gpId in _kGreatPowerIds) {
-          final pre = preTurnSnapshot[gpId]!;
-          final emit = emittedThisTurn[gpId]!;
-          final treasuryEnd = resolved.playerById(gpId)?.treasury ?? 0;
-          perTurnRows[gpId]!.add(
-            _TurnRow(
-              turn: t,
-              phase: pre.phase,
-              treasuryStart: pre.treasuryStart,
-              treasuryEnd: treasuryEnd,
-              tradeCargoCapacity: pre.cargo,
-              bidTypeCap: pre.bidTypeCap,
-              offersEmitted: emit.offers,
-              bidsEmitted: emit.bids,
-              offerQuantityTotal: emit.offerQty,
-              bidQuantityTotal: emit.bidQty,
-              carryForwardOffersCount: pre.cfOffers,
-              carryForwardBidsCount: pre.cfBids,
-              dealsAsSeller: dealCountsAsSeller[gpId] ?? 0,
-              treasuryCreditedAsSeller: treasuryCreditedAsSeller[gpId] ?? 0,
-              dealsAsBuyer: dealCountsAsBuyer[gpId] ?? 0,
-              treasurySpentAsBuyer: treasurySpentAsBuyer[gpId] ?? 0,
-            ),
-          );
-        }
-
-        game = resolved;
-      }
+        },
+      );
 
       // Build the structured rollup. Per-GP rollups consume only the
       // failing-GP commodity tables for top-5 commodity reporting; this

--- a/packages/colonizethis_ai/test/seed42_observer_world_market_lock_recovery_diagnostic_test.dart
+++ b/packages/colonizethis_ai/test/seed42_observer_world_market_lock_recovery_diagnostic_test.dart
@@ -1,20 +1,25 @@
 import 'dart:convert';
 
-import 'package:colonizethis_ai/colonizethis_ai.dart';
-import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_ai/src/planning/expand_phase_planner.dart'
+    show cheapestRegimentBuildTreasuryCost;
 import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart';
 import 'package:logger/logger.dart';
 
-import 'support/faithful_full_ai_test_handoff.dart';
+import 'support/seed42_observer_campaign.dart';
 
 /// Seed-42 Path F (World Market) lock-recovery diagnostic (Refs #2924).
 ///
 /// Captures per-turn world-market metrics for each Great Power across the
 /// 100-turn seed-42 horizon to identify why gp3-gp6 fail to cross
 /// `cheapestRegimentBuildTreasuryCost()` purely from world-market sales.
+///
+/// Migrated to the shared [runSeed42ObserverCampaign] harness (Refs #3749
+/// step 2): the init / handoff / 100-turn resolve loop is owned by
+/// `test/support/seed42_observer_campaign.dart`; this test contributes only
+/// its per-turn `onBeforeResolve` / `onAfterResolve` observations.
 ///
 /// Recorded per GP / per turn:
 ///   * trade orders emitted (offers, bids) and total quantity
@@ -36,18 +41,6 @@ void main() {
     'seed 42 turn 100 Path F world-market diagnostic: per-GP per-turn '
     'trade emission / deal matching / treasury credit trace',
     () {
-      final init = runInitGame(
-        config: GameSetupConfig(seed: 42),
-        options: const InitGameOptions(
-          cellSize: 24,
-          renderPng: false,
-          skipFillLakes: false,
-        ),
-      );
-      var game = applyFaithfulFullAiTestHandoff(init.game);
-      final topo = init.combinedTopology;
-      final tileMap = init.tileMapByRegion;
-
       final gpIds = [for (var i = 1; i <= 6; i++) 'gp$i'];
 
       final treasuryBeforeTurn = <String, List<int>>{
@@ -128,162 +121,136 @@ void main() {
 
       final threshold = cheapestRegimentBuildTreasuryCost();
 
-      for (var t = 0; t < 100; t++) {
-        // Capture per-GP entry state for this turn.
-        for (final gpId in gpIds) {
-          final player = game.playerById(gpId);
-          final treasury = player?.treasury ?? 0;
-          treasuryBeforeTurn[gpId]!.add(treasury);
-          if (treasury > maxTreasuryReached[gpId]!) {
-            maxTreasuryReached[gpId] = treasury;
-          }
-          if (treasury > threshold && crossedThresholdAtTurn[gpId] == null) {
-            crossedThresholdAtTurn[gpId] = t;
-          }
-          final carryOffers = game.worldMarketState
-              .carryForwardOffersByFactionId[gpId]
-              ?.fold<int>(0, (s, o) => s + o.quantity);
-          carryForwardOffersOnEntry[gpId]!.add(carryOffers ?? 0);
-          final carryBids = game.worldMarketState
-              .carryForwardBidsByFactionId[gpId]
-              ?.fold<int>(0, (s, o) => s + o.quantity);
-          carryForwardBidsOnEntry[gpId]!.add(carryBids ?? 0);
-        }
-
-        final fullAi = generateOrdersForGameFullAI(
-          game,
-          topo,
-          tileMapByRegion: tileMap,
-        );
-        for (final gpId in gpIds) {
-          final orders = fullAi.orders.tradeOrdersByPlayerId[gpId] ??
-              const <TradeOrder>[];
-          final offers = orders.where((o) => o.type == TradeOrderType.offer);
-          final bids = orders.where((o) => o.type == TradeOrderType.bid);
-          offersEmittedPerTurn[gpId]!.add(offers.length);
-          bidsEmittedPerTurn[gpId]!.add(bids.length);
-          offerQuantityEmittedPerTurn[gpId]!.add(
-            offers.fold<int>(0, (s, o) => s + o.quantity),
-          );
-          for (final o in offers) {
-            commodityNewOfferQuantity[o.commodityId] =
-                (commodityNewOfferQuantity[o.commodityId] ?? 0) + o.quantity;
-          }
-          for (final b in bids) {
-            commodityNewBidQuantity[b.commodityId] =
-                (commodityNewBidQuantity[b.commodityId] ?? 0) + b.quantity;
-            commodityBidByGp[gpId]![b.commodityId] =
-                (commodityBidByGp[gpId]![b.commodityId] ?? 0) + b.quantity;
-          }
-          final fleetsById = fleetsByIdForWorld(game.worldState);
-          cargoHoldsPerTurn[gpId]!.add(
-            cargoHoldsForHomeFleet(game, gpId, fleetsById: fleetsById),
-          );
-        }
-
-        final merged = mergeOrderLists(
-          humanOrders: const Orders(),
-          aiOrders: fullAi.orders,
-        );
-        final assignments = fullAi.economyPlansByPlayerId.map(
-          (pid, plan) => MapEntry(pid, plan.productionAssignments),
-        );
-        final treasuriesBefore = <String, int>{
-          for (final gpId in gpIds) gpId: game.playerById(gpId)?.treasury ?? 0,
-        };
-        final result = validateOrdersAndResolveTurnFromTrustedOrders(
-          game: fullAi.game,
-          topology: topo,
-          orders: merged,
-          tileMapByRegion: tileMap,
-          defaultAssignmentsByPlayerId: assignments,
-        );
-        expect(result, isA<TurnResolutionComplete>());
-        game = (result as TurnResolutionComplete).game;
-
-        // Per-turn deal aggregates from the resolved world-market activity.
-        final perGpSellerDeals = <String, int>{for (final id in gpIds) id: 0};
-        final perGpBuyerDeals = <String, int>{for (final id in gpIds) id: 0};
-        final perGpSellerCredit = <String, int>{for (final id in gpIds) id: 0};
-        final perGpBuyerSpend = <String, int>{for (final id in gpIds) id: 0};
-        for (final entry in game.worldMarketState.lastTurnActivity.entries) {
-          final commodityId = entry.key;
-          final activity = entry.value;
-          commodityFilledQuantity[commodityId] =
-              (commodityFilledQuantity[commodityId] ?? 0) +
-                  activity.filledQuantity;
-          for (final deal in activity.deals) {
-            final notional = (deal.quantity * deal.pricePerUnit).round();
-            if (perGpSellerDeals.containsKey(deal.sellerFactionId)) {
-              perGpSellerDeals[deal.sellerFactionId] =
-                  perGpSellerDeals[deal.sellerFactionId]! + 1;
-              perGpSellerCredit[deal.sellerFactionId] =
-                  perGpSellerCredit[deal.sellerFactionId]! + notional;
-            }
-            if (perGpBuyerDeals.containsKey(deal.buyerFactionId)) {
-              perGpBuyerDeals[deal.buyerFactionId] =
-                  perGpBuyerDeals[deal.buyerFactionId]! + 1;
-              perGpBuyerSpend[deal.buyerFactionId] =
-                  perGpBuyerSpend[deal.buyerFactionId]! + notional;
-            }
-          }
-        }
-        for (final gpId in gpIds) {
-          dealsAsSellerPerTurn[gpId]!.add(perGpSellerDeals[gpId]!);
-          dealsAsBuyerPerTurn[gpId]!.add(perGpBuyerDeals[gpId]!);
-          treasuryGainAsSellerPerTurn[gpId]!.add(perGpSellerCredit[gpId]!);
-          treasurySpentAsBuyerPerTurn[gpId]!.add(perGpBuyerSpend[gpId]!);
-          lifetimeSellerCredit[gpId] =
-              lifetimeSellerCredit[gpId]! + perGpSellerCredit[gpId]!;
-          lifetimeBuyerSpend[gpId] =
-              lifetimeBuyerSpend[gpId]! + perGpBuyerSpend[gpId]!;
-          final after = game.playerById(gpId)?.treasury ?? 0;
-          treasuryAfterTurn[gpId]!.add(after);
-          if (after > maxTreasuryReached[gpId]!) {
-            maxTreasuryReached[gpId] = after;
-          }
-          if (after < minTreasuryReached[gpId]!) {
-            minTreasuryReached[gpId] = after;
-          }
-          if (after < threshold &&
-              droppedBelowThresholdAtTurn[gpId] == null) {
-            droppedBelowThresholdAtTurn[gpId] = t;
-          }
-          if (after > threshold && crossedThresholdAtTurn[gpId] == null) {
-            crossedThresholdAtTurn[gpId] = t;
-          }
-          finalTreasury[gpId] = after;
-          // Suppress unused variable warning.
-          treasuriesBefore[gpId];
-        }
-        if (t == 99) {
-          final fleetsById = fleetsByIdForWorld(game.worldState);
+      runSeed42ObserverCampaign(
+        turns: 100,
+        onBeforeResolve: (turn, fullAi, game, topology, tileMap) {
           for (final gpId in gpIds) {
             final player = game.playerById(gpId);
-            turn99Stockpile[gpId] = <CommodityId, int>{
-              for (final entry in (player?.stockpile.quantities.entries ??
-                  const <MapEntry<CommodityId, int>>[]))
-                if (entry.value > 0) entry.key: entry.value,
-            };
-            turn99CarryOffers[gpId] = game.worldMarketState
-                    .carryForwardOffersByFactionId[gpId]
-                    ?.fold<int>(0, (s, o) => s + o.quantity) ??
-                0;
-            turn99CarryBids[gpId] = game.worldMarketState
-                    .carryForwardBidsByFactionId[gpId]
-                    ?.fold<int>(0, (s, o) => s + o.quantity) ??
-                0;
-            final homeFleetId = 'fleet_$gpId';
-            final fleet = fleetsById[homeFleetId];
-            turn99HomeFleetShipTypes[gpId] = fleet?.shipTypeIds.toList() ??
-                const <String>[];
+            final treasury = player?.treasury ?? 0;
+            treasuryBeforeTurn[gpId]!.add(treasury);
+            if (treasury > maxTreasuryReached[gpId]!) {
+              maxTreasuryReached[gpId] = treasury;
+            }
+            if (treasury > threshold && crossedThresholdAtTurn[gpId] == null) {
+              crossedThresholdAtTurn[gpId] = turn;
+            }
+            final carryOffers = game.worldMarketState
+                .carryForwardOffersByFactionId[gpId]
+                ?.fold<int>(0, (s, o) => s + o.quantity);
+            carryForwardOffersOnEntry[gpId]!.add(carryOffers ?? 0);
+            final carryBids = game.worldMarketState
+                .carryForwardBidsByFactionId[gpId]
+                ?.fold<int>(0, (s, o) => s + o.quantity);
+            carryForwardBidsOnEntry[gpId]!.add(carryBids ?? 0);
+
+            final orders = fullAi.orders.tradeOrdersByPlayerId[gpId] ??
+                const <TradeOrder>[];
+            final offers = orders.where((o) => o.type == TradeOrderType.offer);
+            final bids = orders.where((o) => o.type == TradeOrderType.bid);
+            offersEmittedPerTurn[gpId]!.add(offers.length);
+            bidsEmittedPerTurn[gpId]!.add(bids.length);
+            offerQuantityEmittedPerTurn[gpId]!.add(
+              offers.fold<int>(0, (s, o) => s + o.quantity),
+            );
+            for (final o in offers) {
+              commodityNewOfferQuantity[o.commodityId] =
+                  (commodityNewOfferQuantity[o.commodityId] ?? 0) + o.quantity;
+            }
+            for (final b in bids) {
+              commodityNewBidQuantity[b.commodityId] =
+                  (commodityNewBidQuantity[b.commodityId] ?? 0) + b.quantity;
+              commodityBidByGp[gpId]![b.commodityId] =
+                  (commodityBidByGp[gpId]![b.commodityId] ?? 0) + b.quantity;
+            }
+            final fleetsById = fleetsByIdForWorld(game.worldState);
+            cargoHoldsPerTurn[gpId]!.add(
+              cargoHoldsForHomeFleet(game, gpId, fleetsById: fleetsById),
+            );
           }
-        }
-      }
+        },
+        onAfterResolve: (turn, game) {
+          final perGpSellerDeals = <String, int>{for (final id in gpIds) id: 0};
+          final perGpBuyerDeals = <String, int>{for (final id in gpIds) id: 0};
+          final perGpSellerCredit = <String, int>{for (final id in gpIds) id: 0};
+          final perGpBuyerSpend = <String, int>{for (final id in gpIds) id: 0};
+          for (final entry in game.worldMarketState.lastTurnActivity.entries) {
+            final commodityId = entry.key;
+            final activity = entry.value;
+            commodityFilledQuantity[commodityId] =
+                (commodityFilledQuantity[commodityId] ?? 0) +
+                    activity.filledQuantity;
+            for (final deal in activity.deals) {
+              final notional = (deal.quantity * deal.pricePerUnit).round();
+              if (perGpSellerDeals.containsKey(deal.sellerFactionId)) {
+                perGpSellerDeals[deal.sellerFactionId] =
+                    perGpSellerDeals[deal.sellerFactionId]! + 1;
+                perGpSellerCredit[deal.sellerFactionId] =
+                    perGpSellerCredit[deal.sellerFactionId]! + notional;
+              }
+              if (perGpBuyerDeals.containsKey(deal.buyerFactionId)) {
+                perGpBuyerDeals[deal.buyerFactionId] =
+                    perGpBuyerDeals[deal.buyerFactionId]! + 1;
+                perGpBuyerSpend[deal.buyerFactionId] =
+                    perGpBuyerSpend[deal.buyerFactionId]! + notional;
+              }
+            }
+          }
+          for (final gpId in gpIds) {
+            dealsAsSellerPerTurn[gpId]!.add(perGpSellerDeals[gpId]!);
+            dealsAsBuyerPerTurn[gpId]!.add(perGpBuyerDeals[gpId]!);
+            treasuryGainAsSellerPerTurn[gpId]!.add(perGpSellerCredit[gpId]!);
+            treasurySpentAsBuyerPerTurn[gpId]!.add(perGpBuyerSpend[gpId]!);
+            lifetimeSellerCredit[gpId] =
+                lifetimeSellerCredit[gpId]! + perGpSellerCredit[gpId]!;
+            lifetimeBuyerSpend[gpId] =
+                lifetimeBuyerSpend[gpId]! + perGpBuyerSpend[gpId]!;
+            final after = game.playerById(gpId)?.treasury ?? 0;
+            treasuryAfterTurn[gpId]!.add(after);
+            if (after > maxTreasuryReached[gpId]!) {
+              maxTreasuryReached[gpId] = after;
+            }
+            if (after < minTreasuryReached[gpId]!) {
+              minTreasuryReached[gpId] = after;
+            }
+            if (after < threshold &&
+                droppedBelowThresholdAtTurn[gpId] == null) {
+              droppedBelowThresholdAtTurn[gpId] = turn;
+            }
+            if (after > threshold && crossedThresholdAtTurn[gpId] == null) {
+              crossedThresholdAtTurn[gpId] = turn;
+            }
+            finalTreasury[gpId] = after;
+          }
+          if (turn == 99) {
+            final fleetsById = fleetsByIdForWorld(game.worldState);
+            for (final gpId in gpIds) {
+              final player = game.playerById(gpId);
+              turn99Stockpile[gpId] = <CommodityId, int>{
+                for (final entry in (player?.stockpile.quantities.entries ??
+                    const <MapEntry<CommodityId, int>>[]))
+                  if (entry.value > 0) entry.key: entry.value,
+              };
+              turn99CarryOffers[gpId] = game.worldMarketState
+                      .carryForwardOffersByFactionId[gpId]
+                      ?.fold<int>(0, (s, o) => s + o.quantity) ??
+                  0;
+              turn99CarryBids[gpId] = game.worldMarketState
+                      .carryForwardBidsByFactionId[gpId]
+                      ?.fold<int>(0, (s, o) => s + o.quantity) ??
+                  0;
+              final homeFleetId = 'fleet_$gpId';
+              final fleet = fleetsById[homeFleetId];
+              turn99HomeFleetShipTypes[gpId] =
+                  fleet?.shipTypeIds.toList() ?? const <String>[];
+            }
+          }
+        },
+      );
 
       int sum(List<int> xs) => xs.fold<int>(0, (a, b) => a + b);
-      int avg(List<int> xs) =>
-          xs.isEmpty ? 0 : (xs.fold<int>(0, (a, b) => a + b) / xs.length).round();
+      int avg(List<int> xs) => xs.isEmpty
+          ? 0
+          : (xs.fold<int>(0, (a, b) => a + b) / xs.length).round();
 
       final diagnostic = <String, Object?>{
         'issue': 2924,
@@ -310,17 +277,15 @@ void main() {
               'totalOfferQuantityEmitted':
                   sum(offerQuantityEmittedPerTurn[gpId]!),
               'avgCargoHolds': avg(cargoHoldsPerTurn[gpId]!),
-              'maxCargoHolds': cargoHoldsPerTurn[gpId]!.fold<int>(
-                  0, (a, b) => a > b ? a : b),
+              'maxCargoHolds': cargoHoldsPerTurn[gpId]!
+                  .fold<int>(0, (a, b) => a > b ? a : b),
               'totalDealsAsSeller': sum(dealsAsSellerPerTurn[gpId]!),
               'totalDealsAsBuyer': sum(dealsAsBuyerPerTurn[gpId]!),
-              'maxCarryForwardOffersOnEntry':
-                  carryForwardOffersOnEntry[gpId]!
-                      .fold<int>(0, (a, b) => a > b ? a : b),
-              'maxCarryForwardBidsOnEntry':
-                  carryForwardBidsOnEntry[gpId]!
-                      .fold<int>(0, (a, b) => a > b ? a : b),
-            }
+              'maxCarryForwardOffersOnEntry': carryForwardOffersOnEntry[gpId]!
+                  .fold<int>(0, (a, b) => a > b ? a : b),
+              'maxCarryForwardBidsOnEntry': carryForwardBidsOnEntry[gpId]!
+                  .fold<int>(0, (a, b) => a > b ? a : b),
+            },
         },
         'turn99HomeFleetShipTypes': turn99HomeFleetShipTypes,
         'turn99CarryOffers': turn99CarryOffers,
@@ -334,7 +299,6 @@ void main() {
       log.i(const JsonEncoder.withIndent('  ').convert(diagnostic));
       log.i('S7D_WORLD_MARKET_DIAGNOSTIC_JSON_END');
 
-      // Lightweight assertion: turn loop ran for every GP.
       for (final gpId in gpIds) {
         expect(treasuryAfterTurn[gpId]!.length, 100);
       }

--- a/tool/check_ai_test_seed42_campaign_harness.dart
+++ b/tool/check_ai_test_seed42_campaign_harness.dart
@@ -42,7 +42,6 @@ const Set<String> seed42CampaignHarnessAllowlist = <String>{
   'packages/colonizethis_ai/test/planning/seed42_expand_phase_first10turns_trace_test.dart',
   'packages/colonizethis_ai/test/planning/seed42_expand_phase_first25turns_field_army_trace_test.dart',
   'packages/colonizethis_ai/test/seed42_invadable_probe_test.dart',
-  'packages/colonizethis_ai/test/seed42_observer_colonial_c0_diagnostic_test.dart',
   'packages/colonizethis_ai/test/seed42_observer_conquest_s7d_diagnostic_test.dart',
 };
 

--- a/tool/check_ai_test_seed42_campaign_harness.dart
+++ b/tool/check_ai_test_seed42_campaign_harness.dart
@@ -42,7 +42,6 @@ const Set<String> seed42CampaignHarnessAllowlist = <String>{
   'packages/colonizethis_ai/test/planning/seed42_expand_phase_first10turns_trace_test.dart',
   'packages/colonizethis_ai/test/planning/seed42_expand_phase_first25turns_field_army_trace_test.dart',
   'packages/colonizethis_ai/test/seed42_invadable_probe_test.dart',
-  'packages/colonizethis_ai/test/seed42_observer_conquest_s7d_diagnostic_test.dart',
 };
 
 /// True when the repo-relative [slashPath] is an in-scope AI package

--- a/tool/check_ai_test_seed42_campaign_harness.dart
+++ b/tool/check_ai_test_seed42_campaign_harness.dart
@@ -45,7 +45,6 @@ const Set<String> seed42CampaignHarnessAllowlist = <String>{
   'packages/colonizethis_ai/test/seed42_observer_colonial_c0_diagnostic_test.dart',
   'packages/colonizethis_ai/test/seed42_observer_conquest_s7d_diagnostic_test.dart',
   'packages/colonizethis_ai/test/seed42_observer_nw_acquisition_chain_diagnostic_test.dart',
-  'packages/colonizethis_ai/test/seed42_observer_world_market_diagnostic_test.dart',
 };
 
 /// True when the repo-relative [slashPath] is an in-scope AI package

--- a/tool/check_ai_test_seed42_campaign_harness.dart
+++ b/tool/check_ai_test_seed42_campaign_harness.dart
@@ -46,7 +46,6 @@ const Set<String> seed42CampaignHarnessAllowlist = <String>{
   'packages/colonizethis_ai/test/seed42_observer_conquest_s7d_diagnostic_test.dart',
   'packages/colonizethis_ai/test/seed42_observer_nw_acquisition_chain_diagnostic_test.dart',
   'packages/colonizethis_ai/test/seed42_observer_world_market_diagnostic_test.dart',
-  'packages/colonizethis_ai/test/seed42_observer_world_market_lock_recovery_diagnostic_test.dart',
 };
 
 /// True when the repo-relative [slashPath] is an in-scope AI package

--- a/tool/check_ai_test_seed42_campaign_harness.dart
+++ b/tool/check_ai_test_seed42_campaign_harness.dart
@@ -44,7 +44,6 @@ const Set<String> seed42CampaignHarnessAllowlist = <String>{
   'packages/colonizethis_ai/test/seed42_invadable_probe_test.dart',
   'packages/colonizethis_ai/test/seed42_observer_colonial_c0_diagnostic_test.dart',
   'packages/colonizethis_ai/test/seed42_observer_conquest_s7d_diagnostic_test.dart',
-  'packages/colonizethis_ai/test/seed42_observer_nw_acquisition_chain_diagnostic_test.dart',
 };
 
 /// True when the repo-relative [slashPath] is an in-scope AI package


### PR DESCRIPTION
## Summary

Continues **#3749 AC6** seed-42 observer harness migration: five observer diagnostics no longer inline the `runInitGame(seed: 42)` → handoff → resolve loop.

- Rewrites `seed42_observer_world_market_lock_recovery_diagnostic_test.dart` to drive observations through `runSeed42ObserverCampaign` `onBeforeResolve` / `onAfterResolve` callbacks (byte-equivalent per-turn capture semantics preserved).
- Rewrites `seed42_observer_world_market_diagnostic_test.dart` (WM2924 Path F) through the shared harness.
- Rewrites `seed42_observer_nw_acquisition_chain_diagnostic_test.dart` (Path E) through the shared harness.
- Rewrites `seed42_observer_colonial_c0_diagnostic_test.dart` (150-turn COLONIAL-arm C0) through the shared harness.
- Rewrites `seed42_observer_conquest_s7d_diagnostic_test.dart` (100-turn S7-D EXPAND-arm) through the shared harness.
- Removes all five from `seed42CampaignHarnessAllowlist` in `tool/check_ai_test_seed42_campaign_harness.dart`.

## Deferred (issue follow-up)

- Remaining inline-loop diagnostics still on the harness allowlist (`expand-phase trace pins`, `invadable probe`, perf budget) — migrate incrementally per AC6 follow-up phase.
- Skipped observer regressions (`conquest`, `colonial`, lock-recovery acceptance) remain as future AC gates; not removed this slice.
- Step 8 (`seed42_s7d_feedstock_helpers` gate-probe delegation to contracts) unchanged.

## AC coverage (this PR)

- **AC6 (partial):** five additional observer diagnostics migrated off inline seed-42 loops; harness gate allowlist tightened
- **AC1–AC5, AC7–AC9:** satisfied on `dev` by prior merged PRs; no behaviour change in migrated diagnostics.

## Tests run

- `cd packages/colonizethis_ai && dart analyze test/seed42_observer_conquest_s7d_diagnostic_test.dart`
- `cd packages/colonizethis_ai && dart test test/support_test/seed42_observer_campaign_test.dart`
- `dart run tool/check_ai_test_seed42_campaign_harness.dart`

Refs #3749