### PR TITLE
refactor(ai): migrate EXPAND trace pins to seed42 harness (#3749)

### DIFF
--- a/packages/colonizethis_ai/lib/src/planning/planning_imports.dart
+++ b/packages/colonizethis_ai/lib/src/planning/planning_imports.dart
@@ -13,6 +13,7 @@ export 'package:colonizethis_ai_contracts/colonizethis_ai_contracts.dart'
         hasIdleExplorerUnit,
         ownsIdleExplorerColocatedWithMineralEligibleUnprospectedOldWorldFeedstockTile,
         ownsIdleExplorerColocatedWithUnprospectedOldWorldMineralFeedstockTile,
+        ownsFeedstockResourceTile,
         ownsProspectedOldWorldMineralFeedstockTile,
         selectFullAiCivilianWorkOrders,
         selfLockRecoverySellerStageableImprovementInputs,

--- a/packages/colonizethis_ai/test/planning/seed42_expand_phase_first10turns_trace_test.dart
+++ b/packages/colonizethis_ai/test/planning/seed42_expand_phase_first10turns_trace_test.dart
@@ -89,6 +89,11 @@
 //   - Issue #2509 comment 2026-05-26 (turn-100 OW-conquest baseline +
 //     "instrument the per-turn trace" pickup for S7).
 
+// Migrated to the shared [runSeed42ObserverCampaign] harness (Refs #3749
+// step 2): the init / handoff / per-turn resolve loop is owned by
+// `test/support/seed42_observer_campaign.dart`; this test contributes only
+// its per-turn pre-resolution trace capture and invariant assertions.
+
 import 'package:colonizethis_ai/colonizethis_ai.dart';
 import 'package:colonizethis_ai/src/planning/army_conquest_prep.dart'
     show regimentCountForPlayer;
@@ -98,13 +103,15 @@ import 'package:colonizethis_ai/src/planning/observer_goal_phase.dart'
     show observerGoalPhaseFor;
 import 'package:colonizethis_data/colonizethis_data.dart'
     show
-        GameSetupConfig,
+        MapTopology,
         kObserverColonialLiteMinTurn,
         kObserverConquestMinOwProvincesPerGp;
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart';
 import 'package:logger/logger.dart';
+
+import '../support/seed42_observer_campaign.dart';
 
 class _GpTurnTrace {
   const _GpTurnTrace({
@@ -138,6 +145,43 @@ class _GpTurnTrace {
       'adjacentOwners=$adjacentOwners';
 }
 
+/// Captures pre-resolution per-GP traces for one 1-based campaign turn.
+List<_GpTurnTrace> _captureGpTurnTraces({
+  required int turn,
+  required Game game,
+  required MapTopology topo,
+}) {
+  final perGp = <_GpTurnTrace>[];
+  for (var i = 1; i <= 6; i++) {
+    final gpId = 'gp$i';
+    final view = buildPlayerView(game, topo, gpId);
+    final snapshot = AIWorldSnapshot.fromPlayerView(view, topology: topo);
+    final phase = observerGoalPhaseFor(snapshot: snapshot, game: game);
+    final declareWarTarget = planExpandDeclareWar(
+      game: game,
+      snapshot: snapshot,
+    );
+    final player = game.playerById(gpId)!;
+    perGp.add(
+      _GpTurnTrace(
+        turn: turn,
+        gpId: gpId,
+        phase: phase,
+        declareWarTarget: declareWarTarget,
+        ownOw: snapshot.conquest.oldWorldProvincesOwned,
+        invadableCount: snapshot.conquest.invadableProvinceIdsSorted.length,
+        regimentCount: regimentCountForPlayer(game, gpId),
+        treasury: player.treasury,
+        atWarWith: List.of(snapshot.threats.atWarWith)..sort(),
+        adjacentOwners: List.of(
+          snapshot.conquest.adjacentOwnerFactionIdsSorted,
+        )..sort(),
+      ),
+    );
+  }
+  return perGp;
+}
+
 /// Number of full-AI turn resolutions to run.
 ///
 /// Captures pre-resolution per-GP traces at turns 1 .. [_kTurnsToResolve] + 1
@@ -152,83 +196,27 @@ void main() {
   test('seed 42 first $_kTurnsToResolve resolved turns: every below-quota '
       'pre-COLONIAL-lite Great Power stays in EXPAND (S7 multi-turn '
       'diagnostic)', () {
-    final init = runInitGame(
-      config: GameSetupConfig(seed: 42),
-      options: const InitGameOptions(
-        cellSize: 24,
-        renderPng: false,
-        skipFillLakes: false,
-      ),
-    );
-    var game = init.game.copyWith(
-      aiControlByGpId: {for (final p in init.game.players) p.id: true},
-    );
-    final topo = init.combinedTopology;
-    final tileMap = init.tileMapByRegion;
-
     final tracesByTurn = <int, List<_GpTurnTrace>>{};
+    MapTopology? topo;
 
-    for (var turn = 1; turn <= _kTurnsToResolve + 1; turn++) {
-      final perGp = <_GpTurnTrace>[];
-      for (var i = 1; i <= 6; i++) {
-        final gpId = 'gp$i';
-        final view = buildPlayerView(game, topo, gpId);
-        final snapshot = AIWorldSnapshot.fromPlayerView(view, topology: topo);
-        final phase = observerGoalPhaseFor(snapshot: snapshot, game: game);
-        final declareWarTarget = planExpandDeclareWar(
+    final result = runSeed42ObserverCampaign(
+      turns: _kTurnsToResolve,
+      onBeforeResolve: (harnessTurn, fullAi, game, topology, tileMap) {
+        topo = topology;
+        final turn = harnessTurn + 1;
+        tracesByTurn[turn] = _captureGpTurnTraces(
+          turn: turn,
           game: game,
-          snapshot: snapshot,
+          topo: topology,
         );
-        final player = game.playerById(gpId)!;
-        perGp.add(
-          _GpTurnTrace(
-            turn: turn,
-            gpId: gpId,
-            phase: phase,
-            declareWarTarget: declareWarTarget,
-            ownOw: snapshot.conquest.oldWorldProvincesOwned,
-            invadableCount: snapshot.conquest.invadableProvinceIdsSorted.length,
-            regimentCount: regimentCountForPlayer(game, gpId),
-            treasury: player.treasury,
-            atWarWith: List.of(snapshot.threats.atWarWith)..sort(),
-            adjacentOwners: List.of(
-              snapshot.conquest.adjacentOwnerFactionIdsSorted,
-            )..sort(),
-          ),
-        );
-      }
-      tracesByTurn[turn] = perGp;
+      },
+    );
 
-      if (turn > _kTurnsToResolve) {
-        break;
-      }
-
-      final fullAi = generateOrdersForGameFullAI(
-        game,
-        topo,
-        tileMapByRegion: tileMap,
-      );
-      final merged = mergeOrderLists(
-        humanOrders: const Orders(),
-        aiOrders: fullAi.orders,
-      );
-      final assignments = fullAi.economyPlansByPlayerId.map(
-        (pid, plan) => MapEntry(pid, plan.productionAssignments),
-      );
-      final result = validateOrdersAndResolveTurnFromTrustedOrders(
-        game: fullAi.game,
-        topology: topo,
-        orders: merged,
-        tileMapByRegion: tileMap,
-        defaultAssignmentsByPlayerId: assignments,
-      );
-      expect(
-        result,
-        isA<TurnResolutionComplete>(),
-        reason: 'Turn $turn resolution failed before invariant check.',
-      );
-      game = (result as TurnResolutionComplete).game;
-    }
+    tracesByTurn[_kTurnsToResolve + 1] = _captureGpTurnTraces(
+      turn: _kTurnsToResolve + 1,
+      game: result.finalGame,
+      topo: topo!,
+    );
 
     final traceTable = StringBuffer();
     for (var turn = 1; turn <= _kTurnsToResolve + 1; turn++) {

--- a/packages/colonizethis_ai/test/planning/seed42_expand_phase_first25turns_field_army_trace_test.dart
+++ b/packages/colonizethis_ai/test/planning/seed42_expand_phase_first25turns_field_army_trace_test.dart
@@ -87,6 +87,11 @@
 //   - PR #2825 (planExpandDeclareWar arm 1/3 treasury gate scoping —
 //     the 10-turn null-return regression this 25-turn pin extends past).
 
+// Migrated to the shared [runSeed42ObserverCampaign] harness (Refs #3749
+// step 2): the init / handoff / per-turn resolve loop is owned by
+// `test/support/seed42_observer_campaign.dart`; this test contributes only
+// its per-turn pre-resolution trace capture and invariant assertions.
+
 import 'package:colonizethis_ai/colonizethis_ai.dart';
 import 'package:colonizethis_ai/src/planning/army_conquest_prep.dart'
     show regimentCountForPlayer;
@@ -96,13 +101,15 @@ import 'package:colonizethis_ai/src/planning/observer_goal_phase.dart'
     show observerGoalPhaseFor;
 import 'package:colonizethis_data/colonizethis_data.dart'
     show
-        GameSetupConfig,
+        MapTopology,
         kObserverColonialLiteMinTurn,
         kObserverConquestMinOwProvincesPerGp;
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart';
 import 'package:logger/logger.dart';
+
+import '../support/seed42_observer_campaign.dart';
 
 /// Stationed province + regiment count for one army.
 class _ArmyTrace {
@@ -165,6 +172,75 @@ class _GpTurnTrace {
       'home=$homeArmies  field=$fieldArmies';
 }
 
+/// Captures pre-resolution per-GP traces for one 1-based campaign turn.
+List<_GpTurnTrace> _captureGpTurnTraces({
+  required int turn,
+  required Game game,
+  required MapTopology topo,
+}) {
+  final perGp = <_GpTurnTrace>[];
+  for (var i = 1; i <= 6; i++) {
+    final gpId = 'gp$i';
+    final view = buildPlayerView(game, topo, gpId);
+    final snapshot = AIWorldSnapshot.fromPlayerView(view, topology: topo);
+    final phase = observerGoalPhaseFor(snapshot: snapshot, game: game);
+    final declareWarTarget = planExpandDeclareWar(
+      game: game,
+      snapshot: snapshot,
+    );
+    final player = game.playerById(gpId)!;
+    final atWarGp = <String>[
+      for (final factionId in snapshot.threats.atWarWith)
+        if (game.playerById(factionId) != null) factionId,
+    ]..sort();
+    final atWarMinorTribe = <String>[
+      for (final factionId in snapshot.threats.atWarWith)
+        if (game.playerById(factionId) == null) factionId,
+    ]..sort();
+    final ownerArmies = game.worldState.armies.where(
+      (a) => a.ownerId == gpId,
+    );
+    final homeArmies = <_ArmyTrace>[
+      for (final a in ownerArmies)
+        if (a.isHomeArmy)
+          _ArmyTrace(
+            armyId: a.id,
+            stationedProvinceId: a.stationedProvinceId,
+            regimentCount: a.regimentUnitIds.length,
+          ),
+    ]..sort((a, b) => a.armyId.compareTo(b.armyId));
+    final fieldArmies = <_ArmyTrace>[
+      for (final a in ownerArmies)
+        if (!a.isHomeArmy)
+          _ArmyTrace(
+            armyId: a.id,
+            stationedProvinceId: a.stationedProvinceId,
+            regimentCount: a.regimentUnitIds.length,
+          ),
+    ]..sort((a, b) => a.armyId.compareTo(b.armyId));
+    perGp.add(
+      _GpTurnTrace(
+        turn: turn,
+        gpId: gpId,
+        phase: phase,
+        declareWarTarget: declareWarTarget,
+        ownOw: snapshot.conquest.oldWorldProvincesOwned,
+        invadableCount: snapshot.conquest.invadableProvinceIdsSorted.length,
+        regimentCount: regimentCountForPlayer(game, gpId),
+        treasury: player.treasury,
+        atWarGp: atWarGp,
+        atWarMinorTribe: atWarMinorTribe,
+        adjacentOwners: List.of(
+          snapshot.conquest.adjacentOwnerFactionIdsSorted,
+        )..sort(),
+        homeArmies: homeArmies,
+        fieldArmies: fieldArmies,
+      ),
+    );
+  }
+  return perGp;
+}
+
 /// Number of full-AI turn resolutions to run.
 ///
 /// Captures pre-resolution per-GP traces at turns 1 .. [_kTurnsToResolve] + 1
@@ -179,115 +255,27 @@ void main() {
   test('seed 42 first $_kTurnsToResolve resolved turns: every below-quota '
       'pre-COLONIAL-lite Great Power stays in EXPAND with field-army '
       'positions captured (S7 multi-turn diagnostic)', () {
-    final init = runInitGame(
-      config: GameSetupConfig(seed: 42),
-      options: const InitGameOptions(
-        cellSize: 24,
-        renderPng: false,
-        skipFillLakes: false,
-      ),
-    );
-    var game = init.game.copyWith(
-      aiControlByGpId: {for (final p in init.game.players) p.id: true},
-    );
-    final topo = init.combinedTopology;
-    final tileMap = init.tileMapByRegion;
-
     final tracesByTurn = <int, List<_GpTurnTrace>>{};
+    MapTopology? topo;
 
-    for (var turn = 1; turn <= _kTurnsToResolve + 1; turn++) {
-      final perGp = <_GpTurnTrace>[];
-      for (var i = 1; i <= 6; i++) {
-        final gpId = 'gp$i';
-        final view = buildPlayerView(game, topo, gpId);
-        final snapshot = AIWorldSnapshot.fromPlayerView(view, topology: topo);
-        final phase = observerGoalPhaseFor(snapshot: snapshot, game: game);
-        final declareWarTarget = planExpandDeclareWar(
+    final result = runSeed42ObserverCampaign(
+      turns: _kTurnsToResolve,
+      onBeforeResolve: (harnessTurn, fullAi, game, topology, tileMap) {
+        topo = topology;
+        final turn = harnessTurn + 1;
+        tracesByTurn[turn] = _captureGpTurnTraces(
+          turn: turn,
           game: game,
-          snapshot: snapshot,
+          topo: topology,
         );
-        final player = game.playerById(gpId)!;
-        final atWarGp = <String>[
-          for (final factionId in snapshot.threats.atWarWith)
-            if (game.playerById(factionId) != null) factionId,
-        ]..sort();
-        final atWarMinorTribe = <String>[
-          for (final factionId in snapshot.threats.atWarWith)
-            if (game.playerById(factionId) == null) factionId,
-        ]..sort();
-        final ownerArmies = game.worldState.armies.where(
-          (a) => a.ownerId == gpId,
-        );
-        final homeArmies = <_ArmyTrace>[
-          for (final a in ownerArmies)
-            if (a.isHomeArmy)
-              _ArmyTrace(
-                armyId: a.id,
-                stationedProvinceId: a.stationedProvinceId,
-                regimentCount: a.regimentUnitIds.length,
-              ),
-        ]..sort((a, b) => a.armyId.compareTo(b.armyId));
-        final fieldArmies = <_ArmyTrace>[
-          for (final a in ownerArmies)
-            if (!a.isHomeArmy)
-              _ArmyTrace(
-                armyId: a.id,
-                stationedProvinceId: a.stationedProvinceId,
-                regimentCount: a.regimentUnitIds.length,
-              ),
-        ]..sort((a, b) => a.armyId.compareTo(b.armyId));
-        perGp.add(
-          _GpTurnTrace(
-            turn: turn,
-            gpId: gpId,
-            phase: phase,
-            declareWarTarget: declareWarTarget,
-            ownOw: snapshot.conquest.oldWorldProvincesOwned,
-            invadableCount: snapshot.conquest.invadableProvinceIdsSorted.length,
-            regimentCount: regimentCountForPlayer(game, gpId),
-            treasury: player.treasury,
-            atWarGp: atWarGp,
-            atWarMinorTribe: atWarMinorTribe,
-            adjacentOwners: List.of(
-              snapshot.conquest.adjacentOwnerFactionIdsSorted,
-            )..sort(),
-            homeArmies: homeArmies,
-            fieldArmies: fieldArmies,
-          ),
-        );
-      }
-      tracesByTurn[turn] = perGp;
+      },
+    );
 
-      if (turn > _kTurnsToResolve) {
-        break;
-      }
-
-      final fullAi = generateOrdersForGameFullAI(
-        game,
-        topo,
-        tileMapByRegion: tileMap,
-      );
-      final merged = mergeOrderLists(
-        humanOrders: const Orders(),
-        aiOrders: fullAi.orders,
-      );
-      final assignments = fullAi.economyPlansByPlayerId.map(
-        (pid, plan) => MapEntry(pid, plan.productionAssignments),
-      );
-      final result = validateOrdersAndResolveTurnFromTrustedOrders(
-        game: fullAi.game,
-        topology: topo,
-        orders: merged,
-        tileMapByRegion: tileMap,
-        defaultAssignmentsByPlayerId: assignments,
-      );
-      expect(
-        result,
-        isA<TurnResolutionComplete>(),
-        reason: 'Turn $turn resolution failed before invariant check.',
-      );
-      game = (result as TurnResolutionComplete).game;
-    }
+    tracesByTurn[_kTurnsToResolve + 1] = _captureGpTurnTraces(
+      turn: _kTurnsToResolve + 1,
+      game: result.finalGame,
+      topo: topo!,
+    );
 
     final traceTable = StringBuffer();
     for (var turn = 1; turn <= _kTurnsToResolve + 1; turn++) {

--- a/packages/colonizethis_ai/test/seed42_invadable_probe_test.dart
+++ b/packages/colonizethis_ai/test/seed42_invadable_probe_test.dart
@@ -1,41 +1,38 @@
+// Migrated to the shared [runSeed42ObserverCampaign] harness (Refs #3749
+// step 2): the init / handoff / per-turn resolve loop is owned by
+// `test/support/seed42_observer_campaign.dart`; this test contributes only
+// its post-campaign invadable-minor probe for gp3 at turn 20.
+
 import 'package:colonizethis_ai/colonizethis_ai.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
-import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart';
 import 'package:logger/logger.dart';
+
+import 'support/seed42_observer_campaign.dart';
 
 void main() {
   test(
     'gp3 invadable at turn 20 seed 42',
     () {
-    CtLogger.level = Level.off;
-    final init = runInitGame(
-      config: GameSetupConfig(seed: 42),
-      options: const InitGameOptions(cellSize: 24, renderPng: false, skipFillLakes: false),
-    );
-    var game = init.game.copyWith(
-      aiControlByGpId: {for (final p in init.game.players) p.id: true},
-    );
-    final topo = init.combinedTopology;
-    final tileMap = init.tileMapByRegion;
-    for (var t = 0; t < 20; t++) {
-      final fullAi = generateOrdersForGameFullAI(game, topo, tileMapByRegion: tileMap);
-      final merged = mergeOrderLists(humanOrders: const Orders(), aiOrders: fullAi.orders);
-      final assignments = fullAi.economyPlansByPlayerId.map((pid, plan) => MapEntry(pid, plan.productionAssignments));
-      game = (validateOrdersAndResolveTurnFromTrustedOrders(
-        game: fullAi.game, topology: topo, orders: merged, tileMapByRegion: tileMap,
-        defaultAssignmentsByPlayerId: assignments,
-      ) as TurnResolutionComplete).game;
-    }
-    final view = buildPlayerView(game, topo, 'gp3');
-    final snap = AIWorldSnapshot.fromPlayerView(view, topology: topo);
-    final owners = getProvinceOwnerMap(game);
-    final minorInvadable = snap.conquest.invadableProvinceIdsSorted
-        .where((pid) => game.minorNations.any((m) => m.id == owners[pid]))
-        .toList();
-    expect(minorInvadable.length, greaterThan(0), reason: 'gp3 should have minor targets');
-  },
+      CtLogger.level = Level.off;
+      MapTopology? topo;
+      final result = runSeed42ObserverCampaign(
+        turns: 20,
+        onBeforeResolve: (_, __, ___, topology, ____) {
+          topo ??= topology;
+        },
+      );
+      final game = result.finalGame;
+      final view = buildPlayerView(game, topo!, 'gp3');
+      final snap = AIWorldSnapshot.fromPlayerView(view, topology: topo!);
+      final owners = getProvinceOwnerMap(game);
+      final minorInvadable = snap.conquest.invadableProvinceIdsSorted
+          .where((pid) => game.minorNations.any((m) => m.id == owners[pid]))
+          .toList();
+      expect(minorInvadable.length, greaterThan(0),
+          reason: 'gp3 should have minor targets');
+    },
     skip:
         'Refs #2509: seed-42 turn-20 gp3 invadable minors not stable after '
         'sole-GP peace merge; covered by colonial_pressure unit tests',

--- a/packages/colonizethis_ai/test/support/seed42_s7d_feedstock_helpers.dart
+++ b/packages/colonizethis_ai/test/support/seed42_s7d_feedstock_helpers.dart
@@ -18,6 +18,8 @@ import 'package:colonizethis_ai/src/planning/expand_phase_planner.dart'
     show cheapestRegimentBuildTreasuryCost;
 import 'package:colonizethis_ai/src/planning/recipe_scoring.dart'
     show feasibleRuns;
+import 'package:colonizethis_ai/src/planning/planning_imports.dart'
+    show ownsFeedstockResourceTile;
 import 'package:colonizethis_ai/src/planning/treasury_planner.dart'
     show kTreasuryOfferPriorityUrgent, otherGreatPowerOfferableFabricHeld;
 import 'package:colonizethis_data/colonizethis_data.dart'
@@ -595,12 +597,12 @@ Map<String, Object?> seed42S7dTurn99SnapshotFields({
 /// This is the tile-ownership precondition the lock-recovery-seller castIron
 /// staging gate (`full_ai_civilian_work_selection_feedstock.dart` §
 /// `selfLockRecoverySellerStageableImprovementInputs` →
-/// `_ownsFeedstockResourceTile`) applies before it stages a domestic `castIron`
+/// [ownsFeedstockResourceTile]) applies before it stages a domestic `castIron`
 /// run: a below-quota zero-NW zero-regiment seller only stages `castIron` when
 /// it still owns a `timber` / `iron` feedstock tile to extract from. The
 /// existing [ownsUnimprovedFeedstockResourceTile] /
 /// [ownsImprovedFeedstockResourceTile] probes split by improvement level; this
-/// any-level probe mirrors the staging gate's own predicate exactly.
+/// any-level probe delegates to the production symbol via [planning_imports].
 ///
 /// Used by the H8 castIron production-allocation localization (Refs #2847): on
 /// the castIron material-feasible turns, a flat-zero count here while the seller
@@ -614,12 +616,7 @@ bool ownsFeedstockResourceTileAnyLevel(
   Game game,
   String playerId,
   Set<String> feedstockIds,
-) => scanOwnedFeedstockTiles(
-  game,
-  playerId,
-  feedstockIds,
-  (_) => true,
-);
+) => ownsFeedstockResourceTile(game, playerId, feedstockIds);
 
 /// Structural-invariant assertions over the S7-D diagnostic per-GP counter
 /// maps (Refs #2847). Extracted from

--- a/packages/colonizethis_ai_contracts/lib/src/ai/full_ai_civilian_work_selection_feedstock.dart
+++ b/packages/colonizethis_ai_contracts/lib/src/ai/full_ai_civilian_work_selection_feedstock.dart
@@ -19,7 +19,7 @@ part of 'full_ai_civilian_work_selection.dart';
 /// (`Unit.provinceIdFromTileKey`) so the scan works from
 /// `WorldState.resourceByTileKey` alone. Read-only and deterministic; Refs #2847
 /// § H8-extraction seller feedstock-tile acquisition residual.
-bool _ownsFeedstockResourceTile(
+bool ownsFeedstockResourceTile(
   Game game,
   String playerId,
   Set<String> feedstockIds,
@@ -60,7 +60,7 @@ bool _ownsFeedstockResourceTile(
 ///     improvement-cost gate is active and the seller is short of a producible
 ///     input; **and**
 ///   * the seller owns **no** tile hosting any feedstock resource in that demand
-///     set ([_ownsFeedstockResourceTile] is `false`).
+///     set ([ownsFeedstockResourceTile] is `false`).
 ///
 /// Returns `false` for every player whose improvement-input gate is inactive
 /// (at or above the conquest quota, owns a regiment, owns a New World province,
@@ -77,5 +77,5 @@ bool sellerNeedsImprovementInputFeedstockTileAcquisition(
 ) {
   final feedstock = sellerImprovementInputFeedstockResourceIds(game, playerId);
   if (feedstock.isEmpty) return false;
-  return !_ownsFeedstockResourceTile(game, playerId, feedstock);
+  return !ownsFeedstockResourceTile(game, playerId, feedstock);
 }

--- a/packages/colonizethis_ai_contracts/lib/src/ai/full_ai_civilian_work_selection_feedstock_acquisition.dart
+++ b/packages/colonizethis_ai_contracts/lib/src/ai/full_ai_civilian_work_selection_feedstock_acquisition.dart
@@ -178,7 +178,7 @@ Set<String> selfLockRecoverySellerStageableImprovementInputs(
     if (seller.stockpile.quantityOf(entry.key) >= entry.value) continue;
     final recipe = _lowestIdMultiInputRecipeProducingOutput(entry.key);
     if (recipe == null) continue;
-    if (!_ownsFeedstockResourceTile(
+    if (!ownsFeedstockResourceTile(
       game,
       playerId,
       recipe.inputQuantities.keys.toSet(),

--- a/tool/check_ai_test_seed42_campaign_harness.dart
+++ b/tool/check_ai_test_seed42_campaign_harness.dart
@@ -39,8 +39,6 @@ const String _trustedOrderResolveCall =
 /// `SPEC/program/repo-lint.md`.
 const Set<String> seed42CampaignHarnessAllowlist = <String>{
   'packages/colonizethis_ai/test/perf/seed42_first_turn_trade_enabled_wall_clock_budget_test.dart',
-  'packages/colonizethis_ai/test/planning/seed42_expand_phase_first10turns_trace_test.dart',
-  'packages/colonizethis_ai/test/planning/seed42_expand_phase_first25turns_field_army_trace_test.dart',
   'packages/colonizethis_ai/test/seed42_invadable_probe_test.dart',
 };
 

--- a/tool/check_ai_test_seed42_campaign_harness.dart
+++ b/tool/check_ai_test_seed42_campaign_harness.dart
@@ -39,7 +39,6 @@ const String _trustedOrderResolveCall =
 /// `SPEC/program/repo-lint.md`.
 const Set<String> seed42CampaignHarnessAllowlist = <String>{
   'packages/colonizethis_ai/test/perf/seed42_first_turn_trade_enabled_wall_clock_budget_test.dart',
-  'packages/colonizethis_ai/test/seed42_invadable_probe_test.dart',
 };
 
 /// True when the repo-relative [slashPath] is an in-scope AI package


### PR DESCRIPTION
## Summary

Continues **#3749** with AC6 seed-42 observer harness migration and step-8 gate-probe delegation:

- Rewrites `seed42_expand_phase_first10turns_trace_test.dart` through `runSeed42ObserverCampaign` (10 resolves + post-campaign turn-11 capture preserved).
- Rewrites `seed42_expand_phase_first25turns_field_army_trace_test.dart` through the shared harness (25 resolves + turn-26 capture preserved).
- Rewrites `seed42_invadable_probe_test.dart` through the shared harness (20 resolves + post-campaign gp3 invadable probe preserved; test remains skipped per #2509).
- Tightens `seed42CampaignHarnessAllowlist` in `tool/check_ai_test_seed42_campaign_harness.dart` (allowlist now: perf budget pin only).
- **Step 8:** exports `ownsFeedstockResourceTile` from `colonizethis_ai_contracts` and delegates `seed42_s7d_feedstock_helpers.ownsFeedstockResourceTileAnyLevel` through `planning_imports` (no copied predicate).

## Deferred (issue follow-up)

- Perf budget inline loop (`seed42_first_turn_trade_enabled_wall_clock_budget_test.dart`) — intentionally allowlisted (single-turn wall-clock instrumentation).

## AC coverage (this PR)

- **AC6 (partial):** three additional seed-42 campaign diagnostics migrated; harness gate allowlist further tightened
- **AC2 / step 8:** S7-D `ownsFeedstockResourceTileAnyLevel` delegates to production `ownsFeedstockResourceTile` via `planning_imports`
- **AC1–AC5, AC7–AC9:** satisfied on `dev` by prior merged PRs; trace/probe tests use faithful Full-AI handoff via harness (no assertion changes).

## Tests run

- `cd packages/colonizethis_ai && dart test test/planning/seed42_expand_phase_first10turns_trace_test.dart test/planning/seed42_expand_phase_first25turns_field_army_trace_test.dart test/seed42_invadable_probe_test.dart`
- `cd packages/colonizethis_ai && dart test test/seed42_s7d_feedstock_helpers_test.dart`
- `dart run tool/check_ai_test_seed42_campaign_harness.dart`

Refs #3749