### PR TITLE
feat(terrain): one-step golden refresh in plantation finalize script (#3961)

### DIFF
--- a/SPEC/ui/pytool-image-tools.md
+++ b/SPEC/ui/pytool-image-tools.md
@@ -70,10 +70,12 @@ uv run --project pytool python pytool/finalize_plantation_field_retune_3961.py \
 # Apply (after PO lock):
 uv run --project pytool python pytool/finalize_plantation_field_retune_3961.py \
   --picks sugar_cane=A,cotton=B,spices=C
-cd app && flutter test test/plains_plantation_terrain_goldens_test.dart --update-goldens
+# Or apply + refresh goldens in one step:
+uv run --project pytool python pytool/finalize_plantation_field_retune_3961.py \
+  --picks sugar_cane=A,cotton=B,spices=C --update-goldens
 ```
 
-**Behaviour:** Requires all three retune crops in `--picks`. `--dry-run` prints resolved means without writing. `--validate-only` checks pairwise field-mean RGB distance (≥ 26) against golden-test distinctness pins without writing files. Apply mode copies PNGs then patches SPEC + dart pins; operator must refresh goldens manually.
+**Behaviour:** Requires all three retune crops in `--picks`. `--dry-run` prints resolved means without writing. `--validate-only` checks pairwise field-mean RGB distance (≥ 26) against golden-test distinctness pins without writing files. Apply mode copies PNGs then patches SPEC + dart pins; operator may pass `--update-goldens` to run `flutter test … --update-goldens` instead of doing so manually.
 
 ---
 

--- a/pytool/assets/terrain/plantation_field_candidates_3961/README.md
+++ b/pytool/assets/terrain/plantation_field_candidates_3961/README.md
@@ -19,9 +19,8 @@ After PO lock (does **not** touch tobacco):
 
 ```bash
 uv run --project pytool python pytool/finalize_plantation_field_retune_3961.py \
-  --picks sugar_cane=A,cotton=B,spices=C
-cd app && flutter test test/plains_plantation_terrain_goldens_test.dart --update-goldens
+  --picks sugar_cane=A,cotton=B,spices=C --update-goldens
 ```
 
-(`--dry-run` previews means without writing. Legacy promote-only path:
+(`--dry-run` / `--validate-only` preview without writing. Legacy promote-only path:
 `paint_plains_plantation_field_gradients.py --promote …` then manual SPEC/test pins.)

--- a/pytool/finalize_plantation_field_retune_3961.py
+++ b/pytool/finalize_plantation_field_retune_3961.py
@@ -18,6 +18,7 @@ import importlib.util
 import json
 import math
 import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -155,6 +156,17 @@ def validate_plantation_picks(
     return errors
 
 
+def refresh_plantation_goldens(*, repo_root: Path = REPO) -> None:
+    """Run flutter golden refresh for plantation terrain strip."""
+    app_dir = repo_root / "app"
+    test_path = "test/plains_plantation_terrain_goldens_test.dart"
+    subprocess.run(
+        ["flutter", "test", test_path, "--update-goldens"],
+        cwd=app_dir,
+        check=True,
+    )
+
+
 def patch_golden_test_midtones(
     test_path: Path,
     means: dict[str, tuple[int, int, int]],
@@ -208,7 +220,14 @@ def main() -> None:
         action="store_true",
         help="Check pairwise field-mean distinctness; no file writes",
     )
+    parser.add_argument(
+        "--update-goldens",
+        action="store_true",
+        help="After apply, run flutter test --update-goldens for plantation strip",
+    )
     args = parser.parse_args()
+    if args.update_goldens and (args.dry_run or args.validate_only):
+        raise SystemExit("--update-goldens requires apply mode (no --dry-run/--validate-only)")
     picks = paint._parse_promote(args.picks)
     candidate_means = load_candidate_means(args.candidate_dir)
     locked_means = resolve_locked_means(
@@ -236,11 +255,17 @@ def main() -> None:
     paint.promote(args.candidate_dir, args.app_terrain_dir, picks)
     patch_spec_midtones(SPEC_LAYERED, locked_means)
     patch_golden_test_midtones(GOLDEN_TEST, locked_means)
-    print(
-        "\nNext: refresh plantation golden from app/:\n"
-        "  cd app && flutter test test/plains_plantation_terrain_goldens_test.dart "
-        "--update-goldens"
-    )
+    if args.update_goldens:
+        print("refreshing plantation goldens...")
+        refresh_plantation_goldens()
+        print("goldens updated")
+    else:
+        print(
+            "\nNext: refresh plantation golden from app/:\n"
+            "  cd app && flutter test test/plains_plantation_terrain_goldens_test.dart "
+            "--update-goldens\n"
+            "Or re-run with --update-goldens after PO lock."
+        )
 
 
 if __name__ == "__main__":

--- a/pytool/test_finalize_plantation_field_retune_3961.py
+++ b/pytool/test_finalize_plantation_field_retune_3961.py
@@ -117,6 +117,19 @@ class FinalizePlantationFieldRetune3961Test(unittest.TestCase):
                 self.mod.main()
             self.assertIn("--update-goldens", str(ctx.exception))
 
+    def test_update_goldens_rejected_with_dry_run(self) -> None:
+        argv = [
+            "finalize",
+            "--picks",
+            "sugar_cane=A,cotton=B,spices=C",
+            "--dry-run",
+            "--update-goldens",
+        ]
+        with patch.object(sys, "argv", argv):
+            with self.assertRaises(SystemExit) as ctx:
+                self.mod.main()
+            self.assertIn("--update-goldens", str(ctx.exception))
+
     def test_refresh_plantation_goldens_invokes_flutter(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             repo = Path(tmp)

--- a/pytool/test_finalize_plantation_field_retune_3961.py
+++ b/pytool/test_finalize_plantation_field_retune_3961.py
@@ -9,6 +9,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 REPO = Path(__file__).resolve().parents[1]
 SCRIPT = REPO / "pytool/finalize_plantation_field_retune_3961.py"
@@ -102,6 +103,39 @@ class FinalizePlantationFieldRetune3961Test(unittest.TestCase):
             letter_by_id=self.paint.LETTER_BY_ID,
         )
         self.assertEqual(self.mod.validate_plantation_picks(locked), [])
+
+    def test_update_goldens_rejected_with_validate_only(self) -> None:
+        argv = [
+            "finalize",
+            "--picks",
+            "sugar_cane=A,cotton=B,spices=C",
+            "--validate-only",
+            "--update-goldens",
+        ]
+        with patch.object(sys, "argv", argv):
+            with self.assertRaises(SystemExit) as ctx:
+                self.mod.main()
+            self.assertIn("--update-goldens", str(ctx.exception))
+
+    def test_refresh_plantation_goldens_invokes_flutter(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            (repo / "app").mkdir()
+            with patch.object(self.mod.subprocess, "run") as run:
+                self.mod.refresh_plantation_goldens(repo_root=repo)
+            run.assert_called_once()
+            args, kwargs = run.call_args
+            self.assertEqual(
+                args[0],
+                [
+                    "flutter",
+                    "test",
+                    "test/plains_plantation_terrain_goldens_test.dart",
+                    "--update-goldens",
+                ],
+            )
+            self.assertEqual(kwargs["cwd"], repo / "app")
+            self.assertTrue(kwargs["check"])
 
     def test_end_to_end_finalize_in_temp_dir(self) -> None:
         means = self.mod.load_candidate_means(CANDIDATES)


### PR DESCRIPTION
## Summary

Adds `--update-goldens` to `finalize_plantation_field_retune_3961.py` so the post-PO-lock workflow can promote candidates, patch SPEC + dart mid-tone pins, and refresh `plains_plantation_terrain_goldens_test.dart` baselines in one command.

## Done in this push

- `--update-goldens` flag on finalize script (runs `flutter test … --update-goldens` after apply)
- Guard: rejected when combined with `--dry-run` or `--validate-only`
- Unit tests for flag guard and `refresh_plantation_goldens()` subprocess invocation
- SPEC + candidate README updated with one-step example

## Deferred (awaiting PO letter lock on #3961)

- `--promote` / SPEC mid-tone lock / ship `tile_plains_{sugar_cane,cotton,spices}.png`
- Refresh plantation golden strip with approved art
- Move issue to `backlog:verification`

PO still needs A/B/C per crop (or reject-all + criteria). Recommended combo `sugar_cane=A,cotton=B,spices=C` passes pairwise distinctness validation (≥26 RGB distance).

Refs #3961

## Test plan

- [x] `uv run --project pytool python pytool/test_finalize_plantation_field_retune_3961.py`
- [x] `uv run --project pytool python pytool/test_render_plantation_po_review_strip_3961.py`
- [x] `finalize_plantation_field_retune_3961.py --picks sugar_cane=A,cotton=B,spices=C --validate-only`


Made with [Cursor](https://cursor.com)