### PR TITLE
refactor(ai): fold colonial lite/civilian/peace fixtures into shared support (#3972)

### DIFF
--- a/packages/colonizethis_ai/test/planning/colonial_phase_planner_civilian_test.dart
+++ b/packages/colonizethis_ai/test/planning/colonial_phase_planner_civilian_test.dart
@@ -61,15 +61,13 @@
 // which the S5 orchestrator refactor will replace with phase-planner
 // dispatch.
 
-import 'package:colonizethis_ai/colonizethis_ai.dart';
 import 'package:colonizethis_ai/src/planning/colonial_phase_planner.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/ai_api.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart';
 
-const String _gp1 = 'gp1';
-const String _gp2 = 'gp2';
+import '../support/colonial_phase_planner_test_support.dart';
 
 // Province ids laid out per SPEC/game/world-model-identity.md. The
 // region prefix doubles as the tile-key region segment, so deriving
@@ -94,60 +92,12 @@ const String _nwTileTown = 'newWorld|p_gamma|0|0';
 const String _nwTileImproved = 'newWorld|p_delta|9|9';
 const String _nwForeignTile = 'newWorld|p_foreign|5|5';
 
-Game _civilianGame({
-  required List<Province> provinces,
-  required List<Unit> owUnits,
-  List<Unit> nwUnits = const [],
-  Map<String, String> resourceByTileKey = const {},
-  TileMapState tileState = const TileMapState(),
-}) {
-  final byRegion = <String, List<Province>>{};
-  for (final province in provinces) {
-    byRegion.putIfAbsent(province.regionId, () => <Province>[]).add(province);
-  }
-  return Game(
-    id: 'g-2509-colonial-phase-planner-civilian',
-    worldState: WorldState(
-      turnState: const TurnState(turnNumber: 132, phase: TurnPhase.orders),
-      oldWorld: RegionData(
-        provinces: byRegion[kOldWorldRegionId] ?? const [],
-        units: owUnits,
-      ),
-      newWorld: RegionData(
-        provinces: byRegion[kNewWorldRegionId] ?? const [],
-        units: nwUnits,
-      ),
-      resourceByTileKey: resourceByTileKey,
-      tileState: tileState,
-    ),
-    players: const [
-      Player(id: _gp1, displayName: 'GP1', isHuman: false),
-      Player(id: _gp2, displayName: 'GP2', isHuman: false),
-    ],
-  );
-}
-
-/// Minimal snapshot with the active player [_gp1]. The planner does not
-/// re-check the phase, so phase-routing fields (`conquest`, `colonial`)
-/// stay empty; the in-module contract is what these tests pin.
-AIWorldSnapshot _civilianSnapshot() {
-  return AIWorldSnapshot(
-    playerId: _gp1,
-    threats: const ThreatSummary(atWarWith: []),
-    opportunities: const OpportunitySummary(),
-    conquest: const ConquestSummary(),
-    colonial: const ColonialSummary(),
-    economy: const EconomySummary(),
-    relations: const {},
-  );
-}
-
 Unit _idleBuilder(String id, {String regionId = kOldWorldRegionId}) {
   final provinceId = regionId == kOldWorldRegionId ? _owProv1 : _nwProv1;
   return Unit(
     id: id,
     type: kUnitTypeBuilder,
-    ownerId: _gp1,
+    ownerId: kColonialPhaseGp1,
     locationProvinceId: provinceId,
     tileKey: '$provinceId|9|9',
   );
@@ -163,15 +113,22 @@ void main() {
       // NW-province-ownership filter would emit `build_improvement`
       // toward OW tiles in violation of the COLONIAL Suppressions
       // rule ("No OW build_improvement except port/supply").
-      final game = _civilianGame(
+      final game = buildColonialCivilianGame(
         provinces: const [
-          Province(id: _owProv1, regionId: kOldWorldRegionId, ownerId: _gp1),
+          Province(
+            id: _owProv1,
+            regionId: kOldWorldRegionId,
+            ownerId: kColonialPhaseGp1,
+          ),
         ],
         owUnits: [_idleBuilder('b1')],
         resourceByTileKey: const {_owTileA: 'grain'},
       );
       expect(
-        planColonialCivilian(game: game, snapshot: _civilianSnapshot()),
+        planColonialCivilian(
+          game: game,
+          snapshot: buildColonialCivilianSnapshot(),
+        ),
         isEmpty,
         reason:
             'Active player owns zero NW provinces -> no eligible tiles. '
@@ -185,15 +142,22 @@ void main() {
       // tile, but no Builder units exist. A regression that emitted a
       // `build_improvement` order without a builder would fail unit
       // assignment validation downstream.
-      final game = _civilianGame(
+      final game = buildColonialCivilianGame(
         provinces: const [
-          Province(id: _nwProv1, regionId: kNewWorldRegionId, ownerId: _gp1),
+          Province(
+            id: _nwProv1,
+            regionId: kNewWorldRegionId,
+            ownerId: kColonialPhaseGp1,
+          ),
         ],
         owUnits: const [],
         resourceByTileKey: const {_nwTileA: 'tobacco'},
       );
       expect(
-        planColonialCivilian(game: game, snapshot: _civilianSnapshot()),
+        planColonialCivilian(
+          game: game,
+          snapshot: buildColonialCivilianSnapshot(),
+        ),
         isEmpty,
         reason:
             'No idle Builders -> no orders. The function must skip its '
@@ -209,16 +173,27 @@ void main() {
       // except tiles needed for port/supply to active NW objectives"
       // in its default form (no active-NW-objective set is yet wired,
       // so the planner suppresses OW improvements unconditionally).
-      final game = _civilianGame(
+      final game = buildColonialCivilianGame(
         provinces: const [
-          Province(id: _owProv1, regionId: kOldWorldRegionId, ownerId: _gp1),
-          Province(id: _nwProv1, regionId: kNewWorldRegionId, ownerId: _gp1),
+          Province(
+            id: _owProv1,
+            regionId: kOldWorldRegionId,
+            ownerId: kColonialPhaseGp1,
+          ),
+          Province(
+            id: _nwProv1,
+            regionId: kNewWorldRegionId,
+            ownerId: kColonialPhaseGp1,
+          ),
         ],
         owUnits: [_idleBuilder('b1')],
         resourceByTileKey: const {_owTileA: 'grain'},
       );
       expect(
-        planColonialCivilian(game: game, snapshot: _civilianSnapshot()),
+        planColonialCivilian(
+          game: game,
+          snapshot: buildColonialCivilianSnapshot(),
+        ),
         isEmpty,
         reason:
             'OW resource tile is structurally suppressed in COLONIAL. '
@@ -234,13 +209,17 @@ void main() {
       // tiles carry rich resources. A regression that scanned
       // `resourceByTileKey` without the province-ownership filter
       // would route the lone Builder onto a foreign NW tile.
-      final game = _civilianGame(
+      final game = buildColonialCivilianGame(
         provinces: const [
-          Province(id: _nwProv1, regionId: kNewWorldRegionId, ownerId: _gp1),
+          Province(
+            id: _nwProv1,
+            regionId: kNewWorldRegionId,
+            ownerId: kColonialPhaseGp1,
+          ),
           Province(
             id: _nwForeignProv,
             regionId: kNewWorldRegionId,
-            ownerId: _gp2,
+            ownerId: kColonialPhaseGp2,
           ),
         ],
         owUnits: [_idleBuilder('b1')],
@@ -248,7 +227,7 @@ void main() {
       );
       final orders = planColonialCivilian(
         game: game,
-        snapshot: _civilianSnapshot(),
+        snapshot: buildColonialCivilianSnapshot(),
       );
       expect(orders.map((o) => o.targetTileKey), const [_nwTileA]);
     });
@@ -260,12 +239,12 @@ void main() {
       // planner must skip it; relying on `resourceByTileKey` alone
       // would permit a regression that places a resource on a town
       // tile and emits an improvement order against the town.
-      final game = _civilianGame(
+      final game = buildColonialCivilianGame(
         provinces: const [
           Province(
             id: _nwProv1,
             regionId: kNewWorldRegionId,
-            ownerId: _gp1,
+            ownerId: kColonialPhaseGp1,
             townTileKey: _nwTileTown,
           ),
         ],
@@ -274,7 +253,7 @@ void main() {
       );
       final orders = planColonialCivilian(
         game: game,
-        snapshot: _civilianSnapshot(),
+        snapshot: buildColonialCivilianSnapshot(),
       );
       expect(orders.map((o) => o.targetTileKey), const [_nwTileA]);
     });
@@ -286,16 +265,23 @@ void main() {
       // waste a Builder cycle and could re-trigger work that the
       // resolver rejects (or, worse, double-count toward the
       // turn-150 improvement gate).
-      final game = _civilianGame(
+      final game = buildColonialCivilianGame(
         provinces: const [
-          Province(id: _nwProv2, regionId: kNewWorldRegionId, ownerId: _gp1),
+          Province(
+            id: _nwProv2,
+            regionId: kNewWorldRegionId,
+            ownerId: kColonialPhaseGp1,
+          ),
         ],
         owUnits: [_idleBuilder('b1')],
         resourceByTileKey: const {_nwTileImproved: 'cotton'},
         tileState: const TileMapState(improvementByTile: {_nwTileImproved: 1}),
       );
       expect(
-        planColonialCivilian(game: game, snapshot: _civilianSnapshot()),
+        planColonialCivilian(
+          game: game,
+          snapshot: buildColonialCivilianSnapshot(),
+        ),
         isEmpty,
         reason:
             'All eligible NW tiles already at improvementLevel >= 1; '
@@ -308,16 +294,20 @@ void main() {
       // Builder -> exactly one order on the lex-first tile key. The
       // surplus tile remains unimproved this turn (acceptable; the
       // next-turn pass will fill another builder slot).
-      final game = _civilianGame(
+      final game = buildColonialCivilianGame(
         provinces: const [
-          Province(id: _nwProv1, regionId: kNewWorldRegionId, ownerId: _gp1),
+          Province(
+            id: _nwProv1,
+            regionId: kNewWorldRegionId,
+            ownerId: kColonialPhaseGp1,
+          ),
         ],
         owUnits: [_idleBuilder('b1')],
         resourceByTileKey: const {_nwTileA: 'tobacco', _nwTileB: 'sugar'},
       );
       final orders = planColonialCivilian(
         game: game,
-        snapshot: _civilianSnapshot(),
+        snapshot: buildColonialCivilianSnapshot(),
       );
       expect(orders.length, 1);
       expect(orders.single.unitId, 'b1');
@@ -329,16 +319,20 @@ void main() {
       // Reverse cap: two idle Builders, one NW tile -> exactly one
       // order bound to the lex-first builder id. The surplus builder
       // remains idle (no fabricated order, no duplicate targeting).
-      final game = _civilianGame(
+      final game = buildColonialCivilianGame(
         provinces: const [
-          Province(id: _nwProv1, regionId: kNewWorldRegionId, ownerId: _gp1),
+          Province(
+            id: _nwProv1,
+            regionId: kNewWorldRegionId,
+            ownerId: kColonialPhaseGp1,
+          ),
         ],
         owUnits: [_idleBuilder('b1'), _idleBuilder('b2')],
         resourceByTileKey: const {_nwTileA: 'tobacco'},
       );
       final orders = planColonialCivilian(
         game: game,
-        snapshot: _civilianSnapshot(),
+        snapshot: buildColonialCivilianSnapshot(),
       );
       expect(orders.length, 1);
       expect(orders.single.unitId, 'b1');
@@ -357,10 +351,18 @@ void main() {
       // unbound (builder cap). Builder input order is intentionally
       // shuffled (`b2` first) so a regression that dropped the
       // builder sort would surface as the wrong unit-to-tile pairing.
-      final game = _civilianGame(
+      final game = buildColonialCivilianGame(
         provinces: const [
-          Province(id: _nwProv1, regionId: kNewWorldRegionId, ownerId: _gp1),
-          Province(id: _nwProv2, regionId: kNewWorldRegionId, ownerId: _gp1),
+          Province(
+            id: _nwProv1,
+            regionId: kNewWorldRegionId,
+            ownerId: kColonialPhaseGp1,
+          ),
+          Province(
+            id: _nwProv2,
+            regionId: kNewWorldRegionId,
+            ownerId: kColonialPhaseGp1,
+          ),
         ],
         owUnits: [_idleBuilder('b2'), _idleBuilder('b1')],
         resourceByTileKey: const {
@@ -371,7 +373,7 @@ void main() {
       );
       final orders = planColonialCivilian(
         game: game,
-        snapshot: _civilianSnapshot(),
+        snapshot: buildColonialCivilianSnapshot(),
       );
       expect(orders.length, 2);
       expect(orders[0].unitId, 'b1');
@@ -390,15 +392,19 @@ void main() {
       // and idle non-Builder civilians (e.g. Merchant) must be
       // skipped. With no idle Builder present the planner returns
       // empty even when an eligible NW tile exists.
-      final game = _civilianGame(
+      final game = buildColonialCivilianGame(
         provinces: const [
-          Province(id: _nwProv1, regionId: kNewWorldRegionId, ownerId: _gp1),
+          Province(
+            id: _nwProv1,
+            regionId: kNewWorldRegionId,
+            ownerId: kColonialPhaseGp1,
+          ),
         ],
         nwUnits: [
           Unit(
             id: 'b_busy',
             type: kUnitTypeBuilder,
-            ownerId: _gp1,
+            ownerId: kColonialPhaseGp1,
             locationProvinceId: _nwProv1,
             tileKey: '$_nwProv1|7|7',
             status: UnitStatus.working,
@@ -406,7 +412,7 @@ void main() {
           Unit(
             id: 'merchant1',
             type: kUnitTypeMerchant,
-            ownerId: _gp1,
+            ownerId: kColonialPhaseGp1,
             locationProvinceId: _nwProv1,
             tileKey: '$_nwProv1|6|6',
           ),
@@ -415,7 +421,10 @@ void main() {
         resourceByTileKey: const {_nwTileA: 'tobacco'},
       );
       expect(
-        planColonialCivilian(game: game, snapshot: _civilianSnapshot()),
+        planColonialCivilian(
+          game: game,
+          snapshot: buildColonialCivilianSnapshot(),
+        ),
         isEmpty,
         reason:
             'Working builders + non-Builder civilians are filtered out; '
@@ -431,16 +440,20 @@ void main() {
       // the "any idle Builder" contract from the function docstring
       // and prevents a regression that adds an implicit region gate
       // on the builder side.
-      final game = _civilianGame(
+      final game = buildColonialCivilianGame(
         provinces: const [
-          Province(id: _nwProv1, regionId: kNewWorldRegionId, ownerId: _gp1),
+          Province(
+            id: _nwProv1,
+            regionId: kNewWorldRegionId,
+            ownerId: kColonialPhaseGp1,
+          ),
         ],
         owUnits: [_idleBuilder('b_ow')],
         resourceByTileKey: const {_nwTileA: 'tobacco'},
       );
       final orders = planColonialCivilian(
         game: game,
-        snapshot: _civilianSnapshot(),
+        snapshot: buildColonialCivilianSnapshot(),
       );
       expect(orders.length, 1);
       expect(orders.single.unitId, 'b_ow');
@@ -453,16 +466,24 @@ void main() {
       // suppression, town exclusion, improvement-level filter,
       // builder-status filter, builder sort, and the min cap in one
       // pass. Two calls must produce the same list.
-      final game = _civilianGame(
+      final game = buildColonialCivilianGame(
         provinces: const [
-          Province(id: _owProv1, regionId: kOldWorldRegionId, ownerId: _gp1),
+          Province(
+            id: _owProv1,
+            regionId: kOldWorldRegionId,
+            ownerId: kColonialPhaseGp1,
+          ),
           Province(
             id: _nwProv1,
             regionId: kNewWorldRegionId,
-            ownerId: _gp1,
+            ownerId: kColonialPhaseGp1,
             townTileKey: _nwTileTown,
           ),
-          Province(id: _nwProv2, regionId: kNewWorldRegionId, ownerId: _gp1),
+          Province(
+            id: _nwProv2,
+            regionId: kNewWorldRegionId,
+            ownerId: kColonialPhaseGp1,
+          ),
         ],
         owUnits: [_idleBuilder('b2'), _idleBuilder('b1')],
         nwUnits: [_idleBuilder('b3', regionId: kNewWorldRegionId)],
@@ -477,11 +498,11 @@ void main() {
       );
       final first = planColonialCivilian(
         game: game,
-        snapshot: _civilianSnapshot(),
+        snapshot: buildColonialCivilianSnapshot(),
       );
       final second = planColonialCivilian(
         game: game,
-        snapshot: _civilianSnapshot(),
+        snapshot: buildColonialCivilianSnapshot(),
       );
       expect(
         first.map((o) => '${o.unitId}->${o.targetTileKey}').toList(),

--- a/packages/colonizethis_ai/test/planning/colonial_phase_planner_colonial_lite_naval_test.dart
+++ b/packages/colonizethis_ai/test/planning/colonial_phase_planner_colonial_lite_naval_test.dart
@@ -99,76 +99,11 @@
 // destination filter (tribe / minor NW invadable provinces) that the
 // orchestrator consumes.
 
-import 'package:colonizethis_ai/colonizethis_ai.dart';
 import 'package:colonizethis_ai/src/planning/colonial_phase_planner.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart';
 
-const String _gp1 = 'gp1';
-const String _gp2 = 'gp2';
-const String _gp3 = 'gp3';
-const String _tribe1 = 'tribe1';
-const String _tribe2 = 'tribe2';
-const String _minor1 = 'minor1';
-
-/// Game scaffold for COLONIAL-lite naval tests. New World provinces,
-/// players, tribes, and minors are passed in so each test can shape
-/// ownership independently. Old World defaults to empty because the
-/// planner does not query OW state (the OW invadable summary is read
-/// only by [planExpandMilitary] / [planColonialMilitary], not by
-/// [planColonialLiteNaval]).
-Game _colonialLiteGame({
-  int turnNumber = 125,
-  List<Province> newWorldProvinces = const [],
-  List<Province> oldWorldProvinces = const [],
-  List<Player> players = const [
-    Player(id: _gp1, displayName: 'GP1', isHuman: false),
-    Player(id: _gp2, displayName: 'GP2', isHuman: false),
-    Player(id: _gp3, displayName: 'GP3', isHuman: false),
-  ],
-  List<Tribe> tribes = const [],
-  List<MinorNation> minorNations = const [],
-}) {
-  return Game(
-    id: 'g-2509-colonial-lite-naval-t$turnNumber',
-    worldState: WorldState(
-      turnState: TurnState(turnNumber: turnNumber, phase: TurnPhase.orders),
-      oldWorld: RegionData(provinces: oldWorldProvinces),
-      newWorld: RegionData(provinces: newWorldProvinces),
-    ),
-    players: players,
-    tribes: tribes,
-    minorNations: minorNations,
-  );
-}
-
-/// Snapshot tuned for COLONIAL-lite: own OW defaults to 9 (the
-/// COLONIAL-lite outer schedule -- "OW ≥9 and <10"). Tests shape
-/// `invadableNw` and `invadableOw` to exercise the structural OW
-/// suppression and the tribe / minor / GP owner filter. The planner
-/// does not re-check the phase so the values are still consistent with
-/// COLONIAL-lite only so debugging traces stay coherent.
-AIWorldSnapshot _colonialLiteSnapshot({
-  List<String> invadableNw = const [],
-  List<String> invadableOw = const [],
-  List<String> atWarWith = const [],
-  int oldWorldProvincesOwned = 9,
-  String playerId = _gp1,
-}) {
-  return AIWorldSnapshot(
-    playerId: playerId,
-    threats: ThreatSummary(atWarWith: atWarWith),
-    opportunities: const OpportunitySummary(),
-    conquest: ConquestSummary(
-      oldWorldProvincesOwned: oldWorldProvincesOwned,
-      provincesToVictory: 31,
-      invadableProvinceIdsSorted: invadableOw,
-    ),
-    colonial: ColonialSummary(invadableNewWorldProvinceIdsSorted: invadableNw),
-    economy: const EconomySummary(),
-    relations: const {},
-  );
-}
+import '../support/colonial_phase_planner_test_support.dart';
 
 void main() {
   group('planColonialLiteNaval', () {
@@ -177,17 +112,17 @@ void main() {
       // player must not crash; the planner returns the default plan.
       // Matches the symmetric guard in [planColonialLiteOvertures] and
       // [planColonialMilitary].
-      final game = _colonialLiteGame(
+      final game = buildColonialLiteNavalGame(
         newWorldProvinces: const [
           Province(
             id: 'newWorld|tribe1_a',
             regionId: 'newWorld',
-            ownerId: _tribe1,
+            ownerId: kColonialPhaseTribe1,
           ),
         ],
-        tribes: const [Tribe(id: _tribe1, displayName: 'T1')],
+        tribes: const [Tribe(id: kColonialPhaseTribe1, displayName: 'T1')],
       );
-      final snapshot = _colonialLiteSnapshot(
+      final snapshot = buildColonialLiteNavalSnapshot(
         invadableNw: const ['newWorld|tribe1_a'],
         playerId: 'ghost-player',
       );
@@ -205,126 +140,119 @@ void main() {
       // No NW frontier means there is no province to filter; the
       // function must short-circuit before any owner scan so an empty
       // constraint never leaks to the orchestrator.
-      final game = _colonialLiteGame();
-      final snapshot = _colonialLiteSnapshot(invadableNw: const []);
+      final game = buildColonialLiteNavalGame();
+      final snapshot = buildColonialLiteNavalSnapshot(invadableNw: const []);
       expect(
         planColonialLiteNaval(game: game, snapshot: snapshot),
         same(ColonialLiteNavalPlan.defaultPlan),
       );
     });
 
-    test(
-      'AC: single tribe-owned NW invadable -> restrict to that province '
-      '+ tribe as sole owner',
-      () {
-        // Canonical happy path from the spec: a single tribe-owned NW
-        // invadable province surfaces in the plan as the exploration
-        // focus. A regression that filtered tribes structurally
-        // would show empty here.
-        final game = _colonialLiteGame(
-          newWorldProvinces: const [
-            Province(
-              id: 'newWorld|tribe1_a',
-              regionId: 'newWorld',
-              ownerId: _tribe1,
-            ),
-          ],
-          tribes: const [Tribe(id: _tribe1, displayName: 'T1')],
-        );
-        final snapshot = _colonialLiteSnapshot(
-          invadableNw: const ['newWorld|tribe1_a'],
-        );
-        expect(
-          planColonialLiteNaval(game: game, snapshot: snapshot),
-          const ColonialLiteNavalPlan(
-            priorityNwProvinceIdsSorted: <String>['newWorld|tribe1_a'],
-            priorityTargetOwnerFactionIdsSorted: <String>[_tribe1],
+    test('AC: single tribe-owned NW invadable -> restrict to that province '
+        '+ tribe as sole owner', () {
+      // Canonical happy path from the spec: a single tribe-owned NW
+      // invadable province surfaces in the plan as the exploration
+      // focus. A regression that filtered tribes structurally
+      // would show empty here.
+      final game = buildColonialLiteNavalGame(
+        newWorldProvinces: const [
+          Province(
+            id: 'newWorld|tribe1_a',
+            regionId: 'newWorld',
+            ownerId: kColonialPhaseTribe1,
           ),
-          reason:
-              'Canonical COLONIAL-lite naval focus: single tribe-owned NW '
-              'invadable -> plan restricts to that province and lists the '
-              'tribe as the sole priority owner.',
-        );
-      },
-    );
+        ],
+        tribes: const [Tribe(id: kColonialPhaseTribe1, displayName: 'T1')],
+      );
+      final snapshot = buildColonialLiteNavalSnapshot(
+        invadableNw: const ['newWorld|tribe1_a'],
+      );
+      expect(
+        planColonialLiteNaval(game: game, snapshot: snapshot),
+        const ColonialLiteNavalPlan(
+          priorityNwProvinceIdsSorted: <String>['newWorld|tribe1_a'],
+          priorityTargetOwnerFactionIdsSorted: <String>[kColonialPhaseTribe1],
+        ),
+        reason:
+            'Canonical COLONIAL-lite naval focus: single tribe-owned NW '
+            'invadable -> plan restricts to that province and lists the '
+            'tribe as the sole priority owner.',
+      );
+    });
 
-    test(
-      'single minor-owned NW invadable -> restrict to that province + minor '
-      'as sole owner',
-      () {
-        // Mirror branch from the minor-owner side. Tribes and minors are
-        // both first-class COLONIAL-lite naval targets per issue #2509
-        // § COLONIAL-lite "establishOverture toward visible NW tribe /
-        // minor owners".
-        final game = _colonialLiteGame(
-          newWorldProvinces: const [
-            Province(
-              id: 'newWorld|minor1_a',
-              regionId: 'newWorld',
-              ownerId: _minor1,
-            ),
-          ],
-          minorNations: const [MinorNation(id: _minor1, displayName: 'M1')],
-        );
-        final snapshot = _colonialLiteSnapshot(
-          invadableNw: const ['newWorld|minor1_a'],
-        );
-        expect(
-          planColonialLiteNaval(game: game, snapshot: snapshot),
-          const ColonialLiteNavalPlan(
-            priorityNwProvinceIdsSorted: <String>['newWorld|minor1_a'],
-            priorityTargetOwnerFactionIdsSorted: <String>[_minor1],
+    test('single minor-owned NW invadable -> restrict to that province + minor '
+        'as sole owner', () {
+      // Mirror branch from the minor-owner side. Tribes and minors are
+      // both first-class COLONIAL-lite naval targets per issue #2509
+      // § COLONIAL-lite "establishOverture toward visible NW tribe /
+      // minor owners".
+      final game = buildColonialLiteNavalGame(
+        newWorldProvinces: const [
+          Province(
+            id: 'newWorld|minor1_a',
+            regionId: 'newWorld',
+            ownerId: kColonialPhaseMinor1,
           ),
-          reason:
-              'Minors are first-class COLONIAL-lite naval targets (same '
-              'class as tribes); the planner does not discriminate '
-              'between Tribe and MinorNation entries.',
-        );
-      },
-    );
+        ],
+        minorNations: const [
+          MinorNation(id: kColonialPhaseMinor1, displayName: 'M1'),
+        ],
+      );
+      final snapshot = buildColonialLiteNavalSnapshot(
+        invadableNw: const ['newWorld|minor1_a'],
+      );
+      expect(
+        planColonialLiteNaval(game: game, snapshot: snapshot),
+        const ColonialLiteNavalPlan(
+          priorityNwProvinceIdsSorted: <String>['newWorld|minor1_a'],
+          priorityTargetOwnerFactionIdsSorted: <String>[kColonialPhaseMinor1],
+        ),
+        reason:
+            'Minors are first-class COLONIAL-lite naval targets (same '
+            'class as tribes); the planner does not discriminate '
+            'between Tribe and MinorNation entries.',
+      );
+    });
 
-    test(
-      'multiple tribe-owned NW invadable -> all those provinces, '
-      'sorted ascending',
-      () {
-        // Multiple tribe-owned NW invadable provinces: the COLONIAL-lite
-        // naval focus keeps ALL of them, sorted ascending, regardless
-        // of the input order. Defensive determinism against future
-        // builder changes (Refs #2509 Must-have #7).
-        final game = _colonialLiteGame(
-          newWorldProvinces: const [
-            Province(
-              id: 'newWorld|tribe1_a',
-              regionId: 'newWorld',
-              ownerId: _tribe1,
-            ),
-            Province(
-              id: 'newWorld|tribe1_b',
-              regionId: 'newWorld',
-              ownerId: _tribe1,
-            ),
-          ],
-          tribes: const [Tribe(id: _tribe1, displayName: 'T1')],
-        );
-        final snapshot = _colonialLiteSnapshot(
-          invadableNw: const ['newWorld|tribe1_b', 'newWorld|tribe1_a'],
-        );
-        expect(
-          planColonialLiteNaval(game: game, snapshot: snapshot),
-          const ColonialLiteNavalPlan(
-            priorityNwProvinceIdsSorted: <String>[
-              'newWorld|tribe1_a',
-              'newWorld|tribe1_b',
-            ],
-            priorityTargetOwnerFactionIdsSorted: <String>[_tribe1],
+    test('multiple tribe-owned NW invadable -> all those provinces, '
+        'sorted ascending', () {
+      // Multiple tribe-owned NW invadable provinces: the COLONIAL-lite
+      // naval focus keeps ALL of them, sorted ascending, regardless
+      // of the input order. Defensive determinism against future
+      // builder changes (Refs #2509 Must-have #7).
+      final game = buildColonialLiteNavalGame(
+        newWorldProvinces: const [
+          Province(
+            id: 'newWorld|tribe1_a',
+            regionId: 'newWorld',
+            ownerId: kColonialPhaseTribe1,
           ),
-          reason:
-              'COLONIAL-lite naval focus keeps ALL tribe-owned NW invadable '
-              'provinces, sorted ascending. Output order is independent of '
-              'the input invadable list order.',
-        );
-      },
-    );
+          Province(
+            id: 'newWorld|tribe1_b',
+            regionId: 'newWorld',
+            ownerId: kColonialPhaseTribe1,
+          ),
+        ],
+        tribes: const [Tribe(id: kColonialPhaseTribe1, displayName: 'T1')],
+      );
+      final snapshot = buildColonialLiteNavalSnapshot(
+        invadableNw: const ['newWorld|tribe1_b', 'newWorld|tribe1_a'],
+      );
+      expect(
+        planColonialLiteNaval(game: game, snapshot: snapshot),
+        const ColonialLiteNavalPlan(
+          priorityNwProvinceIdsSorted: <String>[
+            'newWorld|tribe1_a',
+            'newWorld|tribe1_b',
+          ],
+          priorityTargetOwnerFactionIdsSorted: <String>[kColonialPhaseTribe1],
+        ),
+        reason:
+            'COLONIAL-lite naval focus keeps ALL tribe-owned NW invadable '
+            'provinces, sorted ascending. Output order is independent of '
+            'the input invadable list order.',
+      );
+    });
 
     test('GP-owned NW invadable filtered out (structural)', () {
       // GP-owned NW invadable must NOT appear in the plan. COLONIAL-lite
@@ -332,16 +260,16 @@ void main() {
       // GP-owned NW is structurally excluded because the spec suppresses
       // NW `declareWar` and `purchase_land` here (issue #2509
       // § COLONIAL-lite suppressed list).
-      final game = _colonialLiteGame(
+      final game = buildColonialLiteNavalGame(
         newWorldProvinces: const [
           Province(
             id: 'newWorld|gp2_a',
             regionId: 'newWorld',
-            ownerId: _gp2,
+            ownerId: kColonialPhaseGp2,
           ),
         ],
       );
-      final snapshot = _colonialLiteSnapshot(
+      final snapshot = buildColonialLiteNavalSnapshot(
         invadableNw: const ['newWorld|gp2_a'],
       );
       expect(
@@ -354,82 +282,84 @@ void main() {
       );
     });
 
-    test(
-      'mixed: tribe + minor + GP-owned NW invadable -> only tribe + minor '
-      'returned, sorted ascending',
-      () {
-        // Composite filter pin (GP filter + multi-owner union). The
-        // GP-owned province is dropped; the tribe and minor provinces
-        // surface in `priorityNwProvinceIdsSorted` (sorted ascending),
-        // and both owners appear in
-        // `priorityTargetOwnerFactionIdsSorted` (sorted ascending,
-        // deduplicated).
-        final game = _colonialLiteGame(
-          newWorldProvinces: const [
-            Province(
-              id: 'newWorld|tribe1_a',
-              regionId: 'newWorld',
-              ownerId: _tribe1,
-            ),
-            Province(
-              id: 'newWorld|minor1_a',
-              regionId: 'newWorld',
-              ownerId: _minor1,
-            ),
-            Province(
-              id: 'newWorld|gp2_a',
-              regionId: 'newWorld',
-              ownerId: _gp2,
-            ),
-          ],
-          tribes: const [Tribe(id: _tribe1, displayName: 'T1')],
-          minorNations: const [MinorNation(id: _minor1, displayName: 'M1')],
-        );
-        final snapshot = _colonialLiteSnapshot(
-          invadableNw: const [
-            'newWorld|tribe1_a',
-            'newWorld|minor1_a',
-            'newWorld|gp2_a',
-          ],
-        );
-        expect(
-          planColonialLiteNaval(game: game, snapshot: snapshot),
-          const ColonialLiteNavalPlan(
-            priorityNwProvinceIdsSorted: <String>[
-              'newWorld|minor1_a',
-              'newWorld|tribe1_a',
-            ],
-            priorityTargetOwnerFactionIdsSorted: <String>[_minor1, _tribe1],
+    test('mixed: tribe + minor + GP-owned NW invadable -> only tribe + minor '
+        'returned, sorted ascending', () {
+      // Composite filter pin (GP filter + multi-owner union). The
+      // GP-owned province is dropped; the tribe and minor provinces
+      // surface in `priorityNwProvinceIdsSorted` (sorted ascending),
+      // and both owners appear in
+      // `priorityTargetOwnerFactionIdsSorted` (sorted ascending,
+      // deduplicated).
+      final game = buildColonialLiteNavalGame(
+        newWorldProvinces: const [
+          Province(
+            id: 'newWorld|tribe1_a',
+            regionId: 'newWorld',
+            ownerId: kColonialPhaseTribe1,
           ),
-          reason:
-              'Composite filter: GP-owned NW invadable dropped; tribe + '
-              'minor NW invadable surface in the plan with both lists '
-              'sorted ascending. minor1 < tribe1 lexically so minor1 '
-              'sorts first in both fields.',
-        );
-      },
-    );
+          Province(
+            id: 'newWorld|minor1_a',
+            regionId: 'newWorld',
+            ownerId: kColonialPhaseMinor1,
+          ),
+          Province(
+            id: 'newWorld|gp2_a',
+            regionId: 'newWorld',
+            ownerId: kColonialPhaseGp2,
+          ),
+        ],
+        tribes: const [Tribe(id: kColonialPhaseTribe1, displayName: 'T1')],
+        minorNations: const [
+          MinorNation(id: kColonialPhaseMinor1, displayName: 'M1'),
+        ],
+      );
+      final snapshot = buildColonialLiteNavalSnapshot(
+        invadableNw: const [
+          'newWorld|tribe1_a',
+          'newWorld|minor1_a',
+          'newWorld|gp2_a',
+        ],
+      );
+      expect(
+        planColonialLiteNaval(game: game, snapshot: snapshot),
+        const ColonialLiteNavalPlan(
+          priorityNwProvinceIdsSorted: <String>[
+            'newWorld|minor1_a',
+            'newWorld|tribe1_a',
+          ],
+          priorityTargetOwnerFactionIdsSorted: <String>[
+            kColonialPhaseMinor1,
+            kColonialPhaseTribe1,
+          ],
+        ),
+        reason:
+            'Composite filter: GP-owned NW invadable dropped; tribe + '
+            'minor NW invadable surface in the plan with both lists '
+            'sorted ascending. minor1 < tribe1 lexically so minor1 '
+            'sorts first in both fields.',
+      );
+    });
 
     test('only GP-owned NW invadable -> defaultPlan', () {
       // Priority-arm fall-through pin: with no tribe / minor
       // contributing any NW invadable, the planner returns the default
       // plan and the orchestrator falls back to legacy free-choice
       // colonial naval behaviour.
-      final game = _colonialLiteGame(
+      final game = buildColonialLiteNavalGame(
         newWorldProvinces: const [
           Province(
             id: 'newWorld|gp2_a',
             regionId: 'newWorld',
-            ownerId: _gp2,
+            ownerId: kColonialPhaseGp2,
           ),
           Province(
             id: 'newWorld|gp3_a',
             regionId: 'newWorld',
-            ownerId: _gp3,
+            ownerId: kColonialPhaseGp3,
           ),
         ],
       );
-      final snapshot = _colonialLiteSnapshot(
+      final snapshot = buildColonialLiteNavalSnapshot(
         invadableNw: const ['newWorld|gp2_a', 'newWorld|gp3_a'],
       );
       expect(
@@ -448,24 +378,24 @@ void main() {
       // province (stale fixture, mid-resolution diff, etc.). The
       // planner must silently skip the orphan via the
       // `if (owner == null) continue` branch and not blow up.
-      final game = _colonialLiteGame(
+      final game = buildColonialLiteNavalGame(
         newWorldProvinces: const [
           Province(
             id: 'newWorld|tribe1_a',
             regionId: 'newWorld',
-            ownerId: _tribe1,
+            ownerId: kColonialPhaseTribe1,
           ),
         ],
-        tribes: const [Tribe(id: _tribe1, displayName: 'T1')],
+        tribes: const [Tribe(id: kColonialPhaseTribe1, displayName: 'T1')],
       );
-      final snapshot = _colonialLiteSnapshot(
+      final snapshot = buildColonialLiteNavalSnapshot(
         invadableNw: const ['newWorld|orphan', 'newWorld|tribe1_a'],
       );
       expect(
         planColonialLiteNaval(game: game, snapshot: snapshot),
         const ColonialLiteNavalPlan(
           priorityNwProvinceIdsSorted: <String>['newWorld|tribe1_a'],
-          priorityTargetOwnerFactionIdsSorted: <String>[_tribe1],
+          priorityTargetOwnerFactionIdsSorted: <String>[kColonialPhaseTribe1],
         ),
         reason:
             'Orphan invadable id (no province record) is silently '
@@ -478,23 +408,25 @@ void main() {
       // Pure-function determinism (Refs #2509 Must-have #7) -- the
       // planner is called twice with the same inputs and must return
       // equal plans across both calls.
-      final game = _colonialLiteGame(
+      final game = buildColonialLiteNavalGame(
         newWorldProvinces: const [
           Province(
             id: 'newWorld|tribe1_a',
             regionId: 'newWorld',
-            ownerId: _tribe1,
+            ownerId: kColonialPhaseTribe1,
           ),
           Province(
             id: 'newWorld|minor1_a',
             regionId: 'newWorld',
-            ownerId: _minor1,
+            ownerId: kColonialPhaseMinor1,
           ),
         ],
-        tribes: const [Tribe(id: _tribe1, displayName: 'T1')],
-        minorNations: const [MinorNation(id: _minor1, displayName: 'M1')],
+        tribes: const [Tribe(id: kColonialPhaseTribe1, displayName: 'T1')],
+        minorNations: const [
+          MinorNation(id: kColonialPhaseMinor1, displayName: 'M1'),
+        ],
       );
-      final snapshot = _colonialLiteSnapshot(
+      final snapshot = buildColonialLiteNavalSnapshot(
         invadableNw: const ['newWorld|tribe1_a', 'newWorld|minor1_a'],
       );
       final first = planColonialLiteNaval(game: game, snapshot: snapshot);
@@ -510,20 +442,20 @@ void main() {
       // `colonial.invadableNewWorldProvinceIdsSorted`. This pins the
       // structural OW suppression from the spec ("Naval exploration of
       // unrevealed NW sea zones ...").
-      final game = _colonialLiteGame(
+      final game = buildColonialLiteNavalGame(
         oldWorldProvinces: const [
           Province(
             id: 'oldWorld|tribe1_a',
             regionId: 'oldWorld',
-            ownerId: _tribe1,
+            ownerId: kColonialPhaseTribe1,
           ),
         ],
-        tribes: const [Tribe(id: _tribe1, displayName: 'T1')],
+        tribes: const [Tribe(id: kColonialPhaseTribe1, displayName: 'T1')],
       );
-      final snapshot = _colonialLiteSnapshot(
+      final snapshot = buildColonialLiteNavalSnapshot(
         invadableNw: const [],
         invadableOw: const ['oldWorld|tribe1_a'],
-        atWarWith: const [_tribe1],
+        atWarWith: const [kColonialPhaseTribe1],
       );
       expect(
         planColonialLiteNaval(game: game, snapshot: snapshot),
@@ -543,17 +475,17 @@ void main() {
       // NW-acquisition seed work (exploration + cargo), not
       // retaliation -- the planner must surface tribes / minors even
       // when not yet at war with them.
-      final game = _colonialLiteGame(
+      final game = buildColonialLiteNavalGame(
         newWorldProvinces: const [
           Province(
             id: 'newWorld|tribe1_a',
             regionId: 'newWorld',
-            ownerId: _tribe1,
+            ownerId: kColonialPhaseTribe1,
           ),
         ],
-        tribes: const [Tribe(id: _tribe1, displayName: 'T1')],
+        tribes: const [Tribe(id: kColonialPhaseTribe1, displayName: 'T1')],
       );
-      final snapshot = _colonialLiteSnapshot(
+      final snapshot = buildColonialLiteNavalSnapshot(
         invadableNw: const ['newWorld|tribe1_a'],
         atWarWith: const [],
       );
@@ -561,7 +493,7 @@ void main() {
         planColonialLiteNaval(game: game, snapshot: snapshot),
         const ColonialLiteNavalPlan(
           priorityNwProvinceIdsSorted: <String>['newWorld|tribe1_a'],
-          priorityTargetOwnerFactionIdsSorted: <String>[_tribe1],
+          priorityTargetOwnerFactionIdsSorted: <String>[kColonialPhaseTribe1],
         ),
         reason:
             'COLONIAL-lite naval focus surfaces tribe / minor owners '
@@ -576,25 +508,25 @@ void main() {
       // `priorityTargetOwnerFactionIdsSorted`. This pins the
       // "owner list mirrors actual destinations" contract so a
       // downstream orchestrator never sees a phantom target.
-      final game = _colonialLiteGame(
+      final game = buildColonialLiteNavalGame(
         newWorldProvinces: const [
           Province(
             id: 'newWorld|tribe1_a',
             regionId: 'newWorld',
-            ownerId: _tribe1,
+            ownerId: kColonialPhaseTribe1,
           ),
           Province(
             id: 'newWorld|tribe2_a',
             regionId: 'newWorld',
-            ownerId: _tribe2,
+            ownerId: kColonialPhaseTribe2,
           ),
         ],
         tribes: const [
-          Tribe(id: _tribe1, displayName: 'T1'),
-          Tribe(id: _tribe2, displayName: 'T2'),
+          Tribe(id: kColonialPhaseTribe1, displayName: 'T1'),
+          Tribe(id: kColonialPhaseTribe2, displayName: 'T2'),
         ],
       );
-      final snapshot = _colonialLiteSnapshot(
+      final snapshot = buildColonialLiteNavalSnapshot(
         // tribe2's province is NOT in the snapshot invadable list, so
         // tribe2 must NOT surface as a priority owner.
         invadableNw: const ['newWorld|tribe1_a'],
@@ -603,7 +535,7 @@ void main() {
         planColonialLiteNaval(game: game, snapshot: snapshot),
         const ColonialLiteNavalPlan(
           priorityNwProvinceIdsSorted: <String>['newWorld|tribe1_a'],
-          priorityTargetOwnerFactionIdsSorted: <String>[_tribe1],
+          priorityTargetOwnerFactionIdsSorted: <String>[kColonialPhaseTribe1],
         ),
         reason:
             'Only tribes / minors that actually contribute an NW invadable '
@@ -613,80 +545,84 @@ void main() {
       );
     });
 
-    test('owner list deduplicates across multiple provinces from same tribe',
-        () {
-      // Two provinces owned by `tribe1` must surface `tribe1` only once
-      // in `priorityTargetOwnerFactionIdsSorted`. The set-based owner
-      // collection in the planner is responsible for the dedup.
-      final game = _colonialLiteGame(
-        newWorldProvinces: const [
-          Province(
-            id: 'newWorld|tribe1_a',
-            regionId: 'newWorld',
-            ownerId: _tribe1,
-          ),
-          Province(
-            id: 'newWorld|tribe1_b',
-            regionId: 'newWorld',
-            ownerId: _tribe1,
-          ),
-          Province(
-            id: 'newWorld|tribe1_c',
-            regionId: 'newWorld',
-            ownerId: _tribe1,
-          ),
-        ],
-        tribes: const [Tribe(id: _tribe1, displayName: 'T1')],
-      );
-      final snapshot = _colonialLiteSnapshot(
-        invadableNw: const [
-          'newWorld|tribe1_a',
-          'newWorld|tribe1_b',
-          'newWorld|tribe1_c',
-        ],
-      );
-      expect(
-        planColonialLiteNaval(game: game, snapshot: snapshot),
-        const ColonialLiteNavalPlan(
-          priorityNwProvinceIdsSorted: <String>[
+    test(
+      'owner list deduplicates across multiple provinces from same tribe',
+      () {
+        // Two provinces owned by `tribe1` must surface `tribe1` only once
+        // in `priorityTargetOwnerFactionIdsSorted`. The set-based owner
+        // collection in the planner is responsible for the dedup.
+        final game = buildColonialLiteNavalGame(
+          newWorldProvinces: const [
+            Province(
+              id: 'newWorld|tribe1_a',
+              regionId: 'newWorld',
+              ownerId: kColonialPhaseTribe1,
+            ),
+            Province(
+              id: 'newWorld|tribe1_b',
+              regionId: 'newWorld',
+              ownerId: kColonialPhaseTribe1,
+            ),
+            Province(
+              id: 'newWorld|tribe1_c',
+              regionId: 'newWorld',
+              ownerId: kColonialPhaseTribe1,
+            ),
+          ],
+          tribes: const [Tribe(id: kColonialPhaseTribe1, displayName: 'T1')],
+        );
+        final snapshot = buildColonialLiteNavalSnapshot(
+          invadableNw: const [
             'newWorld|tribe1_a',
             'newWorld|tribe1_b',
             'newWorld|tribe1_c',
           ],
-          priorityTargetOwnerFactionIdsSorted: <String>[_tribe1],
-        ),
-        reason:
-            'Three provinces owned by tribe1 surface tribe1 only once in '
-            'priorityTargetOwnerFactionIdsSorted (set-based dedup).',
-      );
-    });
+        );
+        expect(
+          planColonialLiteNaval(game: game, snapshot: snapshot),
+          const ColonialLiteNavalPlan(
+            priorityNwProvinceIdsSorted: <String>[
+              'newWorld|tribe1_a',
+              'newWorld|tribe1_b',
+              'newWorld|tribe1_c',
+            ],
+            priorityTargetOwnerFactionIdsSorted: <String>[kColonialPhaseTribe1],
+          ),
+          reason:
+              'Three provinces owned by tribe1 surface tribe1 only once in '
+              'priorityTargetOwnerFactionIdsSorted (set-based dedup).',
+        );
+      },
+    );
 
     test('input order shuffled -> ascending sort recovers', () {
       // Defensive determinism pin: even if a future builder regression
       // delivers the invadable list reversed, the planner's trailing
       // `priorityProvinces.sort()` recovers ascending order.
-      final game = _colonialLiteGame(
+      final game = buildColonialLiteNavalGame(
         newWorldProvinces: const [
           Province(
             id: 'newWorld|tribe1_a',
             regionId: 'newWorld',
-            ownerId: _tribe1,
+            ownerId: kColonialPhaseTribe1,
           ),
           Province(
             id: 'newWorld|tribe1_b',
             regionId: 'newWorld',
-            ownerId: _tribe1,
+            ownerId: kColonialPhaseTribe1,
           ),
           Province(
             id: 'newWorld|minor1_a',
             regionId: 'newWorld',
-            ownerId: _minor1,
+            ownerId: kColonialPhaseMinor1,
           ),
         ],
-        tribes: const [Tribe(id: _tribe1, displayName: 'T1')],
-        minorNations: const [MinorNation(id: _minor1, displayName: 'M1')],
+        tribes: const [Tribe(id: kColonialPhaseTribe1, displayName: 'T1')],
+        minorNations: const [
+          MinorNation(id: kColonialPhaseMinor1, displayName: 'M1'),
+        ],
       );
-      final snapshot = _colonialLiteSnapshot(
+      final snapshot = buildColonialLiteNavalSnapshot(
         // Reversed input order.
         invadableNw: const [
           'newWorld|tribe1_b',
@@ -706,53 +642,50 @@ void main() {
       );
       expect(
         plan.priorityTargetOwnerFactionIdsSorted,
-        const <String>[_minor1, _tribe1],
+        const <String>[kColonialPhaseMinor1, kColonialPhaseTribe1],
         reason: 'Owner list also sorted ascending across the dedup set.',
       );
     });
 
-    test(
-      'ColonialLiteNavalPlan value equality + defaultPlan equals explicit '
-      'all-empty instance',
-      () {
-        // Value-class pin so orchestrator wiring tests (#2509 S5) can
-        // compare planner output against the shared defaultPlan OR a
-        // fresh `const ColonialLiteNavalPlan(...)` with matching list
-        // contents. List equality is content-based, not identity-based.
-        const planA = ColonialLiteNavalPlan(
-          priorityNwProvinceIdsSorted: <String>['newWorld|tribe1_a'],
-          priorityTargetOwnerFactionIdsSorted: <String>[_tribe1],
-        );
-        const planB = ColonialLiteNavalPlan(
-          priorityNwProvinceIdsSorted: <String>['newWorld|tribe1_a'],
-          priorityTargetOwnerFactionIdsSorted: <String>[_tribe1],
-        );
-        expect(planA, equals(planB));
-        expect(planA.hashCode, equals(planB.hashCode));
+    test('ColonialLiteNavalPlan value equality + defaultPlan equals explicit '
+        'all-empty instance', () {
+      // Value-class pin so orchestrator wiring tests (#2509 S5) can
+      // compare planner output against the shared defaultPlan OR a
+      // fresh `const ColonialLiteNavalPlan(...)` with matching list
+      // contents. List equality is content-based, not identity-based.
+      const planA = ColonialLiteNavalPlan(
+        priorityNwProvinceIdsSorted: <String>['newWorld|tribe1_a'],
+        priorityTargetOwnerFactionIdsSorted: <String>[kColonialPhaseTribe1],
+      );
+      const planB = ColonialLiteNavalPlan(
+        priorityNwProvinceIdsSorted: <String>['newWorld|tribe1_a'],
+        priorityTargetOwnerFactionIdsSorted: <String>[kColonialPhaseTribe1],
+      );
+      expect(planA, equals(planB));
+      expect(planA.hashCode, equals(planB.hashCode));
 
-        const explicitDefault = ColonialLiteNavalPlan(
-          priorityNwProvinceIdsSorted: <String>[],
-          priorityTargetOwnerFactionIdsSorted: <String>[],
-        );
-        expect(
-          ColonialLiteNavalPlan.defaultPlan,
-          equals(explicitDefault),
-          reason:
-              'defaultPlan compares equal to a fresh all-empty const '
-              'instance; orchestrator wiring tests can assert against '
-              'either form.',
-        );
+      const explicitDefault = ColonialLiteNavalPlan(
+        priorityNwProvinceIdsSorted: <String>[],
+        priorityTargetOwnerFactionIdsSorted: <String>[],
+      );
+      expect(
+        ColonialLiteNavalPlan.defaultPlan,
+        equals(explicitDefault),
+        reason:
+            'defaultPlan compares equal to a fresh all-empty const '
+            'instance; orchestrator wiring tests can assert against '
+            'either form.',
+      );
 
-        // toString smoke test for diagnostic output consistency.
-        expect(
-          planA.toString(),
-          equals(
-            'ColonialLiteNavalPlan('
-            'priorityNwProvinceIdsSorted: [newWorld|tribe1_a], '
-            'priorityTargetOwnerFactionIdsSorted: [tribe1])',
-          ),
-        );
-      },
-    );
+      // toString smoke test for diagnostic output consistency.
+      expect(
+        planA.toString(),
+        equals(
+          'ColonialLiteNavalPlan('
+          'priorityNwProvinceIdsSorted: [newWorld|tribe1_a], '
+          'priorityTargetOwnerFactionIdsSorted: [tribe1])',
+        ),
+      );
+    });
   });
 }

--- a/packages/colonizethis_ai/test/planning/colonial_phase_planner_colonial_lite_overtures_test.dart
+++ b/packages/colonizethis_ai/test/planning/colonial_phase_planner_colonial_lite_overtures_test.dart
@@ -76,76 +76,11 @@
 //      -> only fresh tribe + minor returned:** composite filter pin
 //      (GP filter + embassy filter + sort in one fixture).
 
-import 'package:colonizethis_ai/colonizethis_ai.dart';
 import 'package:colonizethis_ai/src/planning/colonial_phase_planner.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart';
 
-const String _gp1 = 'gp1';
-const String _gp2 = 'gp2';
-const String _tribe1 = 'tribe1';
-const String _tribe2 = 'tribe2';
-const String _tribe3 = 'tribe3';
-const String _minor1 = 'minor1';
-
-/// Game scaffold for COLONIAL-lite overture tests. Tribes, minors, and
-/// overture states are passed in so each test can shape diplomatic
-/// state. Old World and New World provinces are intentionally empty
-/// because the planner does not query province ownership directly -- it
-/// reads the visible-owner faction id lists from the snapshot and the
-/// embassy filter from `game.overtureStates`.
-Game _colonialLiteGame({
-  int turnNumber = 125,
-  List<Player> players = const [
-    Player(id: _gp1, displayName: 'GP1', isHuman: false),
-    Player(id: _gp2, displayName: 'GP2', isHuman: false),
-  ],
-  List<Tribe> tribes = const [],
-  List<MinorNation> minorNations = const [],
-  List<OvertureState> overtureStates = const [],
-}) {
-  return Game(
-    id: 'g-2509-colonial-lite-overtures-t$turnNumber',
-    worldState: WorldState(
-      turnState: TurnState(turnNumber: turnNumber, phase: TurnPhase.orders),
-      oldWorld: const RegionData(),
-      newWorld: const RegionData(),
-    ),
-    players: players,
-    tribes: tribes,
-    minorNations: minorNations,
-    overtureStates: overtureStates,
-  );
-}
-
-/// Snapshot tuned for COLONIAL-lite: own OW defaults to 9 (the
-/// COLONIAL-lite outer schedule -- "OW ≥9 and <10"). Tests shape the
-/// `adjacentNw` and `preferredColonial` candidate lists to exercise the
-/// union, GP filter, and embassy filter. The planner does not re-check
-/// the phase so the values are still consistent with COLONIAL-lite only
-/// so debugging traces stay coherent.
-AIWorldSnapshot _colonialLiteSnapshot({
-  List<String> adjacentNw = const [],
-  List<String> preferredColonial = const [],
-  int oldWorldProvincesOwned = 9,
-  String playerId = _gp1,
-}) {
-  return AIWorldSnapshot(
-    playerId: playerId,
-    threats: const ThreatSummary(),
-    opportunities: const OpportunitySummary(),
-    conquest: ConquestSummary(
-      oldWorldProvincesOwned: oldWorldProvincesOwned,
-      provincesToVictory: 31,
-    ),
-    colonial: ColonialSummary(
-      adjacentNewWorldOwnerFactionIdsSorted: adjacentNw,
-      preferredColonialTargetFactionIdsSorted: preferredColonial,
-    ),
-    economy: const EconomySummary(),
-    relations: const {},
-  );
-}
+import '../support/colonial_phase_planner_test_support.dart';
 
 void main() {
   group('planColonialLiteOvertures', () {
@@ -156,11 +91,15 @@ void main() {
       // A regression that always emitted the snapshot's candidate set
       // here would issue overtures for a player that does not exist
       // in the game roster.
-      final game = _colonialLiteGame(
-        players: const [Player(id: _gp2, displayName: 'GP2', isHuman: false)],
-        tribes: const [Tribe(id: _tribe1, displayName: 'T1')],
+      final game = buildColonialLiteOvertureGame(
+        players: const [
+          Player(id: kColonialPhaseGp2, displayName: 'GP2', isHuman: false),
+        ],
+        tribes: const [Tribe(id: kColonialPhaseTribe1, displayName: 'T1')],
       );
-      final snapshot = _colonialLiteSnapshot(adjacentNw: const [_tribe1]);
+      final snapshot = buildColonialLiteOvertureSnapshot(
+        adjacentNw: const [kColonialPhaseTribe1],
+      );
       expect(
         planColonialLiteOvertures(game: game, snapshot: snapshot),
         isEmpty,
@@ -176,8 +115,8 @@ void main() {
       // union has no candidates. The planner returns empty without
       // touching `game.overtureStates`. This pins the
       // "no visible NW tribe / minor owner" structural short-circuit.
-      final game = _colonialLiteGame();
-      final snapshot = _colonialLiteSnapshot();
+      final game = buildColonialLiteOvertureGame();
+      final snapshot = buildColonialLiteOvertureSnapshot();
       expect(
         planColonialLiteOvertures(game: game, snapshot: snapshot),
         isEmpty,
@@ -193,13 +132,15 @@ void main() {
       // establishOverture"). Adjacent NW owner = tribe1, no overture
       // state at all -> tribe1 returned. A regression that filtered
       // tribes structurally would surface here as empty.
-      final game = _colonialLiteGame(
-        tribes: const [Tribe(id: _tribe1, displayName: 'T1')],
+      final game = buildColonialLiteOvertureGame(
+        tribes: const [Tribe(id: kColonialPhaseTribe1, displayName: 'T1')],
       );
-      final snapshot = _colonialLiteSnapshot(adjacentNw: const [_tribe1]);
+      final snapshot = buildColonialLiteOvertureSnapshot(
+        adjacentNw: const [kColonialPhaseTribe1],
+      );
       expect(
         planColonialLiteOvertures(game: game, snapshot: snapshot),
-        const [_tribe1],
+        const [kColonialPhaseTribe1],
         reason:
             'Single adjacent tribe with no existing overture is the '
             'canonical "if no embassy yet, suggest establishOverture" '
@@ -212,15 +153,15 @@ void main() {
       // `preferredColonialTargetFactionIdsSorted` instead of
       // `adjacentNewWorldOwnerFactionIdsSorted`. Both lists feed the
       // union and behave identically.
-      final game = _colonialLiteGame(
-        tribes: const [Tribe(id: _tribe1, displayName: 'T1')],
+      final game = buildColonialLiteOvertureGame(
+        tribes: const [Tribe(id: kColonialPhaseTribe1, displayName: 'T1')],
       );
-      final snapshot = _colonialLiteSnapshot(
-        preferredColonial: const [_tribe1],
+      final snapshot = buildColonialLiteOvertureSnapshot(
+        preferredColonial: const [kColonialPhaseTribe1],
       );
       expect(
         planColonialLiteOvertures(game: game, snapshot: snapshot),
-        const [_tribe1],
+        const [kColonialPhaseTribe1],
         reason:
             'Preferred-colonial targets contribute candidates just like '
             'adjacent NW owners (both inputs feed the union).',
@@ -233,16 +174,16 @@ void main() {
       // single output entry. A regression that used a list concat
       // would emit `[tribe1, tribe1]` and the orchestrator would emit
       // a duplicate overture order.
-      final game = _colonialLiteGame(
-        tribes: const [Tribe(id: _tribe1, displayName: 'T1')],
+      final game = buildColonialLiteOvertureGame(
+        tribes: const [Tribe(id: kColonialPhaseTribe1, displayName: 'T1')],
       );
-      final snapshot = _colonialLiteSnapshot(
-        adjacentNw: const [_tribe1],
-        preferredColonial: const [_tribe1],
+      final snapshot = buildColonialLiteOvertureSnapshot(
+        adjacentNw: const [kColonialPhaseTribe1],
+        preferredColonial: const [kColonialPhaseTribe1],
       );
       expect(
         planColonialLiteOvertures(game: game, snapshot: snapshot),
-        const [_tribe1],
+        const [kColonialPhaseTribe1],
         reason:
             'tribe1 is present in both candidate lists; the set union '
             'must deduplicate so only one overture is suggested.',
@@ -253,21 +194,28 @@ void main() {
       // Pins the "Tiebreak: lowest factionId (deterministic)" rule
       // across the dedup union. tribe2 + tribe3 from adjacent,
       // tribe1 + minor1 from preferred -> all four sorted ascending.
-      final game = _colonialLiteGame(
+      final game = buildColonialLiteOvertureGame(
         tribes: const [
-          Tribe(id: _tribe1, displayName: 'T1'),
-          Tribe(id: _tribe2, displayName: 'T2'),
-          Tribe(id: _tribe3, displayName: 'T3'),
+          Tribe(id: kColonialPhaseTribe1, displayName: 'T1'),
+          Tribe(id: kColonialPhaseTribe2, displayName: 'T2'),
+          Tribe(id: kColonialPhaseTribe3, displayName: 'T3'),
         ],
-        minorNations: const [MinorNation(id: _minor1, displayName: 'M1')],
+        minorNations: const [
+          MinorNation(id: kColonialPhaseMinor1, displayName: 'M1'),
+        ],
       );
-      final snapshot = _colonialLiteSnapshot(
-        adjacentNw: const [_tribe2, _tribe3],
-        preferredColonial: const [_tribe1, _minor1],
+      final snapshot = buildColonialLiteOvertureSnapshot(
+        adjacentNw: const [kColonialPhaseTribe2, kColonialPhaseTribe3],
+        preferredColonial: const [kColonialPhaseTribe1, kColonialPhaseMinor1],
       );
       expect(
         planColonialLiteOvertures(game: game, snapshot: snapshot),
-        const [_minor1, _tribe1, _tribe2, _tribe3],
+        const [
+          kColonialPhaseMinor1,
+          kColonialPhaseTribe1,
+          kColonialPhaseTribe2,
+          kColonialPhaseTribe3,
+        ],
         reason:
             'Union across both candidate lists is sorted ascending '
             '(lowest factionId tiebreak from the spec).',
@@ -281,13 +229,15 @@ void main() {
       // implies GP-vs-GP wars are out of scope. A regression that
       // skipped the GP filter would emit `establishOverture(gp2)`
       // which the order engine then rejects.
-      final game = _colonialLiteGame(
-        tribes: const [Tribe(id: _tribe1, displayName: 'T1')],
+      final game = buildColonialLiteOvertureGame(
+        tribes: const [Tribe(id: kColonialPhaseTribe1, displayName: 'T1')],
       );
-      final snapshot = _colonialLiteSnapshot(adjacentNw: const [_gp2, _tribe1]);
+      final snapshot = buildColonialLiteOvertureSnapshot(
+        adjacentNw: const [kColonialPhaseGp2, kColonialPhaseTribe1],
+      );
       expect(
         planColonialLiteOvertures(game: game, snapshot: snapshot),
-        const [_tribe1],
+        const [kColonialPhaseTribe1],
         reason:
             'gp2 resolves via `game.playerById`; the GP filter drops it '
             'so only tribe1 is suggested.',
@@ -301,17 +251,19 @@ void main() {
       // filter excludes it. A regression that omitted the embassy
       // filter would re-issue the initial overture against an
       // already-embassied tribe.
-      final game = _colonialLiteGame(
-        tribes: const [Tribe(id: _tribe1, displayName: 'T1')],
+      final game = buildColonialLiteOvertureGame(
+        tribes: const [Tribe(id: kColonialPhaseTribe1, displayName: 'T1')],
         overtureStates: const [
           OvertureState(
-            gpId: _gp1,
-            targetId: _tribe1,
+            gpId: kColonialPhaseGp1,
+            targetId: kColonialPhaseTribe1,
             stage: OvertureStage.embassy,
           ),
         ],
       );
-      final snapshot = _colonialLiteSnapshot(adjacentNw: const [_tribe1]);
+      final snapshot = buildColonialLiteOvertureSnapshot(
+        adjacentNw: const [kColonialPhaseTribe1],
+      );
       expect(
         planColonialLiteOvertures(game: game, snapshot: snapshot),
         isEmpty,
@@ -324,17 +276,19 @@ void main() {
     test('tribe at nap stage -> excluded', () {
       // `OvertureState.hasEmbassy` returns true for `embassy`, `nap`,
       // and `joinEmpire`. Pin the `nap` branch explicitly.
-      final game = _colonialLiteGame(
-        tribes: const [Tribe(id: _tribe1, displayName: 'T1')],
+      final game = buildColonialLiteOvertureGame(
+        tribes: const [Tribe(id: kColonialPhaseTribe1, displayName: 'T1')],
         overtureStates: const [
           OvertureState(
-            gpId: _gp1,
-            targetId: _tribe1,
+            gpId: kColonialPhaseGp1,
+            targetId: kColonialPhaseTribe1,
             stage: OvertureStage.nap,
           ),
         ],
       );
-      final snapshot = _colonialLiteSnapshot(adjacentNw: const [_tribe1]);
+      final snapshot = buildColonialLiteOvertureSnapshot(
+        adjacentNw: const [kColonialPhaseTribe1],
+      );
       expect(
         planColonialLiteOvertures(game: game, snapshot: snapshot),
         isEmpty,
@@ -349,17 +303,19 @@ void main() {
       // absorbed into the empire chain, the planner stops emitting
       // initial overtures (acquisition is now driven by
       // `planColonialAcquisition`).
-      final game = _colonialLiteGame(
-        tribes: const [Tribe(id: _tribe1, displayName: 'T1')],
+      final game = buildColonialLiteOvertureGame(
+        tribes: const [Tribe(id: kColonialPhaseTribe1, displayName: 'T1')],
         overtureStates: const [
           OvertureState(
-            gpId: _gp1,
-            targetId: _tribe1,
+            gpId: kColonialPhaseGp1,
+            targetId: kColonialPhaseTribe1,
             stage: OvertureStage.joinEmpire,
           ),
         ],
       );
-      final snapshot = _colonialLiteSnapshot(adjacentNw: const [_tribe1]);
+      final snapshot = buildColonialLiteOvertureSnapshot(
+        adjacentNw: const [kColonialPhaseTribe1],
+      );
       expect(
         planColonialLiteOvertures(game: game, snapshot: snapshot),
         isEmpty,
@@ -374,20 +330,22 @@ void main() {
       // is treated as "no embassy yet" per `OvertureState.hasEmbassy`
       // returning false. Explicitly pin the case where an overture
       // record exists at stage=none (vs being absent entirely).
-      final game = _colonialLiteGame(
-        tribes: const [Tribe(id: _tribe1, displayName: 'T1')],
+      final game = buildColonialLiteOvertureGame(
+        tribes: const [Tribe(id: kColonialPhaseTribe1, displayName: 'T1')],
         overtureStates: const [
           OvertureState(
-            gpId: _gp1,
-            targetId: _tribe1,
+            gpId: kColonialPhaseGp1,
+            targetId: kColonialPhaseTribe1,
             stage: OvertureStage.none,
           ),
         ],
       );
-      final snapshot = _colonialLiteSnapshot(adjacentNw: const [_tribe1]);
+      final snapshot = buildColonialLiteOvertureSnapshot(
+        adjacentNw: const [kColonialPhaseTribe1],
+      );
       expect(
         planColonialLiteOvertures(game: game, snapshot: snapshot),
-        const [_tribe1],
+        const [kColonialPhaseTribe1],
         reason:
             'Stage=none carries `hasEmbassy=false`; the planner treats '
             'it as "no embassy yet" and suggests the initial overture.',
@@ -399,20 +357,22 @@ void main() {
       // `hasEmbassy=false`. The spec's "if no embassy yet" rule must
       // therefore include the tribe -- the initial overture is what
       // advances past the consulate stage anyway.
-      final game = _colonialLiteGame(
-        tribes: const [Tribe(id: _tribe1, displayName: 'T1')],
+      final game = buildColonialLiteOvertureGame(
+        tribes: const [Tribe(id: kColonialPhaseTribe1, displayName: 'T1')],
         overtureStates: const [
           OvertureState(
-            gpId: _gp1,
-            targetId: _tribe1,
+            gpId: kColonialPhaseGp1,
+            targetId: kColonialPhaseTribe1,
             stage: OvertureStage.tradeConsulate,
           ),
         ],
       );
-      final snapshot = _colonialLiteSnapshot(adjacentNw: const [_tribe1]);
+      final snapshot = buildColonialLiteOvertureSnapshot(
+        adjacentNw: const [kColonialPhaseTribe1],
+      );
       expect(
         planColonialLiteOvertures(game: game, snapshot: snapshot),
-        const [_tribe1],
+        const [kColonialPhaseTribe1],
         reason:
             'tradeConsulate stage still carries `hasEmbassy=false`; the '
             'planner must suggest the initial overture so the relation '
@@ -420,32 +380,37 @@ void main() {
       );
     });
 
-    test('sibling GP holds embassy with same target -> active NOT excluded', () {
-      // The embassy filter is keyed on the (gpId, targetId) pair, not
-      // just targetId. A sibling GP (gp2) holding an embassy with
-      // tribe1 must not block the active player (gp1) from
-      // initiating its own overture. A regression that filtered on
-      // targetId alone would silently de-prioritize tribe1 for every
-      // GP once any one GP advanced past the consulate stage.
-      final game = _colonialLiteGame(
-        tribes: const [Tribe(id: _tribe1, displayName: 'T1')],
-        overtureStates: const [
-          OvertureState(
-            gpId: _gp2,
-            targetId: _tribe1,
-            stage: OvertureStage.embassy,
-          ),
-        ],
-      );
-      final snapshot = _colonialLiteSnapshot(adjacentNw: const [_tribe1]);
-      expect(
-        planColonialLiteOvertures(game: game, snapshot: snapshot),
-        const [_tribe1],
-        reason:
-            'gp2 holds the embassy with tribe1; active player gp1 still '
-            'has no embassy of its own and must initiate an overture.',
-      );
-    });
+    test(
+      'sibling GP holds embassy with same target -> active NOT excluded',
+      () {
+        // The embassy filter is keyed on the (gpId, targetId) pair, not
+        // just targetId. A sibling GP (gp2) holding an embassy with
+        // tribe1 must not block the active player (gp1) from
+        // initiating its own overture. A regression that filtered on
+        // targetId alone would silently de-prioritize tribe1 for every
+        // GP once any one GP advanced past the consulate stage.
+        final game = buildColonialLiteOvertureGame(
+          tribes: const [Tribe(id: kColonialPhaseTribe1, displayName: 'T1')],
+          overtureStates: const [
+            OvertureState(
+              gpId: kColonialPhaseGp2,
+              targetId: kColonialPhaseTribe1,
+              stage: OvertureStage.embassy,
+            ),
+          ],
+        );
+        final snapshot = buildColonialLiteOvertureSnapshot(
+          adjacentNw: const [kColonialPhaseTribe1],
+        );
+        expect(
+          planColonialLiteOvertures(game: game, snapshot: snapshot),
+          const [kColonialPhaseTribe1],
+          reason:
+              'gp2 holds the embassy with tribe1; active player gp1 still '
+              'has no embassy of its own and must initiate an overture.',
+        );
+      },
+    );
 
     test('input order shuffled (adjacent reversed) -> ascending sort', () {
       // Determinism pin (Must-have #7). Inputs are supplied in
@@ -453,19 +418,27 @@ void main() {
       // ascending order. A regression that returned the iteration
       // order of the Set would surface here as a Dart-runtime-defined
       // order rather than the spec's lowest-factionId tiebreak.
-      final game = _colonialLiteGame(
+      final game = buildColonialLiteOvertureGame(
         tribes: const [
-          Tribe(id: _tribe1, displayName: 'T1'),
-          Tribe(id: _tribe2, displayName: 'T2'),
-          Tribe(id: _tribe3, displayName: 'T3'),
+          Tribe(id: kColonialPhaseTribe1, displayName: 'T1'),
+          Tribe(id: kColonialPhaseTribe2, displayName: 'T2'),
+          Tribe(id: kColonialPhaseTribe3, displayName: 'T3'),
         ],
       );
-      final snapshot = _colonialLiteSnapshot(
-        adjacentNw: const [_tribe3, _tribe2, _tribe1],
+      final snapshot = buildColonialLiteOvertureSnapshot(
+        adjacentNw: const [
+          kColonialPhaseTribe3,
+          kColonialPhaseTribe2,
+          kColonialPhaseTribe1,
+        ],
       );
       expect(
         planColonialLiteOvertures(game: game, snapshot: snapshot),
-        const [_tribe1, _tribe2, _tribe3],
+        const [
+          kColonialPhaseTribe1,
+          kColonialPhaseTribe2,
+          kColonialPhaseTribe3,
+        ],
         reason:
             'Trailing `result.sort()` enforces ascending order regardless '
             'of input order (Refs #2509 Must-have #7 / lowest-factionId '
@@ -473,75 +446,92 @@ void main() {
       );
     });
 
-    test('Refs #2509 Must-have #7 determinism: identical inputs -> identical list', () {
-      // Pins Must-have #7 (determinism) at the in-module level. The
-      // mixed-input fixture exercises the union, the GP filter, the
-      // embassy filter, and the sort in one pass; repeating the call
-      // must yield byte-identical lists.
-      final game = _colonialLiteGame(
-        players: const [
-          Player(id: _gp1, displayName: 'GP1', isHuman: false),
-          Player(id: _gp2, displayName: 'GP2', isHuman: false),
-        ],
-        tribes: const [
-          Tribe(id: _tribe1, displayName: 'T1'),
-          Tribe(id: _tribe2, displayName: 'T2'),
-        ],
-        minorNations: const [MinorNation(id: _minor1, displayName: 'M1')],
-        overtureStates: const [
-          OvertureState(
-            gpId: _gp1,
-            targetId: _tribe2,
-            stage: OvertureStage.embassy,
-          ),
-        ],
-      );
-      final snapshot = _colonialLiteSnapshot(
-        adjacentNw: const [_tribe2, _gp2],
-        preferredColonial: const [_tribe1, _minor1],
-      );
-      final first = planColonialLiteOvertures(game: game, snapshot: snapshot);
-      final second = planColonialLiteOvertures(game: game, snapshot: snapshot);
-      expect(second, first);
-    });
+    test(
+      'Refs #2509 Must-have #7 determinism: identical inputs -> identical list',
+      () {
+        // Pins Must-have #7 (determinism) at the in-module level. The
+        // mixed-input fixture exercises the union, the GP filter, the
+        // embassy filter, and the sort in one pass; repeating the call
+        // must yield byte-identical lists.
+        final game = buildColonialLiteOvertureGame(
+          players: const [
+            Player(id: kColonialPhaseGp1, displayName: 'GP1', isHuman: false),
+            Player(id: kColonialPhaseGp2, displayName: 'GP2', isHuman: false),
+          ],
+          tribes: const [
+            Tribe(id: kColonialPhaseTribe1, displayName: 'T1'),
+            Tribe(id: kColonialPhaseTribe2, displayName: 'T2'),
+          ],
+          minorNations: const [
+            MinorNation(id: kColonialPhaseMinor1, displayName: 'M1'),
+          ],
+          overtureStates: const [
+            OvertureState(
+              gpId: kColonialPhaseGp1,
+              targetId: kColonialPhaseTribe2,
+              stage: OvertureStage.embassy,
+            ),
+          ],
+        );
+        final snapshot = buildColonialLiteOvertureSnapshot(
+          adjacentNw: const [kColonialPhaseTribe2, kColonialPhaseGp2],
+          preferredColonial: const [kColonialPhaseTribe1, kColonialPhaseMinor1],
+        );
+        final first = planColonialLiteOvertures(game: game, snapshot: snapshot);
+        final second = planColonialLiteOvertures(
+          game: game,
+          snapshot: snapshot,
+        );
+        expect(second, first);
+      },
+    );
 
-    test('composite: GP + embassied tribe + fresh tribe + minor -> filtered sorted', () {
-      // Composite pin exercising all three filters (GP filter +
-      // embassy filter + sort) in one fixture. Inputs:
-      //   adjacent = [gp2, tribe2, tribe1]
-      //   preferred = [minor1, tribe2]
-      // Embassy state: gp1 -> tribe2 (stage=embassy).
-      // Expected:
-      //   - gp2 dropped by the GP filter
-      //   - tribe2 dropped by the embassy filter (gp1 already has
-      //     embassy)
-      //   - tribe1 + minor1 survive -> sorted ascending = [minor1,
-      //     tribe1]
-      final game = _colonialLiteGame(
-        tribes: const [
-          Tribe(id: _tribe1, displayName: 'T1'),
-          Tribe(id: _tribe2, displayName: 'T2'),
-        ],
-        minorNations: const [MinorNation(id: _minor1, displayName: 'M1')],
-        overtureStates: const [
-          OvertureState(
-            gpId: _gp1,
-            targetId: _tribe2,
-            stage: OvertureStage.embassy,
-          ),
-        ],
-      );
-      final snapshot = _colonialLiteSnapshot(
-        adjacentNw: const [_gp2, _tribe2, _tribe1],
-        preferredColonial: const [_minor1, _tribe2],
-      );
-      expect(
-        planColonialLiteOvertures(game: game, snapshot: snapshot),
-        const [_minor1, _tribe1],
-        reason:
-            'Composite filter: gp2 dropped (GP filter), tribe2 dropped '
-            '(embassy filter), tribe1 + minor1 sorted ascending.',
-      );
-    });
+    test(
+      'composite: GP + embassied tribe + fresh tribe + minor -> filtered sorted',
+      () {
+        // Composite pin exercising all three filters (GP filter +
+        // embassy filter + sort) in one fixture. Inputs:
+        //   adjacent = [gp2, tribe2, tribe1]
+        //   preferred = [minor1, tribe2]
+        // Embassy state: gp1 -> tribe2 (stage=embassy).
+        // Expected:
+        //   - gp2 dropped by the GP filter
+        //   - tribe2 dropped by the embassy filter (gp1 already has
+        //     embassy)
+        //   - tribe1 + minor1 survive -> sorted ascending = [minor1,
+        //     tribe1]
+        final game = buildColonialLiteOvertureGame(
+          tribes: const [
+            Tribe(id: kColonialPhaseTribe1, displayName: 'T1'),
+            Tribe(id: kColonialPhaseTribe2, displayName: 'T2'),
+          ],
+          minorNations: const [
+            MinorNation(id: kColonialPhaseMinor1, displayName: 'M1'),
+          ],
+          overtureStates: const [
+            OvertureState(
+              gpId: kColonialPhaseGp1,
+              targetId: kColonialPhaseTribe2,
+              stage: OvertureStage.embassy,
+            ),
+          ],
+        );
+        final snapshot = buildColonialLiteOvertureSnapshot(
+          adjacentNw: const [
+            kColonialPhaseGp2,
+            kColonialPhaseTribe2,
+            kColonialPhaseTribe1,
+          ],
+          preferredColonial: const [kColonialPhaseMinor1, kColonialPhaseTribe2],
+        );
+        expect(
+          planColonialLiteOvertures(game: game, snapshot: snapshot),
+          const [kColonialPhaseMinor1, kColonialPhaseTribe1],
+          reason:
+              'Composite filter: gp2 dropped (GP filter), tribe2 dropped '
+              '(embassy filter), tribe1 + minor1 sorted ascending.',
+        );
+      },
+    );
   });
 }

--- a/packages/colonizethis_ai/test/planning/colonial_phase_planner_test.dart
+++ b/packages/colonizethis_ai/test/planning/colonial_phase_planner_test.dart
@@ -27,7 +27,7 @@
 // blocker membership guard, the below-quota peer filter, and the
 // deterministic-sort contract). The tribe / minor "never peace" rule
 // is preserved structurally via the `game.playerById` filter; the
-// tests pin that behavior directly. The default `_colonialGame`
+// tests pin that behavior directly. The default `buildColonialPeaceGame`
 // helper puts every roster GP at the OW quota
 // (`kObserverConquestMinOwProvincesPerGp = 10`) so the at-quota tests
 // surface the canonical paths without accidental below-quota
@@ -86,124 +86,11 @@
 // the no-`phasePlan` fallback path through
 // `collectStalledGreatPowerPeaceTargets` covered.
 
-import 'package:colonizethis_ai/colonizethis_ai.dart';
 import 'package:colonizethis_ai/src/planning/colonial_phase_planner.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart';
 
-const String _gp1 = 'gp1';
-const String _gp2 = 'gp2';
-const String _gp3 = 'gp3';
-const String _gp4 = 'gp4';
-const String _tribe1 = 'tribe1';
-const String _minor1 = 'minor1';
-
-/// Minimum at-quota OW province count per GP. Matches
-/// `kObserverConquestMinOwProvincesPerGp = 10` (the COLONIAL phase entry
-/// floor) so the [planColonialPeace] below-quota peer exclusion arm
-/// (Refs #2509 § Must-have #5) does not surface in tests that intend
-/// to exercise the canonical at-quota peace paths.
-const int _kOwProvincesAtQuota = 10;
-
-/// Builds a deterministic list of [Province] entries owned by [ownerId]
-/// in the Old World region. Each province id is shaped
-/// `oldWorld|<ownerId>_<index>` so the synthetic fixtures stay
-/// human-readable in trace dumps and do not collide between players.
-List<Province> _owProvincesForOwner(
-  String ownerId, {
-  int count = _kOwProvincesAtQuota,
-}) {
-  return [
-    for (var i = 0; i < count; i++)
-      Province(
-        id: 'oldWorld|${ownerId}_$i',
-        regionId: 'oldWorld',
-        ownerId: ownerId,
-      ),
-  ];
-}
-
-/// Builds an OW province list putting every default-roster GP
-/// (`gp1`..`gp4`) at [_kOwProvincesAtQuota] OW provinces -- the floor
-/// the new COLONIAL `planColonialPeace` requires before a peer becomes
-/// peaceable. Tests that want to exercise the below-quota exclusion
-/// arm pass [perGpOwCounts] with at least one entry set below the
-/// quota.
-List<Province> _defaultOwQuotaProvinces({
-  Map<String, int> perGpOwCounts = const {},
-}) {
-  return [
-    for (final gp in const [_gp1, _gp2, _gp3, _gp4])
-      ..._owProvincesForOwner(
-        gp,
-        count: perGpOwCounts[gp] ?? _kOwProvincesAtQuota,
-      ),
-  ];
-}
-
-/// Game scaffold with a 4-GP roster + optional tribes / minors. New World
-/// provinces are passed in directly so each test can shape ownership for
-/// the blocker scan. Old World is populated by default so every roster
-/// GP sits at [_kOwProvincesAtQuota] OW provinces, satisfying the
-/// COLONIAL `planColonialPeace` at-quota peer requirement (Refs #2509
-/// § Must-have #5). Tests that intentionally cross the below-quota
-/// arm can override the OW count per GP via [perGpOwCounts] or pass a
-/// fully custom [oldWorldProvinces] list.
-Game _colonialGame({
-  int turnNumber = 130,
-  List<Province> newWorldProvinces = const [],
-  List<Province>? oldWorldProvinces,
-  Map<String, int> perGpOwCounts = const {},
-  List<Player> players = const [
-    Player(id: _gp1, displayName: 'GP1', isHuman: false),
-    Player(id: _gp2, displayName: 'GP2', isHuman: false),
-    Player(id: _gp3, displayName: 'GP3', isHuman: false),
-    Player(id: _gp4, displayName: 'GP4', isHuman: false),
-  ],
-  List<Tribe> tribes = const [],
-  List<MinorNation> minorNations = const [],
-}) {
-  return Game(
-    id: 'g-2509-colonial-phase-planner-peace-t$turnNumber',
-    worldState: WorldState(
-      turnState: TurnState(turnNumber: turnNumber, phase: TurnPhase.orders),
-      oldWorld: RegionData(
-        provinces:
-            oldWorldProvinces ??
-            _defaultOwQuotaProvinces(perGpOwCounts: perGpOwCounts),
-      ),
-      newWorld: RegionData(provinces: newWorldProvinces),
-    ),
-    players: players,
-    tribes: tribes,
-    minorNations: minorNations,
-  );
-}
-
-/// Snapshot tuned for COLONIAL: own OW defaults to 10 (at quota), no OW
-/// invadable, NW invadable list configurable per test so the blocker
-/// scan can produce the desired result. The planner does not re-check
-/// the phase so these tests do not need to satisfy
-/// `observerGoalPhaseFor`; the values are still consistent with
-/// COLONIAL so debugging traces stay coherent.
-AIWorldSnapshot _colonialSnapshot({
-  required List<String> atWarWith,
-  List<String> invadableNw = const [],
-  String playerId = _gp1,
-}) {
-  return AIWorldSnapshot(
-    playerId: playerId,
-    threats: ThreatSummary(atWarWith: atWarWith),
-    opportunities: const OpportunitySummary(),
-    conquest: const ConquestSummary(
-      oldWorldProvincesOwned: 10,
-      provincesToVictory: 31,
-    ),
-    colonial: ColonialSummary(invadableNewWorldProvinceIdsSorted: invadableNw),
-    economy: const EconomySummary(),
-    relations: const {},
-  );
-}
+import '../support/colonial_phase_planner_test_support.dart';
 
 void main() {
   group('planColonialPeace', () {
@@ -213,8 +100,8 @@ void main() {
       // that always emitted the at-peace GP roster here would emit
       // `offerPeace` toward neutral powers and break the "peace ALL
       // at-war GPs" wording (we have nothing to peace).
-      final game = _colonialGame();
-      final snapshot = _colonialSnapshot(atWarWith: const []);
+      final game = buildColonialPeaceGame();
+      final snapshot = buildColonialPeaceSnapshot(atWarWith: const []);
       expect(
         planColonialPeace(game: game, snapshot: snapshot),
         isEmpty,
@@ -234,11 +121,15 @@ void main() {
       // regression that left tribe/minor ids in the output would emit
       // `offerPeace` toward non-GP factions and prematurely end the
       // ongoing tribe / minor conquest required for NW acquisition.
-      final game = _colonialGame(
-        tribes: const [Tribe(id: _tribe1, displayName: 'T1')],
-        minorNations: const [MinorNation(id: _minor1, displayName: 'M1')],
+      final game = buildColonialPeaceGame(
+        tribes: const [Tribe(id: kColonialPhaseTribe1, displayName: 'T1')],
+        minorNations: const [
+          MinorNation(id: kColonialPhaseMinor1, displayName: 'M1'),
+        ],
       );
-      final snapshot = _colonialSnapshot(atWarWith: const [_tribe1, _minor1]);
+      final snapshot = buildColonialPeaceSnapshot(
+        atWarWith: const [kColonialPhaseTribe1, kColonialPhaseMinor1],
+      );
       expect(
         planColonialPeace(game: game, snapshot: snapshot),
         isEmpty,
@@ -255,11 +146,13 @@ void main() {
       // peaced (sorted ascending). Input order shuffled to `[gp3, gp2]`
       // so a regression that dropped the trailing `..sort()` would
       // surface here.
-      final game = _colonialGame();
-      final snapshot = _colonialSnapshot(atWarWith: const [_gp3, _gp2]);
+      final game = buildColonialPeaceGame();
+      final snapshot = buildColonialPeaceSnapshot(
+        atWarWith: const [kColonialPhaseGp3, kColonialPhaseGp2],
+      );
       expect(
         planColonialPeace(game: game, snapshot: snapshot),
-        const [_gp2, _gp3],
+        const [kColonialPhaseGp2, kColonialPhaseGp3],
         reason:
             'Null blocker -> "Peace ALL at-war Great Powers" with no '
             'exception. Returned list is ascending-sorted regardless of '
@@ -274,19 +167,27 @@ void main() {
       // must be peaced. A regression that filtered by blocker without
       // the membership guard would silently leave a non-blocker GP
       // war open while peacing the others.
-      final game = _colonialGame(
+      final game = buildColonialPeaceGame(
         newWorldProvinces: const [
-          Province(id: 'newWorld|gp4_a', regionId: 'newWorld', ownerId: _gp4),
-          Province(id: 'newWorld|gp4_b', regionId: 'newWorld', ownerId: _gp4),
+          Province(
+            id: 'newWorld|gp4_a',
+            regionId: 'newWorld',
+            ownerId: kColonialPhaseGp4,
+          ),
+          Province(
+            id: 'newWorld|gp4_b',
+            regionId: 'newWorld',
+            ownerId: kColonialPhaseGp4,
+          ),
         ],
       );
-      final snapshot = _colonialSnapshot(
-        atWarWith: const [_gp2, _gp3],
+      final snapshot = buildColonialPeaceSnapshot(
+        atWarWith: const [kColonialPhaseGp2, kColonialPhaseGp3],
         invadableNw: const ['newWorld|gp4_a', 'newWorld|gp4_b'],
       );
       expect(
         planColonialPeace(game: game, snapshot: snapshot),
-        const [_gp2, _gp3],
+        const [kColonialPhaseGp2, kColonialPhaseGp3],
         reason:
             'Blocker is gp4 (owns the invadable NW) but gp4 is not in '
             '`gpWars` -- peace ALL live war fronts (the membership guard '
@@ -298,19 +199,31 @@ void main() {
       // Canonical COLONIAL happy path: gp2 owns the invadable NW
       // (blocker), gp3 + gp4 are non-blocker fronts -> peace gp3 and
       // gp4 sorted ascending; keep fighting gp2.
-      final game = _colonialGame(
+      final game = buildColonialPeaceGame(
         newWorldProvinces: const [
-          Province(id: 'newWorld|gp2_a', regionId: 'newWorld', ownerId: _gp2),
-          Province(id: 'newWorld|gp2_b', regionId: 'newWorld', ownerId: _gp2),
+          Province(
+            id: 'newWorld|gp2_a',
+            regionId: 'newWorld',
+            ownerId: kColonialPhaseGp2,
+          ),
+          Province(
+            id: 'newWorld|gp2_b',
+            regionId: 'newWorld',
+            ownerId: kColonialPhaseGp2,
+          ),
         ],
       );
-      final snapshot = _colonialSnapshot(
-        atWarWith: const [_gp2, _gp3, _gp4],
+      final snapshot = buildColonialPeaceSnapshot(
+        atWarWith: const [
+          kColonialPhaseGp2,
+          kColonialPhaseGp3,
+          kColonialPhaseGp4,
+        ],
         invadableNw: const ['newWorld|gp2_a', 'newWorld|gp2_b'],
       );
       expect(
         planColonialPeace(game: game, snapshot: snapshot),
-        const [_gp3, _gp4],
+        const [kColonialPhaseGp3, kColonialPhaseGp4],
         reason:
             'Blocker gp2 is preserved (keep fighting the colonial NW '
             'blocker); non-blocker GPs gp3 + gp4 are peaced in '
@@ -325,13 +238,17 @@ void main() {
       // because the only candidate equals the blocker. A regression
       // that emitted `[gp2]` here would prematurely peace the
       // colonial blocker and stall NW acquisition.
-      final game = _colonialGame(
+      final game = buildColonialPeaceGame(
         newWorldProvinces: const [
-          Province(id: 'newWorld|gp2_a', regionId: 'newWorld', ownerId: _gp2),
+          Province(
+            id: 'newWorld|gp2_a',
+            regionId: 'newWorld',
+            ownerId: kColonialPhaseGp2,
+          ),
         ],
       );
-      final snapshot = _colonialSnapshot(
-        atWarWith: const [_gp2],
+      final snapshot = buildColonialPeaceSnapshot(
+        atWarWith: const [kColonialPhaseGp2],
         invadableNw: const ['newWorld|gp2_a'],
       );
       expect(
@@ -353,18 +270,22 @@ void main() {
       // `gpWars.length <= 1 → const []`: the new spec says "Peace
       // all at-war Great Powers" without a length guard, so a lone
       // non-blocker war must still be peaced.
-      final game = _colonialGame(
+      final game = buildColonialPeaceGame(
         newWorldProvinces: const [
-          Province(id: 'newWorld|gp4_a', regionId: 'newWorld', ownerId: _gp4),
+          Province(
+            id: 'newWorld|gp4_a',
+            regionId: 'newWorld',
+            ownerId: kColonialPhaseGp4,
+          ),
         ],
       );
-      final snapshot = _colonialSnapshot(
-        atWarWith: const [_gp3],
+      final snapshot = buildColonialPeaceSnapshot(
+        atWarWith: const [kColonialPhaseGp3],
         invadableNw: const ['newWorld|gp4_a'],
       );
       expect(
         planColonialPeace(game: game, snapshot: snapshot),
-        const [_gp3],
+        const [kColonialPhaseGp3],
         reason:
             'Sole non-blocker GP front -- new spec "Peace all" arm '
             'fires regardless of `gpWars.length`. The single GP is '
@@ -378,18 +299,26 @@ void main() {
       // with gp2 as blocker -> peace gp3 + gp4 in ascending order
       // regardless of input order. A regression that returned the
       // input order would surface here as `[gp4, gp3]`.
-      final game = _colonialGame(
+      final game = buildColonialPeaceGame(
         newWorldProvinces: const [
-          Province(id: 'newWorld|gp2_a', regionId: 'newWorld', ownerId: _gp2),
+          Province(
+            id: 'newWorld|gp2_a',
+            regionId: 'newWorld',
+            ownerId: kColonialPhaseGp2,
+          ),
         ],
       );
-      final snapshot = _colonialSnapshot(
-        atWarWith: const [_gp4, _gp3, _gp2],
+      final snapshot = buildColonialPeaceSnapshot(
+        atWarWith: const [
+          kColonialPhaseGp4,
+          kColonialPhaseGp3,
+          kColonialPhaseGp2,
+        ],
         invadableNw: const ['newWorld|gp2_a'],
       );
       expect(
         planColonialPeace(game: game, snapshot: snapshot),
-        const [_gp3, _gp4],
+        const [kColonialPhaseGp3, kColonialPhaseGp4],
         reason:
             'Trailing `..sort()` restores ascending order regardless of '
             'input order (Refs #2509 Must-have #7).',
@@ -405,20 +334,32 @@ void main() {
         // blocker (gp2). Input order `[gp4, tribe1, gp3, minor1, gp2]`
         // exercises the GP filter, the blocker scan, and the trailing
         // sort all together.
-        final game = _colonialGame(
+        final game = buildColonialPeaceGame(
           newWorldProvinces: const [
-            Province(id: 'newWorld|gp2_a', regionId: 'newWorld', ownerId: _gp2),
+            Province(
+              id: 'newWorld|gp2_a',
+              regionId: 'newWorld',
+              ownerId: kColonialPhaseGp2,
+            ),
           ],
-          tribes: const [Tribe(id: _tribe1, displayName: 'T1')],
-          minorNations: const [MinorNation(id: _minor1, displayName: 'M1')],
+          tribes: const [Tribe(id: kColonialPhaseTribe1, displayName: 'T1')],
+          minorNations: const [
+            MinorNation(id: kColonialPhaseMinor1, displayName: 'M1'),
+          ],
         );
-        final snapshot = _colonialSnapshot(
-          atWarWith: const [_gp4, _tribe1, _gp3, _minor1, _gp2],
+        final snapshot = buildColonialPeaceSnapshot(
+          atWarWith: const [
+            kColonialPhaseGp4,
+            kColonialPhaseTribe1,
+            kColonialPhaseGp3,
+            kColonialPhaseMinor1,
+            kColonialPhaseGp2,
+          ],
           invadableNw: const ['newWorld|gp2_a'],
         );
         expect(
           planColonialPeace(game: game, snapshot: snapshot),
-          const [_gp3, _gp4],
+          const [kColonialPhaseGp3, kColonialPhaseGp4],
           reason:
               'Non-GP factions filtered out via `game.playerById`; '
               'blocker (gp2) excluded; remaining GP fronts (gp3, gp4) '
@@ -432,15 +373,27 @@ void main() {
       // mixed-input fixture exercises the GP filter, the blocker
       // scan, and the sort in one pass; repeating the call must
       // yield byte-identical lists.
-      final game = _colonialGame(
+      final game = buildColonialPeaceGame(
         newWorldProvinces: const [
-          Province(id: 'newWorld|gp2_a', regionId: 'newWorld', ownerId: _gp2),
+          Province(
+            id: 'newWorld|gp2_a',
+            regionId: 'newWorld',
+            ownerId: kColonialPhaseGp2,
+          ),
         ],
-        tribes: const [Tribe(id: _tribe1, displayName: 'T1')],
-        minorNations: const [MinorNation(id: _minor1, displayName: 'M1')],
+        tribes: const [Tribe(id: kColonialPhaseTribe1, displayName: 'T1')],
+        minorNations: const [
+          MinorNation(id: kColonialPhaseMinor1, displayName: 'M1'),
+        ],
       );
-      final snapshot = _colonialSnapshot(
-        atWarWith: const [_gp4, _tribe1, _gp3, _minor1, _gp2],
+      final snapshot = buildColonialPeaceSnapshot(
+        atWarWith: const [
+          kColonialPhaseGp4,
+          kColonialPhaseTribe1,
+          kColonialPhaseGp3,
+          kColonialPhaseMinor1,
+          kColonialPhaseGp2,
+        ],
         invadableNw: const ['newWorld|gp2_a'],
       );
       final first = planColonialPeace(game: game, snapshot: snapshot);
@@ -460,8 +413,12 @@ void main() {
         // still in EXPAND, otherwise `war_resolver.dart`'s one-sided
         // GP peace conditions would end gp3's only OW frontier-blocker
         // war on a single offerer.
-        final game = _colonialGame(perGpOwCounts: const {_gp3: 7});
-        final snapshot = _colonialSnapshot(atWarWith: const [_gp3]);
+        final game = buildColonialPeaceGame(
+          perGpOwCounts: const {kColonialPhaseGp3: 7},
+        );
+        final snapshot = buildColonialPeaceSnapshot(
+          atWarWith: const [kColonialPhaseGp3],
+        );
         expect(
           planColonialPeace(game: game, snapshot: snapshot),
           isEmpty,
@@ -484,11 +441,19 @@ void main() {
         // dropped by the below-quota exclusion arm. Pins that the
         // exclusion is per-GP and does not short-circuit the whole
         // list.
-        final game = _colonialGame(perGpOwCounts: const {_gp3: 8});
-        final snapshot = _colonialSnapshot(atWarWith: const [_gp4, _gp3, _gp2]);
+        final game = buildColonialPeaceGame(
+          perGpOwCounts: const {kColonialPhaseGp3: 8},
+        );
+        final snapshot = buildColonialPeaceSnapshot(
+          atWarWith: const [
+            kColonialPhaseGp4,
+            kColonialPhaseGp3,
+            kColonialPhaseGp2,
+          ],
+        );
         expect(
           planColonialPeace(game: game, snapshot: snapshot),
-          const [_gp2, _gp4],
+          const [kColonialPhaseGp2, kColonialPhaseGp4],
           reason:
               'Below-quota peer gp3 dropped (OW = 8 < quota = 10); at-quota '
               'peers gp2 + gp4 peaced in ascending sort (Refs #2509 § '
@@ -507,19 +472,27 @@ void main() {
         // (gp3, gp4) are returned sorted ascending. Pins that the
         // composed filter does not double-drop or accidentally
         // surface gp2 via either arm.
-        final game = _colonialGame(
-          perGpOwCounts: const {_gp2: 6},
+        final game = buildColonialPeaceGame(
+          perGpOwCounts: const {kColonialPhaseGp2: 6},
           newWorldProvinces: const [
-            Province(id: 'newWorld|gp2_a', regionId: 'newWorld', ownerId: _gp2),
+            Province(
+              id: 'newWorld|gp2_a',
+              regionId: 'newWorld',
+              ownerId: kColonialPhaseGp2,
+            ),
           ],
         );
-        final snapshot = _colonialSnapshot(
-          atWarWith: const [_gp4, _gp3, _gp2],
+        final snapshot = buildColonialPeaceSnapshot(
+          atWarWith: const [
+            kColonialPhaseGp4,
+            kColonialPhaseGp3,
+            kColonialPhaseGp2,
+          ],
           invadableNw: const ['newWorld|gp2_a'],
         );
         expect(
           planColonialPeace(game: game, snapshot: snapshot),
-          const [_gp3, _gp4],
+          const [kColonialPhaseGp3, kColonialPhaseGp4],
           reason:
               'gp2 is both the colonial NW blocker and a below-quota peer; '
               'either exclusion arm drops it. Remaining at-quota peers '

--- a/packages/colonizethis_ai/test/support/colonial_phase_planner_test_support.dart
+++ b/packages/colonizethis_ai/test/support/colonial_phase_planner_test_support.dart
@@ -1,15 +1,16 @@
-/// Shared fixtures for COLONIAL military / naval unit pins (Refs #3967).
+/// Shared fixtures for COLONIAL military / naval / lite / civilian / peace
+/// unit pins (Refs #3967 / #3972).
 ///
 /// Owns faction id constants, [buildColonialPhaseGame],
-/// [buildColonialPhaseSnapshot], [kNwTreasuryRecoveryOverridePlan], and
-/// [buildLockRecoveryBelowQuotaSnapshot] so
-/// `colonial_phase_planner_military_test.dart` /
-/// `colonial_phase_planner_naval_test.dart` keep only planner-specific
-/// assertions.
+/// [buildColonialPhaseSnapshot], lite / civilian / peace helpers,
+/// [kNwTreasuryRecoveryOverridePlan], and
+/// [buildLockRecoveryBelowQuotaSnapshot] so planner `*_test.dart` files
+/// keep only planner-specific assertions.
 library;
 
 import 'package:colonizethis_ai/colonizethis_ai.dart';
 import 'package:colonizethis_ai/src/planning/expand_phase_planner.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 export 'package:colonizethis_ai/src/planning/expand_phase_planner.dart'
@@ -24,17 +25,28 @@ const String kColonialPhaseGp2 = 'gp2';
 /// Third GP id for multi-owner / isolation pins.
 const String kColonialPhaseGp3 = 'gp3';
 
+/// Fourth GP id for COLONIAL peace multi-peer pins.
+const String kColonialPhaseGp4 = 'gp4';
+
 /// Default tribe id for NW invasion-target pins.
 const String kColonialPhaseTribe1 = 'tribe1';
 
 /// Second tribe id for multi-tribe at-war pins.
 const String kColonialPhaseTribe2 = 'tribe2';
 
+/// Third tribe id for COLONIAL-lite overture union pins.
+const String kColonialPhaseTribe3 = 'tribe3';
+
 /// Default minor-nation id for mixed-owner pins.
 const String kColonialPhaseMinor1 = 'minor1';
 
 /// Canonical NW province id used by Path E lock-recovery waiver pins.
 const String kColonialPhaseNwProvTribeA = 'newWorld|tribe1_a';
+
+/// Minimum at-quota OW province count per GP for COLONIAL peace pins.
+///
+/// Matches `kObserverConquestMinOwProvincesPerGp = 10`.
+const int kColonialPeaceOwProvincesAtQuota = 10;
 
 /// Expand-economy override that arms NW treasury-recovery Path E.
 const ExpandEconomyPlan kNwTreasuryRecoveryOverridePlan = ExpandEconomyPlan(
@@ -64,43 +76,81 @@ const List<Player> kColonialPhaseDefaultPlayers = <Player>[
   ),
 ];
 
-/// Game scaffold for COLONIAL-phase military / naval destination-filter pins.
+/// Three-GP roster without treasury overrides (COLONIAL-lite naval pins).
+const List<Player> kColonialLiteNavalDefaultPlayers = <Player>[
+  Player(id: kColonialPhaseGp1, displayName: 'GP1', isHuman: false),
+  Player(id: kColonialPhaseGp2, displayName: 'GP2', isHuman: false),
+  Player(id: kColonialPhaseGp3, displayName: 'GP3', isHuman: false),
+];
+
+/// Two-GP roster for COLONIAL-lite overture pins.
+const List<Player> kColonialLiteOvertureDefaultPlayers = <Player>[
+  Player(id: kColonialPhaseGp1, displayName: 'GP1', isHuman: false),
+  Player(id: kColonialPhaseGp2, displayName: 'GP2', isHuman: false),
+];
+
+/// Two-GP roster for COLONIAL civilian pins.
+const List<Player> kColonialCivilianDefaultPlayers = <Player>[
+  Player(id: kColonialPhaseGp1, displayName: 'GP1', isHuman: false),
+  Player(id: kColonialPhaseGp2, displayName: 'GP2', isHuman: false),
+];
+
+/// Four-GP roster for COLONIAL peace pins.
+const List<Player> kColonialPeaceDefaultPlayers = <Player>[
+  Player(id: kColonialPhaseGp1, displayName: 'GP1', isHuman: false),
+  Player(id: kColonialPhaseGp2, displayName: 'GP2', isHuman: false),
+  Player(id: kColonialPhaseGp3, displayName: 'GP3', isHuman: false),
+  Player(id: kColonialPhaseGp4, displayName: 'GP4', isHuman: false),
+];
+
+/// Game scaffold for COLONIAL-phase / lite destination-filter pins.
 ///
 /// New World provinces, players, tribes, and minors are passed in so each
 /// test can shape ownership independently. Old World defaults to empty
-/// because the planners do not query OW state for the destination filter
+/// because most planners do not query OW state for the destination filter
 /// (the OW summary is read only for the outer quota gate).
 Game buildColonialPhaseGame({
   int turnNumber = 130,
   List<Province> newWorldProvinces = const [],
   List<Province> oldWorldProvinces = const [],
+  List<Unit> oldWorldUnits = const [],
+  List<Unit> newWorldUnits = const [],
+  Map<String, String> resourceByTileKey = const {},
+  TileMapState tileState = const TileMapState(),
   List<Player> players = kColonialPhaseDefaultPlayers,
   List<Tribe> tribes = const [],
   List<MinorNation> minorNations = const [],
+  List<OvertureState> overtureStates = const [],
   String gameIdPrefix = 'g-2509-colonial-phase-planner',
+  String? gameId,
 }) {
   return Game(
-    id: '$gameIdPrefix-t$turnNumber',
+    id: gameId ?? '$gameIdPrefix-t$turnNumber',
     worldState: WorldState(
       turnState: TurnState(turnNumber: turnNumber, phase: TurnPhase.orders),
-      oldWorld: RegionData(provinces: oldWorldProvinces),
-      newWorld: RegionData(provinces: newWorldProvinces),
+      oldWorld: RegionData(provinces: oldWorldProvinces, units: oldWorldUnits),
+      newWorld: RegionData(provinces: newWorldProvinces, units: newWorldUnits),
+      resourceByTileKey: resourceByTileKey,
+      tileState: tileState,
     ),
     players: players,
     tribes: tribes,
     minorNations: minorNations,
+    overtureStates: overtureStates,
   );
 }
 
-/// Snapshot tuned for COLONIAL: own OW defaults to 10 (at quota).
+/// Snapshot tuned for COLONIAL / COLONIAL-lite destination pins.
 ///
-/// Tests shape `atWarWith`, `invadableNw`, `invadableOw`, and
-/// `oldWorldProvincesOwned` to exercise specific priority arms and the
-/// structural OW suppression.
+/// Own OW defaults to 10 (at quota). Tests shape `atWarWith`,
+/// `invadableNw`, `invadableOw`, adjacent / preferred colonial lists,
+/// and `oldWorldProvincesOwned` to exercise specific priority arms.
 AIWorldSnapshot buildColonialPhaseSnapshot({
-  required List<String> atWarWith,
+  List<String> atWarWith = const [],
   List<String> invadableNw = const [],
   List<String> invadableOw = const [],
+  List<String> adjacentNw = const [],
+  List<String> preferredColonial = const [],
   int oldWorldProvincesOwned = 10,
   String playerId = kColonialPhaseGp1,
 }) {
@@ -113,7 +163,11 @@ AIWorldSnapshot buildColonialPhaseSnapshot({
       provincesToVictory: 31,
       invadableProvinceIdsSorted: invadableOw,
     ),
-    colonial: ColonialSummary(invadableNewWorldProvinceIdsSorted: invadableNw),
+    colonial: ColonialSummary(
+      invadableNewWorldProvinceIdsSorted: invadableNw,
+      adjacentNewWorldOwnerFactionIdsSorted: adjacentNw,
+      preferredColonialTargetFactionIdsSorted: preferredColonial,
+    ),
     economy: const EconomySummary(),
     relations: const {},
   );
@@ -138,5 +192,185 @@ AIWorldSnapshot buildLockRecoveryBelowQuotaSnapshot({
     ),
     economy: const EconomySummary(treasury: 0),
     relations: const {},
+  );
+}
+
+/// COLONIAL-lite naval Game scaffold (turn 125, three-GP roster).
+Game buildColonialLiteNavalGame({
+  int turnNumber = 125,
+  List<Province> newWorldProvinces = const [],
+  List<Province> oldWorldProvinces = const [],
+  List<Player> players = kColonialLiteNavalDefaultPlayers,
+  List<Tribe> tribes = const [],
+  List<MinorNation> minorNations = const [],
+}) {
+  return buildColonialPhaseGame(
+    turnNumber: turnNumber,
+    newWorldProvinces: newWorldProvinces,
+    oldWorldProvinces: oldWorldProvinces,
+    players: players,
+    tribes: tribes,
+    minorNations: minorNations,
+    gameIdPrefix: 'g-2509-colonial-lite-naval',
+  );
+}
+
+/// COLONIAL-lite naval snapshot (OW owned defaults to 9).
+AIWorldSnapshot buildColonialLiteNavalSnapshot({
+  List<String> invadableNw = const [],
+  List<String> invadableOw = const [],
+  List<String> atWarWith = const [],
+  int oldWorldProvincesOwned = 9,
+  String playerId = kColonialPhaseGp1,
+}) {
+  return buildColonialPhaseSnapshot(
+    atWarWith: atWarWith,
+    invadableNw: invadableNw,
+    invadableOw: invadableOw,
+    oldWorldProvincesOwned: oldWorldProvincesOwned,
+    playerId: playerId,
+  );
+}
+
+/// COLONIAL-lite overture Game scaffold (empty regions + overture rows).
+Game buildColonialLiteOvertureGame({
+  int turnNumber = 125,
+  List<Player> players = kColonialLiteOvertureDefaultPlayers,
+  List<Tribe> tribes = const [],
+  List<MinorNation> minorNations = const [],
+  List<OvertureState> overtureStates = const [],
+}) {
+  return buildColonialPhaseGame(
+    turnNumber: turnNumber,
+    players: players,
+    tribes: tribes,
+    minorNations: minorNations,
+    overtureStates: overtureStates,
+    gameIdPrefix: 'g-2509-colonial-lite-overtures',
+  );
+}
+
+/// COLONIAL-lite overture snapshot (OW owned defaults to 9).
+AIWorldSnapshot buildColonialLiteOvertureSnapshot({
+  List<String> adjacentNw = const [],
+  List<String> preferredColonial = const [],
+  int oldWorldProvincesOwned = 9,
+  String playerId = kColonialPhaseGp1,
+}) {
+  return buildColonialPhaseSnapshot(
+    adjacentNw: adjacentNw,
+    preferredColonial: preferredColonial,
+    oldWorldProvincesOwned: oldWorldProvincesOwned,
+    playerId: playerId,
+  );
+}
+
+/// COLONIAL civilian Game scaffold (provinces + units + tile resources).
+Game buildColonialCivilianGame({
+  required List<Province> provinces,
+  required List<Unit> owUnits,
+  List<Unit> nwUnits = const [],
+  Map<String, String> resourceByTileKey = const {},
+  TileMapState tileState = const TileMapState(),
+  List<Player> players = kColonialCivilianDefaultPlayers,
+}) {
+  final byRegion = <String, List<Province>>{};
+  for (final province in provinces) {
+    byRegion.putIfAbsent(province.regionId, () => <Province>[]).add(province);
+  }
+  return buildColonialPhaseGame(
+    turnNumber: 132,
+    oldWorldProvinces: byRegion[kOldWorldRegionId] ?? const [],
+    newWorldProvinces: byRegion[kNewWorldRegionId] ?? const [],
+    oldWorldUnits: owUnits,
+    newWorldUnits: nwUnits,
+    resourceByTileKey: resourceByTileKey,
+    tileState: tileState,
+    players: players,
+    gameId: 'g-2509-colonial-phase-planner-civilian',
+  );
+}
+
+/// Minimal snapshot for COLONIAL civilian in-module pins.
+AIWorldSnapshot buildColonialCivilianSnapshot({
+  String playerId = kColonialPhaseGp1,
+}) {
+  return AIWorldSnapshot(
+    playerId: playerId,
+    threats: const ThreatSummary(atWarWith: []),
+    opportunities: const OpportunitySummary(),
+    conquest: const ConquestSummary(),
+    colonial: const ColonialSummary(),
+    economy: const EconomySummary(),
+    relations: const {},
+  );
+}
+
+/// Builds OW provinces owned by [ownerId] for COLONIAL peace quota pins.
+List<Province> buildColonialPeaceOwProvincesForOwner(
+  String ownerId, {
+  int count = kColonialPeaceOwProvincesAtQuota,
+}) {
+  return [
+    for (var i = 0; i < count; i++)
+      Province(
+        id: 'oldWorld|${ownerId}_$i',
+        regionId: 'oldWorld',
+        ownerId: ownerId,
+      ),
+  ];
+}
+
+/// Default OW quota provinces for the four-GP COLONIAL peace roster.
+List<Province> buildColonialPeaceDefaultOwQuotaProvinces({
+  Map<String, int> perGpOwCounts = const {},
+}) {
+  return [
+    for (final gp in const [
+      kColonialPhaseGp1,
+      kColonialPhaseGp2,
+      kColonialPhaseGp3,
+      kColonialPhaseGp4,
+    ])
+      ...buildColonialPeaceOwProvincesForOwner(
+        gp,
+        count: perGpOwCounts[gp] ?? kColonialPeaceOwProvincesAtQuota,
+      ),
+  ];
+}
+
+/// COLONIAL peace Game scaffold (four-GP roster at OW quota by default).
+Game buildColonialPeaceGame({
+  int turnNumber = 130,
+  List<Province> newWorldProvinces = const [],
+  List<Province>? oldWorldProvinces,
+  Map<String, int> perGpOwCounts = const {},
+  List<Player> players = kColonialPeaceDefaultPlayers,
+  List<Tribe> tribes = const [],
+  List<MinorNation> minorNations = const [],
+}) {
+  return buildColonialPhaseGame(
+    turnNumber: turnNumber,
+    newWorldProvinces: newWorldProvinces,
+    oldWorldProvinces:
+        oldWorldProvinces ??
+        buildColonialPeaceDefaultOwQuotaProvinces(perGpOwCounts: perGpOwCounts),
+    players: players,
+    tribes: tribes,
+    minorNations: minorNations,
+    gameIdPrefix: 'g-2509-colonial-phase-planner-peace',
+  );
+}
+
+/// Snapshot tuned for COLONIAL peace pins (OW owned defaults to 10).
+AIWorldSnapshot buildColonialPeaceSnapshot({
+  required List<String> atWarWith,
+  List<String> invadableNw = const [],
+  String playerId = kColonialPhaseGp1,
+}) {
+  return buildColonialPhaseSnapshot(
+    atWarWith: atWarWith,
+    invadableNw: invadableNw,
+    playerId: playerId,
   );
 }


### PR DESCRIPTION
## Summary
- Completes the deferred optional fold from #3974 for #3972: COLONIAL-lite naval/overtures, civilian, and peace pins now use shared builders in `colonial_phase_planner_test_support.dart`.
- Extends `buildColonialPhaseGame` / snapshot helpers with overture, unit, resource, and exact-`gameId` knobs; adds lite/civilian/peace convenience wrappers.

## Done in this push
- Zero local `_colonialLiteGame` / `_civilianGame` / `_colonialGame` Game factories in the migrated planner tests.
- Shared constants for gp4 / tribe3 and peace OW-quota province helpers.

## Remaining for #3972
- None expected after this slice; prior PR #3974 already covered required ACs (acquisition/economy harnesses, S7D/orchestrator splits, param objects, near-gate lib splits, CI gates).

## Test plan
- [x] `dart analyze` on support + migrated colonial planner tests
- [x] `dart test` colonial lite naval/overtures + civilian + peace + military + naval (102 tests)
- [ ] CI `quality` on PR

Refs #3972

Made with [Cursor](https://cursor.com)