### PR TITLE
fix: reveal fogged NW sea zones on advanced-start warp path (#3919)

### DIFF
--- a/SPEC/game/advanced-starts.md
+++ b/SPEC/game/advanced-starts.md
@@ -20,6 +20,7 @@ Two fixed **advanced start** presets let players begin a campaign at turn **50**
 | Tech count | 23 | 45 |
 | NW GP provinces | 0 (turn-0 ownership) | 6 contiguous per GP |
 | NW revealed | 50–75% contiguous | 100% contiguous |
+| NW sea zones revealed | Fogged path from warp entry to seas adjacent to revealed provinces | Same fogged path; seas adjacent to GP-owned NW provinces also **fullyVisible** (coastal pass after colonization) |
 | NW prospected | ≥50% of prospectable tiles in revealed provinces | ≥75% |
 | Player development | 25% developable tiles → level 1 + roads | 50% |
 | Minor development | 25% purchased + level 1 | 50% |
@@ -33,6 +34,12 @@ Constants: `advancedStartCivilianCounts`, `advancedStartRegimentCount`, `advance
 50-turn cargo ships use a **fixed minimum of one Galleon** per GP (head start for planned colonization; no GP-owned NW provinces at this tier).
 
 50-turn NW reveal uses **62.5%** (`kAdvancedStart50TurnNwRevealFraction = 0.625`), the midpoint of the 50–75% SPEC range, applied deterministically per GP.
+
+### NW sea-zone visibility (advanced start)
+
+After step 8 province flood-fill per GP, the System reveals NW **sea-zone water tiles** at **`fogged`** (not `unknown`, not `fullyVisible`) for every sea zone on the shortest S–S path from that GP's warp-entry NW sea zone(s) to each sea zone P–S adjacent to a flood-filled NW province. NW sea zones not on that connecting path and not P–S adjacent to a revealed province remain **`unknown`**. Old World sea visibility is unchanged (standard turn-0 init: fogged baseline plus coastal `fullyVisible` for GP-owned OW provinces).
+
+At **100-turn** only, after step 9 colonization assigns GP-owned NW provinces, the bootstrap runs the standard coastal sea-zone full-visibility pass so every sea zone P–S adjacent to a GP-**owned** NW province becomes **`fullyVisible`**. Path-only seas adjacent to revealed-but-not-owned provinces stay **`fogged`**.
 
 ## Fixed technology lists
 
@@ -57,9 +64,9 @@ Ordered steps (full issue #3895):
 5. Assign upgraded regiments (best buildable type per military branch from unlocked techs; highest era, tie-break highest FPN+FPM; balanced across infantry/cavalry/artillery).
 6. Assign cargo ships per tier rule (Galleon; fixed minimum until NW dev step supplies extraction volume).
 7. Pre-establish consulates / embassies (OW minors + tribes encountered in step 8).
-8. NW exploration (contiguous flood-fill from warp-link entry).
+8. NW exploration (contiguous flood-fill from warp-link entry) plus fogged NW sea-zone reveal (see **NW sea-zone visibility**).
 9. NW prospecting (% of prospectable tiles).
-10. NW colonization (100-turn only).
+10. NW colonization (100-turn only); then coastal full-visibility for GP-owned NW provinces (100-turn only).
 11. Player + minor tile development and roads.
 12. NW province town → OW capital connectivity.
 
@@ -69,9 +76,10 @@ Ordered steps (full issue #3895):
 
 - Given advanced start `none`, when init completes, then `Game.advancedStartType` is null and `turnNumber` is 0.
 - Given advanced start `turns50` on the locked profile, when init completes, then every GP has exactly 23 listed techs unlocked, 16 peasants, 20,000 treasury, tier civilian counts, 6 upgraded regiments, at least 1 Galleon in the home fleet, and `turnNumber` is 50.
-- Given advanced start `turns50` on the locked profile, when init completes, then every GP has consulates with all OW minors, at least `kAdvancedStart50TurnNwRevealFraction` of NW provinces fully visible (contiguous from warp entry), ≥50% of prospectable tiles in those provinces prospected, and 25% of developable tiles at improvement level 1 in owned provinces with road links to town or capital.
+- Given advanced start `turns50` on the locked profile, when init completes, then every GP has consulates with all OW minors, at least `kAdvancedStart50TurnNwRevealFraction` of NW provinces fully visible (contiguous from warp entry), NW sea zones on the warp-entry path to every sea zone P–S adjacent to that GP's flood-filled provinces are **`fogged`** (not `unknown`, not `fullyVisible`), ≥50% of prospectable tiles in those provinces prospected, and 25% of developable tiles at improvement level 1 in owned provinces with road links to town or capital.
+- Given advanced start `turns50` on the locked profile, when init completes, then NW sea zones not on the connecting path from warp entry and not P–S adjacent to a flood-filled province remain **`unknown`**.
 - Given advanced start `turns50` on the locked profile, when init completes, then 25% of developable tiles in each OW minor province are purchased by a GP (round-robin) at improvement level 1 and recorded in `purchasedTilesByTileKey`.
 - Given advanced start `turns100` on the locked profile, when init completes, then every GP has exactly 45 listed techs unlocked, 16 peasants and 4 apprentices, 40,000 treasury, tier civilian counts including Rail Builder, 12 upgraded regiments, at least 6 Galleons in the home fleet, and `turnNumber` is 100.
-- Given advanced start `turns100` on the locked profile, when init completes, then every GP has embassies with all OW minors and encountered tribes, 100% NW provinces visible, ≥75% of prospectable tiles prospected, 6 contiguous NW provinces owned per GP (tribes retain ≥1 province each), 50% of developable tiles at improvement level 1 in owned provinces (OW + NW) with road links, and 50% of minor developable tiles purchased and developed.
+- Given advanced start `turns100` on the locked profile, when init completes, then every GP has embassies with all OW minors and encountered tribes, 100% NW provinces visible, the same fogged NW sea-zone path rule as 50-turn for the full reveal set, all NW sea zones P–S adjacent to GP-**owned** NW provinces are **`fullyVisible`**, NW sea zones adjacent only to revealed-but-not-owned provinces stay **`fogged`** unless on the warp-entry connecting path, ≥75% of prospectable tiles prospected, 6 contiguous NW provinces owned per GP (tribes retain ≥1 province each), 50% of developable tiles at improvement level 1 in owned provinces (OW + NW) with road links, and 50% of minor developable tiles purchased and developed.
 - Given advanced start ≠ `none` on a non-locked profile, when bootstrap runs, then the System returns the turn-0 game unchanged and logs a warning.
 - Given an advanced-start game is saved and reloaded via `GameSaveAdapter`, when loaded, then `advancedStartType`, turn, techs, treasury, workforce, visibility, province ownership, tile improvements and roads, purchased tiles, prospected tiles, diplomacy overtures, civilian counts, regiment counts, and home-fleet cargo ships match the saved state exactly (load-time general-cap reconciliation excluded).

--- a/packages/colonizethis_setup/lib/src/setup/advanced_start_bootstrap.dart
+++ b/packages/colonizethis_setup/lib/src/setup/advanced_start_bootstrap.dart
@@ -114,6 +114,11 @@ Game applyAdvancedStartBootstrap({
       topologyByRegion: topoByRegion,
     );
 
+    updated = applyAdvancedStartCoastalSeaVisibility(
+      game: updated,
+      topologyByRegion: topoByRegion,
+    );
+
     updated = applyAdvancedStartDevelopment(
       game: updated,
       startType: startType,

--- a/packages/colonizethis_setup/lib/src/setup/advanced_start_bootstrap_world.dart
+++ b/packages/colonizethis_setup/lib/src/setup/advanced_start_bootstrap_world.dart
@@ -48,6 +48,23 @@ String? _ownerIdForLocalProvince(Game game, String localProvinceId) {
   return null;
 }
 
+void _setNwSeaZoneTilesFogged({
+  required Map<String, String> playerVisibility,
+  required Map<String, List<String>> nwTileKeysByProvince,
+  required Iterable<String> seaZoneLocalIds,
+}) {
+  for (final seaLocalId in seaZoneLocalIds) {
+    final bucketKey = canonicalSeaZoneTileBucketKey(kRegionNewWorld, seaLocalId);
+    final tileKeys = nwTileKeysByProvince[bucketKey] ?? const [];
+    for (final tileKey in tileKeys) {
+      final current = playerVisibility[tileKey];
+      if (current == null || current == VisibilityLevel.unknown.name) {
+        playerVisibility[tileKey] = VisibilityLevel.fogged.name;
+      }
+    }
+  }
+}
+
 /// Reveals contiguous NW provinces per GP and prospects a tier fraction of
 /// prospect-required tiles in those provinces.
 AdvancedStartWorldKnowledgeResult applyAdvancedStartWorldKnowledge({
@@ -109,6 +126,17 @@ AdvancedStartWorldKnowledgeResult applyAdvancedStartWorldKnowledge({
       );
     }
 
+    final entrySeaZones = advancedStartNwSeaZonesFromCapital(
+      capitalLocalProvinceId: capitalLocalId,
+      topologyOldWorld: topologyOldWorld,
+      warpLinks: warpLinks,
+    );
+    final foggedSeaZones = advancedStartFoggedNwSeaZoneLocalIds(
+      topologyNewWorld: topologyNewWorld,
+      entrySeaZoneLocalIds: entrySeaZones,
+      revealedProvinceLocalIds: revealedLocalIds.toSet(),
+    );
+
     final playerVisibility =
         visibilityByPlayer.putIfAbsent(player.id, () => <String, String>{});
     final playerProspected =
@@ -127,6 +155,12 @@ AdvancedStartWorldKnowledgeResult applyAdvancedStartWorldKnowledge({
         revealedTileKeys.add(tileKey);
       }
     }
+
+    _setNwSeaZoneTilesFogged(
+      playerVisibility: playerVisibility,
+      nwTileKeysByProvince: tileKeysByProvince,
+      seaZoneLocalIds: foggedSeaZones,
+    );
 
     playerProspected.addAll(
       _prospectTilesForPlayer(
@@ -147,5 +181,37 @@ AdvancedStartWorldKnowledgeResult applyAdvancedStartWorldKnowledge({
   return AdvancedStartWorldKnowledgeResult(
     game: updated,
     encounteredTribeIds: encounteredTribes,
+  );
+}
+
+MapTopology _combinedTopologyFromRegions(
+  Map<String, MapTopology> topologyByRegion,
+) {
+  final allNodes = <TopologyNode>[];
+  final allEdges = <TopologyEdge>[];
+  for (final topology in topologyByRegion.values) {
+    allNodes.addAll(topology.nodes);
+    allEdges.addAll(topology.edges);
+  }
+  return MapTopology(nodes: allNodes, edges: allEdges);
+}
+
+/// Promotes GP-owned coastal NW sea zones to fullyVisible after colonization.
+/// SPEC/game/advanced-starts.md § NW sea-zone visibility.
+Game applyAdvancedStartCoastalSeaVisibility({
+  required Game game,
+  required Map<String, MapTopology> topologyByRegion,
+}) {
+  final combined = _combinedTopologyFromRegions(topologyByRegion);
+  final visibilityAfterCoastal = applyCoastalSeaZoneFullVisibility(
+    game,
+    game.worldState.playerVisibilityByTile,
+    combined,
+    topologyByRegion: topologyByRegion,
+  );
+  return game.copyWith(
+    worldState: game.worldState.copyWith(
+      playerVisibilityByTile: visibilityAfterCoastal,
+    ),
   );
 }

--- a/packages/colonizethis_setup/lib/src/setup/advanced_start_nw_topology.dart
+++ b/packages/colonizethis_setup/lib/src/setup/advanced_start_nw_topology.dart
@@ -136,3 +136,60 @@ List<String> advancedStartFloodFillProvinces({
 
   return collected;
 }
+
+/// NW sea zones to mark [VisibilityLevel.fogged] during advanced-start step 8:
+/// shortest S–S paths from [entrySeaZoneLocalIds] to every sea zone P–S adjacent
+/// to [revealedProvinceLocalIds]. Unreachable targets are omitted.
+List<String> advancedStartFoggedNwSeaZoneLocalIds({
+  required MapTopology topologyNewWorld,
+  required List<String> entrySeaZoneLocalIds,
+  required Set<String> revealedProvinceLocalIds,
+}) {
+  if (entrySeaZoneLocalIds.isEmpty || revealedProvinceLocalIds.isEmpty) {
+    return const [];
+  }
+
+  final targetSeas = <String>{};
+  for (final localId in revealedProvinceLocalIds) {
+    targetSeas.addAll(
+      seaZoneIdsAdjacentToProvince(
+        topologyNewWorld,
+        localId,
+        regionId: kRegionNewWorld,
+      ),
+    );
+  }
+  if (targetSeas.isEmpty) return const [];
+
+  final parents = <String, String?>{};
+  for (final entry in entrySeaZoneLocalIds) {
+    parents[entry] = null;
+  }
+  final visited = <String>{...entrySeaZoneLocalIds};
+  final queue = List<String>.from(entrySeaZoneLocalIds)..sort();
+  var head = 0;
+
+  while (head < queue.length && !targetSeas.every(visited.contains)) {
+    final current = queue[head++];
+    for (final next in adjacentSeaZoneIdsSeaOnly(topologyNewWorld, current)) {
+      if (visited.add(next)) {
+        parents[next] = current;
+        queue.add(next);
+      }
+    }
+  }
+
+  final onPath = <String>{};
+  for (final target in targetSeas) {
+    if (!visited.contains(target)) continue;
+    var node = target;
+    while (true) {
+      if (!onPath.add(node)) break;
+      final parent = parents[node];
+      if (parent == null) break;
+      node = parent;
+    }
+  }
+
+  return onPath.toList()..sort();
+}

--- a/packages/colonizethis_setup/test/setup/advanced_start_bootstrap_world_test.dart
+++ b/packages/colonizethis_setup/test/setup/advanced_start_bootstrap_world_test.dart
@@ -2,6 +2,7 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_diplomacy/colonizethis_diplomacy.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_setup/colonizethis_setup.dart';
+import 'package:colonizethis_setup/src/setup/advanced_start_nw_topology.dart';
 import 'package:colonizethis_test/test.dart';
 import 'package:colonizethis_world/colonizethis_world.dart';
 
@@ -10,6 +11,9 @@ const _nwTiles = <String, List<String>>{
   'newWorld|p1': ['newWorld|p1|0|0', 'newWorld|p1|1|0'],
   'newWorld|p2': ['newWorld|p2|0|0'],
   'newWorld|p3': ['newWorld|p3|0|0'],
+  'newWorld|s1': ['newWorld|s1|0|0'],
+  'newWorld|s2': ['newWorld|s2|0|0'],
+  'newWorld|s3': ['newWorld|s3|0|0'],
 };
 
 Game _worldKnowledgeFixtureGame() {
@@ -31,6 +35,9 @@ Game _worldKnowledgeFixtureGame() {
           'newWorld|p1|1|0': VisibilityLevel.unknown.name,
           'newWorld|p2|0|0': VisibilityLevel.unknown.name,
           'newWorld|p3|0|0': VisibilityLevel.unknown.name,
+          'newWorld|s1|0|0': VisibilityLevel.unknown.name,
+          'newWorld|s2|0|0': VisibilityLevel.unknown.name,
+          'newWorld|s3|0|0': VisibilityLevel.unknown.name,
         },
       },
       playerProspectedTiles: const {'gp1': {}},
@@ -71,12 +78,18 @@ MapTopology _owTopology() => const MapTopology(
 MapTopology _nwTopology() => const MapTopology(
   nodes: [
     TopologyNode(id: 's1', regionId: kRegionNewWorld, type: TopologyNodeType.seaZone),
+    TopologyNode(id: 's2', regionId: kRegionNewWorld, type: TopologyNodeType.seaZone),
+    TopologyNode(id: 's3', regionId: kRegionNewWorld, type: TopologyNodeType.seaZone),
     TopologyNode(id: 'p1', regionId: kRegionNewWorld, type: TopologyNodeType.province),
     TopologyNode(id: 'p2', regionId: kRegionNewWorld, type: TopologyNodeType.province),
     TopologyNode(id: 'p3', regionId: kRegionNewWorld, type: TopologyNodeType.province),
   ],
   edges: [
     TopologyEdge(id1: 's1', id2: 'p1'),
+    TopologyEdge(id1: 's1', id2: 's2'),
+    TopologyEdge(id1: 's2', id2: 'p2'),
+    TopologyEdge(id1: 's2', id2: 's3'),
+    TopologyEdge(id1: 's3', id2: 'p3'),
     TopologyEdge(id1: 'p1', id2: 'p2'),
     TopologyEdge(id1: 'p2', id2: 'p3'),
   ],
@@ -115,6 +128,19 @@ void main() {
       expect(result.encounteredTribeIds, contains('tribe1'));
       expect(result.encounteredTribeIds, isNot(contains('tribe2')));
 
+      expect(
+        visibility['newWorld|s1|0|0'],
+        VisibilityLevel.fogged.name,
+      );
+      expect(
+        visibility['newWorld|s2|0|0'],
+        VisibilityLevel.fogged.name,
+      );
+      expect(
+        visibility['newWorld|s3|0|0'],
+        VisibilityLevel.unknown.name,
+      );
+
       final prospected =
           result.game.worldState.playerProspectedTiles['gp1'] ?? const {};
       expect(prospected, contains('newWorld|p1|0|0'));
@@ -137,6 +163,107 @@ void main() {
         VisibilityLevel.fullyVisible.name,
       );
       expect(result.encounteredTribeIds, containsAll(['tribe1', 'tribe2']));
+
+      expect(
+        visibility['newWorld|s1|0|0'],
+        VisibilityLevel.fogged.name,
+      );
+      expect(
+        visibility['newWorld|s2|0|0'],
+        VisibilityLevel.fogged.name,
+      );
+      expect(
+        visibility['newWorld|s3|0|0'],
+        VisibilityLevel.fogged.name,
+      );
+    });
+  });
+
+  group('advancedStartFoggedNwSeaZoneLocalIds', () {
+    test('returns shortest S-S path from entry to adjacent seas only', () {
+      final seas = advancedStartFoggedNwSeaZoneLocalIds(
+        topologyNewWorld: _nwTopology(),
+        entrySeaZoneLocalIds: const ['s1'],
+        revealedProvinceLocalIds: const {'p1', 'p2'},
+      );
+      expect(seas, ['s1', 's2']);
+    });
+
+    test('returns empty when no entry seas', () {
+      expect(
+        advancedStartFoggedNwSeaZoneLocalIds(
+          topologyNewWorld: _nwTopology(),
+          entrySeaZoneLocalIds: const [],
+          revealedProvinceLocalIds: const {'p1'},
+        ),
+        isEmpty,
+      );
+    });
+  });
+
+  group('applyAdvancedStartCoastalSeaVisibility', () {
+    test('promotes owned-coast NW seas to fullyVisible', () {
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 100),
+          oldWorld: const RegionData(provinces: []),
+          newWorld: RegionData(
+            provinces: [
+              Province(
+                id: 'newWorld|p1',
+                regionId: kRegionNewWorld,
+                ownerId: 'gp1',
+              ),
+              Province(
+                id: 'newWorld|p2',
+                regionId: kRegionNewWorld,
+                ownerId: 'tribe1',
+              ),
+            ],
+          ),
+          playerVisibilityByTile: {
+            'gp1': {
+              'newWorld|s1|0|0': VisibilityLevel.fogged.name,
+              'newWorld|s2|0|0': VisibilityLevel.fogged.name,
+            },
+          },
+          tileKeysByRegionAndProvince: {
+            kRegionNewWorld: {
+              'newWorld|s1': ['newWorld|s1|0|0'],
+              'newWorld|s2': ['newWorld|s2|0|0'],
+            },
+          },
+        ),
+        players: const [
+          Player(
+            id: 'gp1',
+            displayName: 'England',
+            isHuman: true,
+            capitalProvinceId: _owCapital,
+          ),
+        ],
+        minorNations: const [],
+        tribes: const [Tribe(id: 'tribe1', displayName: 'Tribe 1')],
+      );
+
+      final updated = applyAdvancedStartCoastalSeaVisibility(
+        game: game,
+        topologyByRegion: {
+          kRegionNewWorld: _nwTopology(),
+        },
+      );
+
+      final visibility =
+          updated.worldState.playerVisibilityByTile['gp1'] ?? const {};
+      expect(
+        visibility['newWorld|s1|0|0'],
+        VisibilityLevel.fullyVisible.name,
+      );
+      expect(
+        visibility['newWorld|s2|0|0'],
+        VisibilityLevel.fogged.name,
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

- Add `advancedStartFoggedNwSeaZoneLocalIds` — BFS on NW S–S adjacency from warp-entry seas to every sea zone P–S adjacent to flood-filled provinces; returns shortest-path sea set only (no branch seas).
- Extend `applyAdvancedStartWorldKnowledge` to mark those sea-zone water tiles **`fogged`** (`unknown` → `fogged`; does not downgrade `fullyVisible`).
- Add `applyAdvancedStartCoastalSeaVisibility` after NW colonization in bootstrap so GP-owned NW coastal seas become **`fullyVisible`** at 100-turn per normal coastal rules; path-only / tribe-adjacent seas stay fogged.

## SPEC

- Updated `SPEC/game/advanced-starts.md`: tier table row, NW sea-zone visibility section, bootstrap steps 8/10, and acceptance criteria for fogged path + owned-coast exception.

## Tests

- `advanced_start_bootstrap_world_test.dart` — fogged path seas at turns50/100, off-path sea stays unknown, topology helper unit tests, coastal pass promotes GP-owned adjacent sea only.

```
cd packages/colonizethis_setup && dart test test/setup/advanced_start_bootstrap_world_test.dart
```

## Coverage vs issue ACs

| AC | Status |
|----|--------|
| turns50: path seas fogged, land fullyVisible | Done |
| turns50: off-path / non-adjacent seas unknown | Done |
| turns100: fogged path + owned-coast fullyVisible | Done |
| turns100: revealed-not-owned adjacent seas fogged | Done |
| turns100: path-only seas not promoted without ownership | Done |
| `none` tier unchanged | Unchanged (no bootstrap) |
| OW sea visibility unchanged | Unchanged (coastal pass idempotent on OW) |
| SPEC updated | Done |

Refs #3919


Made with [Cursor](https://cursor.com)