### PR TITLE
ci: skip full package_tests for satellite-only package diffs

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -64,6 +64,8 @@ jobs:
               - 'tool/verify_order_engine_codegen.sh'
               - 'tool/compute_app_test_plan.dart'
               - 'test/compute_app_test_plan_test.dart'
+              - 'tool/compute_package_test_plan.py'
+              - 'test/compute_package_test_plan_test.dart'
             # True when any changed path is outside repo-root dot-directories (CI/editor meta). OpenCode
             # review is skipped when the PR only touches those paths (e.g. .github, .cursor).
             opencode_scope:
@@ -74,13 +76,27 @@ jobs:
               - '!.idea/**'
               - '!.husky/**'
             # True when any path that can affect package_tests outcomes changed.
-            # Includes packages/** plus workspace + test-runner files that change how
-            # package tests resolve, execute, or gate coverage. Used to skip the
-            # heavy `package_tests` job for app-only / tool-only / SPEC-only PRs
-            # where the one-way dependency direction (app/tool/ctdev -> packages,
-            # never the reverse) makes re-running package tests unnecessary.
+            # Scoped to CORE packages exercised by tool/run_package_tests.sh plus
+            # workspace/test-runner infra — NOT blanket packages/**. Satellite
+            # packages (app_l10n, fixtures, e2e_support, logger, …) do not reverse-
+            # depend into CORE; changing them must not expand to a full-suite run
+            # (empty CORE flags previously defaulted to every CORE package and
+            # blew the 30m package_tests budget). Refs #3987.
             packages_changed:
-              - 'packages/**'
+              - 'packages/colonizethis_models/**'
+              - 'packages/colonizethis_data/**'
+              - 'packages/colonizethis_save/**'
+              - 'packages/colonizethis_map/**'
+              - 'packages/colonizethis_world/**'
+              - 'packages/colonizethis_combat/**'
+              - 'packages/colonizethis_economy/**'
+              - 'packages/colonizethis_diplomacy/**'
+              - 'packages/colonizethis_setup/**'
+              - 'packages/colonizethis_orders/**'
+              - 'packages/colonizethis_turn/**'
+              - 'packages/colonizethis_ai_contracts/**'
+              - 'packages/colonizethis_logic/**'
+              - 'packages/colonizethis_ai/**'
               - 'pubspec.yaml'
               - 'analysis_options.yaml'
               - 'tool/run_package_tests.sh'
@@ -106,6 +122,8 @@ jobs:
               - 'packages/colonizethis_diplomacy/**'
             pkg_setup:
               - 'packages/colonizethis_setup/**'
+            pkg_orders:
+              - 'packages/colonizethis_orders/**'
             pkg_turn:
               - 'packages/colonizethis_turn/**'
             pkg_ai_contracts:
@@ -129,6 +147,7 @@ jobs:
             --changed-economy="${{ steps.filter.outputs.pkg_economy }}" \
             --changed-diplomacy="${{ steps.filter.outputs.pkg_diplomacy }}" \
             --changed-setup="${{ steps.filter.outputs.pkg_setup }}" \
+            --changed-orders="${{ steps.filter.outputs.pkg_orders }}" \
             --changed-turn="${{ steps.filter.outputs.pkg_turn }}" \
             --changed-ai_contracts="${{ steps.filter.outputs.pkg_ai_contracts }}" \
             --changed-logic="${{ steps.filter.outputs.pkg_logic }}" \
@@ -799,6 +818,9 @@ jobs:
 
       - name: Test app test plan selector (SPEC/program/ci-app-selective-tests.md)
         run: dart test test/compute_app_test_plan_test.dart --reporter=compact
+
+      - name: Test package test plan selector (SPEC/program/test-logging.md)
+        run: dart test test/compute_package_test_plan_test.dart --reporter=compact
 
       - name: Wang incremental assets gate (Python)
         run: |

--- a/SPEC/program/test-logging.md
+++ b/SPEC/program/test-logging.md
@@ -47,7 +47,16 @@ Any package or app that has tests adds **colonizethis_test** as a **dev_dependen
 
 ## Verifying the quality gate
 
-The GitHub workflow **.github/workflows/quality.yml** runs PR checks in parallel jobs: **`package_tests`** (six `colonizethis_*` packages + package coverage gates via **`tool/run_package_tests.sh`**), **`quality`** (lint, analyze, checker tests, `run_observer_game` + observer coverage), and app test shards + **`quality_app_coverage`**. All use `--reporter=compact` (pass/fail only). **Tool package tests** and **`melos run sim_scenarios`** run in **`.github/workflows/nightly.yml`** (daily **23:00 Asia/Hong_Kong**, `workflow_dispatch`); local parity: **`tool/run_nightly_gate_tests.sh`**. Refs #2509.
+The GitHub workflow **.github/workflows/quality.yml** runs PR checks in parallel jobs: **`package_tests`** (CORE `colonizethis_*` packages + package coverage gates via **`tool/run_package_tests.sh`**), **`quality`** (lint, analyze, checker tests, `run_observer_game` + observer coverage), and app test shards + **`quality_app_coverage`**. All use `--reporter=compact` (pass/fail only). **Tool package tests** and **`melos run sim_scenarios`** run in **`.github/workflows/nightly.yml`** (daily **23:00 Asia/Hong_Kong**, `workflow_dispatch`); local parity: **`tool/run_nightly_gate_tests.sh`**. Refs #2509.
+
+**`package_tests` path gate:** The job’s `packages_changed` filter matches only CORE package trees exercised by `tool/run_package_tests.sh` (plus workspace/`tool/run_package_tests.sh` / `tool/compute_package_test_plan.py` / coverage-gate infra). Satellite packages such as `colonizethis_app_l10n` do **not** set `packages_changed`. When every CORE `--changed-*` flag is false, `tool/compute_package_test_plan.py` emits an empty plan and `tool/run_package_tests.sh` exits 0 without running suites — it must **not** expand to the full CORE list (that previously exhausted the 30-minute job budget on l10n-only PRs). Refs #3987.
+
+### Acceptance criteria (package_tests path gate)
+
+- Given a PR whose only `packages/` changes are under `packages/colonizethis_app_l10n/**`, when the Quality `changes` filter runs, then `packages_changed` is false and the `package_tests` job skips CORE suite execution.
+- Given `tool/compute_package_test_plan.py` is invoked with every `--changed-*=false` flag, when it prints JSON, then the list is empty.
+- Given `PACKAGES_TO_TEST` is set to the empty string, when `tool/run_package_tests.sh` runs, then it exits 0 without running any package suite.
+- Given no CLI flags, when `tool/compute_package_test_plan.py` runs, then the JSON list includes every CORE package name used by `tool/run_package_tests.sh`.
 
 You can verify locally in either of these ways:
 

--- a/test/compute_package_test_plan_test.dart
+++ b/test/compute_package_test_plan_test.dart
@@ -1,0 +1,67 @@
+// Unit tests for tool/compute_package_test_plan.py selective plan.
+// SPEC/program/test-logging.md — package_tests path gate.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+void main() {
+  final root = Directory.current.path;
+  final script = '$root/tool/compute_package_test_plan.py';
+
+  Future<List<dynamic>> runPlan(List<String> args) async {
+    final result = await Process.run('python3', [script, ...args]);
+    expect(result.exitCode, 0, reason: result.stderr.toString());
+    return jsonDecode(result.stdout as String) as List<dynamic>;
+  }
+
+  test('no flags defaults to all CORE packages', () async {
+    final plan = await runPlan(const []);
+    expect(plan, contains('colonizethis_logic'));
+    expect(plan, contains('colonizethis_ai'));
+    expect(plan, contains('colonizethis_orders'));
+    expect(plan.length, greaterThanOrEqualTo(14));
+  });
+
+  test('all CORE flags false yields empty plan (CI selective)', () async {
+    final plan = await runPlan(const [
+      '--changed-models=false',
+      '--changed-data=false',
+      '--changed-save=false',
+      '--changed-map=false',
+      '--changed-world=false',
+      '--changed-combat=false',
+      '--changed-economy=false',
+      '--changed-diplomacy=false',
+      '--changed-setup=false',
+      '--changed-orders=false',
+      '--changed-turn=false',
+      '--changed-ai_contracts=false',
+      '--changed-logic=false',
+      '--changed-ai=false',
+    ]);
+    expect(plan, isEmpty);
+  });
+
+  test('orders-only change includes orders in the plan', () async {
+    final plan = await runPlan(const [
+      '--changed-models=false',
+      '--changed-data=false',
+      '--changed-save=false',
+      '--changed-map=false',
+      '--changed-world=false',
+      '--changed-combat=false',
+      '--changed-economy=false',
+      '--changed-diplomacy=false',
+      '--changed-setup=false',
+      '--changed-orders=true',
+      '--changed-turn=false',
+      '--changed-ai_contracts=false',
+      '--changed-logic=false',
+      '--changed-ai=false',
+    ]);
+    expect(plan, contains('colonizethis_orders'));
+    expect(plan, isNot(contains('colonizethis_models')));
+  });
+}

--- a/tool/compute_package_test_plan.py
+++ b/tool/compute_package_test_plan.py
@@ -10,11 +10,14 @@ Accepts per-package change flags via --changed-<name>=true|false.
 Outputs a JSON array of package directory names (e.g. ["colonizethis_logic","colonizethis_ai"])
 to stdout.
 
-When invoked with no changed packages the output includes all packages.
+When invoked with no CLI flags, the output includes all CORE packages (local
+default). When CI passes `--changed-*=true|false` flags and none are true,
+the output is an empty list (do not expand satellite-only diffs to a full
+suite).
 
-Packages outside the six core packages (colonizethis_models, _data, _save,
-_map, _logic, _ai) are ignored because they do not run in the package_tests
-CI job.
+Satellite packages under `packages/` that are not in CORE_PACKAGES (e.g.
+colonizethis_app_l10n) are ignored by this planner; the workflow must not
+treat them as `packages_changed` for the package_tests job.
 
 Example:
   python3 tool/compute_package_test_plan.py \
@@ -125,6 +128,7 @@ SHORT_TO_FULL: dict[str, str] = {
     "economy": "colonizethis_economy",
     "diplomacy": "colonizethis_diplomacy",
     "setup": "colonizethis_setup",
+    "orders": "colonizethis_orders",
     "turn": "colonizethis_turn",
     "ai_contracts": "colonizethis_ai_contracts",
     "logic": "colonizethis_logic",
@@ -132,29 +136,38 @@ SHORT_TO_FULL: dict[str, str] = {
 }
 
 
-def parse_args() -> set[str]:
-    """Parse --changed-<name>=true CLI flags; return set of changed package names.
+def parse_args() -> tuple[set[str], bool]:
+    """Parse --changed-<name>=true CLI flags.
 
+    Returns (changed_package_names, had_changed_flags).
     Accepts both long names (--changed-colonizethis_ai=true) and short names
     (--changed-ai=true)."""
     changed: set[str] = set()
+    had_flags = False
     for arg in sys.argv[1:]:
         m = re.match(r"^--changed-(\S+)=(true|false)$", arg)
-        if m and m.group(2) == "true":
-            name = m.group(1)
-            if name in CORE_PACKAGES:
-                changed.add(name)
-            elif name in SHORT_TO_FULL:
-                changed.add(SHORT_TO_FULL[name])
-    return changed
+        if not m:
+            continue
+        had_flags = True
+        if m.group(2) != "true":
+            continue
+        name = m.group(1)
+        if name in CORE_PACKAGES:
+            changed.add(name)
+        elif name in SHORT_TO_FULL:
+            changed.add(SHORT_TO_FULL[name])
+    return changed, had_flags
 
 
 def main() -> None:
-    changed = parse_args()
+    changed, had_flags = parse_args()
 
     if changed:
         rev_graph = build_reverse_dep_graph()
         result = transitive_downstream(changed, rev_graph)
+    elif had_flags:
+        # CI selective plan: every CORE flag false → nothing to run.
+        result = []
     else:
         result = list(CORE_PACKAGES)
 

--- a/tool/run_package_tests.sh
+++ b/tool/run_package_tests.sh
@@ -18,7 +18,13 @@ cd "$ROOT"
 ALL_PKGS=(colonizethis_models colonizethis_data colonizethis_save colonizethis_map colonizethis_world colonizethis_combat colonizethis_economy colonizethis_diplomacy colonizethis_setup colonizethis_orders colonizethis_turn colonizethis_ai_contracts colonizethis_logic colonizethis_ai)
 
 # ---- read package filter ---------------------------------------------------
-if [ -n "${PACKAGES_TO_TEST:-}" ]; then
+# Distinguishes: unset → all packages (local default); set-but-empty → skip
+# (CI selective plan with no CORE package changes).
+if [ "${PACKAGES_TO_TEST+set}" = "set" ]; then
+  if [ -z "$PACKAGES_TO_TEST" ]; then
+    echo "=== PACKAGES_TO_TEST is empty; skipping package tests ==="
+    exit 0
+  fi
   IFS=',' read -ra PKGS <<< "$PACKAGES_TO_TEST"
 else
   PKGS=("${ALL_PKGS[@]}")


### PR DESCRIPTION
## Summary
- Scope Quality `packages_changed` to CORE package trees (not blanket `packages/**`) so satellite-only diffs such as `colonizethis_app_l10n` do not trigger the heavy `package_tests` job.
- When every CORE `--changed-*` flag is false, `compute_package_test_plan.py` emits an empty plan; `run_package_tests.sh` exits 0 on empty `PACKAGES_TO_TEST` instead of expanding to the full CORE suite.
- Add `pkg_orders` selective detection, unit tests, and SPEC ACs in `SPEC/program/test-logging.md`.

## Why
Discovered while unblocking #3987: an app_l10n-only PR matched `packages/**` with no CORE flags, so the planner expanded to every CORE package and ran toward the 30-minute `package_tests` timeout.

## Test plan
- [x] `python3 tool/compute_package_test_plan.py` (no flags → full CORE list)
- [x] same with all `--changed-*=false` → `[]`
- [x] `PACKAGES_TO_TEST= bash tool/run_package_tests.sh` → skip / exit 0
- [x] `dart test test/compute_package_test_plan_test.dart`

Refs #3987


Made with [Cursor](https://cursor.com)