### PR TITLE
fix: prospect GP/minor owned tiles before advanced-start development (#3918)

### DIFF
--- a/SPEC/game/advanced-starts.md
+++ b/SPEC/game/advanced-starts.md
@@ -20,7 +20,7 @@ Two fixed **advanced start** presets let players begin a campaign at turn **50**
 | Tech count | 23 | 45 |
 | NW GP provinces | 0 (turn-0 ownership) | 6 contiguous per GP |
 | NW revealed | 50–75% contiguous | 100% contiguous |
-| NW prospected | ≥50% of prospectable tiles in revealed provinces | ≥75% |
+| GP + minor prospected | ≥50% of prospect-required tiles in **owned** provinces (GP: OW; 100-turn: OW+NW) | ≥75% (GP: OW+NW owned pool) |
 | Player development | 25% developable tiles → level 1 + roads | 50% |
 | Minor development | 25% purchased + level 1 | 50% |
 | Diplomacy | Consulates (OW minors + encountered tribes) | Embassies |
@@ -58,8 +58,8 @@ Ordered steps (full issue #3895):
 6. Assign cargo ships per tier rule (Galleon; fixed minimum until NW dev step supplies extraction volume).
 7. Pre-establish consulates / embassies (OW minors + tribes encountered in step 8).
 8. NW exploration (contiguous flood-fill from warp-link entry).
-9. NW prospecting (% of prospectable tiles).
-10. NW colonization (100-turn only).
+9. NW colonization (100-turn only).
+10. GP + minor prospecting (% of prospect-required tiles in owned provinces).
 11. Player + minor tile development and roads.
 12. NW province town → OW capital connectivity.
 
@@ -69,9 +69,10 @@ Ordered steps (full issue #3895):
 
 - Given advanced start `none`, when init completes, then `Game.advancedStartType` is null and `turnNumber` is 0.
 - Given advanced start `turns50` on the locked profile, when init completes, then every GP has exactly 23 listed techs unlocked, 16 peasants, 20,000 treasury, tier civilian counts, 6 upgraded regiments, at least 1 Galleon in the home fleet, and `turnNumber` is 50.
-- Given advanced start `turns50` on the locked profile, when init completes, then every GP has consulates with all OW minors, at least `kAdvancedStart50TurnNwRevealFraction` of NW provinces fully visible (contiguous from warp entry), ≥50% of prospectable tiles in those provinces prospected, and 25% of developable tiles at improvement level 1 in owned provinces with road links to town or capital.
+- Given advanced start `turns50` on the locked profile, when init completes, then every GP has consulates with all OW minors, at least `kAdvancedStart50TurnNwRevealFraction` of NW provinces fully visible (contiguous from warp entry), ≥50% of prospect-required tiles in its **combined OW-owned pool** added to `playerProspectedTiles`, and 25% of developable tiles (including prospected minerals) at improvement level 1 in owned OW provinces with road links to town or capital.
 - Given advanced start `turns50` on the locked profile, when init completes, then 25% of developable tiles in each OW minor province are purchased by a GP (round-robin) at improvement level 1 and recorded in `purchasedTilesByTileKey`.
 - Given advanced start `turns100` on the locked profile, when init completes, then every GP has exactly 45 listed techs unlocked, 16 peasants and 4 apprentices, 40,000 treasury, tier civilian counts including Rail Builder, 12 upgraded regiments, at least 6 Galleons in the home fleet, and `turnNumber` is 100.
-- Given advanced start `turns100` on the locked profile, when init completes, then every GP has embassies with all OW minors and encountered tribes, 100% NW provinces visible, ≥75% of prospectable tiles prospected, 6 contiguous NW provinces owned per GP (tribes retain ≥1 province each), 50% of developable tiles at improvement level 1 in owned provinces (OW + NW) with road links, and 50% of minor developable tiles purchased and developed.
+- Given advanced start `turns100` on the locked profile, when init completes, then every GP has embassies with all OW minors and encountered tribes, 100% NW provinces visible, ≥75% of prospect-required tiles in its **combined OW + NW owned pool** prospected **after** NW colonization, 6 contiguous NW provinces owned per GP (tribes retain ≥1 province each), 50% of developable tiles (including prospected minerals) at improvement level 1 in owned provinces (OW + NW) with road links, and 50% of minor developable tiles purchased and developed.
+- Given advanced start `turns50` or `turns100`, when init completes, then each minor nation has the tier prospect fraction applied to minerals in its OW provinces, and minor development can improve prospected mineral tiles that are purchased (not blocked by empty prospected set).
 - Given advanced start ≠ `none` on a non-locked profile, when bootstrap runs, then the System returns the turn-0 game unchanged and logs a warning.
 - Given an advanced-start game is saved and reloaded via `GameSaveAdapter`, when loaded, then `advancedStartType`, turn, techs, treasury, workforce, visibility, province ownership, tile improvements and roads, purchased tiles, prospected tiles, diplomacy overtures, civilian counts, regiment counts, and home-fleet cargo ships match the saved state exactly (load-time general-cap reconciliation excluded).

--- a/packages/colonizethis_setup/lib/colonizethis_setup.dart
+++ b/packages/colonizethis_setup/lib/colonizethis_setup.dart
@@ -5,6 +5,7 @@ export 'src/setup/advanced_start_bootstrap.dart';
 export 'src/setup/advanced_start_bootstrap_colonization.dart';
 export 'src/setup/advanced_start_bootstrap_development.dart';
 export 'src/setup/advanced_start_bootstrap_diplomacy.dart';
+export 'src/setup/advanced_start_bootstrap_prospecting.dart';
 export 'src/setup/advanced_start_bootstrap_world.dart';
 export 'src/setup/capital_choice.dart';
 export 'src/setup/effective_setup_seed.dart';

--- a/packages/colonizethis_setup/lib/src/setup/advanced_start_bootstrap.dart
+++ b/packages/colonizethis_setup/lib/src/setup/advanced_start_bootstrap.dart
@@ -7,6 +7,7 @@ import 'package:colonizethis_world/colonizethis_world.dart';
 import 'advanced_start_bootstrap_colonization.dart';
 import 'advanced_start_bootstrap_development.dart';
 import 'advanced_start_bootstrap_diplomacy.dart';
+import 'advanced_start_bootstrap_prospecting.dart';
 import 'advanced_start_bootstrap_units.dart';
 import 'advanced_start_bootstrap_world.dart';
 import 'setup_logging.dart';
@@ -112,6 +113,11 @@ Game applyAdvancedStartBootstrap({
       warpLinks: warpLinks,
       tileMapByRegion: tileMapByRegion,
       topologyByRegion: topoByRegion,
+    );
+
+    updated = applyAdvancedStartProspecting(
+      game: updated,
+      startType: startType,
     );
 
     updated = applyAdvancedStartDevelopment(

--- a/packages/colonizethis_setup/lib/src/setup/advanced_start_bootstrap_development.dart
+++ b/packages/colonizethis_setup/lib/src/setup/advanced_start_bootstrap_development.dart
@@ -214,6 +214,8 @@ Game applyAdvancedStartMinorDevelopment({
   for (var i = 0; i < game.minorNations.length; i++) {
     final minor = game.minorNations[i];
     final buyerId = game.players[i % game.players.length].id;
+    final buyerProspected =
+        updated.worldState.playerProspectedTiles[buyerId] ?? const <String>{};
     final tileKeysByProvince =
         game.worldState.tileKeysByRegionAndProvince[kRegionOldWorld] ??
         const <String, List<String>>{};
@@ -225,7 +227,7 @@ Game applyAdvancedStartMinorDevelopment({
         _rankDevelopableTileKeys(
           tileKeys: tileKeysByProvince[province.id] ?? const [],
           resourceByTileKey: game.worldState.resourceByTileKey,
-          prospectedTileKeys: const {},
+          prospectedTileKeys: buyerProspected,
         ),
       );
     }

--- a/packages/colonizethis_setup/lib/src/setup/advanced_start_bootstrap_prospecting.dart
+++ b/packages/colonizethis_setup/lib/src/setup/advanced_start_bootstrap_prospecting.dart
@@ -16,6 +16,19 @@ Set<String> _selectProspectFraction({
   return prospectable.take(target).toSet();
 }
 
+Set<String> _prospectRequiredTileKeys(
+  Iterable<String> tileKeys,
+  Map<String, String> resourceByTileKey,
+) {
+  return tileKeys
+      .where((tileKey) {
+        final resourceId = resourceByTileKey[tileKey];
+        return resourceId != null &&
+            kProspectRequiredResourceIds.contains(resourceId);
+      })
+      .toSet();
+}
+
 Set<String> _ownedProspectableTileKeys({
   required Game game,
   required String ownerId,
@@ -30,13 +43,7 @@ Set<String> _ownedProspectableTileKeys({
     for (final province in game.worldState.provincesForRegion(regionId)) {
       if (province.ownerId != ownerId) continue;
       final tileKeys = tileKeysByProvince[province.id] ?? const [];
-      for (final tileKey in tileKeys) {
-        final resourceId = resourceByTileKey[tileKey];
-        if (resourceId != null &&
-            kProspectRequiredResourceIds.contains(resourceId)) {
-          keys.add(tileKey);
-        }
-      }
+      keys.addAll(_prospectRequiredTileKeys(tileKeys, resourceByTileKey));
     }
   }
   return keys;

--- a/packages/colonizethis_setup/lib/src/setup/advanced_start_bootstrap_prospecting.dart
+++ b/packages/colonizethis_setup/lib/src/setup/advanced_start_bootstrap_prospecting.dart
@@ -1,0 +1,104 @@
+// Advanced-start GP and minor prospecting (step 9). SPEC/game/advanced-starts.md.
+
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_world/colonizethis_world.dart';
+
+import 'setup_logging.dart';
+
+Set<String> _selectProspectFraction({
+  required Iterable<String> prospectableTileKeys,
+  required double prospectFraction,
+}) {
+  final prospectable = prospectableTileKeys.toList()..sort();
+  if (prospectable.isEmpty) return const {};
+  final target = (prospectable.length * prospectFraction).ceil();
+  return prospectable.take(target).toSet();
+}
+
+Set<String> _ownedProspectableTileKeys({
+  required Game game,
+  required String ownerId,
+  required List<String> regionIds,
+}) {
+  final resourceByTileKey = game.worldState.resourceByTileKey;
+  final keys = <String>{};
+  for (final regionId in regionIds) {
+    final tileKeysByProvince =
+        game.worldState.tileKeysByRegionAndProvince[regionId] ??
+        const <String, List<String>>{};
+    for (final province in game.worldState.provincesForRegion(regionId)) {
+      if (province.ownerId != ownerId) continue;
+      final tileKeys = tileKeysByProvince[province.id] ?? const [];
+      for (final tileKey in tileKeys) {
+        final resourceId = resourceByTileKey[tileKey];
+        if (resourceId != null &&
+            kProspectRequiredResourceIds.contains(resourceId)) {
+          keys.add(tileKey);
+        }
+      }
+    }
+  }
+  return keys;
+}
+
+/// Prospects a tier fraction of mineral tiles in GP-owned OW+NW provinces and
+/// minor-owned OW provinces (combined pool per faction).
+Game applyAdvancedStartProspecting({
+  required Game game,
+  required AdvancedStartType startType,
+}) {
+  final prospectFraction = advancedStartProspectFraction(startType);
+  if (prospectFraction <= 0) return game;
+
+  final prospectedByPlayer = {
+    for (final entry in game.worldState.playerProspectedTiles.entries)
+      entry.key: Set<String>.from(entry.value),
+  };
+
+  for (final player in game.players) {
+    final pool = _ownedProspectableTileKeys(
+      game: game,
+      ownerId: player.id,
+      regionIds: const [kRegionOldWorld, kRegionNewWorld],
+    );
+    final selected = _selectProspectFraction(
+      prospectableTileKeys: pool,
+      prospectFraction: prospectFraction,
+    );
+    if (selected.isEmpty) continue;
+    prospectedByPlayer
+        .putIfAbsent(player.id, () => <String>{})
+        .addAll(selected);
+  }
+
+  if (game.players.isNotEmpty) {
+    for (var i = 0; i < game.minorNations.length; i++) {
+      final minor = game.minorNations[i];
+      final buyerId = game.players[i % game.players.length].id;
+      final pool = _ownedProspectableTileKeys(
+        game: game,
+        ownerId: minor.id,
+        regionIds: const [kRegionOldWorld],
+      );
+      final selected = _selectProspectFraction(
+        prospectableTileKeys: pool,
+        prospectFraction: prospectFraction,
+      );
+      if (selected.isEmpty) continue;
+      prospectedByPlayer
+          .putIfAbsent(buyerId, () => <String>{})
+          .addAll(selected);
+    }
+  }
+
+  setupLog.i(
+    'logic: advanced start prospecting applied fraction=$prospectFraction',
+  );
+
+  return game.copyWith(
+    worldState: game.worldState.copyWith(
+      playerProspectedTiles: prospectedByPlayer,
+    ),
+  );
+}

--- a/packages/colonizethis_setup/lib/src/setup/advanced_start_bootstrap_world.dart
+++ b/packages/colonizethis_setup/lib/src/setup/advanced_start_bootstrap_world.dart
@@ -1,4 +1,4 @@
-// Advanced-start NW exploration and prospecting (steps 8–9). SPEC/game/advanced-starts.md.
+// Advanced-start NW exploration (step 8). SPEC/game/advanced-starts.md.
 
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
@@ -19,24 +19,6 @@ class AdvancedStartWorldKnowledgeResult {
   final Set<String> encounteredTribeIds;
 }
 
-Set<String> _prospectTilesForPlayer({
-  required Set<String> revealedTileKeys,
-  required Map<String, String> resourceByTileKey,
-  required double prospectFraction,
-}) {
-  final prospectable = revealedTileKeys
-      .where((key) {
-        final resourceId = resourceByTileKey[key];
-        return resourceId != null &&
-            kProspectRequiredResourceIds.contains(resourceId);
-      })
-      .toList()
-    ..sort();
-  if (prospectable.isEmpty) return const {};
-  final target = (prospectable.length * prospectFraction).ceil();
-  return prospectable.take(target).toSet();
-}
-
 String? _ownerIdForLocalProvince(Game game, String localProvinceId) {
   final fullId = ProvinceId.full(kRegionNewWorld, localProvinceId);
   for (final province in game.worldState.newWorld.provinces) {
@@ -48,8 +30,7 @@ String? _ownerIdForLocalProvince(Game game, String localProvinceId) {
   return null;
 }
 
-/// Reveals contiguous NW provinces per GP and prospects a tier fraction of
-/// prospect-required tiles in those provinces.
+/// Reveals contiguous NW provinces per GP for visibility and diplomacy.
 AdvancedStartWorldKnowledgeResult applyAdvancedStartWorldKnowledge({
   required Game game,
   required AdvancedStartType startType,
@@ -58,7 +39,6 @@ AdvancedStartWorldKnowledgeResult applyAdvancedStartWorldKnowledge({
   required List<WarpLink> warpLinks,
 }) {
   final revealFraction = advancedStartNwRevealFraction(startType);
-  final prospectFraction = advancedStartProspectFraction(startType);
   final totalNwProvinces = game.worldState.newWorld.provinces.length;
   final targetProvinceCount = (totalNwProvinces * revealFraction).ceil();
 
@@ -67,10 +47,6 @@ AdvancedStartWorldKnowledgeResult applyAdvancedStartWorldKnowledge({
   final visibilityByPlayer = {
     for (final entry in game.worldState.playerVisibilityByTile.entries)
       entry.key: Map<String, String>.from(entry.value),
-  };
-  final prospectedByPlayer = {
-    for (final entry in game.worldState.playerProspectedTiles.entries)
-      entry.key: Set<String>.from(entry.value),
   };
   final tileKeysByProvince =
       game.worldState.tileKeysByRegionAndProvince[kRegionNewWorld] ??
@@ -111,10 +87,7 @@ AdvancedStartWorldKnowledgeResult applyAdvancedStartWorldKnowledge({
 
     final playerVisibility =
         visibilityByPlayer.putIfAbsent(player.id, () => <String, String>{});
-    final playerProspected =
-        prospectedByPlayer.putIfAbsent(player.id, () => <String>{});
 
-    final revealedTileKeys = <String>{};
     for (final localId in revealedLocalIds) {
       final ownerId = _ownerIdForLocalProvince(game, localId);
       if (ownerId != null && game.tribes.any((t) => t.id == ownerId)) {
@@ -124,23 +97,13 @@ AdvancedStartWorldKnowledgeResult applyAdvancedStartWorldKnowledge({
       final tileKeys = tileKeysByProvince[provinceKey] ?? const [];
       for (final tileKey in tileKeys) {
         playerVisibility[tileKey] = VisibilityLevel.fullyVisible.name;
-        revealedTileKeys.add(tileKey);
       }
     }
-
-    playerProspected.addAll(
-      _prospectTilesForPlayer(
-        revealedTileKeys: revealedTileKeys,
-        resourceByTileKey: game.worldState.resourceByTileKey,
-        prospectFraction: prospectFraction,
-      ),
-    );
   }
 
   final updated = game.copyWith(
     worldState: game.worldState.copyWith(
       playerVisibilityByTile: visibilityByPlayer,
-      playerProspectedTiles: prospectedByPlayer,
     ),
   );
 

--- a/packages/colonizethis_setup/test/setup/advanced_start_bootstrap_development_test.dart
+++ b/packages/colonizethis_setup/test/setup/advanced_start_bootstrap_development_test.dart
@@ -113,5 +113,93 @@ void main() {
         greaterThanOrEqualTo(1),
       );
     });
+
+    test('turns50 develops prospected minerals when no higher-priority tiles', () {
+      final mineralFixture = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 50),
+          oldWorld: RegionData(
+            provinces: [
+              Province(
+                id: 'oldWorld|p1',
+                regionId: kRegionOldWorld,
+                ownerId: 'gp1',
+                townTileKey: 'oldWorld|p1|1|1',
+              ),
+              Province(
+                id: 'oldWorld|m1',
+                regionId: kRegionOldWorld,
+                ownerId: 'minor1',
+                townTileKey: 'oldWorld|m1|0|0',
+              ),
+            ],
+          ),
+          newWorld: const RegionData(provinces: []),
+          tileKeysByRegionAndProvince: {
+            kRegionOldWorld: {
+              'oldWorld|p1': ['oldWorld|p1|0|0', 'oldWorld|p1|1|1'],
+              'oldWorld|m1': ['oldWorld|m1|0|0', 'oldWorld|m1|1|0'],
+            },
+          },
+          resourceByTileKey: {
+            'oldWorld|p1|0|0': 'iron',
+            'oldWorld|m1|1|0': 'copper',
+          },
+          playerProspectedTiles: const {
+            'gp1': {'oldWorld|p1|0|0', 'oldWorld|m1|1|0'},
+          },
+        ),
+        players: const [
+          Player(
+            id: 'gp1',
+            displayName: 'England',
+            isHuman: true,
+            capitalProvinceId: 'oldWorld|p1',
+            capitalTile: CapitalTile(
+              regionId: kRegionOldWorld,
+              provinceId: 'p1',
+              x: 1,
+              y: 1,
+            ),
+          ),
+        ],
+        minorNations: const [
+          MinorNation(
+            id: 'minor1',
+            displayName: 'Minor 1',
+            capitalProvinceId: 'oldWorld|m1',
+            capitalTile: CapitalTile(
+              regionId: kRegionOldWorld,
+              provinceId: 'm1',
+              x: 0,
+              y: 0,
+            ),
+          ),
+        ],
+      );
+
+      final game = applyAdvancedStartDevelopment(
+        game: mineralFixture,
+        startType: AdvancedStartType.turns50,
+        tileMapByRegion: {kRegionOldWorld: _owTileMap()},
+        topologyByRegion: const {
+          kRegionOldWorld: MapTopology(nodes: [], edges: []),
+        },
+      );
+
+      expect(
+        game.worldState.tileState.improvementLevel('oldWorld|p1|0|0'),
+        1,
+      );
+      expect(
+        game.worldState.tileState.improvementLevel('oldWorld|m1|1|0'),
+        1,
+      );
+      expect(
+        game.worldState.purchasedTilesByTileKey['oldWorld|m1|1|0'],
+        'gp1',
+      );
+    });
   });
 }

--- a/packages/colonizethis_setup/test/setup/advanced_start_bootstrap_prospecting_test.dart
+++ b/packages/colonizethis_setup/test/setup/advanced_start_bootstrap_prospecting_test.dart
@@ -1,0 +1,179 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_setup/colonizethis_setup.dart';
+import 'package:colonizethis_test/test.dart';
+import 'package:colonizethis_world/colonizethis_world.dart';
+
+Game _prospectingFixture({
+  required List<Province> owProvinces,
+  required List<Province> nwProvinces,
+  required Map<String, String> resourceByTileKey,
+  required Map<String, List<String>> owTiles,
+  required Map<String, List<String>> nwTiles,
+}) {
+  return Game(
+    id: 'g1',
+    worldState: WorldState(
+      turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 50),
+      oldWorld: RegionData(provinces: owProvinces),
+      newWorld: RegionData(provinces: nwProvinces),
+      playerProspectedTiles: const {'gp1': {}},
+      tileKeysByRegionAndProvince: {
+        kRegionOldWorld: owTiles,
+        kRegionNewWorld: nwTiles,
+      },
+      resourceByTileKey: resourceByTileKey,
+    ),
+    players: const [
+      Player(
+        id: 'gp1',
+        displayName: 'England',
+        isHuman: true,
+        capitalProvinceId: 'oldWorld|p_cap',
+      ),
+    ],
+    minorNations: const [
+      MinorNation(id: 'minor1', displayName: 'Minor 1'),
+    ],
+  );
+}
+
+void main() {
+  group('applyAdvancedStartProspecting', () {
+    test('turns50 prospects GP-owned OW minerals only', () {
+      final game = _prospectingFixture(
+        owProvinces: const [
+          Province(
+            id: 'oldWorld|p1',
+            regionId: kRegionOldWorld,
+            ownerId: 'gp1',
+          ),
+        ],
+        nwProvinces: const [
+          Province(
+            id: 'newWorld|p1',
+            regionId: kRegionNewWorld,
+            ownerId: 'tribe1',
+          ),
+        ],
+        owTiles: {
+          'oldWorld|p1': [
+            'oldWorld|p1|0|0',
+            'oldWorld|p1|1|0',
+            'oldWorld|p1|2|0',
+          ],
+        },
+        nwTiles: {
+          'newWorld|p1': ['newWorld|p1|0|0', 'newWorld|p1|1|0'],
+        },
+        resourceByTileKey: {
+          'oldWorld|p1|0|0': 'iron',
+          'oldWorld|p1|1|0': 'copper',
+          'oldWorld|p1|2|0': 'grain',
+          'newWorld|p1|0|0': 'gold',
+          'newWorld|p1|1|0': 'grain',
+        },
+      );
+
+      final updated = applyAdvancedStartProspecting(
+        game: game,
+        startType: AdvancedStartType.turns50,
+      );
+
+      final prospected =
+          updated.worldState.playerProspectedTiles['gp1'] ?? const {};
+      expect(prospected, contains('oldWorld|p1|0|0'));
+      expect(prospected, isNot(contains('newWorld|p1|0|0')));
+      expect(prospected.length, 1);
+    });
+
+    test('turns100 includes GP-owned NW minerals after colonization ownership', () {
+      final game = _prospectingFixture(
+        owProvinces: const [
+          Province(
+            id: 'oldWorld|p1',
+            regionId: kRegionOldWorld,
+            ownerId: 'gp1',
+          ),
+        ],
+        nwProvinces: const [
+          Province(
+            id: 'newWorld|p1',
+            regionId: kRegionNewWorld,
+            ownerId: 'gp1',
+          ),
+          Province(
+            id: 'newWorld|p2',
+            regionId: kRegionNewWorld,
+            ownerId: 'tribe1',
+          ),
+        ],
+        owTiles: {
+          'oldWorld|p1': ['oldWorld|p1|0|0'],
+        },
+        nwTiles: {
+          'newWorld|p1': ['newWorld|p1|0|0', 'newWorld|p1|1|0'],
+          'newWorld|p2': ['newWorld|p2|0|0'],
+        },
+        resourceByTileKey: {
+          'oldWorld|p1|0|0': 'iron',
+          'newWorld|p1|0|0': 'gold',
+          'newWorld|p1|1|0': 'copper',
+          'newWorld|p2|0|0': 'silver',
+        },
+      );
+
+      final updated = applyAdvancedStartProspecting(
+        game: game,
+        startType: AdvancedStartType.turns100,
+      );
+
+      final prospected =
+          updated.worldState.playerProspectedTiles['gp1'] ?? const {};
+      expect(prospected, containsAll([
+        'oldWorld|p1|0|0',
+        'newWorld|p1|0|0',
+        'newWorld|p1|1|0',
+      ]));
+      expect(prospected, isNot(contains('newWorld|p2|0|0')));
+    });
+
+    test('turns50 prospects minor OW minerals into round-robin buyer GP set', () {
+      final game = _prospectingFixture(
+        owProvinces: const [
+          Province(
+            id: 'oldWorld|p1',
+            regionId: kRegionOldWorld,
+            ownerId: 'gp1',
+          ),
+          Province(
+            id: 'oldWorld|m1',
+            regionId: kRegionOldWorld,
+            ownerId: 'minor1',
+          ),
+        ],
+        nwProvinces: const [],
+        owTiles: {
+          'oldWorld|p1': ['oldWorld|p1|0|0'],
+          'oldWorld|m1': ['oldWorld|m1|0|0', 'oldWorld|m1|1|0'],
+        },
+        nwTiles: const {},
+        resourceByTileKey: {
+          'oldWorld|p1|0|0': 'grain',
+          'oldWorld|m1|0|0': 'iron',
+          'oldWorld|m1|1|0': 'copper',
+        },
+      );
+
+      final updated = applyAdvancedStartProspecting(
+        game: game,
+        startType: AdvancedStartType.turns50,
+      );
+
+      final prospected =
+          updated.worldState.playerProspectedTiles['gp1'] ?? const {};
+      expect(prospected, contains('oldWorld|m1|0|0'));
+      expect(prospected.length, 1);
+    });
+  });
+}

--- a/packages/colonizethis_setup/test/setup/advanced_start_bootstrap_world_test.dart
+++ b/packages/colonizethis_setup/test/setup/advanced_start_bootstrap_world_test.dart
@@ -93,7 +93,7 @@ const _warpLinks = [
 
 void main() {
   group('applyAdvancedStartWorldKnowledge', () {
-    test('turns50 reveals contiguous NW provinces and prospects minerals', () {
+    test('turns50 reveals contiguous NW provinces without prospecting', () {
       final result = applyAdvancedStartWorldKnowledge(
         game: _worldKnowledgeFixtureGame(),
         startType: AdvancedStartType.turns50,
@@ -117,8 +117,7 @@ void main() {
 
       final prospected =
           result.game.worldState.playerProspectedTiles['gp1'] ?? const {};
-      expect(prospected, contains('newWorld|p1|0|0'));
-      expect(prospected, isNot(contains('newWorld|p1|1|0')));
+      expect(prospected, isEmpty);
     });
 
     test('turns100 reveals all NW provinces', () {


### PR DESCRIPTION
## Summary

- Split NW reveal (step 8) from prospecting: `applyAdvancedStartWorldKnowledge` now only flood-fills NW visibility for diplomacy.
- Add `applyAdvancedStartProspecting` that applies the tier prospect fraction to **one combined pool per GP** (OW + NW owned provinces) and per minor (OW owned), writing results to `playerProspectedTiles`.
- Reorder bootstrap: NW reveal → colonization (100-turn) → **prospecting** → development, so GP-owned NW minerals assigned at colonization are included.
- Fix minor development to use the round-robin buyer GP's prospected set instead of an empty set, allowing prospected minor minerals to be purchased and developed.

## SPEC

- Updated `SPEC/game/advanced-starts.md` tier table, bootstrap step order (8–12), and acceptance criteria for GP+minor owned-province prospecting.

## Tests

- `advanced_start_bootstrap_prospecting_test.dart` — GP OW-only (50-turn), GP OW+NW after colonization (100-turn), minor minerals into buyer GP set.
- `advanced_start_bootstrap_world_test.dart` — reveal no longer mutates prospected tiles.
- `advanced_start_bootstrap_development_test.dart` — prospected minerals develop when no higher-priority tiles compete.

```
cd packages/colonizethis_setup && dart test test/setup/advanced_start_bootstrap_world_test.dart test/setup/advanced_start_bootstrap_prospecting_test.dart test/setup/advanced_start_bootstrap_development_test.dart
```

## Coverage vs issue ACs

| AC | Status |
|----|--------|
| GP ≥50% OW-owned minerals prospected (turns50) | Done |
| GP ≥75% OW+NW owned minerals after colonization (turns100) | Done |
| Minor tier fraction on OW minerals; development uses prospected set | Done |
| NW reveal unchanged; tribe-revealed non-owned tiles excluded | Done |
| Save/load prospected tiles | Unchanged (existing round-trip tests) |
| SPEC tier table + bootstrap steps updated | Done |

Refs #3918

Made with [Cursor](https://cursor.com)