### PR TITLE
refactor(combat): split naval resolver detect vs resolve/apply (#3983)

### DIFF
--- a/packages/colonizethis_combat/REFACTOR_TRACE.md
+++ b/packages/colonizethis_combat/REFACTOR_TRACE.md
@@ -16,9 +16,14 @@ Delivered in this slice:
 
 Combat test LOC: **1,577 → 507** physical lines (`find … | wc -l`; target ≤1,340).
 
-Deferred for a follow-up commit/PR on #3983:
+## Phase 3 — slice 2 (Refs #3983)
 
-- Optional naval resolver detect-vs-resolve/apply file split (file still dense after de-part).
+Delivered in this slice:
+
+- Split naval resolver seams: `naval_combat_types.dart` (types + ship clone + retreat constants), `naval_combat_detection.dart` (detect + attacker normalize), `naval_combat_resolver.dart` (strength + resolve + apply; re-exports types/detection for the package barrel).
+
+Deferred (still optional):
+
 - Optional DESCRIPTION_BASELINE file (trace table below + duplicate-description gate cover labels).
 - Optional densify of test_support preamble after harness adoption.
 

--- a/packages/colonizethis_combat/lib/src/combat/naval_combat_detection.dart
+++ b/packages/colonizethis_combat/lib/src/combat/naval_combat_detection.dart
@@ -1,0 +1,132 @@
+// Naval conflict detection and attacker-side normalization.
+// SPEC/program/naval-combat-resolution.md; SPEC/game/ships-and-naval.md.
+
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import 'package:colonizethis_world/src/world/diplomatic_relation_lookup.dart';
+import 'naval_combat_types.dart';
+
+bool _ownerHadMovingFleetInZone(
+  Game game,
+  String seaZoneId,
+  String ownerId,
+  Set<String> movedFleetIds,
+) {
+  if (movedFleetIds.isEmpty) return false;
+  return game.worldState.fleets.any(
+    (f) =>
+        f.isAtSea &&
+        f.seaZoneId == seaZoneId &&
+        f.ownerId == ownerId &&
+        movedFleetIds.contains(f.id),
+  );
+}
+
+bool _isInterceptorMission(FleetMission m) =>
+    m == FleetMission.patrol || m == FleetMission.blockade;
+
+bool _navalBattleShouldSwapAttackerSides({
+  required bool m1,
+  required bool m2,
+  required bool int1,
+  required bool int2,
+  required String s1OwnerId,
+  required String s2OwnerId,
+}) {
+  if (m1 && !m2 && int2) return true;
+  if (m2 && !m1 && int1) return false;
+  if (m1 && !m2) return false;
+  if (m2 && !m1) return true;
+  return s1OwnerId.compareTo(s2OwnerId) > 0;
+}
+
+/// Orders [battle] so [side1] is the attacker and [side2] is the defender per SPEC/program/naval-combat-resolution.md.
+///
+/// Precedence: (1) If exactly one faction moved into the zone and the other is on Patrol or Blockade, the interceptor is the attacker. (2) Else if exactly one faction moved, the mover is the attacker. (3) Else (both moved, or neither) use lexicographically smaller `ownerId` as attacker for deterministic ordering.
+BattleContextSea normalizeNavalBattleSidesForAttacker(
+  BattleContextSea battle,
+  Game game,
+  Set<String> movedFleetIds,
+) {
+  final s1 = battle.side1;
+  final s2 = battle.side2;
+  final m1 = _ownerHadMovingFleetInZone(
+    game,
+    battle.seaZoneId,
+    s1.ownerId,
+    movedFleetIds,
+  );
+  final m2 = _ownerHadMovingFleetInZone(
+    game,
+    battle.seaZoneId,
+    s2.ownerId,
+    movedFleetIds,
+  );
+  final int1 = _isInterceptorMission(s1.mission);
+  final int2 = _isInterceptorMission(s2.mission);
+
+  final swap = _navalBattleShouldSwapAttackerSides(
+    m1: m1,
+    m2: m2,
+    int1: int1,
+    int2: int2,
+    s1OwnerId: s1.ownerId,
+    s2OwnerId: s2.ownerId,
+  );
+
+  if (!swap) {
+    return battle;
+  }
+  return BattleContextSea(seaZoneId: battle.seaZoneId, side1: s2, side2: s1);
+}
+
+/// Conflict detection: returns contested sea zones with two hostile sides.
+/// Populates mission per side from fleet state for retreat aggression.
+List<BattleContextSea> detectNavalConflicts(Game game) {
+  final atWar = hostileFactionsByFaction(game);
+  final byZone = <String, Map<String, List<ShipInstance>>>{};
+  final missionByZoneOwner = <String, Map<String, FleetMission>>{};
+  for (final f in game.worldState.fleets) {
+    if (!f.isAtSea || f.seaZoneId == null)
+      continue; // Naval combat only in sea zones. SPEC/game/ships-and-naval.md.
+    final zoneId = f.seaZoneId!;
+    byZone.putIfAbsent(zoneId, () => {});
+    byZone[zoneId]!.putIfAbsent(f.ownerId, () => []).addAll(f.ships);
+    missionByZoneOwner.putIfAbsent(zoneId, () => {});
+    missionByZoneOwner[zoneId]!.putIfAbsent(f.ownerId, () => f.mission);
+  }
+  final result = <BattleContextSea>[];
+  for (final entry in byZone.entries) {
+    final zoneId = entry.key;
+    final owners = entry.value;
+    if (owners.length < 2) continue;
+    final ownerList = owners.keys.toList();
+    bool added = false;
+    for (var i = 0; i < ownerList.length && !added; i++) {
+      for (var j = i + 1; j < ownerList.length && !added; j++) {
+        final a = ownerList[i];
+        final b = ownerList[j];
+        if (atWar[a]?.contains(b) != true) continue;
+        final missionA = missionByZoneOwner[zoneId]?[a] ?? FleetMission.none;
+        final missionB = missionByZoneOwner[zoneId]?[b] ?? FleetMission.none;
+        result.add(
+          BattleContextSea(
+            seaZoneId: zoneId,
+            side1: NavalBattleSide(
+              ownerId: a,
+              ships: copyNavalShips(owners[a]!),
+              mission: missionA,
+            ),
+            side2: NavalBattleSide(
+              ownerId: b,
+              ships: copyNavalShips(owners[b]!),
+              mission: missionB,
+            ),
+          ),
+        );
+        added = true;
+      }
+    }
+  }
+  return result;
+}

--- a/packages/colonizethis_combat/lib/src/combat/naval_combat_resolver.dart
+++ b/packages/colonizethis_combat/lib/src/combat/naval_combat_resolver.dart
@@ -1,195 +1,17 @@
-// Naval combat: conflict detection, BattleContextSea, resolve. SPEC/program/naval-combat-resolution.md.
-// Interception and retreat: SPEC/game/ships-and-naval.md.
+// Naval combat resolve/apply. Types and detection live in sibling modules.
+// SPEC/program/naval-combat-resolution.md; SPEC/game/ships-and-naval.md.
 
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_combat/src/logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
-import 'package:colonizethis_world/src/world/diplomatic_relation_lookup.dart';
 import 'package:colonizethis_world/colonizethis_world.dart';
 import 'combat_rng.dart';
 import 'military_strength.dart';
+import 'naval_combat_types.dart';
 
-/// Canonical clone of a naval ship-instance list (Refs #3448, AC5).
-///
-/// Centralizes the defensive copy that previously used raw `List.from(...)` at
-/// several naval resolution sites (battle-context snapshots and per-round
-/// working lists). Returns a growable list so callers that mutate the copy
-/// (for example `removeAt` during casualty application) keep working. Routing
-/// every ship-list clone through this one helper lets
-/// `repo.combat_no_raw_copies_in_resolution` forbid re-introducing raw
-/// `List.from` clones on ship collections in the resolution path.
-List<ShipInstance> copyNavalShips(List<ShipInstance> ships) => <ShipInstance>[
-  ...ships,
-];
-
-/// Retreat base chance. SPEC/game/ships-and-naval.md.
-const double kNavalRetreatBaseChance = 0.6;
-
-/// Retreat speed advantage factor per MV point difference.
-const double kNavalRetreatSpeedFactor = 0.1;
-
-/// Enemy aggression when enemy is on Patrol.
-const double kNavalRetreatEnemyPatrol = 0.1;
-
-/// Enemy aggression when enemy is on Blockade.
-const double kNavalRetreatEnemyBlockade = 0.2;
-
-/// One side in a sea battle: owner, ship instances, mission (used for retreat `enemyAggression` from opponent mission).
-class NavalBattleSide {
-  const NavalBattleSide({
-    required this.ownerId,
-    required this.ships,
-    this.mission = FleetMission.none,
-  });
-
-  final String ownerId;
-  final List<ShipInstance> ships;
-  final FleetMission mission;
-
-  /// Type id per ship (combat aggregation).
-  List<String> get shipTypeIds => ships.map((s) => s.typeId).toList();
-}
-
-/// Sea battle context for one zone. SPEC/program/naval-combat-resolution.md.
-///
-/// After [normalizeNavalBattleSidesForAttacker], [side1] is the **attacker** and [side2] is the **defender**.
-class BattleContextSea {
-  const BattleContextSea({
-    required this.seaZoneId,
-    required this.side1,
-    required this.side2,
-  });
-
-  final String seaZoneId;
-  final NavalBattleSide side1;
-  final NavalBattleSide side2;
-}
-
-bool _ownerHadMovingFleetInZone(
-  Game game,
-  String seaZoneId,
-  String ownerId,
-  Set<String> movedFleetIds,
-) {
-  if (movedFleetIds.isEmpty) return false;
-  return game.worldState.fleets.any(
-    (f) =>
-        f.isAtSea &&
-        f.seaZoneId == seaZoneId &&
-        f.ownerId == ownerId &&
-        movedFleetIds.contains(f.id),
-  );
-}
-
-bool _isInterceptorMission(FleetMission m) =>
-    m == FleetMission.patrol || m == FleetMission.blockade;
-
-bool _navalBattleShouldSwapAttackerSides({
-  required bool m1,
-  required bool m2,
-  required bool int1,
-  required bool int2,
-  required String s1OwnerId,
-  required String s2OwnerId,
-}) {
-  if (m1 && !m2 && int2) return true;
-  if (m2 && !m1 && int1) return false;
-  if (m1 && !m2) return false;
-  if (m2 && !m1) return true;
-  return s1OwnerId.compareTo(s2OwnerId) > 0;
-}
-
-/// Orders [battle] so [side1] is the attacker and [side2] is the defender per SPEC/program/naval-combat-resolution.md.
-///
-/// Precedence: (1) If exactly one faction moved into the zone and the other is on Patrol or Blockade, the interceptor is the attacker. (2) Else if exactly one faction moved, the mover is the attacker. (3) Else (both moved, or neither) use lexicographically smaller `ownerId` as attacker for deterministic ordering.
-BattleContextSea normalizeNavalBattleSidesForAttacker(
-  BattleContextSea battle,
-  Game game,
-  Set<String> movedFleetIds,
-) {
-  final s1 = battle.side1;
-  final s2 = battle.side2;
-  final m1 = _ownerHadMovingFleetInZone(
-    game,
-    battle.seaZoneId,
-    s1.ownerId,
-    movedFleetIds,
-  );
-  final m2 = _ownerHadMovingFleetInZone(
-    game,
-    battle.seaZoneId,
-    s2.ownerId,
-    movedFleetIds,
-  );
-  final int1 = _isInterceptorMission(s1.mission);
-  final int2 = _isInterceptorMission(s2.mission);
-
-  final swap = _navalBattleShouldSwapAttackerSides(
-    m1: m1,
-    m2: m2,
-    int1: int1,
-    int2: int2,
-    s1OwnerId: s1.ownerId,
-    s2OwnerId: s2.ownerId,
-  );
-
-  if (!swap) {
-    return battle;
-  }
-  return BattleContextSea(seaZoneId: battle.seaZoneId, side1: s2, side2: s1);
-}
-
-/// Conflict detection: returns contested sea zones with two hostile sides.
-/// Populates mission per side from fleet state for retreat aggression.
-List<BattleContextSea> detectNavalConflicts(Game game) {
-  final atWar = hostileFactionsByFaction(game);
-  final byZone = <String, Map<String, List<ShipInstance>>>{};
-  final missionByZoneOwner = <String, Map<String, FleetMission>>{};
-  for (final f in game.worldState.fleets) {
-    if (!f.isAtSea || f.seaZoneId == null)
-      continue; // Naval combat only in sea zones. SPEC/game/ships-and-naval.md.
-    final zoneId = f.seaZoneId!;
-    byZone.putIfAbsent(zoneId, () => {});
-    byZone[zoneId]!.putIfAbsent(f.ownerId, () => []).addAll(f.ships);
-    missionByZoneOwner.putIfAbsent(zoneId, () => {});
-    missionByZoneOwner[zoneId]!.putIfAbsent(f.ownerId, () => f.mission);
-  }
-  final result = <BattleContextSea>[];
-  for (final entry in byZone.entries) {
-    final zoneId = entry.key;
-    final owners = entry.value;
-    if (owners.length < 2) continue;
-    final ownerList = owners.keys.toList();
-    bool added = false;
-    for (var i = 0; i < ownerList.length && !added; i++) {
-      for (var j = i + 1; j < ownerList.length && !added; j++) {
-        final a = ownerList[i];
-        final b = ownerList[j];
-        if (atWar[a]?.contains(b) != true) continue;
-        final missionA = missionByZoneOwner[zoneId]?[a] ?? FleetMission.none;
-        final missionB = missionByZoneOwner[zoneId]?[b] ?? FleetMission.none;
-        result.add(
-          BattleContextSea(
-            seaZoneId: zoneId,
-            side1: NavalBattleSide(
-              ownerId: a,
-              ships: copyNavalShips(owners[a]!),
-              mission: missionA,
-            ),
-            side2: NavalBattleSide(
-              ownerId: b,
-              ships: copyNavalShips(owners[b]!),
-              mission: missionB,
-            ),
-          ),
-        );
-        added = true;
-      }
-    }
-  }
-  return result;
-}
+export 'naval_combat_detection.dart';
+export 'naval_combat_types.dart';
 
 /// Average movement (MV) for a list of ship types. Used for retreat speed advantage.
 double avgNavalMovement(List<String> shipTypeIds) {
@@ -208,30 +30,6 @@ double navalStrength(List<String> shipTypeIds) {
     total += NavalStatsCatalog.shipStrength(typeId);
   }
   return total;
-}
-
-enum NavalBattleOutcome {
-  side1Victory,
-  side2Victory,
-  stalemate,
-  mutualDestruction,
-}
-
-/// Result of resolving one sea battle: updated fleet lists (sunk ships removed).
-class NavalBattleResult {
-  const NavalBattleResult({
-    required this.survivingShipsSide1,
-    required this.survivingShipsSide2,
-    this.side1Retreated = false,
-    this.side2Retreated = false,
-    this.outcome = NavalBattleOutcome.stalemate,
-  });
-
-  final List<ShipInstance> survivingShipsSide1;
-  final List<ShipInstance> survivingShipsSide2;
-  final bool side1Retreated;
-  final bool side2Retreated;
-  final NavalBattleOutcome outcome;
 }
 
 /// Resolve one sea battle deterministically. Seed from game + zone for RNG.

--- a/packages/colonizethis_combat/lib/src/combat/naval_combat_types.dart
+++ b/packages/colonizethis_combat/lib/src/combat/naval_combat_types.dart
@@ -1,0 +1,84 @@
+// Naval battle types, ship-list clone helper, and retreat constants.
+// SPEC/program/naval-combat-resolution.md; SPEC/game/ships-and-naval.md.
+
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+/// Canonical clone of a naval ship-instance list (Refs #3448, AC5).
+///
+/// Centralizes the defensive copy that previously used raw `List.from(...)` at
+/// several naval resolution sites (battle-context snapshots and per-round
+/// working lists). Returns a growable list so callers that mutate the copy
+/// (for example `removeAt` during casualty application) keep working. Routing
+/// every ship-list clone through this one helper lets
+/// `repo.combat_no_raw_copies_in_resolution` forbid re-introducing raw
+/// `List.from` clones on ship collections in the resolution path.
+List<ShipInstance> copyNavalShips(List<ShipInstance> ships) => <ShipInstance>[
+  ...ships,
+];
+
+/// Retreat base chance. SPEC/game/ships-and-naval.md.
+const double kNavalRetreatBaseChance = 0.6;
+
+/// Retreat speed advantage factor per MV point difference.
+const double kNavalRetreatSpeedFactor = 0.1;
+
+/// Enemy aggression when enemy is on Patrol.
+const double kNavalRetreatEnemyPatrol = 0.1;
+
+/// Enemy aggression when enemy is on Blockade.
+const double kNavalRetreatEnemyBlockade = 0.2;
+
+/// One side in a sea battle: owner, ship instances, mission (used for retreat `enemyAggression` from opponent mission).
+class NavalBattleSide {
+  const NavalBattleSide({
+    required this.ownerId,
+    required this.ships,
+    this.mission = FleetMission.none,
+  });
+
+  final String ownerId;
+  final List<ShipInstance> ships;
+  final FleetMission mission;
+
+  /// Type id per ship (combat aggregation).
+  List<String> get shipTypeIds => ships.map((s) => s.typeId).toList();
+}
+
+/// Sea battle context for one zone. SPEC/program/naval-combat-resolution.md.
+///
+/// After [normalizeNavalBattleSidesForAttacker], [side1] is the **attacker** and [side2] is the **defender**.
+class BattleContextSea {
+  const BattleContextSea({
+    required this.seaZoneId,
+    required this.side1,
+    required this.side2,
+  });
+
+  final String seaZoneId;
+  final NavalBattleSide side1;
+  final NavalBattleSide side2;
+}
+
+enum NavalBattleOutcome {
+  side1Victory,
+  side2Victory,
+  stalemate,
+  mutualDestruction,
+}
+
+/// Result of resolving one sea battle: updated fleet lists (sunk ships removed).
+class NavalBattleResult {
+  const NavalBattleResult({
+    required this.survivingShipsSide1,
+    required this.survivingShipsSide2,
+    this.side1Retreated = false,
+    this.side2Retreated = false,
+    this.outcome = NavalBattleOutcome.stalemate,
+  });
+
+  final List<ShipInstance> survivingShipsSide1;
+  final List<ShipInstance> survivingShipsSide2;
+  final bool side1Retreated;
+  final bool side2Retreated;
+  final NavalBattleOutcome outcome;
+}


### PR DESCRIPTION
## Summary
- Split the dense `naval_combat_resolver.dart` into `naval_combat_types.dart` (types, ship clone, retreat constants), `naval_combat_detection.dart` (detect + attacker normalize), and resolve/apply in `naval_combat_resolver.dart` (re-exports types/detection for the package barrel).
- Update `REFACTOR_TRACE.md` phase-3 slice 2; no combat-resolution semantics changes.

## Done in this push
- Deferred naval detect-vs-resolve/apply seam from #3983 / prior PR #3988.

## Remaining for #3983
- Optional DESCRIPTION_BASELINE file and optional test_support preamble densify (still optional; all stated ACs already met on `dev` via #3988).

## Test plan
- [x] `cd packages/colonizethis_combat && dart analyze lib/src/combat/naval_combat_*.dart`
- [x] `cd packages/colonizethis_combat && dart test` (196 passed)
- [ ] CI `quality` on this PR

Refs #3983

Made with [Cursor](https://cursor.com)