### PR TITLE
feat(terrain): PO strip renderer and pick validation for plantation retune (#3961)

### DIFF
--- a/SPEC/ui/pytool-image-tools.md
+++ b/SPEC/ui/pytool-image-tools.md
@@ -61,16 +61,36 @@ uv run --project pytool python pytool/paint_plains_plantation_field_gradients.py
 
 ```bash
 uv run --project pytool python pytool/test_finalize_plantation_field_retune_3961.py
-# Preview:
+# Preview means (no writes):
 uv run --project pytool python pytool/finalize_plantation_field_retune_3961.py \
   --picks sugar_cane=A,cotton=B,spices=C --dry-run
+# Validate golden distinctness pins (no writes):
+uv run --project pytool python pytool/finalize_plantation_field_retune_3961.py \
+  --picks sugar_cane=A,cotton=B,spices=C --validate-only
 # Apply (after PO lock):
 uv run --project pytool python pytool/finalize_plantation_field_retune_3961.py \
   --picks sugar_cane=A,cotton=B,spices=C
 cd app && flutter test test/plains_plantation_terrain_goldens_test.dart --update-goldens
 ```
 
-**Behaviour:** Requires all three retune crops in `--picks`. `--dry-run` prints resolved means without writing. Apply mode copies PNGs then patches SPEC + dart pins; operator must refresh goldens manually.
+**Behaviour:** Requires all three retune crops in `--picks`. `--dry-run` prints resolved means without writing. `--validate-only` checks pairwise field-mean RGB distance (≥ 26) against golden-test distinctness pins without writing files. Apply mode copies PNGs then patches SPEC + dart pins; operator must refresh goldens manually.
+
+---
+
+### render_plantation_po_review_strip_3961.py
+
+**Purpose:** Rebuild PO sample strips at map tile scale (4× nearest-neighbor) for [#3961](https://github.com/waigore/colonizethisv3/issues/3961): per-crop rows of `grain` / `meat` / `horses` / `tobacco` / candidate A / B / C / CURRENT shipped overlay, plus `strip_all_crops_x4.png` and `CANDIDATE_NOTES.md`. Does not modify app terrain.
+
+**Dependencies:** Pillow; imports `paint_plains_plantation_field_gradients.py`.
+
+**Usage:**
+
+```bash
+uv run --project pytool python pytool/render_plantation_po_review_strip_3961.py
+uv run --project pytool python pytool/test_render_plantation_po_review_strip_3961.py
+```
+
+**Behaviour:** Writes to `tmp/plantation_po_review_strips_3961/` by default (override with `--out-dir`). Requires candidate PNGs under `plantation_field_candidates_3961/`.
 
 ---
 

--- a/pytool/finalize_plantation_field_retune_3961.py
+++ b/pytool/finalize_plantation_field_retune_3961.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import argparse
 import importlib.util
 import json
+import math
 import re
 import sys
 from pathlib import Path
@@ -29,6 +30,9 @@ SPEC_LAYERED = REPO / "SPEC/ui/layered-terrain-rendering.md"
 GOLDEN_TEST = REPO / "app/test/plains_plantation_terrain_goldens_test.dart"
 TOBACCO_MEAN = (128, 108, 42)
 REQUIRED_CROPS = ("sugar_cane", "cotton", "spices")
+PLANTATION_KEYS = ("sugar_cane", "tobacco", "cotton", "spices")
+# Matches app/test/plains_plantation_terrain_goldens_test.dart pairwise check.
+MIN_PAIRWISE_RGB_DISTANCE = 26.0
 
 
 def _load_paint_module():
@@ -128,6 +132,29 @@ def patch_spec_midtones(spec_path: Path, means: dict[str, tuple[int, int, int]])
     return new_line
 
 
+def rgb_distance(a: tuple[int, int, int], b: tuple[int, int, int]) -> float:
+    return math.sqrt(
+        (a[0] - b[0]) ** 2 + (a[1] - b[1]) ** 2 + (a[2] - b[2]) ** 2,
+    )
+
+
+def validate_plantation_picks(
+    means: dict[str, tuple[int, int, int]],
+    *,
+    min_pairwise: float = MIN_PAIRWISE_RGB_DISTANCE,
+) -> list[str]:
+    """Return human-readable validation errors; empty when picks pass golden pins."""
+    errors: list[str] = []
+    for i, a in enumerate(PLANTATION_KEYS):
+        for b in PLANTATION_KEYS[i + 1 :]:
+            dist = rgb_distance(means[a], means[b])
+            if dist < min_pairwise:
+                errors.append(
+                    f"{a} vs {b}: RGB distance {dist:.1f} < {min_pairwise}",
+                )
+    return errors
+
+
 def patch_golden_test_midtones(
     test_path: Path,
     means: dict[str, tuple[int, int, int]],
@@ -176,6 +203,11 @@ def main() -> None:
         action="store_true",
         help="Print actions without writing files",
     )
+    parser.add_argument(
+        "--validate-only",
+        action="store_true",
+        help="Check pairwise field-mean distinctness; no file writes",
+    )
     args = parser.parse_args()
     picks = paint._parse_promote(args.picks)
     candidate_means = load_candidate_means(args.candidate_dir)
@@ -185,10 +217,19 @@ def main() -> None:
         letter_by_id=paint.LETTER_BY_ID,
     )
     print("PO-locked field mask means:")
-    for crop in ("sugar_cane", "tobacco", "cotton", "spices"):
+    for crop in PLANTATION_KEYS:
         rgb = locked_means[crop]
         print(f"  {crop}: {rgb}")
     print(f"SPEC line: {format_midtone_clause(locked_means)}")
+    validation_errors = validate_plantation_picks(locked_means)
+    if validation_errors:
+        print("validation FAILED:")
+        for err in validation_errors:
+            print(f"  - {err}")
+        raise SystemExit(1)
+    print("validation OK: plantation field means are pairwise distinct")
+    if args.validate_only:
+        return
     if args.dry_run:
         print("dry-run: no files written")
         return

--- a/pytool/render_plantation_po_review_strip_3961.py
+++ b/pytool/render_plantation_po_review_strip_3961.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Render PO review strips for plantation field-gradient candidates (Refs #3961).
+
+Builds 4× nearest-neighbor strips at map tile scale: OW reference tiles
+(grain / meat / horses / tobacco), three hand-painted candidates (A/B/C), and
+the current shipped overlay per retune crop. Does not modify app terrain.
+
+See SPEC/ui/pytool-image-tools.md § render_plantation_po_review_strip_3961.py.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+from PIL import Image
+
+REPO = Path(__file__).resolve().parents[1]
+PAINT_SCRIPT = REPO / "pytool/paint_plains_plantation_field_gradients.py"
+DEFAULT_CANDIDATES = (
+    REPO / "pytool/assets/terrain/plantation_field_candidates_3961"
+)
+REFERENCE_STEMS = ("grain", "meat", "horses", "tobacco")
+RETUNE_CROPS = ("sugar_cane", "cotton", "spices")
+LETTERS = ("A", "B", "C")
+TILE_PX = 64
+SCALE = 4
+ROW_GAP_PX = 8
+
+
+def _load_paint_module():
+    spec = importlib.util.spec_from_file_location(
+        "paint_plains_plantation_field_gradients",
+        PAINT_SCRIPT,
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def upscale_nearest(im: Image.Image, scale: int) -> Image.Image:
+    w, h = im.size
+    return im.resize((w * scale, h * scale), Image.Resampling.NEAREST)
+
+
+def load_rgba(path: Path) -> Image.Image:
+    if not path.is_file():
+        raise SystemExit(f"missing tile PNG: {path}")
+    im = Image.open(path).convert("RGBA")
+    if im.size != (TILE_PX, TILE_PX):
+        raise SystemExit(f"expected 64×64, got {im.size} for {path}")
+    return im
+
+
+def concat_horizontal(tiles: list[Image.Image], *, gap: int = 0) -> Image.Image:
+    if not tiles:
+        raise SystemExit("concat_horizontal requires at least one tile")
+    height = tiles[0].height
+    width = sum(t.width for t in tiles) + gap * max(0, len(tiles) - 1)
+    out = Image.new("RGBA", (width, height), (0, 0, 0, 0))
+    x = 0
+    for i, tile in enumerate(tiles):
+        if tile.height != height:
+            raise SystemExit("tile height mismatch in strip row")
+        out.paste(tile, (x, 0))
+        x += tile.width + (gap if i < len(tiles) - 1 else 0)
+    return out
+
+
+def concat_vertical(rows: list[Image.Image], *, gap: int = 0) -> Image.Image:
+    if not rows:
+        raise SystemExit("concat_vertical requires at least one row")
+    width = max(r.width for r in rows)
+    height = sum(r.height for r in rows) + gap * max(0, len(rows) - 1)
+    out = Image.new("RGBA", (width, height), (0, 0, 0, 0))
+    y = 0
+    for i, row in enumerate(rows):
+        out.paste(row, (0, y))
+        y += row.height + (gap if i < len(rows) - 1 else 0)
+    return out
+
+
+def crop_strip_row(
+    terrain_dir: Path,
+    candidate_dir: Path,
+    crop: str,
+    *,
+    letter_by_id: dict[str, dict[str, str]],
+    scale: int,
+) -> Image.Image:
+    tiles: list[Image.Image] = []
+    for stem in REFERENCE_STEMS:
+        tiles.append(upscale_nearest(load_rgba(terrain_dir / f"tile_plains_{stem}.png"), scale))
+    for letter in LETTERS:
+        variant = letter_by_id[crop][letter]
+        path = candidate_dir / f"tile_plains_{crop}_{variant}.png"
+        tiles.append(upscale_nearest(load_rgba(path), scale))
+    tiles.append(
+        upscale_nearest(load_rgba(terrain_dir / f"tile_plains_{crop}.png"), scale),
+    )
+    return concat_horizontal(tiles)
+
+
+def write_candidate_notes(
+    out_dir: Path,
+    candidate_dir: Path,
+    terrain_dir: Path,
+    *,
+    paint_mod,
+) -> None:
+    means_path = candidate_dir / "CANDIDATE_MEANS.json"
+    data = json.loads(means_path.read_text(encoding="utf-8"))
+    field_means = data["field_mask_means"]
+    lines = [
+        "# Plantation field-gradient candidates (Refs #3961)",
+        "",
+        "Row order per strip: grain | meat | horses | tobacco | A | B | C | CURRENT.",
+        "",
+    ]
+    for crop in RETUNE_CROPS:
+        lines.append(f"## {crop}")
+        lines.append("")
+        lines.append("| ID | Variant | Field-mask mean RGB |")
+        lines.append("|----|---------|---------------------|")
+        for letter in LETTERS:
+            variant = paint_mod.LETTER_BY_ID[crop][letter]
+            rgb = field_means[crop][variant]
+            lines.append(f"| **{letter}** | `{variant}` | `({rgb[0]}, {rgb[1]}, {rgb[2]})` |")
+        current = paint_mod.field_mask_mean_rgb(
+            load_rgba(terrain_dir / f"tile_plains_{crop}.png"),
+            mask_from=load_rgba(REPO / "pytool/assets/terrain/tile_plains_plantation_base.png"),
+        )
+        lines.append(f"| CURRENT | shipped | `({current[0]}, {current[1]}, {current[2]})` |")
+        lines.append("")
+    (out_dir / "CANDIDATE_NOTES.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def render_strips(
+    terrain_dir: Path,
+    candidate_dir: Path,
+    out_dir: Path,
+    *,
+    scale: int = SCALE,
+) -> list[Path]:
+    paint = _load_paint_module()
+    out_dir.mkdir(parents=True, exist_ok=True)
+    written: list[Path] = []
+    rows: list[Image.Image] = []
+    for crop in RETUNE_CROPS:
+        row = crop_strip_row(
+            terrain_dir,
+            candidate_dir,
+            crop,
+            letter_by_id=paint.LETTER_BY_ID,
+            scale=scale,
+        )
+        rows.append(row)
+        path = out_dir / f"strip_{crop}_x{scale}.png"
+        row.save(path, optimize=True)
+        written.append(path)
+        print(f"wrote {path}")
+        for letter in LETTERS:
+            variant = paint.LETTER_BY_ID[crop][letter]
+            single = upscale_nearest(
+                load_rgba(candidate_dir / f"tile_plains_{crop}_{variant}.png"),
+                scale,
+            )
+            single_path = out_dir / f"{crop}_{letter}_{variant}_x{scale}.png"
+            single.save(single_path, optimize=True)
+            written.append(single_path)
+    overview = concat_vertical(rows, gap=ROW_GAP_PX * scale // SCALE)
+    overview_path = out_dir / f"strip_all_crops_x{scale}.png"
+    overview.save(overview_path, optimize=True)
+    written.append(overview_path)
+    print(f"wrote {overview_path}")
+    write_candidate_notes(out_dir, candidate_dir, terrain_dir, paint_mod=paint)
+    print(f"wrote {out_dir / 'CANDIDATE_NOTES.md'}")
+    return written
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--candidate-dir",
+        type=Path,
+        default=DEFAULT_CANDIDATES,
+    )
+    parser.add_argument(
+        "--terrain-dir",
+        type=Path,
+        default=REPO / "app/assets/images/terrain",
+    )
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        default=REPO / "tmp/plantation_po_review_strips_3961",
+    )
+    parser.add_argument(
+        "--scale",
+        type=int,
+        default=SCALE,
+        help="Nearest-neighbor upscale factor (default 4)",
+    )
+    args = parser.parse_args()
+    if args.scale < 1:
+        raise SystemExit("--scale must be >= 1")
+    render_strips(
+        args.terrain_dir,
+        args.candidate_dir,
+        args.out_dir,
+        scale=args.scale,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/pytool/test_finalize_plantation_field_retune_3961.py
+++ b/pytool/test_finalize_plantation_field_retune_3961.py
@@ -45,15 +45,6 @@ class FinalizePlantationFieldRetune3961Test(unittest.TestCase):
         self.assertEqual(locked["cotton"], tuple(means["cotton"]["B_grey_fibre"]))
         self.assertEqual(locked["spices"], tuple(means["spices"]["C_ochre_turmeric"]))
 
-    def test_resolve_rejects_incomplete_picks(self) -> None:
-        means = self.mod.load_candidate_means(CANDIDATES)
-        with self.assertRaises(SystemExit):
-            self.mod.resolve_locked_means(
-                means,
-                {"sugar_cane": "A"},
-                letter_by_id=self.paint.LETTER_BY_ID,
-            )
-
     def test_patch_spec_and_dart_round_trip(self) -> None:
         means = {
             "sugar_cane": (109, 137, 77),
@@ -93,6 +84,68 @@ class FinalizePlantationFieldRetune3961Test(unittest.TestCase):
             body = dart.read_text(encoding="utf-8")
             self.assertIn("'tile_plains_sugar_cane': (109, 137, 77)", body)
             self.assertIn("'tile_plains_cotton': (181, 179, 173)", body)
+
+    def test_resolve_rejects_incomplete_picks(self) -> None:
+        means = self.mod.load_candidate_means(CANDIDATES)
+        with self.assertRaises(SystemExit):
+            self.mod.resolve_locked_means(
+                means,
+                {"sugar_cane": "A"},
+                letter_by_id=self.paint.LETTER_BY_ID,
+            )
+
+    def test_validate_recommended_picks_pass_golden_distinctness(self) -> None:
+        means = self.mod.load_candidate_means(CANDIDATES)
+        locked = self.mod.resolve_locked_means(
+            means,
+            {"sugar_cane": "A", "cotton": "B", "spices": "C"},
+            letter_by_id=self.paint.LETTER_BY_ID,
+        )
+        self.assertEqual(self.mod.validate_plantation_picks(locked), [])
+
+    def test_end_to_end_finalize_in_temp_dir(self) -> None:
+        means = self.mod.load_candidate_means(CANDIDATES)
+        picks = {"sugar_cane": "A", "cotton": "B", "spices": "C"}
+        locked = self.mod.resolve_locked_means(
+            means,
+            picks,
+            letter_by_id=self.paint.LETTER_BY_ID,
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            spec = root / "layered.md"
+            spec.write_text(
+                "pipeline\n"
+                "- **Plantation pipeline (Refs #3961):** One base. "
+                "**PO sample gate (in progress):** subtler sugar_cane / cotton / spices "
+                "fields must use hand-painted field gradients via "
+                "`pytool/paint_plains_plantation_field_gradients.py` (3 candidates/crop "
+                "under `pytool/assets/terrain/plantation_field_candidates_3961/`); tobacco "
+                "stays; final SPEC mid-tones + shipped PNGs update only after PO locks a "
+                "letter per crop (`--promote`).\n"
+                "- **PIL field mid-tones (shipped until PO lock):** sugar_cane `(124,179,66)`; "
+                "tobacco `(128,108,42)`; cotton `(214,208,178)`; spices `(196,98,42)`.\n",
+                encoding="utf-8",
+            )
+            dart = root / "goldens_test.dart"
+            dart.write_text(
+                "const _plantationFieldMidTones = <String, (int, int, int)>{\n"
+                "  'tile_plains_sugar_cane': (124, 179, 66),\n"
+                "  'tile_plains_tobacco': (128, 108, 42),\n"
+                "  'tile_plains_cotton': (214, 208, 178),\n"
+                "  'tile_plains_spices': (196, 98, 42),\n"
+                "};\n",
+                encoding="utf-8",
+            )
+            app = root / "app_terrain"
+            app.mkdir()
+            self.paint.promote(CANDIDATES, app, picks)
+            self.mod.patch_spec_midtones(spec, locked)
+            self.mod.patch_golden_test_midtones(dart, locked)
+            for stem in ("sugar_cane", "cotton", "spices"):
+                self.assertTrue((app / f"tile_plains_{stem}.png").is_file())
+            self.assertFalse((app / "tile_plains_tobacco.png").exists())
+            self.assertIn("PO-approved hand-painted fields", spec.read_text(encoding="utf-8"))
 
 
 if __name__ == "__main__":

--- a/pytool/test_render_plantation_po_review_strip_3961.py
+++ b/pytool/test_render_plantation_po_review_strip_3961.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Tests for pytool/render_plantation_po_review_strip_3961.py (Refs #3961)."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from PIL import Image
+
+REPO = Path(__file__).resolve().parents[1]
+SCRIPT = REPO / "pytool/render_plantation_po_review_strip_3961.py"
+CANDIDATES = REPO / "pytool/assets/terrain/plantation_field_candidates_3961"
+TERRAIN = REPO / "app/assets/images/terrain"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location(
+        "render_plantation_po_review_strip_3961",
+        SCRIPT,
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class RenderPlantationPoReviewStrip3961Test(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.mod = _load_module()
+
+    def test_crop_strip_row_has_eight_tiles(self) -> None:
+        paint = self.mod._load_paint_module()
+        row = self.mod.crop_strip_row(
+            TERRAIN,
+            CANDIDATES,
+            "sugar_cane",
+            letter_by_id=paint.LETTER_BY_ID,
+            scale=4,
+        )
+        # 4 refs + 3 candidates + CURRENT shipped = 8 tiles @ 64px × 4
+        self.assertEqual(row.width, 8 * 64 * 4)
+        self.assertEqual(row.height, 64 * 4)
+
+    def test_render_strips_writes_overview_and_notes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            written = self.mod.render_strips(TERRAIN, CANDIDATES, out, scale=2)
+            names = {p.name for p in written}
+            self.assertIn("strip_all_crops_x2.png", names)
+            self.assertIn("strip_sugar_cane_x2.png", names)
+            self.assertTrue((out / "CANDIDATE_NOTES.md").is_file())
+            overview = Image.open(out / "strip_all_crops_x2.png")
+            self.assertGreater(overview.width, 0)
+            self.assertGreater(overview.height, 64 * 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Advances #3961 post-sample tooling while the PO letter lock gate remains open.

- **`render_plantation_po_review_strip_3961.py`** — reproducible 4× PO review strips (`grain` / `meat` / `horses` / `tobacco` / A / B / C / CURRENT per crop) plus `CANDIDATE_NOTES.md` for issue/release posting.
- **`finalize_plantation_field_retune_3961.py --validate-only`** — checks pairwise field-mean RGB distance (≥ 26) against `plains_plantation_terrain_goldens_test.dart` distinctness pins before apply.
- Integration test: full promote + SPEC + dart pin round-trip in a temp dir.

## Deferred (blocked on PO lock)

Per AC **Samples before lock**, shipped terrain PNGs, SPEC mid-tone pins, and plantation goldens are **not** updated in this PR. After @waigore confirms letters on the issue:

```bash
uv run --project pytool python pytool/finalize_plantation_field_retune_3961.py \
  --picks sugar_cane=<A|B|C>,cotton=<A|B|C>,spices=<A|B|C>
cd app && flutter test test/plains_plantation_terrain_goldens_test.dart --update-goldens
```

Recommended picks pass validation: `sugar_cane=A,cotton=B,spices=C`.

## SPEC / AC coverage

| AC / section | This PR |
|--------------|---------|
| Samples before lock | Already satisfied on issue (no change) |
| PO-locked finalize (`layered-terrain-rendering.md` AC) | Tooling + e2e test only; apply deferred |
| `pytool-image-tools.md` | Updated for new scripts/flags |

## Test plan

- [x] `uv run --project pytool python pytool/test_finalize_plantation_field_retune_3961.py`
- [x] `uv run --project pytool python pytool/test_render_plantation_po_review_strip_3961.py`
- [x] `finalize_plantation_field_retune_3961.py --picks sugar_cane=A,cotton=B,spices=C --validate-only`

Refs #3961

Made with [Cursor](https://cursor.com)