### PR TITLE
refactor(ai): de-part Slice A planner clusters (#4079)

### DIFF
--- a/packages/colonizethis_ai/lib/src/perception/perception_snapshot.dart
+++ b/packages/colonizethis_ai/lib/src/perception/perception_snapshot.dart
@@ -3,12 +3,10 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/ai_api.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
-import 'perception_topology.dart';
+import 'perception_snapshot_builders.dart';
 import 'summary_models.dart';
 
 export 'summary_models.dart';
-
-part 'perception_snapshot_builders.dart';
 
 final _log = packageLogger();
 
@@ -40,11 +38,11 @@ class AIWorldSnapshot {
     PlayerView view, {
     MapTopology? topology,
   }) {
-    final threats = _buildThreatSummary(view, topology);
-    final opportunities = _buildOpportunitySummary(view, topology);
-    final conquest = _buildConquestSummary(view, topology, threats, opportunities);
-    final colonial = _buildColonialSummary(view, topology, threats, opportunities);
-    final economy = _buildEconomySummary(view);
+    final threats = buildThreatSummary(view, topology);
+    final opportunities = buildOpportunitySummary(view, topology);
+    final conquest = buildConquestSummary(view, topology, threats, opportunities);
+    final colonial = buildColonialSummary(view, topology, threats, opportunities);
+    final economy = buildEconomySummary(view);
     final snapshot = AIWorldSnapshot(
       playerId: view.playerId,
       threats: threats,

--- a/packages/colonizethis_ai/lib/src/perception/perception_snapshot_builders.dart
+++ b/packages/colonizethis_ai/lib/src/perception/perception_snapshot_builders.dart
@@ -1,6 +1,11 @@
-part of 'perception_snapshot.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/ai_api.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
 
-ThreatSummary _buildThreatSummary(PlayerView view, MapTopology? topology) {
+import 'perception_topology.dart';
+import 'summary_models.dart';
+
+ThreatSummary buildThreatSummary(PlayerView view, MapTopology? topology) {
   final atWarWith = <String>[];
   for (final e in view.diplomacyByOtherId.entries) {
     final rel = e.value;
@@ -61,7 +66,7 @@ ThreatSummary _buildThreatSummary(PlayerView view, MapTopology? topology) {
   );
 }
 
-OpportunitySummary _buildOpportunitySummary(
+OpportunitySummary buildOpportunitySummary(
   PlayerView view,
   MapTopology? topology,
 ) {
@@ -105,7 +110,7 @@ List<String> _weakNeighborOwnerIds(PlayerView view, MapTopology topology) {
   return weakNeighbors;
 }
 
-ConquestSummary _buildConquestSummary(
+ConquestSummary buildConquestSummary(
   PlayerView view,
   MapTopology? topology,
   ThreatSummary threats,
@@ -138,7 +143,7 @@ ConquestSummary _buildConquestSummary(
   );
 }
 
-ColonialSummary _buildColonialSummary(
+ColonialSummary buildColonialSummary(
   PlayerView view,
   MapTopology? topology,
   ThreatSummary threats,
@@ -310,7 +315,7 @@ List<String> _invadableProvinceIdsForRegion(
   return invadable;
 }
 
-EconomySummary _buildEconomySummary(PlayerView view) {
+EconomySummary buildEconomySummary(PlayerView view) {
   final p = view.player;
   final workerCount = p.workerPool.totalWorkers;
   final treasury = p.treasury;

--- a/packages/colonizethis_ai/lib/src/planning/conquest_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/conquest_planner.dart
@@ -1,6 +1,7 @@
 import 'package:colonizethis_logic/order_suggestion_api.dart';
 
 import 'conquest_move_scoring_context.dart';
+import 'conquest_planner_destination_scoring.dart';
 import 'goal_manager.dart';
 import 'planning_imports.dart';
 import '../perception/perception_snapshot.dart';
@@ -8,21 +9,17 @@ import 'expand_phase_planner.dart';
 import 'observer_goal_phase.dart';
 import 'phase_planner_conquest_filter.dart';
 import 'phase_planner_dispatch.dart';
-import 'phase_priority_weights.dart';
 import 'planner_context.dart';
 import 'planning_helpers.dart'
     show
-        clampPhaseWeightUpperUnit,
         colonialPressureScaleFromWeight,
         factionOwnsInvadableOldWorldProvince,
         isAtWarWithAnyGreatPower,
-        minorAtWarPeaceTargetsWhere,
-        oldWorldProvinceLeadOver;
+        minorAtWarPeaceTargetsWhere;
 import '../util/ai_random_utils.dart';
-import '../util/faction_query.dart';
 
-part 'conquest_planner_stalled_scoring.dart';
-part 'conquest_planner_destination_scoring.dart';
+export 'conquest_planner_destination_scoring.dart'
+    show conquestOldWorldArmyMoveScaledBonus, conquestNwInvadableArmyMoveBonus;
 
 final _log = packageLogger();
 
@@ -341,10 +338,10 @@ Orders runConquestArmyMovePlanner({
   // emitting any army move, and the capital armies sit at the capital across
   // every turn of the 100-turn observer run (gp1 OW gain = 0 against the
   // turn-100 +3 gate). Bypass the prefilter on the stalled-expansion path so
-  // the stalled-expansion scoring in `_scoreArmyMoveDestination` (which
+  // the stalled-expansion scoring in `scoreArmyMoveDestination` (which
   // already prefers invadable destinations first, then own-territory
   // adjacent-at-war-frontier marches via
-  // `_stalledExpansionArmyMoveScoreDelta`, and structurally returns `0` for
+  // `stalledExpansionArmyMoveScoreDelta`, and structurally returns `0` for
   // foreign non-invadable destinations) picks the best multi-turn approach
   // move toward the at-war frontier instead. Non-stalled (at-quota) callers
   // keep the strict prefilter so DEVELOP / COLONIAL stay structural.
@@ -380,7 +377,7 @@ Orders runConquestArmyMovePlanner({
   final selected = selectWeightedCandidate(
     candidates: scoringCandidates,
     seed: ctx.seeds.militarySeed + 4000,
-    score: (m) => _scoreArmyMoveDestination(scoringCtx, m),
+    score: (m) => scoreArmyMoveDestination(scoringCtx, m),
   );
   if (selected == null) return ctx.orders;
   if (_log.infoEnabled) {
@@ -458,7 +455,7 @@ Orders _applyStalledArmyMovesForAllFieldArmies({
     final best = selectFeedstockBiasedBestArmyMove(
       candidates: candidates,
       feedstockConquestTarget: feedstockConquestTarget,
-      score: (move) => _scoreArmyMoveDestination(scoringCtx, move),
+      score: (move) => scoreArmyMoveDestination(scoringCtx, move),
     );
     if (best == null) continue;
     if (_log.infoEnabled) {
@@ -518,7 +515,7 @@ Orders _runStalledFrontierArmyMoveFallback({
   final best = selectFeedstockBiasedBestArmyMove(
     candidates: acceptedCandidates,
     feedstockConquestTarget: feedstockConquestTarget,
-    score: (candidate) => _scoreArmyMoveDestination(scoringCtx, candidate),
+    score: (candidate) => scoreArmyMoveDestination(scoringCtx, candidate),
   );
   if (best == null) {
     return ctx.orders;

--- a/packages/colonizethis_ai/lib/src/planning/conquest_planner_destination_scoring.dart
+++ b/packages/colonizethis_ai/lib/src/planning/conquest_planner_destination_scoring.dart
@@ -1,7 +1,12 @@
-part of 'conquest_planner.dart';
+import 'conquest_move_scoring_context.dart';
+import 'conquest_planner_stalled_scoring.dart';
+import 'phase_priority_weights.dart'
+    show kPhasePriorityNwInvadablePursuitWeightThreshold;
+import 'planning_helpers.dart' show clampPhaseWeightUpperUnit;
+import 'planning_imports.dart';
 
 // Destination scoring for conquest army moves (OW/NW weight scaling
-// and _scoreArmyMoveDestination) — Refs #3967 step 4.
+// and scoreArmyMoveDestination) — Refs #3967 step 4.
 
 /// Scales an OW army-move additive score term by the soft-phase
 /// [oldWorldInvasionWeight] (Refs #2847 Phase 3 conquest OW-invasion wiring).
@@ -61,7 +66,7 @@ double conquestNwInvadableArmyMoveBonus({
   return signedBonus * nwInvasionWeight;
 }
 
-double _scoreArmyMoveDestination(
+double scoreArmyMoveDestination(
   ConquestMoveScoringContext ctx,
   ArmyMoveOrder move,
 ) {
@@ -105,8 +110,8 @@ double _scoreArmyMoveDestination(
   );
   var score = 1.0;
   if (stalledExpansion) {
-    final delta = _stalledExpansionArmyMoveScoreDelta(
-      _StalledExpansionArmyMoveScoreDeltaInput(
+    final delta = stalledExpansionArmyMoveScoreDelta(
+      StalledExpansionArmyMoveScoreDeltaInput(
         move: move,
         nationId: nationId,
         game: game,

--- a/packages/colonizethis_ai/lib/src/planning/conquest_planner_stalled_scoring.dart
+++ b/packages/colonizethis_ai/lib/src/planning/conquest_planner_stalled_scoring.dart
@@ -1,4 +1,8 @@
-part of 'conquest_planner.dart';
+import '../perception/perception_snapshot.dart';
+import '../util/faction_query.dart';
+import 'expand_phase_planner.dart' show expandIsGeographicPeerWarLock;
+import 'planning_helpers.dart' show oldWorldProvinceLeadOver;
+import 'planning_imports.dart';
 
 // Geographic peer-war lock helpers and stalled-expansion army-move
 // score deltas extracted from conquest_planner.dart (Refs #3967 step 4).
@@ -70,8 +74,8 @@ final class _GeographicPeerLockTransitInput {
 
 /// Shared destination inputs for stalled-expansion army-move score deltas
 /// (Refs #3997).
-final class _StalledExpansionArmyMoveScoreDeltaInput {
-  const _StalledExpansionArmyMoveScoreDeltaInput({
+final class StalledExpansionArmyMoveScoreDeltaInput {
+  const StalledExpansionArmyMoveScoreDeltaInput({
     required this.move,
     required this.nationId,
     required this.game,
@@ -152,8 +156,8 @@ bool _isGeographicPeerLockMinorTransitDestination(
   return false;
 }
 
-double _stalledExpansionArmyMoveScoreDelta(
-  _StalledExpansionArmyMoveScoreDeltaInput input,
+double stalledExpansionArmyMoveScoreDelta(
+  StalledExpansionArmyMoveScoreDeltaInput input,
 ) {
   final geoLockPeerGpId = _geographicPeerWarLockPeerGpId(input.snapshot);
   final geoLockActive =

--- a/packages/colonizethis_ai/lib/src/planning/diplomatic_candidate_scoring.dart
+++ b/packages/colonizethis_ai/lib/src/planning/diplomatic_candidate_scoring.dart
@@ -1,39 +1,17 @@
 import 'dart:math' as math;
 
 import '../perception/perception_snapshot.dart';
-import '../util/faction_query.dart';
-import 'army_conquest_prep.dart';
-import 'planning_imports.dart';
-import 'expand_phase_planner.dart';
+import 'diplomatic_candidate_scoring_declare_war.dart';
+import 'diplomatic_candidate_scoring_declare_war_context.dart';
+import 'diplomatic_candidate_scoring_establish_overture.dart';
+import 'diplomatic_candidate_scoring_offer_peace.dart';
+import 'diplomatic_candidate_scoring_shared.dart';
+import 'diplomatic_scoring_context.dart';
 import 'goal_manager.dart';
-import 'observer_goal_phase.dart';
-import 'phase_planner_diplomacy_filter.dart';
 import 'phase_planner_dispatch.dart';
-import 'planning_helpers.dart'
-    show
-        anyInvadableProvinceOwnedByGreatPower,
-        anyInvadableProvinceOwnedByMinor,
-        atWarGreatPowerOrderTarget,
-        atWarPeaceTargetBonus,
-        factionOwnsInvadableOldWorldProvince,
-        gpFactionIdsAtWarWith,
-        hasRecentDiplomaticEventWithinCooldown,
-        isAtWarWithAnyGreatPower,
-        isOwnOldWorldBelowConquestQuota,
-        isOwnOldWorldExpansionStalled,
-        kDiplomaticDefaultBaseScore,
-        mutualExhaustedGpStalemateSideQualifies,
-        orderTargetIsAtWarInvadableBlocker;
+import 'planning_imports.dart';
+import 'planning_helpers.dart' show kDiplomaticDefaultBaseScore;
 import 'war_desire_calculator.dart';
-
-part 'diplomatic_scoring_context.dart';
-part 'diplomatic_candidate_scoring_offer_peace.dart';
-part 'diplomatic_candidate_scoring_declare_war_context.dart';
-part 'diplomatic_candidate_scoring_declare_war.dart';
-part 'diplomatic_candidate_scoring_declare_war_bonuses.dart';
-part 'diplomatic_candidate_scoring_establish_overture.dart';
-
-final _log = packageLogger();
 
 /// Bundles inputs for [computeDiplomaticCandidateScores] (Refs #3977 AC5).
 final class DiplomaticCandidateScoringInput {
@@ -102,7 +80,7 @@ List<int> computeDiplomaticCandidateScores(
   // old-world province — exactly the prior `oldWorld.provinces.any` predicate
   // (minor ids are non-empty, and an empty/`null` owner never equals a minor id).
   final anyMinorOwnsOldWorld = game.minorNations.any(
-    (m) => _minorOwnsOldWorldProvinces(game, m.id),
+    (m) => minorOwnsOldWorldProvinces(game, m.id),
   );
   final warDesireByTarget = <String, int>{};
   int memoizedWarDesire(String targetFactionId, num relationScore) {
@@ -123,7 +101,7 @@ List<int> computeDiplomaticCandidateScores(
     var s = kDiplomaticDefaultBaseScore;
     switch (o.type) {
       case DiplomaticOrderType.offerPeace:
-        s = _scoreOfferPeaceDiplomaticOrder(
+        s = scoreOfferPeaceDiplomaticOrder(
           DiplomaticScoringContext(
             order: o,
             nationId: nationId,
@@ -168,8 +146,8 @@ List<int> computeDiplomaticCandidateScores(
         s += (thresholds.warLikelihood - 50);
         break;
       case DiplomaticOrderType.declareWar:
-        s = _scoreDeclareWarDiplomaticOrder(
-          _DeclareWarTargetContext.build(
+        s = scoreDeclareWarDiplomaticOrder(
+          DeclareWarTargetContext.build(
             order: o,
             nationId: nationId,
             game: game,
@@ -192,7 +170,7 @@ List<int> computeDiplomaticCandidateScores(
         );
         break;
       case DiplomaticOrderType.establishOverture:
-        s = _scoreEstablishOvertureDiplomaticOrder(
+        s = scoreEstablishOvertureDiplomaticOrder(
           DiplomaticScoringContext(
             order: o,
             nationId: nationId,
@@ -215,130 +193,3 @@ List<int> computeDiplomaticCandidateScores(
     return s == 0 ? 0 : math.max(1, s);
   }).toList();
 }
-
-bool _minorOwnsOldWorldProvinces(Game game, String minorId) =>
-    ProvinceOwnerCache.of(
-      game.worldState,
-    ).ownsAnyInRegion(minorId, kRegionOldWorld);
-
-Set<String> _activeOldWorldMinorConflictIds({
-  required Game game,
-  required String nationId,
-  required int currentTurn,
-  required int warCooldownTurns,
-}) {
-  final conflicts = <String>{};
-  for (final minor in game.minorNations) {
-    if (!_minorOwnsOldWorldProvinces(game, minor.id)) {
-      continue;
-    }
-    final rel = getRelation(game, nationId, minor.id);
-    if (rel?.state == RelationState.atWar) {
-      conflicts.add(minor.id);
-      continue;
-    }
-    if (_isDecisionOnCooldown(
-      game: game,
-      actorFactionId: nationId,
-      targetFactionId: minor.id,
-      eventTypes: const [DiplomaticEventType.declareWar],
-      cooldownTurns: warCooldownTurns,
-      currentTurn: currentTurn,
-    )) {
-      conflicts.add(minor.id);
-    }
-  }
-  return conflicts;
-}
-
-/// Predicts whether the (`nationId`, `targetFactionId`) relation pair will
-/// receive a same-turn relation-delta event that blocks per-turn decay (Refs
-/// #3753 R9.4). Uses the only deterministic planning-time signal available:
-/// diplomatic orders earlier Full-AI players already committed this turn
-/// ([sameTurnPriorDiplomaticOrders], keyed by acting player id). A prior order
-/// from the target faction directed back at this AI lands an event on the
-/// shared pair, so decay is skipped and the AI keeps full improve-relations
-/// urgency. The predicate is intentionally conservative — any prior order from
-/// the target toward this AI counts — so a false positive only preserves the
-/// pre-existing (non-decay-aware) urgency. Returns false when no prior orders
-/// are available.
-bool _pairHasScheduledRelationEventThisTurn({
-  required Orders? sameTurnPriorDiplomaticOrders,
-  required String nationId,
-  required String targetFactionId,
-}) {
-  if (sameTurnPriorDiplomaticOrders == null) return false;
-  final targetOrders =
-      sameTurnPriorDiplomaticOrders
-          .diplomaticOrdersByPlayerId[targetFactionId] ??
-      const <DiplomaticOrder>[];
-  for (final order in targetOrders) {
-    if (order.targetFactionId == nationId) return true;
-  }
-  return false;
-}
-
-/// Whether some other Great Power currently outranks [nationId] in hidden
-/// relation score with the Minor/Tribe [targetFactionId] — i.e. [nationId] is
-/// not (yet) the favoured trading partner for that seller (Refs #3758 S10/R11;
-/// #3753 R7). The favoured trading partner (highest GP→seller relation) wins
-/// the world-market sell-priority tiebreaker among consulate-holding buyers
-/// (`SPEC/game/world-market.md` § Favored Trading Partner), so a trailing AI
-/// has an incentive to invest in the relationship.
-///
-/// The active AI's own score defaults to [relationScoreNeutral] (50) when no
-/// relation row exists. Each other Great Power contributes a competing score
-/// **only** when it holds an existing relation row with the target (a GP with
-/// no contact contributes none). Returns `false` when [nationId]'s score is
-/// greater than or equal to every other Great Power's score (the AI is already
-/// the favoured partner, ties included). Pure and deterministic over [Game].
-bool _aiTrailsFavouredTradingPartner({
-  required Game game,
-  required String nationId,
-  required String targetFactionId,
-}) {
-  final favoured = favouredTradingPartner(game, targetFactionId);
-  if (favoured == null) return false;
-  return favoured != nationId;
-}
-
-/// Count of **non-empty resource tiles owned by [sellerId]** — a deterministic
-/// proxy for the Minor/Tribe seller's world-market sales volume (`Q × P`) used
-/// by the embassy-kickback overture valuation (Refs #3758 R7/R8 / S6; #3753
-/// R8.3). Iterates [WorldState.resourceByTileKey] (bounded by the count of
-/// resource-bearing tiles, far smaller than the global tile count), maps each
-/// tile to its province via [Unit.provinceIdFromTileKey], and counts tiles whose
-/// province is owned by [sellerId] per [provinceOwner]. Purchased tiles are
-/// **included** because their goods still sell on the world market and still
-/// pay the kickback to every embassy holder. Pure and deterministic over
-/// [Game]. SPEC/ai/phase-planner-architecture.md § Embassy-kickback overture.
-int _sellerSellableResourceTileCount({
-  required Game game,
-  required String sellerId,
-  required Map<String, String> provinceOwner,
-}) {
-  var count = 0;
-  for (final entry in game.worldState.resourceByTileKey.entries) {
-    if (entry.value.isEmpty) continue;
-    final provinceId = Unit.provinceIdFromTileKey(entry.key);
-    if (provinceOwner[provinceId] == sellerId) count++;
-  }
-  return count;
-}
-
-bool _isDecisionOnCooldown({
-  required Game game,
-  required String actorFactionId,
-  required String targetFactionId,
-  required List<DiplomaticEventType> eventTypes,
-  required int cooldownTurns,
-  required int currentTurn,
-}) => hasRecentDiplomaticEventWithinCooldown(
-  game: game,
-  currentTurn: currentTurn,
-  cooldownTurns: cooldownTurns,
-  matches: (event) =>
-      eventTypes.contains(event.type) &&
-      event.fromFactionId == actorFactionId &&
-      event.toFactionId == targetFactionId,
-);

--- a/packages/colonizethis_ai/lib/src/planning/diplomatic_candidate_scoring_declare_war.dart
+++ b/packages/colonizethis_ai/lib/src/planning/diplomatic_candidate_scoring_declare_war.dart
@@ -1,16 +1,29 @@
-part of 'diplomatic_candidate_scoring.dart';
+import 'army_conquest_prep.dart' show regimentCountForPlayer;
+import 'diplomatic_candidate_scoring_declare_war_bonuses.dart';
+import 'diplomatic_candidate_scoring_declare_war_context.dart';
+import 'diplomatic_candidate_scoring_shared.dart';
+import 'expand_phase_planner.dart';
+import 'observer_goal_phase.dart';
+import 'phase_planner_diplomacy_filter.dart';
+import 'planning_helpers.dart'
+    show
+        anyInvadableProvinceOwnedByMinor,
+        gpFactionIdsAtWarWith,
+        isAtWarWithAnyGreatPower;
+import 'planning_imports.dart';
 
 /// Declare-war score ladder.
 ///
-/// Entry point [_scoreDeclareWarDiplomaticOrder] accepts a prebuilt
-/// [_DeclareWarTargetContext] (see
+/// Entry point [scoreDeclareWarDiplomaticOrder] accepts a prebuilt
+/// [DeclareWarTargetContext] (see
 /// `diplomatic_candidate_scoring_declare_war_context.dart`), then walks the
 /// suppression chain ([_declareWarSuppressedScore]) before delegating the
 /// surviving candidates to the bonus addends
 /// (`diplomatic_candidate_scoring_declare_war_bonuses.dart`). Call sites build
-/// the context once (Refs #3967); behaviour is unchanged.
-int _scoreDeclareWarDiplomaticOrder(
-  _DeclareWarTargetContext ctx, {
+/// the context once (Refs #3967); de-parted into its own library (Refs #4079
+/// Slice A); behaviour is unchanged.
+int scoreDeclareWarDiplomaticOrder(
+  DeclareWarTargetContext ctx, {
   Orders? sameTurnPriorDiplomaticOrders,
 }) {
   final suppressed = _declareWarSuppressedScore(
@@ -20,12 +33,12 @@ int _scoreDeclareWarDiplomaticOrder(
   if (suppressed != null) {
     return suppressed;
   }
-  return _scoreDeclareWarBonuses(ctx);
+  return scoreDeclareWarBonuses(ctx);
 }
 
 /// Returns a suppressed score when declare-war should not proceed; null = score.
 int? _declareWarSuppressedScore(
-  _DeclareWarTargetContext ctx, {
+  DeclareWarTargetContext ctx, {
   Orders? sameTurnPriorDiplomaticOrders,
 }) {
   return _declareWarSuppressedDevelopPhaseScore(ctx) ??
@@ -43,7 +56,7 @@ int? _declareWarSuppressedScore(
       _declareWarSuppressedRelationAndCooldownScore(ctx);
 }
 
-int? _declareWarSuppressedDevelopPhaseScore(_DeclareWarTargetContext ctx) {
+int? _declareWarSuppressedDevelopPhaseScore(DeclareWarTargetContext ctx) {
   // Refs #2509 S5: derive DEVELOP suppression from the dispatched phase
   // plan instead of recomputing `observerGoalPhaseFor` per declare-war
   // candidate via `isObserverDevelopPhase`. The phase dispatcher already
@@ -83,7 +96,7 @@ int? _declareWarSuppressedDevelopPhaseScore(_DeclareWarTargetContext ctx) {
 /// the suppression ordering in `_declareWarSuppressedScore` and the
 /// independent Phase 4 retirement paths for the EXPAND / COLONIAL-lite Phase 2
 /// resolvers are unchanged.
-int? _declareWarSuppressedNwColonialScore(_DeclareWarTargetContext ctx) {
+int? _declareWarSuppressedNwColonialScore(DeclareWarTargetContext ctx) {
   if (ctx.nwAcquisitionWeight > 0.0) {
     return null;
   }
@@ -93,7 +106,7 @@ int? _declareWarSuppressedNwColonialScore(_DeclareWarTargetContext ctx) {
   return null;
 }
 
-int? _declareWarSuppressedExpandColonialScore(_DeclareWarTargetContext ctx) {
+int? _declareWarSuppressedExpandColonialScore(DeclareWarTargetContext ctx) {
   // Refs #2847 Phase 3 diplomacy wiring: derive EXPAND NW-colonial
   // suppression from the soft-phase NW acquisition weight on the
   // dispatched phase plan instead of the boolean
@@ -105,7 +118,7 @@ int? _declareWarSuppressedExpandColonialScore(_DeclareWarTargetContext ctx) {
   // floor at OW<=7, so EXPAND turns now keep NW declare-war candidates
   // scorable at low priority rather than structurally collapsing them.
   // Callers without a phase plan use the legacy-derived weight (1.0 /
-  // 0.0) from `_DeclareWarTargetContext.build`, preserving the
+  // 0.0) from `DeclareWarTargetContext.build`, preserving the
   // pre-soft-phase behaviour for tests and other entry points. The
   // soft-phase NW-weight predicate body is shared with the COLONIAL-lite
   // branch via `_declareWarSuppressedNwColonialScore` (Refs #3717).
@@ -132,7 +145,7 @@ int? _declareWarSuppressedExpandColonialScore(_DeclareWarTargetContext ctx) {
 // ("establishOverture, colonial naval/cargo") is unaffected and the rule
 // stays distinct from the broader DEVELOP suppression
 // (`_declareWarSuppressedDevelopPhaseScore`).
-int? _declareWarSuppressedColonialLiteScore(_DeclareWarTargetContext ctx) {
+int? _declareWarSuppressedColonialLiteScore(DeclareWarTargetContext ctx) {
   // Refs #2847 Phase 3 diplomacy wiring: collapsed to the same soft-phase
   // NW-weight predicate as `_declareWarSuppressedExpandColonialScore`.
   // Under the soft-phase curve both EXPAND and COLONIAL-lite share the
@@ -148,13 +161,13 @@ int? _declareWarSuppressedColonialLiteScore(_DeclareWarTargetContext ctx) {
   // can retire the EXPAND / COLONIAL-lite Phase 2 boolean resolvers
   // independently of this scoring path. Callers without a phase plan
   // use the legacy-derived weight (1.0 / 0.0) from
-  // `_DeclareWarTargetContext.build`. The soft-phase NW-weight predicate
+  // `DeclareWarTargetContext.build`. The soft-phase NW-weight predicate
   // body is shared with the EXPAND branch via
   // `_declareWarSuppressedNwColonialScore` (Refs #3717).
   return _declareWarSuppressedNwColonialScore(ctx);
 }
 
-int? _declareWarSuppressedStalledOwFrontierScore(_DeclareWarTargetContext ctx) {
+int? _declareWarSuppressedStalledOwFrontierScore(DeclareWarTargetContext ctx) {
   if (ctx.isTribeTarget &&
       ctx.stalledOwExpansion &&
       (ctx.minorsHoldOldWorldProvinces ||
@@ -192,7 +205,7 @@ int? _declareWarSuppressedStalledOwFrontierScore(_DeclareWarTargetContext ctx) {
         !distantInvadableMinorOwner &&
         !(ctx.behindVictoryPace &&
             ctx.anyMinorOwnsOldWorld &&
-            _minorOwnsOldWorldProvinces(ctx.game, ctx.order.targetFactionId))) {
+            minorOwnsOldWorldProvinces(ctx.game, ctx.order.targetFactionId))) {
       return 0;
     }
   }
@@ -215,7 +228,7 @@ int? _declareWarSuppressedStalledOwFrontierScore(_DeclareWarTargetContext ctx) {
 }
 
 int? _declareWarSuppressedAdjacentGpScore(
-  _DeclareWarTargetContext ctx, {
+  DeclareWarTargetContext ctx, {
   Orders? sameTurnPriorDiplomaticOrders,
 }) {
   if (ctx.order.type == DiplomaticOrderType.declareWar && ctx.isAdjacentGp) {
@@ -371,7 +384,7 @@ int? _declareWarSuppressedAdjacentGpScore(
 }
 
 int? _declareWarSuppressedWarConcentrationScore(
-  _DeclareWarTargetContext ctx, {
+  DeclareWarTargetContext ctx, {
   Orders? sameTurnPriorDiplomaticOrders,
 }) {
   final atWarWithGp = isAtWarWithAnyGreatPower(ctx.game, ctx.snapshot);
@@ -460,7 +473,7 @@ int? _declareWarSuppressedWarConcentrationScore(
 }
 
 int? _declareWarSuppressedRelationAndCooldownScore(
-  _DeclareWarTargetContext ctx,
+  DeclareWarTargetContext ctx,
 ) {
   final effectiveMaxRelation = ctx.behindVictoryPace && ctx.isMinorTarget
       ? kDeclareWarMinorMaxRelationWhenFarFromVictory
@@ -470,7 +483,7 @@ int? _declareWarSuppressedRelationAndCooldownScore(
   if (ctx.relationScore > effectiveMaxRelation) {
     return 0;
   }
-  if (_isDecisionOnCooldown(
+  if (isDecisionOnCooldown(
     game: ctx.game,
     actorFactionId: ctx.nationId,
     targetFactionId: ctx.order.targetFactionId,

--- a/packages/colonizethis_ai/lib/src/planning/diplomatic_candidate_scoring_declare_war_bonuses.dart
+++ b/packages/colonizethis_ai/lib/src/planning/diplomatic_candidate_scoring_declare_war_bonuses.dart
@@ -1,7 +1,23 @@
-part of 'diplomatic_candidate_scoring.dart';
+import 'dart:math' as math;
+
+import '../util/faction_query.dart';
+import 'diplomatic_candidate_scoring_declare_war_context.dart';
+import 'diplomatic_candidate_scoring_shared.dart';
+import 'expand_phase_planner.dart';
+import 'goal_manager.dart';
+import 'phase_planner_diplomacy_filter.dart';
+import 'planning_helpers.dart'
+    show
+        gpFactionIdsAtWarWith,
+        isAtWarWithAnyGreatPower,
+        isOwnOldWorldBelowConquestQuota,
+        kDiplomaticDefaultBaseScore;
+import 'planning_imports.dart';
+
+final _log = packageLogger();
 
 /// OW-expansion declare-war addend scaled by [oldWorldConquestWeight].
-int _owConquestDeclareWarBonus(_DeclareWarTargetContext ctx, int baseBonus) =>
+int _owConquestDeclareWarBonus(DeclareWarTargetContext ctx, int baseBonus) =>
     declareWarOldWorldConquestScaledBonus(
       baseBonus: baseBonus,
       oldWorldConquestWeight: ctx.oldWorldConquestWeight,
@@ -17,7 +33,7 @@ int _owConquestDeclareWarBonus(_DeclareWarTargetContext ctx, int baseBonus) =>
 /// [raiseToDeclareWarOldWorldConquestFloor] helper — byte-identical to the
 /// inline keyword call it replaces.
 int _raiseToOwConquestDeclareWarFloor(
-  _DeclareWarTargetContext ctx, {
+  DeclareWarTargetContext ctx, {
   required int currentScore,
   required int floorBonus,
 }) => raiseToDeclareWarOldWorldConquestFloor(
@@ -26,14 +42,14 @@ int _raiseToOwConquestDeclareWarFloor(
   oldWorldConquestWeight: ctx.oldWorldConquestWeight,
 );
 
-int _scoreDeclareWarBonuses(_DeclareWarTargetContext ctx) {
+int scoreDeclareWarBonuses(DeclareWarTargetContext ctx) {
   var s = _declareWarCoreBonuses(ctx);
   s = _declareWarExpansionAndColonialBonuses(ctx, s);
   s = _declareWarAdjacencyAndStalledBonuses(ctx, s);
   return _declareWarFinalizeBonuses(ctx, s);
 }
 
-int _declareWarCoreBonuses(_DeclareWarTargetContext ctx) {
+int _declareWarCoreBonuses(DeclareWarTargetContext ctx) {
   final warDesire = ctx.warDesireForTarget(
     ctx.order.targetFactionId,
     ctx.relationScore,
@@ -72,7 +88,7 @@ int _declareWarCoreBonuses(_DeclareWarTargetContext ctx) {
   return s;
 }
 
-int _stalledOwMinorRecoveryBonus(_DeclareWarTargetContext ctx) {
+int _stalledOwMinorRecoveryBonus(DeclareWarTargetContext ctx) {
   final owned = ctx.snapshot.conquest.oldWorldProvincesOwned;
   if (owned <= kFewOldWorldProvincesDefendThreshold) {
     return kDeclareWarWeakGpOwMinorRecoveryBonus;
@@ -83,7 +99,7 @@ int _stalledOwMinorRecoveryBonus(_DeclareWarTargetContext ctx) {
   return 0;
 }
 
-int _declareWarColonialNwTribeBonuses(_DeclareWarTargetContext ctx, int s) {
+int _declareWarColonialNwTribeBonuses(DeclareWarTargetContext ctx, int s) {
   if (!ctx.colonialPressure || !ctx.ownsInvadableNw || !ctx.isTribeTarget) {
     return s;
   }
@@ -114,10 +130,10 @@ int _declareWarColonialNwTribeBonuses(_DeclareWarTargetContext ctx, int s) {
 }
 
 int _declareWarStalledOldWorldExpansionBonuses(
-  _DeclareWarTargetContext ctx,
+  DeclareWarTargetContext ctx,
   int s,
 ) {
-  // Reuse the precomputed [_DeclareWarTargetContext.stalledOwExpansion] field
+  // Reuse the precomputed [DeclareWarTargetContext.stalledOwExpansion] field
   // (built once from the same `snapshot.conquest.oldWorldProvincesOwned`)
   // instead of recomputing the observer expansion-pressure predicate inline
   // (Refs #3717 diplomatic-scoring dedup).
@@ -146,8 +162,8 @@ int _declareWarStalledOldWorldExpansionBonuses(
   return s;
 }
 
-int _declareWarEarlyExpansionBonuses(_DeclareWarTargetContext ctx, int s) {
-  // Reuse the precomputed [_DeclareWarTargetContext.stalledOwExpansion] field
+int _declareWarEarlyExpansionBonuses(DeclareWarTargetContext ctx, int s) {
+  // Reuse the precomputed [DeclareWarTargetContext.stalledOwExpansion] field
   // rather than recomputing the observer expansion-pressure predicate inline
   // (Refs #3717 diplomatic-scoring dedup).
   final observerExpansionPressure = ctx.stalledOwExpansion;
@@ -169,7 +185,7 @@ int _declareWarEarlyExpansionBonuses(_DeclareWarTargetContext ctx, int s) {
 }
 
 int _declareWarColonialPressureOwMinorPenalty(
-  _DeclareWarTargetContext ctx,
+  DeclareWarTargetContext ctx,
   int s,
 ) {
   if (!ctx.colonialPressure ||
@@ -186,7 +202,7 @@ int _declareWarColonialPressureOwMinorPenalty(
 }
 
 int _declareWarExpansionAndColonialBonuses(
-  _DeclareWarTargetContext ctx,
+  DeclareWarTargetContext ctx,
   int s,
 ) {
   if (ctx.ownsInvadableNw && ctx.isMinorTarget && !ctx.stalledOwExpansion) {
@@ -202,7 +218,7 @@ int _declareWarExpansionAndColonialBonuses(
   return s;
 }
 
-int _declareWarAdjacentOwnerBonuses(_DeclareWarTargetContext ctx, int s) {
+int _declareWarAdjacentOwnerBonuses(DeclareWarTargetContext ctx, int s) {
   if (ctx.isAdjacentOwner) {
     s += _owConquestDeclareWarBonus(ctx, kDeclareWarAdjacentOwnerBonus);
     if (ctx.behindVictoryPace && ctx.isMinorTarget) {
@@ -275,7 +291,7 @@ int _declareWarAdjacentOwnerBonuses(_DeclareWarTargetContext ctx, int s) {
   return s;
 }
 
-int _declareWarAdjacencyAndStalledBonuses(_DeclareWarTargetContext ctx, int s) {
+int _declareWarAdjacencyAndStalledBonuses(DeclareWarTargetContext ctx, int s) {
   s = _declareWarAdjacentOwnerBonuses(ctx, s);
   if (!ctx.isAdjacentOwner &&
       ctx.stalledOwExpansion &&
@@ -336,7 +352,7 @@ int _declareWarAdjacencyAndStalledBonuses(_DeclareWarTargetContext ctx, int s) {
       ctx.invadableOwOwnedByGp &&
       ctx.isMinorTarget &&
       !ctx.isTribeTarget &&
-      _minorOwnsOldWorldProvinces(ctx.game, ctx.order.targetFactionId)) {
+      minorOwnsOldWorldProvinces(ctx.game, ctx.order.targetFactionId)) {
     s += _owConquestDeclareWarBonus(ctx, kDeclareWarStalledAnyOwMinorBonus);
   }
   if (ctx.stalledOwExpansion && ctx.invadableGpBlockerWeaker) {
@@ -412,7 +428,7 @@ int _declareWarAdjacencyAndStalledBonuses(_DeclareWarTargetContext ctx, int s) {
   return s;
 }
 
-int _declareWarFinalizeBonuses(_DeclareWarTargetContext ctx, int s) {
+int _declareWarFinalizeBonuses(DeclareWarTargetContext ctx, int s) {
   if (ctx.primaryGoal == StrategicGoal.conquer) {
     s += 20;
   }
@@ -483,7 +499,7 @@ int _declareWarFinalizeBonuses(_DeclareWarTargetContext ctx, int s) {
 }
 
 /// Plateau minor declare is blocked only by distracting multi-front GP wars.
-bool _gpWarBlocksPlateauMinorDeclare(_DeclareWarTargetContext ctx) {
+bool _gpWarBlocksPlateauMinorDeclare(DeclareWarTargetContext ctx) {
   final gpWars = gpFactionIdsAtWarWith(ctx.game, ctx.snapshot);
   if (gpWars.isEmpty) {
     return false;

--- a/packages/colonizethis_ai/lib/src/planning/diplomatic_candidate_scoring_declare_war_context.dart
+++ b/packages/colonizethis_ai/lib/src/planning/diplomatic_candidate_scoring_declare_war_context.dart
@@ -1,16 +1,29 @@
-part of 'diplomatic_candidate_scoring.dart';
+import '../perception/perception_snapshot.dart';
+import '../util/faction_query.dart';
+import 'diplomatic_candidate_scoring_shared.dart';
+import 'expand_phase_planner.dart';
+import 'goal_manager.dart';
+import 'observer_goal_phase.dart';
+import 'phase_planner_diplomacy_filter.dart';
+import 'phase_planner_dispatch.dart';
+import 'planning_helpers.dart'
+    show
+        anyInvadableProvinceOwnedByGreatPower,
+        factionOwnsInvadableOldWorldProvince;
+import 'planning_imports.dart';
 
 /// Context builder for the declare-war scoring family.
 ///
-/// Holds [_DeclareWarTargetContext], the precomputed per-target projection
+/// Holds [DeclareWarTargetContext], the precomputed per-target projection
 /// consumed by the declare-war score ladder in
 /// `diplomatic_candidate_scoring_declare_war.dart` and the bonus addends in
 /// `diplomatic_candidate_scoring_declare_war_bonuses.dart`. Split out of the
 /// score-ladder module so the context-builder and score-ladder concerns live
-/// in separate files (Refs #3749). All members stay library-private `part`
-/// declarations of `diplomatic_candidate_scoring.dart`; behaviour is unchanged.
-final class _DeclareWarTargetContext {
-  _DeclareWarTargetContext._({
+/// in separate files (Refs #3749; de-parted into its own library Refs #4079
+/// Slice A — bumped to package-private (no leading `_`) so sibling scoring
+/// libraries can import it). Behaviour is unchanged.
+final class DeclareWarTargetContext {
+  DeclareWarTargetContext._({
     required this.order,
     required this.nationId,
     required this.game,
@@ -232,7 +245,7 @@ final class _DeclareWarTargetContext {
   bool get lowWarLikelihood =>
       thresholds.warLikelihood <= kDeclareWarLowWarLikelihoodThreshold;
 
-  factory _DeclareWarTargetContext.build({
+  factory DeclareWarTargetContext.build({
     required DiplomaticOrder order,
     required String nationId,
     required Game game,
@@ -332,7 +345,7 @@ final class _DeclareWarTargetContext {
           isMinorFaction(game, factionId) &&
           invadableOwners.contains(factionId),
     );
-    final activeMinorConflicts = _activeOldWorldMinorConflictIds(
+    final activeMinorConflicts = activeOldWorldMinorConflictIds(
       game: game,
       nationId: nationId,
       currentTurn: currentTurn,
@@ -368,7 +381,7 @@ final class _DeclareWarTargetContext {
           provinceOwner: provinceOwner,
           factionId: order.targetFactionId,
         );
-    return _DeclareWarTargetContext._(
+    return DeclareWarTargetContext._(
       order: order,
       nationId: nationId,
       game: game,

--- a/packages/colonizethis_ai/lib/src/planning/diplomatic_candidate_scoring_establish_overture.dart
+++ b/packages/colonizethis_ai/lib/src/planning/diplomatic_candidate_scoring_establish_overture.dart
@@ -1,11 +1,18 @@
-part of 'diplomatic_candidate_scoring.dart';
+import 'dart:math' as math;
+
+import '../util/faction_query.dart';
+import 'diplomatic_candidate_scoring_shared.dart';
+import 'diplomatic_scoring_context.dart';
+import 'observer_goal_phase.dart' show shouldSuppressNewWorldColonialOrders;
+import 'planning_helpers.dart' show kDiplomaticDefaultBaseScore;
+import 'planning_imports.dart';
 
 /// Pre-weighted-random score for an `establishOverture` diplomatic order
 /// candidate (0 = suppressed). Extracted from [computeDiplomaticCandidateScores]
 /// to keep that dispatcher under the function-size gate; behaviour-preserving.
 /// Combines the improve-relations urgency (decay-aware), colonial-tribe and
 /// FTP-competition bonuses, and the embassy-kickback valuation. Refs #3758.
-int _scoreEstablishOvertureDiplomaticOrder(
+int scoreEstablishOvertureDiplomaticOrder(
   DiplomaticScoringContext ctx,
   EstablishOvertureScoringParams params,
 ) {
@@ -30,7 +37,7 @@ int _scoreEstablishOvertureDiplomaticOrder(
           ))) {
     return 0;
   }
-  if (_isDecisionOnCooldown(
+  if (isDecisionOnCooldown(
     game: game,
     actorFactionId: nationId,
     targetFactionId: order.targetFactionId,
@@ -59,7 +66,7 @@ int _scoreEstablishOvertureDiplomaticOrder(
   if (rel != null &&
       rel.atPeace &&
       rel.score < relationScoreNeutral &&
-      !_pairHasScheduledRelationEventThisTurn(
+      !pairHasScheduledRelationEventThisTurn(
         sameTurnPriorDiplomaticOrders: sameTurnPriorDiplomaticOrders,
         nationId: nationId,
         targetFactionId: order.targetFactionId,
@@ -91,7 +98,7 @@ int _scoreEstablishOvertureDiplomaticOrder(
   // § Favoured-trading-partner competition overture.
   if (isMinorOrTribeFaction(game, order.targetFactionId) &&
       (rel == null || rel.atPeace) &&
-      _aiTrailsFavouredTradingPartner(
+      aiTrailsFavouredTradingPartner(
         game: game,
         nationId: nationId,
         targetFactionId: order.targetFactionId,
@@ -112,7 +119,7 @@ int _scoreEstablishOvertureDiplomaticOrder(
       (rel == null || rel.atPeace)) {
     final overture = getOverture(game, nationId, order.targetFactionId);
     if (overture == null || !overture.hasEmbassy) {
-      final volume = _sellerSellableResourceTileCount(
+      final volume = sellerSellableResourceTileCount(
         game: game,
         sellerId: order.targetFactionId,
         provinceOwner: provinceOwner,

--- a/packages/colonizethis_ai/lib/src/planning/diplomatic_candidate_scoring_offer_peace.dart
+++ b/packages/colonizethis_ai/lib/src/planning/diplomatic_candidate_scoring_offer_peace.dart
@@ -1,4 +1,21 @@
-part of 'diplomatic_candidate_scoring.dart';
+import '../perception/perception_snapshot.dart';
+import '../util/faction_query.dart';
+import 'army_conquest_prep.dart' show regimentCountForPlayer;
+import 'diplomatic_candidate_scoring_shared.dart';
+import 'diplomatic_scoring_context.dart';
+import 'expand_phase_planner.dart';
+import 'planning_helpers.dart'
+    show
+        atWarGreatPowerOrderTarget,
+        atWarPeaceTargetBonus,
+        factionOwnsInvadableOldWorldProvince,
+        gpFactionIdsAtWarWith,
+        isOwnOldWorldBelowConquestQuota,
+        isOwnOldWorldExpansionStalled,
+        kDiplomaticDefaultBaseScore,
+        mutualExhaustedGpStalemateSideQualifies,
+        orderTargetIsAtWarInvadableBlocker;
+import 'planning_imports.dart';
 
 /// True when [order] proposes offerPeace toward the sole at-war Great Power and
 /// the mutual-exhausted plateau conditions hold for both sides. Mirrors
@@ -188,7 +205,7 @@ int _offerPeacePeaceTargetListAdjustments({
   return s;
 }
 
-int _scoreOfferPeaceDiplomaticOrder(
+int scoreOfferPeaceDiplomaticOrder(
   DiplomaticScoringContext ctx,
   OfferPeaceScoringParams params,
 ) {
@@ -209,7 +226,7 @@ int _scoreOfferPeaceDiplomaticOrder(
   s -= (warDesire - 50);
   if (isMinorOrTribeFaction(game, order.targetFactionId) &&
       snapshot.threats.atWarWith.contains(order.targetFactionId) &&
-      (!_minorOwnsOldWorldProvinces(game, order.targetFactionId) ||
+      (!minorOwnsOldWorldProvinces(game, order.targetFactionId) ||
           !invadableOwners.contains(order.targetFactionId))) {
     s += kOfferPeaceFutileMinorWarBonus;
   }

--- a/packages/colonizethis_ai/lib/src/planning/diplomatic_candidate_scoring_shared.dart
+++ b/packages/colonizethis_ai/lib/src/planning/diplomatic_candidate_scoring_shared.dart
@@ -1,0 +1,137 @@
+// Shared helpers for the diplomatic candidate scoring family (offer-peace,
+// establish-overture, declare-war context/bonuses/ladder). Extracted from the
+// former `diplomatic_candidate_scoring.dart` `part` cluster so each scoring
+// module can import a single narrow dependency instead of sharing a `part of`
+// namespace (Refs #4079 Slice A). Behaviour-preserving: bodies are unchanged
+// from the prior library-private helpers, only the leading `_` was dropped so
+// sibling libraries can import them.
+
+import 'planning_helpers.dart' show hasRecentDiplomaticEventWithinCooldown;
+import 'planning_imports.dart';
+
+bool minorOwnsOldWorldProvinces(Game game, String minorId) =>
+    ProvinceOwnerCache.of(
+      game.worldState,
+    ).ownsAnyInRegion(minorId, kRegionOldWorld);
+
+Set<String> activeOldWorldMinorConflictIds({
+  required Game game,
+  required String nationId,
+  required int currentTurn,
+  required int warCooldownTurns,
+}) {
+  final conflicts = <String>{};
+  for (final minor in game.minorNations) {
+    if (!minorOwnsOldWorldProvinces(game, minor.id)) {
+      continue;
+    }
+    final rel = getRelation(game, nationId, minor.id);
+    if (rel?.state == RelationState.atWar) {
+      conflicts.add(minor.id);
+      continue;
+    }
+    if (isDecisionOnCooldown(
+      game: game,
+      actorFactionId: nationId,
+      targetFactionId: minor.id,
+      eventTypes: const [DiplomaticEventType.declareWar],
+      cooldownTurns: warCooldownTurns,
+      currentTurn: currentTurn,
+    )) {
+      conflicts.add(minor.id);
+    }
+  }
+  return conflicts;
+}
+
+/// Predicts whether the (`nationId`, `targetFactionId`) relation pair will
+/// receive a same-turn relation-delta event that blocks per-turn decay (Refs
+/// #3753 R9.4). Uses the only deterministic planning-time signal available:
+/// diplomatic orders earlier Full-AI players already committed this turn
+/// ([sameTurnPriorDiplomaticOrders], keyed by acting player id). A prior order
+/// from the target faction directed back at this AI lands an event on the
+/// shared pair, so decay is skipped and the AI keeps full improve-relations
+/// urgency. The predicate is intentionally conservative — any prior order from
+/// the target toward this AI counts — so a false positive only preserves the
+/// pre-existing (non-decay-aware) urgency. Returns false when no prior orders
+/// are available.
+bool pairHasScheduledRelationEventThisTurn({
+  required Orders? sameTurnPriorDiplomaticOrders,
+  required String nationId,
+  required String targetFactionId,
+}) {
+  if (sameTurnPriorDiplomaticOrders == null) return false;
+  final targetOrders =
+      sameTurnPriorDiplomaticOrders
+          .diplomaticOrdersByPlayerId[targetFactionId] ??
+      const <DiplomaticOrder>[];
+  for (final order in targetOrders) {
+    if (order.targetFactionId == nationId) return true;
+  }
+  return false;
+}
+
+/// Whether some other Great Power currently outranks [nationId] in hidden
+/// relation score with the Minor/Tribe [targetFactionId] — i.e. [nationId] is
+/// not (yet) the favoured trading partner for that seller (Refs #3758 S10/R11;
+/// #3753 R7). The favoured trading partner (highest GP→seller relation) wins
+/// the world-market sell-priority tiebreaker among consulate-holding buyers
+/// (`SPEC/game/world-market.md` § Favored Trading Partner), so a trailing AI
+/// has an incentive to invest in the relationship.
+///
+/// The active AI's own score defaults to [relationScoreNeutral] (50) when no
+/// relation row exists. Each other Great Power contributes a competing score
+/// **only** when it holds an existing relation row with the target (a GP with
+/// no contact contributes none). Returns `false` when [nationId]'s score is
+/// greater than or equal to every other Great Power's score (the AI is already
+/// the favoured partner, ties included). Pure and deterministic over [Game].
+bool aiTrailsFavouredTradingPartner({
+  required Game game,
+  required String nationId,
+  required String targetFactionId,
+}) {
+  final favoured = favouredTradingPartner(game, targetFactionId);
+  if (favoured == null) return false;
+  return favoured != nationId;
+}
+
+/// Count of **non-empty resource tiles owned by [sellerId]** — a deterministic
+/// proxy for the Minor/Tribe seller's world-market sales volume (`Q × P`) used
+/// by the embassy-kickback overture valuation (Refs #3758 R7/R8 / S6; #3753
+/// R8.3). Iterates [WorldState.resourceByTileKey] (bounded by the count of
+/// resource-bearing tiles, far smaller than the global tile count), maps each
+/// tile to its province via [Unit.provinceIdFromTileKey], and counts tiles whose
+/// province is owned by [sellerId] per [provinceOwner]. Purchased tiles are
+/// **included** because their goods still sell on the world market and still
+/// pay the kickback to every embassy holder. Pure and deterministic over
+/// [Game]. SPEC/ai/phase-planner-architecture.md § Embassy-kickback overture.
+int sellerSellableResourceTileCount({
+  required Game game,
+  required String sellerId,
+  required Map<String, String> provinceOwner,
+}) {
+  var count = 0;
+  for (final entry in game.worldState.resourceByTileKey.entries) {
+    if (entry.value.isEmpty) continue;
+    final provinceId = Unit.provinceIdFromTileKey(entry.key);
+    if (provinceOwner[provinceId] == sellerId) count++;
+  }
+  return count;
+}
+
+bool isDecisionOnCooldown({
+  required Game game,
+  required String actorFactionId,
+  required String targetFactionId,
+  required List<DiplomaticEventType> eventTypes,
+  required int cooldownTurns,
+  required int currentTurn,
+}) => hasRecentDiplomaticEventWithinCooldown(
+  game: game,
+  currentTurn: currentTurn,
+  cooldownTurns: cooldownTurns,
+  matches: (event) =>
+      eventTypes.contains(event.type) &&
+      event.fromFactionId == actorFactionId &&
+      event.toFactionId == targetFactionId,
+);

--- a/packages/colonizethis_ai/lib/src/planning/diplomatic_scoring_context.dart
+++ b/packages/colonizethis_ai/lib/src/planning/diplomatic_scoring_context.dart
@@ -1,4 +1,5 @@
-part of 'diplomatic_candidate_scoring.dart';
+import '../perception/perception_snapshot.dart';
+import 'planning_imports.dart';
 
 /// Shared diplomatic order-scoring inputs (Refs #3822 Phase 3).
 typedef WarDesireForTarget = int Function(

--- a/packages/colonizethis_ai/lib/src/planning/economy_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/economy_planner.dart
@@ -13,32 +13,15 @@ import 'phase_planner_economy_filter.dart';
 import 'phase_planner_expand_economy.dart';
 import 'planning_helpers.dart' show isAtWarWithAnyGreatPower;
 import 'ai_commodity_ids.dart';
+import 'economy_planner_labour.dart';
 import 'effective_labour_state.dart';
 import 'planning_imports.dart';
-import 'recipe_scoring.dart';
-import 'scored_candidate.dart';
 import 'treasury_planner.dart';
 
-part 'economy_planner_labour.dart';
+export 'economy_planner_constants.dart';
+export 'economy_planner_labour.dart' show LabourAllocationInput;
 
 final _log = packageLogger('economy_planner');
-
-/// Recipe-score boost for outputs that supply a missing cheapest-regiment
-/// build input when the EXPAND regiment-rebuild directive is active
-/// (Refs #2847 H8 production companion).
-const double kRegimentBuildInputProductionScoreBoost = 50.0;
-
-/// Recipe-score boost an **affluent supplier** applies to a domestically
-/// produced improvement input (e.g. `castIron`) that a *peer* lock-recovery
-/// seller needs but the world market structurally cannot supply (Refs #2847
-/// H8-supply castIron source). Deliberately **small** — far below the
-/// shortage-driven score of the supplier's own essential recipes
-/// (`kShortageWeight * kShortageThreshold == 16`) — so the supplier only
-/// converts **leftover** labour/feedstock into a releasable surplus and never
-/// starves its own conquest economy. This keeps the +6 OW baseline for the
-/// healthy GPs (gp1/gp2) safe by construction. Planner-internal (not a new
-/// `ai_victory_config.dart` constant).
-const double kSupplierBuildInputReleaseProductionScoreBoost = 5.0;
 
 /// Runs the economy planner for one AI-controlled player. Deterministic given
 /// [game], [view], [config], and [seeds]. Returns production assignments and
@@ -143,7 +126,7 @@ EconomyPlan runEconomyPlanner({
   final expandEconomy = phasePlan != null
       ? expandEconomyPlanFromPhasePlan(phasePlan)
       : ExpandEconomyPlan.defaultPlan;
-  final missingRegimentBuildInputs = _missingCheapestRegimentBuildInputIds(
+  final missingRegimentBuildInputs = missingCheapestRegimentBuildInputIds(
     stockpile,
   );
   // Refs #2847 § H8-extraction (S7-D lumber re-localization): when the
@@ -200,7 +183,7 @@ EconomyPlan runEconomyPlanner({
   // Refs #2847 § castIron labour peasant-recruit fabric bootstrap: the peasant
   // recruit row costs 2 `fabric` while the cheapest regiment build input only
   // requires 1, so a seller holding one unit is not in
-  // `_missingCheapestRegimentBuildInputIds` yet still cannot pay the recruit
+  // `missingCheapestRegimentBuildInputIds` yet still cannot pay the recruit
   // the #3303 boost emits. Stage domestic `fabric` production whenever the
   // castIron-labour population-bound gate holds and the stockpile is short the
   // recruit cost — **independent of** `forceCheapestRegimentBuild` / treasury
@@ -281,8 +264,8 @@ EconomyPlan runEconomyPlanner({
   // only relaxes the seller path while preserving the supplier's release sizing
   // and the +6 OW baseline.
   final feedstockReserveOutputIds = <String>{
-    ..._multiInputImprovementOutputs(domesticImprovementInputOutputs),
-    ..._multiInputImprovementOutputs(stageableImprovementInputs),
+    ...multiInputImprovementOutputs(domesticImprovementInputOutputs),
+    ...multiInputImprovementOutputs(stageableImprovementInputs),
     ...supplierReleaseImprovementInputs,
   };
 
@@ -290,7 +273,7 @@ EconomyPlan runEconomyPlanner({
       ? GrowthStage.compute(game, view.playerId, snapshot: snapshot)
       : null;
 
-  final assignments = _allocateLabour(
+  final assignments = allocateLabour(
     LabourAllocationInput(
       stockpile: stockpile,
       workers: workers,

--- a/packages/colonizethis_ai/lib/src/planning/economy_planner_constants.dart
+++ b/packages/colonizethis_ai/lib/src/planning/economy_planner_constants.dart
@@ -1,0 +1,20 @@
+// Shared score-boost constants for economy planning (root + labour).
+// Extracted to avoid an economy_planner_labour.dart <-> economy_planner.dart
+// import cycle (Refs #4079 Slice A).
+
+/// Recipe-score boost for outputs that supply a missing cheapest-regiment
+/// build input when the EXPAND regiment-rebuild directive is active
+/// (Refs #2847 H8 production companion).
+const double kRegimentBuildInputProductionScoreBoost = 50.0;
+
+/// Recipe-score boost an **affluent supplier** applies to a domestically
+/// produced improvement input (e.g. `castIron`) that a *peer* lock-recovery
+/// seller needs but the world market structurally cannot supply (Refs #2847
+/// H8-supply castIron source). Deliberately **small** — far below the
+/// shortage-driven score of the supplier's own essential recipes
+/// (`kShortageWeight * kShortageThreshold == 16`) — so the supplier only
+/// converts **leftover** labour/feedstock into a releasable surplus and never
+/// starves its own conquest economy. This keeps the +6 OW baseline for the
+/// healthy GPs (gp1/gp2) safe by construction. Planner-internal (not a new
+/// `ai_victory_config.dart` constant).
+const double kSupplierBuildInputReleaseProductionScoreBoost = 5.0;

--- a/packages/colonizethis_ai/lib/src/planning/economy_planner_labour.dart
+++ b/packages/colonizethis_ai/lib/src/planning/economy_planner_labour.dart
@@ -1,6 +1,13 @@
-part of 'economy_planner.dart';
+import 'ai_commodity_ids.dart';
+import 'economy_planner_constants.dart';
+import 'growth_stage.dart';
+import 'planning_imports.dart';
+import 'recipe_scoring.dart';
+import 'scored_candidate.dart';
 
-/// Bundles inputs for [_allocateLabour] (Refs #3977 AC5).
+final _log = packageLogger('economy_planner_labour');
+
+/// Bundles inputs for [allocateLabour] (Refs #3977 AC5).
 final class LabourAllocationInput {
   const LabourAllocationInput({
     required this.stockpile,
@@ -35,7 +42,7 @@ final class LabourAllocationInput {
 
 /// Commodity ids the cheapest regiment still needs in the stockpile before
 /// `suggestBuildOrders` will surface it (Refs #2847 H8).
-Set<String> _missingCheapestRegimentBuildInputIds(Stockpile stockpile) {
+Set<String> missingCheapestRegimentBuildInputIds(Stockpile stockpile) {
   final missing = <String>{};
   for (final entry
       in RegimentEconomyCatalog.peasantLevies.buildInputs.entries) {
@@ -46,7 +53,7 @@ Set<String> _missingCheapestRegimentBuildInputIds(Stockpile stockpile) {
   return missing;
 }
 
-List<AssignedRecipe> _allocateLabour(LabourAllocationInput input) {
+List<AssignedRecipe> allocateLabour(LabourAllocationInput input) {
   final stockpile = input.stockpile;
   final workers = input.workers;
   final effectiveLabour = input.effectiveLabour;
@@ -277,7 +284,7 @@ void _assignCastIronLabourFabricPrePass({
 /// Deterministic over the static `ProductionRecipesCatalog`; returns the empty
 /// set when [outputIds] is empty so feasibility falls back to the unreduced
 /// stockpile (behaviour-equal).
-Set<String> _multiInputImprovementOutputs(Set<String> outputIds) {
+Set<String> multiInputImprovementOutputs(Set<String> outputIds) {
   if (outputIds.isEmpty) return const <String>{};
   final result = <String>{};
   for (final outputId in outputIds) {

--- a/packages/colonizethis_ai/lib/src/planning/recruitment_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/recruitment_planner.dart
@@ -2,141 +2,14 @@
 // decisions for one AI-controlled Great Power per turn. SPEC/ai/economy-planner.md
 // § Recruitment planner. Refs #2692 S8.
 
-import 'package:colonizethis_logic/order_suggestion_api.dart';
-
-import '../perception/perception_snapshot.dart';
-import 'ai_commodity_ids.dart';
-import 'growth_stage.dart';
 import 'observer_goal_phase.dart';
 import 'planning_imports.dart';
+import 'recruitment_planner_candidates.dart';
+import 'recruitment_planner_types.dart';
 
-part 'recruitment_planner_candidates.dart';
+export 'recruitment_planner_types.dart';
 
 final _log = packageLogger('recruitment_planner');
-
-/// Result of the recruitment planner.
-///
-/// Spec: SPEC/ai/economy-planner.md § Recruitment planner (Refs #2692 S8).
-class RecruitmentPlan {
-  const RecruitmentPlan({
-    required this.recruitOrders,
-    required this.buildUnitOrders,
-    required this.rejected,
-  });
-
-  /// Empty plan returned when the player view is missing or both candidate
-  /// lists are empty after planner-side filtering.
-  static const RecruitmentPlan empty = RecruitmentPlan(
-    recruitOrders: [],
-    buildUnitOrders: [],
-    rejected: [],
-  );
-
-  /// Recruit / train orders the planner has decided to emit this turn.
-  /// Drawn from `OrderSuggestionAPI.suggestRecruitWorkerOrders` only.
-  final List<RecruitWorkerOrder> recruitOrders;
-
-  /// Build (regiment + ship) orders the planner has decided to emit this turn.
-  /// Drawn from `OrderSuggestionAPI.suggestBuildOrders` only.
-  final List<BuildUnitOrder> buildUnitOrders;
-
-  /// Candidates dropped by planner-side rules (peasant reservation or soft
-  /// luxury cap). Order is stable for the same inputs.
-  final List<RejectedRecruitmentSuggestion> rejected;
-}
-
-/// Stable rejection reason: candidate would exceed the peasant reservation
-/// ledger including pending consumes from `currentOrders` and accepted
-/// emissions earlier in this plan.
-const String kRecruitmentRejectInsufficientWorkers = 'Insufficient workers';
-
-/// Stable rejection reason: candidate would push the trained-tier count
-/// above the (deficit-aware) soft luxury cap defined in
-/// `SPEC/game/workers-and-population.md` Requirement #10.
-const String kRecruitmentRejectSoftLuxuryCap = 'Soft luxury cap exceeded';
-
-/// Stable rejection reason: growth-stage military priority is below the build
-/// suppression threshold (Refs #3371).
-const String kRecruitmentRejectMilitaryBuildSuppressed =
-    'Military build suppressed';
-
-/// Stable rejection reason: a fabric-costing peasant-recruit candidate is
-/// dropped so the GP's scarce fabric is reserved to fund a regiment build
-/// (Refs #3371 AC13 — growth-stage military fabric reservation).
-const String kRecruitmentRejectMilitaryFabricReservation =
-    'Military fabric reservation';
-
-/// Stable rejection reason: a paper-costing candidate (trained-worker recruit
-/// or civilian build) is dropped because emitting it would push the shared
-/// paper budget — current paper minus the research reservation
-/// (`researchReservedPaper`) minus paper already committed by pending orders
-/// and accepted emissions earlier in this plan — below `0`
-/// (Refs #3793 AC7 — shared paper budget ledger).
-const String kRecruitmentRejectPaperBudget = 'Paper budget exceeded';
-
-/// One dropped candidate from [runRecruitmentPlanner]. Refs #2692 S8.
-class RejectedRecruitmentSuggestion {
-  const RejectedRecruitmentSuggestion({
-    required this.reason,
-    required this.targetTier,
-  });
-
-  /// Stable reason token. One of
-  /// [kRecruitmentRejectInsufficientWorkers] or
-  /// [kRecruitmentRejectSoftLuxuryCap].
-  final String reason;
-
-  /// For recruit candidates: `WorkerTier.name`.
-  /// For build candidates: `BuildUnitOrder.unitType`.
-  final String targetTier;
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is RejectedRecruitmentSuggestion &&
-          reason == other.reason &&
-          targetTier == other.targetTier;
-
-  @override
-  int get hashCode => Object.hash(reason, targetTier);
-
-  @override
-  String toString() =>
-      'RejectedRecruitmentSuggestion(reason: $reason, tier: $targetTier)';
-}
-
-/// Bundles inputs for [runRecruitmentPlanner] (Refs #3972 AC5).
-final class RecruitmentPlannerInput {
-  const RecruitmentPlannerInput({
-    required this.game,
-    required this.view,
-    required this.currentOrders,
-    required this.config,
-    required this.seeds,
-    required this.goalPhase,
-    required this.suggestionApi,
-    this.topology,
-    this.economyPlanHint,
-    this.growthStagePlannerEnabled = kGrowthStagePlannerEnabled,
-    this.paperBudgetLedgerEnabled = false,
-    this.includeCivilianBuilds = false,
-    this.snapshot,
-  });
-
-  final Game game;
-  final PlayerView view;
-  final Orders currentOrders;
-  final AIConfig config;
-  final AISeedBundle seeds;
-  final ObserverGoalPhase goalPhase;
-  final OrderSuggestionAPI suggestionApi;
-  final MapTopology? topology;
-  final EconomyPlan? economyPlanHint;
-  final bool growthStagePlannerEnabled;
-  final bool paperBudgetLedgerEnabled;
-  final bool includeCivilianBuilds;
-  final AIWorldSnapshot? snapshot;
-}
 
 /// Plans worker recruit / train, regiment builds, and ship builds for one
 /// AI-controlled player on one turn. Deterministic given inputs.
@@ -180,13 +53,13 @@ RecruitmentPlan runRecruitmentPlanner(RecruitmentPlannerInput input) {
     return RecruitmentPlan.empty;
   }
 
-  final prepared = _prepareRecruitmentPlan(input: input, player: player);
+  final prepared = prepareRecruitmentPlan(input: input, player: player);
   final recruitOrders = <RecruitWorkerOrder>[];
   final buildUnitOrders = <BuildUnitOrder>[];
   final rejected = <RejectedRecruitmentSuggestion>[];
 
   void processRecruit() {
-    _processRecruitCandidates(
+    processRecruitCandidates(
       prepared: prepared,
       recruitOrders: recruitOrders,
       rejected: rejected,
@@ -194,7 +67,7 @@ RecruitmentPlan runRecruitmentPlanner(RecruitmentPlannerInput input) {
   }
 
   void processBuilds() {
-    _processBuildCandidates(
+    processBuildCandidates(
       prepared: prepared,
       buildUnitOrders: buildUnitOrders,
       rejected: rejected,

--- a/packages/colonizethis_ai/lib/src/planning/recruitment_planner_candidates.dart
+++ b/packages/colonizethis_ai/lib/src/planning/recruitment_planner_candidates.dart
@@ -1,11 +1,12 @@
-part of 'recruitment_planner.dart';
+import 'ai_commodity_ids.dart';
+import 'growth_stage.dart';
+import 'planning_imports.dart';
+import 'recruitment_planner_types.dart';
 
 // Candidate gather / evaluate / emit for the recruitment planner
-// (Refs #3997 AC5 concern split). Behaviour-preserving move into a `part of`
-// the recruitment-planner library so imports and private visibility are
-// unchanged.
+// (Refs #3997 AC5 concern split; de-parted Refs #4079 Slice A).
 
-/// Prepared candidate pools + ledger state for one [runRecruitmentPlanner] call.
+/// Prepared candidate pools + ledger state for one `runRecruitmentPlanner` call.
 final class _PreparedRecruitmentPlan {
   const _PreparedRecruitmentPlan({
     required this.recruitCandidates,
@@ -22,7 +23,7 @@ final class _PreparedRecruitmentPlan {
   final bool reserveFabricForMilitary;
 }
 
-_PreparedRecruitmentPlan _prepareRecruitmentPlan({
+_PreparedRecruitmentPlan prepareRecruitmentPlan({
   required RecruitmentPlannerInput input,
   required Player player,
 }) {
@@ -109,7 +110,7 @@ _PreparedRecruitmentPlan _prepareRecruitmentPlan({
   );
 }
 
-void _processRecruitCandidates({
+void processRecruitCandidates({
   required _PreparedRecruitmentPlan prepared,
   required List<RecruitWorkerOrder> recruitOrders,
   required List<RejectedRecruitmentSuggestion> rejected,
@@ -155,7 +156,7 @@ void _processRecruitCandidates({
   }
 }
 
-void _processBuildCandidates({
+void processBuildCandidates({
   required _PreparedRecruitmentPlan prepared,
   required List<BuildUnitOrder> buildUnitOrders,
   required List<RejectedRecruitmentSuggestion> rejected,

--- a/packages/colonizethis_ai/lib/src/planning/recruitment_planner_types.dart
+++ b/packages/colonizethis_ai/lib/src/planning/recruitment_planner_types.dart
@@ -1,0 +1,135 @@
+// Shared types + constants for the recruitment planner root and its
+// candidates module. Extracted to avoid a
+// recruitment_planner.dart <-> recruitment_planner_candidates.dart import
+// cycle (Refs #4079 Slice A).
+
+import 'package:colonizethis_logic/order_suggestion_api.dart';
+
+import '../perception/perception_snapshot.dart';
+import 'growth_stage.dart';
+import 'observer_goal_phase.dart';
+import 'planning_imports.dart';
+
+/// Result of the recruitment planner.
+///
+/// Spec: SPEC/ai/economy-planner.md § Recruitment planner (Refs #2692 S8).
+class RecruitmentPlan {
+  const RecruitmentPlan({
+    required this.recruitOrders,
+    required this.buildUnitOrders,
+    required this.rejected,
+  });
+
+  /// Empty plan returned when the player view is missing or both candidate
+  /// lists are empty after planner-side filtering.
+  static const RecruitmentPlan empty = RecruitmentPlan(
+    recruitOrders: [],
+    buildUnitOrders: [],
+    rejected: [],
+  );
+
+  /// Recruit / train orders the planner has decided to emit this turn.
+  /// Drawn from `OrderSuggestionAPI.suggestRecruitWorkerOrders` only.
+  final List<RecruitWorkerOrder> recruitOrders;
+
+  /// Build (regiment + ship) orders the planner has decided to emit this turn.
+  /// Drawn from `OrderSuggestionAPI.suggestBuildOrders` only.
+  final List<BuildUnitOrder> buildUnitOrders;
+
+  /// Candidates dropped by planner-side rules (peasant reservation or soft
+  /// luxury cap). Order is stable for the same inputs.
+  final List<RejectedRecruitmentSuggestion> rejected;
+}
+
+/// Stable rejection reason: candidate would exceed the peasant reservation
+/// ledger including pending consumes from `currentOrders` and accepted
+/// emissions earlier in this plan.
+const String kRecruitmentRejectInsufficientWorkers = 'Insufficient workers';
+
+/// Stable rejection reason: candidate would push the trained-tier count
+/// above the (deficit-aware) soft luxury cap defined in
+/// `SPEC/game/workers-and-population.md` Requirement #10.
+const String kRecruitmentRejectSoftLuxuryCap = 'Soft luxury cap exceeded';
+
+/// Stable rejection reason: growth-stage military priority is below the build
+/// suppression threshold (Refs #3371).
+const String kRecruitmentRejectMilitaryBuildSuppressed =
+    'Military build suppressed';
+
+/// Stable rejection reason: a fabric-costing peasant-recruit candidate is
+/// dropped so the GP's scarce fabric is reserved to fund a regiment build
+/// (Refs #3371 AC13 — growth-stage military fabric reservation).
+const String kRecruitmentRejectMilitaryFabricReservation =
+    'Military fabric reservation';
+
+/// Stable rejection reason: a paper-costing candidate (trained-worker recruit
+/// or civilian build) is dropped because emitting it would push the shared
+/// paper budget — current paper minus the research reservation
+/// (`researchReservedPaper`) minus paper already committed by pending orders
+/// and accepted emissions earlier in this plan — below `0`
+/// (Refs #3793 AC7 — shared paper budget ledger).
+const String kRecruitmentRejectPaperBudget = 'Paper budget exceeded';
+
+/// One dropped candidate from [runRecruitmentPlanner]. Refs #2692 S8.
+class RejectedRecruitmentSuggestion {
+  const RejectedRecruitmentSuggestion({
+    required this.reason,
+    required this.targetTier,
+  });
+
+  /// Stable reason token. One of
+  /// [kRecruitmentRejectInsufficientWorkers] or
+  /// [kRecruitmentRejectSoftLuxuryCap].
+  final String reason;
+
+  /// For recruit candidates: `WorkerTier.name`.
+  /// For build candidates: `BuildUnitOrder.unitType`.
+  final String targetTier;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RejectedRecruitmentSuggestion &&
+          reason == other.reason &&
+          targetTier == other.targetTier;
+
+  @override
+  int get hashCode => Object.hash(reason, targetTier);
+
+  @override
+  String toString() =>
+      'RejectedRecruitmentSuggestion(reason: $reason, tier: $targetTier)';
+}
+
+/// Bundles inputs for `runRecruitmentPlanner` (Refs #3972 AC5).
+final class RecruitmentPlannerInput {
+  const RecruitmentPlannerInput({
+    required this.game,
+    required this.view,
+    required this.currentOrders,
+    required this.config,
+    required this.seeds,
+    required this.goalPhase,
+    required this.suggestionApi,
+    this.topology,
+    this.economyPlanHint,
+    this.growthStagePlannerEnabled = kGrowthStagePlannerEnabled,
+    this.paperBudgetLedgerEnabled = false,
+    this.includeCivilianBuilds = false,
+    this.snapshot,
+  });
+
+  final Game game;
+  final PlayerView view;
+  final Orders currentOrders;
+  final AIConfig config;
+  final AISeedBundle seeds;
+  final ObserverGoalPhase goalPhase;
+  final OrderSuggestionAPI suggestionApi;
+  final MapTopology? topology;
+  final EconomyPlan? economyPlanHint;
+  final bool growthStagePlannerEnabled;
+  final bool paperBudgetLedgerEnabled;
+  final bool includeCivilianBuilds;
+  final AIWorldSnapshot? snapshot;
+}

--- a/packages/colonizethis_ai/lib/src/planning/research_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/research_planner.dart
@@ -69,7 +69,7 @@ bool _isAtWar(PlannerContext ctx) => ctx.game.diplomacyRelations.any(
 /// Whether [ctx]'s player has stalled Old World expansion this turn, i.e. owns
 /// at most `kStalledOldWorldProvinceThreshold` Old World provinces. Counts the
 /// player's Old World holdings from the player view (same scan perception uses
-/// in `_buildConquestSummary`); evaluated lazily only when the stalled cap
+/// in `buildConquestSummary`); evaluated lazily only when the stalled cap
 /// could bind. Refs #3472 (Stalled-expansion cap).
 bool _isStalledExpansion(PlannerContext ctx) {
   var owned = 0;

--- a/packages/colonizethis_ai/test/support/s7d/s7d_campaign_rollup.dart
+++ b/packages/colonizethis_ai/test/support/s7d/s7d_campaign_rollup.dart
@@ -396,7 +396,7 @@ class Seed42S7dCampaignRollup {
   //   * `castIronRecipeLabourFeasibleTurns` — the castIron recipe also
   //     clears the planner's own labour gate (`feasibleRuns(...) > 0`
   //     against the full `effectiveLabourForWorkers`, the same compute
-  //     `economy_planner.dart` § `_allocateLabour` runs). A near-zero count
+  //     `economy_planner_labour.dart` § `allocateLabour` runs). A near-zero count
   //     here while `gpCastIronRecipeFeasibleTurns` is high localizes the
   //     break to **labour starvation** (effective labour, after mandatory
   //     food upkeep, cannot fund even one `labourPerOutput` run), moving the

--- a/packages/colonizethis_ai/test/support/s7d/supply_probes.dart
+++ b/packages/colonizethis_ai/test/support/s7d/supply_probes.dart
@@ -207,7 +207,7 @@ bool stockpileAffordsAnyProductionRecipe(
 /// labour — the labour-aware analogue of [stockpileAffordsAnyProductionRecipe].
 ///
 /// Mirrors the economy planner's own per-recipe feasibility test
-/// (`economy_planner.dart` § `_allocateLabour` → `feasibleRuns`) by computing
+/// (`economy_planner_labour.dart` § `allocateLabour` → `feasibleRuns`) by computing
 /// `effectiveLabourForWorkers` from the same inputs the planner uses (the
 /// player's `WorkerPool` + `Stockpile`, with land-regiment and ship upkeep food
 /// reserved via `regimentTypeCountsForPlayer` / `shipTypeCountsForPlayer`) and

--- a/packages/colonizethis_ai/test/support_test/planner_parameter_objects_test.dart
+++ b/packages/colonizethis_ai/test/support_test/planner_parameter_objects_test.dart
@@ -31,10 +31,17 @@ void main() {
         contains('List<TradeOrder> runTreasuryPlanner(TreasuryPlannerInput input)'),
       );
 
+      final recruitmentTypes = File(
+        p.join(planningDir.path, 'recruitment_planner_types.dart'),
+      ).readAsStringSync();
+      expect(
+        recruitmentTypes,
+        contains('final class RecruitmentPlannerInput'),
+      );
+
       final recruitment = File(
         p.join(planningDir.path, 'recruitment_planner.dart'),
       ).readAsStringSync();
-      expect(recruitment, contains('final class RecruitmentPlannerInput'));
       expect(
         recruitment,
         contains(
@@ -43,22 +50,42 @@ void main() {
       );
     });
 
-    test('recruitment planner is concern-split under the near-gate preference '
-        '(Refs #3997 AC5)', () {
+    test('recruitment planner is concern-split into explicit-import libraries '
+        '(Refs #3997 AC5; #4079 Slice A)', () {
       final recruitment = File(
         p.join(planningDir.path, 'recruitment_planner.dart'),
       );
       final candidates = File(
         p.join(planningDir.path, 'recruitment_planner_candidates.dart'),
       );
+      final types = File(
+        p.join(planningDir.path, 'recruitment_planner_types.dart'),
+      );
       expect(candidates.existsSync(), isTrue);
+      expect(types.existsSync(), isTrue);
+
+      final recruitmentSource = recruitment.readAsStringSync();
+      final candidatesSource = candidates.readAsStringSync();
+      final typesSource = types.readAsStringSync();
+      for (final source in [
+        recruitmentSource,
+        candidatesSource,
+        typesSource,
+      ]) {
+        expect(source, isNot(contains("part '")));
+        expect(source, isNot(contains('part of ')));
+      }
       expect(
-        recruitment.readAsStringSync(),
-        contains("part 'recruitment_planner_candidates.dart';"),
+        recruitmentSource,
+        contains("import 'recruitment_planner_candidates.dart';"),
       );
       expect(
-        candidates.readAsStringSync(),
-        contains("part of 'recruitment_planner.dart';"),
+        recruitmentSource,
+        contains("import 'recruitment_planner_types.dart';"),
+      );
+      expect(
+        candidatesSource,
+        contains("import 'recruitment_planner_types.dart';"),
       );
       expect(
         recruitment.readAsLinesSync().length,
@@ -115,8 +142,9 @@ void main() {
       expect(recruitment, isNot(contains('runRecruitmentPlanner({')));
     });
 
-    test('economy labour helpers are topic-split under the near-gate preference',
-        () {
+    test(
+        'economy labour helpers are topic-split into an explicit-import '
+        'library (Refs #4079 Slice A)', () {
       final economy = File(
         p.join(planningDir.path, 'economy_planner.dart'),
       );
@@ -124,13 +152,16 @@ void main() {
         p.join(planningDir.path, 'economy_planner_labour.dart'),
       );
       expect(labour.existsSync(), isTrue);
+
+      final economySource = economy.readAsStringSync();
+      final labourSource = labour.readAsStringSync();
+      for (final source in [economySource, labourSource]) {
+        expect(source, isNot(contains("part '")));
+        expect(source, isNot(contains('part of ')));
+      }
       expect(
-        economy.readAsStringSync(),
-        contains("part 'economy_planner_labour.dart';"),
-      );
-      expect(
-        labour.readAsStringSync(),
-        contains("part of 'economy_planner.dart';"),
+        economySource,
+        contains("import 'economy_planner_labour.dart';"),
       );
       expect(
         economy.readAsLinesSync().length,


### PR DESCRIPTION
## Summary
- **Slice A of #4079:** convert smaller `part`/`part of` clusters in `colonizethis_ai` into proper importable libraries (perception snapshot builders, diplomatic candidate scoring family, conquest scoring, recruitment types/candidates, economy labour).
- Structural only — no AI scoring/ordering/behavior changes; public barrel exports remain compatible.
- Structural pins in `planner_parameter_objects_test.dart` updated for recruitment/economy; Slice B part pins left intact.

## Done in this push
- De-parted Slice A clusters with shared/types/constants hubs where needed to avoid cycles.
- Package-private renames of former library-private `_` cross-file helpers.

## Remaining for #4079
- **Slice B:** de-part treasury / expand / colonial / orchestrator / diplomacy pass-helper clusters; add `repo.ai_no_part_directives`.
- **Slice C:** lib ≤500 physical-line splits + source size ratchet.
- **Slice D:** residual ≥650 test/support densify + soft-gate tighten.
- Expand-peace dual-name dedup (can land with B/C).

## Test plan
- [x] `flutter test` planner_parameter_objects + diplomatic_candidate_scoring + recruitment_planner
- [x] Broader planning/perception/support_test sweep (2260 passed in implementation pass)
- [ ] CI quality on this PR

Refs #4079

Made with [Cursor](https://cursor.com)