### PR TITLE
ci: gate plantation field-retune pytool tests (#3961)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -835,6 +835,9 @@ jobs:
           sudo apt-get install -y --no-install-recommends python3-pil
           cd pytool && python3 test_wang_incremental_assets_and_preview.py
 
+      - name: Plantation field retune gate (Python, Refs #3961)
+        run: cd pytool && python3 test_plantation_field_retune_3961_gate.py
+
       - name: Test run_observer_game (Dart, coverage)
         if: needs.changes.outputs.tests == 'true'
         env:

--- a/SPEC/ui/pytool-image-tools.md
+++ b/SPEC/ui/pytool-image-tools.md
@@ -53,7 +53,7 @@ uv run --project pytool python pytool/paint_plains_plantation_field_gradients.py
 
 ### finalize_plantation_field_retune_3961.py
 
-**Purpose:** After PO locks A/B/C per crop on [#3961](https://github.com/waigore/colonizethisv3/issues/3961), promote candidates, patch SPEC mid-tone pins in [layered-terrain-rendering.md](layered-terrain-rendering.md), and patch `app/test/plains_plantation_terrain_goldens_test.dart` mean-RGB constants from `CANDIDATE_MEANS.json`. Tobacco stays unchanged. Does not auto-run golden refresh.
+**Purpose:** After PO locks A/B/C per crop on [#3961](https://github.com/waigore/colonizethisv3/issues/3961), promote candidates, patch SPEC mid-tone pins in [layered-terrain-rendering.md](layered-terrain-rendering.md), and patch `app/test/plains_plantation_terrain_goldens_test.dart` mean-RGB constants from `CANDIDATE_MEANS.json`. Tobacco stays unchanged. Golden refresh is optional via `--update-goldens`.
 
 **Dependencies:** Pillow; imports `paint_plains_plantation_field_gradients.py`.
 

--- a/pytool/paint_plains_plantation_field_gradients.py
+++ b/pytool/paint_plains_plantation_field_gradients.py
@@ -216,8 +216,16 @@ def field_mask_mean_rgb(
     return (rs // n, gs // n, bs // n)
 
 
+def _rgba_pixels(im: Image.Image):
+    """Pixel sequence compatible with apt Pillow 10.x and Pillow 12+."""
+    rgba = im.convert("RGBA")
+    # Pillow 12+: get_flattened_data; older: getdata (deprecated in 12).
+    flat = getattr(rgba, "get_flattened_data", None)
+    return flat() if flat is not None else rgba.getdata()
+
+
 def _alpha_bytes(im: Image.Image) -> list[int]:
-    return [p[3] for p in im.convert("RGBA").get_flattened_data()]
+    return [p[3] for p in _rgba_pixels(im)]
 
 
 def write_candidates(

--- a/pytool/recolour_plains_plantation_tiles.py
+++ b/pytool/recolour_plains_plantation_tiles.py
@@ -100,11 +100,16 @@ def main() -> None:
     if src.size != (64, 64):
         raise SystemExit(f"expected 64×64 base, got {src.size}")
     args.out_dir.mkdir(parents=True, exist_ok=True)
-    base_alpha = [p[3] for p in src.convert("RGBA").get_flattened_data()]
+    def _rgba_pixels(im: Image.Image):
+        rgba = im.convert("RGBA")
+        flat = getattr(rgba, "get_flattened_data", None)
+        return flat() if flat is not None else rgba.getdata()
+
+    base_alpha = [p[3] for p in _rgba_pixels(src)]
     for stem, rgb in FIELD_TARGETS.items():
         out_path = args.out_dir / f"tile_plains_{stem}.png"
         out = recolour_field(src, rgb)
-        out_alpha = [p[3] for p in out.convert("RGBA").get_flattened_data()]
+        out_alpha = [p[3] for p in _rgba_pixels(out)]
         if out_alpha != base_alpha:
             raise SystemExit(f"alpha silhouette changed for {stem}")
         out.save(out_path, optimize=True)

--- a/pytool/test_paint_plains_plantation_field_gradients.py
+++ b/pytool/test_paint_plains_plantation_field_gradients.py
@@ -46,16 +46,14 @@ class PaintPlainsPlantationFieldGradientsTest(unittest.TestCase):
         src = Image.open(BASE).convert("RGBA")
         stops = self.mod.CANDIDATES["sugar_cane"]["A_sage_olive"]
         out = self.mod.paint_field_gradient(src, stops)
+        src_px = self.mod._rgba_pixels(src)
+        out_px = self.mod._rgba_pixels(out)
         self.assertEqual(
-            [p[3] for p in out.get_flattened_data()],
-            [p[3] for p in src.get_flattened_data()],
+            [p[3] for p in out_px],
+            [p[3] for p in src_px],
         )
         changed = 0
-        for a, b in zip(
-            src.get_flattened_data(),
-            out.get_flattened_data(),
-            strict=True,
-        ):
+        for a, b in zip(src_px, out_px, strict=True):
             if self.mod.is_field_highlight(*a) and a[:3] != b[:3]:
                 changed += 1
         self.assertGreater(changed, 50)
@@ -65,8 +63,8 @@ class PaintPlainsPlantationFieldGradientsTest(unittest.TestCase):
         stops = self.mod.CANDIDATES["cotton"]["B_grey_fibre"]
         out = self.mod.paint_field_gradient(src, stops)
         for a, b in zip(
-            src.get_flattened_data(),
-            out.get_flattened_data(),
+            self.mod._rgba_pixels(src),
+            self.mod._rgba_pixels(out),
             strict=True,
         ):
             if not self.mod.is_field_highlight(*a):

--- a/pytool/test_plantation_field_retune_3961_gate.py
+++ b/pytool/test_plantation_field_retune_3961_gate.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Quality gate: plantation field-retune pytool tests (Refs #3961).
+
+Runs paint, finalize, and PO review-strip unittest modules in one CI step.
+No network; requires Pillow and committed candidate PNGs.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+PYTOOL = REPO / "pytool"
+TESTS = (
+    "test_paint_plains_plantation_field_gradients.py",
+    "test_finalize_plantation_field_retune_3961.py",
+    "test_render_plantation_po_review_strip_3961.py",
+)
+
+
+def main() -> None:
+    for name in TESTS:
+        path = PYTOOL / name
+        if not path.is_file():
+            raise SystemExit(f"missing gate test module: {path}")
+        print(f"=== {name} ===", flush=True)
+        result = subprocess.run([sys.executable, str(path)], check=False)
+        if result.returncode != 0:
+            raise SystemExit(result.returncode)
+    print("plantation field retune gate: OK", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tool/run_quality_gate_tests.sh
+++ b/tool/run_quality_gate_tests.sh
@@ -22,6 +22,10 @@ fi
 (cd pytool && python3 test_wang_incremental_assets_and_preview.py)
 
 echo ""
+echo "=== Plantation field retune gate (Python, Refs #3961) ==="
+(cd pytool && python3 test_plantation_field_retune_3961_gate.py)
+
+echo ""
 echo "=== Package tests (colonizethis; CI: package_tests job) ==="
 # Match CI: packages sequential (MAX_JOBS=1), intra-package -j 4.
 PACKAGE_TEST_MAX_JOBS=1 PACKAGE_TEST_CONCURRENCY=4 tool/run_package_tests.sh


### PR DESCRIPTION
## Summary

- Add `pytool/test_plantation_field_retune_3961_gate.py` to run paint, finalize, and PO review-strip unittest modules in one step.
- Wire the gate into `quality.yml` and `tool/run_quality_gate_tests.sh` (after the Wang incremental assets gate; reuses the same `python3-pil` install step).
- Clarify `finalize_plantation_field_retune_3961.py` SPEC purpose line (`--update-goldens` is optional, not absent).

## Scope

**Done in this PR:** CI/local quality-gate coverage for all plantation retune pytool tests already on `dev` (#4034, #4044–#4047).

**Deferred (blocked on PO letter lock):** promote approved PNGs, SPEC mid-tone pins, shipped terrain art, and plantation golden refresh. AC “Samples before lock” still needs one A/B/C pick per crop from PO.

After PO lock:
```bash
uv run --project pytool python pytool/finalize_plantation_field_retune_3961.py \
  --picks sugar_cane=A,cotton=B,spices=C --update-goldens
```

## Test plan

- [x] `cd pytool && python3 test_plantation_field_retune_3961_gate.py` (16 tests, OK)

Refs #3961

Made with [Cursor](https://cursor.com)