### PR TITLE
refactor(ai_contracts): barrel imports and densify selection suite (#4084)

### DIFF
--- a/packages/colonizethis_ai_contracts/lib/src/ai/ai_planner.dart
+++ b/packages/colonizethis_ai_contracts/lib/src/ai/ai_planner.dart
@@ -4,9 +4,9 @@ library;
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
+import 'package:colonizethis_world/colonizethis_world.dart';
+
 import '../constants.dart';
-import 'package:colonizethis_world/src/world/ai_control.dart';
-import 'package:colonizethis_world/src/world/army_migration.dart';
 import 'simple_ai_heuristics.dart';
 
 /// Generates orders for a single AI-controlled GP. Deterministic given game

--- a/packages/colonizethis_ai_contracts/lib/src/ai/full_ai_civilian_work_ow_feedstock_localization_ownership.dart
+++ b/packages/colonizethis_ai_contracts/lib/src/ai/full_ai_civilian_work_ow_feedstock_localization_ownership.dart
@@ -1,11 +1,11 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
-import '../constants.dart';
-import 'package:colonizethis_orders/src/orders/orders_application_helpers.dart'
+import 'package:colonizethis_orders/colonizethis_orders.dart'
     show isMineralEligibleTile;
-import 'package:colonizethis_world/src/world/province_lookup.dart';
-import 'package:colonizethis_world/src/world/unit_lookup.dart';
+import 'package:colonizethis_world/colonizethis_world.dart';
+
+import '../constants.dart';
 
 /// True iff [playerId] owns at least one **Old World** province tile hosting a
 /// **mineral** feedstock resource in [feedstockIds] that the player **has**

--- a/packages/colonizethis_ai_contracts/lib/src/ai/full_ai_civilian_work_ow_feedstock_localization_prospect_probe.dart
+++ b/packages/colonizethis_ai_contracts/lib/src/ai/full_ai_civilian_work_ow_feedstock_localization_prospect_probe.dart
@@ -1,9 +1,11 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
-import '../constants.dart';
-import 'package:colonizethis_orders/src/orders/bundled_civilian_work_order.dart'
-    show validateCivilianBundledWorkMoveLeg;
+import 'package:colonizethis_orders/colonizethis_orders.dart'
+    show
+        isMineralEligibleTile,
+        provinceHasAtLeastVisibility,
+        validateCivilianBundledWorkMoveLeg;
 import 'package:colonizethis_orders/src/orders/order_resolution_context.dart'
     show OrderResolutionContext, orderResolutionContextFromView;
 import 'package:colonizethis_orders/src/orders/order_suggestion_context.dart'
@@ -12,13 +14,9 @@ import 'package:colonizethis_orders/src/orders/order_suggestion_context.dart'
         isWorkOrderAcceptedWithValidator;
 import 'package:colonizethis_orders/src/orders/order_suggestion_work.dart'
     show suggestWorkOrders;
-import 'package:colonizethis_orders/src/orders/order_visibility.dart'
-    show provinceHasAtLeastVisibility;
-import 'package:colonizethis_orders/src/orders/orders_application_helpers.dart'
-    show isMineralEligibleTile;
-import 'package:colonizethis_world/src/world/player_view.dart';
-import 'package:colonizethis_world/src/world/province_lookup.dart';
-import 'package:colonizethis_world/src/world/unit_lookup.dart';
+import 'package:colonizethis_world/colonizethis_world.dart';
+
+import '../constants.dart';
 
 /// Per-gate pass signals for a co-located mineral-eligible feedstock `prospect`
 /// probe (Refs #2847 § H8-extraction prospect intra-pass localization).

--- a/packages/colonizethis_ai_contracts/lib/src/ai/full_ai_civilian_work_selection.dart
+++ b/packages/colonizethis_ai_contracts/lib/src/ai/full_ai_civilian_work_selection.dart
@@ -1,12 +1,12 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
+import 'package:colonizethis_orders/src/orders/feedstock_extraction_targets.dart';
+import 'package:colonizethis_world/colonizethis_world.dart';
+
 import 'full_ai_civilian_work_selection_build_purchase.dart';
 import 'full_ai_civilian_work_selection_shared.dart';
 import 'full_ai_civilian_work_selection_unit_paths.dart';
-import 'package:colonizethis_orders/src/orders/feedstock_extraction_targets.dart';
-import 'package:colonizethis_world/src/world/faction_membership.dart';
-import 'package:colonizethis_world/src/world/player_view.dart';
 
 /// Idle civilian (no new work) for Full AI observability.
 class FullAiCivilianWorkIdle {

--- a/packages/colonizethis_ai_contracts/lib/src/ai/full_ai_civilian_work_selection_build_purchase.dart
+++ b/packages/colonizethis_ai_contracts/lib/src/ai/full_ai_civilian_work_selection_build_purchase.dart
@@ -1,12 +1,11 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
+import 'package:colonizethis_world/colonizethis_world.dart';
+
 import '../constants.dart';
 import 'full_ai_civilian_work_selection_feedstock_predicates.dart';
 import 'full_ai_civilian_work_selection_shared.dart';
-import 'package:colonizethis_world/src/world/faction_membership.dart';
-import 'package:colonizethis_world/src/world/player_view.dart';
-import 'package:colonizethis_world/src/world/province_lookup.dart';
 
 // Builder (`build_improvement`) and Merchant (`purchase_land`) candidate
 // scoring / row selection, plus the Old World feedstock unit reservation that

--- a/packages/colonizethis_ai_contracts/lib/src/ai/full_ai_civilian_work_selection_explore_prospect.dart
+++ b/packages/colonizethis_ai_contracts/lib/src/ai/full_ai_civilian_work_selection_explore_prospect.dart
@@ -3,12 +3,11 @@ import 'dart:math' as math;
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
+import 'package:colonizethis_orders/colonizethis_orders.dart';
+import 'package:colonizethis_world/colonizethis_world.dart';
+
 import '../constants.dart';
 import 'full_ai_civilian_work_selection_feedstock_predicates.dart';
-import 'package:colonizethis_orders/src/orders/build_rail_work_rules.dart';
-import 'package:colonizethis_world/src/world/faction_membership.dart';
-import 'package:colonizethis_world/src/world/player_view.dart';
-import 'package:colonizethis_world/src/world/province_lookup.dart';
 
 // Explorer / prospect candidate scoring and per-row selection for Full AI
 // civilian work (mineral exposure balancing, explore/prospect scoring, and the

--- a/packages/colonizethis_ai_contracts/lib/src/ai/full_ai_civilian_work_selection_feedstock.dart
+++ b/packages/colonizethis_ai_contracts/lib/src/ai/full_ai_civilian_work_selection_feedstock.dart
@@ -1,7 +1,7 @@
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'package:colonizethis_orders/src/orders/feedstock_extraction_targets.dart';
-import 'package:colonizethis_world/src/world/province_lookup.dart';
+import 'package:colonizethis_world/colonizethis_world.dart';
 
 // Old World feedstock-tile ownership predicates and the feedstock-tile
 // acquisition residual for the below-quota zero-NW lock-recovery seller /

--- a/packages/colonizethis_ai_contracts/lib/src/ai/full_ai_civilian_work_selection_feedstock_acquisition.dart
+++ b/packages/colonizethis_ai_contracts/lib/src/ai/full_ai_civilian_work_selection_feedstock_acquisition.dart
@@ -1,9 +1,10 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
-import 'full_ai_civilian_work_selection_feedstock.dart';
 import 'package:colonizethis_orders/src/orders/feedstock_extraction_targets.dart';
-import 'package:colonizethis_world/src/world/province_lookup.dart';
+import 'package:colonizethis_world/colonizethis_world.dart';
+
+import 'full_ai_civilian_work_selection_feedstock.dart';
 
 // Seller feedstock-tile acquisition target selection plus the
 // lock-recovery producible improvement-input staging and Old World

--- a/packages/colonizethis_ai_contracts/lib/src/ai/full_ai_civilian_work_selection_feedstock_predicates.dart
+++ b/packages/colonizethis_ai_contracts/lib/src/ai/full_ai_civilian_work_selection_feedstock_predicates.dart
@@ -5,8 +5,9 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
+import 'package:colonizethis_world/colonizethis_world.dart';
+
 import '../constants.dart';
-import 'package:colonizethis_world/src/world/province_lookup.dart';
 
 /// True iff [playerId] owns at least one **Old World** province tile hosting a
 /// resource in [feedstockIds] that is still unimproved (`improvementLevel < 1`)

--- a/packages/colonizethis_ai_contracts/lib/src/ai/full_ai_civilian_work_selection_spy.dart
+++ b/packages/colonizethis_ai_contracts/lib/src/ai/full_ai_civilian_work_selection_spy.dart
@@ -1,10 +1,11 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
+import 'package:colonizethis_world/colonizethis_world.dart';
+
 import '../constants.dart';
 import 'full_ai_civilian_work_selection.dart' show FullAiCivilianWorkIdle;
 import 'full_ai_civilian_work_selection_shared.dart';
-import 'package:colonizethis_world/src/world/unit_lookup.dart';
 
 // Spy (`counter_spy`) candidate scoring / row selection. Refs #3834 R11.
 // Empire-wide counter-espionage: one spy on counter_spy anywhere is sufficient.

--- a/packages/colonizethis_ai_contracts/lib/src/ai/full_ai_civilian_work_selection_unit_paths.dart
+++ b/packages/colonizethis_ai_contracts/lib/src/ai/full_ai_civilian_work_selection_unit_paths.dart
@@ -1,6 +1,8 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
+import 'package:colonizethis_world/colonizethis_world.dart';
+
 import '../constants.dart';
 import 'full_ai_civilian_work_selection.dart' show FullAiCivilianWorkIdle;
 import 'full_ai_civilian_work_selection_build_purchase.dart';
@@ -10,8 +12,6 @@ import 'full_ai_civilian_work_selection_rail.dart';
 import 'full_ai_civilian_work_selection_shared.dart';
 import 'full_ai_civilian_work_selection_spy.dart';
 import 'full_ai_civilian_work_selection_upgrade_town.dart';
-import 'package:colonizethis_world/src/world/faction_membership.dart';
-import 'package:colonizethis_world/src/world/player_view.dart';
 
 // Per-unit civilian-work path selection: the Builder / Merchant / Explorer /
 // lexicographic appenders and the per-unit dispatcher that routes each unit's

--- a/packages/colonizethis_ai_contracts/lib/src/ai/simple_ai_heuristics.dart
+++ b/packages/colonizethis_ai_contracts/lib/src/ai/simple_ai_heuristics.dart
@@ -7,17 +7,13 @@ import 'dart:math' as math;
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
+import 'package:colonizethis_orders/colonizethis_orders.dart';
+import 'package:colonizethis_orders/src/orders/order_suggestion_context.dart';
+import 'package:colonizethis_world/colonizethis_world.dart';
+
 import '../ai_contracts_logging.dart';
 import '../constants.dart';
-import 'package:colonizethis_orders/src/orders/draft_orders_mutations.dart';
-import 'package:colonizethis_orders/src/orders/order_suggestion.dart';
-import 'package:colonizethis_orders/src/orders/order_suggestion_context.dart';
-import 'package:colonizethis_world/src/world/army_migration.dart';
-import 'package:colonizethis_world/src/world/faction_membership.dart';
-import 'package:colonizethis_world/src/world/player_view.dart';
-
 import 'simple_ai_heuristics_category.dart';
-import 'simple_ai_heuristics_seed.dart';
 
 export 'simple_ai_heuristics_seed.dart' show turnSeedForPlayer;
 

--- a/packages/colonizethis_ai_contracts/test/full_ai_civilian_work_selection_test.dart
+++ b/packages/colonizethis_ai_contracts/test/full_ai_civilian_work_selection_test.dart
@@ -1,58 +1,34 @@
-import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_ai_contracts/colonizethis_ai_contracts.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart';
+
+import 'support/civilian_work_selection_fixture.dart';
 
 void main() {
   group('selectFullAiCivilianWorkOrders', () {
     test(
       'non-Explorer picks lexicographically smallest (target, targetTileKey)',
       () {
-        const playerId = 'gp1';
-        final game = Game(
-          id: 'g',
-          worldState: WorldState(
-            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
-            oldWorld: const RegionData(),
-            newWorld: const RegionData(),
-          ),
-          players: const [
-            Player(id: playerId, displayName: 'GP', isHuman: false),
-          ],
-        );
-        const topology = MapTopology(nodes: [], edges: []);
-        final view = PlayerView(
-          playerId: playerId,
-          player: game.players.single,
-          ownUnitsById: {
-            'b1': Unit(
-              id: 'b1',
-              type: kUnitTypeBuilder,
-              ownerId: playerId,
-              locationProvinceId: 'oldWorld|p1',
-            ),
-          },
-          provincesById: const {},
-          visibilityByTile: const {},
-          prospectedTiles: const {},
-          diplomacyByOtherId: const {},
-        );
-        final suggestions = [
-          const WorkOrder(
-            unitId: 'b1',
-            target: kWorkTargetBuildRoad,
-            targetTileKey: 'oldWorld|p1|1|0',
-          ),
-          const WorkOrder(
-            unitId: 'b1',
-            target: kWorkTargetBuildImprovement,
-            targetTileKey: 'oldWorld|p1|0|0',
-          ),
-        ];
+        final game = civilianWorkSelectionGame();
         final r = selectFullAiCivilianWorkOrders(
-          workSuggestions: suggestions,
-          view: view,
+          workSuggestions: const [
+            WorkOrder(
+              unitId: 'b1',
+              target: kWorkTargetBuildRoad,
+              targetTileKey: 'oldWorld|p1|1|0',
+            ),
+            WorkOrder(
+              unitId: 'b1',
+              target: kWorkTargetBuildImprovement,
+              targetTileKey: 'oldWorld|p1|0|0',
+            ),
+          ],
+          view: civilianWorkSelectionView(
+            game: game,
+            unitId: 'b1',
+            unitType: kUnitTypeBuilder,
+          ),
           game: game,
         );
         expect(r.workOrders, hasLength(1));
@@ -61,129 +37,89 @@ void main() {
       },
     );
 
-    test('Builder prefers unimproved resource tile over lexicographically smaller road', () {
-      const playerId = 'gp1';
-      const tileRoad = 'oldWorld|p1|0|0';
-      const tileResource = 'oldWorld|p1|1|0';
-      final game = Game(
-        id: 'g',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
-          oldWorld: const RegionData(),
-          newWorld: const RegionData(),
+    test(
+      'Builder prefers unimproved resource tile over lexicographically smaller road',
+      () {
+        const tileRoad = 'oldWorld|p1|0|0';
+        const tileResource = 'oldWorld|p1|1|0';
+        final game = civilianWorkSelectionGame(
           resourceByTileKey: {tileResource: 'grain'},
-        ),
-        players: const [
-          Player(id: playerId, displayName: 'GP', isHuman: false),
-        ],
-      );
-      final view = PlayerView(
-        playerId: playerId,
-        player: game.players.single,
-        ownUnitsById: {
-          'b1': Unit(
-            id: 'b1',
-            type: kUnitTypeBuilder,
-            ownerId: playerId,
-            locationProvinceId: 'oldWorld|p1',
-          ),
-        },
-        provincesById: const {},
-        visibilityByTile: const {},
-        prospectedTiles: const {},
-        diplomacyByOtherId: const {},
-      );
-      final r = selectFullAiCivilianWorkOrders(
-        workSuggestions: [
-          const WorkOrder(
+        );
+        final r = selectFullAiCivilianWorkOrders(
+          workSuggestions: const [
+            WorkOrder(
+              unitId: 'b1',
+              target: kWorkTargetBuildRoad,
+              targetTileKey: tileRoad,
+            ),
+            WorkOrder(
+              unitId: 'b1',
+              target: kWorkTargetBuildImprovement,
+              targetTileKey: tileResource,
+            ),
+          ],
+          view: civilianWorkSelectionView(
+            game: game,
             unitId: 'b1',
-            target: kWorkTargetBuildRoad,
-            targetTileKey: tileRoad,
+            unitType: kUnitTypeBuilder,
           ),
-          const WorkOrder(
-            unitId: 'b1',
-            target: kWorkTargetBuildImprovement,
-            targetTileKey: tileResource,
-          ),
-        ],
-        view: view,
-        game: game,
-      );
-      expect(r.workOrders.single.targetTileKey, tileResource);
-    });
+          game: game,
+        );
+        expect(r.workOrders.single.targetTileKey, tileResource);
+      },
+    );
 
     test(
       'Explorer with two equal E_score explores picks lexicographically smaller tile',
       () {
-        const playerId = 'gp1';
         const ow = 'oldWorld';
         const pA = '$ow|pA';
         const pB = '$ow|pB';
         const tileB = 'oldWorld|pB|0|0';
         const tileA = 'oldWorld|pA|0|0';
-        final game = Game(
-          id: 'g',
-          worldState: WorldState(
-            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
-            oldWorld: RegionData(
-              provinces: [
-                Province(id: pA, regionId: ow, ownerId: 'tribe1'),
-                Province(id: pB, regionId: ow, ownerId: 'tribe1'),
-              ],
-              units: const [],
-            ),
-            newWorld: const RegionData(),
-            playerVisibilityByTile: const {
-              playerId: {tileA: 'unknown', tileB: 'unknown'},
-            },
-            tileKeysByRegionAndProvince: const {
-              ow: {
-                pA: [tileA],
-                pB: [tileB],
-              },
-            },
+        final game = civilianWorkSelectionGame(
+          oldWorld: RegionData(
+            provinces: [
+              Province(id: pA, regionId: ow, ownerId: 'tribe1'),
+              Province(id: pB, regionId: ow, ownerId: 'tribe1'),
+            ],
+            units: const [],
           ),
-          players: const [
-            Player(id: playerId, displayName: 'GP', isHuman: false),
-          ],
+          playerVisibilityByTile: const {
+            'gp1': {tileA: 'unknown', tileB: 'unknown'},
+          },
+          tileKeysByRegionAndProvince: const {
+            ow: {
+              pA: [tileA],
+              pB: [tileB],
+            },
+          },
           tribes: const [Tribe(id: 'tribe1', displayName: 'T')],
         );
-        const topology = MapTopology(nodes: [], edges: []);
-        final view = PlayerView(
-          playerId: playerId,
-          player: game.players.single,
-          ownUnitsById: {
-            'e1': Unit(
-              id: 'e1',
-              type: kUnitTypeExplorer,
-              ownerId: playerId,
-              locationProvinceId: pA,
-              tileKey: tileA,
-            ),
-          },
-          provincesById: const {},
-          visibilityByTile: const {
-            tileA: VisibilityLevel.unknown,
-            tileB: VisibilityLevel.unknown,
-          },
-          prospectedTiles: const {},
-          diplomacyByOtherId: const {},
-        );
-        final suggestions = [
-          WorkOrder(
-            unitId: 'e1',
-            target: kWorkTargetExplore,
-            targetTileKey: tileB,
-          ),
-          WorkOrder(
-            unitId: 'e1',
-            target: kWorkTargetExplore,
-            targetTileKey: tileA,
-          ),
-        ];
         final r = selectFullAiCivilianWorkOrders(
-          workSuggestions: suggestions,
-          view: view,
+          workSuggestions: [
+            WorkOrder(
+              unitId: 'e1',
+              target: kWorkTargetExplore,
+              targetTileKey: tileB,
+            ),
+            WorkOrder(
+              unitId: 'e1',
+              target: kWorkTargetExplore,
+              targetTileKey: tileA,
+            ),
+          ],
+          view: civilianWorkSelectionView(
+            game: game,
+            unitId: 'e1',
+            unitType: kUnitTypeExplorer,
+            locationProvinceId: pA,
+            tileKey: tileA,
+            visibilityByTile: const {
+              tileA: VisibilityLevel.unknown,
+              tileB: VisibilityLevel.unknown,
+            },
+          ),
           game: game,
         );
         expect(r.workOrders.single.targetTileKey, tileA);
@@ -194,38 +130,14 @@ void main() {
     test(
       'idle Explorer with empty explore/prospect suggestions logs no_suggestions',
       () {
-        const playerId = 'gp1';
-        final game = Game(
-          id: 'g',
-          worldState: WorldState(
-            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
-            oldWorld: const RegionData(),
-            newWorld: const RegionData(),
-          ),
-          players: const [
-            Player(id: playerId, displayName: 'GP', isHuman: false),
-          ],
-        );
-        const topology = MapTopology(nodes: [], edges: []);
-        final view = PlayerView(
-          playerId: playerId,
-          player: game.players.single,
-          ownUnitsById: {
-            'e1': Unit(
-              id: 'e1',
-              type: kUnitTypeExplorer,
-              ownerId: playerId,
-              locationProvinceId: 'oldWorld|p1',
-            ),
-          },
-          provincesById: const {},
-          visibilityByTile: const {},
-          prospectedTiles: const {},
-          diplomacyByOtherId: const {},
-        );
+        final game = civilianWorkSelectionGame();
         final r = selectFullAiCivilianWorkOrders(
           workSuggestions: const [],
-          view: view,
+          view: civilianWorkSelectionView(
+            game: game,
+            unitId: 'e1',
+            unitType: kUnitTypeExplorer,
+          ),
           game: game,
         );
         expect(r.workOrders, isEmpty);
@@ -237,38 +149,9 @@ void main() {
   });
 
   group('growth-stage feedstock build routing (Refs #3371 AC1/AC2)', () {
-    const playerId = 'gp1';
     const grainTile = 'oldWorld|p1|0|0';
     const woolTile = 'oldWorld|p1|1|0';
     const timberTile = 'oldWorld|p1|2|0';
-
-    Game gameWith(Map<String, String> resourceByTileKey) => Game(
-      id: 'g',
-      worldState: WorldState(
-        turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
-        oldWorld: const RegionData(),
-        newWorld: const RegionData(),
-        resourceByTileKey: resourceByTileKey,
-      ),
-      players: const [Player(id: playerId, displayName: 'GP', isHuman: false)],
-    );
-
-    PlayerView viewWith(Game game) => PlayerView(
-      playerId: playerId,
-      player: game.players.single,
-      ownUnitsById: {
-        'b1': Unit(
-          id: 'b1',
-          type: kUnitTypeBuilder,
-          ownerId: playerId,
-          locationProvinceId: 'oldWorld|p1',
-        ),
-      },
-      provincesById: const {},
-      visibilityByTile: const {},
-      prospectedTiles: const {},
-      diplomacyByOtherId: const {},
-    );
 
     const grainSuggestion = WorkOrder(
       unitId: 'b1',
@@ -286,46 +169,58 @@ void main() {
       targetTileKey: timberTile,
     );
 
-    test('negative: without growth-stage sets, lex-first grain tile wins', () {
-      final game = gameWith({grainTile: 'grain', woolTile: 'wool'});
-      final r = selectFullAiCivilianWorkOrders(
-        workSuggestions: const [grainSuggestion, woolSuggestion],
-        view: viewWith(game),
+    FullAiCivilianWorkSelectionResult selectOn(
+      Map<String, String> resources, {
+      Set<String> fabric = const {},
+      Set<String> infra = const {},
+      required List<WorkOrder> suggestions,
+    }) {
+      final game = civilianWorkSelectionGame(resourceByTileKey: resources);
+      return selectFullAiCivilianWorkOrders(
+        workSuggestions: suggestions,
+        view: civilianWorkSelectionView(
+          game: game,
+          unitId: 'b1',
+          unitType: kUnitTypeBuilder,
+        ),
         game: game,
+        growthStageFabricFeedstockResourceIds: fabric,
+        growthStageInfraFeedstockResourceIds: infra,
+      );
+    }
+
+    test('negative: without growth-stage sets, lex-first grain tile wins', () {
+      final r = selectOn(
+        {grainTile: 'grain', woolTile: 'wool'},
+        suggestions: const [grainSuggestion, woolSuggestion],
       );
       expect(r.workOrders.single.targetTileKey, grainTile);
     });
 
     test('positive: fabric feedstock set routes Builder to wool over grain', () {
-      final game = gameWith({grainTile: 'grain', woolTile: 'wool'});
-      final r = selectFullAiCivilianWorkOrders(
-        workSuggestions: const [grainSuggestion, woolSuggestion],
-        view: viewWith(game),
-        game: game,
-        growthStageFabricFeedstockResourceIds: const {'wool', 'cotton'},
+      final r = selectOn(
+        {grainTile: 'grain', woolTile: 'wool'},
+        fabric: const {'wool', 'cotton'},
+        suggestions: const [grainSuggestion, woolSuggestion],
       );
       expect(r.workOrders.single.targetTileKey, woolTile);
     });
 
     test('positive: fabric feedstock outranks infrastructure feedstock', () {
-      final game = gameWith({woolTile: 'wool', timberTile: 'timber'});
-      final r = selectFullAiCivilianWorkOrders(
-        workSuggestions: const [timberSuggestion, woolSuggestion],
-        view: viewWith(game),
-        game: game,
-        growthStageFabricFeedstockResourceIds: const {'wool', 'cotton'},
-        growthStageInfraFeedstockResourceIds: const {'timber', 'iron', 'coal'},
+      final r = selectOn(
+        {woolTile: 'wool', timberTile: 'timber'},
+        fabric: const {'wool', 'cotton'},
+        infra: const {'timber', 'iron', 'coal'},
+        suggestions: const [timberSuggestion, woolSuggestion],
       );
       expect(r.workOrders.single.targetTileKey, woolTile);
     });
 
     test('positive: infrastructure feedstock set routes Builder to timber', () {
-      final game = gameWith({grainTile: 'grain', timberTile: 'timber'});
-      final r = selectFullAiCivilianWorkOrders(
-        workSuggestions: const [grainSuggestion, timberSuggestion],
-        view: viewWith(game),
-        game: game,
-        growthStageInfraFeedstockResourceIds: const {'timber', 'iron', 'coal'},
+      final r = selectOn(
+        {grainTile: 'grain', timberTile: 'timber'},
+        infra: const {'timber', 'iron', 'coal'},
+        suggestions: const [grainSuggestion, timberSuggestion],
       );
       expect(r.workOrders.single.targetTileKey, timberTile);
     });

--- a/packages/colonizethis_ai_contracts/test/support/civilian_work_selection_fixture.dart
+++ b/packages/colonizethis_ai_contracts/test/support/civilian_work_selection_fixture.dart
@@ -1,0 +1,55 @@
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_world/colonizethis_world.dart';
+
+/// Shared empty orders-phase [Game] for Full AI civilian-work selection pins.
+Game civilianWorkSelectionGame({
+  String playerId = 'gp1',
+  Map<String, String> resourceByTileKey = const {},
+  RegionData? oldWorld,
+  Map<String, Map<String, String>> playerVisibilityByTile = const {},
+  Map<String, Map<String, List<String>>> tileKeysByRegionAndProvince = const {},
+  List<Tribe> tribes = const [],
+}) {
+  return Game(
+    id: 'g',
+    worldState: WorldState(
+      turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+      oldWorld: oldWorld ?? const RegionData(),
+      newWorld: const RegionData(),
+      resourceByTileKey: resourceByTileKey,
+      playerVisibilityByTile: playerVisibilityByTile,
+      tileKeysByRegionAndProvince: tileKeysByRegionAndProvince,
+    ),
+    players: [Player(id: playerId, displayName: 'GP', isHuman: false)],
+    tribes: tribes,
+  );
+}
+
+/// Builder/Explorer [PlayerView] over [game] with a single owned civilian unit.
+PlayerView civilianWorkSelectionView({
+  required Game game,
+  required String unitId,
+  required String unitType,
+  String playerId = 'gp1',
+  String locationProvinceId = 'oldWorld|p1',
+  String? tileKey,
+  Map<String, VisibilityLevel> visibilityByTile = const {},
+}) {
+  return PlayerView(
+    playerId: playerId,
+    player: game.players.single,
+    ownUnitsById: {
+      unitId: Unit(
+        id: unitId,
+        type: unitType,
+        ownerId: playerId,
+        locationProvinceId: locationProvinceId,
+        tileKey: tileKey,
+      ),
+    },
+    provincesById: const {},
+    visibilityByTile: visibilityByTile,
+    prospectedTiles: const {},
+    diplomacyByOtherId: const {},
+  );
+}


### PR DESCRIPTION
## Summary
- Prefer published `colonizethis_world` / `colonizethis_orders` barrels for deep `src/` imports that are already exported (issue #4084 proposed work #6 / secondary encapsulation smell).
- Densify mid-band `full_ai_civilian_work_selection_test` (333→228) via shared `test/support/civilian_work_selection_fixture.dart` (AC6 follow-up after #4085 merge).

## Done in this push
- Barrel conversion across selection / localization / heuristics / planner for published world + orders symbols.
- Shared selection Game/PlayerView fixture; suite AC axes retained.
- Package `dart test` → 192 passed.

## AC status (this run audit)
With #4085 (merged) + this PR, ACs 1–8 are satisfied on the branch:
- AC1: zero `part`/`part of` under `lib/`; `repo.ai_contracts_no_part_directives` passes
- AC2: public barrel symbols preserved (prior #4085)
- AC3–4: lib files all under 450 phys (largest explore_prospect 343); localization/heuristics topic-split
- AC5: shared H8 seller/supplier support builders; no local `_flaggedSellerGame`/`_supplierGame` outside support; H8 fixture gate passes
- AC6: near-ceiling suites densified; all `*_test.dart` ≤400 (domain test-size gate passes); selection suite densified here
- AC7: no_part + optional H8 shared-fixture CI rules + SPEC rows present
- AC8: `dart test` in package → 192 passed locally this run

## Deferred (intentional / out of scope)
- Deep imports remain only for orders modules **not** on the orders barrel (`feedstock_extraction_targets`, `order_suggestion_context`, `order_suggestion_work`, `order_resolution_context`) and the intentional `constants.dart` re-export of `order_work_constants.dart`. Widening the orders barrel is out of scope.

## Context
Follow-up after #4085 merged mid-run with ACs 1–8 largely complete; this slice finishes the deferred barrel/densify remainder on a fresh branch from `dev`.

## Tests
- `dart test` in `packages/colonizethis_ai_contracts` → 192 passed
- `dart run tool/ct_repo_lint.dart --rule repo.ai_contracts_no_part_directives` → pass
- `dart run tool/ct_repo_lint.dart --rule repo.ai_contracts_h8_test_shared_fixtures` → pass
- `dart run tool/ct_repo_lint.dart --rule repo.domain_package_source_file_size` → pass
- `dart run tool/ct_repo_lint.dart --rule repo.domain_package_test_file_size` → pass

Refs #4084

Made with [Cursor](https://cursor.com)