### PR TITLE
feat(ui): activate OVL60001 observe mode in screen registry (#4098)

### DIFF
--- a/SPEC/ui/observe-mode.md
+++ b/SPEC/ui/observe-mode.md
@@ -1,7 +1,8 @@
 # In-app observe mode (debug console)
 
 **Screen ID:** `OVL60001` — stable; do not reassign.
-**SPEC/ui** — Session-only spectator mode entered via `/observe` when `CT_DEBUG_CONSOLE=true`. Out of scope: `tool/run_observer_game` CLI ([run_observer_game-tool.md](../program/run_observer_game-tool.md)).
+**SPEC/ui** — Session-only spectator mode entered via `/observe` when `CT_DEBUG_CONSOLE=true`. Implementation: `app/lib/features/game/widgets/panels/observe_mode_not_defined_panel.dart` (global-observe sentinel for P4–P17 chrome; session wiring in `observe_session_provider.dart` / `shell_player_context*.dart`). Out of scope: `tool/run_observer_game` CLI ([run_observer_game-tool.md](../program/run_observer_game-tool.md)).
+**Widgetbook:** `Observe Mode Not Defined Panel` → `widgetbook_host/lib/catalogs/catalog_observe_mode.dart`.
 
 ---
 

--- a/SPEC/ui/screen-registry.md
+++ b/SPEC/ui/screen-registry.md
@@ -70,7 +70,7 @@ Status: `draft` = ID reserved, spec incomplete; `active` = spec + Widgetbook + c
 | `OVL30001` | Overture dialogue | [overture-dialogue-overlay.md](overture-dialogue-overlay.md) | `app/lib/features/game/widgets/dialogue/overture_dialogue_overlay.dart` | Overture Dialogue Overlay | active |
 | `OVL40001` | Call to arms dialogue overlay | [call-to-arms-dialogue-overlay.md](call-to-arms-dialogue-overlay.md) | `app/lib/features/game/widgets/dialogue/call_to_arms_dialogue_overlay.dart` | Call to Arms Dialogue Overlay | active |
 | `OVL50001` | Pending intervention overlay | [pending-intervention-overlay.md](screens/pending-intervention-overlay.md) | `app/lib/features/game/widgets/dialogue/intervention_dialogue_overlay.dart` | Dialogue | active |
-| `OVL60001` | Observe mode overlay | [observe-mode.md](observe-mode.md) | TBD | — | draft |
+| `OVL60001` | Observe mode overlay | [observe-mode.md](observe-mode.md) | `app/lib/features/game/widgets/panels/observe_mode_not_defined_panel.dart` | Observe Mode Not Defined Panel | active |
 | `OVL70001` | Player turn event feed | [player-turn-event-feed.md](player-turn-event-feed.md) | TBD | — | draft |
 | `OVL80001` | Tribe first contact herald | [tribe-first-contact-overlay.md](tribe-first-contact-overlay.md) | `app/lib/features/game/widgets/dialogue/tribe_first_contact_overlay.dart` | Tribe First Contact Overlay | active |
 | `SYS10001` | Debug log viewer | — | `app/lib/features/debug_log/debug_log_viewer_screen.dart` | — | draft |

--- a/app/lib/features/game/widgets/panels/observe_mode_not_defined_panel.dart
+++ b/app/lib/features/game/widgets/panels/observe_mode_not_defined_panel.dart
@@ -1,14 +1,17 @@
 import 'package:flutter/material.dart';
 
+import '../../../../config/ui_screen_ids.dart';
 import '../../../../providers/observe_session_provider.dart';
 import '../../../../widgets/ct_gap.dart';
 import '../../../../widgets/ct_panel.dart';
 import '../../../../widgets/ct_spacing.dart';
 
 /// Placeholder for P4–P17 chrome when global observe hides player-scoped data.
-/// SPEC/ui/observe-mode.md.
+/// SPEC/ui/observe-mode.md (`OVL60001`).
 class ObserveModeNotDefinedPanel extends StatelessWidget {
   const ObserveModeNotDefinedPanel({super.key, this.title});
+
+  static const screenId = UiScreenIds.observeModeOverlay;
 
   final String? title;
 

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
     sdk: flutter
   flutter_localizations:
     sdk: flutter
-  flame: ^1.37.0
+  flame: ^1.38.0
   jenny: ^1.5.1
   logger: ^2.0.2
   flutter_riverpod: ^3.3.1

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -277,10 +277,10 @@ packages:
     dependency: transitive
     description:
       name: flame
-      sha256: b9e65f6d7d06a301d6ea3cde03731cad3cdc255d56e0fb53c56c1e7806aaaf6a
+      sha256: c918f8d0e340cbc5e3b20603bd5dc0bac6d939133fed4044366180081a63561d
       url: "https://pub.dev"
     source: hosted
-    version: "1.37.0"
+    version: "1.38.0"
   flutter:
     dependency: transitive
     description: flutter

--- a/test/observe_mode_activation_4098_test.dart
+++ b/test/observe_mode_activation_4098_test.dart
@@ -1,0 +1,122 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+import '../tool/check_screen_registry_active_paths.dart';
+
+/// Acceptance pins for issue #4098: OVL60001 observe mode is registry-active
+/// with a real Implementation path, screenId binding, Widgetbook folder, and
+/// remains omitted from the player game manual.
+void main() {
+  final repoRoot = Directory.current.path;
+
+  group('issue #4098 OVL60001 observe mode activation', () {
+    test('OVL60001 is active with existing implementation path', () {
+      final registry = File(
+        p.join(repoRoot, 'SPEC', 'ui', 'screen-registry.md'),
+      ).readAsStringSync();
+      final rows = parseScreenRegistryRows(registry);
+      final byId = {for (final r in rows) r.id: r};
+
+      final row = byId['OVL60001'];
+      expect(row, isNotNull, reason: 'OVL60001 missing from registry');
+      expect(row!.status, 'active', reason: 'OVL60001 status');
+      const expectedPath =
+          'app/lib/features/game/widgets/panels/observe_mode_not_defined_panel.dart';
+      final path = extractDartPathFromCell(row.implementationCell);
+      expect(path, expectedPath, reason: 'OVL60001 implementation path');
+      expect(
+        File(p.join(repoRoot, path!)).existsSync(),
+        isTrue,
+        reason: 'OVL60001 file missing: $path',
+      );
+      expect(
+        registry.contains('| Observe Mode Not Defined Panel |'),
+        isTrue,
+        reason: 'OVL60001 Widgetbook folder missing from registry row',
+      );
+    });
+
+    test('ObserveModeNotDefinedPanel binds UiScreenIds.observeModeOverlay', () {
+      final panelSource = File(
+        p.join(
+          repoRoot,
+          'app',
+          'lib',
+          'features',
+          'game',
+          'widgets',
+          'panels',
+          'observe_mode_not_defined_panel.dart',
+        ),
+      ).readAsStringSync();
+      expect(
+        panelSource.contains('static const screenId = UiScreenIds.observeModeOverlay'),
+        isTrue,
+      );
+      expect(panelSource.contains("UiScreenIds.observeModeOverlay"), isTrue);
+
+      final idsSource = File(
+        p.join(repoRoot, 'app', 'lib', 'config', 'ui_screen_ids.dart'),
+      ).readAsStringSync();
+      expect(
+        idsSource.contains("static const String observeModeOverlay = 'OVL60001'"),
+        isTrue,
+      );
+    });
+
+    test('Widgetbook catalog registers Observe Mode Not Defined Panel', () {
+      final catalogPart = File(
+        p.join(
+          repoRoot,
+          'widgetbook_host',
+          'lib',
+          'catalogs',
+          'catalog_observe_mode.dart',
+        ),
+      ).readAsStringSync();
+      expect(catalogPart.contains("name: 'Observe Mode Not Defined Panel'"), isTrue);
+
+      final catalog = File(
+        p.join(repoRoot, 'widgetbook_host', 'lib', 'catalogs', 'catalog.dart'),
+      ).readAsStringSync();
+      expect(catalog.contains("part 'catalog_observe_mode.dart'"), isTrue);
+      expect(
+        catalog.contains('...observeModeNotDefinedPanelDirectories,'),
+        isTrue,
+      );
+    });
+
+    test('docs/manual chapters do not cite OVL60001', () {
+      final chapters = Directory(p.join(repoRoot, 'docs', 'manual'))
+          .listSync()
+          .whereType<File>()
+          .where((f) {
+            final name = p.basename(f.path);
+            return RegExp(r'^\d{2}-.+\.md$').hasMatch(name);
+          });
+
+      expect(chapters, isNotEmpty, reason: 'expected numbered manual chapters');
+      for (final chapter in chapters) {
+        final body = chapter.readAsStringSync();
+        expect(
+          body.contains('OVL60001'),
+          isFalse,
+          reason: p.relative(chapter.path, from: repoRoot),
+        );
+      }
+    });
+
+    test('negative: OVL60001 is not left as draft/TBD in registry', () {
+      final registry = File(
+        p.join(repoRoot, 'SPEC', 'ui', 'screen-registry.md'),
+      ).readAsStringSync();
+      final rows = parseScreenRegistryRows(registry);
+      final row = rows.firstWhere((r) => r.id == 'OVL60001');
+      expect(row.status, isNot('draft'));
+      expect(row.implementationCell.trim(), isNot('TBD'));
+      expect(extractDartPathFromCell(row.implementationCell), isNotNull);
+    });
+  });
+}

--- a/widgetbook_host/lib/catalogs/catalog.dart
+++ b/widgetbook_host/lib/catalogs/catalog.dart
@@ -46,6 +46,7 @@ import 'package:colonizethis_app/features/game/widgets/shell/game_top_bar.dart';
 import 'package:colonizethis_app/features/game/widgets/units/military/military_units_panel.dart';
 import 'package:colonizethis_app/features/game/widgets/units/naval/naval_units_panel.dart';
 import 'package:colonizethis_app/features/game/widgets/units/shared/units_panel_viewport_constraints.dart';
+import 'package:colonizethis_app/features/game/widgets/panels/observe_mode_not_defined_panel.dart';
 import 'package:colonizethis_app/features/game/widgets/panels/pause_menu_panel.dart';
 import 'package:colonizethis_app/features/shell/save_load/load_game_list_dialog.dart';
 import 'package:colonizethis_app/features/shell/save_load/save_game_name_dialog.dart';
@@ -143,6 +144,7 @@ part 'catalog_data_screens.dart';
 part 'catalog_game_chrome.dart';
 part 'catalog_shell_chrome.dart';
 part 'catalog_event_feed.dart';
+part 'catalog_observe_mode.dart';
 
 Unit? _unitByIdForCatalog(Game game, String unitId) {
   for (final u in game.worldState.oldWorld.units) {
@@ -285,6 +287,7 @@ List<WidgetbookNode> get _ctWidgetbookDirectories => [
   ...gameRegionMinimapDirectories,
   ...gameMapProvinceDetailSidePanelDirectories,
   ...playerTurnEventFeedCardDirectories,
+  ...observeModeNotDefinedPanelDirectories,
   ...pauseMenuPanelDirectories,
   ...saveLoadDialogDirectories,
   ...settingsDialogDirectories,

--- a/widgetbook_host/lib/catalogs/catalog_observe_mode.dart
+++ b/widgetbook_host/lib/catalogs/catalog_observe_mode.dart
@@ -1,0 +1,47 @@
+// coverage:ignore-file
+// Dev-only Widgetbook catalog part; excluded from app coverage gate via
+// instrumentation (matches catalog.dart). Story builders are only exercised
+// in the developer-facing Widgetbook app, not in widget unit tests.
+//
+// Observe-mode global sentinel panel (`OVL60001`). SPEC/ui/observe-mode.md.
+part of 'catalog.dart';
+
+/// Global-observe "not defined" sentinel stories.
+/// SPEC/ui/observe-mode.md (`OVL60001`).
+List<WidgetbookNode> get observeModeNotDefinedPanelDirectories => [
+  WidgetbookFolder(
+    name: 'Observe Mode Not Defined Panel',
+    children: [
+      WidgetbookUseCase(
+        name: 'Default — label only',
+        builder: (context) => _observeModeNotDefinedPanelFrame(
+          child: const ObserveModeNotDefinedPanel(),
+        ),
+      ),
+      WidgetbookUseCase(
+        name: 'With title — Trade',
+        builder: (context) => _observeModeNotDefinedPanelFrame(
+          // ignore: avoid_hardcoded_strings_in_widgets
+          child: const ObserveModeNotDefinedPanel(title: 'Trade'),
+        ),
+      ),
+      WidgetbookUseCase(
+        name: 'Mobile viewport',
+        builder: (context) => mobileViewport(
+          context,
+          _observeModeNotDefinedPanelFrame(
+            // ignore: avoid_hardcoded_strings_in_widgets
+            child: const ObserveModeNotDefinedPanel(title: 'Diplomacy'),
+          ),
+        ),
+      ),
+    ],
+  ),
+];
+
+Widget _observeModeNotDefinedPanelFrame({required Widget child}) {
+  return ColoredBox(
+    color: EditorialMonoclePalette.bgDeep,
+    child: Center(child: child),
+  );
+}


### PR DESCRIPTION
## Summary
- Promote `OVL60001` to `active` in `SPEC/ui/screen-registry.md` with Implementation path to `ObserveModeNotDefinedPanel` and Widgetbook folder `Observe Mode Not Defined Panel`.
- Bind `static const screenId = UiScreenIds.observeModeOverlay` on the panel; update `SPEC/ui/observe-mode.md` header paths.
- Add Widgetbook catalog part + use cases (default, titled, mobile).
- Pin ACs in `test/observe_mode_activation_4098_test.dart` (positive registry/path/binding/Widgetbook; negative draft/TBD and manual omission).
- Bump `flame` to 1.38.0 so `repo.workspace_outdated_resolvable` passes (same gate as #4101).

## Done in this push
- Full issue #4098 scope (registry + screenId + Widgetbook + manual omission guard).

## Deferred
- None for #4098. Player-manual how-to for observe mode remains intentionally out of scope.
- `SYS20001` / `SYS10001` stay draft (separate issues).

## Manual review
- Touched `SPEC/ui/observe-mode.md` and `screen-registry.md`. No chapter updates: observe mode must stay omitted from `docs/manual/**` (debug/spectator surface); AC test pins that.

## Test plan
- [x] `dart test test/observe_mode_activation_4098_test.dart`
- [x] `dart test test/check_screen_registry_active_paths_test.dart`
- [x] `dart run tool/check_screen_registry_active_paths.dart`
- [ ] CI quality workflows on PR

Refs #4098


Made with [Cursor](https://cursor.com)