### PR TITLE
docs: mark advanced start bootstrap implemented on dev (#3895)

### DIFF
--- a/SPEC/game/advanced-starts.md
+++ b/SPEC/game/advanced-starts.md
@@ -63,7 +63,7 @@ Ordered steps (full issue #3895):
 11. Player + minor tile development and roads.
 12. NW province town → OW capital connectivity.
 
-**Implementation status:** Steps **1–12** and Hive save/load round-trip for advanced-start state are implemented. Full issue closure awaits PR merge and verify-github-issue on #3895.
+**Implementation status:** Steps **1–12** and Hive save/load round-trip for advanced-start state are implemented on `dev` (PR #3897). Full issue closure awaits `verify-github-issue` on #3895.
 
 ## Acceptance criteria (partial — foundation + units slice)
 


### PR DESCRIPTION
## Summary

- Updates `SPEC/game/advanced-starts.md` implementation status to reflect that bootstrap steps 1–12 and save/load round-trip are merged on `dev` via PR #3897.

Refs #3895

## Done in this PR

| Area | Status |
|------|--------|
| SPEC implementation status accuracy | Done |

## Deferred

- Full issue closure and label transition handled after `verify-github-issue` confirms all ACs on merged `dev`.

## Test plan

- [x] Docs-only change; no code behavior change.


Made with [Cursor](https://cursor.com)