### PR TITLE
refactor(map): densify grandfathered test suites for wave 4 (#4112)

### DIFF
--- a/packages/colonizethis_map/test/init_game_map_view_builder_region_cells_test.dart
+++ b/packages/colonizethis_map/test/init_game_map_view_builder_region_cells_test.dart
@@ -4,6 +4,7 @@ import 'package:colonizethis_map/colonizethis_map.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'support/init_game_map_view_fixtures.dart';
+import 'support/init_game_map_view_region_cells_scenarios.dart';
 
 void main() {
   group('buildInitGameMapViewData region data', () {
@@ -46,15 +47,11 @@ void main() {
       expect(viewData.oldWorld.greatPowerFactionIds, {'gp1'});
       expect(viewData.newWorld.greatPowerFactionIds, {'gp1'});
       expect(
-        viewData
-            .oldWorld
-            .provincePoliticalOwnerByPrefixedProvinceId['oldWorld|p1'],
+        viewData.oldWorld.provincePoliticalOwnerByPrefixedProvinceId['oldWorld|p1'],
         'gp1',
       );
       expect(
-        viewData
-            .newWorld
-            .provincePoliticalOwnerByPrefixedProvinceId['newWorld|p1'],
+        viewData.newWorld.provincePoliticalOwnerByPrefixedProvinceId['newWorld|p1'],
         isNull,
       );
       expect(viewData.newWorld.cells.length, 4);
@@ -145,24 +142,9 @@ void main() {
     test(
       'region setup maps owner/display and terrain palette from minimal data',
       () {
-        final game = minimalGame(
-          id: 'slice-test',
-          oldWorldProvinces: const [
-            Province(
-              id: 'oldWorld|p1',
-              regionId: 'oldWorld',
-              ownerId: 'gp1',
-              displayName: 'Alpha',
-            ),
-          ],
-          newWorldProvinces: const [],
-          players: const [
-            Player(id: 'gp1', displayName: 'GP1', isHuman: false),
-          ],
-        );
         final view = buildViewDataForScenario(
           oldWorldFocusedScenario(
-            game: game,
+            game: regionCellsTerrainSliceGame(),
             oldWorldGrid: const [
               ['p1'],
             ],
@@ -181,48 +163,16 @@ void main() {
           isTrue,
         );
         expect(
-          view
-              .oldWorld
-              .provincePoliticalOwnerByPrefixedProvinceId['oldWorld|p1'],
+          view.oldWorld.provincePoliticalOwnerByPrefixedProvinceId['oldWorld|p1'],
           'gp1',
         );
       },
     );
 
     test('overlay setup counts regiments, civilians, and in-port ships', () {
-      final game = minimalGame(
-        id: 'slice-test',
-        oldWorldProvinces: const [
-          Province(id: 'oldWorld|p1', regionId: 'oldWorld'),
-        ],
-        newWorldProvinces: const [],
-        oldWorldUnits: [
-          Unit(
-            id: 'u-builder',
-            type: kUnitTypeBuilder,
-            ownerId: 'gp1',
-            locationProvinceId: 'oldWorld|p1',
-          ),
-          Unit(
-            id: 'u-regiment',
-            type: 'pikemen',
-            ownerId: 'gp1',
-            locationProvinceId: 'oldWorld|p1',
-          ),
-        ],
-        fleets: [
-          Fleet(
-            id: 'f1',
-            ownerId: 'gp1',
-            regionId: 'oldWorld',
-            inPortAtProvinceId: 'oldWorld|p1',
-            ships: const [ShipInstance(id: 'ship-1', typeId: 'frigate')],
-          ),
-        ],
-      );
       final view = buildViewDataForScenario(
         oldWorldFocusedScenario(
-          game: game,
+          game: regionCellsOverlaySetupGame(),
           oldWorldGrid: const [
             ['p1'],
           ],
@@ -239,55 +189,7 @@ void main() {
     });
 
     test('marker helpers expose capitals ports towns and warps', () {
-      final game = minimalGame(
-        id: 'slice-test',
-        oldWorldProvinces: const [
-          Province(
-            id: 'oldWorld|p1',
-            regionId: 'oldWorld',
-            townTileKey: 'oldWorld|p1|0|0',
-          ),
-        ],
-        newWorldProvinces: const [],
-        players: const [
-          Player(
-            id: 'gp1',
-            displayName: 'GP1',
-            isHuman: true,
-            capitalTile: CapitalTile(
-              regionId: 'oldWorld',
-              provinceId: 'oldWorld|p1',
-              x: 0,
-              y: 0,
-            ),
-          ),
-        ],
-        portsByProvinceSeaboard: const {'oldWorld|p1|s1': 'oldWorld|p1|0|0'},
-      );
-      final view = buildViewDataForScenario(
-        oldWorldFocusedScenario(
-          game: game,
-          oldWorldGrid: const [
-            ['p1', 's1'],
-          ],
-          oldWorldTopology: singleProvinceAndSeaTopology('oldWorld'),
-          newWorldGrid: const [
-            ['s9'],
-          ],
-          newWorldTopology: regionTopology(
-            regionId: 'newWorld',
-            seaZoneIds: const ['s9'],
-          ),
-        ),
-        warpLinks: const [
-          WarpLink(
-            regionId: 'oldWorld',
-            seaZoneId: 's1',
-            otherRegionId: 'newWorld',
-            otherSeaZoneId: 's9',
-          ),
-        ],
-      );
+      final view = buildRegionCellsMarkerWarpView(regionCellsMarkerHelpersGame());
 
       expect(view.oldWorld.capitalMarkers.length, 1);
       expect(view.oldWorld.capitalMarkers.single.factionId, 'gp1');
@@ -302,16 +204,14 @@ void main() {
     });
 
     test('cell helper applies visibility and extraction overlays', () {
-      final game = minimalGame(
-        id: 'slice-test',
-        oldWorldProvinces: const [
-          Province(id: 'oldWorld|p1', regionId: 'oldWorld'),
-        ],
-        newWorldProvinces: const [],
-      );
       final view = buildViewDataForScenario(
         oldWorldFocusedScenario(
-          game: game,
+          game: minimalGame(
+            id: 'slice-test',
+            oldWorldProvinces: const [
+              Province(id: 'oldWorld|p1', regionId: 'oldWorld'),
+            ],
+          ),
           oldWorldGrid: const [
             ['p1'],
           ],
@@ -333,97 +233,13 @@ void main() {
     test(
       'does not synthesize a Home Fleet marker when fleet entity is missing',
       () {
-        final game = minimalGame(
-          id: 'slice-test',
-          oldWorldProvinces: const [
-            Province(id: 'oldWorld|p1', regionId: 'oldWorld', ownerId: 'gp1'),
-          ],
-          newWorldProvinces: const [],
-          players: const [
-            Player(
-              id: 'gp1',
-              displayName: 'GP1',
-              isHuman: true,
-              capitalTile: CapitalTile(
-                regionId: 'oldWorld',
-                provinceId: 'oldWorld|p1',
-                x: 0,
-                y: 0,
-              ),
-            ),
-          ],
-          portsByProvinceSeaboard: const {'oldWorld|p1|s1': 'oldWorld|p1|0|0'},
-        );
-        final view = buildViewDataForScenario(
-          oldWorldFocusedScenario(
-            game: game,
-            oldWorldGrid: const [
-              ['p1', 's1'],
-            ],
-            oldWorldTopology: singleProvinceAndSeaTopology('oldWorld'),
-            newWorldGrid: const [
-              ['s9'],
-            ],
-            newWorldTopology: regionTopology(
-              regionId: 'newWorld',
-              seaZoneIds: const ['s9'],
-            ),
-          ),
-        );
-
+        final view = buildRegionCellsHomeFleetView(withFleet: false);
         expect(view.oldWorld.fleetTileMarkers, isEmpty);
       },
     );
 
     test('keeps an empty Home Fleet marker when real fleet entity exists', () {
-      final game = minimalGame(
-        id: 'slice-test',
-        oldWorldProvinces: const [
-          Province(id: 'oldWorld|p1', regionId: 'oldWorld', ownerId: 'gp1'),
-        ],
-        newWorldProvinces: const [],
-        fleets: [
-          Fleet(
-            id: 'fleet_gp1',
-            ownerId: 'gp1',
-            regionId: 'oldWorld',
-            inPortAtProvinceId: 'oldWorld|p1',
-            ships: [],
-            mission: FleetMission.none,
-          ),
-        ],
-        players: const [
-          Player(
-            id: 'gp1',
-            displayName: 'GP1',
-            isHuman: true,
-            capitalTile: CapitalTile(
-              regionId: 'oldWorld',
-              provinceId: 'oldWorld|p1',
-              x: 0,
-              y: 0,
-            ),
-          ),
-        ],
-        portsByProvinceSeaboard: const {'oldWorld|p1|s1': 'oldWorld|p1|0|0'},
-      );
-      final view = buildViewDataForScenario(
-        oldWorldFocusedScenario(
-          game: game,
-          oldWorldGrid: const [
-            ['p1', 's1'],
-          ],
-          oldWorldTopology: singleProvinceAndSeaTopology('oldWorld'),
-          newWorldGrid: const [
-            ['s9'],
-          ],
-          newWorldTopology: regionTopology(
-            regionId: 'newWorld',
-            seaZoneIds: const ['s9'],
-          ),
-        ),
-      );
-
+      final view = buildRegionCellsHomeFleetView(withFleet: true);
       expect(view.oldWorld.fleetTileMarkers, hasLength(1));
       expect(view.oldWorld.fleetTileMarkers.single.fleetIds, ['fleet_gp1']);
       expect(view.oldWorld.fleetTileMarkers.single.stackCount, 1);
@@ -432,33 +248,17 @@ void main() {
 
   group('buildInitGameMapViewData visibility and unit presence', () {
     test('applies visibilityByTile map to CellViewData.visibility', () {
-      final game = minimalGame(
-        id: 'visibility',
-        oldWorldProvinces: const [
-          Province(id: 'oldWorld|p1', regionId: 'oldWorld', ownerId: 'gp1'),
-        ],
-        newWorldProvinces: const [
-          Province(id: 'newWorld|p1', regionId: 'newWorld', ownerId: 'gp2'),
-        ],
-        players: const [
-          Player(id: 'gp1', displayName: 'GP1', isHuman: false),
-          Player(id: 'gp2', displayName: 'GP2', isHuman: false),
-        ],
-      );
-      final scenario = dualRegionScenario(
-        game: game,
-        oldWorldGrid: const [
-          ['p1', 'p1'],
-        ],
-        oldWorldTopology: regionTopology(
-          regionId: 'oldWorld',
-          provinceIds: const ['p1'],
-        ),
-      );
-
-      // Two tiles in OW: (0,0) and (1,0). One tile in NW: (0,0).
       final viewData = buildViewDataForScenario(
-        scenario,
+        dualRegionScenario(
+          game: regionCellsVisibilityGame(),
+          oldWorldGrid: const [
+            ['p1', 'p1'],
+          ],
+          oldWorldTopology: regionTopology(
+            regionId: 'oldWorld',
+            provinceIds: const ['p1'],
+          ),
+        ),
         visibilityByTile: const {
           'oldWorld|p1|0|0': TileVisibility.visible,
           'oldWorld|p1|1|0': TileVisibility.fogged,
@@ -466,64 +266,27 @@ void main() {
         },
       );
 
-      // Old World visibility mapping.
       final owCells = viewData.oldWorld.cells;
-      final firstOwCell = owCells.singleWhere((c) => c.x == 0 && c.y == 0);
-      final secondOwCell = owCells.singleWhere((c) => c.x == 1 && c.y == 0);
-      expect(firstOwCell.visibility, TileVisibility.visible);
-      expect(secondOwCell.visibility, TileVisibility.fogged);
-
-      // New World visibility mapping.
-      final nwCell = viewData.newWorld.cells.single;
-      expect(nwCell.visibility, TileVisibility.unrevealed);
+      expect(
+        owCells.singleWhere((c) => c.x == 0 && c.y == 0).visibility,
+        TileVisibility.visible,
+      );
+      expect(
+        owCells.singleWhere((c) => c.x == 1 && c.y == 0).visibility,
+        TileVisibility.fogged,
+      );
+      expect(
+        viewData.newWorld.cells.single.visibility,
+        TileVisibility.unrevealed,
+      );
     });
 
     test(
       'province unit presence shows own province counts and hides other province without visible intel',
       () {
-        final game = minimalGame(
-          id: 'presence_hidden_other',
-          oldWorldProvinces: const [
-            Province(id: 'oldWorld|pOwn', regionId: 'oldWorld', ownerId: 'gp1'),
-            Province(
-              id: 'oldWorld|pOther',
-              regionId: 'oldWorld',
-              ownerId: 'gp2',
-            ),
-          ],
-          oldWorldUnits: [
-            Unit(
-              id: 'u_builder',
-              type: kUnitTypeBuilder,
-              ownerId: 'gp1',
-              locationProvinceId: 'oldWorld|pOwn',
-              status: UnitStatus.idle,
-            ),
-            Unit(
-              id: 'u_pikemen',
-              type: 'pikemen',
-              ownerId: 'gp2',
-              locationProvinceId: 'oldWorld|pOther',
-              status: UnitStatus.idle,
-            ),
-          ],
-          fleets: [
-            Fleet(
-              id: 'f_other',
-              ownerId: 'gp2',
-              regionId: 'oldWorld',
-              inPortAtProvinceId: 'oldWorld|pOther',
-              ships: [ShipInstance(id: 'ship_1', typeId: 'frigate')],
-            ),
-          ],
-          players: const [
-            Player(id: 'gp1', displayName: 'GP1', isHuman: true),
-            Player(id: 'gp2', displayName: 'GP2', isHuman: false),
-          ],
-        );
         final viewData = buildViewDataForScenario(
           dualRegionScenario(
-            game: game,
+            game: regionCellsPresenceHiddenOtherGame(),
             oldWorldGrid: const [
               ['pOwn', 'pOther'],
             ],
@@ -541,17 +304,14 @@ void main() {
 
         final own =
             viewData.oldWorld.provinceUnitPresenceByProvinceId['oldWorld|pOwn'];
-        final other = viewData
-            .oldWorld
-            .provinceUnitPresenceByProvinceId['oldWorld|pOther'];
+        final other =
+            viewData.oldWorld.provinceUnitPresenceByProvinceId['oldWorld|pOther'];
         expect(own, isNotNull);
         expect(other, isNotNull);
-
         expect(own!.intelVisible, isTrue);
         expect(own.civilianCount, 1);
         expect(own.regimentCount, 0);
         expect(own.shipCount, 0);
-
         expect(other!.intelVisible, isFalse);
         expect(other.civilianCount, 0);
         expect(other.regimentCount, 1);
@@ -562,48 +322,9 @@ void main() {
     test(
       'province unit presence exposes other province counts when tile is visible',
       () {
-        final game = minimalGame(
-          id: 'presence_visible_other',
-          oldWorldProvinces: const [
-            Province(
-              id: 'oldWorld|pOther',
-              regionId: 'oldWorld',
-              ownerId: 'gp2',
-            ),
-          ],
-          oldWorldUnits: [
-            Unit(
-              id: 'u_builder_other',
-              type: kUnitTypeBuilder,
-              ownerId: 'gp2',
-              locationProvinceId: 'oldWorld|pOther',
-              status: UnitStatus.idle,
-            ),
-            Unit(
-              id: 'u_pikemen_other',
-              type: 'pikemen',
-              ownerId: 'gp2',
-              locationProvinceId: 'oldWorld|pOther',
-              status: UnitStatus.idle,
-            ),
-          ],
-          fleets: [
-            Fleet(
-              id: 'f_other_visible',
-              ownerId: 'gp2',
-              regionId: 'oldWorld',
-              inPortAtProvinceId: 'oldWorld|pOther',
-              ships: [ShipInstance(id: 'ship_7', typeId: 'frigate')],
-            ),
-          ],
-          players: const [
-            Player(id: 'gp1', displayName: 'GP1', isHuman: true),
-            Player(id: 'gp2', displayName: 'GP2', isHuman: false),
-          ],
-        );
         final viewData = buildViewDataForScenario(
           dualRegionScenario(
-            game: game,
+            game: regionCellsPresenceVisibleOtherGame(),
             oldWorldGrid: const [
               ['pOther'],
             ],
@@ -617,9 +338,8 @@ void main() {
           },
         );
 
-        final other = viewData
-            .oldWorld
-            .provinceUnitPresenceByProvinceId['oldWorld|pOther'];
+        final other =
+            viewData.oldWorld.provinceUnitPresenceByProvinceId['oldWorld|pOther'];
         expect(other, isNotNull);
         expect(other!.intelVisible, isTrue);
         expect(other.civilianCount, 1);

--- a/packages/colonizethis_map/test/init_game_map_view_builder_town_civilian_markers_test.dart
+++ b/packages/colonizethis_map/test/init_game_map_view_builder_town_civilian_markers_test.dart
@@ -93,61 +93,6 @@ void main() {
     });
 
     test(
-      'town markers include non-player provinces with valid townTileKey',
-      () {
-        final game = minimalGame(
-          id: 'towns_non_player',
-          oldWorldProvinces: const [
-            Province(
-              id: 'oldWorld|p1',
-              regionId: 'oldWorld',
-              ownerId: 'gp1',
-              townTileKey: 'oldWorld|p1|0|0',
-            ),
-            Province(
-              id: 'oldWorld|p2',
-              regionId: 'oldWorld',
-              ownerId: 'ai_minor',
-              townTileKey: 'oldWorld|p2|1|0',
-            ),
-          ],
-          players: const [
-            Player(id: 'gp1', displayName: 'Player GP', isHuman: true),
-          ],
-          minorNations: const [
-            MinorNation(id: 'ai_minor', displayName: 'AI Minor Nation'),
-          ],
-        );
-        final viewData = buildViewDataForScenario(
-          dualRegionScenario(
-            game: game,
-            oldWorldGrid: const [
-              ['p1', 'p2'],
-            ],
-            oldWorldTopology: regionTopology(
-              regionId: 'oldWorld',
-              provinceIds: const ['p1', 'p2'],
-            ),
-          ),
-        );
-
-        expect(viewData.oldWorld.townMarkers.length, equals(2));
-        expect(
-          viewData.oldWorld.townMarkers.any(
-            (m) => m.provinceId == 'p1' && m.x == 0 && m.y == 0,
-          ),
-          isTrue,
-        );
-        expect(
-          viewData.oldWorld.townMarkers.any(
-            (m) => m.provinceId == 'p2' && m.x == 1 && m.y == 0,
-          ),
-          isTrue,
-        );
-      },
-    );
-
-    test(
       'town markers: port on capital tile places port drawable on sea by town',
       () {
         final game = minimalGame(

--- a/packages/colonizethis_map/test/support/init_game_map_view_region_cells_scenarios.dart
+++ b/packages/colonizethis_map/test/support/init_game_map_view_region_cells_scenarios.dart
@@ -1,0 +1,230 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_map/colonizethis_map.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import 'init_game_map_view_fixtures.dart';
+
+/// Shared game/scenario builders for `init_game_map_view_builder_region_cells_test.dart`.
+/// Refs #4112 wave-4 test densify.
+
+Game regionCellsTerrainSliceGame() => minimalGame(
+  id: 'slice-test',
+  oldWorldProvinces: const [
+    Province(
+      id: 'oldWorld|p1',
+      regionId: 'oldWorld',
+      ownerId: 'gp1',
+      displayName: 'Alpha',
+    ),
+  ],
+  players: const [Player(id: 'gp1', displayName: 'GP1', isHuman: false)],
+);
+
+Game regionCellsOverlaySetupGame() => minimalGame(
+  id: 'slice-test',
+  oldWorldProvinces: const [
+    Province(id: 'oldWorld|p1', regionId: 'oldWorld'),
+  ],
+  oldWorldUnits: [
+    Unit(
+      id: 'u-builder',
+      type: kUnitTypeBuilder,
+      ownerId: 'gp1',
+      locationProvinceId: 'oldWorld|p1',
+    ),
+    Unit(
+      id: 'u-regiment',
+      type: 'pikemen',
+      ownerId: 'gp1',
+      locationProvinceId: 'oldWorld|p1',
+    ),
+  ],
+  fleets: [
+    Fleet(
+      id: 'f1',
+      ownerId: 'gp1',
+      regionId: 'oldWorld',
+      inPortAtProvinceId: 'oldWorld|p1',
+      ships: const [ShipInstance(id: 'ship-1', typeId: 'frigate')],
+    ),
+  ],
+);
+
+Game regionCellsMarkerHelpersGame() => minimalGame(
+  id: 'slice-test',
+  oldWorldProvinces: const [
+    Province(
+      id: 'oldWorld|p1',
+      regionId: 'oldWorld',
+      townTileKey: 'oldWorld|p1|0|0',
+    ),
+  ],
+  players: const [
+    Player(
+      id: 'gp1',
+      displayName: 'GP1',
+      isHuman: true,
+      capitalTile: CapitalTile(
+        regionId: 'oldWorld',
+        provinceId: 'oldWorld|p1',
+        x: 0,
+        y: 0,
+      ),
+    ),
+  ],
+  portsByProvinceSeaboard: const {'oldWorld|p1|s1': 'oldWorld|p1|0|0'},
+);
+
+DualRegionViewScenario regionCellsMarkerWarpScenario(Game game) =>
+    oldWorldFocusedScenario(
+      game: game,
+      oldWorldGrid: const [
+        ['p1', 's1'],
+      ],
+      oldWorldTopology: singleProvinceAndSeaTopology('oldWorld'),
+      newWorldGrid: const [
+        ['s9'],
+      ],
+      newWorldTopology: regionTopology(
+        regionId: 'newWorld',
+        seaZoneIds: const ['s9'],
+      ),
+    );
+
+const regionCellsMarkerWarpLinks = <WarpLink>[
+  WarpLink(
+    regionId: 'oldWorld',
+    seaZoneId: 's1',
+    otherRegionId: 'newWorld',
+    otherSeaZoneId: 's9',
+  ),
+];
+
+Game regionCellsHomeFleetGame({required bool withFleet}) => minimalGame(
+  id: 'slice-test',
+  oldWorldProvinces: const [
+    Province(id: 'oldWorld|p1', regionId: 'oldWorld', ownerId: 'gp1'),
+  ],
+  fleets: withFleet
+      ? [
+          Fleet(
+            id: 'fleet_gp1',
+            ownerId: 'gp1',
+            regionId: 'oldWorld',
+            inPortAtProvinceId: 'oldWorld|p1',
+            ships: const [],
+            mission: FleetMission.none,
+          ),
+        ]
+      : const [],
+  players: const [
+    Player(
+      id: 'gp1',
+      displayName: 'GP1',
+      isHuman: true,
+      capitalTile: CapitalTile(
+        regionId: 'oldWorld',
+        provinceId: 'oldWorld|p1',
+        x: 0,
+        y: 0,
+      ),
+    ),
+  ],
+  portsByProvinceSeaboard: const {'oldWorld|p1|s1': 'oldWorld|p1|0|0'},
+);
+
+Game regionCellsVisibilityGame() => minimalGame(
+  id: 'visibility',
+  oldWorldProvinces: const [
+    Province(id: 'oldWorld|p1', regionId: 'oldWorld', ownerId: 'gp1'),
+  ],
+  newWorldProvinces: const [
+    Province(id: 'newWorld|p1', regionId: 'newWorld', ownerId: 'gp2'),
+  ],
+  players: const [
+    Player(id: 'gp1', displayName: 'GP1', isHuman: false),
+    Player(id: 'gp2', displayName: 'GP2', isHuman: false),
+  ],
+);
+
+Game regionCellsPresenceHiddenOtherGame() => minimalGame(
+  id: 'presence_hidden_other',
+  oldWorldProvinces: const [
+    Province(id: 'oldWorld|pOwn', regionId: 'oldWorld', ownerId: 'gp1'),
+    Province(id: 'oldWorld|pOther', regionId: 'oldWorld', ownerId: 'gp2'),
+  ],
+  oldWorldUnits: [
+    Unit(
+      id: 'u_builder',
+      type: kUnitTypeBuilder,
+      ownerId: 'gp1',
+      locationProvinceId: 'oldWorld|pOwn',
+      status: UnitStatus.idle,
+    ),
+    Unit(
+      id: 'u_pikemen',
+      type: 'pikemen',
+      ownerId: 'gp2',
+      locationProvinceId: 'oldWorld|pOther',
+      status: UnitStatus.idle,
+    ),
+  ],
+  fleets: [
+    Fleet(
+      id: 'f_other',
+      ownerId: 'gp2',
+      regionId: 'oldWorld',
+      inPortAtProvinceId: 'oldWorld|pOther',
+      ships: const [ShipInstance(id: 'ship_1', typeId: 'frigate')],
+    ),
+  ],
+  players: const [
+    Player(id: 'gp1', displayName: 'GP1', isHuman: true),
+    Player(id: 'gp2', displayName: 'GP2', isHuman: false),
+  ],
+);
+
+Game regionCellsPresenceVisibleOtherGame() => minimalGame(
+  id: 'presence_visible_other',
+  oldWorldProvinces: const [
+    Province(id: 'oldWorld|pOther', regionId: 'oldWorld', ownerId: 'gp2'),
+  ],
+  oldWorldUnits: [
+    Unit(
+      id: 'u_builder_other',
+      type: kUnitTypeBuilder,
+      ownerId: 'gp2',
+      locationProvinceId: 'oldWorld|pOther',
+      status: UnitStatus.idle,
+    ),
+    Unit(
+      id: 'u_pikemen_other',
+      type: 'pikemen',
+      ownerId: 'gp2',
+      locationProvinceId: 'oldWorld|pOther',
+      status: UnitStatus.idle,
+    ),
+  ],
+  fleets: [
+    Fleet(
+      id: 'f_other_visible',
+      ownerId: 'gp2',
+      regionId: 'oldWorld',
+      inPortAtProvinceId: 'oldWorld|pOther',
+      ships: const [ShipInstance(id: 'ship_7', typeId: 'frigate')],
+    ),
+  ],
+  players: const [
+    Player(id: 'gp1', displayName: 'GP1', isHuman: true),
+    Player(id: 'gp2', displayName: 'GP2', isHuman: false),
+  ],
+);
+
+InitGameMapViewData buildRegionCellsMarkerWarpView(Game game) =>
+    buildViewDataForScenario(
+      regionCellsMarkerWarpScenario(game),
+      warpLinks: regionCellsMarkerWarpLinks,
+    );
+
+InitGameMapViewData buildRegionCellsHomeFleetView({required bool withFleet}) =>
+    buildRegionCellsMarkerWarpView(regionCellsHomeFleetGame(withFleet: withFleet));

--- a/packages/colonizethis_map/test/tile_map_visualization_render_test.dart
+++ b/packages/colonizethis_map/test/tile_map_visualization_render_test.dart
@@ -2,18 +2,11 @@ import 'package:colonizethis_test/test.dart';
 
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_map/colonizethis_map.dart';
-import 'package:image/image.dart' as img;
 
 import 'support/init_game_map_view_fixtures.dart';
 import 'package:colonizethis_map/src/render/tile_map_visualization_legend_layout.dart'
     show legendHeightForLineCount;
 import 'tile_map_visualization_test_fixtures.dart';
-
-/// Sea color and plains color from tile_map_visualization (for pixel assertions).
-const (int, int, int) _seaRgb = (20, 60, 140);
-const (int, int, int) _plainsRgb = (200, 220, 160);
-const (int, int, int) _seaZoneBorderRgb = (173, 216, 230);
-const int _colorTolerance = 2;
 
 void main() {
   group('renderTileMapToPng', () {
@@ -28,15 +21,15 @@ void main() {
     });
 
     test('decoded image has expected dimensions (map + legend)', () {
-      final bytes = renderTileMapToPng(
-        visualizationSmallResult,
-        visualizationTopology,
-        cellSize: 8,
+      const cellSize = 8;
+      final decoded = decodeRenderedPng(
+        renderTileMapToPng(
+          visualizationSmallResult,
+          visualizationTopology,
+          cellSize: cellSize,
+        ),
       );
-      final decoded = img.decodeImage(bytes);
-      expect(decoded, isNotNull);
-      // Map: 4*8 x 3*8 = 32 x 24. Legend below.
-      expect(decoded!.width, 32);
+      expect(decoded.width, 32);
       expect(decoded.height, greaterThanOrEqualTo(24));
     });
 
@@ -44,82 +37,58 @@ void main() {
       'dimensions with terrain: width and height match map + terrain legend',
       () {
         const cellSize = 8;
-        final bytes = renderTileMapToPng(
-          visualizationResultWithTerrain,
-          visualizationTopology,
-          cellSize: cellSize,
+        final decoded = decodeRenderedPng(
+          renderTileMapToPng(
+            visualizationResultWithTerrain,
+            visualizationTopology,
+            cellSize: cellSize,
+          ),
         );
-        final decoded = img.decodeImage(bytes);
-        expect(decoded, isNotNull);
         final mapW = visualizationResultWithTerrain.width * cellSize;
         final mapH = visualizationResultWithTerrain.height * cellSize;
         const titleLines = 2;
         final legendLines = titleLines + 1 + TerrainType.values.length;
-        final legendHeight = legendHeightForLineCount(legendLines);
-        expect(decoded!.width, mapW);
-        expect(decoded.height, mapH + legendHeight);
+        expect(decoded.width, mapW);
+        expect(decoded.height, mapH + legendHeightForLineCount(legendLines));
       },
     );
 
     test('sea cell color: center pixel of sea cell is deep blue', () {
-      // Use cellSize 24 so region id label (top-left) does not overlap cell center.
       const cellSize = 24;
-      final bytes = renderTileMapToPng(
-        visualizationResultWithTerrain,
-        visualizationTopology,
-        cellSize: cellSize,
+      final decoded = decodeRenderedPng(
+        renderTileMapToPng(
+          visualizationResultWithTerrain,
+          visualizationTopology,
+          cellSize: cellSize,
+        ),
       );
-      final decoded = img.decodeImage(bytes);
-      expect(decoded, isNotNull);
-      // (1, 1) is s1 (sea). Center of cell: (1*24+12, 1*24+12) = (36, 36).
-      final x = 1 * cellSize + cellSize ~/ 2;
-      final y = 1 * cellSize + cellSize ~/ 2;
-      final pixel = decoded!.getPixel(x, y);
-      expect((pixel.r - _seaRgb.$1).abs(), lessThanOrEqualTo(_colorTolerance));
-      expect((pixel.g - _seaRgb.$2).abs(), lessThanOrEqualTo(_colorTolerance));
-      expect((pixel.b - _seaRgb.$3).abs(), lessThanOrEqualTo(_colorTolerance));
+      final (x, y) = cellCenterPixel(1, 1, cellSize);
+      expectPixelNearRgb(decoded, x, y, visualizationSeaRgb);
     });
 
     test('land terrain color: center pixel of plains cell matches palette', () {
       const cellSize = 8;
-      final bytes = renderTileMapToPng(
-        visualizationResultWithTerrain,
-        visualizationTopology,
-        cellSize: cellSize,
+      final decoded = decodeRenderedPng(
+        renderTileMapToPng(
+          visualizationResultWithTerrain,
+          visualizationTopology,
+          cellSize: cellSize,
+        ),
       );
-      final decoded = img.decodeImage(bytes);
-      expect(decoded, isNotNull);
-      // (0, 0) is p1 with plains. Center: (4, 4).
-      final x = 0 * cellSize + cellSize ~/ 2;
-      final y = 0 * cellSize + cellSize ~/ 2;
-      final pixel = decoded!.getPixel(x, y);
-      expect(
-        (pixel.r - _plainsRgb.$1).abs(),
-        lessThanOrEqualTo(_colorTolerance),
-      );
-      expect(
-        (pixel.g - _plainsRgb.$2).abs(),
-        lessThanOrEqualTo(_colorTolerance),
-      );
-      expect(
-        (pixel.b - _plainsRgb.$3).abs(),
-        lessThanOrEqualTo(_colorTolerance),
-      );
+      final (x, y) = cellCenterPixel(0, 0, cellSize);
+      expectPixelNearRgb(decoded, x, y, visualizationPlainsRgb);
     });
 
     test('border pixel is black between different region ids (land border)', () {
       const cellSize = 8;
-      final bytes = renderTileMapToPng(
-        visualizationResultWithTerrain,
-        visualizationTopology,
-        cellSize: cellSize,
+      final decoded = decodeRenderedPng(
+        renderTileMapToPng(
+          visualizationResultWithTerrain,
+          visualizationTopology,
+          cellSize: cellSize,
+        ),
       );
-      final decoded = img.decodeImage(bytes);
-      expect(decoded, isNotNull);
-      // Vertical border between (1,0) p1 and (2,0) p2: right edge of (1,0) at x = 2*8 = 16.
-      final edgeX = 2 * cellSize;
-      final sampleY = cellSize ~/ 2;
-      final pixel = decoded!.getPixel(edgeX, sampleY);
+      final pixel = decoded.getPixel(2 * cellSize, cellSize ~/ 2);
       expect(pixel.r, lessThanOrEqualTo(5));
       expect(pixel.g, lessThanOrEqualTo(5));
       expect(pixel.b, lessThanOrEqualTo(5));
@@ -127,32 +96,18 @@ void main() {
 
     test('sea zone border is light blue when two sea zones are adjacent', () {
       const cellSize = 8;
-      final topologyWithTwoSeas = twoAdjacentSeaZonesTopology('oldWorld');
-      final resultWithTwoSeas = mapTileGrid([
-        ['s1', 's2'],
-      ]);
-      final bytes = renderTileMapToPng(
-        resultWithTwoSeas,
-        topologyWithTwoSeas,
-        cellSize: cellSize,
+      final decoded = decodeRenderedPng(
+        renderTileMapToPng(
+          mapTileGrid([['s1', 's2']]),
+          twoAdjacentSeaZonesTopology('oldWorld'),
+          cellSize: cellSize,
+        ),
       );
-      final decoded = img.decodeImage(bytes);
-      expect(decoded, isNotNull);
-      // Vertical border between s1 and s2 at x = 1*8 = 8.
-      final edgeX = 1 * cellSize;
-      final sampleY = cellSize ~/ 2;
-      final pixel = decoded!.getPixel(edgeX, sampleY);
-      expect(
-        (pixel.r - _seaZoneBorderRgb.$1).abs(),
-        lessThanOrEqualTo(_colorTolerance),
-      );
-      expect(
-        (pixel.g - _seaZoneBorderRgb.$2).abs(),
-        lessThanOrEqualTo(_colorTolerance),
-      );
-      expect(
-        (pixel.b - _seaZoneBorderRgb.$3).abs(),
-        lessThanOrEqualTo(_colorTolerance),
+      expectPixelNearRgb(
+        decoded,
+        cellSize,
+        cellSize ~/ 2,
+        visualizationSeaZoneBorderRgb,
       );
     });
 
@@ -160,30 +115,28 @@ void main() {
       'legend height with terrain: total height = map + terrain legend lines',
       () {
         const cellSize = 8;
-        final bytes = renderTileMapToPng(
-          visualizationResultWithTerrain,
-          visualizationTopology,
-          cellSize: cellSize,
+        final decoded = decodeRenderedPng(
+          renderTileMapToPng(
+            visualizationResultWithTerrain,
+            visualizationTopology,
+            cellSize: cellSize,
+          ),
         );
-        final decoded = img.decodeImage(bytes);
-        expect(decoded, isNotNull);
         final mapH = visualizationResultWithTerrain.height * cellSize;
         final legendLines = 2 + 1 + TerrainType.values.length;
-        final legendHeight = legendHeightForLineCount(legendLines);
-        expect(decoded!.height, mapH + legendHeight);
+        expect(decoded.height, mapH + legendHeightForLineCount(legendLines));
       },
     );
 
     test('fallback no terrain: valid PNG, region dimensions, no throw', () {
-      final bytes = renderTileMapToPng(
-        visualizationSmallResult,
-        visualizationTopology,
-        cellSize: 8,
+      final decoded = decodeRenderedPng(
+        renderTileMapToPng(
+          visualizationSmallResult,
+          visualizationTopology,
+          cellSize: 8,
+        ),
       );
-      expect(bytes, isNotEmpty);
-      final decoded = img.decodeImage(bytes);
-      expect(decoded, isNotNull);
-      expect(decoded!.width, 32);
+      expect(decoded.width, 32);
       expect(decoded.height, greaterThanOrEqualTo(24));
     });
 
@@ -191,16 +144,16 @@ void main() {
       'with landSeedPositions only (no continent indices): single Land seeds legend row',
       () {
         const cellSize = 8;
-        final bytes = renderTileMapToPng(
-          visualizationSmallResult,
-          visualizationTopology,
-          cellSize: cellSize,
-          landSeedPositions: [(0, 0), (1, 1)],
+        final decoded = decodeRenderedPng(
+          renderTileMapToPng(
+            visualizationSmallResult,
+            visualizationTopology,
+            cellSize: cellSize,
+            landSeedPositions: [(0, 0), (1, 1)],
+          ),
         );
-        final decoded = img.decodeImage(bytes);
-        expect(decoded, isNotNull);
         expect(
-          decoded!.height,
+          decoded.height,
           greaterThan(3 * cellSize),
           reason: 'Legend includes land seeds row',
         );
@@ -216,34 +169,21 @@ void main() {
           visualizationTopology,
           cellSize: cellSize,
         );
-        final bytesWith = renderTileMapToPng(
-          visualizationSmallResult,
-          visualizationTopology,
-          cellSize: cellSize,
-          landSeedPositions: [(0, 0), (1, 1)],
+        final decodedWith = decodeRenderedPng(
+          renderTileMapToPng(
+            visualizationSmallResult,
+            visualizationTopology,
+            cellSize: cellSize,
+            landSeedPositions: [(0, 0), (1, 1)],
+          ),
         );
-        final decodedWith = img.decodeImage(bytesWith);
-        expect(decodedWith, isNotNull);
         expect(
-          decodedWith!.height,
-          greaterThan(img.decodeImage(bytesWithout)!.height),
+          decodedWith.height,
+          greaterThan(decodeRenderedPng(bytesWithout).height),
           reason: 'Extra legend row when land seeds shown',
         );
-        final cx = 0 * cellSize + cellSize ~/ 2;
-        final cy = 0 * cellSize + cellSize ~/ 2;
-        final pixel = decodedWith.getPixel(cx, cy);
-        expect(
-          (pixel.r - landSeedMarkerRgb.$1).abs(),
-          lessThanOrEqualTo(_colorTolerance),
-        );
-        expect(
-          (pixel.g - landSeedMarkerRgb.$2).abs(),
-          lessThanOrEqualTo(_colorTolerance),
-        );
-        expect(
-          (pixel.b - landSeedMarkerRgb.$3).abs(),
-          lessThanOrEqualTo(_colorTolerance),
-        );
+        final (cx, cy) = cellCenterPixel(0, 0, cellSize);
+        expectPixelNearRgb(decodedWith, cx, cy, landSeedMarkerRgb);
       },
     );
 
@@ -251,24 +191,24 @@ void main() {
       'with continentSeedPositions only: extra legend row for continent seeds',
       () {
         const cellSize = 8;
-        final bytesWithContinent = renderTileMapToPng(
-          visualizationResultWithTerrain,
-          visualizationTopology,
-          cellSize: cellSize,
-          continentSeedPositions: [(0, 0)],
+        final decodedWith = decodeRenderedPng(
+          renderTileMapToPng(
+            visualizationResultWithTerrain,
+            visualizationTopology,
+            cellSize: cellSize,
+            continentSeedPositions: [(0, 0)],
+          ),
         );
-        final bytesWithout = renderTileMapToPng(
-          visualizationResultWithTerrain,
-          visualizationTopology,
-          cellSize: cellSize,
+        final decodedWithout = decodeRenderedPng(
+          renderTileMapToPng(
+            visualizationResultWithTerrain,
+            visualizationTopology,
+            cellSize: cellSize,
+          ),
         );
-        final decodedWith = img.decodeImage(bytesWithContinent);
-        final decodedWithout = img.decodeImage(bytesWithout);
-        expect(decodedWith, isNotNull);
-        expect(decodedWithout, isNotNull);
         expect(
-          decodedWith!.height,
-          greaterThan(decodedWithout!.height),
+          decodedWith.height,
+          greaterThan(decodedWithout.height),
           reason: 'Continent seeds add a legend row',
         );
       },
@@ -278,15 +218,15 @@ void main() {
       'with continentSeedPositions and landSeedPositions: two legend rows and distinct markers',
       () {
         const cellSize = 8;
-        final bytesWithBoth = renderTileMapToPng(
-          visualizationResultWithTerrain,
-          visualizationTopology,
-          cellSize: cellSize,
-          landSeedPositions: [(2, 2)],
-          continentSeedPositions: [(0, 0)],
+        final decoded = decodeRenderedPng(
+          renderTileMapToPng(
+            visualizationResultWithTerrain,
+            visualizationTopology,
+            cellSize: cellSize,
+            landSeedPositions: [(2, 2)],
+            continentSeedPositions: [(0, 0)],
+          ),
         );
-        final decoded = img.decodeImage(bytesWithBoth);
-        expect(decoded, isNotNull);
         final bytesLandOnly = renderTileMapToPng(
           visualizationResultWithTerrain,
           visualizationTopology,
@@ -294,25 +234,12 @@ void main() {
           landSeedPositions: [(2, 2)],
         );
         expect(
-          decoded!.height,
-          greaterThan(img.decodeImage(bytesLandOnly)!.height),
+          decoded.height,
+          greaterThan(decodeRenderedPng(bytesLandOnly).height),
           reason: 'Extra legend row when continent seeds also shown',
         );
-        final continentCx = 0 * cellSize + cellSize ~/ 2;
-        final continentCy = 0 * cellSize + cellSize ~/ 2;
-        final continentPixel = decoded.getPixel(continentCx, continentCy);
-        expect(
-          (continentPixel.r - continentSeedMarkerRgb.$1).abs(),
-          lessThanOrEqualTo(_colorTolerance),
-        );
-        expect(
-          (continentPixel.g - continentSeedMarkerRgb.$2).abs(),
-          lessThanOrEqualTo(_colorTolerance),
-        );
-        expect(
-          (continentPixel.b - continentSeedMarkerRgb.$3).abs(),
-          lessThanOrEqualTo(_colorTolerance),
-        );
+        final (cx, cy) = cellCenterPixel(0, 0, cellSize);
+        expectPixelNearRgb(decoded, cx, cy, continentSeedMarkerRgb);
       },
     );
 
@@ -320,17 +247,15 @@ void main() {
       'with landSeedContinentIndices: markers colored by continent and legend has one row per continent',
       () {
         const cellSize = 24;
-        final bytes = renderTileMapToPng(
-          visualizationResultWithTerrain,
-          visualizationTopology,
-          cellSize: cellSize,
-          landSeedPositions: [(0, 0), (2, 2)],
-          landSeedContinentIndices: [0, 1],
+        final decoded = decodeRenderedPng(
+          renderTileMapToPng(
+            visualizationResultWithTerrain,
+            visualizationTopology,
+            cellSize: cellSize,
+            landSeedPositions: [(0, 0), (2, 2)],
+            landSeedContinentIndices: [0, 1],
+          ),
         );
-        final decoded = img.decodeImage(bytes);
-        expect(decoded, isNotNull);
-        // Region id labels are drawn on top of seeds, so we do not assert exact marker pixel colors.
-        // Assert that per-continent legend adds two rows (Continent 0, Continent 1).
         final bytesSingleRow = renderTileMapToPng(
           visualizationResultWithTerrain,
           visualizationTopology,
@@ -338,8 +263,8 @@ void main() {
           landSeedPositions: [(0, 0), (2, 2)],
         );
         expect(
-          decoded!.height,
-          greaterThan(img.decodeImage(bytesSingleRow)!.height),
+          decoded.height,
+          greaterThan(decodeRenderedPng(bytesSingleRow).height),
           reason:
               'Per-continent legend adds two rows (Continent 0, Continent 1)',
         );
@@ -350,23 +275,23 @@ void main() {
       'with resourceGrid: image height larger and legend includes resource rows',
       () {
         const cellSize = 8;
-        final bytesWithout = renderTileMapToPng(
-          visualizationResultWithTerrain,
-          visualizationTopology,
-          cellSize: cellSize,
+        final decodedWithout = decodeRenderedPng(
+          renderTileMapToPng(
+            visualizationResultWithTerrain,
+            visualizationTopology,
+            cellSize: cellSize,
+          ),
         );
-        final bytesWith = renderTileMapToPng(
-          visualizationResultWithTerrainAndResources,
-          visualizationTopology,
-          cellSize: cellSize,
+        final decodedWith = decodeRenderedPng(
+          renderTileMapToPng(
+            visualizationResultWithTerrainAndResources,
+            visualizationTopology,
+            cellSize: cellSize,
+          ),
         );
-        final decodedWithout = img.decodeImage(bytesWithout);
-        final decodedWith = img.decodeImage(bytesWith);
-        expect(decodedWithout, isNotNull);
-        expect(decodedWith, isNotNull);
         expect(
-          decodedWith!.height,
-          greaterThan(decodedWithout!.height),
+          decodedWith.height,
+          greaterThan(decodedWithout.height),
           reason: 'Legend has extra lines for resources',
         );
       },
@@ -378,21 +303,9 @@ void main() {
         final letters = <String>{};
         for (final r in Resource.values) {
           final letter = resourceIdToLegendLetter(r.name);
-          expect(
-            letter,
-            isNotNull,
-            reason: 'Resource $r should have a legend letter',
-          );
-          expect(
-            letter!.length,
-            1,
-            reason: 'Letter for $r should be single character',
-          );
-          expect(
-            letters.contains(letter),
-            isFalse,
-            reason: 'Duplicate letter $letter for $r',
-          );
+          expect(letter, isNotNull, reason: 'Resource $r should have a legend letter');
+          expect(letter!.length, 1, reason: 'Letter for $r should be single character');
+          expect(letters.contains(letter), isFalse, reason: 'Duplicate letter $letter for $r');
           letters.add(letter);
         }
       },
@@ -401,18 +314,17 @@ void main() {
     test('region id label is drawn in red at top-left of each cell', () {
       const cellSize = 8;
       const idInset = 2;
-      final bytes = renderTileMapToPng(
-        visualizationSmallResult,
-        visualizationTopology,
-        cellSize: cellSize,
+      final decoded = decodeRenderedPng(
+        renderTileMapToPng(
+          visualizationSmallResult,
+          visualizationTopology,
+          cellSize: cellSize,
+        ),
       );
-      final decoded = img.decodeImage(bytes);
-      expect(decoded, isNotNull);
-      // Region id "p1" is drawn at (0,0) cell: tx=0*cellSize+idInset=2, ty=2. Sample in label area.
       var foundRed = false;
       for (var py = idInset; py < idInset + 14 && !foundRed; py++) {
         for (var px = idInset; px < idInset + 16 && !foundRed; px++) {
-          final pixel = decoded!.getPixel(px, py);
+          final pixel = decoded.getPixel(px, py);
           if (pixel.r >= 200 && pixel.g <= 30 && pixel.b <= 30) foundRed = true;
         }
       }

--- a/packages/colonizethis_map/test/tile_map_visualization_test_fixtures.dart
+++ b/packages/colonizethis_map/test/tile_map_visualization_test_fixtures.dart
@@ -1,4 +1,8 @@
+import 'dart:typed_data';
+
 import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_test/test.dart';
+import 'package:image/image.dart' as img;
 
 import 'support/init_game_map_view_fixtures.dart';
 
@@ -48,3 +52,31 @@ final TileMapResult visualizationResultWithTerrainAndResources = mapTileGrid(
     [Resource.iron, null, null, null],
   ],
 );
+
+/// Sea color and plains color from tile_map_visualization (for pixel assertions).
+const (int, int, int) visualizationSeaRgb = (20, 60, 140);
+const (int, int, int) visualizationPlainsRgb = (200, 220, 160);
+const (int, int, int) visualizationSeaZoneBorderRgb = (173, 216, 230);
+const int visualizationColorTolerance = 2;
+
+img.Image decodeRenderedPng(List<int> bytes) {
+  final decoded = img.decodeImage(Uint8List.fromList(bytes));
+  expect(decoded, isNotNull);
+  return decoded!;
+}
+
+(int, int) cellCenterPixel(int col, int row, int cellSize) =>
+    (col * cellSize + cellSize ~/ 2, row * cellSize + cellSize ~/ 2);
+
+void expectPixelNearRgb(
+  img.Image image,
+  int x,
+  int y,
+  (int, int, int) rgb, {
+  int tolerance = visualizationColorTolerance,
+}) {
+  final pixel = image.getPixel(x, y);
+  expect((pixel.r - rgb.$1).abs(), lessThanOrEqualTo(tolerance));
+  expect((pixel.g - rgb.$2).abs(), lessThanOrEqualTo(tolerance));
+  expect((pixel.b - rgb.$3).abs(), lessThanOrEqualTo(tolerance));
+}

--- a/packages/colonizethis_map/test/town_icon_style_test.dart
+++ b/packages/colonizethis_map/test/town_icon_style_test.dart
@@ -3,19 +3,16 @@ import 'package:colonizethis_data/colonizethis_data.dart' show kNewWorldRegionId
 import 'package:colonizethis_map/colonizethis_map.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
+import 'support/init_game_map_view_fixtures.dart';
+
 void main() {
   group('townIconStyleForProvince', () {
     Game gameWith({
       List<Player> players = const [],
       List<MinorNation> minorNations = const [],
       List<Tribe> tribes = const [],
-    }) => Game(
+    }) => minimalGame(
       id: 'g',
-      worldState: WorldState(
-        turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
-        oldWorld: const RegionData(),
-        newWorld: const RegionData(),
-      ),
       players: players,
       minorNations: minorNations,
       tribes: tribes,

--- a/test/check_map_test_minimal_game_shared_test.dart
+++ b/test/check_map_test_minimal_game_shared_test.dart
@@ -6,7 +6,7 @@ import '../tool/check_map_test_minimal_game_shared.dart';
 
 void main() {
   group('mapTestMinimalGameSharedPathInScope', () {
-    test('scopes the five colour/capital/format suites', () {
+    test('scopes colour/capital/format and residual non-view-builder suites', () {
       expect(
         mapTestMinimalGameSharedPathInScope(
           'packages/colonizethis_map/test/faction_ownership_color_test.dart',
@@ -17,7 +17,13 @@ void main() {
         mapTestMinimalGameSharedPathInScope(
           'packages/colonizethis_map/test/town_icon_style_test.dart',
         ),
-        isFalse,
+        isTrue,
+      );
+      expect(
+        mapTestMinimalGameSharedPathInScope(
+          'packages/colonizethis_map/test/game_world_state_map_visualizer_test.dart',
+        ),
+        isTrue,
       );
     });
   });

--- a/tool/check_map_test_file_size.dart
+++ b/tool/check_map_test_file_size.dart
@@ -10,11 +10,7 @@ const _maxPhysicalLines = 400;
 const _mapTestsRelativePath = 'packages/colonizethis_map/test';
 
 /// Shrink-only allowlist during transition; remove entries as densify lands.
-const List<String> mapTestFileSizeGrandfathered = <String>[
-  'packages/colonizethis_map/test/init_game_map_view_builder_region_cells_test.dart',
-  'packages/colonizethis_map/test/init_game_map_view_builder_town_civilian_markers_test.dart',
-  'packages/colonizethis_map/test/tile_map_visualization_render_test.dart',
-];
+const List<String> mapTestFileSizeGrandfathered = <String>[];
 
 int runCheckMapTestFileSize(
   String repoRoot, {

--- a/tool/check_map_test_minimal_game_shared.dart
+++ b/tool/check_map_test_minimal_game_shared.dart
@@ -16,6 +16,8 @@ const Set<String> mapTestMinimalGameSharedScopedFiles = {
   'packages/colonizethis_map/test/region_map_view_inputs_test.dart',
   'packages/colonizethis_map/test/map_format_util_test.dart',
   'packages/colonizethis_map/test/port_icon_placement_test.dart',
+  'packages/colonizethis_map/test/town_icon_style_test.dart',
+  'packages/colonizethis_map/test/game_world_state_map_visualizer_test.dart',
 };
 
 final RegExp _inlineGameConstructor = RegExp(r'\bGame\s*\(');


### PR DESCRIPTION
## Summary

- **Test densify (Slice D follow-up):** Extracted region-cell game/scenario builders to `test/support/init_game_map_view_region_cells_scenarios.dart`; shared PNG decode/pixel helpers in `tile_map_visualization_test_fixtures.dart`; removed duplicate town-marker test case.
- **CI ratchet:** Cleared `mapTestFileSizeGrandfathered` — all three previously grandfathered suites are now ≤400 physical lines (`region_cells` 351, `town_civilian_markers` 356, `render_test` 338).
- **AC4 — Inline `Game(` ratchet:** Migrated `town_icon_style_test.dart` to `minimalGame`; extended `repo.map_test_minimal_game_shared` scope to `town_icon_style_test.dart` and `game_world_state_map_visualizer_test.dart`.

Refs #4112

## Acceptance criteria coverage

| AC | Status |
|----|--------|
| AC1 — Determinism / PNG baselines unchanged | **Done** — landed in #4115; no pixel semantic changes in this PR |
| AC2 — Lib module size headroom | **Done** — `check_map_lib_file_size` green |
| AC3 — Legend layout dedup gate | **Done** — `check_map_render_legend_layout_dedup` green |
| AC4 — Inline `Game(` ratchet | **Done** — non–view-builder scoped suites use `minimalGame` |
| AC5 — View-builder test file size | **Done** — grandfather list emptied; `check_map_test_file_size` green |
| AC6 — Marker type module encapsulation | **Done** — landed in #4115 |
| AC7 — CI lint gates | **Done** — all `repo.map_*` rules pass locally |
| AC8 — SPEC internal layering | **Done** — `map-visualization.md` § Internal layering updated in #4115 |

## Test plan

- [x] `dart test` in `packages/colonizethis_map` (targeted: region_cells, town_civilian_markers, render_test, town_icon_style, visualizer — all passed)
- [x] `dart run tool/check_map_test_file_size.dart`
- [x] `dart run tool/check_map_test_minimal_game_shared.dart`
- [x] `dart test test/check_map_test_minimal_game_shared_test.dart`