### PR TITLE
refactor(app): extract shared TradeScreen test hosts (#3952)

### DIFF
--- a/app/test/support/trade_screen_test_support.dart
+++ b/app/test/support/trade_screen_test_support.dart
@@ -1,0 +1,343 @@
+// Shared TradeScreen widget-test hosts and Game builders (Refs #3952).
+//
+// Market-tab / Deal Book / E8 standalone suites previously each re-declared
+// private `_buildGame` / `_pumpTradeScreen*` helpers wrapping the same
+// `ProviderContainer` + `shellPlayerContextProvider` + `TradeScreen` pump
+// sequence. This module owns the parameterized builders and pump hosts;
+// trade test files keep only override lists and assertions.
+//
+// Extends the lightweight panel fixture seam in `panel_fixtures/trade.dart`
+// (`buildTradePanelTestGame`) for scaffold/viewport pins that need only
+// `game.players` + empty world-market state.
+
+import 'package:colonizethis_app/features/game/flame/region_map/region_map.dart'
+    show CtMapVisibilityMode;
+import 'package:colonizethis_app/features/game/screens/trade/trade_screen.dart';
+import 'package:colonizethis_app/features/game/widgets/shell/shell_player_context.dart';
+import 'package:colonizethis_app/providers/games_provider.dart';
+import 'package:colonizethis_app/providers/production_allocation_provider.dart';
+import 'package:colonizethis_app/widgets/ct_tab_strip.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart' show homeFleetIdFor;
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart' show Override;
+import 'package:flutter_test/flutter_test.dart';
+
+import 'app_shell_harness.dart';
+import 'min_viewport_harness.dart';
+import 'panel_fixtures/trade.dart';
+
+/// Canonical human GP id used by Market-tab / Deal Book / E8 standalone hosts.
+const String kTradeTestHumanPlayerId = 'gp_h';
+
+/// Tall viewport so the 22-commodity Market list lays out without scrolling.
+const Size kTradeMarketTabViewport = Size(1024, 4096);
+
+/// Capital province id used when seeding a synthetic home fleet for cargo-cap
+/// pins (`tradeCargoCapacityOverride == 10`).
+const String kTradeTestCapitalProvinceId = 'oldWorld|cap1';
+
+/// Stockpile map covering every tradeable commodity at [quantity] (excludes
+/// riches and `spices`). Used by Offer-side interactive suites so the sellable
+/// clamp does not zero out default Offer taps.
+Map<CommodityId, int> tradeableStockpileFilled(int quantity) {
+  return <CommodityId, int>{
+    for (final Commodity c in CommodityCatalog.all)
+      if (c.category != CommodityCategory.riches && c.id != 'spices')
+        c.id: quantity,
+  };
+}
+
+/// Parameterized lightweight [Game] for TradeScreen widget tests.
+///
+/// Defaults match the Market-tab family (`gp_h`, treasury 500, empty regions).
+/// Pass [players] / [worldMarketState] / [fleets] / [oldWorld] when a suite
+/// needs foreign GPs, carry-forwards, or a home fleet for cargo capacity.
+Game buildTradeTestGame({
+  String id = 'test_trade_screen',
+  String playerId = kTradeTestHumanPlayerId,
+  String displayName = 'England',
+  int treasury = 500,
+  Map<CommodityId, int>? stockpile,
+  Map<CommodityId, int>? prices,
+  Map<CommodityId, MarketActivity>? lastTurnActivity,
+  Map<String, List<TradeOrder>> carryForwardBids =
+      const <String, List<TradeOrder>>{},
+  Map<String, List<TradeOrder>> carryForwardOffers =
+      const <String, List<TradeOrder>>{},
+  List<Player>? players,
+  List<Fleet> fleets = const <Fleet>[],
+  RegionData oldWorld = const RegionData(),
+  RegionData newWorld = const RegionData(),
+  WorldMarketState? worldMarketState,
+  /// When `10`, seeds a galleon+fluyte home fleet (cargoHold 6+4). Other
+  /// values throw — only the E5c / E8 cargo-cap mapping is supported.
+  int? tradeCargoCapacityOverride,
+}) {
+  final List<Fleet> resolvedFleets = List<Fleet>.of(fleets);
+  RegionData resolvedOldWorld = oldWorld;
+  if (tradeCargoCapacityOverride != null) {
+    final int galleonHolds = NavalStatsCatalog.galleon.cargoHold;
+    final int fluyteHolds = NavalStatsCatalog.fluyte.cargoHold;
+    if (galleonHolds + fluyteHolds != 10) {
+      throw StateError(
+        'NavalStatsCatalog cargoHold drift: '
+        'galleon=$galleonHolds + fluyte=$fluyteHolds != 10. '
+        'Update the override mapping in trade_screen_test_support.dart.',
+      );
+    }
+    if (tradeCargoCapacityOverride != 10) {
+      throw StateError(
+        'Only tradeCargoCapacityOverride == 10 is currently supported '
+        'by trade_screen_test_support.',
+      );
+    }
+    resolvedFleets.add(
+      Fleet(
+        id: homeFleetIdFor(playerId),
+        ownerId: playerId,
+        regionId: 'oldWorld',
+        inPortAtProvinceId: kTradeTestCapitalProvinceId,
+        ships: const [
+          ShipInstance(id: 'h1', typeId: 'galleon'),
+          ShipInstance(id: 'h2', typeId: 'fluyte'),
+        ],
+      ),
+    );
+    if (resolvedOldWorld.provinces.isEmpty) {
+      resolvedOldWorld = const RegionData(
+        provinces: [
+          Province(
+            id: 'cap1',
+            regionId: 'oldWorld',
+            // ignore: avoid_hardcoded_strings_in_widgets
+            displayName: 'Capital',
+          ),
+        ],
+      );
+    }
+  }
+
+  return Game(
+    id: id,
+    worldState: WorldState(
+      turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+      oldWorld: resolvedOldWorld,
+      newWorld: newWorld,
+      fleets: resolvedFleets,
+    ),
+    turnTimeMapping: TurnTimeMapping.gdd01,
+    players:
+        players ??
+        [
+          Player(
+            id: playerId,
+            // ignore: avoid_hardcoded_strings_in_widgets
+            displayName: displayName,
+            isHuman: true,
+            treasury: treasury,
+            stockpile: Stockpile(
+              quantities: stockpile ?? const <CommodityId, int>{},
+            ),
+          ),
+        ],
+    diplomacyRelations: const [],
+    diplomaticHistoryEvents: const [],
+    dossierEvidenceEntries: const [],
+    worldMarketState:
+        worldMarketState ??
+        WorldMarketState(
+          prices: prices ?? const <CommodityId, int>{},
+          lastTurnActivity:
+              lastTurnActivity ?? const <CommodityId, MarketActivity>{},
+          carryForwardBidsByFactionId: carryForwardBids,
+          carryForwardOffersByFactionId: carryForwardOffers,
+        ),
+  );
+}
+
+/// Scaffold / 320 dp pin fixture — delegates to [buildTradePanelTestGame].
+Game buildTradeScaffoldTestGame() => buildTradePanelTestGame();
+
+/// Global-observe [ShellPlayerContext] matching `shellPlayerContextProvider`'s
+/// observe branch (hides player chrome → `ObserveModeNotDefinedPanel`).
+ShellPlayerContext tradeTestGlobalObserveShellContext() {
+  return const ShellPlayerContext(
+    effectiveHumanPlayerId: null,
+    viewingPlayerId: null,
+    mapVisibilityMode: CtMapVisibilityMode.full,
+    playerView: null,
+    omniscientDetail: true,
+    showPlayerChrome: false,
+    canMutateViaUi: false,
+    debugCommandTargetPlayerId: null,
+    inObservePhase: true,
+    // ignore: avoid_hardcoded_strings_in_widgets
+    observeBannerLabel: 'Observing: global',
+    treasuryNotDefined: true,
+    cargoNotDefined: true,
+  );
+}
+
+/// Per-player shell context for isolated TradeScreen pumps.
+ShellPlayerContext tradeTestShellPlayerContext({
+  required Player player,
+  bool canMutateViaUi = true,
+}) {
+  return ShellPlayerContext(
+    effectiveHumanPlayerId: player.id,
+    viewingPlayerId: player.id,
+    mapVisibilityMode: CtMapVisibilityMode.full,
+    playerView: null,
+    omniscientDetail: false,
+    showPlayerChrome: true,
+    canMutateViaUi: canMutateViaUi,
+    debugCommandTargetPlayerId: player.id,
+    inObservePhase: !canMutateViaUi,
+    // ignore: avoid_hardcoded_strings_in_widgets
+    observeBannerLabel: canMutateViaUi ? null : 'Observing',
+    treasuryNotDefined: false,
+    cargoNotDefined: false,
+  );
+}
+
+Player _humanOrFirst(Game game) {
+  return game.players.firstWhere(
+    (Player p) => p.isHuman,
+    orElse: () => game.players.first,
+  );
+}
+
+/// One-way pump (no container read-back). Optional [initialTabIndex] and
+/// [selectDealBookTab] cover E6/E7 Deal Book foregrounding.
+Future<void> pumpTradeScreen(
+  WidgetTester tester, {
+  required Game game,
+  Player? player,
+  Size? viewport,
+  int? initialTabIndex,
+  bool selectDealBookTab = false,
+  bool globalObserve = false,
+  bool canMutateViaUi = true,
+  List<Override> extraOverrides = const <Override>[],
+}) async {
+  final Player resolved = player ?? _humanOrFirst(game);
+  final TradeScreen screen = initialTabIndex == null
+      ? TradeScreen(game: game, player: resolved)
+      : TradeScreen(
+          game: game,
+          player: resolved,
+          initialTabIndex: initialTabIndex,
+        );
+  await pumpAppShell(
+    tester,
+    viewport: viewport,
+    overrides: [
+      currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
+      if (globalObserve)
+        shellPlayerContextProvider.overrideWithValue(
+          tradeTestGlobalObserveShellContext(),
+        )
+      else if (!canMutateViaUi)
+        shellPlayerContextProvider.overrideWith(
+          (ref) => tradeTestShellPlayerContext(
+            player: resolved,
+            canMutateViaUi: false,
+          ),
+        ),
+      ...extraOverrides,
+    ],
+    child: screen,
+  );
+  if (selectDealBookTab) {
+    final Finder dealBookLabel = find.descendant(
+      of: find.byType(CtTabStrip),
+      matching: find.text(TradeScreen.dealBookTabLabel),
+    );
+    expect(dealBookLabel, findsOneWidget);
+    await tester.tap(dealBookLabel);
+    await tester.pump();
+  }
+}
+
+/// Container-backed pump for suites that read `currentOrdersProvider` after
+/// taps. Registers `addTearDown(container.dispose)`.
+Future<ProviderContainer> pumpTradeScreenWithContainer(
+  WidgetTester tester, {
+  required Game game,
+  Player? player,
+  Orders initialOrders = const Orders(),
+  Size viewport = kTradeMarketTabViewport,
+  bool canMutateViaUi = true,
+  bool globalObserve = false,
+  List<Override> extraOverrides = const <Override>[],
+  Map<String, int> initialDesiredOutputByRecipe = const <String, int>{},
+  int? initialTabIndex,
+}) async {
+  final Player resolved = player ?? _humanOrFirst(game);
+  final ProviderContainer container = ProviderContainer(
+    overrides: [
+      currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
+      currentOrdersProvider.overrideWith(
+        () => CurrentOrdersNotifier(initialOrders),
+      ),
+      if (globalObserve)
+        shellPlayerContextProvider.overrideWithValue(
+          tradeTestGlobalObserveShellContext(),
+        )
+      else
+        shellPlayerContextProvider.overrideWith(
+          (ref) => tradeTestShellPlayerContext(
+            player: resolved,
+            canMutateViaUi: canMutateViaUi,
+          ),
+        ),
+      ...extraOverrides,
+    ],
+  );
+  addTearDown(container.dispose);
+  if (initialDesiredOutputByRecipe.isNotEmpty) {
+    container
+        .read(productionDesiredOutputProvider.notifier)
+        .replaceAll(initialDesiredOutputByRecipe);
+  }
+  final TradeScreen screen = initialTabIndex == null
+      ? TradeScreen(game: game, player: resolved)
+      : TradeScreen(
+          game: game,
+          player: resolved,
+          initialTabIndex: initialTabIndex,
+        );
+  await pumpAppShellWithContainer(
+    tester,
+    container: container,
+    viewport: viewport,
+    child: screen,
+  );
+  return container;
+}
+
+/// 320 dp / wide-viewport pin via [pumpAtMinViewport].
+Future<void> pumpTradeScreenAtMinViewport(
+  WidgetTester tester, {
+  required Size size,
+  required Game game,
+  Player? player,
+  bool globalObserve = false,
+}) async {
+  final Player resolved = player ?? _humanOrFirst(game);
+  await pumpAtMinViewport(
+    tester,
+    size: size,
+    overrides: [
+      currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
+      if (globalObserve)
+        shellPlayerContextProvider.overrideWithValue(
+          tradeTestGlobalObserveShellContext(),
+        ),
+    ],
+    child: TradeScreen(game: game, player: resolved),
+  );
+}

--- a/app/test/support/trade_screen_test_support_test.dart
+++ b/app/test/support/trade_screen_test_support_test.dart
@@ -1,0 +1,49 @@
+// Smoke tests for shared TradeScreen test hosts (Refs #3952).
+
+import 'package:colonizethis_app/config/themes.dart';
+import 'package:colonizethis_app/features/game/screens/trade/trade_screen.dart';
+import 'package:colonizethis_app/widgets/ct_top_bar.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'trade_screen_test_support.dart';
+
+void main() {
+  suppressLogsForTests();
+
+  testWidgets('pumpTradeScreen mounts TradeScreen under editorial-monocle', (
+    WidgetTester tester,
+  ) async {
+    await pumpTradeScreen(tester, game: buildTradeTestGame());
+
+    expect(find.byType(TradeScreen), findsOneWidget);
+    expect(find.byKey(TradeScreen.topBarKey), findsOneWidget);
+    final CtTopBar topBar = tester.widget<CtTopBar>(
+      find.byKey(TradeScreen.topBarKey),
+    );
+    expect(topBar.title, TradeScreen.topBarTitle);
+
+    final ThemeData observedTheme = Theme.of(
+      tester.element(find.byType(TradeScreen)),
+    );
+    expect(observedTheme.colorScheme, AppThemes.editorialMonocle.colorScheme);
+  });
+
+  testWidgets('pumpTradeScreenWithContainer returns a readable container', (
+    WidgetTester tester,
+  ) async {
+    final container = await pumpTradeScreenWithContainer(
+      tester,
+      game: buildTradeTestGame(treasury: 100),
+    );
+    expect(find.byType(TradeScreen), findsOneWidget);
+    expect(container.read, isNotNull);
+  });
+
+  test('buildTradeTestGame seeds cargo-10 home fleet when requested', () {
+    final game = buildTradeTestGame(tradeCargoCapacityOverride: 10);
+    expect(game.worldState.fleets, isNotEmpty);
+    expect(game.worldState.oldWorld.provinces, isNotEmpty);
+  });
+}

--- a/app/test/trade_screen_320dp_min_viewport_test.dart
+++ b/app/test/trade_screen_320dp_min_viewport_test.dart
@@ -42,20 +42,15 @@
 // coverage to).
 
 import 'package:colonizethis_app/config/constants.dart';
-import 'package:colonizethis_app/features/game/flame/region_map/region_map.dart'
-    show CtMapVisibilityMode;
 import 'package:colonizethis_app/features/game/screens/trade/trade_screen.dart';
-import 'package:colonizethis_app/features/game/widgets/shell/shell_player_context.dart';
 import 'package:colonizethis_app/features/game/widgets/panels/observe_mode_not_defined_panel.dart';
-import 'package:colonizethis_app/providers/games_provider.dart';
 import 'package:colonizethis_app/widgets/ct_top_bar.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'support/min_viewport_harness.dart';
-import 'support/panel_test_fixtures.dart';
+import 'support/trade_screen_test_support.dart';
 
 /// Minimum supported viewport dimensions for SPEC/ui/mobile-adaptation.md
 /// § 7. Width matches [kMinViewportWidth]; height (640 dp) mirrors the
@@ -70,66 +65,6 @@ const Size _kMinViewport = Size(kMinViewportWidth, 640);
 /// `unit_panels_320dp_min_viewport_test.dart`.
 const Size _kWideRegressionViewport = Size(1024, 768);
 
-/// Builds a [ShellPlayerContext] mirroring the global-observe branch
-/// surfaced by `shellPlayerContextProvider`. Mirrors the helper used by
-/// `trade_screen_scaffold_test.dart` so the observe pin exercises the
-/// same path the in-app observe session takes.
-ShellPlayerContext _globalObserveShellContext() {
-  return const ShellPlayerContext(
-    effectiveHumanPlayerId: null,
-    viewingPlayerId: null,
-    mapVisibilityMode: CtMapVisibilityMode.full,
-    playerView: null,
-    omniscientDetail: true,
-    // `showPlayerChrome: false` flips `shellPanelsNotDefined(ref)` to
-    // true so `TradeScreen.bodyBuilder` short-circuits to the
-    // `ObserveModeNotDefinedPanel` sentinel per SPEC/ui/observe-mode.md.
-    showPlayerChrome: false,
-    canMutateViaUi: false,
-    debugCommandTargetPlayerId: null,
-    inObservePhase: true,
-    // ignore: avoid_hardcoded_strings_in_widgets
-    observeBannerLabel: 'Observing: global',
-    treasuryNotDefined: true,
-    cargoNotDefined: true,
-  );
-}
-
-/// Pumps the [TradeScreen] at [size] under the running editorial-monocle
-/// theme. Sets the surface size (so the binding's render flex math sees
-/// the minimum viewport) and overrides MediaQuery so widget code that
-/// reads `MediaQuery.sizeOf(context).width` resolves to the same value
-/// — the pattern already used by every other `*_320dp_min_viewport_test.dart`
-/// file. Overrides `currentGameProvider` (and optionally
-/// `shellPlayerContextProvider` for the global-observe branch) so the
-/// shell renders without touching Hive / GameService.
-Future<void> _pumpTradeScreen(
-  WidgetTester tester, {
-  required Size size,
-  required Game game,
-  required Player player,
-  bool globalObserve = false,
-}) async {
-  // Single pump (the harness default) is enough: TradeScreen's chrome
-  // paints synchronously and the placeholder body is a single static
-  // `CtPanel`. We avoid `pumpAndSettle` because
-  // `CtGameFeatureScreenShell`'s bus listener attaches per the live
-  // `currentGameProvider` and we want the 320 dp overflow assertion to
-  // evaluate on the first frame.
-  await pumpAtMinViewport(
-    tester,
-    size: size,
-    overrides: [
-      currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
-      if (globalObserve)
-        shellPlayerContextProvider.overrideWithValue(
-          _globalObserveShellContext(),
-        ),
-    ],
-    child: TradeScreen(game: game, player: player),
-  );
-}
-
 void main() {
   suppressLogsForTests();
 
@@ -141,165 +76,151 @@ void main() {
     // (for the supplied `player`), the static `CommodityCatalog` for the market
     // table, and a default-empty `WorldMarketState` for the Deal Book — no
     // generated map/topology data — so the procedural map generator is avoided.
-    game = buildTradePanelTestGame();
+    game = buildTradeScaffoldTestGame();
     humanPlayer = game.players.firstWhere(
       (p) => p.isHuman,
       orElse: () => game.players.first,
     );
   });
 
-  group(
-    'SPEC/ui/mobile-adaptation.md § 7 — TradeScreen (default) @ 320 dp '
-    '(Refs #2870 S10, #2993)',
-    () {
-      testWidgets(
-        'AC (positive) TradeScreen default @ 320×640: no RenderFlex '
+  group('SPEC/ui/mobile-adaptation.md § 7 — TradeScreen (default) @ 320 dp '
+      '(Refs #2870 S10, #2993)', () {
+    testWidgets('AC (positive) TradeScreen default @ 320×640: no RenderFlex '
         'overflow exception, dark CtTopBar (title `Trade`, back label '
-        '`Map`) + scaffold placeholder body both render',
-        (WidgetTester tester) async {
-          await _pumpTradeScreen(
-            tester,
-            size: _kMinViewport,
-            game: game,
-            player: humanPlayer,
-          );
-
-          expect(
-            tester.takeException(),
-            isNull,
-            reason:
-                'SPEC/ui/mobile-adaptation.md § 7: TradeScreen must not '
-                'emit a RenderFlex overflow exception at '
-                'kMinViewportWidth (320 dp). The dark CtTopBar '
-                '(36 dp tall — back chevron + `Map` label + 18 × 18 px '
-                'trade icon + `Trade` title) above the two-tab body '
-                '(`CtPanel` hosting `CtTabStrip` with Market + Deal Book '
-                'placeholder bodies) must lay out within the 320 dp column.',
-          );
-
-          final topBarFinder = find.byKey(TradeScreen.topBarKey);
-          expect(topBarFinder, findsOneWidget);
-          final CtTopBar topBar = tester.widget<CtTopBar>(topBarFinder);
-          expect(topBar.title, TradeScreen.topBarTitle);
-          expect(topBar.backButtonLabel, TradeScreen.topBarBackLabel);
-
-          expect(
-            find.byKey(TradeScreen.tabsBodyKey),
-            findsOneWidget,
-            reason:
-                'Default (non-observe) path must mount the two-tab body '
-                'keyed `tradeScreenTabsBody` at 320 dp. '
-                'SPEC/ui/trade-screen.md § Body (current scaffold).',
-          );
-          expect(
-            find.byType(ObserveModeNotDefinedPanel),
-            findsNothing,
-            reason:
-                'Default path must NOT render the observe sentinel — '
-                'that is the global-observe variant covered by the '
-                'second group below.',
-          );
-        },
+        '`Map`) + scaffold placeholder body both render', (
+      WidgetTester tester,
+    ) async {
+      await pumpTradeScreenAtMinViewport(
+        tester,
+        size: _kMinViewport,
+        game: game,
+        player: humanPlayer,
       );
 
-      testWidgets(
-        'Negative control: TradeScreen default @ 1024×768 also pumps '
+      expect(
+        tester.takeException(),
+        isNull,
+        reason:
+            'SPEC/ui/mobile-adaptation.md § 7: TradeScreen must not '
+            'emit a RenderFlex overflow exception at '
+            'kMinViewportWidth (320 dp). The dark CtTopBar '
+            '(36 dp tall — back chevron + `Map` label + 18 × 18 px '
+            'trade icon + `Trade` title) above the two-tab body '
+            '(`CtPanel` hosting `CtTabStrip` with Market + Deal Book '
+            'placeholder bodies) must lay out within the 320 dp column.',
+      );
+
+      final topBarFinder = find.byKey(TradeScreen.topBarKey);
+      expect(topBarFinder, findsOneWidget);
+      final CtTopBar topBar = tester.widget<CtTopBar>(topBarFinder);
+      expect(topBar.title, TradeScreen.topBarTitle);
+      expect(topBar.backButtonLabel, TradeScreen.topBarBackLabel);
+
+      expect(
+        find.byKey(TradeScreen.tabsBodyKey),
+        findsOneWidget,
+        reason:
+            'Default (non-observe) path must mount the two-tab body '
+            'keyed `tradeScreenTabsBody` at 320 dp. '
+            'SPEC/ui/trade-screen.md § Body (current scaffold).',
+      );
+      expect(
+        find.byType(ObserveModeNotDefinedPanel),
+        findsNothing,
+        reason:
+            'Default path must NOT render the observe sentinel — '
+            'that is the global-observe variant covered by the '
+            'second group below.',
+      );
+    });
+
+    testWidgets('Negative control: TradeScreen default @ 1024×768 also pumps '
         'without exception (regression sentinel for the overflow '
-        'contract — keeps the 320 dp positive pin meaningful)',
-        (WidgetTester tester) async {
-          await _pumpTradeScreen(
-            tester,
-            size: _kWideRegressionViewport,
-            game: game,
-            player: humanPlayer,
-          );
-
-          expect(tester.takeException(), isNull);
-          expect(find.byKey(TradeScreen.topBarKey), findsOneWidget);
-          expect(find.byKey(TradeScreen.tabsBodyKey), findsOneWidget);
-        },
+        'contract — keeps the 320 dp positive pin meaningful)', (
+      WidgetTester tester,
+    ) async {
+      await pumpTradeScreenAtMinViewport(
+        tester,
+        size: _kWideRegressionViewport,
+        game: game,
+        player: humanPlayer,
       );
-    },
-  );
 
-  group(
-    'SPEC/ui/mobile-adaptation.md § 7 — TradeScreen (global observe) @ '
-    '320 dp (Refs #2870 S10, #2993)',
-    () {
-      testWidgets(
-        'AC (positive) TradeScreen global-observe @ 320×640: no '
+      expect(tester.takeException(), isNull);
+      expect(find.byKey(TradeScreen.topBarKey), findsOneWidget);
+      expect(find.byKey(TradeScreen.tabsBodyKey), findsOneWidget);
+    });
+  });
+
+  group('SPEC/ui/mobile-adaptation.md § 7 — TradeScreen (global observe) @ '
+      '320 dp (Refs #2870 S10, #2993)', () {
+    testWidgets('AC (positive) TradeScreen global-observe @ 320×640: no '
         'RenderFlex overflow exception, dark CtTopBar still paints, '
         'ObserveModeNotDefinedPanel sentinel renders, scaffold '
-        'placeholder body is absent',
-        (WidgetTester tester) async {
-          await _pumpTradeScreen(
-            tester,
-            size: _kMinViewport,
-            game: game,
-            player: humanPlayer,
-            globalObserve: true,
-          );
-
-          expect(
-            tester.takeException(),
-            isNull,
-            reason:
-                'SPEC/ui/mobile-adaptation.md § 7: TradeScreen global-'
-                'observe body must not emit a RenderFlex overflow '
-                'exception at kMinViewportWidth (320 dp). The dark '
-                'CtTopBar plus the `ObserveModeNotDefinedPanel(title: '
-                "'Trade')` sentinel must lay out within the 320 dp "
-                'column.',
-          );
-
-          expect(
-            find.byKey(TradeScreen.topBarKey),
-            findsOneWidget,
-            reason:
-                'Observe override only swaps the body (see SPEC/ui/'
-                'trade-screen.md § States and variants); the dark '
-                'CtTopBar must still paint so the AC for the chrome '
-                'is exercised at 320 dp under both variants.',
-          );
-
-          final observePanelFinder = find.byType(ObserveModeNotDefinedPanel);
-          expect(observePanelFinder, findsOneWidget);
-          final ObserveModeNotDefinedPanel observePanel = tester
-              .widget<ObserveModeNotDefinedPanel>(observePanelFinder);
-          // SPEC/ui/trade-screen.md § States and variants requires the
-          // literal localized `Trade` title under the observe sentinel.
-          // ignore: avoid_hardcoded_strings_in_widgets
-          expect(observePanel.title, 'Trade');
-
-          expect(
-            find.byKey(TradeScreen.tabsBodyKey),
-            findsNothing,
-            reason:
-                'Global-observe path MUST NOT mount the tabs body — '
-                'SPEC/ui/trade-screen.md § States and variants reserves '
-                'the observe sentinel for that branch.',
-          );
-        },
+        'placeholder body is absent', (WidgetTester tester) async {
+      await pumpTradeScreenAtMinViewport(
+        tester,
+        size: _kMinViewport,
+        game: game,
+        player: humanPlayer,
+        globalObserve: true,
       );
 
-      testWidgets(
-        'Negative control: TradeScreen global-observe @ 1024×768 also '
+      expect(
+        tester.takeException(),
+        isNull,
+        reason:
+            'SPEC/ui/mobile-adaptation.md § 7: TradeScreen global-'
+            'observe body must not emit a RenderFlex overflow '
+            'exception at kMinViewportWidth (320 dp). The dark '
+            'CtTopBar plus the `ObserveModeNotDefinedPanel(title: '
+            "'Trade')` sentinel must lay out within the 320 dp "
+            'column.',
+      );
+
+      expect(
+        find.byKey(TradeScreen.topBarKey),
+        findsOneWidget,
+        reason:
+            'Observe override only swaps the body (see SPEC/ui/'
+            'trade-screen.md § States and variants); the dark '
+            'CtTopBar must still paint so the AC for the chrome '
+            'is exercised at 320 dp under both variants.',
+      );
+
+      final observePanelFinder = find.byType(ObserveModeNotDefinedPanel);
+      expect(observePanelFinder, findsOneWidget);
+      final ObserveModeNotDefinedPanel observePanel = tester
+          .widget<ObserveModeNotDefinedPanel>(observePanelFinder);
+      // SPEC/ui/trade-screen.md § States and variants requires the
+      // literal localized `Trade` title under the observe sentinel.
+      // ignore: avoid_hardcoded_strings_in_widgets
+      expect(observePanel.title, 'Trade');
+
+      expect(
+        find.byKey(TradeScreen.tabsBodyKey),
+        findsNothing,
+        reason:
+            'Global-observe path MUST NOT mount the tabs body — '
+            'SPEC/ui/trade-screen.md § States and variants reserves '
+            'the observe sentinel for that branch.',
+      );
+    });
+
+    testWidgets('Negative control: TradeScreen global-observe @ 1024×768 also '
         'pumps without exception (regression sentinel for the overflow '
-        'contract under the observe variant)',
-        (WidgetTester tester) async {
-          await _pumpTradeScreen(
-            tester,
-            size: _kWideRegressionViewport,
-            game: game,
-            player: humanPlayer,
-            globalObserve: true,
-          );
-
-          expect(tester.takeException(), isNull);
-          expect(find.byKey(TradeScreen.topBarKey), findsOneWidget);
-          expect(find.byType(ObserveModeNotDefinedPanel), findsOneWidget);
-        },
+        'contract under the observe variant)', (WidgetTester tester) async {
+      await pumpTradeScreenAtMinViewport(
+        tester,
+        size: _kWideRegressionViewport,
+        game: game,
+        player: humanPlayer,
+        globalObserve: true,
       );
-    },
-  );
+
+      expect(tester.takeException(), isNull);
+      expect(find.byKey(TradeScreen.topBarKey), findsOneWidget);
+      expect(find.byType(ObserveModeNotDefinedPanel), findsOneWidget);
+    });
+  });
 }

--- a/app/test/trade_screen_deal_book_tab_e6_test.dart
+++ b/app/test/trade_screen_deal_book_tab_e6_test.dart
@@ -21,73 +21,24 @@
 //    so the player can audit why a deal cleared.
 
 import 'package:colonizethis_app/features/game/screens/trade/trade_screen.dart';
-import 'package:colonizethis_app/providers/games_provider.dart';
-import 'package:colonizethis_app/widgets/ct_tab_strip.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'support/app_shell_harness.dart';
+import 'support/trade_screen_test_support.dart';
 
-/// Synthetic [Game] with the human player `gp_h` and a foreign GP
-/// `gp_a` used to prove player isolation in the ledger filter. The
-/// `worldMarketState` is fully caller-controlled so each test pins the
-/// scenario it cares about (filled deals, carry-forwards, empties).
-Game _buildGame({
-  Map<CommodityId, MarketActivity> activity = const <CommodityId, MarketActivity>{},
-  Map<String, List<TradeOrder>> carryForwardBids =
-      const <String, List<TradeOrder>>{},
-  Map<String, List<TradeOrder>> carryForwardOffers =
-      const <String, List<TradeOrder>>{},
-}) {
-  return Game(
-    id: 'test_trade_screen_deal_book_e6',
-    worldState: WorldState(
-      turnState: TurnState(phase: TurnPhase.orders, turnNumber: 1),
-      oldWorld: const RegionData(),
-      newWorld: const RegionData(),
-    ),
-    turnTimeMapping: TurnTimeMapping.gdd01,
-    players: [
-      // ignore: avoid_hardcoded_strings_in_widgets
-      Player(id: 'gp_h', displayName: 'England', isHuman: true, treasury: 500),
-      // ignore: avoid_hardcoded_strings_in_widgets
-      Player(id: 'gp_a', displayName: 'Aragon', isHuman: false, treasury: 500),
-    ],
-    diplomacyRelations: const [],
-    diplomaticHistoryEvents: const [],
-    dossierEvidenceEntries: const [],
-    worldMarketState: WorldMarketState(
-      prices: const <CommodityId, int>{},
-      lastTurnActivity: activity,
-      carryForwardOffersByFactionId: carryForwardOffers,
-      carryForwardBidsByFactionId: carryForwardBids,
-    ),
-  );
-}
-
-Future<void> _pumpDealBookTab(
-  WidgetTester tester, {
-  required Game game,
-}) async {
-  final Player player = game.players.firstWhere((p) => p.isHuman);
-  await pumpAppShell(
-    tester,
-    overrides: [
-      currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
-    ],
-    child: TradeScreen(game: game, player: player),
-  );
-  // Tab into the Deal Book tab so the live content is foregrounded.
-  final dealBookLabel = find.descendant(
-    of: find.byType(CtTabStrip),
-    matching: find.text(TradeScreen.dealBookTabLabel),
-  );
-  expect(dealBookLabel, findsOneWidget);
-  await tester.tap(dealBookLabel);
-  await tester.pump();
-}
+const List<Player> _players = <Player>[
+  // ignore: avoid_hardcoded_strings_in_widgets
+  Player(
+    id: kTradeTestHumanPlayerId,
+    displayName: 'England',
+    isHuman: true,
+    treasury: 500,
+  ),
+  // ignore: avoid_hardcoded_strings_in_widgets
+  Player(id: 'gp_a', displayName: 'Aragon', isHuman: false, treasury: 500),
+];
 
 void main() {
   suppressLogsForTests();
@@ -97,35 +48,24 @@ void main() {
       'empty state: panels show empty copy and totals read 0 when the '
       'player has no filled deals and no carry-forwards',
       (tester) async {
-        await _pumpDealBookTab(tester, game: _buildGame());
+        await pumpTradeScreen(
+          tester,
+          game: buildTradeTestGame(players: _players),
+          selectDealBookTab: true,
+        );
 
         // Both empty-state keys are mounted because both filled and
         // unfilled lists are empty per side.
-        expect(
-          find.byKey(TradeScreen.dealBookBidsEmptyKey),
-          findsOneWidget,
-        );
-        expect(
-          find.byKey(TradeScreen.dealBookOffersEmptyKey),
-          findsOneWidget,
-        );
+        expect(find.byKey(TradeScreen.dealBookBidsEmptyKey), findsOneWidget);
+        expect(find.byKey(TradeScreen.dealBookOffersEmptyKey), findsOneWidget);
         // Empty-state copy renders the per-side literal.
-        expect(
-          find.text(TradeScreen.dealBookBidsEmptyText),
-          findsOneWidget,
-        );
-        expect(
-          find.text(TradeScreen.dealBookOffersEmptyText),
-          findsOneWidget,
-        );
+        expect(find.text(TradeScreen.dealBookBidsEmptyText), findsOneWidget);
+        expect(find.text(TradeScreen.dealBookOffersEmptyText), findsOneWidget);
         // Totals rows are always mounted and render 0 in the empty case.
         final bidsTotals = tester.widget<Text>(
           find.byKey(TradeScreen.dealBookBidsTotalsKey),
         );
-        expect(
-          bidsTotals.data,
-          '${TradeScreen.dealBookTotalSpentLabel}: 0',
-        );
+        expect(bidsTotals.data, '${TradeScreen.dealBookTotalSpentLabel}: 0');
         final offersTotals = tester.widget<Text>(
           find.byKey(TradeScreen.dealBookOffersTotalsKey),
         );
@@ -140,8 +80,9 @@ void main() {
       'filled bid row floors legacy fractional pricePerUnit to integer '
       'display (Refs #3093)',
       (tester) async {
-        final game = _buildGame(
-          activity: const <CommodityId, MarketActivity>{
+        final game = buildTradeTestGame(
+          players: _players,
+          lastTurnActivity: const <CommodityId, MarketActivity>{
             'timber': MarketActivity(
               totalBidQuantity: 5,
               totalOfferQuantity: 5,
@@ -158,17 +99,14 @@ void main() {
             ),
           },
         );
-        await _pumpDealBookTab(tester, game: game);
+        await pumpTradeScreen(tester, game: game, selectDealBookTab: true);
 
         // ignore: avoid_hardcoded_strings_in_widgets
         expect(find.text('timber — qty 5 × 30 = 150'), findsOneWidget);
         final bidsTotals = tester.widget<Text>(
           find.byKey(TradeScreen.dealBookBidsTotalsKey),
         );
-        expect(
-          bidsTotals.data,
-          '${TradeScreen.dealBookTotalSpentLabel}: 150',
-        );
+        expect(bidsTotals.data, '${TradeScreen.dealBookTotalSpentLabel}: 150');
       },
     );
 
@@ -176,8 +114,9 @@ void main() {
       'filled bid (player == buyer) renders with notional and contributes '
       'to the bids panel total spent; unrelated deal is excluded',
       (tester) async {
-        final game = _buildGame(
-          activity: const <CommodityId, MarketActivity>{
+        final game = buildTradeTestGame(
+          players: _players,
+          lastTurnActivity: const <CommodityId, MarketActivity>{
             'timber': MarketActivity(
               totalBidQuantity: 5,
               totalOfferQuantity: 5,
@@ -211,33 +150,24 @@ void main() {
             ),
           },
         );
-        await _pumpDealBookTab(tester, game: game);
+        await pumpTradeScreen(tester, game: game, selectDealBookTab: true);
 
         // The bids panel has exactly one filled row keyed at index 0
         // (the timber buy), and the empty-state key is absent because
         // the panel is no longer empty.
         expect(
           find.byKey(
-            TradeScreen.dealBookFilledRowKey(
-              TradeScreen.dealBookSideBids,
-              0,
-            ),
+            TradeScreen.dealBookFilledRowKey(TradeScreen.dealBookSideBids, 0),
           ),
           findsOneWidget,
         );
         expect(
           find.byKey(
-            TradeScreen.dealBookFilledRowKey(
-              TradeScreen.dealBookSideBids,
-              1,
-            ),
+            TradeScreen.dealBookFilledRowKey(TradeScreen.dealBookSideBids, 1),
           ),
           findsNothing,
         );
-        expect(
-          find.byKey(TradeScreen.dealBookBidsEmptyKey),
-          findsNothing,
-        );
+        expect(find.byKey(TradeScreen.dealBookBidsEmptyKey), findsNothing);
 
         // Row text encodes quantity × price = notional and uses the
         // commodity id as the leading label per the SPEC E6 contract.
@@ -249,17 +179,11 @@ void main() {
         final bidsTotals = tester.widget<Text>(
           find.byKey(TradeScreen.dealBookBidsTotalsKey),
         );
-        expect(
-          bidsTotals.data,
-          '${TradeScreen.dealBookTotalSpentLabel}: 150',
-        );
+        expect(bidsTotals.data, '${TradeScreen.dealBookTotalSpentLabel}: 150');
 
         // The offers panel stays empty (the player did not sell
         // anything this turn).
-        expect(
-          find.byKey(TradeScreen.dealBookOffersEmptyKey),
-          findsOneWidget,
-        );
+        expect(find.byKey(TradeScreen.dealBookOffersEmptyKey), findsOneWidget);
         final offersTotals = tester.widget<Text>(
           find.byKey(TradeScreen.dealBookOffersTotalsKey),
         );
@@ -275,8 +199,9 @@ void main() {
       'into the total received; multiple deals across commodities tally '
       'a combined total',
       (tester) async {
-        final game = _buildGame(
-          activity: const <CommodityId, MarketActivity>{
+        final game = buildTradeTestGame(
+          players: _players,
+          lastTurnActivity: const <CommodityId, MarketActivity>{
             'timber': MarketActivity(
               totalBidQuantity: 7,
               totalOfferQuantity: 7,
@@ -307,25 +232,19 @@ void main() {
             ),
           },
         );
-        await _pumpDealBookTab(tester, game: game);
+        await pumpTradeScreen(tester, game: game, selectDealBookTab: true);
 
         // Both filled rows render in the offers panel (indices 0 and 1
         // in encounter order — ordered by lastTurnActivity map iteration).
         expect(
           find.byKey(
-            TradeScreen.dealBookFilledRowKey(
-              TradeScreen.dealBookSideOffers,
-              0,
-            ),
+            TradeScreen.dealBookFilledRowKey(TradeScreen.dealBookSideOffers, 0),
           ),
           findsOneWidget,
         );
         expect(
           find.byKey(
-            TradeScreen.dealBookFilledRowKey(
-              TradeScreen.dealBookSideOffers,
-              1,
-            ),
+            TradeScreen.dealBookFilledRowKey(TradeScreen.dealBookSideOffers, 1),
           ),
           findsOneWidget,
         );
@@ -340,10 +259,7 @@ void main() {
         );
 
         // The bids panel stays empty because the player did not buy.
-        expect(
-          find.byKey(TradeScreen.dealBookBidsEmptyKey),
-          findsOneWidget,
-        );
+        expect(find.byKey(TradeScreen.dealBookBidsEmptyKey), findsOneWidget);
       },
     );
 
@@ -351,7 +267,8 @@ void main() {
       'carry-forward bids render in the bids panel and do NOT contribute '
       'to the total spent (they have not cleared)',
       (tester) async {
-        final game = _buildGame(
+        final game = buildTradeTestGame(
+          players: _players,
           carryForwardBids: <String, List<TradeOrder>>{
             'gp_h': <TradeOrder>[
               TradeOrder(
@@ -363,30 +280,21 @@ void main() {
             ],
           },
         );
-        await _pumpDealBookTab(tester, game: game);
+        await pumpTradeScreen(tester, game: game, selectDealBookTab: true);
 
         // Unfilled row keyed under the bids side.
         expect(
           find.byKey(
-            TradeScreen.dealBookUnfilledRowKey(
-              TradeScreen.dealBookSideBids,
-              0,
-            ),
+            TradeScreen.dealBookUnfilledRowKey(TradeScreen.dealBookSideBids, 0),
           ),
           findsOneWidget,
         );
         // ignore: avoid_hardcoded_strings_in_widgets
-        expect(
-          find.text('timber — qty 8 (priority 2)'),
-          findsOneWidget,
-        );
+        expect(find.text('timber — qty 8 (priority 2)'), findsOneWidget);
         // No filled row pinned for the bids side.
         expect(
           find.byKey(
-            TradeScreen.dealBookFilledRowKey(
-              TradeScreen.dealBookSideBids,
-              0,
-            ),
+            TradeScreen.dealBookFilledRowKey(TradeScreen.dealBookSideBids, 0),
           ),
           findsNothing,
         );
@@ -394,20 +302,11 @@ void main() {
         final bidsTotals = tester.widget<Text>(
           find.byKey(TradeScreen.dealBookBidsTotalsKey),
         );
-        expect(
-          bidsTotals.data,
-          '${TradeScreen.dealBookTotalSpentLabel}: 0',
-        );
+        expect(bidsTotals.data, '${TradeScreen.dealBookTotalSpentLabel}: 0');
         // Bids panel is no longer empty (carry-forward populates it).
-        expect(
-          find.byKey(TradeScreen.dealBookBidsEmptyKey),
-          findsNothing,
-        );
+        expect(find.byKey(TradeScreen.dealBookBidsEmptyKey), findsNothing);
         // Offers panel still empty.
-        expect(
-          find.byKey(TradeScreen.dealBookOffersEmptyKey),
-          findsOneWidget,
-        );
+        expect(find.byKey(TradeScreen.dealBookOffersEmptyKey), findsOneWidget);
       },
     );
 
@@ -415,7 +314,8 @@ void main() {
       'carry-forward offers render in the offers panel; per-side filter '
       'isolation: another player\'s carry-forwards never appear',
       (tester) async {
-        final game = _buildGame(
+        final game = buildTradeTestGame(
+          players: _players,
           carryForwardOffers: <String, List<TradeOrder>>{
             'gp_h': <TradeOrder>[
               TradeOrder(
@@ -443,7 +343,7 @@ void main() {
             ],
           },
         );
-        await _pumpDealBookTab(tester, game: game);
+        await pumpTradeScreen(tester, game: game, selectDealBookTab: true);
 
         // Two carry-forward rows from gp_h scoped to the offers side.
         expect(
@@ -474,8 +374,9 @@ void main() {
       'FRR / FTP tags render on filled rows when the matcher annotated '
       'the deal so players can audit how a fill cleared',
       (tester) async {
-        final game = _buildGame(
-          activity: const <CommodityId, MarketActivity>{
+        final game = buildTradeTestGame(
+          players: _players,
+          lastTurnActivity: const <CommodityId, MarketActivity>{
             'timber': MarketActivity(
               totalBidQuantity: 6,
               totalOfferQuantity: 6,
@@ -502,24 +403,18 @@ void main() {
             ),
           },
         );
-        await _pumpDealBookTab(tester, game: game);
+        await pumpTradeScreen(tester, game: game, selectDealBookTab: true);
 
         // Both deals appear as filled bid rows for the human player.
         expect(
           find.byKey(
-            TradeScreen.dealBookFilledRowKey(
-              TradeScreen.dealBookSideBids,
-              0,
-            ),
+            TradeScreen.dealBookFilledRowKey(TradeScreen.dealBookSideBids, 0),
           ),
           findsOneWidget,
         );
         expect(
           find.byKey(
-            TradeScreen.dealBookFilledRowKey(
-              TradeScreen.dealBookSideBids,
-              1,
-            ),
+            TradeScreen.dealBookFilledRowKey(TradeScreen.dealBookSideBids, 1),
           ),
           findsOneWidget,
         );
@@ -533,51 +428,51 @@ void main() {
         final bidsTotals = tester.widget<Text>(
           find.byKey(TradeScreen.dealBookBidsTotalsKey),
         );
-        expect(
-          bidsTotals.data,
-          '${TradeScreen.dealBookTotalSpentLabel}: 180',
-        );
+        expect(bidsTotals.data, '${TradeScreen.dealBookTotalSpentLabel}: 180');
       },
     );
 
-    testWidgets(
-      'side-by-side layout: when the viewport is at least '
-      'dealBookTwoPanelMinWidth (600 dp) wide, the bids panel sits to '
-      'the left of the offers panel',
-      (tester) async {
-        // 700 dp wide × 800 dp tall — wider than the 600 dp threshold.
-        tester.view.physicalSize = const Size(700 * 3, 800 * 3);
-        tester.view.devicePixelRatio = 3.0;
-        addTearDown(() {
-          tester.view.resetPhysicalSize();
-          tester.view.resetDevicePixelRatio();
-        });
+    testWidgets('side-by-side layout: when the viewport is at least '
+        'dealBookTwoPanelMinWidth (600 dp) wide, the bids panel sits to '
+        'the left of the offers panel', (tester) async {
+      // 700 dp wide × 800 dp tall — wider than the 600 dp threshold.
+      tester.view.physicalSize = const Size(700 * 3, 800 * 3);
+      tester.view.devicePixelRatio = 3.0;
+      addTearDown(() {
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      });
 
-        await _pumpDealBookTab(tester, game: _buildGame());
+      await pumpTradeScreen(
+        tester,
+        game: buildTradeTestGame(players: _players),
+        selectDealBookTab: true,
+      );
 
-        final Offset bidsTopLeft =
-            tester.getTopLeft(find.byKey(TradeScreen.dealBookBidsPanelKey));
-        final Offset offersTopLeft =
-            tester.getTopLeft(find.byKey(TradeScreen.dealBookOffersPanelKey));
+      final Offset bidsTopLeft = tester.getTopLeft(
+        find.byKey(TradeScreen.dealBookBidsPanelKey),
+      );
+      final Offset offersTopLeft = tester.getTopLeft(
+        find.byKey(TradeScreen.dealBookOffersPanelKey),
+      );
 
-        expect(
-          offersTopLeft.dx,
-          greaterThan(bidsTopLeft.dx),
-          reason:
-              'SPEC/ui/trade-screen.md § Body — Deal Book tab pins the '
-              'bids panel to the left of the offers panel when the '
-              'viewport meets the dealBookTwoPanelMinWidth threshold.',
-        );
-        // Same baseline Y so the panels read as a single row.
-        expect(
-          offersTopLeft.dy,
-          equals(bidsTopLeft.dy),
-          reason:
-              'Two-panel mode aligns the bids and offers panels at the '
-              'same top so the ledger reads as one row.',
-        );
-      },
-    );
+      expect(
+        offersTopLeft.dx,
+        greaterThan(bidsTopLeft.dx),
+        reason:
+            'SPEC/ui/trade-screen.md § Body — Deal Book tab pins the '
+            'bids panel to the left of the offers panel when the '
+            'viewport meets the dealBookTwoPanelMinWidth threshold.',
+      );
+      // Same baseline Y so the panels read as a single row.
+      expect(
+        offersTopLeft.dy,
+        equals(bidsTopLeft.dy),
+        reason:
+            'Two-panel mode aligns the bids and offers panels at the '
+            'same top so the ledger reads as one row.',
+      );
+    });
 
     testWidgets(
       'stacked layout: at the 320 dp minimum viewport the offers panel '
@@ -592,14 +487,20 @@ void main() {
           tester.view.resetDevicePixelRatio();
         });
 
-        await _pumpDealBookTab(tester, game: _buildGame());
+        await pumpTradeScreen(
+          tester,
+          game: buildTradeTestGame(players: _players),
+          selectDealBookTab: true,
+        );
 
         expect(tester.takeException(), isNull);
 
-        final Offset bidsTopLeft =
-            tester.getTopLeft(find.byKey(TradeScreen.dealBookBidsPanelKey));
-        final Offset offersTopLeft =
-            tester.getTopLeft(find.byKey(TradeScreen.dealBookOffersPanelKey));
+        final Offset bidsTopLeft = tester.getTopLeft(
+          find.byKey(TradeScreen.dealBookBidsPanelKey),
+        );
+        final Offset offersTopLeft = tester.getTopLeft(
+          find.byKey(TradeScreen.dealBookOffersPanelKey),
+        );
         expect(
           offersTopLeft.dy,
           greaterThan(bidsTopLeft.dy),

--- a/app/test/trade_screen_initial_tab_index_e7_test.dart
+++ b/app/test/trade_screen_initial_tab_index_e7_test.dart
@@ -21,49 +21,14 @@
 import 'package:colonizethis_app/features/game/screens/trade/trade_screen.dart';
 import 'package:colonizethis_app/widgets/ct_tab_strip.dart';
 import 'package:widgetbook_host/catalogs/catalog.dart';
-import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:widgetbook/widgetbook.dart' show WidgetbookFolder, WidgetbookUseCase;
+import 'package:widgetbook/widgetbook.dart'
+    show WidgetbookFolder, WidgetbookUseCase;
 
 import 'support/app_shell_harness.dart';
-
-Game _buildGameForTradeScreen() {
-  return Game(
-    id: 'test_trade_screen_e7',
-    worldState: WorldState(
-      turnState: TurnState(phase: TurnPhase.orders, turnNumber: 1),
-      oldWorld: const RegionData(),
-      newWorld: const RegionData(),
-    ),
-    turnTimeMapping: TurnTimeMapping.gdd01,
-    players: [
-      // ignore: avoid_hardcoded_strings_in_widgets
-      Player(id: 'gp_h', displayName: 'England', isHuman: true, treasury: 500),
-    ],
-    diplomacyRelations: const [],
-    diplomaticHistoryEvents: const [],
-    dossierEvidenceEntries: const [],
-    worldMarketState: const WorldMarketState(),
-  );
-}
-
-Future<void> _pumpTradeScreen(
-  WidgetTester tester, {
-  required Game game,
-  int? initialTabIndex,
-}) async {
-  final Player player = game.players.firstWhere((p) => p.isHuman);
-  final TradeScreen screen = initialTabIndex == null
-      ? TradeScreen(game: game, player: player)
-      : TradeScreen(
-          game: game,
-          player: player,
-          initialTabIndex: initialTabIndex,
-        );
-  await pumpAppShell(tester, child: screen);
-}
+import 'support/trade_screen_test_support.dart';
 
 void main() {
   suppressLogsForTests();
@@ -73,28 +38,19 @@ void main() {
       'initialTabIndex: 1 foregrounds the Deal Book tab body on first '
       'frame without simulating a label tap',
       (tester) async {
-        await _pumpTradeScreen(
+        await pumpTradeScreen(
           tester,
-          game: _buildGameForTradeScreen(),
+          game: buildTradeTestGame(id: 'test_trade_screen_e7'),
           initialTabIndex: 1,
         );
 
         // Foregrounded (visible) on first frame: Deal Book body.
-        expect(
-          find.byKey(TradeScreen.dealBookTabBodyKey),
-          findsOneWidget,
-        );
-        expect(
-          find.byKey(TradeScreen.dealBookContentKey),
-          findsOneWidget,
-        );
+        expect(find.byKey(TradeScreen.dealBookTabBodyKey), findsOneWidget);
+        expect(find.byKey(TradeScreen.dealBookContentKey), findsOneWidget);
 
         // Off-stage (still in the IndexedStack): Market body. Found
         // only when `skipOffstage: false` is explicitly passed.
-        expect(
-          find.byKey(TradeScreen.marketTabBodyKey),
-          findsNothing,
-        );
+        expect(find.byKey(TradeScreen.marketTabBodyKey), findsNothing);
         expect(
           find.byKey(TradeScreen.marketTabBodyKey, skipOffstage: false),
           findsOneWidget,
@@ -102,153 +58,114 @@ void main() {
       },
     );
 
-    testWidgets(
-      'default initialTabIndex (omitted) preserves the Market tab '
-      'foregrounded contract from E4',
-      (tester) async {
-        await _pumpTradeScreen(
-          tester,
-          game: _buildGameForTradeScreen(),
-        );
+    testWidgets('default initialTabIndex (omitted) preserves the Market tab '
+        'foregrounded contract from E4', (tester) async {
+      await pumpTradeScreen(
+        tester,
+        game: buildTradeTestGame(id: 'test_trade_screen_e7'),
+      );
 
-        expect(
-          find.byKey(TradeScreen.marketTabBodyKey),
-          findsOneWidget,
-        );
-        expect(
-          find.byKey(TradeScreen.dealBookTabBodyKey),
-          findsNothing,
-        );
-        expect(
-          find.byKey(TradeScreen.dealBookTabBodyKey, skipOffstage: false),
-          findsOneWidget,
-        );
-      },
-    );
+      expect(find.byKey(TradeScreen.marketTabBodyKey), findsOneWidget);
+      expect(find.byKey(TradeScreen.dealBookTabBodyKey), findsNothing);
+      expect(
+        find.byKey(TradeScreen.dealBookTabBodyKey, skipOffstage: false),
+        findsOneWidget,
+      );
+    });
 
-    testWidgets(
-      'initialTabIndex: 0 explicitly mirrors the omitted-default '
-      'contract',
-      (tester) async {
-        await _pumpTradeScreen(
-          tester,
-          game: _buildGameForTradeScreen(),
-          initialTabIndex: 0,
-        );
+    testWidgets('initialTabIndex: 0 explicitly mirrors the omitted-default '
+        'contract', (tester) async {
+      await pumpTradeScreen(
+        tester,
+        game: buildTradeTestGame(id: 'test_trade_screen_e7'),
+        initialTabIndex: 0,
+      );
 
-        expect(
-          find.byKey(TradeScreen.marketTabBodyKey),
-          findsOneWidget,
-        );
-        expect(
-          find.byKey(TradeScreen.dealBookTabBodyKey),
-          findsNothing,
-        );
-      },
-    );
+      expect(find.byKey(TradeScreen.marketTabBodyKey), findsOneWidget);
+      expect(find.byKey(TradeScreen.dealBookTabBodyKey), findsNothing);
+    });
   });
 
   group('CtTabStrip initialTabIndex (Refs #2993 E7)', () {
-    testWidgets(
-      'positive initialTabIndex foregrounds the matching tab body on '
-      'first frame',
-      (tester) async {
-        await pumpAppShell(
-          tester,
-          child: Scaffold(
-            body: CtTabStrip(
-              initialTabIndex: 1,
-              tabLabels: const <String>['First', 'Second', 'Third'],
-              tabViews: const <Widget>[
-                Text(
-                  'first-body',
-                  key: ValueKey<String>('tab-body-first'),
-                ),
-                Text(
-                  'second-body',
-                  key: ValueKey<String>('tab-body-second'),
-                ),
-                Text(
-                  'third-body',
-                  key: ValueKey<String>('tab-body-third'),
-                ),
-              ],
-            ),
+    testWidgets('positive initialTabIndex foregrounds the matching tab body on '
+        'first frame', (tester) async {
+      await pumpAppShell(
+        tester,
+        child: Scaffold(
+          body: CtTabStrip(
+            initialTabIndex: 1,
+            tabLabels: const <String>['First', 'Second', 'Third'],
+            tabViews: const <Widget>[
+              Text('first-body', key: ValueKey<String>('tab-body-first')),
+              Text('second-body', key: ValueKey<String>('tab-body-second')),
+              Text('third-body', key: ValueKey<String>('tab-body-third')),
+            ],
           ),
-        );
+        ),
+      );
 
-        expect(
-          find.byKey(const ValueKey<String>('tab-body-second')),
-          findsOneWidget,
-        );
-        expect(
-          find.byKey(const ValueKey<String>('tab-body-first')),
-          findsNothing,
-        );
-        expect(
-          find.byKey(const ValueKey<String>('tab-body-third')),
-          findsNothing,
-        );
-      },
-    );
+      expect(
+        find.byKey(const ValueKey<String>('tab-body-second')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const ValueKey<String>('tab-body-first')),
+        findsNothing,
+      );
+      expect(
+        find.byKey(const ValueKey<String>('tab-body-third')),
+        findsNothing,
+      );
+    });
 
-    test(
-      'out-of-bounds initialTabIndex throws an assertion error '
-      '(programmer-error contract)',
-      () {
-        expect(
-          () => CtTabStrip(
-            initialTabIndex: 5,
-            tabLabels: const <String>['A', 'B'],
-            tabViews: const <Widget>[Text('a'), Text('b')],
-          ),
-          throwsA(isA<AssertionError>()),
-        );
-        expect(
-          () => CtTabStrip(
-            initialTabIndex: -1,
-            tabLabels: const <String>['A', 'B'],
-            tabViews: const <Widget>[Text('a'), Text('b')],
-          ),
-          throwsA(isA<AssertionError>()),
-        );
-      },
-    );
+    test('out-of-bounds initialTabIndex throws an assertion error '
+        '(programmer-error contract)', () {
+      expect(
+        () => CtTabStrip(
+          initialTabIndex: 5,
+          tabLabels: const <String>['A', 'B'],
+          tabViews: const <Widget>[Text('a'), Text('b')],
+        ),
+        throwsA(isA<AssertionError>()),
+      );
+      expect(
+        () => CtTabStrip(
+          initialTabIndex: -1,
+          tabLabels: const <String>['A', 'B'],
+          tabViews: const <Widget>[Text('a'), Text('b')],
+        ),
+        throwsA(isA<AssertionError>()),
+      );
+    });
   });
 
   group('Widgetbook tradeScreenDirectories (Refs #2993 E7)', () {
-    test(
-      'registers exactly one Trade Screen folder containing the SPEC-'
-      'pinned use cases in documented order',
-      () {
-        final directories = tradeScreenDirectories;
-        expect(directories, hasLength(1));
-        final folder = directories.single;
-        expect(folder, isA<WidgetbookFolder>());
-        final tradeFolder = folder as WidgetbookFolder;
-        expect(tradeFolder.name, 'Trade Screen');
+    test('registers exactly one Trade Screen folder containing the SPEC-'
+        'pinned use cases in documented order', () {
+      final directories = tradeScreenDirectories;
+      expect(directories, hasLength(1));
+      final folder = directories.single;
+      expect(folder, isA<WidgetbookFolder>());
+      final tradeFolder = folder as WidgetbookFolder;
+      expect(tradeFolder.name, 'Trade Screen');
 
-        final children = tradeFolder.children ?? const [];
-        final useCaseNames = <String>[
-          for (final node in children)
-            if (node is WidgetbookUseCase) node.name,
-        ];
-        expect(
-          useCaseNames,
-          <String>[
-            'Scaffold (Market tab)',
-            'Scaffold (mobile)',
-            'Market tab — staged bid + offer (Refs #2993 E5b)',
-            'Market tab — cargo saturated (Refs #2993 E5c)',
-            'Market tab — sectioned grouping (Refs #3093)',
-            'Market tab — sellable clamp (Refs #3093)',
-            'Market tab — treasury bid cap (Refs #3093)',
-            'Deal Book tab — empty (Refs #2993 E7)',
-            'Deal Book tab — mixed fills + carry-forwards (Refs #2993 E7)',
-            'Deal Book tab — mobile (stacked) (Refs #2993 E7)',
-          ],
-        );
-      },
-    );
+      final children = tradeFolder.children ?? const [];
+      final useCaseNames = <String>[
+        for (final node in children)
+          if (node is WidgetbookUseCase) node.name,
+      ];
+      expect(useCaseNames, <String>[
+        'Scaffold (Market tab)',
+        'Scaffold (mobile)',
+        'Market tab — staged bid + offer (Refs #2993 E5b)',
+        'Market tab — cargo saturated (Refs #2993 E5c)',
+        'Market tab — sectioned grouping (Refs #3093)',
+        'Market tab — sellable clamp (Refs #3093)',
+        'Market tab — treasury bid cap (Refs #3093)',
+        'Deal Book tab — empty (Refs #2993 E7)',
+        'Deal Book tab — mixed fills + carry-forwards (Refs #2993 E7)',
+        'Deal Book tab — mobile (stacked) (Refs #2993 E7)',
+      ]);
+    });
   });
 }

--- a/app/test/trade_screen_issue_acceptance_criteria_e8_test.dart
+++ b/app/test/trade_screen_issue_acceptance_criteria_e8_test.dart
@@ -54,8 +54,6 @@ import 'package:colonizethis_app/core/services/app_event_handler/app_event_handl
 import 'package:colonizethis_app/core/services/game_service/game_service.dart';
 import 'package:colonizethis_app/features/game/flame/controls/controls.dart';
 import 'package:colonizethis_app/features/game/screens/game/game_screen_shared.dart';
-import 'package:colonizethis_app/features/game/flame/region_map/region_map.dart'
-    show CtMapVisibilityMode;
 import 'package:colonizethis_app/features/game/screens/trade/trade_screen.dart';
 import 'package:colonizethis_app/features/game/widgets/shell/shell_player_context.dart';
 import 'package:colonizethis_app/features/game/widgets/panels/observe_mode_not_defined_panel.dart';
@@ -68,8 +66,6 @@ import 'package:colonizethis_app/widgets/ct_panel.dart';
 import 'package:colonizethis_app/widgets/ct_tab_strip.dart';
 import 'package:colonizethis_app/widgets/ct_top_bar.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/colonizethis_logic.dart'
-    show homeFleetIdFor;
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_save/colonizethis_save.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
@@ -79,101 +75,19 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
 
 import 'support/app_shell_harness.dart';
-import 'support/panel_test_fixtures.dart';
+import 'support/trade_screen_test_support.dart';
 import 'widget_test_pumps.dart';
 
-// Player ids used by the isolated `_pumpTradeScreenStandalone` harness
+// Player ids used by the isolated shared TradeScreen harness
 // (AC #2, #3, #4, #5, and observe-variant tests). The route-host
 // fixture (AC #1, #6) uses the human player from the shared lightweight
 // `buildTradePanelTestGame()` fixture (Refs #3656).
-const String _humanPlayerId = 'gp_h';
-const String _capProvinceId = 'oldWorld|cap1';
+const String _humanPlayerId = kTradeTestHumanPlayerId;
 
 CommodityId get _timber => CommodityCatalog.timber.id;
 CommodityId get _iron => CommodityCatalog.iron.id;
 CommodityId get _fabric => CommodityCatalog.fabric.id;
 CommodityId get _grain => CommodityCatalog.grain.id;
-
-Game _buildStandaloneGame({
-  int? tradeCargoCapacityOverride,
-  WorldMarketState? worldMarketState,
-}) {
-  final List<Fleet> fleets = <Fleet>[];
-  if (tradeCargoCapacityOverride != null) {
-    final int galleonHolds = NavalStatsCatalog.galleon.cargoHold;
-    final int fluyteHolds = NavalStatsCatalog.fluyte.cargoHold;
-    if (galleonHolds + fluyteHolds != 10) {
-      throw StateError(
-        'NavalStatsCatalog cargoHold drift: '
-        'galleon=$galleonHolds + fluyte=$fluyteHolds != 10. '
-        'Update the override mapping in this test.',
-      );
-    }
-    if (tradeCargoCapacityOverride != 10) {
-      throw StateError(
-        'Only tradeCargoCapacityOverride == 10 is currently supported '
-        'by this test harness.',
-      );
-    }
-    fleets.add(
-      Fleet(
-        id: homeFleetIdFor(_humanPlayerId),
-        ownerId: _humanPlayerId,
-        regionId: 'oldWorld',
-        inPortAtProvinceId: _capProvinceId,
-        ships: const [
-          ShipInstance(id: 'h1', typeId: 'galleon'),
-          ShipInstance(id: 'h2', typeId: 'fluyte'),
-        ],
-      ),
-    );
-  }
-  return Game(
-    id: 'test_trade_screen_e8',
-    worldState: WorldState(
-      turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
-      oldWorld: const RegionData(
-        provinces: [
-          Province(
-            id: 'cap1',
-            regionId: 'oldWorld',
-            // ignore: avoid_hardcoded_strings_in_widgets
-            displayName: 'Capital',
-          ),
-        ],
-      ),
-      newWorld: const RegionData(),
-      fleets: fleets,
-    ),
-    turnTimeMapping: TurnTimeMapping.gdd01,
-    players: [
-      // Refs #3093 — sellable clamp slice. Offer chips + offer-side
-      // `+` are now gated by the per-commodity offer cap
-      // (`stockpile − industryAllocation`). Seed a baseline stockpile
-      // of 99 units for every tradeable commodity so the E8 acceptance
-      // criteria tests (which stage Offer orders without specifying
-      // stockpile) keep passing under the new contract.
-      Player(
-        id: _humanPlayerId,
-        // ignore: avoid_hardcoded_strings_in_widgets
-        displayName: 'England',
-        isHuman: true,
-        treasury: 500,
-        stockpile: Stockpile(
-          quantities: <CommodityId, int>{
-            for (final Commodity c in CommodityCatalog.all)
-              if (c.category != CommodityCategory.riches && c.id != 'spices')
-                c.id: 99,
-          },
-        ),
-      ),
-    ],
-    diplomacyRelations: const [],
-    diplomaticHistoryEvents: const [],
-    dossierEvidenceEntries: const [],
-    worldMarketState: worldMarketState ?? const WorldMarketState(),
-  );
-}
 
 Orders _ordersWith(List<TradeOrder> tradeOrders) {
   return Orders(
@@ -201,61 +115,9 @@ TradeOrder _offer(CommodityId commodityId, int quantity, {int priority = 1}) {
   );
 }
 
-/// Pumps [TradeScreen] in isolation against a [ProviderContainer]
-/// that exposes [currentGameProvider], [currentOrdersProvider], and a
-/// (mockable) [shellPlayerContextProvider]. Uses a tall (1024 × 4096)
-/// surface so every alphabetical row in the 22-commodity Market tab
-/// list is laid out at once — `tester.tap` resolves against visible
-/// targets without scrolling.
-Future<ProviderContainer> _pumpTradeScreenStandalone(
-  WidgetTester tester, {
-  required Game game,
-  Orders initialOrders = const Orders(),
-  bool canMutateViaUi = true,
-}) async {
-  final Player player = game.players.first;
-  final ProviderContainer container = ProviderContainer(
-    overrides: [
-      currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
-      currentOrdersProvider.overrideWith(
-        () => CurrentOrdersNotifier(initialOrders),
-      ),
-      shellPlayerContextProvider.overrideWith(
-        (ref) => ShellPlayerContext(
-          effectiveHumanPlayerId: player.id,
-          viewingPlayerId: player.id,
-          mapVisibilityMode: CtMapVisibilityMode.full,
-          playerView: null,
-          omniscientDetail: false,
-          showPlayerChrome: true,
-          canMutateViaUi: canMutateViaUi,
-          debugCommandTargetPlayerId: player.id,
-          inObservePhase: !canMutateViaUi,
-          // ignore: avoid_hardcoded_strings_in_widgets
-          observeBannerLabel: canMutateViaUi ? null : 'Observing',
-          treasuryNotDefined: false,
-          cargoNotDefined: false,
-        ),
-      ),
-    ],
-  );
-  addTearDown(container.dispose);
-  await pumpAppShellWithContainer(
-    tester,
-    container: container,
-    viewport: const Size(1024, 4096),
-    child: TradeScreen(game: game, player: player),
-  );
-  return container;
-}
-
-TradeOrder? _stagedOrder(
-  ProviderContainer container,
-  CommodityId commodityId,
-) {
+TradeOrder? _stagedOrder(ProviderContainer container, CommodityId commodityId) {
   final Orders orders = container.read(currentOrdersProvider);
-  final List<TradeOrder>? list =
-      orders.tradeOrdersByPlayerId[_humanPlayerId];
+  final List<TradeOrder>? list = orders.tradeOrdersByPlayerId[_humanPlayerId];
   if (list == null) return null;
   for (final TradeOrder o in list) {
     if (o.commodityId == commodityId) return o;
@@ -297,7 +159,7 @@ void main() {
     // (AC #1, #6) only need a Game with a human player for navigation and the
     // TradeScreen chrome — no generated map/topology data — so the ~7-11s
     // procedural map generator is avoided.
-    routeHostGame = buildTradePanelTestGame();
+    routeHostGame = buildTradeScaffoldTestGame();
     routeHostPlayer = routeHostGame.players.firstWhere(
       (p) => p.isHuman,
       orElse: () => routeHostGame.players.first,
@@ -306,45 +168,25 @@ void main() {
     gamesBox = await Hive.openBox<dynamic>(HiveBoxNames.games);
   });
 
-  ShellPlayerContext globalObserveShellContext() {
-    return const ShellPlayerContext(
-      effectiveHumanPlayerId: null,
-      viewingPlayerId: null,
-      mapVisibilityMode: CtMapVisibilityMode.full,
-      playerView: null,
-      omniscientDetail: true,
-      showPlayerChrome: false,
-      canMutateViaUi: false,
-      debugCommandTargetPlayerId: null,
-      inObservePhase: true,
-      // ignore: avoid_hardcoded_strings_in_widgets
-      observeBannerLabel: 'Observing: global',
-      treasuryNotDefined: true,
-      cargoNotDefined: true,
-    );
-  }
-
   routeHostOverrides({bool globalObserve = false}) => [
-      gamesBoxProvider.overrideWith((ref) => gamesBox),
-      gameServiceProvider.overrideWith(
-        (ref) => GameService(gamesBox, GameSaveAdapter()),
+    gamesBoxProvider.overrideWith((ref) => gamesBox),
+    gameServiceProvider.overrideWith(
+      (ref) => GameService(gamesBox, GameSaveAdapter()),
+    ),
+    currentGameProvider.overrideWith(() => CurrentGameNotifier(routeHostGame)),
+    currentOrdersProvider.overrideWith(
+      () => CurrentOrdersNotifier(const Orders()),
+    ),
+    appEventBusProvider.overrideWith((ref) {
+      final bus = AppEventBus.create();
+      ref.onDispose(bus.dispose);
+      return bus;
+    }),
+    if (globalObserve)
+      shellPlayerContextProvider.overrideWithValue(
+        tradeTestGlobalObserveShellContext(),
       ),
-      currentGameProvider.overrideWith(
-        () => CurrentGameNotifier(routeHostGame),
-      ),
-      currentOrdersProvider.overrideWith(
-        () => CurrentOrdersNotifier(const Orders()),
-      ),
-      appEventBusProvider.overrideWith((ref) {
-        final bus = AppEventBus.create();
-        ref.onDispose(bus.dispose);
-        return bus;
-      }),
-      if (globalObserve)
-        shellPlayerContextProvider.overrideWithValue(
-          globalObserveShellContext(),
-        ),
-    ];
+  ];
 
   Widget buildLeftRailHost({bool globalObserve = false}) {
     return buildAppShell(
@@ -402,624 +244,559 @@ void main() {
     );
   }
 
-  group(
-    'AC #1 — Left rail Trade icon opens TradeScreen full-screen dark '
-    'editorial-monocle surface (#2993 E8 (a))',
-    () {
-      testWidgets(
-        'tapping kEmpireTradeButtonKey pushes TradeScreen with the dark '
-        'CtTopBar (Trade title, Map back affordance, 18 px trade icon) '
-        'and the two-tab Market + Deal Book body',
-        (tester) async {
-          await tester.pumpWidget(buildLeftRailHost());
-          await pumpSettleCapped(tester);
+  group('AC #1 — Left rail Trade icon opens TradeScreen full-screen dark '
+      'editorial-monocle surface (#2993 E8 (a))', () {
+    testWidgets(
+      'tapping kEmpireTradeButtonKey pushes TradeScreen with the dark '
+      'CtTopBar (Trade title, Map back affordance, 18 px trade icon) '
+      'and the two-tab Market + Deal Book body',
+      (tester) async {
+        await tester.pumpWidget(buildLeftRailHost());
+        await pumpSettleCapped(tester);
 
-          // Given the left rail is visible, the Trade button sits below
-          // Production and above Civilian Units per SPEC § Trigger
-          // conditions (Refs `#2993` R4).
-          final trade = find.byKey(kEmpireTradeButtonKey);
-          expect(trade, findsOneWidget);
-          final productionY = tester
-              .getTopLeft(find.byKey(kEmpireProductionButtonKey)).dy;
-          final tradeY = tester.getTopLeft(trade).dy;
-          final civilianY = tester
-              .getTopLeft(find.byKey(kEmpireCivilianUnitsButtonKey)).dy;
-          expect(tradeY, greaterThan(productionY));
-          expect(civilianY, greaterThan(tradeY));
+        // Given the left rail is visible, the Trade button sits below
+        // Production and above Civilian Units per SPEC § Trigger
+        // conditions (Refs `#2993` R4).
+        final trade = find.byKey(kEmpireTradeButtonKey);
+        expect(trade, findsOneWidget);
+        final productionY = tester
+            .getTopLeft(find.byKey(kEmpireProductionButtonKey))
+            .dy;
+        final tradeY = tester.getTopLeft(trade).dy;
+        final civilianY = tester
+            .getTopLeft(find.byKey(kEmpireCivilianUnitsButtonKey))
+            .dy;
+        expect(tradeY, greaterThan(productionY));
+        expect(civilianY, greaterThan(tradeY));
 
-          await tester.tap(trade);
-          await pumpSettleCapped(tester);
+        await tester.tap(trade);
+        await pumpSettleCapped(tester);
 
-          // Then the Trade Screen mounts with the editorial-monocle
-          // dark chrome (no light Material AppBar).
-          expect(find.byType(TradeScreen), findsOneWidget);
-          expect(find.byType(AppBar), findsNothing);
+        // Then the Trade Screen mounts with the editorial-monocle
+        // dark chrome (no light Material AppBar).
+        expect(find.byType(TradeScreen), findsOneWidget);
+        expect(find.byType(AppBar), findsNothing);
 
-          final topBarFinder = find.byKey(TradeScreen.topBarKey);
-          expect(topBarFinder, findsOneWidget);
-          final CtTopBar topBar = tester.widget<CtTopBar>(topBarFinder);
-          expect(topBar.title, TradeScreen.topBarTitle);
-          expect(topBar.backButtonLabel, TradeScreen.topBarBackLabel);
+        final topBarFinder = find.byKey(TradeScreen.topBarKey);
+        expect(topBarFinder, findsOneWidget);
+        final CtTopBar topBar = tester.widget<CtTopBar>(topBarFinder);
+        expect(topBar.title, TradeScreen.topBarTitle);
+        expect(topBar.backButtonLabel, TradeScreen.topBarBackLabel);
 
-          // And the body hosts the two-tab Market + Deal Book strip.
-          expect(find.byKey(TradeScreen.tabsBodyKey), findsOneWidget);
-          final stripFinder = find.descendant(
+        // And the body hosts the two-tab Market + Deal Book strip.
+        expect(find.byKey(TradeScreen.tabsBodyKey), findsOneWidget);
+        final stripFinder = find.descendant(
+          of: find.byKey(TradeScreen.tabsBodyKey),
+          matching: find.byType(CtTabStrip),
+        );
+        expect(stripFinder, findsOneWidget);
+        final CtTabStrip strip = tester.widget<CtTabStrip>(stripFinder);
+        expect(strip.tabLabels, <String>[
+          TradeScreen.marketTabLabel,
+          TradeScreen.dealBookTabLabel,
+        ]);
+
+        // The dark editorial-monocle CtPanel surface wraps the strip
+        // (no hardcoded light-theme parchment).
+        expect(
+          find.descendant(
             of: find.byKey(TradeScreen.tabsBodyKey),
-            matching: find.byType(CtTabStrip),
-          );
-          expect(stripFinder, findsOneWidget);
-          final CtTabStrip strip = tester.widget<CtTabStrip>(stripFinder);
-          expect(strip.tabLabels, <String>[
-            TradeScreen.marketTabLabel,
-            TradeScreen.dealBookTabLabel,
-          ]);
+            matching: find.byType(CtPanel),
+          ),
+          findsOneWidget,
+        );
+      },
+    );
 
-          // The dark editorial-monocle CtPanel surface wraps the strip
-          // (no hardcoded light-theme parchment).
-          expect(
-            find.descendant(
-              of: find.byKey(TradeScreen.tabsBodyKey),
-              matching: find.byType(CtPanel),
-            ),
-            findsOneWidget,
-          );
-        },
-      );
+    testWidgets(
+      'CtTopBar back affordance returns to the host route (TradeScreen '
+      'is dismissed) — confirms the full-screen feature contract pops '
+      'cleanly without leaking chrome',
+      (tester) async {
+        await tester.pumpWidget(buildTradeRouteHost());
+        await pumpSettleCapped(tester);
 
-      testWidgets(
-        'CtTopBar back affordance returns to the host route (TradeScreen '
-        'is dismissed) — confirms the full-screen feature contract pops '
-        'cleanly without leaking chrome',
-        (tester) async {
-          await tester.pumpWidget(buildTradeRouteHost());
-          await pumpSettleCapped(tester);
+        await tester.tap(find.text('open trade'));
+        await pumpSettleCapped(tester);
+        expect(find.byType(TradeScreen), findsOneWidget);
 
-          await tester.tap(find.text('open trade'));
-          await pumpSettleCapped(tester);
-          expect(find.byType(TradeScreen), findsOneWidget);
+        final back = find.descendant(
+          of: find.byType(CtTopBar),
+          matching: find.byType(CtBackButton),
+        );
+        expect(back, findsOneWidget);
+        await tester.tap(back);
+        await pumpSettleCapped(tester);
+        expect(find.byType(TradeScreen), findsNothing);
+      },
+    );
+  });
 
-          final back = find.descendant(
-            of: find.byType(CtTopBar),
-            matching: find.byType(CtBackButton),
-          );
-          expect(back, findsOneWidget);
-          await tester.tap(back);
-          await pumpSettleCapped(tester);
-          expect(find.byType(TradeScreen), findsNothing);
-        },
-      );
-    },
-  );
-
-  group(
-    'AC #2 — Bid toggle + quantity stepper stages a TradeOrder with the '
-    'correct type, quantity, and (default) priority in '
-    'currentOrdersProvider (#2993 E8 (b))',
-    () {
-      testWidgets(
-        'Given no staged TradeOrder, when the player taps `Bid` on '
+  group('AC #2 — Bid toggle + quantity stepper stages a TradeOrder with the '
+      'correct type, quantity, and (default) priority in '
+      'currentOrdersProvider (#2993 E8 (b))', () {
+    testWidgets('Given no staged TradeOrder, when the player taps `Bid` on '
         'timber and increments the stepper to 5, then '
         'tradeOrdersByPlayerId[player.id] contains exactly one '
-        'TradeOrder(type=bid, quantity=5, priority=1) for timber',
-        (tester) async {
-          final ProviderContainer container = await _pumpTradeScreenStandalone(
-            tester,
-            game: _buildStandaloneGame(),
-          );
-          expect(_stagedOrder(container, _timber), isNull);
+        'TradeOrder(type=bid, quantity=5, priority=1) for timber', (
+      tester,
+    ) async {
+      final ProviderContainer container = await pumpTradeScreenWithContainer(
+        tester,
+        game: buildTradeTestGame(
+          id: 'test_trade_screen_e8',
+          stockpile: tradeableStockpileFilled(99),
+        ),
+      );
+      expect(_stagedOrder(container, _timber), isNull);
 
-          await tester.tap(
-            find.byKey(TradeScreen.marketRowBidChipKey(_timber)),
-          );
-          await tester.pump();
-          // Increment from 1 → 5 (4 taps).
-          for (int i = 0; i < 4; i++) {
-            await tester.tap(
-              find.byKey(TradeScreen.marketRowIncrementKey(_timber)),
-            );
-            await tester.pump();
-          }
+      await tester.tap(find.byKey(TradeScreen.marketRowBidChipKey(_timber)));
+      await tester.pump();
+      // Increment from 1 → 5 (4 taps).
+      for (int i = 0; i < 4; i++) {
+        await tester.tap(
+          find.byKey(TradeScreen.marketRowIncrementKey(_timber)),
+        );
+        await tester.pump();
+      }
 
-          final TradeOrder? staged = _stagedOrder(container, _timber);
-          expect(staged, isNotNull);
-          expect(staged!.commodityId, _timber);
-          expect(staged.type, TradeOrderType.bid);
-          expect(staged.quantity, 5);
-          // SPEC/ui/trade-screen.md § Body — planned follow-up `#2993`
-          // E5b cont.: the interactive priority dropdown is deferred
-          // until `kMaxTradePriority` is exposed by `#2989`. Until then
-          // staged orders use `marketRowDefaultPriority` (1). The
-          // priority-2 leg of issue AC #2 is therefore covered by the
-          // deferred slice and tracked in SPEC.
-          expect(staged.priority, TradeScreen.marketRowDefaultPriority);
-          // Exactly one staged TradeOrder for the player on timber.
-          expect(_stagedRowCountForPlayer(container), 1);
-        },
+      final TradeOrder? staged = _stagedOrder(container, _timber);
+      expect(staged, isNotNull);
+      expect(staged!.commodityId, _timber);
+      expect(staged.type, TradeOrderType.bid);
+      expect(staged.quantity, 5);
+      // SPEC/ui/trade-screen.md § Body — planned follow-up `#2993`
+      // E5b cont.: the interactive priority dropdown is deferred
+      // until `kMaxTradePriority` is exposed by `#2989`. Until then
+      // staged orders use `marketRowDefaultPriority` (1). The
+      // priority-2 leg of issue AC #2 is therefore covered by the
+      // deferred slice and tracked in SPEC.
+      expect(staged.priority, TradeScreen.marketRowDefaultPriority);
+      // Exactly one staged TradeOrder for the player on timber.
+      expect(_stagedRowCountForPlayer(container), 1);
+    });
+
+    testWidgets('Offer toggle stages a TradeOrder(type=offer, quantity=1, '
+        'priority=1) with no quantity carry-over from an unstaged row', (
+      tester,
+    ) async {
+      final ProviderContainer container = await pumpTradeScreenWithContainer(
+        tester,
+        game: buildTradeTestGame(
+          id: 'test_trade_screen_e8',
+          stockpile: tradeableStockpileFilled(99),
+        ),
       );
 
-      testWidgets(
-        'Offer toggle stages a TradeOrder(type=offer, quantity=1, '
-        'priority=1) with no quantity carry-over from an unstaged row',
-        (tester) async {
-          final ProviderContainer container = await _pumpTradeScreenStandalone(
-            tester,
-            game: _buildStandaloneGame(),
-          );
+      await tester.tap(find.byKey(TradeScreen.marketRowOfferChipKey(_fabric)));
+      await tester.pump();
 
-          await tester.tap(
-            find.byKey(TradeScreen.marketRowOfferChipKey(_fabric)),
-          );
-          await tester.pump();
+      final TradeOrder? staged = _stagedOrder(container, _fabric);
+      expect(staged, isNotNull);
+      expect(staged!.type, TradeOrderType.offer);
+      expect(staged.quantity, TradeScreen.marketRowQuantityDefault);
+      expect(staged.priority, TradeScreen.marketRowDefaultPriority);
+    });
+  });
 
-          final TradeOrder? staged = _stagedOrder(container, _fabric);
-          expect(staged, isNotNull);
-          expect(staged!.type, TradeOrderType.offer);
-          expect(staged.quantity, TradeScreen.marketRowQuantityDefault);
-          expect(staged.priority, TradeScreen.marketRowDefaultPriority);
-        },
-      );
-    },
-  );
+  group('AC #3 — Per-commodity mutual exclusion: bid on X and offer on X '
+      'cannot coexist (#2993 E8 (c))', () {
+    testWidgets(
+      'Given a staged Bid for timber (qty 3), when the player taps the '
+      '`Offer` chip on timber, then the prior bid is replaced by a '
+      'single TradeOrder(type=offer, quantity=3) — at most one staged '
+      'TradeOrder per (player, commodityId)',
+      (tester) async {
+        final ProviderContainer container = await pumpTradeScreenWithContainer(
+          tester,
+          game: buildTradeTestGame(
+            id: 'test_trade_screen_e8',
+            stockpile: tradeableStockpileFilled(99),
+          ),
+        );
 
-  group(
-    'AC #3 — Per-commodity mutual exclusion: bid on X and offer on X '
-    'cannot coexist (#2993 E8 (c))',
-    () {
-      testWidgets(
-        'Given a staged Bid for timber (qty 3), when the player taps the '
-        '`Offer` chip on timber, then the prior bid is replaced by a '
-        'single TradeOrder(type=offer, quantity=3) — at most one staged '
-        'TradeOrder per (player, commodityId)',
-        (tester) async {
-          final ProviderContainer container = await _pumpTradeScreenStandalone(
-            tester,
-            game: _buildStandaloneGame(),
-          );
+        // Stage Bid + increment to qty 3.
+        await tester.tap(find.byKey(TradeScreen.marketRowBidChipKey(_timber)));
+        await tester.pump();
+        await tester.tap(
+          find.byKey(TradeScreen.marketRowIncrementKey(_timber)),
+        );
+        await tester.pump();
+        await tester.tap(
+          find.byKey(TradeScreen.marketRowIncrementKey(_timber)),
+        );
+        await tester.pump();
+        TradeOrder? staged = _stagedOrder(container, _timber);
+        expect(staged?.type, TradeOrderType.bid);
+        expect(staged?.quantity, 3);
 
-          // Stage Bid + increment to qty 3.
-          await tester.tap(
-            find.byKey(TradeScreen.marketRowBidChipKey(_timber)),
-          );
-          await tester.pump();
-          await tester.tap(
-            find.byKey(TradeScreen.marketRowIncrementKey(_timber)),
-          );
-          await tester.pump();
-          await tester.tap(
-            find.byKey(TradeScreen.marketRowIncrementKey(_timber)),
-          );
-          await tester.pump();
-          TradeOrder? staged = _stagedOrder(container, _timber);
-          expect(staged?.type, TradeOrderType.bid);
-          expect(staged?.quantity, 3);
+        // Toggle to Offer: prior quantity is preserved across the
+        // direction change (SPEC § Behavior — User actions table).
+        await tester.tap(
+          find.byKey(TradeScreen.marketRowOfferChipKey(_timber)),
+        );
+        await tester.pump();
 
-          // Toggle to Offer: prior quantity is preserved across the
-          // direction change (SPEC § Behavior — User actions table).
-          await tester.tap(
-            find.byKey(TradeScreen.marketRowOfferChipKey(_timber)),
-          );
-          await tester.pump();
+        staged = _stagedOrder(container, _timber);
+        expect(staged?.type, TradeOrderType.offer);
+        expect(staged?.quantity, 3);
 
-          staged = _stagedOrder(container, _timber);
-          expect(staged?.type, TradeOrderType.offer);
-          expect(staged?.quantity, 3);
+        // Mutual exclusion guarantee — exactly one TradeOrder for the
+        // commodity in the player's staged trade orders list.
+        final Orders orders = container.read(currentOrdersProvider);
+        final List<TradeOrder>? list =
+            orders.tradeOrdersByPlayerId[_humanPlayerId];
+        expect(list, isNotNull);
+        final int timberCount = list!
+            .where((TradeOrder o) => o.commodityId == _timber)
+            .length;
+        expect(
+          timberCount,
+          1,
+          reason:
+              'Mutual exclusion contract: tradeOrdersByPlayerId must '
+              'contain at most one TradeOrder per (player, commodityId).',
+        );
+      },
+    );
 
-          // Mutual exclusion guarantee — exactly one TradeOrder for the
-          // commodity in the player's staged trade orders list.
-          final Orders orders = container.read(currentOrdersProvider);
-          final List<TradeOrder>? list =
-              orders.tradeOrdersByPlayerId[_humanPlayerId];
-          expect(list, isNotNull);
-          final int timberCount = list!
-              .where((TradeOrder o) => o.commodityId == _timber)
-              .length;
-          expect(
-            timberCount,
-            1,
-            reason:
-                'Mutual exclusion contract: tradeOrdersByPlayerId must '
-                'contain at most one TradeOrder per (player, commodityId).',
-          );
-        },
-      );
+    testWidgets(
+      'Cross-commodity mutual exclusion is per-commodity, not per-player: '
+      'staging Bid on timber AND Offer on fabric keeps both staged '
+      '(tradeOrdersByPlayerId[player.id].length == 2)',
+      (tester) async {
+        final ProviderContainer container = await pumpTradeScreenWithContainer(
+          tester,
+          game: buildTradeTestGame(
+            id: 'test_trade_screen_e8',
+            stockpile: tradeableStockpileFilled(99),
+          ),
+        );
 
-      testWidgets(
-        'Cross-commodity mutual exclusion is per-commodity, not per-player: '
-        'staging Bid on timber AND Offer on fabric keeps both staged '
-        '(tradeOrdersByPlayerId[player.id].length == 2)',
-        (tester) async {
-          final ProviderContainer container = await _pumpTradeScreenStandalone(
-            tester,
-            game: _buildStandaloneGame(),
-          );
+        await tester.tap(find.byKey(TradeScreen.marketRowBidChipKey(_timber)));
+        await tester.pump();
+        await tester.tap(
+          find.byKey(TradeScreen.marketRowOfferChipKey(_fabric)),
+        );
+        await tester.pump();
 
-          await tester.tap(
-            find.byKey(TradeScreen.marketRowBidChipKey(_timber)),
-          );
-          await tester.pump();
-          await tester.tap(
-            find.byKey(TradeScreen.marketRowOfferChipKey(_fabric)),
-          );
-          await tester.pump();
+        expect(_stagedOrder(container, _timber)?.type, TradeOrderType.bid);
+        expect(_stagedOrder(container, _fabric)?.type, TradeOrderType.offer);
+        expect(_stagedRowCountForPlayer(container), 2);
+      },
+    );
+  });
 
-          expect(_stagedOrder(container, _timber)?.type, TradeOrderType.bid);
-          expect(
-            _stagedOrder(container, _fabric)?.type,
-            TradeOrderType.offer,
-          );
-          expect(_stagedRowCountForPlayer(container), 2);
-        },
-      );
-    },
-  );
-
-  group(
-    'AC #4 — Deal Book renders previous-turn filled + carry-forward rows '
-    'with correct quantities, prices, and treasury totals (#2993 E8 (d))',
-    () {
-      testWidgets(
-        'Given a partial timber bid (filled 5 of 10 at price 8.4, '
+  group('AC #4 — Deal Book renders previous-turn filled + carry-forward rows '
+      'with correct quantities, prices, and treasury totals (#2993 E8 (d))', () {
+    testWidgets('Given a partial timber bid (filled 5 of 10 at price 8.4, '
         'displayed as floor=8) plus a carry-forward fabric offer of qty '
         '3 (no fills), when the player opens the Deal Book tab, then '
         'the bids panel shows the timber filled row + timber '
         'carry-forward row + total spent of 40 (= 5 × floor(8.4)), and '
         'the offers panel shows the fabric carry-forward row with total '
-        'received of 0',
-        (tester) async {
-          final WorldMarketState worldMarket = WorldMarketState(
-            prices: const <CommodityId, int>{},
-            lastTurnActivity: const <CommodityId, MarketActivity>{
-              // Filled portion of the timber bid (5 of 10 at 8.4).
-              'timber': MarketActivity(
-                totalBidQuantity: 10,
-                totalOfferQuantity: 5,
-                filledQuantity: 5,
-                deals: <FilledDeal>[
-                  FilledDeal(
-                    sellerFactionId: 'gp_a',
-                    buyerFactionId: _humanPlayerId,
-                    commodityId: 'timber',
-                    quantity: 5,
-                    pricePerUnit: 8.4,
-                  ),
-                ],
+        'received of 0', (tester) async {
+      final WorldMarketState worldMarket = WorldMarketState(
+        prices: const <CommodityId, int>{},
+        lastTurnActivity: const <CommodityId, MarketActivity>{
+          // Filled portion of the timber bid (5 of 10 at 8.4).
+          'timber': MarketActivity(
+            totalBidQuantity: 10,
+            totalOfferQuantity: 5,
+            filledQuantity: 5,
+            deals: <FilledDeal>[
+              FilledDeal(
+                sellerFactionId: 'gp_a',
+                buyerFactionId: _humanPlayerId,
+                commodityId: 'timber',
+                quantity: 5,
+                pricePerUnit: 8.4,
               ),
-            },
-            carryForwardBidsByFactionId: <String, List<TradeOrder>>{
-              _humanPlayerId: <TradeOrder>[
-                // Unfilled remainder of the timber bid (5 of 10).
-                TradeOrder(
-                  commodityId: 'timber',
-                  type: TradeOrderType.bid,
-                  quantity: 5,
-                  priority: 1,
-                ),
-              ],
-            },
-            carryForwardOffersByFactionId: <String, List<TradeOrder>>{
-              _humanPlayerId: <TradeOrder>[
-                // Fully unfilled fabric offer (3 of 3).
-                TradeOrder(
-                  commodityId: 'fabric',
-                  type: TradeOrderType.offer,
-                  quantity: 3,
-                  priority: 1,
-                ),
-              ],
-            },
-          );
-
-          await _pumpTradeScreenStandalone(
-            tester,
-            game: _buildStandaloneGame(worldMarketState: worldMarket),
-          );
-          await _switchToDealBook(tester);
-
-          // Filled timber row in the bids panel: qty 5 × floor(8.4) = 5 × 8 = 40
-          // per `SPEC/ui/trade-screen.md` § Deal Book (integer filled-row prices).
-          expect(
-            find.byKey(
-              TradeScreen.dealBookFilledRowKey(
-                TradeScreen.dealBookSideBids,
-                0,
-              ),
+            ],
+          ),
+        },
+        carryForwardBidsByFactionId: <String, List<TradeOrder>>{
+          _humanPlayerId: <TradeOrder>[
+            // Unfilled remainder of the timber bid (5 of 10).
+            TradeOrder(
+              commodityId: 'timber',
+              type: TradeOrderType.bid,
+              quantity: 5,
+              priority: 1,
             ),
-            findsOneWidget,
-          );
-          // ignore: avoid_hardcoded_strings_in_widgets
-          expect(find.text('timber — qty 5 × 8 = 40'), findsOneWidget);
-
-          // Unfilled timber carry-forward row in the bids panel.
-          expect(
-            find.byKey(
-              TradeScreen.dealBookUnfilledRowKey(
-                TradeScreen.dealBookSideBids,
-                0,
-              ),
+          ],
+        },
+        carryForwardOffersByFactionId: <String, List<TradeOrder>>{
+          _humanPlayerId: <TradeOrder>[
+            // Fully unfilled fabric offer (3 of 3).
+            TradeOrder(
+              commodityId: 'fabric',
+              type: TradeOrderType.offer,
+              quantity: 3,
+              priority: 1,
             ),
-            findsOneWidget,
-          );
-          // ignore: avoid_hardcoded_strings_in_widgets
-          expect(
-            find.text('timber — qty 5 (priority 1)'),
-            findsOneWidget,
-          );
-
-          // Bids panel total spent = filled notional only with integer
-          // unit prices: quantity × floor(pricePerUnit) = 5 × 8 = 40
-          // (carry-forwards do not contribute to treasury totals per
-          // `SPEC/ui/trade-screen.md` § Deal Book).
-          final Text bidsTotals = tester.widget<Text>(
-            find.byKey(TradeScreen.dealBookBidsTotalsKey),
-          );
-          expect(
-            bidsTotals.data,
-            '${TradeScreen.dealBookTotalSpentLabel}: 40',
-          );
-
-          // Offers panel: no filled deal, one carry-forward fabric offer.
-          expect(
-            find.byKey(
-              TradeScreen.dealBookFilledRowKey(
-                TradeScreen.dealBookSideOffers,
-                0,
-              ),
-            ),
-            findsNothing,
-          );
-          expect(
-            find.byKey(
-              TradeScreen.dealBookUnfilledRowKey(
-                TradeScreen.dealBookSideOffers,
-                0,
-              ),
-            ),
-            findsOneWidget,
-          );
-          // ignore: avoid_hardcoded_strings_in_widgets
-          expect(
-            find.text('fabric — qty 3 (priority 1)'),
-            findsOneWidget,
-          );
-
-          final Text offersTotals = tester.widget<Text>(
-            find.byKey(TradeScreen.dealBookOffersTotalsKey),
-          );
-          expect(
-            offersTotals.data,
-            '${TradeScreen.dealBookTotalReceivedLabel}: 0',
-          );
-
-          // Per-side empty-state copy must NOT render — both sides are
-          // non-empty (bids has filled+unfilled, offers has unfilled).
-          expect(
-            find.byKey(TradeScreen.dealBookBidsEmptyKey),
-            findsNothing,
-          );
-          expect(
-            find.byKey(TradeScreen.dealBookOffersEmptyKey),
-            findsNothing,
-          );
+          ],
         },
       );
-    },
-  );
 
-  group(
-    'AC #5 — Cross-commodity cargo cap: capacity 10 with attempted bids '
-    'totalling 12 across commodities clamps the indicator to 0, caps the '
-    'offending stepper, and mounts the warning (#2993 E8 (e))',
-    () {
-      testWidgets(
-        'Given tradeCargoCapacity == 10, staging Bid timber qty 6 then '
+      await pumpTradeScreenWithContainer(
+        tester,
+        game: buildTradeTestGame(
+          id: 'test_trade_screen_e8',
+          stockpile: tradeableStockpileFilled(99),
+          worldMarketState: worldMarket,
+        ),
+      );
+      await _switchToDealBook(tester);
+
+      // Filled timber row in the bids panel: qty 5 × floor(8.4) = 5 × 8 = 40
+      // per `SPEC/ui/trade-screen.md` § Deal Book (integer filled-row prices).
+      expect(
+        find.byKey(
+          TradeScreen.dealBookFilledRowKey(TradeScreen.dealBookSideBids, 0),
+        ),
+        findsOneWidget,
+      );
+      // ignore: avoid_hardcoded_strings_in_widgets
+      expect(find.text('timber — qty 5 × 8 = 40'), findsOneWidget);
+
+      // Unfilled timber carry-forward row in the bids panel.
+      expect(
+        find.byKey(
+          TradeScreen.dealBookUnfilledRowKey(TradeScreen.dealBookSideBids, 0),
+        ),
+        findsOneWidget,
+      );
+      // ignore: avoid_hardcoded_strings_in_widgets
+      expect(find.text('timber — qty 5 (priority 1)'), findsOneWidget);
+
+      // Bids panel total spent = filled notional only with integer
+      // unit prices: quantity × floor(pricePerUnit) = 5 × 8 = 40
+      // (carry-forwards do not contribute to treasury totals per
+      // `SPEC/ui/trade-screen.md` § Deal Book).
+      final Text bidsTotals = tester.widget<Text>(
+        find.byKey(TradeScreen.dealBookBidsTotalsKey),
+      );
+      expect(bidsTotals.data, '${TradeScreen.dealBookTotalSpentLabel}: 40');
+
+      // Offers panel: no filled deal, one carry-forward fabric offer.
+      expect(
+        find.byKey(
+          TradeScreen.dealBookFilledRowKey(TradeScreen.dealBookSideOffers, 0),
+        ),
+        findsNothing,
+      );
+      expect(
+        find.byKey(
+          TradeScreen.dealBookUnfilledRowKey(TradeScreen.dealBookSideOffers, 0),
+        ),
+        findsOneWidget,
+      );
+      // ignore: avoid_hardcoded_strings_in_widgets
+      expect(find.text('fabric — qty 3 (priority 1)'), findsOneWidget);
+
+      final Text offersTotals = tester.widget<Text>(
+        find.byKey(TradeScreen.dealBookOffersTotalsKey),
+      );
+      expect(offersTotals.data, '${TradeScreen.dealBookTotalReceivedLabel}: 0');
+
+      // Per-side empty-state copy must NOT render — both sides are
+      // non-empty (bids has filled+unfilled, offers has unfilled).
+      expect(find.byKey(TradeScreen.dealBookBidsEmptyKey), findsNothing);
+      expect(find.byKey(TradeScreen.dealBookOffersEmptyKey), findsNothing);
+    });
+  });
+
+  group('AC #5 — Cross-commodity cargo cap: capacity 10 with attempted bids '
+      'totalling 12 across commodities clamps the indicator to 0, caps the '
+      'offending stepper, and mounts the warning (#2993 E8 (e))', () {
+    testWidgets('Given tradeCargoCapacity == 10, staging Bid timber qty 6 then '
         'staging Bid iron qty 4 saturates the cargo (indicator: '
         '"Cargo remaining: 0", warning mounted). A subsequent attempt to '
         'add 2 more units (the 12th unit of cross-commodity bids) by '
         'either toggling a third commodity to Bid or incrementing an '
         'existing bid is rejected — the staged bid total never exceeds '
-        '10 and the warning row stays mounted.',
-        (tester) async {
-          final ProviderContainer container = await _pumpTradeScreenStandalone(
-            tester,
-            game: _buildStandaloneGame(tradeCargoCapacityOverride: 10),
-            initialOrders: _ordersWith(<TradeOrder>[
-              _bid(_timber, 6),
-              _bid(_iron, 4),
-            ]),
-          );
-
-          // (i) Cargo indicator clamps at 0 once total bids == capacity.
-          expect(_cargoIndicatorText(tester), 'Cargo remaining: 0');
-          // (iii) Warning row is mounted.
-          expect(
-            find.byKey(TradeScreen.marketCargoWarningKey),
-            findsOneWidget,
-          );
-          expect(
-            find.text(TradeScreen.cargoLimitWarningText),
-            findsOneWidget,
-          );
-
-          // (ii) Offending stepper is capped — increment on timber is
-          // a silent no-op because cross-commodity bid total already
-          // saturates the cargo budget.
-          await tester.tap(
-            find.byKey(TradeScreen.marketRowIncrementKey(_timber)),
-          );
-          await tester.pump();
-          expect(
-            _stagedOrder(container, _timber)?.quantity,
-            6,
-            reason:
-                'Refs #2993 E5c: bid increment blocked when cross-'
-                'commodity bid total saturates tradeCargoCapacity.',
-          );
-
-          // Toggle Bid on a fresh commodity (grain) is also a no-op
-          // because maxAllowedBidQuantity == 0 at saturation.
-          await tester.tap(
-            find.byKey(TradeScreen.marketRowBidChipKey(_grain)),
-          );
-          await tester.pump();
-          expect(_stagedOrder(container, _grain), isNull);
-
-          // Cross-commodity total never exceeds the capacity.
-          final Orders orders = container.read(currentOrdersProvider);
-          final int totalBidUnits = orders
-                  .tradeOrdersByPlayerId[_humanPlayerId]
-                  ?.where((TradeOrder o) => o.type == TradeOrderType.bid)
-                  .fold<int>(0, (sum, o) => sum + o.quantity) ??
-              0;
-          expect(totalBidUnits, 10);
-          expect(_cargoIndicatorText(tester), 'Cargo remaining: 0');
-          expect(
-            find.byKey(TradeScreen.marketCargoWarningKey),
-            findsOneWidget,
-          );
-        },
+        '10 and the warning row stays mounted.', (tester) async {
+      final ProviderContainer container = await pumpTradeScreenWithContainer(
+        tester,
+        game: buildTradeTestGame(
+          id: 'test_trade_screen_e8',
+          treasury: 100000,
+          stockpile: tradeableStockpileFilled(99),
+          tradeCargoCapacityOverride: 10,
+        ),
+        initialOrders: _ordersWith(<TradeOrder>[
+          _bid(_timber, 6),
+          _bid(_iron, 4),
+        ]),
       );
 
-      testWidgets(
-        'Toggle clamp: with timber 9 + offer fabric 5 (cargo remaining 1), '
-        'tapping `Bid` on fabric clamps the new staged quantity to the '
-        'remaining cargo (1, not the prior offer\'s 5)',
-        (tester) async {
-          final ProviderContainer container = await _pumpTradeScreenStandalone(
-            tester,
-            game: _buildStandaloneGame(tradeCargoCapacityOverride: 10),
-            initialOrders: _ordersWith(<TradeOrder>[
-              _bid(_timber, 9),
-              _offer(_fabric, 5),
-            ]),
-          );
+      // (i) Cargo indicator clamps at 0 once total bids == capacity.
+      expect(_cargoIndicatorText(tester), 'Cargo remaining: 0');
+      // (iii) Warning row is mounted.
+      expect(find.byKey(TradeScreen.marketCargoWarningKey), findsOneWidget);
+      expect(find.text(TradeScreen.cargoLimitWarningText), findsOneWidget);
 
-          await tester.tap(
-            find.byKey(TradeScreen.marketRowBidChipKey(_fabric)),
-          );
-          await tester.pump();
-
-          final TradeOrder? fabric = _stagedOrder(container, _fabric);
-          expect(fabric?.type, TradeOrderType.bid);
-          expect(
-            fabric?.quantity,
-            1,
-            reason:
-                'Refs #2993 E5c: bid toggle clamps quantity to '
-                'maxAllowedBidQuantity (remainingCargo + '
-                'priorBidContribution).',
-          );
-          expect(_cargoIndicatorText(tester), 'Cargo remaining: 0');
-          expect(
-            find.byKey(TradeScreen.marketCargoWarningKey),
-            findsOneWidget,
-          );
-        },
+      // (ii) Offending stepper is capped — increment on timber is
+      // a silent no-op because cross-commodity bid total already
+      // saturates the cargo budget.
+      await tester.tap(find.byKey(TradeScreen.marketRowIncrementKey(_timber)));
+      await tester.pump();
+      expect(
+        _stagedOrder(container, _timber)?.quantity,
+        6,
+        reason:
+            'Refs #2993 E5c: bid increment blocked when cross-'
+            'commodity bid total saturates tradeCargoCapacity.',
       );
-    },
-  );
 
-  group(
-    'AC #6 — Observe mode disables bid/offer controls and surfaces the '
-    'Observe-mode indicator (#2993 E8 (f))',
-    () {
-      testWidgets(
-        'Global observe mode (shellPanelsNotDefined == true): the body '
+      // Toggle Bid on a fresh commodity (grain) is also a no-op
+      // because maxAllowedBidQuantity == 0 at saturation.
+      await tester.tap(find.byKey(TradeScreen.marketRowBidChipKey(_grain)));
+      await tester.pump();
+      expect(_stagedOrder(container, _grain), isNull);
+
+      // Cross-commodity total never exceeds the capacity.
+      final Orders orders = container.read(currentOrdersProvider);
+      final int totalBidUnits =
+          orders.tradeOrdersByPlayerId[_humanPlayerId]
+              ?.where((TradeOrder o) => o.type == TradeOrderType.bid)
+              .fold<int>(0, (sum, o) => sum + o.quantity) ??
+          0;
+      expect(totalBidUnits, 10);
+      expect(_cargoIndicatorText(tester), 'Cargo remaining: 0');
+      expect(find.byKey(TradeScreen.marketCargoWarningKey), findsOneWidget);
+    });
+
+    testWidgets(
+      'Toggle clamp: with timber 9 + offer fabric 5 (cargo remaining 1), '
+      'tapping `Bid` on fabric clamps the new staged quantity to the '
+      'remaining cargo (1, not the prior offer\'s 5)',
+      (tester) async {
+        final ProviderContainer container = await pumpTradeScreenWithContainer(
+          tester,
+          game: buildTradeTestGame(
+            id: 'test_trade_screen_e8',
+            treasury: 100000,
+            stockpile: tradeableStockpileFilled(99),
+            tradeCargoCapacityOverride: 10,
+          ),
+          initialOrders: _ordersWith(<TradeOrder>[
+            _bid(_timber, 9),
+            _offer(_fabric, 5),
+          ]),
+        );
+
+        await tester.tap(find.byKey(TradeScreen.marketRowBidChipKey(_fabric)));
+        await tester.pump();
+
+        final TradeOrder? fabric = _stagedOrder(container, _fabric);
+        expect(fabric?.type, TradeOrderType.bid);
+        expect(
+          fabric?.quantity,
+          1,
+          reason:
+              'Refs #2993 E5c: bid toggle clamps quantity to '
+              'maxAllowedBidQuantity (remainingCargo + '
+              'priorBidContribution).',
+        );
+        expect(_cargoIndicatorText(tester), 'Cargo remaining: 0');
+        expect(find.byKey(TradeScreen.marketCargoWarningKey), findsOneWidget);
+      },
+    );
+  });
+
+  group('AC #6 — Observe mode disables bid/offer controls and surfaces the '
+      'Observe-mode indicator (#2993 E8 (f))', () {
+    testWidgets('Global observe mode (shellPanelsNotDefined == true): the body '
         'short-circuits to ObserveModeNotDefinedPanel(title: "Trade"); '
         'no Market or Deal Book tab bodies and no bid/offer chips or '
         'stepper buttons are mounted, but the dark CtTopBar chrome '
-        'still paints',
-        (tester) async {
-          await tester.pumpWidget(
-            buildTradeRouteHost(globalObserve: true),
-          );
-          await pumpSettleCapped(tester);
+        'still paints', (tester) async {
+      await tester.pumpWidget(buildTradeRouteHost(globalObserve: true));
+      await pumpSettleCapped(tester);
 
-          await tester.tap(find.text('open trade'));
-          await pumpSettleCapped(tester);
+      await tester.tap(find.text('open trade'));
+      await pumpSettleCapped(tester);
 
-          // TradeScreen mounted with dark chrome still present.
-          expect(find.byType(TradeScreen), findsOneWidget);
-          expect(find.byKey(TradeScreen.topBarKey), findsOneWidget);
+      // TradeScreen mounted with dark chrome still present.
+      expect(find.byType(TradeScreen), findsOneWidget);
+      expect(find.byKey(TradeScreen.topBarKey), findsOneWidget);
 
-          // Observe-mode indicator: the ObserveModeNotDefinedPanel
-          // titled "Trade" is the SPEC-canonical surface that signals
-          // observe mode is active (variant `c`).
-          final observePanelFinder = find.byType(ObserveModeNotDefinedPanel);
-          expect(observePanelFinder, findsOneWidget);
-          final ObserveModeNotDefinedPanel observePanel =
-              tester.widget<ObserveModeNotDefinedPanel>(observePanelFinder);
-          // ignore: avoid_hardcoded_strings_in_widgets
-          expect(observePanel.title, 'Trade');
+      // Observe-mode indicator: the ObserveModeNotDefinedPanel
+      // titled "Trade" is the SPEC-canonical surface that signals
+      // observe mode is active (variant `c`).
+      final observePanelFinder = find.byType(ObserveModeNotDefinedPanel);
+      expect(observePanelFinder, findsOneWidget);
+      final ObserveModeNotDefinedPanel observePanel = tester
+          .widget<ObserveModeNotDefinedPanel>(observePanelFinder);
+      // ignore: avoid_hardcoded_strings_in_widgets
+      expect(observePanel.title, 'Trade');
 
-          // No Market / Deal Book tab bodies → no bid/offer chips and
-          // no stepper buttons can be mounted in the tree (controls
-          // are scoped under the tab strip which itself is absent).
-          expect(find.byKey(TradeScreen.tabsBodyKey), findsNothing);
-          expect(find.byKey(TradeScreen.marketTabBodyKey), findsNothing);
-          expect(find.byKey(TradeScreen.dealBookTabBodyKey), findsNothing);
-          expect(find.byType(CtTabStrip), findsNothing);
-          // Per-row chip and stepper keys for the canonical timber row
-          // must not exist anywhere in the widget tree under observe.
-          expect(
-            find.byKey(TradeScreen.marketRowBidChipKey(_timber)),
-            findsNothing,
-          );
-          expect(
-            find.byKey(TradeScreen.marketRowOfferChipKey(_timber)),
-            findsNothing,
-          );
-          expect(
-            find.byKey(TradeScreen.marketRowIncrementKey(_timber)),
-            findsNothing,
-          );
-        },
+      // No Market / Deal Book tab bodies → no bid/offer chips and
+      // no stepper buttons can be mounted in the tree (controls
+      // are scoped under the tab strip which itself is absent).
+      expect(find.byKey(TradeScreen.tabsBodyKey), findsNothing);
+      expect(find.byKey(TradeScreen.marketTabBodyKey), findsNothing);
+      expect(find.byKey(TradeScreen.dealBookTabBodyKey), findsNothing);
+      expect(find.byType(CtTabStrip), findsNothing);
+      // Per-row chip and stepper keys for the canonical timber row
+      // must not exist anywhere in the widget tree under observe.
+      expect(
+        find.byKey(TradeScreen.marketRowBidChipKey(_timber)),
+        findsNothing,
       );
+      expect(
+        find.byKey(TradeScreen.marketRowOfferChipKey(_timber)),
+        findsNothing,
+      );
+      expect(
+        find.byKey(TradeScreen.marketRowIncrementKey(_timber)),
+        findsNothing,
+      );
+    });
 
-      testWidgets(
-        'Per-GP observe variant (canMutateViaUi == false, not global '
+    testWidgets('Per-GP observe variant (canMutateViaUi == false, not global '
         'observe): the Market tab body remains mounted (read-only data '
         'still renders) but the IgnorePointer wrapper blocks taps; '
         'currentOrdersProvider is not mutated when the player tries '
-        'to stage a Bid',
-        (tester) async {
-          final ProviderContainer container = await _pumpTradeScreenStandalone(
-            tester,
-            game: _buildStandaloneGame(),
-            canMutateViaUi: false,
-          );
-
-          // Market tab body is mounted (chrome stays read-only, not
-          // hidden behind the global-observe sentinel).
-          expect(
-            find.byKey(TradeScreen.marketTabBodyKey),
-            findsOneWidget,
-          );
-
-          // Attempting to tap Bid / increment is absorbed by the
-          // IgnorePointer; `warnIfMissed: false` silences the expected
-          // hit-test warning that the wrapper surfaces when it
-          // swallows pointer events.
-          await tester.tap(
-            find.byKey(TradeScreen.marketRowBidChipKey(_timber)),
-            warnIfMissed: false,
-          );
-          await tester.pump();
-          await tester.tap(
-            find.byKey(TradeScreen.marketRowIncrementKey(_timber)),
-            warnIfMissed: false,
-          );
-          await tester.pump();
-
-          expect(
-            _stagedOrder(container, _timber),
-            isNull,
-            reason:
-                'Per-GP observe variant must not mutate '
-                'currentOrdersProvider even when the player attempts '
-                'to drive the chip / stepper controls.',
-          );
-        },
+        'to stage a Bid', (tester) async {
+      final ProviderContainer container = await pumpTradeScreenWithContainer(
+        tester,
+        game: buildTradeTestGame(
+          id: 'test_trade_screen_e8',
+          stockpile: tradeableStockpileFilled(99),
+        ),
+        canMutateViaUi: false,
       );
-    },
-  );
+
+      // Market tab body is mounted (chrome stays read-only, not
+      // hidden behind the global-observe sentinel).
+      expect(find.byKey(TradeScreen.marketTabBodyKey), findsOneWidget);
+
+      // Attempting to tap Bid / increment is absorbed by the
+      // IgnorePointer; `warnIfMissed: false` silences the expected
+      // hit-test warning that the wrapper surfaces when it
+      // swallows pointer events.
+      await tester.tap(
+        find.byKey(TradeScreen.marketRowBidChipKey(_timber)),
+        warnIfMissed: false,
+      );
+      await tester.pump();
+      await tester.tap(
+        find.byKey(TradeScreen.marketRowIncrementKey(_timber)),
+        warnIfMissed: false,
+      );
+      await tester.pump();
+
+      expect(
+        _stagedOrder(container, _timber),
+        isNull,
+        reason:
+            'Per-GP observe variant must not mutate '
+            'currentOrdersProvider even when the player attempts '
+            'to drive the chip / stepper controls.',
+      );
+    });
+  });
 }

--- a/app/test/trade_screen_market_tab_commodity_table_test.dart
+++ b/app/test/trade_screen_market_tab_commodity_table_test.dart
@@ -28,605 +28,526 @@
 // out of scope for this pin file.
 
 import 'package:colonizethis_app/features/game/screens/trade/trade_screen.dart';
-import 'package:colonizethis_app/providers/games_provider.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'support/app_shell_harness.dart';
-
-/// Builds a synthetic Game with one human player and a populated
-/// [WorldMarketState] so the Market tab table renders deterministic
-/// rows the assertions below pin. Mirrors the lightweight Widgetbook
-/// Game factory in `catalog_part6.dart` so the same data shape proves
-/// the contract in both surfaces.
-Game _buildGame({
-  Map<CommodityId, int>? prices,
-  Map<CommodityId, MarketActivity>? activity,
-}) {
-  return Game(
-    id: 'test_trade_screen_market_tab',
-    worldState: WorldState(
-      turnState: TurnState(phase: TurnPhase.orders, turnNumber: 1),
-      oldWorld: const RegionData(),
-      newWorld: const RegionData(),
-    ),
-    turnTimeMapping: TurnTimeMapping.gdd01,
-    players: [
-      // ignore: avoid_hardcoded_strings_in_widgets
-      Player(id: 'gp_h', displayName: 'England', isHuman: true, treasury: 500),
-    ],
-    diplomacyRelations: const [],
-    diplomaticHistoryEvents: const [],
-    dossierEvidenceEntries: const [],
-    worldMarketState: WorldMarketState(
-      prices: prices ?? const <CommodityId, int>{},
-      lastTurnActivity:
-          activity ?? const <CommodityId, MarketActivity>{},
-    ),
-  );
-}
-
-/// Pumps the [TradeScreen] in isolation (no Hive, no AppEventBus
-/// listeners) so the assertions can pin the Market tab body without
-/// the full in-game shell. Mirrors the lightweight harness used by
-/// `trade_screen_320dp_min_viewport_test.dart`.
-Future<void> _pumpTradeScreen(
-  WidgetTester tester, {
-  required Game game,
-}) async {
-  final Player player = game.players.first;
-  await pumpAppShell(
-    tester,
-    overrides: [
-      currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
-    ],
-    child: TradeScreen(game: game, player: player),
-  );
-}
+import 'support/trade_screen_test_support.dart';
 
 void main() {
   suppressLogsForTests();
 
-  group(
-    'TradeScreen Market tab read-only commodity table (Refs #2993 E5a)',
-    () {
-      testWidgets(
-        'renders 22 tradeable rows (CommodityCatalog minus riches + spices) '
-        'inside marketCommodityListKey',
-        (tester) async {
-          await _pumpTradeScreen(tester, game: _buildGame());
+  group('TradeScreen Market tab read-only commodity table (Refs #2993 E5a)', () {
+    testWidgets(
+      'renders 22 tradeable rows (CommodityCatalog minus riches + spices) '
+      'inside marketCommodityListKey',
+      (tester) async {
+        await pumpTradeScreen(tester, game: buildTradeTestGame());
 
-          final list = find.byKey(TradeScreen.marketCommodityListKey);
-          expect(list, findsOneWidget);
+        final list = find.byKey(TradeScreen.marketCommodityListKey);
+        expect(list, findsOneWidget);
 
-          final List<Commodity> tradeable = <Commodity>[
-            for (final Commodity c in CommodityCatalog.all)
-              if (c.category != CommodityCategory.riches && c.id != 'spices') c,
-          ];
-          expect(
-            tradeable.length,
-            22,
-            reason:
-                'SPEC/game/world-market.md §Tradeable commodities — the '
-                'tradeable set is the full CommodityCatalog minus riches '
-                'and spices (22 rows). If this count changes, '
-                'SPEC/game/world-market.md and SPEC/ui/trade-screen.md '
-                'must both be updated together with the row pin below.',
-          );
+        final List<Commodity> tradeable = <Commodity>[
+          for (final Commodity c in CommodityCatalog.all)
+            if (c.category != CommodityCategory.riches && c.id != 'spices') c,
+        ];
+        expect(
+          tradeable.length,
+          22,
+          reason:
+              'SPEC/game/world-market.md §Tradeable commodities — the '
+              'tradeable set is the full CommodityCatalog minus riches '
+              'and spices (22 rows). If this count changes, '
+              'SPEC/game/world-market.md and SPEC/ui/trade-screen.md '
+              'must both be updated together with the row pin below.',
+        );
 
-          // Each tradeable commodity must be present as a row keyed by
-          // its commodity id, scoped under the marketCommodityListKey.
-          for (final Commodity c in tradeable) {
-            final rowFinder = find.descendant(
-              of: list,
-              matching: find.byKey(TradeScreen.marketCommodityRowKey(c.id)),
-            );
-            expect(
-              rowFinder,
-              findsOneWidget,
-              reason:
-                  'tradeable commodity `${c.id}` must render a row keyed '
-                  'tradeScreenMarketRow:${c.id} inside the Market tab list.',
-            );
-          }
-        },
-      );
-
-      testWidgets(
-        'excludes riches commodities and the `spices` advanced commodity '
-        '(negative AC: no row key for gold / silver / gems / diamonds / spices)',
-        (tester) async {
-          await _pumpTradeScreen(tester, game: _buildGame());
-
-          final list = find.byKey(TradeScreen.marketCommodityListKey);
-          expect(list, findsOneWidget);
-
-          for (final CommodityId excluded in <CommodityId>[
-            CommodityCatalog.gold.id,
-            CommodityCatalog.silver.id,
-            CommodityCatalog.gems.id,
-            CommodityCatalog.diamonds.id,
-            CommodityCatalog.spices.id,
-          ]) {
-            expect(
-              find.byKey(TradeScreen.marketCommodityRowKey(excluded)),
-              findsNothing,
-              reason:
-                  'SPEC/game/world-market.md §Tradeable commodities — '
-                  '`$excluded` is not tradeable and must not render a row.',
-            );
-          }
-        },
-      );
-
-      testWidgets(
-        'rows are grouped under Food / Raw Materials / Manufactured '
-        'CtSectionLabel headers in catalog order — deterministic order '
-        'pin (#3093 sectioned grouping)',
-        (tester) async {
-          await _pumpTradeScreen(tester, game: _buildGame());
-
-          // All three section headers mounted in order Food → Raw
-          // Materials → Manufactured. The pin verifies their vertical
-          // positions in the parent column, which guarantees the
-          // expected reading order.
-          final Offset foodHeaderOffset = tester.getTopLeft(
-            find.byKey(TradeScreen.marketSectionFoodKey),
-          );
-          final Offset rawMaterialsHeaderOffset = tester.getTopLeft(
-            find.byKey(TradeScreen.marketSectionRawMaterialsKey),
-          );
-          final Offset manufacturedHeaderOffset = tester.getTopLeft(
-            find.byKey(TradeScreen.marketSectionManufacturedKey),
-          );
-
-          expect(
-            rawMaterialsHeaderOffset.dy,
-            greaterThan(foodHeaderOffset.dy),
-            reason:
-                'SPEC/ui/trade-screen.md § Market tab — sectioned '
-                'grouping (#3093): the Raw Materials section header must '
-                'appear below the Food section header.',
+        // Each tradeable commodity must be present as a row keyed by
+        // its commodity id, scoped under the marketCommodityListKey.
+        for (final Commodity c in tradeable) {
+          final rowFinder = find.descendant(
+            of: list,
+            matching: find.byKey(TradeScreen.marketCommodityRowKey(c.id)),
           );
           expect(
-            manufacturedHeaderOffset.dy,
-            greaterThan(rawMaterialsHeaderOffset.dy),
-            reason:
-                'SPEC/ui/trade-screen.md § Market tab — sectioned '
-                'grouping (#3093): the Manufactured section header must '
-                'appear below the Raw Materials section header.',
-          );
-
-          // Each section contains its category's commodities in
-          // CommodityCatalog.all iteration order (the same order the
-          // Production panel uses). Build the expected per-section
-          // lists from the live catalog so a future ruleset extension
-          // automatically reflects in the assertion without manual
-          // edits.
-          final List<Commodity> foodCommodities = <Commodity>[
-            for (final Commodity c in CommodityCatalog.all)
-              if (c.category == CommodityCategory.food && c.id != 'spices') c,
-          ];
-          final List<Commodity> rawMaterialCommodities = <Commodity>[
-            for (final Commodity c in CommodityCatalog.all)
-              if (c.category == CommodityCategory.rawMaterial &&
-                  c.id != 'spices')
-                c,
-          ];
-          final List<Commodity> manufacturedCommodities = <Commodity>[
-            for (final Commodity c in CommodityCatalog.all)
-              if (c.category == CommodityCategory.manufactured &&
-                  c.id != 'spices')
-                c,
-          ];
-
-          for (final List<Commodity> sectionRows in <List<Commodity>>[
-            foodCommodities,
-            rawMaterialCommodities,
-            manufacturedCommodities,
-          ]) {
-            for (int i = 1; i < sectionRows.length; i++) {
-              final Offset prior = tester.getTopLeft(
-                find.byKey(
-                  TradeScreen.marketCommodityRowKey(sectionRows[i - 1].id),
-                ),
-              );
-              final Offset current = tester.getTopLeft(
-                find.byKey(
-                  TradeScreen.marketCommodityRowKey(sectionRows[i].id),
-                ),
-              );
-              expect(
-                current.dy,
-                greaterThan(prior.dy),
-                reason:
-                    'Row `${sectionRows[i].id}` must appear below row '
-                    '`${sectionRows[i - 1].id}` (catalog order within '
-                    'its category section).',
-              );
-            }
-          }
-
-          // Cross-section pin: the last food row must precede the Raw
-          // Materials header which must precede the first raw-material
-          // row; likewise for the manufactured boundary. This catches
-          // regressions where a single commodity slips out of its
-          // section into the wrong bucket.
-          final Offset lastFoodRow = tester.getTopLeft(
-            find.byKey(
-              TradeScreen.marketCommodityRowKey(foodCommodities.last.id),
-            ),
-          );
-          final Offset firstRawMaterialRow = tester.getTopLeft(
-            find.byKey(
-              TradeScreen.marketCommodityRowKey(
-                rawMaterialCommodities.first.id,
-              ),
-            ),
-          );
-          expect(
-            lastFoodRow.dy,
-            lessThan(rawMaterialsHeaderOffset.dy),
-            reason:
-                'The last Food row (`${foodCommodities.last.id}`) must '
-                'sit above the Raw Materials section header.',
-          );
-          expect(
-            rawMaterialsHeaderOffset.dy,
-            lessThan(firstRawMaterialRow.dy),
-            reason:
-                'The Raw Materials section header must sit above the '
-                'first Raw Materials row '
-                '(`${rawMaterialCommodities.first.id}`).',
-          );
-
-          final Offset lastRawMaterialRow = tester.getTopLeft(
-            find.byKey(
-              TradeScreen.marketCommodityRowKey(
-                rawMaterialCommodities.last.id,
-              ),
-            ),
-          );
-          final Offset firstManufacturedRow = tester.getTopLeft(
-            find.byKey(
-              TradeScreen.marketCommodityRowKey(
-                manufacturedCommodities.first.id,
-              ),
-            ),
-          );
-          expect(
-            lastRawMaterialRow.dy,
-            lessThan(manufacturedHeaderOffset.dy),
-            reason:
-                'The last Raw Materials row '
-                '(`${rawMaterialCommodities.last.id}`) must sit above '
-                'the Manufactured section header.',
-          );
-          expect(
-            manufacturedHeaderOffset.dy,
-            lessThan(firstManufacturedRow.dy),
-            reason:
-                'The Manufactured section header must sit above the '
-                'first Manufactured row '
-                '(`${manufacturedCommodities.first.id}`).',
-          );
-        },
-      );
-
-      testWidgets(
-        'CtSectionLabel headers render their localized labels '
-        '(Food / Raw Materials / Manufactured)',
-        (tester) async {
-          await _pumpTradeScreen(tester, game: _buildGame());
-
-          // Section labels rendered as upper-case small-caps by
-          // CtSectionLabel; pin the visible (upper-cased) literal.
-          expect(
-            find.descendant(
-              of: find.byKey(TradeScreen.marketSectionFoodKey),
-              // ignore: avoid_hardcoded_strings_in_widgets
-              matching: find.text('FOOD'),
-            ),
+            rowFinder,
             findsOneWidget,
             reason:
-                'CtSectionLabel renders its text in upper-case so the '
-                'Food header should read `FOOD` (l10n English fallback '
-                'when the host MaterialApp has no l10n delegates).',
+                'tradeable commodity `${c.id}` must render a row keyed '
+                'tradeScreenMarketRow:${c.id} inside the Market tab list.',
           );
+        }
+      },
+    );
+
+    testWidgets(
+      'excludes riches commodities and the `spices` advanced commodity '
+      '(negative AC: no row key for gold / silver / gems / diamonds / spices)',
+      (tester) async {
+        await pumpTradeScreen(tester, game: buildTradeTestGame());
+
+        final list = find.byKey(TradeScreen.marketCommodityListKey);
+        expect(list, findsOneWidget);
+
+        for (final CommodityId excluded in <CommodityId>[
+          CommodityCatalog.gold.id,
+          CommodityCatalog.silver.id,
+          CommodityCatalog.gems.id,
+          CommodityCatalog.diamonds.id,
+          CommodityCatalog.spices.id,
+        ]) {
           expect(
-            find.descendant(
-              of: find.byKey(TradeScreen.marketSectionRawMaterialsKey),
-              // ignore: avoid_hardcoded_strings_in_widgets
-              matching: find.text('RAW MATERIALS'),
-            ),
-            findsOneWidget,
-            reason:
-                'CtSectionLabel renders its text in upper-case so the '
-                'Raw Materials header should read `RAW MATERIALS`.',
-          );
-          expect(
-            find.descendant(
-              of: find.byKey(TradeScreen.marketSectionManufacturedKey),
-              // ignore: avoid_hardcoded_strings_in_widgets
-              matching: find.text('MANUFACTURED'),
-            ),
-            findsOneWidget,
-            reason:
-                'CtSectionLabel renders its text in upper-case so the '
-                'Manufactured header should read `MANUFACTURED`.',
-          );
-        },
-      );
-
-      testWidgets(
-        'every section header is mounted inside the Market tab body '
-        '(not under the off-stage Deal Book tab body)',
-        (tester) async {
-          await _pumpTradeScreen(tester, game: _buildGame());
-
-          for (final Key sectionKey in <Key>[
-            TradeScreen.marketSectionFoodKey,
-            TradeScreen.marketSectionRawMaterialsKey,
-            TradeScreen.marketSectionManufacturedKey,
-          ]) {
-            expect(
-              find.descendant(
-                of: find.byKey(TradeScreen.marketTabBodyKey),
-                matching: find.byKey(sectionKey),
-              ),
-              findsOneWidget,
-              reason:
-                  'Section header `$sectionKey` must be mounted inside '
-                  'the Market tab body keyed `marketTabBodyKey`.',
-            );
-            expect(
-              find.descendant(
-                of: find.byKey(
-                  TradeScreen.dealBookTabBodyKey,
-                  skipOffstage: false,
-                ),
-                matching: find.byKey(sectionKey),
-              ),
-              findsNothing,
-              reason:
-                  'Section header `$sectionKey` must NOT leak into the '
-                  'off-stage Deal Book tab body subtree.',
-            );
-          }
-        },
-      );
-
-      testWidgets(
-        'renders the live `WorldMarketState.prices` integer price for a '
-        'seeded commodity (timber=30 → `30`) and falls back to the resource '
-        'catalog default for both unseeded raw resources (iron → `80`) and '
-        'manufactured commodities (lumber → `60`, castIron → `160`) — '
-        '`SPEC/game/commodity-catalog.md` § Manufactured base prices, '
-        'Refs #3093',
-        (tester) async {
-          await _pumpTradeScreen(
-            tester,
-            game: _buildGame(
-              prices: const <CommodityId, int>{'timber': 30},
-            ),
-          );
-
-          // Seeded commodity row shows the integer price text (Refs #3093 —
-          // `Map<CommodityId, int>` post-floor at persistence boundary).
-          final timberRow = find.byKey(
-            TradeScreen.marketCommodityRowKey(CommodityCatalog.timber.id),
-          );
-          expect(timberRow, findsOneWidget);
-          expect(
-            find.descendant(of: timberRow, matching: find.text('30')),
-            findsOneWidget,
-            reason:
-                'SPEC/ui/trade-screen.md § Body — Market tab (Refs #3093): '
-                'the price cell reads `Game.worldMarketState.prices[id]` '
-                'as a whole integer (price storage is now '
-                '`Map<CommodityId, int>` per #3093 issue body § Price '
-                'presentation & data model).',
-          );
-
-          // Unseeded raw-resource commodity row falls back to the resource
-          // catalog default integer price (#3093 — iron defaults to 80 via
-          // `ResourceRules.defaultRules.defaultMarketPriceForCommodityId`).
-          final ironRow = find.byKey(
-            TradeScreen.marketCommodityRowKey(CommodityCatalog.iron.id),
-          );
-          expect(ironRow, findsOneWidget);
-          expect(
-            find.descendant(of: ironRow, matching: find.text('80')),
-            findsOneWidget,
-            reason:
-                'SPEC/ui/trade-screen.md § Body — Market tab (Refs #3093): '
-                'rows fall back to the resource catalog '
-                '`defaultMarketPrice` integer when '
-                '`WorldMarketState.prices` lacks an entry. Iron is a raw '
-                'resource with catalog default 80.',
-          );
-          // Negative pin: iron must NOT render the em-dash price glyph.
-          // The price-slot em-dash is now reserved as a defensive
-          // fallback for tradeable commodities that ship without a
-          // catalog default — none exist under the current ruleset
-          // (Refs #3093 manufactured-default-prices slice). Only the
-          // quantity-idle em-dash remains in an iron row when no trade
-          // order is staged.
-          expect(
-            find.descendant(
-              of: ironRow,
-              matching: find.text(
-                // ignore: avoid_hardcoded_strings_in_widgets
-                '—',
-              ),
-            ),
-            findsOneWidget,
-            reason:
-                'Refs #3093 — only the quantity-idle em-dash remains in '
-                'an iron row when no trade order is staged. The price-'
-                'slot em-dash must NOT appear for raw-resource commodities '
-                'with a catalog default (regression guard against losing '
-                'the catalog fallback).',
-          );
-
-          // The quantity-idle em-dash specifically lives under the
-          // quantity readout key — keep this scoped pin so a future
-          // regression that swaps the quantity glyph still surfaces a
-          // readable failure.
-          expect(
-            find.byKey(
-              TradeScreen.marketRowQuantityTextKey(CommodityCatalog.iron.id),
-            ),
-            findsOneWidget,
-            reason:
-                'Refs #2993 E5b — every commodity row exposes its '
-                'quantity readout via the marketRowQuantityTextKey, '
-                'including rows whose staged TradeOrder is empty (the '
-                'idle em-dash glyph).',
-          );
-
-          // Manufactured commodity row (now seeded by the catalog): the
-          // price slot reads the input-cost-derived base price from
-          // SPEC/game/commodity-catalog.md § Manufactured base prices.
-          // Lumber's canonical recipe (`timber x 2` at 30 each) yields
-          // 60; castIron's (`iron x 2`) yields 160.
-          final lumberRow = find.byKey(
-            TradeScreen.marketCommodityRowKey(CommodityCatalog.lumber.id),
-          );
-          expect(lumberRow, findsOneWidget);
-          expect(
-            find.descendant(of: lumberRow, matching: find.text('60')),
-            findsOneWidget,
-            reason:
-                'Refs #3093 (manufactured-default-prices slice) — the '
-                'lumber price cell falls back to `ResourceRules.defaultRules'
-                '.defaultMarketPriceForCommodityId("lumber") = 60` '
-                '(SPEC/game/commodity-catalog.md § Manufactured base prices: '
-                '`timber x 2` at `30` each).',
-          );
-          // Negative pin: the lumber price slot must NOT render the
-          // em-dash glyph now that the catalog publishes a manufactured
-          // base price for it. Only the quantity-idle em-dash remains.
-          expect(
-            find.descendant(
-              of: lumberRow,
-              matching: find.text(
-                // ignore: avoid_hardcoded_strings_in_widgets
-                '—',
-              ),
-            ),
-            findsOneWidget,
-            reason:
-                'Refs #3093 (manufactured-default-prices slice) — the '
-                'price-slot em-dash MUST NOT appear for manufactured '
-                'commodities now that SPEC/game/commodity-catalog.md § '
-                'Manufactured base prices supplies a published catalog '
-                'default. Only the quantity-idle em-dash should remain '
-                'when no TradeOrder is staged.',
-          );
-
-          final castIronRow = find.byKey(
-            TradeScreen.marketCommodityRowKey(CommodityCatalog.castIron.id),
-          );
-          expect(castIronRow, findsOneWidget);
-          expect(
-            find.descendant(of: castIronRow, matching: find.text('160')),
-            findsOneWidget,
-            reason:
-                'Refs #3093 — castIron base price `160` per '
-                'SPEC/game/commodity-catalog.md § Manufactured base prices '
-                '(`timber x 2 + iron x 2` = `60 + 160`).',
-          );
-        },
-      );
-
-      testWidgets(
-        'renders the previous-turn aggregate volume line `Bids X / Offers Y` '
-        'from WorldMarketState.lastTurnActivity (with zero-default for '
-        'commodities absent from the activity map)',
-        (tester) async {
-          await _pumpTradeScreen(
-            tester,
-            game: _buildGame(
-              activity: const <CommodityId, MarketActivity>{
-                'timber': MarketActivity(
-                  totalBidQuantity: 12,
-                  totalOfferQuantity: 8,
-                ),
-              },
-            ),
-          );
-
-          final timberRow = find.byKey(
-            TradeScreen.marketCommodityRowKey(CommodityCatalog.timber.id),
-          );
-          expect(timberRow, findsOneWidget);
-          expect(
-            find.descendant(
-              of: timberRow,
-              // ignore: avoid_hardcoded_strings_in_widgets
-              matching: find.text('Bids 12 / Offers 8'),
-            ),
-            findsOneWidget,
-            reason:
-                'SPEC/ui/trade-screen.md § Body — Market tab: per-row '
-                'inline aggregate volumes sourced from '
-                '`WorldMarketState.lastTurnActivity[commodityId]`.',
-          );
-
-          // Commodity not present in the activity map falls back to 0/0.
-          final fabricRow = find.byKey(
-            TradeScreen.marketCommodityRowKey(CommodityCatalog.fabric.id),
-          );
-          expect(fabricRow, findsOneWidget);
-          expect(
-            find.descendant(
-              of: fabricRow,
-              // ignore: avoid_hardcoded_strings_in_widgets
-              matching: find.text('Bids 0 / Offers 0'),
-            ),
-            findsOneWidget,
-            reason:
-                'SPEC/ui/trade-screen.md § Body — Market tab: rows for '
-                'commodities absent from `WorldMarketState.lastTurnActivity` '
-                'default to a zero-volume line so the column reads '
-                'consistently for every row.',
-          );
-        },
-      );
-
-      testWidgets(
-        'commodity rows render only inside the Market tab body — the off-stage '
-        'Deal Book tab placeholder body does not host any commodity row keys',
-        (tester) async {
-          await _pumpTradeScreen(tester, game: _buildGame());
-
-          // Sanity: Market tab body hosts the list and rows.
-          expect(
-            find.descendant(
-              of: find.byKey(TradeScreen.marketTabBodyKey),
-              matching: find.byKey(TradeScreen.marketCommodityListKey),
-            ),
-            findsOneWidget,
-          );
-
-          // The off-stage Deal Book body must not host any commodity row
-          // — both off-stage and on-stage scopes.
-          expect(
-            find.descendant(
-              of: find.byKey(
-                TradeScreen.dealBookTabBodyKey,
-                skipOffstage: false,
-              ),
-              matching: find.byKey(TradeScreen.marketCommodityListKey),
-            ),
+            find.byKey(TradeScreen.marketCommodityRowKey(excluded)),
             findsNothing,
+            reason:
+                'SPEC/game/world-market.md §Tradeable commodities — '
+                '`$excluded` is not tradeable and must not render a row.',
           );
-        },
+        }
+      },
+    );
+
+    testWidgets('rows are grouped under Food / Raw Materials / Manufactured '
+        'CtSectionLabel headers in catalog order — deterministic order '
+        'pin (#3093 sectioned grouping)', (tester) async {
+      await pumpTradeScreen(tester, game: buildTradeTestGame());
+
+      // All three section headers mounted in order Food → Raw
+      // Materials → Manufactured. The pin verifies their vertical
+      // positions in the parent column, which guarantees the
+      // expected reading order.
+      final Offset foodHeaderOffset = tester.getTopLeft(
+        find.byKey(TradeScreen.marketSectionFoodKey),
       );
-    },
-  );
+      final Offset rawMaterialsHeaderOffset = tester.getTopLeft(
+        find.byKey(TradeScreen.marketSectionRawMaterialsKey),
+      );
+      final Offset manufacturedHeaderOffset = tester.getTopLeft(
+        find.byKey(TradeScreen.marketSectionManufacturedKey),
+      );
+
+      expect(
+        rawMaterialsHeaderOffset.dy,
+        greaterThan(foodHeaderOffset.dy),
+        reason:
+            'SPEC/ui/trade-screen.md § Market tab — sectioned '
+            'grouping (#3093): the Raw Materials section header must '
+            'appear below the Food section header.',
+      );
+      expect(
+        manufacturedHeaderOffset.dy,
+        greaterThan(rawMaterialsHeaderOffset.dy),
+        reason:
+            'SPEC/ui/trade-screen.md § Market tab — sectioned '
+            'grouping (#3093): the Manufactured section header must '
+            'appear below the Raw Materials section header.',
+      );
+
+      // Each section contains its category's commodities in
+      // CommodityCatalog.all iteration order (the same order the
+      // Production panel uses). Build the expected per-section
+      // lists from the live catalog so a future ruleset extension
+      // automatically reflects in the assertion without manual
+      // edits.
+      final List<Commodity> foodCommodities = <Commodity>[
+        for (final Commodity c in CommodityCatalog.all)
+          if (c.category == CommodityCategory.food && c.id != 'spices') c,
+      ];
+      final List<Commodity> rawMaterialCommodities = <Commodity>[
+        for (final Commodity c in CommodityCatalog.all)
+          if (c.category == CommodityCategory.rawMaterial && c.id != 'spices')
+            c,
+      ];
+      final List<Commodity> manufacturedCommodities = <Commodity>[
+        for (final Commodity c in CommodityCatalog.all)
+          if (c.category == CommodityCategory.manufactured && c.id != 'spices')
+            c,
+      ];
+
+      for (final List<Commodity> sectionRows in <List<Commodity>>[
+        foodCommodities,
+        rawMaterialCommodities,
+        manufacturedCommodities,
+      ]) {
+        for (int i = 1; i < sectionRows.length; i++) {
+          final Offset prior = tester.getTopLeft(
+            find.byKey(
+              TradeScreen.marketCommodityRowKey(sectionRows[i - 1].id),
+            ),
+          );
+          final Offset current = tester.getTopLeft(
+            find.byKey(TradeScreen.marketCommodityRowKey(sectionRows[i].id)),
+          );
+          expect(
+            current.dy,
+            greaterThan(prior.dy),
+            reason:
+                'Row `${sectionRows[i].id}` must appear below row '
+                '`${sectionRows[i - 1].id}` (catalog order within '
+                'its category section).',
+          );
+        }
+      }
+
+      // Cross-section pin: the last food row must precede the Raw
+      // Materials header which must precede the first raw-material
+      // row; likewise for the manufactured boundary. This catches
+      // regressions where a single commodity slips out of its
+      // section into the wrong bucket.
+      final Offset lastFoodRow = tester.getTopLeft(
+        find.byKey(TradeScreen.marketCommodityRowKey(foodCommodities.last.id)),
+      );
+      final Offset firstRawMaterialRow = tester.getTopLeft(
+        find.byKey(
+          TradeScreen.marketCommodityRowKey(rawMaterialCommodities.first.id),
+        ),
+      );
+      expect(
+        lastFoodRow.dy,
+        lessThan(rawMaterialsHeaderOffset.dy),
+        reason:
+            'The last Food row (`${foodCommodities.last.id}`) must '
+            'sit above the Raw Materials section header.',
+      );
+      expect(
+        rawMaterialsHeaderOffset.dy,
+        lessThan(firstRawMaterialRow.dy),
+        reason:
+            'The Raw Materials section header must sit above the '
+            'first Raw Materials row '
+            '(`${rawMaterialCommodities.first.id}`).',
+      );
+
+      final Offset lastRawMaterialRow = tester.getTopLeft(
+        find.byKey(
+          TradeScreen.marketCommodityRowKey(rawMaterialCommodities.last.id),
+        ),
+      );
+      final Offset firstManufacturedRow = tester.getTopLeft(
+        find.byKey(
+          TradeScreen.marketCommodityRowKey(manufacturedCommodities.first.id),
+        ),
+      );
+      expect(
+        lastRawMaterialRow.dy,
+        lessThan(manufacturedHeaderOffset.dy),
+        reason:
+            'The last Raw Materials row '
+            '(`${rawMaterialCommodities.last.id}`) must sit above '
+            'the Manufactured section header.',
+      );
+      expect(
+        manufacturedHeaderOffset.dy,
+        lessThan(firstManufacturedRow.dy),
+        reason:
+            'The Manufactured section header must sit above the '
+            'first Manufactured row '
+            '(`${manufacturedCommodities.first.id}`).',
+      );
+    });
+
+    testWidgets('CtSectionLabel headers render their localized labels '
+        '(Food / Raw Materials / Manufactured)', (tester) async {
+      await pumpTradeScreen(tester, game: buildTradeTestGame());
+
+      // Section labels rendered as upper-case small-caps by
+      // CtSectionLabel; pin the visible (upper-cased) literal.
+      expect(
+        find.descendant(
+          of: find.byKey(TradeScreen.marketSectionFoodKey),
+          // ignore: avoid_hardcoded_strings_in_widgets
+          matching: find.text('FOOD'),
+        ),
+        findsOneWidget,
+        reason:
+            'CtSectionLabel renders its text in upper-case so the '
+            'Food header should read `FOOD` (l10n English fallback '
+            'when the host MaterialApp has no l10n delegates).',
+      );
+      expect(
+        find.descendant(
+          of: find.byKey(TradeScreen.marketSectionRawMaterialsKey),
+          // ignore: avoid_hardcoded_strings_in_widgets
+          matching: find.text('RAW MATERIALS'),
+        ),
+        findsOneWidget,
+        reason:
+            'CtSectionLabel renders its text in upper-case so the '
+            'Raw Materials header should read `RAW MATERIALS`.',
+      );
+      expect(
+        find.descendant(
+          of: find.byKey(TradeScreen.marketSectionManufacturedKey),
+          // ignore: avoid_hardcoded_strings_in_widgets
+          matching: find.text('MANUFACTURED'),
+        ),
+        findsOneWidget,
+        reason:
+            'CtSectionLabel renders its text in upper-case so the '
+            'Manufactured header should read `MANUFACTURED`.',
+      );
+    });
+
+    testWidgets('every section header is mounted inside the Market tab body '
+        '(not under the off-stage Deal Book tab body)', (tester) async {
+      await pumpTradeScreen(tester, game: buildTradeTestGame());
+
+      for (final Key sectionKey in <Key>[
+        TradeScreen.marketSectionFoodKey,
+        TradeScreen.marketSectionRawMaterialsKey,
+        TradeScreen.marketSectionManufacturedKey,
+      ]) {
+        expect(
+          find.descendant(
+            of: find.byKey(TradeScreen.marketTabBodyKey),
+            matching: find.byKey(sectionKey),
+          ),
+          findsOneWidget,
+          reason:
+              'Section header `$sectionKey` must be mounted inside '
+              'the Market tab body keyed `marketTabBodyKey`.',
+        );
+        expect(
+          find.descendant(
+            of: find.byKey(TradeScreen.dealBookTabBodyKey, skipOffstage: false),
+            matching: find.byKey(sectionKey),
+          ),
+          findsNothing,
+          reason:
+              'Section header `$sectionKey` must NOT leak into the '
+              'off-stage Deal Book tab body subtree.',
+        );
+      }
+    });
+
+    testWidgets(
+      'renders the live `WorldMarketState.prices` integer price for a '
+      'seeded commodity (timber=30 → `30`) and falls back to the resource '
+      'catalog default for both unseeded raw resources (iron → `80`) and '
+      'manufactured commodities (lumber → `60`, castIron → `160`) — '
+      '`SPEC/game/commodity-catalog.md` § Manufactured base prices, '
+      'Refs #3093',
+      (tester) async {
+        await pumpTradeScreen(
+          tester,
+          game: buildTradeTestGame(
+            id: 'test_trade_screen_market_tab',
+            prices: const <CommodityId, int>{'timber': 30},
+          ),
+        );
+
+        // Seeded commodity row shows the integer price text (Refs #3093 —
+        // `Map<CommodityId, int>` post-floor at persistence boundary).
+        final timberRow = find.byKey(
+          TradeScreen.marketCommodityRowKey(CommodityCatalog.timber.id),
+        );
+        expect(timberRow, findsOneWidget);
+        expect(
+          find.descendant(of: timberRow, matching: find.text('30')),
+          findsOneWidget,
+          reason:
+              'SPEC/ui/trade-screen.md § Body — Market tab (Refs #3093): '
+              'the price cell reads `Game.worldMarketState.prices[id]` '
+              'as a whole integer (price storage is now '
+              '`Map<CommodityId, int>` per #3093 issue body § Price '
+              'presentation & data model).',
+        );
+
+        // Unseeded raw-resource commodity row falls back to the resource
+        // catalog default integer price (#3093 — iron defaults to 80 via
+        // `ResourceRules.defaultRules.defaultMarketPriceForCommodityId`).
+        final ironRow = find.byKey(
+          TradeScreen.marketCommodityRowKey(CommodityCatalog.iron.id),
+        );
+        expect(ironRow, findsOneWidget);
+        expect(
+          find.descendant(of: ironRow, matching: find.text('80')),
+          findsOneWidget,
+          reason:
+              'SPEC/ui/trade-screen.md § Body — Market tab (Refs #3093): '
+              'rows fall back to the resource catalog '
+              '`defaultMarketPrice` integer when '
+              '`WorldMarketState.prices` lacks an entry. Iron is a raw '
+              'resource with catalog default 80.',
+        );
+        // Negative pin: iron must NOT render the em-dash price glyph.
+        // The price-slot em-dash is now reserved as a defensive
+        // fallback for tradeable commodities that ship without a
+        // catalog default — none exist under the current ruleset
+        // (Refs #3093 manufactured-default-prices slice). Only the
+        // quantity-idle em-dash remains in an iron row when no trade
+        // order is staged.
+        expect(
+          find.descendant(
+            of: ironRow,
+            matching: find.text(
+              // ignore: avoid_hardcoded_strings_in_widgets
+              '—',
+            ),
+          ),
+          findsOneWidget,
+          reason:
+              'Refs #3093 — only the quantity-idle em-dash remains in '
+              'an iron row when no trade order is staged. The price-'
+              'slot em-dash must NOT appear for raw-resource commodities '
+              'with a catalog default (regression guard against losing '
+              'the catalog fallback).',
+        );
+
+        // The quantity-idle em-dash specifically lives under the
+        // quantity readout key — keep this scoped pin so a future
+        // regression that swaps the quantity glyph still surfaces a
+        // readable failure.
+        expect(
+          find.byKey(
+            TradeScreen.marketRowQuantityTextKey(CommodityCatalog.iron.id),
+          ),
+          findsOneWidget,
+          reason:
+              'Refs #2993 E5b — every commodity row exposes its '
+              'quantity readout via the marketRowQuantityTextKey, '
+              'including rows whose staged TradeOrder is empty (the '
+              'idle em-dash glyph).',
+        );
+
+        // Manufactured commodity row (now seeded by the catalog): the
+        // price slot reads the input-cost-derived base price from
+        // SPEC/game/commodity-catalog.md § Manufactured base prices.
+        // Lumber's canonical recipe (`timber x 2` at 30 each) yields
+        // 60; castIron's (`iron x 2`) yields 160.
+        final lumberRow = find.byKey(
+          TradeScreen.marketCommodityRowKey(CommodityCatalog.lumber.id),
+        );
+        expect(lumberRow, findsOneWidget);
+        expect(
+          find.descendant(of: lumberRow, matching: find.text('60')),
+          findsOneWidget,
+          reason:
+              'Refs #3093 (manufactured-default-prices slice) — the '
+              'lumber price cell falls back to `ResourceRules.defaultRules'
+              '.defaultMarketPriceForCommodityId("lumber") = 60` '
+              '(SPEC/game/commodity-catalog.md § Manufactured base prices: '
+              '`timber x 2` at `30` each).',
+        );
+        // Negative pin: the lumber price slot must NOT render the
+        // em-dash glyph now that the catalog publishes a manufactured
+        // base price for it. Only the quantity-idle em-dash remains.
+        expect(
+          find.descendant(
+            of: lumberRow,
+            matching: find.text(
+              // ignore: avoid_hardcoded_strings_in_widgets
+              '—',
+            ),
+          ),
+          findsOneWidget,
+          reason:
+              'Refs #3093 (manufactured-default-prices slice) — the '
+              'price-slot em-dash MUST NOT appear for manufactured '
+              'commodities now that SPEC/game/commodity-catalog.md § '
+              'Manufactured base prices supplies a published catalog '
+              'default. Only the quantity-idle em-dash should remain '
+              'when no TradeOrder is staged.',
+        );
+
+        final castIronRow = find.byKey(
+          TradeScreen.marketCommodityRowKey(CommodityCatalog.castIron.id),
+        );
+        expect(castIronRow, findsOneWidget);
+        expect(
+          find.descendant(of: castIronRow, matching: find.text('160')),
+          findsOneWidget,
+          reason:
+              'Refs #3093 — castIron base price `160` per '
+              'SPEC/game/commodity-catalog.md § Manufactured base prices '
+              '(`timber x 2 + iron x 2` = `60 + 160`).',
+        );
+      },
+    );
+
+    testWidgets(
+      'renders the previous-turn aggregate volume line `Bids X / Offers Y` '
+      'from WorldMarketState.lastTurnActivity (with zero-default for '
+      'commodities absent from the activity map)',
+      (tester) async {
+        await pumpTradeScreen(
+          tester,
+          game: buildTradeTestGame(
+            id: 'test_trade_screen_market_tab',
+            lastTurnActivity: const <CommodityId, MarketActivity>{
+              'timber': MarketActivity(
+                totalBidQuantity: 12,
+                totalOfferQuantity: 8,
+              ),
+            },
+          ),
+        );
+
+        final timberRow = find.byKey(
+          TradeScreen.marketCommodityRowKey(CommodityCatalog.timber.id),
+        );
+        expect(timberRow, findsOneWidget);
+        expect(
+          find.descendant(
+            of: timberRow,
+            // ignore: avoid_hardcoded_strings_in_widgets
+            matching: find.text('Bids 12 / Offers 8'),
+          ),
+          findsOneWidget,
+          reason:
+              'SPEC/ui/trade-screen.md § Body — Market tab: per-row '
+              'inline aggregate volumes sourced from '
+              '`WorldMarketState.lastTurnActivity[commodityId]`.',
+        );
+
+        // Commodity not present in the activity map falls back to 0/0.
+        final fabricRow = find.byKey(
+          TradeScreen.marketCommodityRowKey(CommodityCatalog.fabric.id),
+        );
+        expect(fabricRow, findsOneWidget);
+        expect(
+          find.descendant(
+            of: fabricRow,
+            // ignore: avoid_hardcoded_strings_in_widgets
+            matching: find.text('Bids 0 / Offers 0'),
+          ),
+          findsOneWidget,
+          reason:
+              'SPEC/ui/trade-screen.md § Body — Market tab: rows for '
+              'commodities absent from `WorldMarketState.lastTurnActivity` '
+              'default to a zero-volume line so the column reads '
+              'consistently for every row.',
+        );
+      },
+    );
+
+    testWidgets(
+      'commodity rows render only inside the Market tab body — the off-stage '
+      'Deal Book tab placeholder body does not host any commodity row keys',
+      (tester) async {
+        await pumpTradeScreen(tester, game: buildTradeTestGame());
+
+        // Sanity: Market tab body hosts the list and rows.
+        expect(
+          find.descendant(
+            of: find.byKey(TradeScreen.marketTabBodyKey),
+            matching: find.byKey(TradeScreen.marketCommodityListKey),
+          ),
+          findsOneWidget,
+        );
+
+        // The off-stage Deal Book body must not host any commodity row
+        // — both off-stage and on-stage scopes.
+        expect(
+          find.descendant(
+            of: find.byKey(TradeScreen.dealBookTabBodyKey, skipOffstage: false),
+            matching: find.byKey(TradeScreen.marketCommodityListKey),
+          ),
+          findsNothing,
+        );
+      },
+    );
+  });
 }

--- a/app/test/trade_screen_market_tab_e5b_interactive_controls_test.dart
+++ b/app/test/trade_screen_market_tab_e5b_interactive_controls_test.dart
@@ -21,120 +21,24 @@
 //    `canMutateViaUi == false` (observe variant) — controls render but
 //    taps do not mutate `currentOrdersProvider`.
 
-import 'package:colonizethis_app/features/game/flame/region_map/region_map.dart'
-    show CtMapVisibilityMode;
 import 'package:colonizethis_app/features/game/screens/trade/trade_screen.dart';
-import 'package:colonizethis_app/features/game/widgets/shell/shell_player_context.dart';
 import 'package:colonizethis_app/providers/games_provider.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'support/app_shell_harness.dart';
+import 'support/trade_screen_test_support.dart';
 
-const String _humanPlayerId = 'gp_h';
-
-Game _buildGame() {
-  // Refs #3093 — sellable clamp slice. The Offer chip + offer-side
-  // `+` are now gated by the per-commodity offer cap
-  // (`stockpile − industryAllocation`). Seed a baseline stockpile of
-  // 99 units for every tradeable commodity so the E5b interactive-
-  // control tests (which stage Offer orders without specifying
-  // stockpile) keep passing under the new contract.
-  final Map<CommodityId, int> stockpile = <CommodityId, int>{
-    for (final Commodity c in CommodityCatalog.all)
-      if (c.category != CommodityCategory.riches && c.id != 'spices') c.id: 99,
-  };
-  return Game(
-    id: 'test_trade_screen_e5b',
-    worldState: WorldState(
-      turnState: TurnState(phase: TurnPhase.orders, turnNumber: 1),
-      oldWorld: const RegionData(),
-      newWorld: const RegionData(),
-    ),
-    turnTimeMapping: TurnTimeMapping.gdd01,
-    players: [
-      Player(
-        id: _humanPlayerId,
-        // ignore: avoid_hardcoded_strings_in_widgets
-        displayName: 'England',
-        isHuman: true,
-        treasury: 500,
-        stockpile: Stockpile(quantities: stockpile),
-      ),
-    ],
-    diplomacyRelations: const [],
-    diplomaticHistoryEvents: const [],
-    dossierEvidenceEntries: const [],
-    worldMarketState: const WorldMarketState(),
-  );
-}
-
-/// Pumps the [TradeScreen] in isolation under a [ProviderScope] that
-/// exposes [currentGameProvider], [currentOrdersProvider], and a
-/// (mockable) [shellPlayerContextProvider]. Mirrors the harness used
-/// by the E5a commodity-table tests so the assertions can pin the
-/// Market tab body without the full in-game shell.
-///
-/// Uses a tall (1024 × 4096) test viewport so every alphabetical row
-/// in the 22-commodity tradeable list is laid out inside the scroll
-/// view at once — `tester.tap` resolves to a visible target without
-/// the test having to scroll the list. Mirrors the pattern used by
-/// `production_screen_top_bar_test.dart` for similarly long lists.
-Future<ProviderContainer> _pumpTradeScreen(
-  WidgetTester tester, {
-  required Game game,
-  Orders initialOrders = const Orders(),
-  bool canMutateViaUi = true,
-}) async {
-  final Player player = game.players.first;
-  final ProviderContainer container = ProviderContainer(
-    overrides: [
-      currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
-      currentOrdersProvider.overrideWith(
-        () => CurrentOrdersNotifier(initialOrders),
-      ),
-      shellPlayerContextProvider.overrideWith(
-        (ref) => ShellPlayerContext(
-          effectiveHumanPlayerId: player.id,
-          viewingPlayerId: player.id,
-          mapVisibilityMode: CtMapVisibilityMode.full,
-          playerView: null,
-          omniscientDetail: false,
-          showPlayerChrome: true,
-          canMutateViaUi: canMutateViaUi,
-          debugCommandTargetPlayerId: player.id,
-          inObservePhase: !canMutateViaUi,
-          observeBannerLabel: canMutateViaUi ? null : 'Observing',
-          treasuryNotDefined: false,
-          cargoNotDefined: false,
-        ),
-      ),
-    ],
-  );
-  addTearDown(container.dispose);
-  await pumpAppShellWithContainer(
-    tester,
-    container: container,
-    viewport: const Size(1024, 4096),
-    child: TradeScreen(game: game, player: player),
-  );
-  return container;
-}
+const String _humanPlayerId = kTradeTestHumanPlayerId;
 
 CommodityId get _timber => CommodityCatalog.timber.id;
 CommodityId get _fabric => CommodityCatalog.fabric.id;
 
-TradeOrder? _stagedOrder(
-  ProviderContainer container,
-  CommodityId commodityId,
-) {
+TradeOrder? _stagedOrder(ProviderContainer container, CommodityId commodityId) {
   final Orders orders = container.read(currentOrdersProvider);
-  final List<TradeOrder>? list =
-      orders.tradeOrdersByPlayerId[_humanPlayerId];
+  final List<TradeOrder>? list = orders.tradeOrdersByPlayerId[_humanPlayerId];
   if (list == null) return null;
   for (final TradeOrder o in list) {
     if (o.commodityId == commodityId) return o;
@@ -145,356 +49,364 @@ TradeOrder? _stagedOrder(
 void main() {
   suppressLogsForTests();
 
-  group(
-    'TradeScreen Market tab interactive controls (Refs #2993 E5b)',
-    () {
-      testWidgets(
-        'every tradeable row exposes None / Bid / Offer chips and the '
-        '`+` / quantity / `−` stepper widgets keyed per commodity',
-        (tester) async {
-          await _pumpTradeScreen(tester, game: _buildGame());
-
-          for (final Commodity c in CommodityCatalog.all) {
-            if (c.category == CommodityCategory.riches || c.id == 'spices') {
-              continue;
-            }
-            final row = find.byKey(TradeScreen.marketCommodityRowKey(c.id));
-            expect(row, findsOneWidget);
-            expect(
-              find.descendant(
-                of: row,
-                matching: find.byKey(TradeScreen.marketRowNoneChipKey(c.id)),
-              ),
-              findsOneWidget,
-              reason: 'commodity `${c.id}` row must mount its `None` chip.',
-            );
-            expect(
-              find.descendant(
-                of: row,
-                matching: find.byKey(TradeScreen.marketRowBidChipKey(c.id)),
-              ),
-              findsOneWidget,
-              reason: 'commodity `${c.id}` row must mount its `Bid` chip.',
-            );
-            expect(
-              find.descendant(
-                of: row,
-                matching: find.byKey(TradeScreen.marketRowOfferChipKey(c.id)),
-              ),
-              findsOneWidget,
-              reason: 'commodity `${c.id}` row must mount its `Offer` chip.',
-            );
-            expect(
-              find.descendant(
-                of: row,
-                matching:
-                    find.byKey(TradeScreen.marketRowDecrementKey(c.id)),
-              ),
-              findsOneWidget,
-              reason:
-                  'commodity `${c.id}` row must mount its decrement button.',
-            );
-            expect(
-              find.descendant(
-                of: row,
-                matching:
-                    find.byKey(TradeScreen.marketRowIncrementKey(c.id)),
-              ),
-              findsOneWidget,
-              reason:
-                  'commodity `${c.id}` row must mount its increment button.',
-            );
-            expect(
-              find.descendant(
-                of: row,
-                matching:
-                    find.byKey(TradeScreen.marketRowQuantityTextKey(c.id)),
-              ),
-              findsOneWidget,
-              reason:
-                  'commodity `${c.id}` row must mount its quantity readout.',
-            );
-          }
-        },
+  group('TradeScreen Market tab interactive controls (Refs #2993 E5b)', () {
+    testWidgets('every tradeable row exposes None / Bid / Offer chips and the '
+        '`+` / quantity / `−` stepper widgets keyed per commodity', (
+      tester,
+    ) async {
+      await pumpTradeScreenWithContainer(
+        tester,
+        game: buildTradeTestGame(
+          id: 'test_trade_screen_e5b',
+          stockpile: tradeableStockpileFilled(99),
+        ),
       );
 
-      testWidgets(
-        'tapping `Bid` on an unstaged row stages a TradeOrder with '
-        'type=bid, quantity=1, priority=1 in currentOrdersProvider',
-        (tester) async {
-          final ProviderContainer container = await _pumpTradeScreen(
-            tester,
-            game: _buildGame(),
-          );
-          expect(_stagedOrder(container, _timber), isNull);
+      for (final Commodity c in CommodityCatalog.all) {
+        if (c.category == CommodityCategory.riches || c.id == 'spices') {
+          continue;
+        }
+        final row = find.byKey(TradeScreen.marketCommodityRowKey(c.id));
+        expect(row, findsOneWidget);
+        expect(
+          find.descendant(
+            of: row,
+            matching: find.byKey(TradeScreen.marketRowNoneChipKey(c.id)),
+          ),
+          findsOneWidget,
+          reason: 'commodity `${c.id}` row must mount its `None` chip.',
+        );
+        expect(
+          find.descendant(
+            of: row,
+            matching: find.byKey(TradeScreen.marketRowBidChipKey(c.id)),
+          ),
+          findsOneWidget,
+          reason: 'commodity `${c.id}` row must mount its `Bid` chip.',
+        );
+        expect(
+          find.descendant(
+            of: row,
+            matching: find.byKey(TradeScreen.marketRowOfferChipKey(c.id)),
+          ),
+          findsOneWidget,
+          reason: 'commodity `${c.id}` row must mount its `Offer` chip.',
+        );
+        expect(
+          find.descendant(
+            of: row,
+            matching: find.byKey(TradeScreen.marketRowDecrementKey(c.id)),
+          ),
+          findsOneWidget,
+          reason: 'commodity `${c.id}` row must mount its decrement button.',
+        );
+        expect(
+          find.descendant(
+            of: row,
+            matching: find.byKey(TradeScreen.marketRowIncrementKey(c.id)),
+          ),
+          findsOneWidget,
+          reason: 'commodity `${c.id}` row must mount its increment button.',
+        );
+        expect(
+          find.descendant(
+            of: row,
+            matching: find.byKey(TradeScreen.marketRowQuantityTextKey(c.id)),
+          ),
+          findsOneWidget,
+          reason: 'commodity `${c.id}` row must mount its quantity readout.',
+        );
+      }
+    });
 
-          await tester.tap(find.byKey(TradeScreen.marketRowBidChipKey(_timber)));
-          await tester.pump();
-
-          final TradeOrder? staged = _stagedOrder(container, _timber);
-          expect(staged, isNotNull);
-          expect(staged!.commodityId, _timber);
-          expect(staged.type, TradeOrderType.bid);
-          expect(
-            staged.quantity,
-            TradeScreen.marketRowQuantityDefault,
-            reason:
-                'Refs #2993 E5b: a freshly toggled Bid stages '
-                'quantity=1 (the stepper minimum). Subsequent + taps '
-                'increment from there.',
-          );
-          expect(
-            staged.priority,
-            TradeScreen.marketRowDefaultPriority,
-            reason:
-                'Refs #2993 E5b: priority defaults to 1 until the '
-                'priority dropdown ships in a follow-up slice.',
-          );
-        },
+    testWidgets('tapping `Bid` on an unstaged row stages a TradeOrder with '
+        'type=bid, quantity=1, priority=1 in currentOrdersProvider', (
+      tester,
+    ) async {
+      final ProviderContainer container = await pumpTradeScreenWithContainer(
+        tester,
+        game: buildTradeTestGame(
+          id: 'test_trade_screen_e5b',
+          stockpile: tradeableStockpileFilled(99),
+        ),
       );
+      expect(_stagedOrder(container, _timber), isNull);
 
-      testWidgets(
-        'tapping `Offer` on a row that already has a staged bid '
+      await tester.tap(find.byKey(TradeScreen.marketRowBidChipKey(_timber)));
+      await tester.pump();
+
+      final TradeOrder? staged = _stagedOrder(container, _timber);
+      expect(staged, isNotNull);
+      expect(staged!.commodityId, _timber);
+      expect(staged.type, TradeOrderType.bid);
+      expect(
+        staged.quantity,
+        TradeScreen.marketRowQuantityDefault,
+        reason:
+            'Refs #2993 E5b: a freshly toggled Bid stages '
+            'quantity=1 (the stepper minimum). Subsequent + taps '
+            'increment from there.',
+      );
+      expect(
+        staged.priority,
+        TradeScreen.marketRowDefaultPriority,
+        reason:
+            'Refs #2993 E5b: priority defaults to 1 until the '
+            'priority dropdown ships in a follow-up slice.',
+      );
+    });
+
+    testWidgets('tapping `Offer` on a row that already has a staged bid '
         'REPLACES the prior bid (mutual exclusion: at most one staged '
-        'TradeOrder per commodity)',
-        (tester) async {
-          final ProviderContainer container = await _pumpTradeScreen(
-            tester,
-            game: _buildGame(),
-          );
-
-          await tester.tap(find.byKey(TradeScreen.marketRowBidChipKey(_timber)));
-          await tester.pump();
-          await tester.tap(find.byKey(TradeScreen.marketRowIncrementKey(_timber)));
-          await tester.pump();
-          // After Bid + one increment: timber bid, quantity=2.
-          TradeOrder? staged = _stagedOrder(container, _timber);
-          expect(staged, isNotNull);
-          expect(staged!.type, TradeOrderType.bid);
-          expect(staged.quantity, 2);
-
-          // Toggle to Offer: the prior bid must be replaced by an
-          // offer. Quantity is preserved (2) since it tracks the
-          // staged direction's quantity.
-          await tester
-              .tap(find.byKey(TradeScreen.marketRowOfferChipKey(_timber)));
-          await tester.pump();
-          staged = _stagedOrder(container, _timber);
-          expect(staged, isNotNull);
-          expect(staged!.type, TradeOrderType.offer);
-          expect(staged.quantity, 2);
-
-          // Mutual exclusion: list contains at most one staged
-          // TradeOrder for the timber commodity.
-          final Orders orders = container.read(currentOrdersProvider);
-          final List<TradeOrder>? list =
-              orders.tradeOrdersByPlayerId[_humanPlayerId];
-          expect(list, isNotNull);
-          final int timberCount =
-              list!.where((TradeOrder o) => o.commodityId == _timber).length;
-          expect(
-            timberCount,
-            1,
-            reason:
-                'Refs #2993 E5b mutual exclusion: tradeOrdersByPlayerId '
-                'must contain at most one TradeOrder per (player, '
-                'commodityId) pair.',
-          );
-        },
+        'TradeOrder per commodity)', (tester) async {
+      final ProviderContainer container = await pumpTradeScreenWithContainer(
+        tester,
+        game: buildTradeTestGame(
+          id: 'test_trade_screen_e5b',
+          stockpile: tradeableStockpileFilled(99),
+        ),
       );
 
-      testWidgets(
-        'tapping `None` on a row with a staged direction removes the '
-        'TradeOrder for the commodity from currentOrdersProvider',
-        (tester) async {
-          final ProviderContainer container = await _pumpTradeScreen(
-            tester,
-            game: _buildGame(),
-          );
-          await tester.tap(find.byKey(TradeScreen.marketRowBidChipKey(_timber)));
-          await tester.pump();
-          expect(_stagedOrder(container, _timber), isNotNull);
+      await tester.tap(find.byKey(TradeScreen.marketRowBidChipKey(_timber)));
+      await tester.pump();
+      await tester.tap(find.byKey(TradeScreen.marketRowIncrementKey(_timber)));
+      await tester.pump();
+      // After Bid + one increment: timber bid, quantity=2.
+      TradeOrder? staged = _stagedOrder(container, _timber);
+      expect(staged, isNotNull);
+      expect(staged!.type, TradeOrderType.bid);
+      expect(staged.quantity, 2);
 
-          await tester.tap(find.byKey(TradeScreen.marketRowNoneChipKey(_timber)));
-          await tester.pump();
-          expect(
-            _stagedOrder(container, _timber),
-            isNull,
-            reason:
-                'Refs #2993 E5b: tapping the None chip removes the '
-                'staged TradeOrder for the row\'s commodity.',
-          );
-        },
+      // Toggle to Offer: the prior bid must be replaced by an
+      // offer. Quantity is preserved (2) since it tracks the
+      // staged direction's quantity.
+      await tester.tap(find.byKey(TradeScreen.marketRowOfferChipKey(_timber)));
+      await tester.pump();
+      staged = _stagedOrder(container, _timber);
+      expect(staged, isNotNull);
+      expect(staged!.type, TradeOrderType.offer);
+      expect(staged.quantity, 2);
+
+      // Mutual exclusion: list contains at most one staged
+      // TradeOrder for the timber commodity.
+      final Orders orders = container.read(currentOrdersProvider);
+      final List<TradeOrder>? list =
+          orders.tradeOrdersByPlayerId[_humanPlayerId];
+      expect(list, isNotNull);
+      final int timberCount = list!
+          .where((TradeOrder o) => o.commodityId == _timber)
+          .length;
+      expect(
+        timberCount,
+        1,
+        reason:
+            'Refs #2993 E5b mutual exclusion: tradeOrdersByPlayerId '
+            'must contain at most one TradeOrder per (player, '
+            'commodityId) pair.',
       );
+    });
 
-      testWidgets(
-        '`+` increments quantity by 1 and `−` decrements by 1 (clamped '
-        'at marketRowQuantityMin = 1 when a direction is staged)',
-        (tester) async {
-          final ProviderContainer container = await _pumpTradeScreen(
-            tester,
-            game: _buildGame(),
-          );
-          await tester.tap(find.byKey(TradeScreen.marketRowBidChipKey(_timber)));
-          await tester.pump();
-          // Initial quantity: 1.
-          expect(_stagedOrder(container, _timber)!.quantity, 1);
-
-          // + → 2 → 3 → 4
-          await tester.tap(find.byKey(TradeScreen.marketRowIncrementKey(_timber)));
-          await tester.pump();
-          await tester.tap(find.byKey(TradeScreen.marketRowIncrementKey(_timber)));
-          await tester.pump();
-          await tester.tap(find.byKey(TradeScreen.marketRowIncrementKey(_timber)));
-          await tester.pump();
-          expect(_stagedOrder(container, _timber)!.quantity, 4);
-
-          // − → 3 → 2 → 1
-          await tester.tap(find.byKey(TradeScreen.marketRowDecrementKey(_timber)));
-          await tester.pump();
-          await tester.tap(find.byKey(TradeScreen.marketRowDecrementKey(_timber)));
-          await tester.pump();
-          await tester.tap(find.byKey(TradeScreen.marketRowDecrementKey(_timber)));
-          await tester.pump();
-          expect(_stagedOrder(container, _timber)!.quantity, 1);
-
-          // Further − is a no-op (clamped at the lower bound of 1).
-          await tester.tap(find.byKey(TradeScreen.marketRowDecrementKey(_timber)));
-          await tester.pump();
-          expect(
-            _stagedOrder(container, _timber)!.quantity,
-            TradeScreen.marketRowQuantityMin,
-            reason:
-                'Refs #2993 E5b: the per-row stepper clamps at '
-                '`marketRowQuantityMin = 1` while a direction is '
-                'staged (going below 1 is equivalent to None and is '
-                'reached via the None chip, not the decrement button).',
-          );
-        },
+    testWidgets('tapping `None` on a row with a staged direction removes the '
+        'TradeOrder for the commodity from currentOrdersProvider', (
+      tester,
+    ) async {
+      final ProviderContainer container = await pumpTradeScreenWithContainer(
+        tester,
+        game: buildTradeTestGame(
+          id: 'test_trade_screen_e5b',
+          stockpile: tradeableStockpileFilled(99),
+        ),
       );
+      await tester.tap(find.byKey(TradeScreen.marketRowBidChipKey(_timber)));
+      await tester.pump();
+      expect(_stagedOrder(container, _timber), isNotNull);
 
-      testWidgets(
-        'increment / decrement buttons are no-ops while no direction is '
-        'staged (the `−` and `+` taps must not create a TradeOrder)',
-        (tester) async {
-          final ProviderContainer container = await _pumpTradeScreen(
-            tester,
-            game: _buildGame(),
-          );
-          // No staged direction yet — increment must NOT auto-stage a
-          // bid/offer. The +/- buttons only operate on already-staged
-          // TradeOrders. The user must pick a direction first.
-          await tester.tap(find.byKey(TradeScreen.marketRowIncrementKey(_timber)));
-          await tester.pump();
-          await tester.tap(find.byKey(TradeScreen.marketRowDecrementKey(_timber)));
-          await tester.pump();
-          expect(
-            _stagedOrder(container, _timber),
-            isNull,
-            reason:
-                'Refs #2993 E5b: stepper taps without a staged '
-                'direction are silent no-ops (the user picks Bid / '
-                'Offer first; the stepper then adjusts the staged '
-                'TradeOrder.quantity).',
-          );
-        },
+      await tester.tap(find.byKey(TradeScreen.marketRowNoneChipKey(_timber)));
+      await tester.pump();
+      expect(
+        _stagedOrder(container, _timber),
+        isNull,
+        reason:
+            'Refs #2993 E5b: tapping the None chip removes the '
+            'staged TradeOrder for the row\'s commodity.',
       );
+    });
 
-      testWidgets(
-        'mutual exclusion across distinct commodities — staging timber '
+    testWidgets('`+` increments quantity by 1 and `−` decrements by 1 (clamped '
+        'at marketRowQuantityMin = 1 when a direction is staged)', (
+      tester,
+    ) async {
+      final ProviderContainer container = await pumpTradeScreenWithContainer(
+        tester,
+        game: buildTradeTestGame(
+          id: 'test_trade_screen_e5b',
+          stockpile: tradeableStockpileFilled(99),
+        ),
+      );
+      await tester.tap(find.byKey(TradeScreen.marketRowBidChipKey(_timber)));
+      await tester.pump();
+      // Initial quantity: 1.
+      expect(_stagedOrder(container, _timber)!.quantity, 1);
+
+      // + → 2 → 3 → 4
+      await tester.tap(find.byKey(TradeScreen.marketRowIncrementKey(_timber)));
+      await tester.pump();
+      await tester.tap(find.byKey(TradeScreen.marketRowIncrementKey(_timber)));
+      await tester.pump();
+      await tester.tap(find.byKey(TradeScreen.marketRowIncrementKey(_timber)));
+      await tester.pump();
+      expect(_stagedOrder(container, _timber)!.quantity, 4);
+
+      // − → 3 → 2 → 1
+      await tester.tap(find.byKey(TradeScreen.marketRowDecrementKey(_timber)));
+      await tester.pump();
+      await tester.tap(find.byKey(TradeScreen.marketRowDecrementKey(_timber)));
+      await tester.pump();
+      await tester.tap(find.byKey(TradeScreen.marketRowDecrementKey(_timber)));
+      await tester.pump();
+      expect(_stagedOrder(container, _timber)!.quantity, 1);
+
+      // Further − is a no-op (clamped at the lower bound of 1).
+      await tester.tap(find.byKey(TradeScreen.marketRowDecrementKey(_timber)));
+      await tester.pump();
+      expect(
+        _stagedOrder(container, _timber)!.quantity,
+        TradeScreen.marketRowQuantityMin,
+        reason:
+            'Refs #2993 E5b: the per-row stepper clamps at '
+            '`marketRowQuantityMin = 1` while a direction is '
+            'staged (going below 1 is equivalent to None and is '
+            'reached via the None chip, not the decrement button).',
+      );
+    });
+
+    testWidgets(
+      'increment / decrement buttons are no-ops while no direction is '
+      'staged (the `−` and `+` taps must not create a TradeOrder)',
+      (tester) async {
+        final ProviderContainer container = await pumpTradeScreenWithContainer(
+          tester,
+          game: buildTradeTestGame(
+            id: 'test_trade_screen_e5b',
+            stockpile: tradeableStockpileFilled(99),
+          ),
+        );
+        // No staged direction yet — increment must NOT auto-stage a
+        // bid/offer. The +/- buttons only operate on already-staged
+        // TradeOrders. The user must pick a direction first.
+        await tester.tap(
+          find.byKey(TradeScreen.marketRowIncrementKey(_timber)),
+        );
+        await tester.pump();
+        await tester.tap(
+          find.byKey(TradeScreen.marketRowDecrementKey(_timber)),
+        );
+        await tester.pump();
+        expect(
+          _stagedOrder(container, _timber),
+          isNull,
+          reason:
+              'Refs #2993 E5b: stepper taps without a staged '
+              'direction are silent no-ops (the user picks Bid / '
+              'Offer first; the stepper then adjusts the staged '
+              'TradeOrder.quantity).',
+        );
+      },
+    );
+
+    testWidgets('mutual exclusion across distinct commodities — staging timber '
         'as Bid and fabric as Offer keeps both as a single TradeOrder '
-        'each in currentOrdersProvider',
-        (tester) async {
-          final ProviderContainer container = await _pumpTradeScreen(
-            tester,
-            game: _buildGame(),
-          );
-          await tester.tap(find.byKey(TradeScreen.marketRowBidChipKey(_timber)));
-          await tester.pump();
-          await tester.tap(find.byKey(TradeScreen.marketRowOfferChipKey(_fabric)));
-          await tester.pump();
-
-          expect(_stagedOrder(container, _timber)?.type,
-              TradeOrderType.bid);
-          expect(_stagedOrder(container, _fabric)?.type,
-              TradeOrderType.offer);
-          final Orders orders = container.read(currentOrdersProvider);
-          expect(
-            orders.tradeOrdersByPlayerId[_humanPlayerId]?.length,
-            2,
-            reason:
-                'Refs #2993 E5b: the player can stage one TradeOrder '
-                'per commodity simultaneously; mutual exclusion is '
-                'per-commodity, not per-player.',
-          );
-        },
+        'each in currentOrdersProvider', (tester) async {
+      final ProviderContainer container = await pumpTradeScreenWithContainer(
+        tester,
+        game: buildTradeTestGame(
+          id: 'test_trade_screen_e5b',
+          stockpile: tradeableStockpileFilled(99),
+        ),
       );
+      await tester.tap(find.byKey(TradeScreen.marketRowBidChipKey(_timber)));
+      await tester.pump();
+      await tester.tap(find.byKey(TradeScreen.marketRowOfferChipKey(_fabric)));
+      await tester.pump();
 
-      testWidgets(
-        'observe variant (canMutateViaUi == false): direction chips and '
-        'stepper taps do NOT mutate currentOrdersProvider — the table '
-        'reads as read-only',
-        (tester) async {
-          final ProviderContainer container = await _pumpTradeScreen(
-            tester,
-            game: _buildGame(),
-            canMutateViaUi: false,
-          );
-
-          await tester.tap(
-            find.byKey(TradeScreen.marketRowBidChipKey(_timber)),
-            warnIfMissed: false,
-          );
-          await tester.pump();
-          await tester.tap(
-            find.byKey(TradeScreen.marketRowIncrementKey(_timber)),
-            warnIfMissed: false,
-          );
-          await tester.pump();
-
-          expect(
-            _stagedOrder(container, _timber),
-            isNull,
-            reason:
-                'Refs #2993 E5b observe variant: when '
-                'canMutateViaUi == false, the Market tab body is '
-                'wrapped in IgnorePointer so the controls are visible '
-                'but not interactive — taps do not stage trade '
-                'orders.',
-          );
-        },
+      expect(_stagedOrder(container, _timber)?.type, TradeOrderType.bid);
+      expect(_stagedOrder(container, _fabric)?.type, TradeOrderType.offer);
+      final Orders orders = container.read(currentOrdersProvider);
+      expect(
+        orders.tradeOrdersByPlayerId[_humanPlayerId]?.length,
+        2,
+        reason:
+            'Refs #2993 E5b: the player can stage one TradeOrder '
+            'per commodity simultaneously; mutual exclusion is '
+            'per-commodity, not per-player.',
       );
+    });
 
-      testWidgets(
-        'observe variant still mounts the row controls and quantity '
+    testWidgets(
+      'observe variant (canMutateViaUi == false): direction chips and '
+      'stepper taps do NOT mutate currentOrdersProvider — the table '
+      'reads as read-only',
+      (tester) async {
+        final ProviderContainer container = await pumpTradeScreenWithContainer(
+          tester,
+          game: buildTradeTestGame(
+            id: 'test_trade_screen_e5b',
+            stockpile: tradeableStockpileFilled(99),
+          ),
+          canMutateViaUi: false,
+        );
+
+        await tester.tap(
+          find.byKey(TradeScreen.marketRowBidChipKey(_timber)),
+          warnIfMissed: false,
+        );
+        await tester.pump();
+        await tester.tap(
+          find.byKey(TradeScreen.marketRowIncrementKey(_timber)),
+          warnIfMissed: false,
+        );
+        await tester.pump();
+
+        expect(
+          _stagedOrder(container, _timber),
+          isNull,
+          reason:
+              'Refs #2993 E5b observe variant: when '
+              'canMutateViaUi == false, the Market tab body is '
+              'wrapped in IgnorePointer so the controls are visible '
+              'but not interactive — taps do not stage trade '
+              'orders.',
+        );
+      },
+    );
+
+    testWidgets('observe variant still mounts the row controls and quantity '
         'readout (the chrome remains visible — only interaction is '
-        'blocked, matching the Production screen pattern)',
-        (tester) async {
-          await _pumpTradeScreen(
-            tester,
-            game: _buildGame(),
-            canMutateViaUi: false,
-          );
-
-          final timberRow = find.byKey(
-            TradeScreen.marketCommodityRowKey(_timber),
-          );
-          expect(
-            find.descendant(
-              of: timberRow,
-              matching: find.byKey(TradeScreen.marketRowNoneChipKey(_timber)),
-            ),
-            findsOneWidget,
-          );
-          expect(
-            find.descendant(
-              of: timberRow,
-              matching: find.byKey(TradeScreen.marketRowQuantityTextKey(_timber)),
-            ),
-            findsOneWidget,
-          );
-        },
+        'blocked, matching the Production screen pattern)', (tester) async {
+      await pumpTradeScreenWithContainer(
+        tester,
+        game: buildTradeTestGame(
+          id: 'test_trade_screen_e5b',
+          stockpile: tradeableStockpileFilled(99),
+        ),
+        canMutateViaUi: false,
       );
-    },
-  );
+
+      final timberRow = find.byKey(TradeScreen.marketCommodityRowKey(_timber));
+      expect(
+        find.descendant(
+          of: timberRow,
+          matching: find.byKey(TradeScreen.marketRowNoneChipKey(_timber)),
+        ),
+        findsOneWidget,
+      );
+      expect(
+        find.descendant(
+          of: timberRow,
+          matching: find.byKey(TradeScreen.marketRowQuantityTextKey(_timber)),
+        ),
+        findsOneWidget,
+      );
+    });
+  });
 }

--- a/app/test/trade_screen_market_tab_e5c_cargo_cap_test.dart
+++ b/app/test/trade_screen_market_tab_e5c_cargo_cap_test.dart
@@ -31,104 +31,18 @@
 //    warning still mount with live text values; the chip / stepper
 //    taps are blocked by the existing `IgnorePointer` wrapper.
 
-import 'package:colonizethis_app/features/game/flame/region_map/region_map.dart'
-    show CtMapVisibilityMode;
 import 'package:colonizethis_app/features/game/screens/trade/trade_screen.dart';
-import 'package:colonizethis_app/features/game/widgets/shell/shell_player_context.dart';
 import 'package:colonizethis_app/providers/games_provider.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/colonizethis_logic.dart'
-    show homeFleetIdFor;
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'support/app_shell_harness.dart';
+import 'support/trade_screen_test_support.dart';
 
-const String _humanPlayerId = 'gp_h';
-const String _capProvinceId = 'oldWorld|cap1';
-
-/// Builds a game whose human player has either:
-///   * no home fleet (so `cargoHoldsForHomeFleet` falls back to the
-///     `defaultCargoHoldsStub = 24`), or
-///   * a synthetic home fleet whose ship-type ids sum to
-///     [tradeCargoCapacityOverride] cargo holds (used to pin the
-///     capacity at 10 for the saturation / clamp ACs).
-///
-/// Cargo-hold totals chosen so `tradeCargoCapacity == 10`:
-///   * `galleon` (cargoHold 6) + `fluyte` (cargoHold 4) = 10.
-Game _buildGame({int? tradeCargoCapacityOverride}) {
-  final List<Fleet> fleets = <Fleet>[];
-  if (tradeCargoCapacityOverride != null) {
-    // Validate the override mapping at call-site so a stale catalog
-    // change is caught by the test runner instead of producing a
-    // mis-sized fleet.
-    final int galleonHolds = NavalStatsCatalog.galleon.cargoHold;
-    final int fluyteHolds = NavalStatsCatalog.fluyte.cargoHold;
-    if (galleonHolds + fluyteHolds != 10) {
-      throw StateError(
-        'NavalStatsCatalog cargoHold drift: '
-        'galleon=$galleonHolds + fluyte=$fluyteHolds != 10. '
-        'Update the override mapping in this test.',
-      );
-    }
-    if (tradeCargoCapacityOverride != 10) {
-      throw StateError(
-        'Only tradeCargoCapacityOverride == 10 is currently '
-        'supported by this test harness.',
-      );
-    }
-    fleets.add(
-      Fleet(
-        id: homeFleetIdFor(_humanPlayerId),
-        ownerId: _humanPlayerId,
-        regionId: 'oldWorld',
-        inPortAtProvinceId: _capProvinceId,
-        ships: const [
-          ShipInstance(id: 'h1', typeId: 'galleon'),
-          ShipInstance(id: 'h2', typeId: 'fluyte'),
-        ],
-      ),
-    );
-  }
-  return Game(
-    id: 'test_trade_screen_e5c',
-    worldState: WorldState(
-      turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
-      oldWorld: const RegionData(
-        provinces: [
-          Province(
-            id: 'cap1',
-            regionId: 'oldWorld',
-            // ignore: avoid_hardcoded_strings_in_widgets
-            displayName: 'Capital',
-          ),
-        ],
-      ),
-      newWorld: const RegionData(),
-      fleets: fleets,
-    ),
-    turnTimeMapping: TurnTimeMapping.gdd01,
-    players: const [
-      // ignore: avoid_hardcoded_strings_in_widgets
-      Player(id: _humanPlayerId, displayName: 'England', isHuman: true,
-          // Cargo-cap test: treasury must never bind so the rule-7
-          // bid-treasury cap (active now that manufactured commodities
-          // carry catalog base prices per #3093) cannot clamp the
-          // cargo-cap quantities being asserted here. The largest
-          // possible bid in this file is bounded by tradeCargoCapacity
-          // (max 24 cargo units); a treasury of 100_000 keeps the
-          // most expensive manufactured commodity well within budget.
-          treasury: 100000),
-    ],
-    diplomacyRelations: const [],
-    diplomaticHistoryEvents: const [],
-    dossierEvidenceEntries: const [],
-    worldMarketState: const WorldMarketState(),
-  );
-}
+const String _humanPlayerId = kTradeTestHumanPlayerId;
 
 Orders _orders(List<TradeOrder> tradeOrders) {
   return Orders(
@@ -156,66 +70,14 @@ TradeOrder _offer(CommodityId commodityId, int quantity) {
   );
 }
 
-/// Mirrors the E5b harness — pumps [TradeScreen] in isolation under a
-/// [ProviderScope] that exposes [currentGameProvider],
-/// [currentOrdersProvider], and a (mockable) [shellPlayerContextProvider].
-/// Uses a tall (1024 × 4096) test viewport so every alphabetical row
-/// in the 22-commodity list lays out inside the scroll view at once.
-Future<ProviderContainer> _pumpTradeScreen(
-  WidgetTester tester, {
-  required Game game,
-  Orders initialOrders = const Orders(),
-  bool canMutateViaUi = true,
-}) async {
-  final Player player = game.players.first;
-  final ProviderContainer container = ProviderContainer(
-    overrides: [
-      currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
-      currentOrdersProvider.overrideWith(
-        () => CurrentOrdersNotifier(initialOrders),
-      ),
-      shellPlayerContextProvider.overrideWith(
-        (ref) => ShellPlayerContext(
-          effectiveHumanPlayerId: player.id,
-          viewingPlayerId: player.id,
-          mapVisibilityMode: CtMapVisibilityMode.full,
-          playerView: null,
-          omniscientDetail: false,
-          showPlayerChrome: true,
-          canMutateViaUi: canMutateViaUi,
-          // ignore: avoid_hardcoded_strings_in_widgets
-          debugCommandTargetPlayerId: player.id,
-          inObservePhase: !canMutateViaUi,
-          // ignore: avoid_hardcoded_strings_in_widgets
-          observeBannerLabel: canMutateViaUi ? null : 'Observing',
-          treasuryNotDefined: false,
-          cargoNotDefined: false,
-        ),
-      ),
-    ],
-  );
-  addTearDown(container.dispose);
-  await pumpAppShellWithContainer(
-    tester,
-    container: container,
-    viewport: const Size(1024, 4096),
-    child: TradeScreen(game: game, player: player),
-  );
-  return container;
-}
-
 CommodityId get _timber => CommodityCatalog.timber.id;
 CommodityId get _iron => CommodityCatalog.iron.id;
 CommodityId get _fabric => CommodityCatalog.fabric.id;
 CommodityId get _grain => CommodityCatalog.grain.id;
 
-TradeOrder? _stagedOrder(
-  ProviderContainer container,
-  CommodityId commodityId,
-) {
+TradeOrder? _stagedOrder(ProviderContainer container, CommodityId commodityId) {
   final Orders orders = container.read(currentOrdersProvider);
-  final List<TradeOrder>? list =
-      orders.tradeOrdersByPlayerId[_humanPlayerId];
+  final List<TradeOrder>? list = orders.tradeOrdersByPlayerId[_humanPlayerId];
   if (list == null) return null;
   for (final TradeOrder o in list) {
     if (o.commodityId == commodityId) return o;
@@ -225,8 +87,7 @@ TradeOrder? _stagedOrder(
 
 int _totalStagedBid(ProviderContainer container) {
   final Orders orders = container.read(currentOrdersProvider);
-  final List<TradeOrder>? list =
-      orders.tradeOrdersByPlayerId[_humanPlayerId];
+  final List<TradeOrder>? list = orders.tradeOrdersByPlayerId[_humanPlayerId];
   if (list == null || list.isEmpty) return 0;
   int total = 0;
   for (final TradeOrder o in list) {
@@ -245,370 +106,325 @@ String _cargoIndicatorText(WidgetTester tester) {
 void main() {
   suppressLogsForTests();
 
-  group(
-    'TradeScreen Market tab cargo indicator + cap + warning '
-    '(Refs #2993 E5c)',
-    () {
-      testWidgets(
-        'no home fleet and no staged orders → indicator reads '
+  group('TradeScreen Market tab cargo indicator + cap + warning '
+      '(Refs #2993 E5c)', () {
+    testWidgets('no home fleet and no staged orders → indicator reads '
         '"Cargo remaining: 24" (defaultCargoHoldsStub) and the '
-        'warning row is absent',
-        (tester) async {
-          await _pumpTradeScreen(tester, game: _buildGame());
-
-          expect(
-            find.byKey(TradeScreen.marketCargoIndicatorKey),
-            findsOneWidget,
-          );
-          expect(_cargoIndicatorText(tester), 'Cargo remaining: 24');
-          expect(
-            find.byKey(TradeScreen.marketCargoWarningKey),
-            findsNothing,
-          );
-        },
+        'warning row is absent', (tester) async {
+      await pumpTradeScreenWithContainer(
+        tester,
+        game: buildTradeTestGame(id: 'test_trade_screen_e5c', treasury: 100000),
       );
 
-      testWidgets(
-        'staged offers do not consume cargo → indicator stays at the '
-        'full capacity and the warning row is absent',
-        (tester) async {
-          await _pumpTradeScreen(
-            tester,
-            game: _buildGame(),
-            initialOrders: _orders(<TradeOrder>[
-              _offer(_fabric, 7),
-              _offer(_timber, 3),
-            ]),
-          );
+      expect(find.byKey(TradeScreen.marketCargoIndicatorKey), findsOneWidget);
+      expect(_cargoIndicatorText(tester), 'Cargo remaining: 24');
+      expect(find.byKey(TradeScreen.marketCargoWarningKey), findsNothing);
+    });
 
-          expect(_cargoIndicatorText(tester), 'Cargo remaining: 24');
-          expect(
-            find.byKey(TradeScreen.marketCargoWarningKey),
-            findsNothing,
-          );
-        },
+    testWidgets('staged offers do not consume cargo → indicator stays at the '
+        'full capacity and the warning row is absent', (tester) async {
+      await pumpTradeScreenWithContainer(
+        tester,
+        game: buildTradeTestGame(id: 'test_trade_screen_e5c', treasury: 100000),
+        initialOrders: _orders(<TradeOrder>[
+          _offer(_fabric, 7),
+          _offer(_timber, 3),
+        ]),
       );
 
-      testWidgets(
-        'staged bids totalling 7 (timber 4 + iron 3) under capacity 24 → '
-        'indicator reads "Cargo remaining: 17" and no warning is shown',
-        (tester) async {
-          await _pumpTradeScreen(
-            tester,
-            game: _buildGame(),
-            initialOrders: _orders(<TradeOrder>[
-              _bid(_timber, 4),
-              _bid(_iron, 3),
-            ]),
-          );
+      expect(_cargoIndicatorText(tester), 'Cargo remaining: 24');
+      expect(find.byKey(TradeScreen.marketCargoWarningKey), findsNothing);
+    });
 
-          expect(_cargoIndicatorText(tester), 'Cargo remaining: 17');
-          expect(
-            find.byKey(TradeScreen.marketCargoWarningKey),
-            findsNothing,
-          );
-        },
-      );
+    testWidgets(
+      'staged bids totalling 7 (timber 4 + iron 3) under capacity 24 → '
+      'indicator reads "Cargo remaining: 17" and no warning is shown',
+      (tester) async {
+        await pumpTradeScreenWithContainer(
+          tester,
+          game: buildTradeTestGame(
+            id: 'test_trade_screen_e5c',
+            treasury: 100000,
+          ),
+          initialOrders: _orders(<TradeOrder>[
+            _bid(_timber, 4),
+            _bid(_iron, 3),
+          ]),
+        );
 
-      testWidgets(
-        'capacity 10 with bids totalling 10 → indicator reads '
+        expect(_cargoIndicatorText(tester), 'Cargo remaining: 17');
+        expect(find.byKey(TradeScreen.marketCargoWarningKey), findsNothing);
+      },
+    );
+
+    testWidgets('capacity 10 with bids totalling 10 → indicator reads '
         '"Cargo remaining: 0" AND the warning row is mounted with '
-        'the canonical copy',
-        (tester) async {
-          await _pumpTradeScreen(
-            tester,
-            game: _buildGame(tradeCargoCapacityOverride: 10),
-            initialOrders: _orders(<TradeOrder>[
-              _bid(_timber, 6),
-              _bid(_iron, 4),
-            ]),
-          );
-
-          expect(_cargoIndicatorText(tester), 'Cargo remaining: 0');
-          expect(
-            find.byKey(TradeScreen.marketCargoWarningKey),
-            findsOneWidget,
-          );
-          expect(
-            find.text(TradeScreen.cargoLimitWarningText),
-            findsOneWidget,
-          );
-        },
+        'the canonical copy', (tester) async {
+      await pumpTradeScreenWithContainer(
+        tester,
+        game: buildTradeTestGame(
+          id: 'test_trade_screen_e5c',
+          treasury: 100000,
+          tradeCargoCapacityOverride: 10,
+        ),
+        initialOrders: _orders(<TradeOrder>[_bid(_timber, 6), _bid(_iron, 4)]),
       );
 
-      testWidgets(
-        'capacity 10 with bid timber 6 (cargo remaining 4): incrementing '
-        'timber `+` four times brings staged quantity to 10 then the '
-        'fifth `+` tap is a silent no-op (cross-commodity total clamped '
-        'at 10) and the warning row mounts at saturation',
-        (tester) async {
-          final ProviderContainer container = await _pumpTradeScreen(
-            tester,
-            game: _buildGame(tradeCargoCapacityOverride: 10),
-            initialOrders: _orders(<TradeOrder>[_bid(_timber, 6)]),
-          );
+      expect(_cargoIndicatorText(tester), 'Cargo remaining: 0');
+      expect(find.byKey(TradeScreen.marketCargoWarningKey), findsOneWidget);
+      expect(find.text(TradeScreen.cargoLimitWarningText), findsOneWidget);
+    });
 
-          expect(_cargoIndicatorText(tester), 'Cargo remaining: 4');
-          expect(
-            find.byKey(TradeScreen.marketCargoWarningKey),
-            findsNothing,
-          );
+    testWidgets(
+      'capacity 10 with bid timber 6 (cargo remaining 4): incrementing '
+      'timber `+` four times brings staged quantity to 10 then the '
+      'fifth `+` tap is a silent no-op (cross-commodity total clamped '
+      'at 10) and the warning row mounts at saturation',
+      (tester) async {
+        final ProviderContainer container = await pumpTradeScreenWithContainer(
+          tester,
+          game: buildTradeTestGame(
+            id: 'test_trade_screen_e5c',
+            treasury: 100000,
+            tradeCargoCapacityOverride: 10,
+          ),
+          initialOrders: _orders(<TradeOrder>[_bid(_timber, 6)]),
+        );
 
-          for (int i = 0; i < 4; i++) {
-            await tester
-                .tap(find.byKey(TradeScreen.marketRowIncrementKey(_timber)));
-            await tester.pump();
-          }
-          expect(_stagedOrder(container, _timber)?.quantity, 10);
-          expect(_totalStagedBid(container), 10);
-          expect(_cargoIndicatorText(tester), 'Cargo remaining: 0');
-          expect(
-            find.byKey(TradeScreen.marketCargoWarningKey),
-            findsOneWidget,
-          );
+        expect(_cargoIndicatorText(tester), 'Cargo remaining: 4');
+        expect(find.byKey(TradeScreen.marketCargoWarningKey), findsNothing);
 
-          // 5th increment is blocked by the cross-commodity cap.
-          await tester
-              .tap(find.byKey(TradeScreen.marketRowIncrementKey(_timber)));
+        for (int i = 0; i < 4; i++) {
+          await tester.tap(
+            find.byKey(TradeScreen.marketRowIncrementKey(_timber)),
+          );
           await tester.pump();
-          expect(
-            _stagedOrder(container, _timber)?.quantity,
-            10,
-            reason: 'Refs #2993 E5c: bid increment blocked when '
-                'cross-commodity bid total saturates tradeCargoCapacity.',
-          );
-          expect(_totalStagedBid(container), 10);
-        },
-      );
+        }
+        expect(_stagedOrder(container, _timber)?.quantity, 10);
+        expect(_totalStagedBid(container), 10);
+        expect(_cargoIndicatorText(tester), 'Cargo remaining: 0');
+        expect(find.byKey(TradeScreen.marketCargoWarningKey), findsOneWidget);
 
-      testWidgets(
-        'capacity 10 with cargo saturated (timber 6 + iron 4): tapping '
+        // 5th increment is blocked by the cross-commodity cap.
+        await tester.tap(
+          find.byKey(TradeScreen.marketRowIncrementKey(_timber)),
+        );
+        await tester.pump();
+        expect(
+          _stagedOrder(container, _timber)?.quantity,
+          10,
+          reason:
+              'Refs #2993 E5c: bid increment blocked when '
+              'cross-commodity bid total saturates tradeCargoCapacity.',
+        );
+        expect(_totalStagedBid(container), 10);
+      },
+    );
+
+    testWidgets('capacity 10 with cargo saturated (timber 6 + iron 4): tapping '
         '`Bid` on a fresh commodity (grain) is a silent no-op — no '
         'TradeOrder for grain is staged and the cross-commodity bid '
-        'total stays at 10',
-        (tester) async {
-          final ProviderContainer container = await _pumpTradeScreen(
-            tester,
-            game: _buildGame(tradeCargoCapacityOverride: 10),
-            initialOrders: _orders(<TradeOrder>[
-              _bid(_timber, 6),
-              _bid(_iron, 4),
-            ]),
-          );
-
-          expect(_stagedOrder(container, _grain), isNull);
-
-          await tester
-              .tap(find.byKey(TradeScreen.marketRowBidChipKey(_grain)));
-          await tester.pump();
-
-          expect(
-            _stagedOrder(container, _grain),
-            isNull,
-            reason: 'Refs #2993 E5c: Bid toggle is a no-op when '
-                'maxAllowedBidQuantity <= 0.',
-          );
-          expect(_totalStagedBid(container), 10);
-          expect(_cargoIndicatorText(tester), 'Cargo remaining: 0');
-          expect(
-            find.byKey(TradeScreen.marketCargoWarningKey),
-            findsOneWidget,
-          );
-        },
+        'total stays at 10', (tester) async {
+      final ProviderContainer container = await pumpTradeScreenWithContainer(
+        tester,
+        game: buildTradeTestGame(
+          id: 'test_trade_screen_e5c',
+          treasury: 100000,
+          tradeCargoCapacityOverride: 10,
+        ),
+        initialOrders: _orders(<TradeOrder>[_bid(_timber, 6), _bid(_iron, 4)]),
       );
 
-      testWidgets(
-        'capacity 10 with cargo saturated and a staged offer: tapping '
+      expect(_stagedOrder(container, _grain), isNull);
+
+      await tester.tap(find.byKey(TradeScreen.marketRowBidChipKey(_grain)));
+      await tester.pump();
+
+      expect(
+        _stagedOrder(container, _grain),
+        isNull,
+        reason:
+            'Refs #2993 E5c: Bid toggle is a no-op when '
+            'maxAllowedBidQuantity <= 0.',
+      );
+      expect(_totalStagedBid(container), 10);
+      expect(_cargoIndicatorText(tester), 'Cargo remaining: 0');
+      expect(find.byKey(TradeScreen.marketCargoWarningKey), findsOneWidget);
+    });
+
+    testWidgets('capacity 10 with cargo saturated and a staged offer: tapping '
         '`Bid` on the offer row is also blocked (the prior offer '
-        'survives because the toggle is rejected)',
-        (tester) async {
-          final ProviderContainer container = await _pumpTradeScreen(
-            tester,
-            game: _buildGame(tradeCargoCapacityOverride: 10),
-            initialOrders: _orders(<TradeOrder>[
-              _bid(_timber, 6),
-              _bid(_iron, 4),
-              _offer(_fabric, 5),
-            ]),
-          );
-
-          await tester
-              .tap(find.byKey(TradeScreen.marketRowBidChipKey(_fabric)));
-          await tester.pump();
-
-          final TradeOrder? fabric = _stagedOrder(container, _fabric);
-          expect(
-            fabric?.type,
-            TradeOrderType.offer,
-            reason: 'Refs #2993 E5c: bid toggle is rejected when '
-                'maxAllowedBidQuantity <= 0; the prior offer stays.',
-          );
-          expect(fabric?.quantity, 5);
-          expect(_totalStagedBid(container), 10);
-        },
+        'survives because the toggle is rejected)', (tester) async {
+      final ProviderContainer container = await pumpTradeScreenWithContainer(
+        tester,
+        game: buildTradeTestGame(
+          id: 'test_trade_screen_e5c',
+          treasury: 100000,
+          tradeCargoCapacityOverride: 10,
+        ),
+        initialOrders: _orders(<TradeOrder>[
+          _bid(_timber, 6),
+          _bid(_iron, 4),
+          _offer(_fabric, 5),
+        ]),
       );
 
-      testWidgets(
-        'capacity 10 with offer fabric 8 (cargo remaining 10): tapping '
+      await tester.tap(find.byKey(TradeScreen.marketRowBidChipKey(_fabric)));
+      await tester.pump();
+
+      final TradeOrder? fabric = _stagedOrder(container, _fabric);
+      expect(
+        fabric?.type,
+        TradeOrderType.offer,
+        reason:
+            'Refs #2993 E5c: bid toggle is rejected when '
+            'maxAllowedBidQuantity <= 0; the prior offer stays.',
+      );
+      expect(fabric?.quantity, 5);
+      expect(_totalStagedBid(container), 10);
+    });
+
+    testWidgets('capacity 10 with offer fabric 8 (cargo remaining 10): tapping '
         '`Bid` on fabric preserves the prior quantity (8 ≤ 10) and '
-        'reduces cargo remaining to 2',
-        (tester) async {
-          final ProviderContainer container = await _pumpTradeScreen(
-            tester,
-            game: _buildGame(tradeCargoCapacityOverride: 10),
-            initialOrders: _orders(<TradeOrder>[_offer(_fabric, 8)]),
-          );
-
-          expect(_cargoIndicatorText(tester), 'Cargo remaining: 10');
-
-          await tester
-              .tap(find.byKey(TradeScreen.marketRowBidChipKey(_fabric)));
-          await tester.pump();
-
-          final TradeOrder? fabric = _stagedOrder(container, _fabric);
-          expect(fabric?.type, TradeOrderType.bid);
-          expect(fabric?.quantity, 8);
-          expect(_totalStagedBid(container), 8);
-          expect(_cargoIndicatorText(tester), 'Cargo remaining: 2');
-          expect(
-            find.byKey(TradeScreen.marketCargoWarningKey),
-            findsNothing,
-          );
-        },
+        'reduces cargo remaining to 2', (tester) async {
+      final ProviderContainer container = await pumpTradeScreenWithContainer(
+        tester,
+        game: buildTradeTestGame(
+          id: 'test_trade_screen_e5c',
+          treasury: 100000,
+          tradeCargoCapacityOverride: 10,
+        ),
+        initialOrders: _orders(<TradeOrder>[_offer(_fabric, 8)]),
       );
 
-      testWidgets(
-        'capacity 10 with bid timber 9 (cargo remaining 1) AND offer '
+      expect(_cargoIndicatorText(tester), 'Cargo remaining: 10');
+
+      await tester.tap(find.byKey(TradeScreen.marketRowBidChipKey(_fabric)));
+      await tester.pump();
+
+      final TradeOrder? fabric = _stagedOrder(container, _fabric);
+      expect(fabric?.type, TradeOrderType.bid);
+      expect(fabric?.quantity, 8);
+      expect(_totalStagedBid(container), 8);
+      expect(_cargoIndicatorText(tester), 'Cargo remaining: 2');
+      expect(find.byKey(TradeScreen.marketCargoWarningKey), findsNothing);
+    });
+
+    testWidgets('capacity 10 with bid timber 9 (cargo remaining 1) AND offer '
         'fabric 5: tapping `Bid` on fabric clamps the new staged '
-        'quantity to the remaining cargo (1, not the prior 5)',
-        (tester) async {
-          final ProviderContainer container = await _pumpTradeScreen(
-            tester,
-            game: _buildGame(tradeCargoCapacityOverride: 10),
-            initialOrders: _orders(<TradeOrder>[
-              _bid(_timber, 9),
-              _offer(_fabric, 5),
-            ]),
-          );
-
-          expect(_cargoIndicatorText(tester), 'Cargo remaining: 1');
-
-          await tester
-              .tap(find.byKey(TradeScreen.marketRowBidChipKey(_fabric)));
-          await tester.pump();
-
-          final TradeOrder? fabric = _stagedOrder(container, _fabric);
-          expect(fabric?.type, TradeOrderType.bid);
-          expect(
-            fabric?.quantity,
-            1,
-            reason: 'Refs #2993 E5c: bid toggle clamps quantity to '
-                'maxAllowedBidQuantity (remainingCargo + priorBidContribution).',
-          );
-          expect(_totalStagedBid(container), 10);
-          expect(_cargoIndicatorText(tester), 'Cargo remaining: 0');
-          expect(
-            find.byKey(TradeScreen.marketCargoWarningKey),
-            findsOneWidget,
-          );
-        },
+        'quantity to the remaining cargo (1, not the prior 5)', (tester) async {
+      final ProviderContainer container = await pumpTradeScreenWithContainer(
+        tester,
+        game: buildTradeTestGame(
+          id: 'test_trade_screen_e5c',
+          treasury: 100000,
+          tradeCargoCapacityOverride: 10,
+        ),
+        initialOrders: _orders(<TradeOrder>[
+          _bid(_timber, 9),
+          _offer(_fabric, 5),
+        ]),
       );
 
-      testWidgets(
-        'capacity 10 saturated with bid timber 10: tapping `−` on '
+      expect(_cargoIndicatorText(tester), 'Cargo remaining: 1');
+
+      await tester.tap(find.byKey(TradeScreen.marketRowBidChipKey(_fabric)));
+      await tester.pump();
+
+      final TradeOrder? fabric = _stagedOrder(container, _fabric);
+      expect(fabric?.type, TradeOrderType.bid);
+      expect(
+        fabric?.quantity,
+        1,
+        reason:
+            'Refs #2993 E5c: bid toggle clamps quantity to '
+            'maxAllowedBidQuantity (remainingCargo + priorBidContribution).',
+      );
+      expect(_totalStagedBid(container), 10);
+      expect(_cargoIndicatorText(tester), 'Cargo remaining: 0');
+      expect(find.byKey(TradeScreen.marketCargoWarningKey), findsOneWidget);
+    });
+
+    testWidgets('capacity 10 saturated with bid timber 10: tapping `−` on '
         'timber frees one unit of cargo, removes the warning row, and '
-        'updates the indicator to "Cargo remaining: 1"',
-        (tester) async {
-          final ProviderContainer container = await _pumpTradeScreen(
-            tester,
-            game: _buildGame(tradeCargoCapacityOverride: 10),
-            initialOrders: _orders(<TradeOrder>[_bid(_timber, 10)]),
-          );
-
-          expect(_cargoIndicatorText(tester), 'Cargo remaining: 0');
-          expect(
-            find.byKey(TradeScreen.marketCargoWarningKey),
-            findsOneWidget,
-          );
-
-          await tester
-              .tap(find.byKey(TradeScreen.marketRowDecrementKey(_timber)));
-          await tester.pump();
-
-          expect(_stagedOrder(container, _timber)?.quantity, 9);
-          expect(_cargoIndicatorText(tester), 'Cargo remaining: 1');
-          expect(
-            find.byKey(TradeScreen.marketCargoWarningKey),
-            findsNothing,
-          );
-        },
+        'updates the indicator to "Cargo remaining: 1"', (tester) async {
+      final ProviderContainer container = await pumpTradeScreenWithContainer(
+        tester,
+        game: buildTradeTestGame(
+          id: 'test_trade_screen_e5c',
+          treasury: 100000,
+          tradeCargoCapacityOverride: 10,
+        ),
+        initialOrders: _orders(<TradeOrder>[_bid(_timber, 10)]),
       );
 
-      testWidgets(
-        'capacity 10 saturated with bid timber 10: tapping `None` on '
+      expect(_cargoIndicatorText(tester), 'Cargo remaining: 0');
+      expect(find.byKey(TradeScreen.marketCargoWarningKey), findsOneWidget);
+
+      await tester.tap(find.byKey(TradeScreen.marketRowDecrementKey(_timber)));
+      await tester.pump();
+
+      expect(_stagedOrder(container, _timber)?.quantity, 9);
+      expect(_cargoIndicatorText(tester), 'Cargo remaining: 1');
+      expect(find.byKey(TradeScreen.marketCargoWarningKey), findsNothing);
+    });
+
+    testWidgets('capacity 10 saturated with bid timber 10: tapping `None` on '
         'timber removes the staged TradeOrder, frees the entire cargo '
-        'budget, and removes the warning row',
-        (tester) async {
-          final ProviderContainer container = await _pumpTradeScreen(
-            tester,
-            game: _buildGame(tradeCargoCapacityOverride: 10),
-            initialOrders: _orders(<TradeOrder>[_bid(_timber, 10)]),
-          );
-
-          await tester
-              .tap(find.byKey(TradeScreen.marketRowNoneChipKey(_timber)));
-          await tester.pump();
-
-          expect(_stagedOrder(container, _timber), isNull);
-          expect(_totalStagedBid(container), 0);
-          expect(_cargoIndicatorText(tester), 'Cargo remaining: 10');
-          expect(
-            find.byKey(TradeScreen.marketCargoWarningKey),
-            findsNothing,
-          );
-        },
+        'budget, and removes the warning row', (tester) async {
+      final ProviderContainer container = await pumpTradeScreenWithContainer(
+        tester,
+        game: buildTradeTestGame(
+          id: 'test_trade_screen_e5c',
+          treasury: 100000,
+          tradeCargoCapacityOverride: 10,
+        ),
+        initialOrders: _orders(<TradeOrder>[_bid(_timber, 10)]),
       );
 
-      testWidgets(
-        'observe mode (canMutateViaUi == false): the cargo indicator '
+      await tester.tap(find.byKey(TradeScreen.marketRowNoneChipKey(_timber)));
+      await tester.pump();
+
+      expect(_stagedOrder(container, _timber), isNull);
+      expect(_totalStagedBid(container), 0);
+      expect(_cargoIndicatorText(tester), 'Cargo remaining: 10');
+      expect(find.byKey(TradeScreen.marketCargoWarningKey), findsNothing);
+    });
+
+    testWidgets('observe mode (canMutateViaUi == false): the cargo indicator '
         'and warning row stay mounted with live text values; the chip '
         'taps are blocked by the existing IgnorePointer wrapper so '
-        'currentOrdersProvider is not mutated',
-        (tester) async {
-          final ProviderContainer container = await _pumpTradeScreen(
-            tester,
-            game: _buildGame(tradeCargoCapacityOverride: 10),
-            initialOrders: _orders(<TradeOrder>[
-              _bid(_timber, 6),
-              _bid(_iron, 4),
-            ]),
-            canMutateViaUi: false,
-          );
-
-          expect(_cargoIndicatorText(tester), 'Cargo remaining: 0');
-          expect(
-            find.byKey(TradeScreen.marketCargoWarningKey),
-            findsOneWidget,
-          );
-
-          // Attempting to tap the increment / None chip is swallowed by
-          // IgnorePointer (`warnIfMissed: false` silences the expected
-          // hit-test warning that surfaces when the wrapper absorbs
-          // the pointer event).
-          await tester.tap(
-            find.byKey(TradeScreen.marketRowNoneChipKey(_timber)),
-            warnIfMissed: false,
-          );
-          await tester.pump();
-
-          expect(
-            _stagedOrder(container, _timber)?.quantity,
-            6,
-            reason: 'Observe mode must not mutate currentOrdersProvider.',
-          );
-          expect(_cargoIndicatorText(tester), 'Cargo remaining: 0');
-        },
+        'currentOrdersProvider is not mutated', (tester) async {
+      final ProviderContainer container = await pumpTradeScreenWithContainer(
+        tester,
+        game: buildTradeTestGame(
+          id: 'test_trade_screen_e5c',
+          treasury: 100000,
+          tradeCargoCapacityOverride: 10,
+        ),
+        initialOrders: _orders(<TradeOrder>[_bid(_timber, 6), _bid(_iron, 4)]),
+        canMutateViaUi: false,
       );
-    },
-  );
+
+      expect(_cargoIndicatorText(tester), 'Cargo remaining: 0');
+      expect(find.byKey(TradeScreen.marketCargoWarningKey), findsOneWidget);
+
+      // Attempting to tap the increment / None chip is swallowed by
+      // IgnorePointer (`warnIfMissed: false` silences the expected
+      // hit-test warning that surfaces when the wrapper absorbs
+      // the pointer event).
+      await tester.tap(
+        find.byKey(TradeScreen.marketRowNoneChipKey(_timber)),
+        warnIfMissed: false,
+      );
+      await tester.pump();
+
+      expect(
+        _stagedOrder(container, _timber)?.quantity,
+        6,
+        reason: 'Observe mode must not mutate currentOrdersProvider.',
+      );
+      expect(_cargoIndicatorText(tester), 'Cargo remaining: 0');
+    });
+  });
 }

--- a/app/test/trade_screen_market_tab_observe_mode_chrome_test.dart
+++ b/app/test/trade_screen_market_tab_observe_mode_chrome_test.dart
@@ -53,364 +53,279 @@
 //     is not in scope for this pin.
 
 import 'package:colonizethis_app/config/app_constants.dart';
-import 'package:colonizethis_app/features/game/flame/region_map/region_map.dart'
-    show CtMapVisibilityMode;
 import 'package:colonizethis_app/features/game/screens/trade/trade_screen.dart';
-import 'package:colonizethis_app/features/game/widgets/shell/shell_player_context.dart';
-import 'package:colonizethis_app/providers/games_provider.dart';
 import 'package:colonizethis_app/widgets/resource_icon.dart';
 import 'package:colonizethis_app/widgets/strict_asset_icon.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'support/app_shell_harness.dart';
-
-const String _humanPlayerId = 'gp_h';
+import 'support/trade_screen_test_support.dart';
 
 CommodityId get _timber => CommodityCatalog.timber.id;
-
-/// Builds a synthetic [Game] with one human player and a baseline
-/// stockpile of 99 units for every tradeable commodity so the sellable
-/// readout pin can assert `(99)` on the row under test without depending
-/// on the in-game shell fixture.
-///
-/// [prices] feeds `WorldMarketState.prices` so the integer-price pin
-/// can assert the timber row renders `30` under observe mode.
-Game _buildGame({Map<CommodityId, int>? prices}) {
-  final Map<CommodityId, int> stockpile = <CommodityId, int>{
-    for (final Commodity c in CommodityCatalog.all)
-      if (c.category != CommodityCategory.riches && c.id != 'spices') c.id: 99,
-  };
-  return Game(
-    id: 'test_trade_screen_market_tab_observe_mode_chrome',
-    worldState: WorldState(
-      turnState: TurnState(phase: TurnPhase.orders, turnNumber: 1),
-      oldWorld: const RegionData(),
-      newWorld: const RegionData(),
-    ),
-    turnTimeMapping: TurnTimeMapping.gdd01,
-    players: [
-      Player(
-        id: _humanPlayerId,
-        // ignore: avoid_hardcoded_strings_in_widgets
-        displayName: 'England',
-        isHuman: true,
-        treasury: 500,
-        stockpile: Stockpile(quantities: stockpile),
-      ),
-    ],
-    diplomacyRelations: const [],
-    diplomaticHistoryEvents: const [],
-    dossierEvidenceEntries: const [],
-    worldMarketState: WorldMarketState(
-      prices: prices ?? const <CommodityId, int>{},
-      lastTurnActivity: const <CommodityId, MarketActivity>{},
-    ),
-  );
-}
-
-/// Pumps [TradeScreen] under a [ProviderScope] whose
-/// `shellPlayerContextProvider` is overridden to `canMutateViaUi: false`
-/// (the per-GP observe variant — distinct from the `showPlayerChrome:
-/// false` global-observe sentinel that swaps the body for
-/// [ObserveModeNotDefinedPanel]). Uses a tall (1024 × 4096) surface so
-/// every alphabetical row in the 22-commodity tradeable list lays out
-/// inside the scroll view at once — mirrors the harness in
-/// `trade_screen_market_tab_e5b_interactive_controls_test.dart`.
-Future<void> _pumpTradeScreenObserveMode(
-  WidgetTester tester, {
-  required Game game,
-}) async {
-  final Player player = game.players.first;
-  final ProviderContainer container = ProviderContainer(
-    overrides: [
-      currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
-      currentOrdersProvider.overrideWith(
-        () => CurrentOrdersNotifier(const Orders()),
-      ),
-      shellPlayerContextProvider.overrideWith(
-        (ref) => ShellPlayerContext(
-          effectiveHumanPlayerId: player.id,
-          viewingPlayerId: player.id,
-          mapVisibilityMode: CtMapVisibilityMode.full,
-          playerView: null,
-          omniscientDetail: false,
-          showPlayerChrome: true,
-          canMutateViaUi: false,
-          debugCommandTargetPlayerId: player.id,
-          inObservePhase: true,
-          // ignore: avoid_hardcoded_strings_in_widgets
-          observeBannerLabel: 'Observing',
-          treasuryNotDefined: false,
-          cargoNotDefined: false,
-        ),
-      ),
-    ],
-  );
-  addTearDown(container.dispose);
-  await pumpAppShellWithContainer(
-    tester,
-    container: container,
-    viewport: const Size(1024, 4096),
-    child: TradeScreen(game: game, player: player),
-  );
-}
 
 void main() {
   suppressLogsForTests();
 
-  group(
-    'TradeScreen Market tab observe-mode chrome parity (Refs #3093)',
-    () {
-      testWidgets(
-        'sectioned grouping (Food / Raw Materials / Manufactured) '
-        'remains mounted when canMutateViaUi == false',
-        (tester) async {
-          await _pumpTradeScreenObserveMode(tester, game: _buildGame());
-
-          final marketTab = find.byKey(TradeScreen.marketTabBodyKey);
-          expect(
-            marketTab,
-            findsOneWidget,
-            reason:
-                'Refs #3093 observe-mode chrome parity: the Market tab '
-                'body must still mount under observe mode — the body is '
-                'wrapped in IgnorePointer + Opacity but not removed '
-                '(SPEC/ui/trade-screen.md § Body — Observe-mode).',
-          );
-
-          for (final Key sectionKey in <Key>[
-            TradeScreen.marketSectionFoodKey,
-            TradeScreen.marketSectionRawMaterialsKey,
-            TradeScreen.marketSectionManufacturedKey,
-          ]) {
-            expect(
-              find.descendant(of: marketTab, matching: find.byKey(sectionKey)),
-              findsOneWidget,
-              reason:
-                  'Refs #3093 observe-mode chrome parity: the '
-                  'sectioned grouping header keyed $sectionKey must '
-                  'still mount when canMutateViaUi == false — section '
-                  'labels are read-only chrome that never depends on '
-                  'the player\'s ability to mutate orders.',
-            );
-          }
-        },
+  group('TradeScreen Market tab observe-mode chrome parity (Refs #3093)', () {
+    testWidgets('sectioned grouping (Food / Raw Materials / Manufactured) '
+        'remains mounted when canMutateViaUi == false', (tester) async {
+      await pumpTradeScreenWithContainer(
+        tester,
+        game: buildTradeTestGame(
+          id: 'test_trade_screen_market_tab_observe_mode_chrome',
+          stockpile: tradeableStockpileFilled(99),
+        ),
+        canMutateViaUi: false,
       );
 
-      testWidgets(
-        'row icons (leading ResourceIcon 20 dp + trailing treasury '
+      final marketTab = find.byKey(TradeScreen.marketTabBodyKey);
+      expect(
+        marketTab,
+        findsOneWidget,
+        reason:
+            'Refs #3093 observe-mode chrome parity: the Market tab '
+            'body must still mount under observe mode — the body is '
+            'wrapped in IgnorePointer + Opacity but not removed '
+            '(SPEC/ui/trade-screen.md § Body — Observe-mode).',
+      );
+
+      for (final Key sectionKey in <Key>[
+        TradeScreen.marketSectionFoodKey,
+        TradeScreen.marketSectionRawMaterialsKey,
+        TradeScreen.marketSectionManufacturedKey,
+      ]) {
+        expect(
+          find.descendant(of: marketTab, matching: find.byKey(sectionKey)),
+          findsOneWidget,
+          reason:
+              'Refs #3093 observe-mode chrome parity: the '
+              'sectioned grouping header keyed $sectionKey must '
+              'still mount when canMutateViaUi == false — section '
+              'labels are read-only chrome that never depends on '
+              'the player\'s ability to mutate orders.',
+        );
+      }
+    });
+
+    testWidgets('row icons (leading ResourceIcon 20 dp + trailing treasury '
         'coin 14 dp) remain mounted on every tradeable row when '
-        'canMutateViaUi == false',
-        (tester) async {
-          await _pumpTradeScreenObserveMode(tester, game: _buildGame());
-
-          final list = find.byKey(TradeScreen.marketCommodityListKey);
-          expect(list, findsOneWidget);
-
-          for (final Commodity c in CommodityCatalog.all) {
-            if (c.category == CommodityCategory.riches || c.id == 'spices') {
-              continue;
-            }
-            final iconFinder = find.descendant(
-              of: list,
-              matching: find.byKey(TradeScreen.marketRowResourceIconKey(c.id)),
-            );
-            expect(
-              iconFinder,
-              findsOneWidget,
-              reason:
-                  'Refs #3093 observe-mode chrome parity: tradeable '
-                  'commodity `${c.id}` must still mount its '
-                  'ResourceIcon under observe mode — row icons are '
-                  'decorative chrome that never depends on '
-                  'canMutateViaUi.',
-            );
-            final ResourceIcon icon = tester.widget<ResourceIcon>(iconFinder);
-            expect(
-              icon.size,
-              TradeScreen.marketRowResourceIconSize,
-              reason:
-                  'Refs #3093 observe-mode chrome parity: leading '
-                  'ResourceIcon on row `${c.id}` must paint at 20 dp '
-                  'regardless of canMutateViaUi.',
-            );
-
-            final coinFinder = find.descendant(
-              of: list,
-              matching: find.byKey(TradeScreen.marketRowPriceCoinIconKey(c.id)),
-            );
-            expect(
-              coinFinder,
-              findsOneWidget,
-              reason:
-                  'Refs #3093 observe-mode chrome parity: tradeable '
-                  'commodity `${c.id}` must still mount its trailing '
-                  'treasury-coin StrictAssetIcon under observe mode.',
-            );
-            final StrictAssetIcon coin = tester.widget<StrictAssetIcon>(
-              coinFinder,
-            );
-            expect(
-              coin.assetPath,
-              '${kAppIconAssetPrefix}ui_icon_treasury_coin.png',
-              reason:
-                  'Refs #3093 observe-mode chrome parity: trailing '
-                  'coin glyph on row `${c.id}` must still reuse the '
-                  'canonical treasury-coin asset under observe mode.',
-            );
-            expect(coin.width, TradeScreen.marketRowPriceCoinIconSize);
-            expect(coin.height, TradeScreen.marketRowPriceCoinIconSize);
-          }
-        },
+        'canMutateViaUi == false', (tester) async {
+      await pumpTradeScreenWithContainer(
+        tester,
+        game: buildTradeTestGame(
+          id: 'test_trade_screen_market_tab_observe_mode_chrome',
+          stockpile: tradeableStockpileFilled(99),
+        ),
+        canMutateViaUi: false,
       );
 
-      testWidgets(
-        'sellable readout `(N)` remains mounted on every tradeable row '
+      final list = find.byKey(TradeScreen.marketCommodityListKey);
+      expect(list, findsOneWidget);
+
+      for (final Commodity c in CommodityCatalog.all) {
+        if (c.category == CommodityCategory.riches || c.id == 'spices') {
+          continue;
+        }
+        final iconFinder = find.descendant(
+          of: list,
+          matching: find.byKey(TradeScreen.marketRowResourceIconKey(c.id)),
+        );
+        expect(
+          iconFinder,
+          findsOneWidget,
+          reason:
+              'Refs #3093 observe-mode chrome parity: tradeable '
+              'commodity `${c.id}` must still mount its '
+              'ResourceIcon under observe mode — row icons are '
+              'decorative chrome that never depends on '
+              'canMutateViaUi.',
+        );
+        final ResourceIcon icon = tester.widget<ResourceIcon>(iconFinder);
+        expect(
+          icon.size,
+          TradeScreen.marketRowResourceIconSize,
+          reason:
+              'Refs #3093 observe-mode chrome parity: leading '
+              'ResourceIcon on row `${c.id}` must paint at 20 dp '
+              'regardless of canMutateViaUi.',
+        );
+
+        final coinFinder = find.descendant(
+          of: list,
+          matching: find.byKey(TradeScreen.marketRowPriceCoinIconKey(c.id)),
+        );
+        expect(
+          coinFinder,
+          findsOneWidget,
+          reason:
+              'Refs #3093 observe-mode chrome parity: tradeable '
+              'commodity `${c.id}` must still mount its trailing '
+              'treasury-coin StrictAssetIcon under observe mode.',
+        );
+        final StrictAssetIcon coin = tester.widget<StrictAssetIcon>(coinFinder);
+        expect(
+          coin.assetPath,
+          '${kAppIconAssetPrefix}ui_icon_treasury_coin.png',
+          reason:
+              'Refs #3093 observe-mode chrome parity: trailing '
+              'coin glyph on row `${c.id}` must still reuse the '
+              'canonical treasury-coin asset under observe mode.',
+        );
+        expect(coin.width, TradeScreen.marketRowPriceCoinIconSize);
+        expect(coin.height, TradeScreen.marketRowPriceCoinIconSize);
+      }
+    });
+
+    testWidgets('sellable readout `(N)` remains mounted on every tradeable row '
         'when canMutateViaUi == false (N = raw stockpile when no '
-        'offers / industry-allocation reservations exist)',
-        (tester) async {
-          await _pumpTradeScreenObserveMode(tester, game: _buildGame());
-
-          final list = find.byKey(TradeScreen.marketCommodityListKey);
-          expect(list, findsOneWidget);
-
-          for (final Commodity c in CommodityCatalog.all) {
-            if (c.category == CommodityCategory.riches || c.id == 'spices') {
-              continue;
-            }
-            final sellableFinder = find.descendant(
-              of: list,
-              matching: find.byKey(
-                TradeScreen.marketRowSellableReadoutKey(c.id),
-              ),
-            );
-            expect(
-              sellableFinder,
-              findsOneWidget,
-              reason:
-                  'Refs #3093 observe-mode chrome parity: the sellable '
-                  'readout for tradeable commodity `${c.id}` must '
-                  'still mount under observe mode — the readout '
-                  'reflects the player\'s stockpile / reservation '
-                  'state regardless of canMutateViaUi.',
-            );
-            final Text sellable = tester.widget<Text>(sellableFinder);
-            expect(
-              sellable.data,
-              // ignore: avoid_hardcoded_strings_in_widgets
-              '(99)',
-              reason:
-                  'Refs #3093 observe-mode chrome parity: with raw '
-                  'stockpile 99, no staged offers, and no '
-                  'industry-allocation reservations, the sellable '
-                  'readout for `${c.id}` must render the literal '
-                  '`(99)` under observe mode.',
-            );
-          }
-        },
+        'offers / industry-allocation reservations exist)', (tester) async {
+      await pumpTradeScreenWithContainer(
+        tester,
+        game: buildTradeTestGame(
+          id: 'test_trade_screen_market_tab_observe_mode_chrome',
+          stockpile: tradeableStockpileFilled(99),
+        ),
+        canMutateViaUi: false,
       );
 
-      testWidgets(
-        'integer price text remains mounted under observe mode — '
+      final list = find.byKey(TradeScreen.marketCommodityListKey);
+      expect(list, findsOneWidget);
+
+      for (final Commodity c in CommodityCatalog.all) {
+        if (c.category == CommodityCategory.riches || c.id == 'spices') {
+          continue;
+        }
+        final sellableFinder = find.descendant(
+          of: list,
+          matching: find.byKey(TradeScreen.marketRowSellableReadoutKey(c.id)),
+        );
+        expect(
+          sellableFinder,
+          findsOneWidget,
+          reason:
+              'Refs #3093 observe-mode chrome parity: the sellable '
+              'readout for tradeable commodity `${c.id}` must '
+              'still mount under observe mode — the readout '
+              'reflects the player\'s stockpile / reservation '
+              'state regardless of canMutateViaUi.',
+        );
+        final Text sellable = tester.widget<Text>(sellableFinder);
+        expect(
+          sellable.data,
+          // ignore: avoid_hardcoded_strings_in_widgets
+          '(99)',
+          reason:
+              'Refs #3093 observe-mode chrome parity: with raw '
+              'stockpile 99, no staged offers, and no '
+              'industry-allocation reservations, the sellable '
+              'readout for `${c.id}` must render the literal '
+              '`(99)` under observe mode.',
+        );
+      }
+    });
+
+    testWidgets('integer price text remains mounted under observe mode — '
         'worldMarketState.prices == {timber: 30} renders the literal '
-        '`30` on the timber row',
-        (tester) async {
-          await _pumpTradeScreenObserveMode(
-            tester,
-            game: _buildGame(
-              prices: const <CommodityId, int>{'timber': 30},
-            ),
-          );
-
-          final timberRow = find.byKey(
-            TradeScreen.marketCommodityRowKey(_timber),
-          );
-          expect(timberRow, findsOneWidget);
-          expect(
-            find.descendant(
-              of: timberRow,
-              // ignore: avoid_hardcoded_strings_in_widgets
-              matching: find.text('30'),
-            ),
-            findsOneWidget,
-            reason:
-                'Refs #3093 observe-mode chrome parity: the integer '
-                'price text rendered by `_formatPrice` must still '
-                'mount under observe mode — integer-price chrome is '
-                'read-only and never depends on canMutateViaUi.',
-          );
-        },
+        '`30` on the timber row', (tester) async {
+      await pumpTradeScreenWithContainer(
+        tester,
+        game: buildTradeTestGame(
+          id: 'test_trade_screen_market_tab_observe_mode_chrome',
+          stockpile: tradeableStockpileFilled(99),
+          prices: const <CommodityId, int>{'timber': 30},
+        ),
+        canMutateViaUi: false,
       );
 
-      testWidgets(
-        'catalog default-price fallback resolves under observe mode — '
+      final timberRow = find.byKey(TradeScreen.marketCommodityRowKey(_timber));
+      expect(timberRow, findsOneWidget);
+      expect(
+        find.descendant(
+          of: timberRow,
+          // ignore: avoid_hardcoded_strings_in_widgets
+          matching: find.text('30'),
+        ),
+        findsOneWidget,
+        reason:
+            'Refs #3093 observe-mode chrome parity: the integer '
+            'price text rendered by `_formatPrice` must still '
+            'mount under observe mode — integer-price chrome is '
+            'read-only and never depends on canMutateViaUi.',
+      );
+    });
+
+    testWidgets('catalog default-price fallback resolves under observe mode — '
         'iron row (price absent from worldMarketState.prices) renders '
         'the integer catalog default `80` immediately to the right of '
-        'the row treasury-coin glyph (no em-dash in the price slot)',
-        (tester) async {
-          // worldMarketState.prices is intentionally empty here so the
-          // row must fall back to ResourceRules.defaultMarketPriceForCommodityId
-          // for every tradeable commodity. The negative pin uses iron
-          // (catalog default = 80 per ResourceRules.defaultRules) so a
-          // regression that drops the catalog fallback under observe
-          // mode surfaces as the em-dash glyph appearing in the price
-          // slot instead of the integer literal `80`.
-          await _pumpTradeScreenObserveMode(tester, game: _buildGame());
-
-          final ironRow = find.byKey(
-            TradeScreen.marketCommodityRowKey(CommodityCatalog.iron.id),
-          );
-          expect(ironRow, findsOneWidget);
-
-          expect(
-            find.descendant(
-              of: ironRow,
-              // ignore: avoid_hardcoded_strings_in_widgets
-              matching: find.text('80'),
-            ),
-            findsOneWidget,
-            reason:
-                'Refs #3093 observe-mode chrome parity: with '
-                'worldMarketState.prices empty, the iron row must '
-                'still render the published catalog default price `80` '
-                'under observe mode (ResourceRules.defaultRules '
-                'covers every tradeable commodity per '
-                'SPEC/game/world-market.md § Price discovery). The '
-                'em-dash glyph must never paint in the price slot.',
-          );
-
-          // The coin glyph mounts to the immediate left of the price
-          // text, so pinning the spatial relationship under observe
-          // mode guards against a regression that hides the coin or
-          // the integer price specifically on the observed surface.
-          final coinRect = tester.getRect(
-            find.byKey(
-              TradeScreen.marketRowPriceCoinIconKey(CommodityCatalog.iron.id),
-            ),
-          );
-          final priceRect = tester.getRect(
-            find.descendant(
-              of: ironRow,
-              // ignore: avoid_hardcoded_strings_in_widgets
-              matching: find.text('80'),
-            ),
-          );
-          expect(
-            coinRect.right,
-            lessThanOrEqualTo(priceRect.left),
-            reason:
-                'Refs #3093 observe-mode chrome parity: the trailing '
-                'treasury-coin glyph must still paint immediately to '
-                'the left of the integer price text under observe '
-                'mode (Refs #3093 § Market tab — row icons).',
-          );
-        },
+        'the row treasury-coin glyph (no em-dash in the price slot)', (
+      tester,
+    ) async {
+      // worldMarketState.prices is intentionally empty here so the
+      // row must fall back to ResourceRules.defaultMarketPriceForCommodityId
+      // for every tradeable commodity. The negative pin uses iron
+      // (catalog default = 80 per ResourceRules.defaultRules) so a
+      // regression that drops the catalog fallback under observe
+      // mode surfaces as the em-dash glyph appearing in the price
+      // slot instead of the integer literal `80`.
+      await pumpTradeScreenWithContainer(
+        tester,
+        game: buildTradeTestGame(
+          id: 'test_trade_screen_market_tab_observe_mode_chrome',
+          stockpile: tradeableStockpileFilled(99),
+        ),
+        canMutateViaUi: false,
       );
-    },
-  );
+
+      final ironRow = find.byKey(
+        TradeScreen.marketCommodityRowKey(CommodityCatalog.iron.id),
+      );
+      expect(ironRow, findsOneWidget);
+
+      expect(
+        find.descendant(
+          of: ironRow,
+          // ignore: avoid_hardcoded_strings_in_widgets
+          matching: find.text('80'),
+        ),
+        findsOneWidget,
+        reason:
+            'Refs #3093 observe-mode chrome parity: with '
+            'worldMarketState.prices empty, the iron row must '
+            'still render the published catalog default price `80` '
+            'under observe mode (ResourceRules.defaultRules '
+            'covers every tradeable commodity per '
+            'SPEC/game/world-market.md § Price discovery). The '
+            'em-dash glyph must never paint in the price slot.',
+      );
+
+      // The coin glyph mounts to the immediate left of the price
+      // text, so pinning the spatial relationship under observe
+      // mode guards against a regression that hides the coin or
+      // the integer price specifically on the observed surface.
+      final coinRect = tester.getRect(
+        find.byKey(
+          TradeScreen.marketRowPriceCoinIconKey(CommodityCatalog.iron.id),
+        ),
+      );
+      final priceRect = tester.getRect(
+        find.descendant(
+          of: ironRow,
+          // ignore: avoid_hardcoded_strings_in_widgets
+          matching: find.text('80'),
+        ),
+      );
+      expect(
+        coinRect.right,
+        lessThanOrEqualTo(priceRect.left),
+        reason:
+            'Refs #3093 observe-mode chrome parity: the trailing '
+            'treasury-coin glyph must still paint immediately to '
+            'the left of the integer price text under observe '
+            'mode (Refs #3093 § Market tab — row icons).',
+      );
+    });
+  });
 }

--- a/app/test/trade_screen_market_tab_price_column_test.dart
+++ b/app/test/trade_screen_market_tab_price_column_test.dart
@@ -7,57 +7,15 @@
 
 import 'package:colonizethis_app/config/constants.dart';
 import 'package:colonizethis_app/features/game/screens/trade/trade_screen.dart';
-import 'package:colonizethis_app/providers/games_provider.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'support/app_shell_harness.dart';
+import 'support/trade_screen_test_support.dart';
 
 const Size _kMinViewport = Size(kMinViewportWidth, 640);
-
-Game _buildGame({
-  Map<CommodityId, int>? prices,
-}) {
-  return Game(
-    id: 'test_trade_screen_market_tab_price_column',
-    worldState: WorldState(
-      turnState: TurnState(phase: TurnPhase.orders, turnNumber: 1),
-      oldWorld: const RegionData(),
-      newWorld: const RegionData(),
-    ),
-    turnTimeMapping: TurnTimeMapping.gdd01,
-    players: [
-      // ignore: avoid_hardcoded_strings_in_widgets
-      Player(id: 'gp_h', displayName: 'England', isHuman: true, treasury: 500),
-    ],
-    diplomacyRelations: const [],
-    diplomaticHistoryEvents: const [],
-    dossierEvidenceEntries: const [],
-    worldMarketState: WorldMarketState(
-      prices: prices ?? const <CommodityId, int>{},
-      lastTurnActivity: const <CommodityId, MarketActivity>{},
-    ),
-  );
-}
-
-Future<void> _pumpTradeScreen(
-  WidgetTester tester, {
-  required Game game,
-  Size viewport = const Size(800, 900),
-}) async {
-  final Player player = game.players.first;
-  await pumpAppShell(
-    tester,
-    viewport: viewport,
-    overrides: [
-      currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
-    ],
-    child: TradeScreen(game: game, player: player),
-  );
-}
 
 double _priceTextRight(
   WidgetTester tester,
@@ -107,25 +65,22 @@ void main() {
       'price right edges share a column across rows with different digit '
       'lengths',
       (tester) async {
-        await _pumpTradeScreen(
+        await pumpTradeScreen(
           tester,
-          game: _buildGame(
-            prices: const <CommodityId, int>{
-              'timber': 5,
-              'iron': 220,
-            },
+          game: buildTradeTestGame(
+            id: 'test_trade_screen_market_tab_price_column',
+            prices: const <CommodityId, int>{'timber': 5, 'iron': 220},
           ),
         );
 
-        final double timberPriceRight =
-            _priceTextRight(tester, 'timber', '5');
-        final double ironPriceRight =
-            _priceTextRight(tester, 'iron', '220');
+        final double timberPriceRight = _priceTextRight(tester, 'timber', '5');
+        final double ironPriceRight = _priceTextRight(tester, 'iron', '220');
 
         expect(
           timberPriceRight,
           closeTo(ironPriceRight, 1),
-          reason: 'Single-digit and three-digit prices must share the same '
+          reason:
+              'Single-digit and three-digit prices must share the same '
               'right edge (shared price column).',
         );
       },
@@ -134,16 +89,19 @@ void main() {
     testWidgets(
       'price right edge is flush with the row right padding boundary',
       (tester) async {
-        await _pumpTradeScreen(
+        await pumpTradeScreen(
           tester,
-          game: _buildGame(
+          game: buildTradeTestGame(
+            id: 'test_trade_screen_market_tab_price_column',
             prices: const <CommodityId, int>{'timber': 30},
           ),
         );
 
         final double priceRight = _priceTextRight(tester, 'timber', '30');
         final double rowRight = tester
-            .getTopRight(find.byKey(TradeScreen.marketCommodityRowKey('timber')))
+            .getTopRight(
+              find.byKey(TradeScreen.marketCommodityRowKey('timber')),
+            )
             .dx;
 
         expect(
@@ -154,58 +112,59 @@ void main() {
       },
     );
 
-    testWidgets(
-      'coin paints immediately to the left of the price text',
-      (tester) async {
-        await _pumpTradeScreen(
-          tester,
-          game: _buildGame(
-            prices: const <CommodityId, int>{'timber': 30},
-          ),
-        );
+    testWidgets('coin paints immediately to the left of the price text', (
+      tester,
+    ) async {
+      await pumpTradeScreen(
+        tester,
+        game: buildTradeTestGame(
+          id: 'test_trade_screen_market_tab_price_column',
+          prices: const <CommodityId, int>{'timber': 30},
+        ),
+      );
 
-        final coinFinder = find.descendant(
-          of: find.byKey(TradeScreen.marketCommodityRowKey('timber')),
-          matching: find.byKey(TradeScreen.marketRowPriceCoinIconKey('timber')),
-        );
-        final priceFinder = find.descendant(
-          of: find.byKey(TradeScreen.marketCommodityRowKey('timber')),
-          matching: find.text('30'),
-        );
+      final coinFinder = find.descendant(
+        of: find.byKey(TradeScreen.marketCommodityRowKey('timber')),
+        matching: find.byKey(TradeScreen.marketRowPriceCoinIconKey('timber')),
+      );
+      final priceFinder = find.descendant(
+        of: find.byKey(TradeScreen.marketCommodityRowKey('timber')),
+        matching: find.text('30'),
+      );
 
-        final coinRect = tester.getRect(coinFinder);
-        final priceRect = tester.getRect(priceFinder);
+      final coinRect = tester.getRect(coinFinder);
+      final priceRect = tester.getRect(priceFinder);
 
-        expect(
-          coinRect.right,
-          lessThanOrEqualTo(priceRect.left),
-          reason: 'Treasury-coin glyph must remain immediately left of price.',
-        );
-      },
-    );
+      expect(
+        coinRect.right,
+        lessThanOrEqualTo(priceRect.left),
+        reason: 'Treasury-coin glyph must remain immediately left of price.',
+      );
+    });
 
     testWidgets(
       'rows with different name lengths still share the price column edge',
       (tester) async {
-        await _pumpTradeScreen(
+        await pumpTradeScreen(
           tester,
-          game: _buildGame(
-            prices: const <CommodityId, int>{
-              'timber': 30,
-              'refinedSugar': 70,
-            },
+          game: buildTradeTestGame(
+            id: 'test_trade_screen_market_tab_price_column',
+            prices: const <CommodityId, int>{'timber': 30, 'refinedSugar': 70},
           ),
         );
 
-        final double timberPriceRight =
-            _priceTextRight(tester, 'timber', '30');
-        final double sugarPriceRight =
-            _priceTextRight(tester, 'refinedSugar', '70');
+        final double timberPriceRight = _priceTextRight(tester, 'timber', '30');
+        final double sugarPriceRight = _priceTextRight(
+          tester,
+          'refinedSugar',
+          '70',
+        );
 
         expect(
           timberPriceRight,
           closeTo(sugarPriceRight, 1),
-          reason: 'Short and long commodity names must not stagger the price '
+          reason:
+              'Short and long commodity names must not stagger the price '
               'column.',
         );
       },
@@ -217,15 +176,15 @@ void main() {
       (tester) async {
         TradeScreen.marketPriceResourceRulesOverride = _emptyMarketPriceRules();
 
-        await _pumpTradeScreen(
+        await pumpTradeScreen(
           tester,
-          game: _buildGame(
+          game: buildTradeTestGame(
+            id: 'test_trade_screen_market_tab_price_column',
             prices: const <CommodityId, int>{'timber': 5},
           ),
         );
 
-        final double integerPriceRight =
-            _priceTextRight(tester, 'timber', '5');
+        final double integerPriceRight = _priceTextRight(tester, 'timber', '5');
         final double emDashPriceRight = _priceTextRight(
           tester,
           'iron',
@@ -236,7 +195,8 @@ void main() {
         expect(
           emDashPriceRight,
           closeTo(integerPriceRight, 1),
-          reason: 'Em-dash fallback must right-align in the same column as '
+          reason:
+              'Em-dash fallback must right-align in the same column as '
               'integer prices.',
         );
 
@@ -252,33 +212,28 @@ void main() {
       },
     );
 
-    testWidgets(
-      'shared price column holds at kMinViewportWidth (320 dp)',
-      (tester) async {
-        await _pumpTradeScreen(
-          tester,
-          game: _buildGame(
-            prices: const <CommodityId, int>{
-              'grain': 50,
-              'timber': 5,
-            },
-          ),
-          viewport: _kMinViewport,
-        );
+    testWidgets('shared price column holds at kMinViewportWidth (320 dp)', (
+      tester,
+    ) async {
+      await pumpTradeScreen(
+        tester,
+        game: buildTradeTestGame(
+          id: 'test_trade_screen_market_tab_price_column',
+          prices: const <CommodityId, int>{'grain': 50, 'timber': 5},
+        ),
+        viewport: _kMinViewport,
+      );
 
-        expect(tester.takeException(), isNull);
+      expect(tester.takeException(), isNull);
 
-        final double grainPriceRight =
-            _priceTextRight(tester, 'grain', '50');
-        final double timberPriceRight =
-            _priceTextRight(tester, 'timber', '5');
+      final double grainPriceRight = _priceTextRight(tester, 'grain', '50');
+      final double timberPriceRight = _priceTextRight(tester, 'timber', '5');
 
-        expect(
-          grainPriceRight,
-          closeTo(timberPriceRight, 1),
-          reason: '320 dp viewport must preserve the shared price column.',
-        );
-      },
-    );
+      expect(
+        grainPriceRight,
+        closeTo(timberPriceRight, 1),
+        reason: '320 dp viewport must preserve the shared price column.',
+      );
+    });
   });
 }

--- a/app/test/trade_screen_market_tab_row_icons_test.dart
+++ b/app/test/trade_screen_market_tab_row_icons_test.dart
@@ -31,7 +31,6 @@
 
 import 'package:colonizethis_app/config/app_constants.dart';
 import 'package:colonizethis_app/features/game/screens/trade/trade_screen.dart';
-import 'package:colonizethis_app/providers/games_provider.dart';
 import 'package:colonizethis_app/widgets/resource_icon.dart';
 import 'package:colonizethis_app/widgets/strict_asset_icon.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
@@ -39,124 +38,85 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter_test/flutter_test.dart';
 
-import 'support/app_shell_harness.dart';
-
-/// Builds a synthetic Game with one human player so the Market tab
-/// renders without depending on the in-game shell. Mirrors the
-/// lightweight Game factory in `trade_screen_market_tab_commodity_table_test.dart`.
-Game _buildGame({
-  Map<CommodityId, int>? prices,
-}) {
-  return Game(
-    id: 'test_trade_screen_market_tab_row_icons',
-    worldState: WorldState(
-      turnState: TurnState(phase: TurnPhase.orders, turnNumber: 1),
-      oldWorld: const RegionData(),
-      newWorld: const RegionData(),
-    ),
-    turnTimeMapping: TurnTimeMapping.gdd01,
-    players: [
-      // ignore: avoid_hardcoded_strings_in_widgets
-      Player(id: 'gp_h', displayName: 'England', isHuman: true, treasury: 500),
-    ],
-    diplomacyRelations: const [],
-    diplomaticHistoryEvents: const [],
-    dossierEvidenceEntries: const [],
-    worldMarketState: WorldMarketState(
-      prices: prices ?? const <CommodityId, int>{},
-      lastTurnActivity: const <CommodityId, MarketActivity>{},
-    ),
-  );
-}
-
-Future<void> _pumpTradeScreen(
-  WidgetTester tester, {
-  required Game game,
-}) async {
-  final Player player = game.players.first;
-  await pumpAppShell(
-    tester,
-    overrides: [
-      currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
-    ],
-    child: TradeScreen(game: game, player: player),
-  );
-}
+import 'support/trade_screen_test_support.dart';
 
 void main() {
   suppressLogsForTests();
 
   group('TradeScreen Market tab row icons (Refs #3093)', () {
-    testWidgets(
-      'every tradeable row mounts a 20 dp ResourceIcon keyed '
-      'marketRowResourceIconKey under the marketCommodityListKey',
-      (tester) async {
-        await _pumpTradeScreen(tester, game: _buildGame());
+    testWidgets('every tradeable row mounts a 20 dp ResourceIcon keyed '
+        'marketRowResourceIconKey under the marketCommodityListKey', (
+      tester,
+    ) async {
+      await pumpTradeScreen(
+        tester,
+        game: buildTradeTestGame(id: 'test_trade_screen_market_tab_row_icons'),
+      );
 
-        final list = find.byKey(TradeScreen.marketCommodityListKey);
-        expect(list, findsOneWidget);
+      final list = find.byKey(TradeScreen.marketCommodityListKey);
+      expect(list, findsOneWidget);
 
-        final List<Commodity> tradeable = <Commodity>[
-          for (final Commodity c in CommodityCatalog.all)
-            if (c.category != CommodityCategory.riches && c.id != 'spices') c,
-        ];
+      final List<Commodity> tradeable = <Commodity>[
+        for (final Commodity c in CommodityCatalog.all)
+          if (c.category != CommodityCategory.riches && c.id != 'spices') c,
+      ];
+      expect(
+        tradeable.length,
+        22,
+        reason:
+            'SPEC/game/world-market.md §Tradeable commodities — '
+            'must be 22 rows; if this drifts, the row-icons slice '
+            'pin must also be updated.',
+      );
+
+      for (final Commodity c in tradeable) {
+        final iconFinder = find.descendant(
+          of: list,
+          matching: find.byKey(TradeScreen.marketRowResourceIconKey(c.id)),
+        );
         expect(
-          tradeable.length,
-          22,
+          iconFinder,
+          findsOneWidget,
           reason:
-              'SPEC/game/world-market.md §Tradeable commodities — '
-              'must be 22 rows; if this drifts, the row-icons slice '
-              'pin must also be updated.',
+              'tradeable commodity `${c.id}` must mount its '
+              'ResourceIcon keyed '
+              'tradeScreenMarketRow:${c.id}:resourceIcon.',
         );
 
-        for (final Commodity c in tradeable) {
-          final iconFinder = find.descendant(
-            of: list,
-            matching: find.byKey(TradeScreen.marketRowResourceIconKey(c.id)),
-          );
-          expect(
-            iconFinder,
-            findsOneWidget,
-            reason:
-                'tradeable commodity `${c.id}` must mount its '
-                'ResourceIcon keyed '
-                'tradeScreenMarketRow:${c.id}:resourceIcon.',
-          );
-
-          // The keyed widget must be a ResourceIcon (not just any
-          // widget under the key) so screen-reader and analyzer tooling
-          // can rely on the type contract.
-          final ResourceIcon icon = tester.widget<ResourceIcon>(iconFinder);
-          expect(
-            icon.commodityId,
-            c.id,
-            reason:
-                'ResourceIcon on the row for `${c.id}` must carry the '
-                'matching commodityId so the asset paint matches the '
-                'row label.',
-          );
-          expect(
-            icon.size,
-            TradeScreen.marketRowResourceIconSize,
-            reason:
-                'ResourceIcon on the Trade row must paint at 20 dp '
-                '(TradeScreen.marketRowResourceIconSize) — matches the '
-                'Production panel `CtResourceCell.leadingIconSize`.',
-          );
-        }
-      },
-    );
+        // The keyed widget must be a ResourceIcon (not just any
+        // widget under the key) so screen-reader and analyzer tooling
+        // can rely on the type contract.
+        final ResourceIcon icon = tester.widget<ResourceIcon>(iconFinder);
+        expect(
+          icon.commodityId,
+          c.id,
+          reason:
+              'ResourceIcon on the row for `${c.id}` must carry the '
+              'matching commodityId so the asset paint matches the '
+              'row label.',
+        );
+        expect(
+          icon.size,
+          TradeScreen.marketRowResourceIconSize,
+          reason:
+              'ResourceIcon on the Trade row must paint at 20 dp '
+              '(TradeScreen.marketRowResourceIconSize) — matches the '
+              'Production panel `CtResourceCell.leadingIconSize`.',
+        );
+      }
+    });
 
     testWidgets(
       'every tradeable row mounts a 14 dp treasury-coin StrictAssetIcon '
       'keyed marketRowPriceCoinIconKey under the marketCommodityListKey',
       (tester) async {
-        await _pumpTradeScreen(
+        await pumpTradeScreen(
           tester,
           // Mix priced (timber=30) and unpriced (no entry) commodities
           // to prove the coin glyph mounts in both cases — it is a
           // visual currency cue, not a price-availability flag.
-          game: _buildGame(
+          game: buildTradeTestGame(
+            id: 'test_trade_screen_market_tab_row_icons',
             prices: const <CommodityId, int>{'timber': 30},
           ),
         );
@@ -185,8 +145,9 @@ void main() {
                 'em-dash fallback.',
           );
 
-          final StrictAssetIcon coin =
-              tester.widget<StrictAssetIcon>(coinFinder);
+          final StrictAssetIcon coin = tester.widget<StrictAssetIcon>(
+            coinFinder,
+          );
           expect(
             coin.assetPath,
             '${kAppIconAssetPrefix}ui_icon_treasury_coin.png',
@@ -206,9 +167,10 @@ void main() {
       'left of the commodity name and the coin paints to the left of '
       'the integer price text',
       (tester) async {
-        await _pumpTradeScreen(
+        await pumpTradeScreen(
           tester,
-          game: _buildGame(
+          game: buildTradeTestGame(
+            id: 'test_trade_screen_market_tab_row_icons',
             prices: const <CommodityId, int>{'timber': 30},
           ),
         );
@@ -249,38 +211,38 @@ void main() {
       },
     );
 
-    testWidgets(
-      'row icon keys never leak into rows for excluded commodities '
-      '(negative AC: no ResourceIcon / coin keys for gold, silver, '
-      'gems, diamonds, spices)',
-      (tester) async {
-        await _pumpTradeScreen(tester, game: _buildGame());
+    testWidgets('row icon keys never leak into rows for excluded commodities '
+        '(negative AC: no ResourceIcon / coin keys for gold, silver, '
+        'gems, diamonds, spices)', (tester) async {
+      await pumpTradeScreen(
+        tester,
+        game: buildTradeTestGame(id: 'test_trade_screen_market_tab_row_icons'),
+      );
 
-        for (final CommodityId excluded in <CommodityId>[
-          CommodityCatalog.gold.id,
-          CommodityCatalog.silver.id,
-          CommodityCatalog.gems.id,
-          CommodityCatalog.diamonds.id,
-          CommodityCatalog.spices.id,
-        ]) {
-          expect(
-            find.byKey(TradeScreen.marketRowResourceIconKey(excluded)),
-            findsNothing,
-            reason:
-                'SPEC/game/world-market.md §Tradeable commodities — '
-                '`$excluded` is not tradeable and must not mount its '
-                'row ResourceIcon.',
-          );
-          expect(
-            find.byKey(TradeScreen.marketRowPriceCoinIconKey(excluded)),
-            findsNothing,
-            reason:
-                'SPEC/game/world-market.md §Tradeable commodities — '
-                '`$excluded` is not tradeable and must not mount its '
-                'row treasury-coin glyph.',
-          );
-        }
-      },
-    );
+      for (final CommodityId excluded in <CommodityId>[
+        CommodityCatalog.gold.id,
+        CommodityCatalog.silver.id,
+        CommodityCatalog.gems.id,
+        CommodityCatalog.diamonds.id,
+        CommodityCatalog.spices.id,
+      ]) {
+        expect(
+          find.byKey(TradeScreen.marketRowResourceIconKey(excluded)),
+          findsNothing,
+          reason:
+              'SPEC/game/world-market.md §Tradeable commodities — '
+              '`$excluded` is not tradeable and must not mount its '
+              'row ResourceIcon.',
+        );
+        expect(
+          find.byKey(TradeScreen.marketRowPriceCoinIconKey(excluded)),
+          findsNothing,
+          reason:
+              'SPEC/game/world-market.md §Tradeable commodities — '
+              '`$excluded` is not tradeable and must not mount its '
+              'row treasury-coin glyph.',
+        );
+      }
+    });
   });
 }

--- a/app/test/trade_screen_market_tab_sellable_clamp_test.dart
+++ b/app/test/trade_screen_market_tab_sellable_clamp_test.dart
@@ -15,12 +15,8 @@
 //   * Decrement on a saturated offer row still works and refreshes
 //     the headroom display.
 
-import 'package:colonizethis_app/features/game/flame/region_map/region_map.dart'
-    show CtMapVisibilityMode;
 import 'package:colonizethis_app/features/game/screens/trade/trade_screen.dart';
-import 'package:colonizethis_app/features/game/widgets/shell/shell_player_context.dart';
 import 'package:colonizethis_app/providers/games_provider.dart';
-import 'package:colonizethis_app/providers/production_allocation_provider.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
@@ -28,86 +24,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'support/app_shell_harness.dart';
+import 'support/trade_screen_test_support.dart';
 
-const String _humanPlayerId = 'gp_h';
+const String _humanPlayerId = kTradeTestHumanPlayerId;
 
 CommodityId get _timber => CommodityCatalog.timber.id;
 CommodityId get _iron => CommodityCatalog.iron.id;
-
-Game _buildGame({Map<CommodityId, int>? stockpile}) {
-  return Game(
-    id: 'test_trade_screen_sellable_clamp',
-    worldState: WorldState(
-      turnState: TurnState(phase: TurnPhase.orders, turnNumber: 1),
-      oldWorld: const RegionData(),
-      newWorld: const RegionData(),
-    ),
-    turnTimeMapping: TurnTimeMapping.gdd01,
-    players: [
-      Player(
-        id: _humanPlayerId,
-        // ignore: avoid_hardcoded_strings_in_widgets
-        displayName: 'England',
-        isHuman: true,
-        treasury: 500,
-        stockpile: Stockpile(
-          quantities: stockpile ?? const <CommodityId, int>{},
-        ),
-      ),
-    ],
-    diplomacyRelations: const [],
-    diplomaticHistoryEvents: const [],
-    dossierEvidenceEntries: const [],
-    worldMarketState: const WorldMarketState(),
-  );
-}
-
-Future<ProviderContainer> _pumpTradeScreen(
-  WidgetTester tester, {
-  required Game game,
-  Orders initialOrders = const Orders(),
-  Map<String, int> initialDesiredOutputByRecipe = const <String, int>{},
-}) async {
-  final Player player = game.players.first;
-  final ProviderContainer container = ProviderContainer(
-    overrides: [
-      currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
-      currentOrdersProvider.overrideWith(
-        () => CurrentOrdersNotifier(initialOrders),
-      ),
-      shellPlayerContextProvider.overrideWith(
-        (ref) => ShellPlayerContext(
-          effectiveHumanPlayerId: player.id,
-          viewingPlayerId: player.id,
-          mapVisibilityMode: CtMapVisibilityMode.full,
-          playerView: null,
-          omniscientDetail: false,
-          showPlayerChrome: true,
-          canMutateViaUi: true,
-          debugCommandTargetPlayerId: player.id,
-          inObservePhase: false,
-          observeBannerLabel: null,
-          treasuryNotDefined: false,
-          cargoNotDefined: false,
-        ),
-      ),
-    ],
-  );
-  addTearDown(container.dispose);
-  if (initialDesiredOutputByRecipe.isNotEmpty) {
-    container
-        .read(productionDesiredOutputProvider.notifier)
-        .replaceAll(initialDesiredOutputByRecipe);
-  }
-  await pumpAppShellWithContainer(
-    tester,
-    container: container,
-    viewport: const Size(1024, 4096),
-    child: TradeScreen(game: game, player: player),
-  );
-  return container;
-}
 
 TradeOrder? _stagedOrder(ProviderContainer container, CommodityId commodityId) {
   final Orders orders = container.read(currentOrdersProvider);
@@ -123,193 +45,201 @@ void main() {
   suppressLogsForTests();
 
   group('TradeScreen Market tab sellable clamp (Refs #3093)', () {
-    testWidgets(
-      'renders `(N)` next to commodity name where N = stockpile − '
-      'stagedOffer (offer cap minus the row\'s staged offer)',
-      (tester) async {
-        await _pumpTradeScreen(
-          tester,
-          game: _buildGame(
-            stockpile: const <CommodityId, int>{'timber': 10, 'iron': 7},
-          ),
-        );
+    testWidgets('renders `(N)` next to commodity name where N = stockpile − '
+        'stagedOffer (offer cap minus the row\'s staged offer)', (
+      tester,
+    ) async {
+      await pumpTradeScreenWithContainer(
+        tester,
+        game: buildTradeTestGame(
+          stockpile: const <CommodityId, int>{'timber': 10, 'iron': 7},
+        ),
+      );
 
-        // No staged offers and no production allocation in this test →
-        // industry-allocation projection contributes 0, headroom equals
-        // the raw stockpile. The new industry-allocation reservation
-        // path is exercised by the canonical AC test below.
-        final Finder timberSellable = find.byKey(
-          TradeScreen.marketRowSellableReadoutKey(_timber),
-        );
-        expect(timberSellable, findsOneWidget);
-        expect(
-          tester.widget<Text>(timberSellable).data,
-          // ignore: avoid_hardcoded_strings_in_widgets
-          '(10)',
-        );
+      // No staged offers and no production allocation in this test →
+      // industry-allocation projection contributes 0, headroom equals
+      // the raw stockpile. The new industry-allocation reservation
+      // path is exercised by the canonical AC test below.
+      final Finder timberSellable = find.byKey(
+        TradeScreen.marketRowSellableReadoutKey(_timber),
+      );
+      expect(timberSellable, findsOneWidget);
+      expect(
+        tester.widget<Text>(timberSellable).data,
+        // ignore: avoid_hardcoded_strings_in_widgets
+        '(10)',
+      );
 
-        final Finder ironSellable = find.byKey(
-          TradeScreen.marketRowSellableReadoutKey(_iron),
-        );
-        expect(
-          tester.widget<Text>(ironSellable).data,
-          // ignore: avoid_hardcoded_strings_in_widgets
-          '(7)',
-        );
-      },
-    );
+      final Finder ironSellable = find.byKey(
+        TradeScreen.marketRowSellableReadoutKey(_iron),
+      );
+      expect(
+        tester.widget<Text>(ironSellable).data,
+        // ignore: avoid_hardcoded_strings_in_widgets
+        '(7)',
+      );
+    });
 
-    testWidgets(
-      'canonical AC (Refs #3093): stockpile=10 timber, production '
-      'allocation consumes 2 timber (paper_from_timber @ 2 labour), '
-      'staged offer 2 → `(6)` readout and `+` can only grow the offer '
-      'by 6 (staged quantity caps at 8 = stockpile − reservation)',
-      (tester) async {
-        final ProviderContainer container = await _pumpTradeScreen(
-          tester,
-          game: _buildGame(
-            stockpile: const <CommodityId, int>{'timber': 10},
-          ),
-          initialOrders: Orders(
-            tradeOrdersByPlayerId: {
-              _humanPlayerId: [
-                TradeOrder(
-                  commodityId: _timber,
-                  type: TradeOrderType.offer,
-                  quantity: 2,
-                  priority: 1,
-                ),
-              ],
-            },
-          ),
-          // paper_from_timber consumes 2 timber per run, 2 labour per
-          // output; desired output 1 → assigned labour 2 → runs 1 →
-          // 2 timber reserved.
-          initialDesiredOutputByRecipe: const <String, int>{
-            'paper_from_timber': 1,
+    testWidgets('canonical AC (Refs #3093): stockpile=10 timber, production '
+        'allocation consumes 2 timber (paper_from_timber @ 2 labour), '
+        'staged offer 2 → `(6)` readout and `+` can only grow the offer '
+        'by 6 (staged quantity caps at 8 = stockpile − reservation)', (
+      tester,
+    ) async {
+      final ProviderContainer container = await pumpTradeScreenWithContainer(
+        tester,
+        game: buildTradeTestGame(
+          stockpile: const <CommodityId, int>{'timber': 10},
+        ),
+        initialOrders: Orders(
+          tradeOrdersByPlayerId: {
+            _humanPlayerId: [
+              TradeOrder(
+                commodityId: _timber,
+                type: TradeOrderType.offer,
+                quantity: 2,
+                priority: 1,
+              ),
+            ],
           },
-        );
+        ),
+        // paper_from_timber consumes 2 timber per run, 2 labour per
+        // output; desired output 1 → assigned labour 2 → runs 1 →
+        // 2 timber reserved.
+        initialDesiredOutputByRecipe: const <String, int>{
+          'paper_from_timber': 1,
+        },
+      );
 
-        // Sellable headroom = max(0, 10 - 2) - 2 = 6.
-        expect(
-          tester
-              .widget<Text>(
-                  find.byKey(TradeScreen.marketRowSellableReadoutKey(_timber)))
-              .data,
-          // ignore: avoid_hardcoded_strings_in_widgets
-          '(6)',
-        );
+      // Sellable headroom = max(0, 10 - 2) - 2 = 6.
+      expect(
+        tester
+            .widget<Text>(
+              find.byKey(TradeScreen.marketRowSellableReadoutKey(_timber)),
+            )
+            .data,
+        // ignore: avoid_hardcoded_strings_in_widgets
+        '(6)',
+      );
 
-        // The offer cap (stockpile − reservation) is 8, so 6 +-taps
-        // grow the staged offer from 2 to 8 (= cap). Per the issue AC:
-        // "offer increment cannot exceed 6" — i.e. the player gains
-        // at most +6 units before saturating, which lands the staged
-        // quantity at 8 (matching the cap).
-        for (int i = 0; i < 6; i++) {
-          await tester
-              .tap(find.byKey(TradeScreen.marketRowIncrementKey(_timber)));
-          await tester.pump();
-        }
-        expect(_stagedOrder(container, _timber)?.quantity, 8,
-            reason: 'Six +-taps grow the staged offer from 2 to 8 '
-                '(= 10 stockpile − 2 industry allocation).');
-        expect(
-          tester
-              .widget<Text>(
-                  find.byKey(TradeScreen.marketRowSellableReadoutKey(_timber)))
-              .data,
-          // ignore: avoid_hardcoded_strings_in_widgets
-          '(0)',
-          reason: 'At cap, sellable readout drops to (0).',
+      // The offer cap (stockpile − reservation) is 8, so 6 +-taps
+      // grow the staged offer from 2 to 8 (= cap). Per the issue AC:
+      // "offer increment cannot exceed 6" — i.e. the player gains
+      // at most +6 units before saturating, which lands the staged
+      // quantity at 8 (matching the cap).
+      for (int i = 0; i < 6; i++) {
+        await tester.tap(
+          find.byKey(TradeScreen.marketRowIncrementKey(_timber)),
         );
-
-        // Next + tap is a silent no-op; quantity stays at 8.
-        await tester
-            .tap(find.byKey(TradeScreen.marketRowIncrementKey(_timber)));
         await tester.pump();
-        expect(_stagedOrder(container, _timber)?.quantity, 8,
-            reason: 'Tapping `+` at saturation must not exceed the offer '
-                'cap of 8 (= 10 stockpile − 2 industry allocation).');
-      },
-    );
+      }
+      expect(
+        _stagedOrder(container, _timber)?.quantity,
+        8,
+        reason:
+            'Six +-taps grow the staged offer from 2 to 8 '
+            '(= 10 stockpile − 2 industry allocation).',
+      );
+      expect(
+        tester
+            .widget<Text>(
+              find.byKey(TradeScreen.marketRowSellableReadoutKey(_timber)),
+            )
+            .data,
+        // ignore: avoid_hardcoded_strings_in_widgets
+        '(0)',
+        reason: 'At cap, sellable readout drops to (0).',
+      );
 
-    testWidgets(
-      'industry-allocation reservation hides the Offer chip when '
-      'allocation fully reserves stockpile (cap drops to 0)',
-      (tester) async {
-        final ProviderContainer container = await _pumpTradeScreen(
-          tester,
-          game: _buildGame(
-            stockpile: const <CommodityId, int>{'timber': 4},
-          ),
-          // Two runs of paper_from_timber consume 4 timber.
-          initialDesiredOutputByRecipe: const <String, int>{
-            'paper_from_timber': 2,
-          },
-        );
+      // Next + tap is a silent no-op; quantity stays at 8.
+      await tester.tap(find.byKey(TradeScreen.marketRowIncrementKey(_timber)));
+      await tester.pump();
+      expect(
+        _stagedOrder(container, _timber)?.quantity,
+        8,
+        reason:
+            'Tapping `+` at saturation must not exceed the offer '
+            'cap of 8 (= 10 stockpile − 2 industry allocation).',
+      );
+    });
 
-        expect(
-          tester
-              .widget<Text>(
-                  find.byKey(TradeScreen.marketRowSellableReadoutKey(_timber)))
-              .data,
-          // ignore: avoid_hardcoded_strings_in_widgets
-          '(0)',
-        );
-        await tester
-            .tap(find.byKey(TradeScreen.marketRowOfferChipKey(_timber)));
-        await tester.pump();
-        expect(_stagedOrder(container, _timber), isNull,
-            reason: 'Full industry-allocation reservation disables the '
-                'Offer chip — tap must be a silent no-op.');
-      },
-    );
+    testWidgets('industry-allocation reservation hides the Offer chip when '
+        'allocation fully reserves stockpile (cap drops to 0)', (tester) async {
+      final ProviderContainer container = await pumpTradeScreenWithContainer(
+        tester,
+        game: buildTradeTestGame(
+          stockpile: const <CommodityId, int>{'timber': 4},
+        ),
+        // Two runs of paper_from_timber consume 4 timber.
+        initialDesiredOutputByRecipe: const <String, int>{
+          'paper_from_timber': 2,
+        },
+      );
 
-    testWidgets(
-      'industry-allocation reservation on one commodity does not '
-      'reduce another commodity\'s sellable headroom',
-      (tester) async {
-        await _pumpTradeScreen(
-          tester,
-          game: _buildGame(
-            stockpile: const <CommodityId, int>{'timber': 10, 'iron': 7},
-          ),
-          // paper_from_timber consumes only timber.
-          initialDesiredOutputByRecipe: const <String, int>{
-            'paper_from_timber': 1,
-          },
-        );
+      expect(
+        tester
+            .widget<Text>(
+              find.byKey(TradeScreen.marketRowSellableReadoutKey(_timber)),
+            )
+            .data,
+        // ignore: avoid_hardcoded_strings_in_widgets
+        '(0)',
+      );
+      await tester.tap(find.byKey(TradeScreen.marketRowOfferChipKey(_timber)));
+      await tester.pump();
+      expect(
+        _stagedOrder(container, _timber),
+        isNull,
+        reason:
+            'Full industry-allocation reservation disables the '
+            'Offer chip — tap must be a silent no-op.',
+      );
+    });
 
-        expect(
-          tester
-              .widget<Text>(
-                  find.byKey(TradeScreen.marketRowSellableReadoutKey(_timber)))
-              .data,
-          // ignore: avoid_hardcoded_strings_in_widgets
-          '(8)',
-          reason: 'Timber sellable = 10 - 2 (paper reservation) = 8.',
-        );
-        expect(
-          tester
-              .widget<Text>(
-                  find.byKey(TradeScreen.marketRowSellableReadoutKey(_iron)))
-              .data,
-          // ignore: avoid_hardcoded_strings_in_widgets
-          '(7)',
-          reason:
-              'Iron has no production allocation; headroom equals raw '
-              'stockpile.',
-        );
-      },
-    );
+    testWidgets('industry-allocation reservation on one commodity does not '
+        'reduce another commodity\'s sellable headroom', (tester) async {
+      await pumpTradeScreenWithContainer(
+        tester,
+        game: buildTradeTestGame(
+          stockpile: const <CommodityId, int>{'timber': 10, 'iron': 7},
+        ),
+        // paper_from_timber consumes only timber.
+        initialDesiredOutputByRecipe: const <String, int>{
+          'paper_from_timber': 1,
+        },
+      );
+
+      expect(
+        tester
+            .widget<Text>(
+              find.byKey(TradeScreen.marketRowSellableReadoutKey(_timber)),
+            )
+            .data,
+        // ignore: avoid_hardcoded_strings_in_widgets
+        '(8)',
+        reason: 'Timber sellable = 10 - 2 (paper reservation) = 8.',
+      );
+      expect(
+        tester
+            .widget<Text>(
+              find.byKey(TradeScreen.marketRowSellableReadoutKey(_iron)),
+            )
+            .data,
+        // ignore: avoid_hardcoded_strings_in_widgets
+        '(7)',
+        reason:
+            'Iron has no production allocation; headroom equals raw '
+            'stockpile.',
+      );
+    });
 
     testWidgets(
       'with stockpile=10 timber and staged offer for 2 timber, the `(N)` '
       'readout shows `(8)` (headroom = cap − staged)',
       (tester) async {
-        await _pumpTradeScreen(
+        await pumpTradeScreenWithContainer(
           tester,
-          game: _buildGame(
+          game: buildTradeTestGame(
             stockpile: const <CommodityId, int>{'timber': 10},
           ),
           initialOrders: Orders(
@@ -341,9 +271,9 @@ void main() {
       'rows with zero stockpile and no staged offer render `(0)` and the '
       'Offer chip + offer-side `+` are disabled (silent no-op on tap)',
       (tester) async {
-        final ProviderContainer container = await _pumpTradeScreen(
+        final ProviderContainer container = await pumpTradeScreenWithContainer(
           tester,
-          game: _buildGame(stockpile: const <CommodityId, int>{}),
+          game: buildTradeTestGame(stockpile: const <CommodityId, int>{}),
         );
 
         // (0) display for an empty-stockpile commodity.
@@ -357,7 +287,9 @@ void main() {
         );
 
         // Offer chip tap → silent no-op.
-        await tester.tap(find.byKey(TradeScreen.marketRowOfferChipKey(_timber)));
+        await tester.tap(
+          find.byKey(TradeScreen.marketRowOfferChipKey(_timber)),
+        );
         await tester.pump();
         expect(
           _stagedOrder(container, _timber),
@@ -369,69 +301,69 @@ void main() {
       },
     );
 
-    testWidgets(
-      'Offer chip becomes enabled when the player gains stockpile by '
-      'releasing a staged offer (re-evaluate on order changes)',
-      (tester) async {
-        final ProviderContainer container = await _pumpTradeScreen(
-          tester,
-          game: _buildGame(
-            stockpile: const <CommodityId, int>{'timber': 3},
-          ),
-          initialOrders: Orders(
-            tradeOrdersByPlayerId: {
-              _humanPlayerId: [
-                TradeOrder(
-                  commodityId: _timber,
-                  type: TradeOrderType.offer,
-                  quantity: 3,
-                  priority: 1,
-                ),
-              ],
-            },
-          ),
-        );
+    testWidgets('Offer chip becomes enabled when the player gains stockpile by '
+        'releasing a staged offer (re-evaluate on order changes)', (
+      tester,
+    ) async {
+      final ProviderContainer container = await pumpTradeScreenWithContainer(
+        tester,
+        game: buildTradeTestGame(
+          stockpile: const <CommodityId, int>{'timber': 3},
+        ),
+        initialOrders: Orders(
+          tradeOrdersByPlayerId: {
+            _humanPlayerId: [
+              TradeOrder(
+                commodityId: _timber,
+                type: TradeOrderType.offer,
+                quantity: 3,
+                priority: 1,
+              ),
+            ],
+          },
+        ),
+      );
 
-        // Headroom is 0 with the saturated offer.
-        expect(
-          tester
-              .widget<Text>(
-                  find.byKey(TradeScreen.marketRowSellableReadoutKey(_timber)))
-              .data,
-          // ignore: avoid_hardcoded_strings_in_widgets
-          '(0)',
-        );
+      // Headroom is 0 with the saturated offer.
+      expect(
+        tester
+            .widget<Text>(
+              find.byKey(TradeScreen.marketRowSellableReadoutKey(_timber)),
+            )
+            .data,
+        // ignore: avoid_hardcoded_strings_in_widgets
+        '(0)',
+      );
 
-        // Decrement the saturated offer down by 1 → headroom updates to 1.
-        await tester.tap(find.byKey(TradeScreen.marketRowDecrementKey(_timber)));
-        await tester.pump();
-        expect(
-          tester
-              .widget<Text>(
-                  find.byKey(TradeScreen.marketRowSellableReadoutKey(_timber)))
-              .data,
-          // ignore: avoid_hardcoded_strings_in_widgets
-          '(1)',
-        );
-        expect(
-          _stagedOrder(container, _timber)?.quantity,
-          2,
-        );
-      },
-    );
+      // Decrement the saturated offer down by 1 → headroom updates to 1.
+      await tester.tap(find.byKey(TradeScreen.marketRowDecrementKey(_timber)));
+      await tester.pump();
+      expect(
+        tester
+            .widget<Text>(
+              find.byKey(TradeScreen.marketRowSellableReadoutKey(_timber)),
+            )
+            .data,
+        // ignore: avoid_hardcoded_strings_in_widgets
+        '(1)',
+      );
+      expect(_stagedOrder(container, _timber)?.quantity, 2);
+    });
 
     testWidgets(
       'tapping `Offer` on a fresh commodity clamps the staged quantity to '
       'the per-commodity offer cap (default 1 ≤ cap → preserves default)',
       (tester) async {
-        final ProviderContainer container = await _pumpTradeScreen(
+        final ProviderContainer container = await pumpTradeScreenWithContainer(
           tester,
-          game: _buildGame(
+          game: buildTradeTestGame(
             stockpile: const <CommodityId, int>{'timber': 5},
           ),
         );
 
-        await tester.tap(find.byKey(TradeScreen.marketRowOfferChipKey(_timber)));
+        await tester.tap(
+          find.byKey(TradeScreen.marketRowOfferChipKey(_timber)),
+        );
         await tester.pump();
 
         final TradeOrder? staged = _stagedOrder(container, _timber);
@@ -451,12 +383,14 @@ void main() {
       'tapping `Offer` on a fresh commodity with offer cap = 0 is a silent '
       'no-op (no TradeOrder is staged)',
       (tester) async {
-        final ProviderContainer container = await _pumpTradeScreen(
+        final ProviderContainer container = await pumpTradeScreenWithContainer(
           tester,
-          game: _buildGame(stockpile: const <CommodityId, int>{}),
+          game: buildTradeTestGame(stockpile: const <CommodityId, int>{}),
         );
 
-        await tester.tap(find.byKey(TradeScreen.marketRowOfferChipKey(_timber)));
+        await tester.tap(
+          find.byKey(TradeScreen.marketRowOfferChipKey(_timber)),
+        );
         await tester.pump();
 
         expect(_stagedOrder(container, _timber), isNull);
@@ -467,9 +401,9 @@ void main() {
       'tapping `Offer` on a row previously staged as Bid with a quantity '
       'exceeding the cap clamps the staged offer quantity down to the cap',
       (tester) async {
-        final ProviderContainer container = await _pumpTradeScreen(
+        final ProviderContainer container = await pumpTradeScreenWithContainer(
           tester,
-          game: _buildGame(
+          game: buildTradeTestGame(
             stockpile: const <CommodityId, int>{'timber': 4},
           ),
           initialOrders: Orders(
@@ -486,7 +420,9 @@ void main() {
           ),
         );
 
-        await tester.tap(find.byKey(TradeScreen.marketRowOfferChipKey(_timber)));
+        await tester.tap(
+          find.byKey(TradeScreen.marketRowOfferChipKey(_timber)),
+        );
         await tester.pump();
 
         final TradeOrder? staged = _stagedOrder(container, _timber);
@@ -506,9 +442,9 @@ void main() {
       'incrementing a saturated Offer row is a silent no-op (the staged '
       'quantity stays at the cap and the headroom stays at (0))',
       (tester) async {
-        final ProviderContainer container = await _pumpTradeScreen(
+        final ProviderContainer container = await pumpTradeScreenWithContainer(
           tester,
-          game: _buildGame(
+          game: buildTradeTestGame(
             stockpile: const <CommodityId, int>{'timber': 5},
           ),
           initialOrders: Orders(
@@ -525,14 +461,17 @@ void main() {
           ),
         );
 
-        await tester.tap(find.byKey(TradeScreen.marketRowIncrementKey(_timber)));
+        await tester.tap(
+          find.byKey(TradeScreen.marketRowIncrementKey(_timber)),
+        );
         await tester.pump();
 
         expect(_stagedOrder(container, _timber)?.quantity, 5);
         expect(
           tester
               .widget<Text>(
-                  find.byKey(TradeScreen.marketRowSellableReadoutKey(_timber)))
+                find.byKey(TradeScreen.marketRowSellableReadoutKey(_timber)),
+              )
               .data,
           // ignore: avoid_hardcoded_strings_in_widgets
           '(0)',
@@ -540,89 +479,88 @@ void main() {
       },
     );
 
-    testWidgets(
-      'incrementing an Offer row with headroom > 0 raises the staged '
-      'quantity by 1 and the headroom display decreases accordingly',
-      (tester) async {
-        final ProviderContainer container = await _pumpTradeScreen(
-          tester,
-          game: _buildGame(
-            stockpile: const <CommodityId, int>{'timber': 7},
-          ),
-          initialOrders: Orders(
-            tradeOrdersByPlayerId: {
-              _humanPlayerId: [
-                TradeOrder(
-                  commodityId: _timber,
-                  type: TradeOrderType.offer,
-                  quantity: 2,
-                  priority: 1,
-                ),
-              ],
-            },
-          ),
-        );
+    testWidgets('incrementing an Offer row with headroom > 0 raises the staged '
+        'quantity by 1 and the headroom display decreases accordingly', (
+      tester,
+    ) async {
+      final ProviderContainer container = await pumpTradeScreenWithContainer(
+        tester,
+        game: buildTradeTestGame(
+          stockpile: const <CommodityId, int>{'timber': 7},
+        ),
+        initialOrders: Orders(
+          tradeOrdersByPlayerId: {
+            _humanPlayerId: [
+              TradeOrder(
+                commodityId: _timber,
+                type: TradeOrderType.offer,
+                quantity: 2,
+                priority: 1,
+              ),
+            ],
+          },
+        ),
+      );
 
-        // Initial headroom 5 (= 7 - 2).
-        expect(
-          tester
-              .widget<Text>(
-                  find.byKey(TradeScreen.marketRowSellableReadoutKey(_timber)))
-              .data,
-          // ignore: avoid_hardcoded_strings_in_widgets
-          '(5)',
-        );
+      // Initial headroom 5 (= 7 - 2).
+      expect(
+        tester
+            .widget<Text>(
+              find.byKey(TradeScreen.marketRowSellableReadoutKey(_timber)),
+            )
+            .data,
+        // ignore: avoid_hardcoded_strings_in_widgets
+        '(5)',
+      );
 
-        await tester.tap(find.byKey(TradeScreen.marketRowIncrementKey(_timber)));
-        await tester.pump();
-        expect(_stagedOrder(container, _timber)?.quantity, 3);
-        expect(
-          tester
-              .widget<Text>(
-                  find.byKey(TradeScreen.marketRowSellableReadoutKey(_timber)))
-              .data,
-          // ignore: avoid_hardcoded_strings_in_widgets
-          '(4)',
-        );
-      },
-    );
+      await tester.tap(find.byKey(TradeScreen.marketRowIncrementKey(_timber)));
+      await tester.pump();
+      expect(_stagedOrder(container, _timber)?.quantity, 3);
+      expect(
+        tester
+            .widget<Text>(
+              find.byKey(TradeScreen.marketRowSellableReadoutKey(_timber)),
+            )
+            .data,
+        // ignore: avoid_hardcoded_strings_in_widgets
+        '(4)',
+      );
+    });
 
-    testWidgets(
-      'bids do not consume the offer headroom (bid row\'s `(N)` is '
-      'unaffected by the staged bid quantity)',
-      (tester) async {
-        await _pumpTradeScreen(
-          tester,
-          game: _buildGame(
-            stockpile: const <CommodityId, int>{'timber': 10},
-          ),
-          initialOrders: Orders(
-            tradeOrdersByPlayerId: {
-              _humanPlayerId: [
-                TradeOrder(
-                  commodityId: _timber,
-                  type: TradeOrderType.bid,
-                  quantity: 4,
-                  priority: 1,
-                ),
-              ],
-            },
-          ),
-        );
+    testWidgets('bids do not consume the offer headroom (bid row\'s `(N)` is '
+        'unaffected by the staged bid quantity)', (tester) async {
+      await pumpTradeScreenWithContainer(
+        tester,
+        game: buildTradeTestGame(
+          stockpile: const <CommodityId, int>{'timber': 10},
+        ),
+        initialOrders: Orders(
+          tradeOrdersByPlayerId: {
+            _humanPlayerId: [
+              TradeOrder(
+                commodityId: _timber,
+                type: TradeOrderType.bid,
+                quantity: 4,
+                priority: 1,
+              ),
+            ],
+          },
+        ),
+      );
 
-        expect(
-          tester
-              .widget<Text>(
-                  find.byKey(TradeScreen.marketRowSellableReadoutKey(_timber)))
-              .data,
-          // ignore: avoid_hardcoded_strings_in_widgets
-          '(10)',
-          reason:
-              'Refs #3093 — bids do not reserve stockpile (per '
-              'SPEC/game/world-market.md § Cargo). The offer headroom '
-              'is independent of staged bids.',
-        );
-      },
-    );
+      expect(
+        tester
+            .widget<Text>(
+              find.byKey(TradeScreen.marketRowSellableReadoutKey(_timber)),
+            )
+            .data,
+        // ignore: avoid_hardcoded_strings_in_widgets
+        '(10)',
+        reason:
+            'Refs #3093 — bids do not reserve stockpile (per '
+            'SPEC/game/world-market.md § Cargo). The offer headroom '
+            'is independent of staged bids.',
+      );
+    });
   });
 }

--- a/app/test/trade_screen_market_tab_treasury_bid_cap_test.dart
+++ b/app/test/trade_screen_market_tab_treasury_bid_cap_test.dart
@@ -18,122 +18,40 @@
 //     reduce the bid budget; net non-bid income leaves it at raw
 //     treasury (conservative clamp per SPEC).
 
-import 'package:colonizethis_app/features/game/flame/region_map/region_map.dart'
-    show CtMapVisibilityMode;
 import 'package:colonizethis_app/features/game/screens/trade/trade_screen.dart';
-import 'package:colonizethis_app/features/game/widgets/shell/shell_player_context.dart';
 import 'package:colonizethis_app/providers/games_provider.dart';
 import 'package:colonizethis_app/providers/treasury_summary_provider.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart' show Override;
 import 'package:flutter_test/flutter_test.dart';
 
-import 'support/app_shell_harness.dart';
+import 'support/trade_screen_test_support.dart';
 
-const String _humanPlayerId = 'gp_h';
+const String _humanPlayerId = kTradeTestHumanPlayerId;
 
 const CommodityId _timber = 'timber';
 const CommodityId _iron = 'iron';
 const CommodityId _lumber = 'lumber';
 
-Game _buildGame({
-  int treasury = 100,
-  Map<CommodityId, int>? prices,
-  Map<CommodityId, int>? stockpile,
-}) {
-  return Game(
-    id: 'test_trade_screen_treasury_bid_cap',
-    worldState: WorldState(
-      turnState: TurnState(phase: TurnPhase.orders, turnNumber: 1),
-      oldWorld: const RegionData(),
-      newWorld: const RegionData(),
-    ),
-    turnTimeMapping: TurnTimeMapping.gdd01,
-    players: [
-      Player(
-        id: _humanPlayerId,
-        // ignore: avoid_hardcoded_strings_in_widgets
-        displayName: 'England',
-        isHuman: true,
-        treasury: treasury,
-        stockpile: Stockpile(
-          quantities: stockpile ?? const <CommodityId, int>{},
-        ),
-      ),
-    ],
-    diplomacyRelations: const [],
-    diplomaticHistoryEvents: const [],
-    dossierEvidenceEntries: const [],
-    worldMarketState: WorldMarketState(
-      prices: prices ?? const <CommodityId, int>{},
-    ),
-  );
-}
-
-Future<ProviderContainer> _pumpTradeScreen(
-  WidgetTester tester, {
-  required Game game,
-  Orders initialOrders = const Orders(),
-  int? nonBidProjectedDelta,
-}) async {
+Override _treasurySummaryOverride(Game game, int nonBidProjectedDelta) {
   final Player player = game.players.first;
-  final ProviderContainer container = ProviderContainer(
-    overrides: [
-      currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
-      currentOrdersProvider.overrideWith(
-        () => CurrentOrdersNotifier(initialOrders),
-      ),
-      shellPlayerContextProvider.overrideWith(
-        (ref) => ShellPlayerContext(
-          effectiveHumanPlayerId: player.id,
-          viewingPlayerId: player.id,
-          mapVisibilityMode: CtMapVisibilityMode.full,
-          playerView: null,
-          omniscientDetail: false,
-          showPlayerChrome: true,
-          canMutateViaUi: true,
-          debugCommandTargetPlayerId: player.id,
-          inObservePhase: false,
-          observeBannerLabel: null,
-          treasuryNotDefined: false,
-          cargoNotDefined: false,
-        ),
-      ),
-      if (nonBidProjectedDelta != null)
-        // Mirror production `treasurySummaryProvider`: derive
-        // `projectedDelta` from the *current* orders so the value updates
-        // as bids are staged. The test fixture pins the **non-bid** delta
-        // and we subtract the live staged bid spend so the public
-        // `projectedDelta` field still represents the full projection
-        // (including bids) that `_projectedNonBidTreasuryDelta` will then
-        // net back out via `projectedDelta + stagedBidSpend`.
-        treasurySummaryProvider.overrideWith((ref) {
-          final Orders orders = ref.watch(currentOrdersProvider);
-          final int bidSpend = stagedBidTotalSpendByPlayer(
-            orders: orders,
-            playerId: _humanPlayerId,
-            game: game,
-            resourceRules: ResourceRules.defaultRules,
-          );
-          return TreasurySummary(
-            treasury: player.treasury,
-            projectedDelta: nonBidProjectedDelta - bidSpend,
-          );
-        }),
-    ],
-  );
-  addTearDown(container.dispose);
-  await pumpAppShellWithContainer(
-    tester,
-    container: container,
-    viewport: const Size(1024, 4096),
-    child: TradeScreen(game: game, player: player),
-  );
-  return container;
+  return treasurySummaryProvider.overrideWith((ref) {
+    final Orders orders = ref.watch(currentOrdersProvider);
+    final int bidSpend = stagedBidTotalSpendByPlayer(
+      orders: orders,
+      playerId: _humanPlayerId,
+      game: game,
+      resourceRules: ResourceRules.defaultRules,
+    );
+    return TreasurySummary(
+      treasury: player.treasury,
+      projectedDelta: nonBidProjectedDelta - bidSpend,
+    );
+  });
 }
 
 TradeOrder? _stagedOrder(ProviderContainer container, CommodityId commodityId) {
@@ -154,12 +72,9 @@ void main() {
       'treasury 100, timber price 30, no staged orders → tapping Bid stages '
       'a TradeOrder with quantity 1 (default fits inside the budget of 3)',
       (tester) async {
-        final ProviderContainer container = await _pumpTradeScreen(
+        final ProviderContainer container = await pumpTradeScreenWithContainer(
           tester,
-          game: _buildGame(
-            treasury: 100,
-            prices: const {_timber: 30},
-          ),
+          game: buildTradeTestGame(treasury: 100, prices: const {_timber: 30}),
         );
 
         await tester.tap(find.byKey(TradeScreen.marketRowBidChipKey(_timber)));
@@ -178,52 +93,48 @@ void main() {
       },
     );
 
-    testWidgets(
-      'treasury 100, timber price 30, staged Bid timber qty 3 → '
-      'incrementing further is a silent no-op (budget saturated)',
-      (tester) async {
-        final ProviderContainer container = await _pumpTradeScreen(
-          tester,
-          game: _buildGame(
-            treasury: 100,
-            prices: const {_timber: 30},
-          ),
-          initialOrders: Orders(
-            tradeOrdersByPlayerId: {
-              _humanPlayerId: [
-                TradeOrder(
-                  commodityId: _timber,
-                  type: TradeOrderType.bid,
-                  quantity: 3,
-                  priority: 1,
-                ),
-              ],
-            },
-          ),
-        );
+    testWidgets('treasury 100, timber price 30, staged Bid timber qty 3 → '
+        'incrementing further is a silent no-op (budget saturated)', (
+      tester,
+    ) async {
+      final ProviderContainer container = await pumpTradeScreenWithContainer(
+        tester,
+        game: buildTradeTestGame(treasury: 100, prices: const {_timber: 30}),
+        initialOrders: Orders(
+          tradeOrdersByPlayerId: {
+            _humanPlayerId: [
+              TradeOrder(
+                commodityId: _timber,
+                type: TradeOrderType.bid,
+                quantity: 3,
+                priority: 1,
+              ),
+            ],
+          },
+        ),
+      );
 
-        await tester.tap(find.byKey(TradeScreen.marketRowIncrementKey(_timber)));
-        await tester.pump();
+      await tester.tap(find.byKey(TradeScreen.marketRowIncrementKey(_timber)));
+      await tester.pump();
 
-        final TradeOrder? staged = _stagedOrder(container, _timber);
-        expect(
-          staged?.quantity,
-          3,
-          reason:
-              'Refs #3093 — total spend 4×30=120 exceeds treasury 100, so '
-              'the `+` tap is a silent no-op.',
-        );
-      },
-    );
+      final TradeOrder? staged = _stagedOrder(container, _timber);
+      expect(
+        staged?.quantity,
+        3,
+        reason:
+            'Refs #3093 — total spend 4×30=120 exceeds treasury 100, so '
+            'the `+` tap is a silent no-op.',
+      );
+    });
 
     testWidgets(
       'treasury 100, staged Bid timber qty 3 (spend 90), iron price 80 → '
       'tapping the Bid chip on a fresh iron row is a silent no-op '
       '(headroom 10 < rowPrice 80)',
       (tester) async {
-        final ProviderContainer container = await _pumpTradeScreen(
+        final ProviderContainer container = await pumpTradeScreenWithContainer(
           tester,
-          game: _buildGame(
+          game: buildTradeTestGame(
             treasury: 100,
             prices: const {_timber: 30, _iron: 80},
           ),
@@ -255,56 +166,53 @@ void main() {
       },
     );
 
-    testWidgets(
-      'treasury 50, timber price 30, staged Offer timber qty 4 → '
-      'tapping Bid clamps the staged bid quantity to treasury budget '
-      '(min(4, 50 / 30) = min(4, 1) = 1)',
-      (tester) async {
-        final ProviderContainer container = await _pumpTradeScreen(
-          tester,
-          game: _buildGame(
-            treasury: 50,
-            prices: const {_timber: 30},
-            stockpile: const {_timber: 10},
-          ),
-          initialOrders: Orders(
-            tradeOrdersByPlayerId: {
-              _humanPlayerId: [
-                TradeOrder(
-                  commodityId: _timber,
-                  type: TradeOrderType.offer,
-                  quantity: 4,
-                  priority: 1,
-                ),
-              ],
-            },
-          ),
-        );
+    testWidgets('treasury 50, timber price 30, staged Offer timber qty 4 → '
+        'tapping Bid clamps the staged bid quantity to treasury budget '
+        '(min(4, 50 / 30) = min(4, 1) = 1)', (tester) async {
+      final ProviderContainer container = await pumpTradeScreenWithContainer(
+        tester,
+        game: buildTradeTestGame(
+          treasury: 50,
+          prices: const {_timber: 30},
+          stockpile: const {_timber: 10},
+        ),
+        initialOrders: Orders(
+          tradeOrdersByPlayerId: {
+            _humanPlayerId: [
+              TradeOrder(
+                commodityId: _timber,
+                type: TradeOrderType.offer,
+                quantity: 4,
+                priority: 1,
+              ),
+            ],
+          },
+        ),
+      );
 
-        await tester.tap(find.byKey(TradeScreen.marketRowBidChipKey(_timber)));
-        await tester.pump();
+      await tester.tap(find.byKey(TradeScreen.marketRowBidChipKey(_timber)));
+      await tester.pump();
 
-        final TradeOrder? staged = _stagedOrder(container, _timber);
-        expect(staged, isNotNull);
-        expect(staged!.type, TradeOrderType.bid);
-        expect(
-          staged.quantity,
-          1,
-          reason:
-              'Refs #3093 — prior offer qty 4 is clamped down to treasury '
-              'budget 50 / 30 = 1 when toggling Offer → Bid.',
-        );
-      },
-    );
+      final TradeOrder? staged = _stagedOrder(container, _timber);
+      expect(staged, isNotNull);
+      expect(staged!.type, TradeOrderType.bid);
+      expect(
+        staged.quantity,
+        1,
+        reason:
+            'Refs #3093 — prior offer qty 4 is clamped down to treasury '
+            'budget 50 / 30 = 1 when toggling Offer → Bid.',
+      );
+    });
 
     testWidgets(
       'treasury 100, price map omits commodity and catalog default is also '
       'null (manufactured `lumber`) → Bid toggle stages a TradeOrder under '
       'the cargo cap only (treasury clamp skipped)',
       (tester) async {
-        final ProviderContainer container = await _pumpTradeScreen(
+        final ProviderContainer container = await pumpTradeScreenWithContainer(
           tester,
-          game: _buildGame(
+          game: buildTradeTestGame(
             treasury: 100,
             prices: const <CommodityId, int>{},
           ),
@@ -329,37 +237,31 @@ void main() {
       },
     );
 
-    testWidgets(
-      'treasury 100, timber price 30, staged Bid timber qty 2 → '
-      'decrementing the staged bid still works (decrement is not gated by '
-      'the treasury cap)',
-      (tester) async {
-        final ProviderContainer container = await _pumpTradeScreen(
-          tester,
-          game: _buildGame(
-            treasury: 100,
-            prices: const {_timber: 30},
-          ),
-          initialOrders: Orders(
-            tradeOrdersByPlayerId: {
-              _humanPlayerId: [
-                TradeOrder(
-                  commodityId: _timber,
-                  type: TradeOrderType.bid,
-                  quantity: 2,
-                  priority: 1,
-                ),
-              ],
-            },
-          ),
-        );
+    testWidgets('treasury 100, timber price 30, staged Bid timber qty 2 → '
+        'decrementing the staged bid still works (decrement is not gated by '
+        'the treasury cap)', (tester) async {
+      final ProviderContainer container = await pumpTradeScreenWithContainer(
+        tester,
+        game: buildTradeTestGame(treasury: 100, prices: const {_timber: 30}),
+        initialOrders: Orders(
+          tradeOrdersByPlayerId: {
+            _humanPlayerId: [
+              TradeOrder(
+                commodityId: _timber,
+                type: TradeOrderType.bid,
+                quantity: 2,
+                priority: 1,
+              ),
+            ],
+          },
+        ),
+      );
 
-        await tester.tap(find.byKey(TradeScreen.marketRowDecrementKey(_timber)));
-        await tester.pump();
+      await tester.tap(find.byKey(TradeScreen.marketRowDecrementKey(_timber)));
+      await tester.pump();
 
-        expect(_stagedOrder(container, _timber)?.quantity, 1);
-      },
-    );
+      expect(_stagedOrder(container, _timber)?.quantity, 1);
+    });
 
     testWidgets(
       'treasury 100, timber price 30, non-bid pending cost = 40 → tapping '
@@ -373,13 +275,14 @@ void main() {
         // staging like the real app would. The fixture pins the non-bid
         // contribution at -40 (e.g. 40 treasury of build/recruit/civilian
         // commitments).
-        final ProviderContainer container = await _pumpTradeScreen(
+        final Game game = buildTradeTestGame(
+          treasury: 100,
+          prices: const {_timber: 30},
+        );
+        final ProviderContainer container = await pumpTradeScreenWithContainer(
           tester,
-          game: _buildGame(
-            treasury: 100,
-            prices: const {_timber: 30},
-          ),
-          nonBidProjectedDelta: -40,
+          game: game,
+          extraOverrides: <Override>[_treasurySummaryOverride(game, -40)],
         );
 
         await tester.tap(find.byKey(TradeScreen.marketRowBidChipKey(_timber)));
@@ -387,22 +290,35 @@ void main() {
 
         TradeOrder? staged = _stagedOrder(container, _timber);
         expect(staged?.type, TradeOrderType.bid);
-        expect(staged?.quantity, 1,
-            reason: 'Budget 60 / price 30 = 2 headroom; default qty 1 fits.');
+        expect(
+          staged?.quantity,
+          1,
+          reason: 'Budget 60 / price 30 = 2 headroom; default qty 1 fits.',
+        );
 
-        await tester.tap(find.byKey(TradeScreen.marketRowIncrementKey(_timber)));
+        await tester.tap(
+          find.byKey(TradeScreen.marketRowIncrementKey(_timber)),
+        );
         await tester.pump();
         staged = _stagedOrder(container, _timber);
-        expect(staged?.quantity, 2,
-            reason: 'Spend grows to 60; still inside the 60 budget.');
+        expect(
+          staged?.quantity,
+          2,
+          reason: 'Spend grows to 60; still inside the 60 budget.',
+        );
 
-        await tester.tap(find.byKey(TradeScreen.marketRowIncrementKey(_timber)));
+        await tester.tap(
+          find.byKey(TradeScreen.marketRowIncrementKey(_timber)),
+        );
         await tester.pump();
         staged = _stagedOrder(container, _timber);
-        expect(staged?.quantity, 2,
-            reason:
-                'Refs #3093 — qty 3 would cost 90, exceeding the 60 budget; '
-                'the + tap must silent-no-op.');
+        expect(
+          staged?.quantity,
+          2,
+          reason:
+              'Refs #3093 — qty 3 would cost 90, exceeding the 60 budget; '
+              'the + tap must silent-no-op.',
+        );
       },
     );
 
@@ -413,13 +329,14 @@ void main() {
       (tester) async {
         // Refs #3093 — projected pending deficit exceeds raw treasury so the
         // helper clamps the bid budget at 0. Even default qty 1 cannot land.
-        final ProviderContainer container = await _pumpTradeScreen(
+        final Game game = buildTradeTestGame(
+          treasury: 50,
+          prices: const {_timber: 30},
+        );
+        final ProviderContainer container = await pumpTradeScreenWithContainer(
           tester,
-          game: _buildGame(
-            treasury: 50,
-            prices: const {_timber: 30},
-          ),
-          nonBidProjectedDelta: -60,
+          game: game,
+          extraOverrides: <Override>[_treasurySummaryOverride(game, -60)],
         );
 
         await tester.tap(find.byKey(TradeScreen.marketRowBidChipKey(_timber)));
@@ -443,13 +360,14 @@ void main() {
       (tester) async {
         // Refs #3093 — net non-bid income never raises the bid budget
         // (conservative clamp per SPEC § Treasury budget for bids).
-        final ProviderContainer container = await _pumpTradeScreen(
+        final Game game = buildTradeTestGame(
+          treasury: 100,
+          prices: const {_iron: 80},
+        );
+        final ProviderContainer container = await pumpTradeScreenWithContainer(
           tester,
-          game: _buildGame(
-            treasury: 100,
-            prices: const {_iron: 80},
-          ),
-          nonBidProjectedDelta: 25,
+          game: game,
+          extraOverrides: <Override>[_treasurySummaryOverride(game, 25)],
         );
 
         await tester.tap(find.byKey(TradeScreen.marketRowBidChipKey(_iron)));
@@ -457,11 +375,14 @@ void main() {
 
         final TradeOrder? staged = _stagedOrder(container, _iron);
         expect(staged?.type, TradeOrderType.bid);
-        expect(staged?.quantity, 1,
-            reason:
-                'Net non-bid income (+25) is ignored by the bid clamp; '
-                'budget stays at raw treasury 100 so the default qty 1 (spend '
-                '80) lands.');
+        expect(
+          staged?.quantity,
+          1,
+          reason:
+              'Net non-bid income (+25) is ignored by the bid clamp; '
+              'budget stays at raw treasury 100 so the default qty 1 (spend '
+              '80) lands.',
+        );
       },
     );
 
@@ -474,12 +395,13 @@ void main() {
         // dynamic treasury summary. The non-bid delta is +10 (income), so
         // the helper clamps the deficit to 0 and leaves the budget at raw
         // treasury 100. Spend 60 + 30 = 90 ≤ 100, so the increment lands.
-        final ProviderContainer container = await _pumpTradeScreen(
+        final Game game = buildTradeTestGame(
+          treasury: 100,
+          prices: const {_timber: 30},
+        );
+        final ProviderContainer container = await pumpTradeScreenWithContainer(
           tester,
-          game: _buildGame(
-            treasury: 100,
-            prices: const {_timber: 30},
-          ),
+          game: game,
           initialOrders: Orders(
             tradeOrdersByPlayerId: {
               _humanPlayerId: [
@@ -492,16 +414,21 @@ void main() {
               ],
             },
           ),
-          nonBidProjectedDelta: 10,
+          extraOverrides: <Override>[_treasurySummaryOverride(game, 10)],
         );
 
-        await tester.tap(find.byKey(TradeScreen.marketRowIncrementKey(_timber)));
+        await tester.tap(
+          find.byKey(TradeScreen.marketRowIncrementKey(_timber)),
+        );
         await tester.pump();
-        expect(_stagedOrder(container, _timber)?.quantity, 3,
-            reason:
-                'Reconstructed non-bid delta is +10 (net income); budget '
-                'stays at raw treasury 100, allowing the increment to qty 3 '
-                '(spend 90).');
+        expect(
+          _stagedOrder(container, _timber)?.quantity,
+          3,
+          reason:
+              'Reconstructed non-bid delta is +10 (net income); budget '
+              'stays at raw treasury 100, allowing the increment to qty 3 '
+              '(spend 90).',
+        );
       },
     );
 
@@ -513,12 +440,13 @@ void main() {
         // Refs #3093 — cross-commodity bid gate under pending non-bid costs.
         // Bid budget = 100 − 40 = 60; existing timber spend = 30; iron toggle
         // would need 80 of remaining 30 headroom.
-        final ProviderContainer container = await _pumpTradeScreen(
+        final Game game = buildTradeTestGame(
+          treasury: 100,
+          prices: const {_timber: 30, _iron: 80},
+        );
+        final ProviderContainer container = await pumpTradeScreenWithContainer(
           tester,
-          game: _buildGame(
-            treasury: 100,
-            prices: const {_timber: 30, _iron: 80},
-          ),
+          game: game,
           initialOrders: Orders(
             tradeOrdersByPlayerId: {
               _humanPlayerId: [
@@ -531,16 +459,19 @@ void main() {
               ],
             },
           ),
-          nonBidProjectedDelta: -40,
+          extraOverrides: <Override>[_treasurySummaryOverride(game, -40)],
         );
 
         await tester.tap(find.byKey(TradeScreen.marketRowBidChipKey(_iron)));
         await tester.pump();
 
-        expect(_stagedOrder(container, _iron), isNull,
-            reason:
-                'Bid budget 60 − existing timber spend 30 leaves 30 headroom; '
-                'iron price 80 > 30 → toggle is silent no-op.');
+        expect(
+          _stagedOrder(container, _iron),
+          isNull,
+          reason:
+              'Bid budget 60 − existing timber spend 30 leaves 30 headroom; '
+              'iron price 80 > 30 → toggle is silent no-op.',
+        );
         expect(_stagedOrder(container, _timber)?.quantity, 1);
       },
     );

--- a/app/test/trade_screen_scaffold_test.dart
+++ b/app/test/trade_screen_scaffold_test.dart
@@ -10,7 +10,6 @@ import 'package:colonizethis_app/core/services/app_event_handler/app_event_handl
 import 'package:colonizethis_app/core/services/game_service/game_service.dart';
 import 'package:colonizethis_app/features/game/flame/controls/controls.dart';
 import 'package:colonizethis_app/features/game/screens/game/game_screen_shared.dart';
-import 'package:colonizethis_app/features/game/flame/region_map/region_map.dart' show CtMapVisibilityMode;
 import 'package:colonizethis_app/features/game/screens/trade/trade_screen.dart';
 import 'package:colonizethis_app/features/game/widgets/shell/shell_player_context.dart';
 import 'package:colonizethis_app/features/game/widgets/panels/observe_mode_not_defined_panel.dart';
@@ -31,6 +30,7 @@ import 'package:hive/hive.dart';
 
 import 'support/app_shell_harness.dart';
 import 'support/panel_test_fixtures.dart';
+import 'support/trade_screen_test_support.dart';
 import 'widget_test_pumps.dart';
 
 void main() {
@@ -56,27 +56,6 @@ void main() {
     gamesBox = await Hive.openBox<dynamic>(HiveBoxNames.games);
   });
 
-  ShellPlayerContext globalObserveShellContext() {
-    return const ShellPlayerContext(
-      effectiveHumanPlayerId: null,
-      viewingPlayerId: null,
-      mapVisibilityMode: CtMapVisibilityMode.full,
-      playerView: null,
-      omniscientDetail: true,
-      // Hides player chrome so `shellPanelsNotDefined(ref)` returns true and
-      // body switches to ObserveModeNotDefinedPanel — matches the global
-      // observe branch in `shellPlayerContextProvider` (observe-mode.md).
-      showPlayerChrome: false,
-      canMutateViaUi: false,
-      debugCommandTargetPlayerId: null,
-      inObservePhase: true,
-      // ignore: avoid_hardcoded_strings_in_widgets
-      observeBannerLabel: 'Observing: global',
-      treasuryNotDefined: true,
-      cargoNotDefined: true,
-    );
-  }
-
   baseOverrides({bool globalObserve = false}) => [
     gamesBoxProvider.overrideWith((ref) => gamesBox),
     gameServiceProvider.overrideWith(
@@ -93,7 +72,7 @@ void main() {
     }),
     if (globalObserve)
       shellPlayerContextProvider.overrideWithValue(
-        globalObserveShellContext(),
+        tradeTestGlobalObserveShellContext(),
       ),
   ];
 
@@ -230,8 +209,8 @@ void main() {
 
         final observePanelFinder = find.byType(ObserveModeNotDefinedPanel);
         expect(observePanelFinder, findsOneWidget);
-        final ObserveModeNotDefinedPanel observePanel =
-            tester.widget<ObserveModeNotDefinedPanel>(observePanelFinder);
+        final ObserveModeNotDefinedPanel observePanel = tester
+            .widget<ObserveModeNotDefinedPanel>(observePanelFinder);
         // ignore: avoid_hardcoded_strings_in_widgets
         expect(observePanel.title, 'Trade');
 
@@ -243,28 +222,27 @@ void main() {
       },
     );
 
-    testWidgets(
-      'CtTopBar back affordance pops back to the host route',
-      (tester) async {
-        await tester.pumpWidget(buildTradeRouteHost());
-        await pumpSettleCapped(tester);
+    testWidgets('CtTopBar back affordance pops back to the host route', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildTradeRouteHost());
+      await pumpSettleCapped(tester);
 
-        await tester.tap(find.text('open trade'));
-        await pumpSettleCapped(tester);
-        expect(find.byType(TradeScreen), findsOneWidget);
+      await tester.tap(find.text('open trade'));
+      await pumpSettleCapped(tester);
+      expect(find.byType(TradeScreen), findsOneWidget);
 
-        final back = find.descendant(
-          of: find.byType(CtTopBar),
-          matching: find.byType(CtBackButton),
-        );
-        expect(back, findsOneWidget);
-        await tester.tap(back);
-        await pumpSettleCapped(tester);
+      final back = find.descendant(
+        of: find.byType(CtTopBar),
+        matching: find.byType(CtBackButton),
+      );
+      expect(back, findsOneWidget);
+      await tester.tap(back);
+      await pumpSettleCapped(tester);
 
-        expect(find.byType(TradeScreen), findsNothing);
-        expect(find.text('open trade'), findsOneWidget);
-      },
-    );
+      expect(find.byType(TradeScreen), findsNothing);
+      expect(find.text('open trade'), findsOneWidget);
+    });
   });
 
   group('TradeScreen tab scaffold slice (Refs #2993 E4)', () {
@@ -415,65 +393,54 @@ void main() {
         // the live content; their per-row contents are exercised by the
         // dedicated E6 panel tests in trade_screen_deal_book_tab_e6_test.dart.
         expect(find.byKey(TradeScreen.dealBookBidsPanelKey), findsOneWidget);
-        expect(
-          find.byKey(TradeScreen.dealBookOffersPanelKey),
-          findsOneWidget,
-        );
-        expect(
-          find.byKey(TradeScreen.dealBookBidsTotalsKey),
-          findsOneWidget,
-        );
-        expect(
-          find.byKey(TradeScreen.dealBookOffersTotalsKey),
-          findsOneWidget,
-        );
+        expect(find.byKey(TradeScreen.dealBookOffersPanelKey), findsOneWidget);
+        expect(find.byKey(TradeScreen.dealBookBidsTotalsKey), findsOneWidget);
+        expect(find.byKey(TradeScreen.dealBookOffersTotalsKey), findsOneWidget);
       },
     );
   });
 
   group('GameMapEmpireLeftRail Trade button (Refs #2993 E3)', () {
-    testWidgets(
-      'rail exposes kEmpireTradeButtonKey between Production and '
-      'Civilian Units',
-      (tester) async {
-        await tester.pumpWidget(buildLeftRailHost());
-        await pumpSettleCapped(tester);
+    testWidgets('rail exposes kEmpireTradeButtonKey between Production and '
+        'Civilian Units', (tester) async {
+      await tester.pumpWidget(buildLeftRailHost());
+      await pumpSettleCapped(tester);
 
-        final trade = find.byKey(kEmpireTradeButtonKey);
-        expect(trade, findsOneWidget);
+      final trade = find.byKey(kEmpireTradeButtonKey);
+      expect(trade, findsOneWidget);
 
-        final productionTopLeft = tester
-            .getTopLeft(find.byKey(kEmpireProductionButtonKey));
-        final tradeTopLeft = tester.getTopLeft(trade);
-        final civilianTopLeft = tester
-            .getTopLeft(find.byKey(kEmpireCivilianUnitsButtonKey));
+      final productionTopLeft = tester.getTopLeft(
+        find.byKey(kEmpireProductionButtonKey),
+      );
+      final tradeTopLeft = tester.getTopLeft(trade);
+      final civilianTopLeft = tester.getTopLeft(
+        find.byKey(kEmpireCivilianUnitsButtonKey),
+      );
 
-        // Vertical stack ordering: Production -> Trade -> Civilian Units.
-        expect(
-          tradeTopLeft.dy,
-          greaterThan(productionTopLeft.dy),
-          reason: 'Trade button sits below Production per SPEC #2993 R4.',
-        );
-        expect(
-          civilianTopLeft.dy,
-          greaterThan(tradeTopLeft.dy),
-          reason: 'Civilian Units sits below Trade per SPEC #2993 R4.',
-        );
-      },
-    );
+      // Vertical stack ordering: Production -> Trade -> Civilian Units.
+      expect(
+        tradeTopLeft.dy,
+        greaterThan(productionTopLeft.dy),
+        reason: 'Trade button sits below Production per SPEC #2993 R4.',
+      );
+      expect(
+        civilianTopLeft.dy,
+        greaterThan(tradeTopLeft.dy),
+        reason: 'Civilian Units sits below Trade per SPEC #2993 R4.',
+      );
+    });
 
-    testWidgets(
-      'tapping Trade navigates to TradeScreen via Routes.generate',
-      (tester) async {
-        await tester.pumpWidget(buildLeftRailHost());
-        await pumpSettleCapped(tester);
+    testWidgets('tapping Trade navigates to TradeScreen via Routes.generate', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildLeftRailHost());
+      await pumpSettleCapped(tester);
 
-        await tester.tap(find.byKey(kEmpireTradeButtonKey));
-        await pumpSettleCapped(tester);
+      await tester.tap(find.byKey(kEmpireTradeButtonKey));
+      await pumpSettleCapped(tester);
 
-        expect(find.byType(TradeScreen), findsOneWidget);
-        expect(find.byKey(TradeScreen.topBarKey), findsOneWidget);
-      },
-    );
+      expect(find.byType(TradeScreen), findsOneWidget);
+      expect(find.byKey(TradeScreen.topBarKey), findsOneWidget);
+    });
   });
 }

--- a/test/check_app_test_no_duplicate_scaffolding_test.dart
+++ b/test/check_app_test_no_duplicate_scaffolding_test.dart
@@ -45,6 +45,22 @@ Future<void> _pumpFooScreenAtSize(WidgetTester tester, Size size) async {
 }
 ''';
 
+const _kConsolidatedTradeHost = '''
+import 'support/trade_screen_test_support.dart';
+
+void main() {
+  testWidgets('renders trade', (tester) async {
+    await pumpTradeScreen(tester, game: buildTradeTestGame());
+  });
+}
+''';
+
+const _kReintroducedTradeHosts = '''
+Game _buildGame() => throw UnimplementedError();
+
+Future<void> _pumpTradeScreen(WidgetTester tester) async {}
+''';
+
 void _writeGovernedFile(Directory temp, String name, String contents) {
   File('${temp.path}/app/test/$name')
     ..createSync(recursive: true)
@@ -73,7 +89,10 @@ void main() {
     expect(code, 0);
     expect(
       logs.join('\n'),
-      contains('no duplicated min-viewport or widgetbook use-case scaffolding found'),
+      contains(
+        'no duplicated min-viewport, widgetbook use-case, or trade-screen '
+        'host scaffolding found',
+      ),
     );
   });
 
@@ -182,10 +201,7 @@ Future<void> pumpAtMinViewport(WidgetTester tester, Size size) async {
       'check_app_test_no_dup_scaffolding_widgetbook_',
     );
     addTearDown(() => temp.deleteSync(recursive: true));
-    _writeGovernedFile(
-      temp,
-      'widgetbook_foo_stories_test.dart',
-      '''
+    _writeGovernedFile(temp, 'widgetbook_foo_stories_test.dart', '''
 import 'package:widgetbook/widgetbook.dart';
 
 WidgetbookUseCase _useCase(
@@ -195,8 +211,7 @@ WidgetbookUseCase _useCase(
 }) {
   throw UnimplementedError();
 }
-''',
-    );
+''');
 
     final logs = <String>[];
     final code = runCheckAppTestNoDuplicateScaffolding(
@@ -209,6 +224,57 @@ WidgetbookUseCase _useCase(
     expect(
       logs.join('\n'),
       contains('function "_useCase" duplicates widgetbook_test_harness.dart'),
+    );
+  });
+
+  test('passes when a trade-screen test uses the shared trade host', () {
+    final temp = Directory.systemTemp.createTempSync(
+      'check_app_test_no_dup_scaffolding_trade_pass_',
+    );
+    addTearDown(() => temp.deleteSync(recursive: true));
+    _writeGovernedFile(
+      temp,
+      'trade_screen_foo_test.dart',
+      _kConsolidatedTradeHost,
+    );
+
+    final code = runCheckAppTestNoDuplicateScaffolding(temp.path);
+    expect(code, 0);
+  });
+
+  test('fails when private trade-screen hosts are reintroduced', () {
+    final temp = Directory.systemTemp.createTempSync(
+      'check_app_test_no_dup_scaffolding_trade_fail_',
+    );
+    addTearDown(() => temp.deleteSync(recursive: true));
+    _writeGovernedFile(
+      temp,
+      'trade_screen_foo_test.dart',
+      _kReintroducedTradeHosts,
+    );
+
+    final logs = <String>[];
+    final code = runCheckAppTestNoDuplicateScaffolding(
+      temp.path,
+      info: logs.add,
+      err: logs.add,
+    );
+
+    expect(code, 1);
+    final joined = logs.join('\n');
+    expect(
+      joined,
+      contains(
+        'trade_screen_foo_test.dart:1: function "_buildGame" duplicates '
+        'trade_screen_test_support.dart',
+      ),
+    );
+    expect(
+      joined,
+      contains(
+        'trade_screen_foo_test.dart:3: function "_pumpTradeScreen" duplicates '
+        'trade_screen_test_support.dart',
+      ),
     );
   });
 }

--- a/tool/check_app_test_no_duplicate_scaffolding.dart
+++ b/tool/check_app_test_no_duplicate_scaffolding.dart
@@ -76,12 +76,20 @@ int runCheckAppTestNoDuplicateScaffolding(
       );
       parsed.unit.accept(visitor);
     }
+    if (_isGovernedTradeScreenFile(relativePath)) {
+      final visitor = _TradeScreenHostVisitor(
+        relativePath: relativePath,
+        lineInfo: parsed.unit.lineInfo,
+        violations: violations,
+      );
+      parsed.unit.accept(visitor);
+    }
   }
 
   if (violations.isEmpty) {
     logI(
-      'check_app_test_no_duplicate_scaffolding: no duplicated min-viewport or '
-      'widgetbook use-case scaffolding found.',
+      'check_app_test_no_duplicate_scaffolding: no duplicated min-viewport, '
+      'widgetbook use-case, or trade-screen host scaffolding found.',
     );
     return 0;
   }
@@ -98,7 +106,9 @@ int runCheckAppTestNoDuplicateScaffolding(
     '   Min-viewport: use pumpAtMinViewport / buildMinViewportApp from '
     'app/test/support/min_viewport_harness.dart. '
     'Widgetbook: use findWidgetbookUseCase from '
-    'app/test/support/widgetbook_test_harness.dart.',
+    'app/test/support/widgetbook_test_harness.dart. '
+    'Trade: use buildTradeTestGame / pumpTradeScreen* from '
+    'app/test/support/trade_screen_test_support.dart.',
   );
   return 1;
 }
@@ -126,6 +136,18 @@ bool _isGovernedMinViewportFile(String relativePath) {
   }
   if (relativePath.endsWith('.g.dart') ||
       relativePath.endsWith('.mocks.dart')) {
+    return false;
+  }
+  return true;
+}
+
+/// True for `app/test/trade_screen_*_test.dart` (Refs #3952), excluding support.
+bool _isGovernedTradeScreenFile(String relativePath) {
+  final name = p.basename(relativePath);
+  if (!name.startsWith('trade_screen_') || !name.endsWith('_test.dart')) {
+    return false;
+  }
+  if (relativePath.startsWith('app/test/support/')) {
     return false;
   }
   return true;
@@ -222,6 +244,45 @@ class _WidgetbookUseCaseVisitor extends RecursiveAstVisitor<void> {
       _report(
         node.name.offset,
         'function "_useCase" duplicates widgetbook_test_harness.dart',
+      );
+    }
+    super.visitFunctionDeclaration(node);
+  }
+}
+
+class _TradeScreenHostVisitor extends RecursiveAstVisitor<void> {
+  _TradeScreenHostVisitor({
+    required this.relativePath,
+    required this.lineInfo,
+    required this.violations,
+  });
+
+  final String relativePath;
+  final LineInfo lineInfo;
+  final List<String> violations;
+
+  static const Set<String> _forbiddenNames = {
+    '_buildGame',
+    '_buildGameForTradeScreen',
+    '_buildStandaloneGame',
+    '_pumpTradeScreen',
+    '_pumpTradeScreenObserveMode',
+    '_pumpTradeScreenStandalone',
+    '_pumpDealBookTab',
+  };
+
+  void _report(int offset, String detail) {
+    final line = lineInfo.getLocation(offset).lineNumber;
+    violations.add('$relativePath:$line: $detail');
+  }
+
+  @override
+  void visitFunctionDeclaration(FunctionDeclaration node) {
+    final name = node.name.lexeme;
+    if (_forbiddenNames.contains(name)) {
+      _report(
+        node.name.offset,
+        'function "$name" duplicates trade_screen_test_support.dart',
       );
     }
     super.visitFunctionDeclaration(node);


### PR DESCRIPTION
## Summary

- Add `app/test/support/trade_screen_test_support.dart` with parameterized `buildTradeTestGame`, `pumpTradeScreen` / `pumpTradeScreenWithContainer` / `pumpTradeScreenAtMinViewport`, and shared observe/shell context helpers.
- Migrate all 13 `trade_screen_*_test.dart` files off private `_buildGame` / `_pumpTradeScreen*` / `_pumpDealBookTab` hosts; add support smoke tests.
- Extend `tool/check_app_test_no_duplicate_scaffolding.dart` so reintroduced private trade hosts fail CI (unit coverage in `test/check_app_test_no_duplicate_scaffolding_test.dart`).

## Deferred (remaining for #3952)

- Golden capture harness + migrate `*golden*_test.dart` / `*_goldens_test.dart`
- Yarn/AssetBundle fixtures for dialogue overlay pins
- Diplomacy golden `_pumpBuilt` → `pumpDiplomacyPanelBuilt`
- Feature-screen top-bar lib DRY (`GameFeatureScreenTopBar`)
- Golden/Yarn AST gates

## AC coverage (this PR)

- [x] `trade_screen_test_support.dart` exists; all `trade_screen_*_test.dart` use it — no private `_pumpTradeScreen*` / `_buildGame` remain
- [x] At least one extended AST gate (trade host) passes on clean tree and fails on synthetic duplicate
- [x] Migrated trade widget tests green (`flutter test test/trade_screen_*.dart` + support smoke)
- [ ] Golden / Yarn / top-bar ACs — deferred

Refs #3952

## Test plan

- [x] `dart run tool/check_app_test_no_duplicate_scaffolding.dart`
- [x] `dart test test/check_app_test_no_duplicate_scaffolding_test.dart`
- [x] `cd app && flutter test test/trade_screen_*.dart test/support/trade_screen_test_support_test.dart` (113 passed)
- [x] `dart analyze` on migrated trade test files — clean


Made with [Cursor](https://cursor.com)