### PR TITLE
fix: seed spy fog integration tests for deterministic spy-resolution RNG (#3876)

### DIFF
--- a/packages/colonizethis_turn/test/integration/resolve_turn_spy_fog_end_of_turn_test.dart
+++ b/packages/colonizethis_turn/test/integration/resolve_turn_spy_fog_end_of_turn_test.dart
@@ -14,6 +14,7 @@ test(
             const tileKeyP2 = 'oldWorld|P2|0|0';
             final game = Game(
               id: 'g1',
+              globalGameSeed: turnTestSpyFogGameSeed,
               worldState: WorldState(
                 turnState: const TurnState(
                   phase: TurnPhase.endOfTurn,
@@ -74,6 +75,7 @@ test(
             const tileKeyNwP1 = 'newWorld|P1|0|0';
             final game = Game(
               id: 'g1',
+              globalGameSeed: turnTestSpyFogGameSeed,
               worldState: WorldState(
                 turnState: const TurnState(
                   phase: TurnPhase.endOfTurn,
@@ -167,6 +169,7 @@ test(
             const tileKeyP2 = 'oldWorld|P2|0|0';
             final game = Game(
               id: 'g1',
+              globalGameSeed: turnTestSpyFogGameSeed,
               worldState: WorldState(
                 turnState: const TurnState(
                   phase: TurnPhase.endOfTurn,
@@ -218,6 +221,7 @@ test(
             const tileKeyP2 = 'oldWorld|P2|0|0';
             final game = Game(
               id: 'g1',
+              globalGameSeed: turnTestSpyFogGameSeed,
               worldState: WorldState(
                 turnState: const TurnState(
                   phase: TurnPhase.endOfTurn,

--- a/packages/colonizethis_turn/test/integration/resolve_turn_spy_fog_end_of_turn_visibility_test.dart
+++ b/packages/colonizethis_turn/test/integration/resolve_turn_spy_fog_end_of_turn_visibility_test.dart
@@ -32,7 +32,7 @@ test(
 
             final game = Game(
               id: 'g1',
-              globalGameSeed: 42,
+              globalGameSeed: turnTestSpyFogGameSeed,
               worldState: WorldState(
                 turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
                 oldWorld: RegionData(
@@ -116,6 +116,7 @@ test(
 
             final game = Game(
               id: 'g1',
+              globalGameSeed: turnTestSpyFogGameSeed,
               worldState: WorldState(
                 turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
                 oldWorld: RegionData(
@@ -179,6 +180,7 @@ test(
 
             final game = Game(
               id: 'g1',
+              globalGameSeed: turnTestSpyFogGameSeed,
               worldState: WorldState(
                 turnState: const TurnState(
                   phase: TurnPhase.endOfTurn,
@@ -256,7 +258,7 @@ test(
 
             final game = Game(
               id: 'g1',
-              globalGameSeed: 42,
+              globalGameSeed: turnTestSpyFogGameSeed,
               worldState: WorldState(
                 turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
                 oldWorld: RegionData(

--- a/packages/colonizethis_turn/test/support/turn_resolver_test_harness.dart
+++ b/packages/colonizethis_turn/test/support/turn_resolver_test_harness.dart
@@ -5,6 +5,11 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 /// Old World region id for two-province integration setups in turn tests.
 const turnTestOldWorldRegionId = 'oldWorld';
 
+/// Fixed [Game.globalGameSeed] for spy/fog integration tests so spy-resolution
+/// kill rolls stay deterministic (unset seed uses [Random] per
+/// [spyPhaseRandom]).
+const turnTestSpyFogGameSeed = 42;
+
 /// Two adjacent Old World provinces connected by a topology edge.
 MapTopology twoAdjacentOldWorldProvinceTopology({
   String id1 = 'P1',


### PR DESCRIPTION
## Summary

- Adds `turnTestSpyFogGameSeed` to the turn integration test harness and applies it to all spy/fog integration `Game` fixtures.
- Replaces ad-hoc `globalGameSeed: 42` literals on dev with the shared constant for consistency.

Refs #3876

## Root cause

`resolveTurnForGame` always runs from the orders phase unless `startFromPhase` is set. Spy/fog integration tests that set up foreign spies therefore hit `resolveSpyPhase`, which uses unseeded `Random()` when `Game.globalGameSeed` is null — causing flaky visibility assertions under CI's `--test-randomize-ordering-seed=42 -j 4`.

## Done in this PR

| AC / slice | Status |
|------------|--------|
| Stabilize spy fog integration tests under CI package test job | Done |

## Deferred

- Remaining #3876 slices (if any) tracked on the issue after merge of #3894.

## Test plan

- [x] `cd packages/colonizethis_turn && dart test --test-randomize-ordering-seed=42 -j 4 test/integration/resolve_turn_spy_fog_end_of_turn_*.dart`
- [x] `dart run tool/check_turn_integration_no_part_fragments.dart`


Made with [Cursor](https://cursor.com)