### PR TITLE
fix(terrain): PO strip single-tile filenames match release assets (#3961)

### DIFF
--- a/pytool/render_plantation_po_review_strip_3961.py
+++ b/pytool/render_plantation_po_review_strip_3961.py
@@ -51,7 +51,8 @@ def upscale_nearest(im: Image.Image, scale: int) -> Image.Image:
 def load_rgba(path: Path) -> Image.Image:
     if not path.is_file():
         raise SystemExit(f"missing tile PNG: {path}")
-    im = Image.open(path).convert("RGBA")
+    with Image.open(path) as opened:
+        im = opened.convert("RGBA")
     if im.size != (TILE_PX, TILE_PX):
         raise SystemExit(f"expected 64×64, got {im.size} for {path}")
     return im
@@ -165,12 +166,13 @@ def render_strips(
         written.append(path)
         print(f"wrote {path}")
         for letter in LETTERS:
+            # Variant ids already include the letter (e.g. A_sage_olive).
             variant = paint.LETTER_BY_ID[crop][letter]
             single = upscale_nearest(
                 load_rgba(candidate_dir / f"tile_plains_{crop}_{variant}.png"),
                 scale,
             )
-            single_path = out_dir / f"{crop}_{letter}_{variant}_x{scale}.png"
+            single_path = out_dir / f"{crop}_{variant}_x{scale}.png"
             single.save(single_path, optimize=True)
             written.append(single_path)
     overview = concat_vertical(rows, gap=ROW_GAP_PX * scale // SCALE)

--- a/pytool/test_render_plantation_po_review_strip_3961.py
+++ b/pytool/test_render_plantation_po_review_strip_3961.py
@@ -54,10 +54,15 @@ class RenderPlantationPoReviewStrip3961Test(unittest.TestCase):
             names = {p.name for p in written}
             self.assertIn("strip_all_crops_x2.png", names)
             self.assertIn("strip_sugar_cane_x2.png", names)
+            # Variant ids already include the letter; do not double it.
+            self.assertIn("sugar_cane_A_sage_olive_x2.png", names)
+            self.assertIn("cotton_B_grey_fibre_x2.png", names)
+            self.assertIn("spices_C_ochre_turmeric_x2.png", names)
+            self.assertNotIn("sugar_cane_A_A_sage_olive_x2.png", names)
             self.assertTrue((out / "CANDIDATE_NOTES.md").is_file())
-            overview = Image.open(out / "strip_all_crops_x2.png")
-            self.assertGreater(overview.width, 0)
-            self.assertGreater(overview.height, 64 * 2)
+            with Image.open(out / "strip_all_crops_x2.png") as overview:
+                self.assertGreater(overview.width, 0)
+                self.assertGreater(overview.height, 64 * 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Fix `render_plantation_po_review_strip_3961.py` writing `{crop}_{letter}_{variant}_xN.png` (e.g. `sugar_cane_A_A_sage_olive_x4.png`). Variant ids already include the letter (`A_sage_olive`), so regenerated singles now match release `po-samples-3961` names.
- Close Pillow handles in `load_rgba` and assert release-compatible names in the strip unit test.

## Scope
- **Done:** tooling filename bugfix only.
- **Deferred:** shipping retuned `tile_plains_{sugar_cane,cotton,spices}.png`, SPEC mid-tone lock, and golden refresh — still gated on PO A/B/C letter lock (AC Samples before lock).

## Test plan
- [x] `uv run --project pytool python pytool/test_render_plantation_po_review_strip_3961.py`
- [x] Regenerated strips emit `sugar_cane_A_sage_olive_x4.png` (not `A_A_…`)

Refs #3961


Made with [Cursor](https://cursor.com)