### PR TITLE
feat: research-complete feed row opens Technology Slots (#4144)

### DIFF
--- a/SPEC/ui/player-turn-event-feed.md
+++ b/SPEC/ui/player-turn-event-feed.md
@@ -41,8 +41,9 @@
 - Work-order completion lines tap-focus the target tile.
 - Province-discovery lines tap-focus the discovered province.
 - Sea-discovery lines tap-focus a sea-zone anchor tile.
+- Research-complete lines for catalog-known techs show the tech display name, a trailing chevron link affordance, and open `GAME40001` **Technology** on the Slots tab via `NavigateToRouteEvent(Routes.technology, …)` (same args as the empire left-rail Technology button).
 - Other lines are non-tappable in v1.
-- Fallback: if no valid map anchor can be resolved for a tappable row, render it non-tappable and keep app stable.
+- Fallback: if no valid map anchor can be resolved for a tappable row, or the research event tech id is absent from the catalog, render it non-tappable with safe copy and keep app stable.
 
 ---
 
@@ -86,6 +87,10 @@ The newspaper toggle lives in [`GameTabBar`](../../app/lib/features/game/widgets
 - Given a tappable province-scoped line whose province anchor resolves to a tile key, when the user taps that row, then the app emits `LocateMapTileEvent` for that tile.
 - Given a tappable naval-combat line whose sea-zone anchor resolves to a tile key, when the user taps that row, then the app emits `LocateMapTileEvent` for that tile.
 - Given a non-tappable line or unresolved anchor, when the user taps the row, then no map-focus event is emitted and the app remains stable.
+- Given a human `AppResearchCompleteEvent` for a catalog-known tech, when the feed renders, then the row shows the tech display name (never the raw tech id), a trailing chevron link affordance, and is tappable.
+- Given a catalog-known research-complete row, when the user taps it, then the app emits `NavigateToRouteEvent` for `Routes.technology` with the same route args as the empire left-rail Technology button.
+- Given a research-complete event whose tech id is not in the catalog, when the feed renders, then the row is non-tappable with safe fallback copy and no raw tech id appears.
+- Given a narrow-layout (`< 600` dp host width) map shell with a tappable research-complete row, when the row builds, then its tap target is at least 44 dp tall.
 - Given a diplomacy feed line with `changeType` of `declare_war`, `peace`, `alliance`, or `break_alliance`, when rendered, then the line uses a concrete outcome template (not the generic "diplomacy changed" fallback).
 - Given The Player toggles `showPlayerTurnEventsFeed` and saves the game, when the game is loaded, then `mapViewState.showPlayerTurnEventsFeed` restores with the same value.
 - Given a legacy save where `mapViewState.showPlayerTurnEventsFeed` is absent, when the game loads, then the loaded value defaults to `false`.

--- a/app/lib/features/game/flame/map_state/game_map_area_turn_feed.dart
+++ b/app/lib/features/game/flame/map_state/game_map_area_turn_feed.dart
@@ -62,9 +62,15 @@ mixin GameMapAreaTurnFeed
                 ),
               ),
             ct_models.AppResearchCompleteEvent(:final techId) =>
-              PlayerTurnEventFeedEntry(
-                text: 'Research complete! $techId unlocked!',
-              ),
+              isCatalogTech(techId)
+                  ? PlayerTurnEventFeedEntry(
+                      text: researchCompleteLine(techId),
+                      linkAffordance: true,
+                      onTap: navigateToTechnologyScreen,
+                    )
+                  : PlayerTurnEventFeedEntry(
+                      text: researchCompleteLine(techId),
+                    ),
             ct_models.AppOrderRejectedEvent(:final reasonCode) =>
               PlayerTurnEventFeedEntry(
                 text: 'Order rejected! Reason: $reasonCode!',

--- a/app/lib/features/game/flame/map_state/game_map_area_turn_feed_labels.dart
+++ b/app/lib/features/game/flame/map_state/game_map_area_turn_feed_labels.dart
@@ -2,12 +2,15 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:colonizethis_app/core/utils/prefixed_id.dart';
-import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_data/colonizethis_data.dart'
+    show TopologyNodeType, techById, techDisplayName;
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart' as ct_models;
 
+import '../../../../config/routes.dart';
 import '../../../../providers/app_event_bus_provider.dart';
 import '../../../../providers/game_service_provider.dart';
+import '../../../../providers/games_provider.dart';
 
 import 'map_location_resolver.dart';
 import 'game_map_area.dart';
@@ -146,5 +149,25 @@ mixin GameMapAreaTurnFeedLabels
       return;
     }
     emitLocateMapTile(tileKey: tileKey, regionId: regionId);
+  }
+
+  bool isCatalogTech(String techId) => techById(techId) != null;
+
+  String researchCompleteLine(String techId) {
+    if (!isCatalogTech(techId)) {
+      return 'Research complete — technology unlocked!';
+    }
+    return 'Research complete: ${techDisplayName(techId)} unlocked';
+  }
+
+  void navigateToTechnologyScreen() {
+    final orders = ref.read(currentOrdersProvider);
+    ref.read(appEventBusProvider).emit(
+          ct_models.NavigateToRouteEvent(Routes.technology, {
+            'game': widget.game,
+            'humanPlayerId': mapPlayerId,
+            'currentOrders': orders,
+          }),
+        );
   }
 }

--- a/app/lib/features/game/widgets/shell/player_turn_event_feed.dart
+++ b/app/lib/features/game/widgets/shell/player_turn_event_feed.dart
@@ -7,8 +7,16 @@ export 'player_turn_event_feed_toggle_glyph.dart'
     show NewspaperGlyph, PlayerTurnEventFeedUnreadBadge;
 
 class PlayerTurnEventFeedEntry {
-  const PlayerTurnEventFeedEntry({required this.text, this.onTap});
+  const PlayerTurnEventFeedEntry({
+    required this.text,
+    this.onTap,
+    this.linkAffordance = false,
+  });
 
   final String text;
   final VoidCallback? onTap;
+
+  /// When true, the row shows a trailing chevron so screen-navigation taps
+  /// read as links (distinct from map-focus tappable rows).
+  final bool linkAffordance;
 }

--- a/app/lib/features/game/widgets/shell/player_turn_event_feed_card.dart
+++ b/app/lib/features/game/widgets/shell/player_turn_event_feed_card.dart
@@ -1,4 +1,4 @@
-import 'package:colonizethis_app_ui_chrome/config/editorial_monocle_palette.dart';
+import 'package:colonizethis_app_ui_chrome/colonizethis_app_ui_chrome.dart';
 import 'package:flutter/material.dart';
 
 import '../../../../config/constants.dart';
@@ -10,32 +10,7 @@ import 'player_turn_event_feed.dart';
 /// Floating, scrollable news card rendered on the in-game map stack when
 /// the player toggles the newspaper button in [GameTabBar].
 ///
-/// Implements `Refs #2861` S7 dark editorial-monocle restyle: the legacy
-/// near-black Material box is replaced with a token-resolved
-/// `surface → bg` gradient (per [CtGradients.panelGradient]) framed by a
-/// 1 dp [EditorialMonoclePalette.accentDim] brass border, matching the
-/// floating chrome family used by `GameMapPlayersBar`, the empire left
-/// rail, and the side menu. The card never displays an `Events` title row
-/// (per `SPEC/ui/player-turn-event-feed.md` § Acceptance criteria); the
-/// header slot is reserved for empty-state copy and event entries only.
-///
-/// Wide layout (default, `narrow: false`): card width is
-/// [kGameMapWideProvinceSidePanelWidth] (320 dp), so the card and the
-/// open province side panel never sit side-by-side without the wide
-/// inset (issue #2861 S7).
-///
-/// Narrow layout (issue #2870 S3 / Req 11, `MediaQuery.size.width <
-/// kNarrowBreakpoint`): host constructs the card with `narrow: true`.
-/// The card width then resolves to
-/// `clamp(narrowMinWidth, viewport.width / 2, narrowMaxWidth)` dp,
-/// mirroring the mockup `.news-feed-card @media (max-width:600px)
-/// { width:clamp(180px, 50vw, 260px); }` rule from
-/// `SPEC/ui/mockups/GAME10001-game-screen.html`. The province bottom
-/// sheet covers the card from the bottom on narrow, so no wide
-/// side-panel inset applies.
-///
-/// All colours resolve from [EditorialMonoclePalette] tokens (issue #2858);
-/// no hard-coded hex literals. SPEC: `SPEC/ui/player-turn-event-feed.md`.
+/// SPEC: `SPEC/ui/player-turn-event-feed.md`.
 class PlayerTurnEventFeedCard extends StatelessWidget {
   const PlayerTurnEventFeedCard({
     super.key,
@@ -49,56 +24,21 @@ class PlayerTurnEventFeedCard extends StatelessWidget {
 
   /// When true, render the card at narrow-viewport measurements per
   /// `SPEC/ui/mobile-adaptation.md` § In-game shell (issue #2870 S3).
-  /// The width resolves to
-  /// `clamp(narrowMinWidth, viewport.width / 2, narrowMaxWidth)` dp.
   final bool narrow;
 
-  /// Card border thickness (brass strip width). Matches the 1 dp border
-  /// used by [GameMapPlayersBarChip] for visual cohesion.
   static const double borderWidth = 1;
-
-  /// Outer padding inside the card frame (mockup parity with the legacy
-  /// 10 px content inset).
   static const EdgeInsetsGeometry contentPadding = EdgeInsets.all(10);
-
-  /// Max content height inside the scroll viewport so the card never grows
-  /// taller than ~½ of the wide map stack (parity with the legacy 220 px
-  /// cap that consumers depended on for layout flow).
   static const double maxContentHeight = 220;
-
-  /// Vertical gap between consecutive event rows inside the scroll
-  /// viewport (matches the legacy `ListView.separated` cadence).
-  static const double rowGap = 6;
-
-  /// Inner vertical padding for tappable rows so the press-state highlight
-  /// reads as a tap target without overflowing adjacent rows.
-  static const double tappableRowVerticalPadding = 2;
-
-  /// Lower bound for the narrow-layout card width
-  /// (mockup `clamp(180px, 50vw, 260px)` lower bound).
   static const double narrowMinWidth = 180;
-
-  /// Upper bound for the narrow-layout card width
-  /// (mockup `clamp(180px, 50vw, 260px)` upper bound).
   static const double narrowMaxWidth = 260;
-
-  /// Multiplier applied to viewport width to derive the narrow card width
-  /// inside the [narrowMinWidth] – [narrowMaxWidth] envelope (mockup
-  /// `50vw` term).
   static const double narrowViewportFraction = 0.5;
 
-  /// Minimum tap-target height for tappable rows on narrow viewports
-  /// (`SPEC/ui/mobile-adaptation.md` § 1).
-  static const double narrowTappableRowMinHeight = 44;
+  /// Minimum tap-target height for tappable rows on narrow viewports.
+  static const double narrowTappableRowMinHeight =
+      CtEventFeedEntriesList.narrowTappableRowMinHeightDefault;
 
-  /// Stable key consumers / tests can use to find the framed surface
-  /// inside the floating card (parity with sibling chrome keys such as
-  /// `GameTabBar.surfaceKey`).
   static const Key surfaceKey = Key('player_turn_event_feed_card_surface');
 
-  /// Resolves the narrow-layout card width for a given viewport width
-  /// per the mockup `clamp(180px, 50vw, 260px)` rule. Exposed for
-  /// widget-test pinning so the contract stays in step with the SPEC.
   static double resolveNarrowWidth(double viewportWidth) {
     final double scaled = viewportWidth * narrowViewportFraction;
     if (scaled < narrowMinWidth) return narrowMinWidth;
@@ -137,78 +77,22 @@ class PlayerTurnEventFeedCard extends StatelessWidget {
             constraints: const BoxConstraints(maxHeight: maxContentHeight),
             child: entries.isEmpty
                 ? Text(emptyLabel, style: emptyStyle)
-                : _FeedEntriesList(entries: entries, bodyStyle: bodyStyle),
+                : CtEventFeedEntriesList(
+                    entries: entries
+                        .map(
+                          (PlayerTurnEventFeedEntry e) => CtEventFeedEntry(
+                            text: e.text,
+                            onTap: e.onTap,
+                            linkAffordance: e.linkAffordance,
+                          ),
+                        )
+                        .toList(growable: false),
+                    bodyStyle: bodyStyle,
+                    narrowBreakpoint: kNarrowBreakpoint,
+                  ),
           ),
         ),
       ),
-    );
-  }
-}
-
-/// Internal list that renders feed rows with shared dark-theme text style
-/// and a tap-down highlight for entries that resolve a map anchor.
-class _FeedEntriesList extends StatelessWidget {
-  const _FeedEntriesList({required this.entries, required this.bodyStyle});
-
-  final List<PlayerTurnEventFeedEntry> entries;
-  final TextStyle bodyStyle;
-
-  @override
-  Widget build(BuildContext context) {
-    final bool narrowViewport =
-        MediaQuery.sizeOf(context).width < kNarrowBreakpoint;
-    return ListView.separated(
-      shrinkWrap: true,
-      itemCount: entries.length,
-      separatorBuilder: (_, _) =>
-          const SizedBox(height: PlayerTurnEventFeedCard.rowGap),
-      itemBuilder: (BuildContext context, int index) {
-        final PlayerTurnEventFeedEntry entry = entries[index];
-        final Widget text = Text(entry.text, style: bodyStyle);
-        final Widget rowContent = entry.linkAffordance
-            ? Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: <Widget>[
-                  Expanded(child: text),
-                  Icon(
-                    Icons.chevron_right,
-                    size: 16,
-                    color: EditorialMonoclePalette.accentDim,
-                  ),
-                ],
-              )
-            : text;
-        if (entry.onTap == null) {
-          return rowContent;
-        }
-        final Widget tappableChild = Padding(
-          padding: const EdgeInsets.symmetric(
-            vertical: PlayerTurnEventFeedCard.tappableRowVerticalPadding,
-          ),
-          child: rowContent,
-        );
-        final Widget inkChild = narrowViewport
-            ? ConstrainedBox(
-                constraints: const BoxConstraints(
-                  minHeight: PlayerTurnEventFeedCard.narrowTappableRowMinHeight,
-                ),
-                child: Align(
-                  alignment: Alignment.centerLeft,
-                  child: tappableChild,
-                ),
-              )
-            : tappableChild;
-        return Material(
-          color: Colors.transparent,
-          child: InkWell(
-            onTap: entry.onTap,
-            splashColor: EditorialMonoclePalette.surfaceLite,
-            highlightColor: EditorialMonoclePalette.surfaceLite,
-            hoverColor: EditorialMonoclePalette.surfaceLite,
-            child: inkChild,
-          ),
-        );
-      },
     );
   }
 }

--- a/app/lib/features/game/widgets/shell/player_turn_event_feed_card.dart
+++ b/app/lib/features/game/widgets/shell/player_turn_event_feed_card.dart
@@ -1,6 +1,7 @@
 import 'package:colonizethis_app_ui_chrome/config/editorial_monocle_palette.dart';
 import 'package:flutter/material.dart';
 
+import '../../../../config/constants.dart';
 import '../../../../widgets/ct_gradients.dart';
 import '../../screens/game/game_screen_shared.dart'
     show kGameMapWideProvinceSidePanelWidth;
@@ -86,6 +87,10 @@ class PlayerTurnEventFeedCard extends StatelessWidget {
   /// `50vw` term).
   static const double narrowViewportFraction = 0.5;
 
+  /// Minimum tap-target height for tappable rows on narrow viewports
+  /// (`SPEC/ui/mobile-adaptation.md` § 1).
+  static const double narrowTappableRowMinHeight = 44;
+
   /// Stable key consumers / tests can use to find the framed surface
   /// inside the floating card (parity with sibling chrome keys such as
   /// `GameTabBar.surfaceKey`).
@@ -150,6 +155,8 @@ class _FeedEntriesList extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final bool narrowViewport =
+        MediaQuery.sizeOf(context).width < kNarrowBreakpoint;
     return ListView.separated(
       shrinkWrap: true,
       itemCount: entries.length,
@@ -158,9 +165,39 @@ class _FeedEntriesList extends StatelessWidget {
       itemBuilder: (BuildContext context, int index) {
         final PlayerTurnEventFeedEntry entry = entries[index];
         final Widget text = Text(entry.text, style: bodyStyle);
+        final Widget rowContent = entry.linkAffordance
+            ? Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Expanded(child: text),
+                  Icon(
+                    Icons.chevron_right,
+                    size: 16,
+                    color: EditorialMonoclePalette.accentDim,
+                  ),
+                ],
+              )
+            : text;
         if (entry.onTap == null) {
-          return text;
+          return rowContent;
         }
+        final Widget tappableChild = Padding(
+          padding: const EdgeInsets.symmetric(
+            vertical: PlayerTurnEventFeedCard.tappableRowVerticalPadding,
+          ),
+          child: rowContent,
+        );
+        final Widget inkChild = narrowViewport
+            ? ConstrainedBox(
+                constraints: const BoxConstraints(
+                  minHeight: PlayerTurnEventFeedCard.narrowTappableRowMinHeight,
+                ),
+                child: Align(
+                  alignment: Alignment.centerLeft,
+                  child: tappableChild,
+                ),
+              )
+            : tappableChild;
         return Material(
           color: Colors.transparent,
           child: InkWell(
@@ -168,12 +205,7 @@ class _FeedEntriesList extends StatelessWidget {
             splashColor: EditorialMonoclePalette.surfaceLite,
             highlightColor: EditorialMonoclePalette.surfaceLite,
             hoverColor: EditorialMonoclePalette.surfaceLite,
-            child: Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: PlayerTurnEventFeedCard.tappableRowVerticalPadding,
-              ),
-              child: text,
-            ),
+            child: inkChild,
           ),
         );
       },

--- a/app/test/game_map_area_event_feed_test.dart
+++ b/app/test/game_map_area_event_feed_test.dart
@@ -1,4 +1,5 @@
 import 'package:colonizethis_app/config/constants.dart';
+import 'package:colonizethis_app/config/routes.dart';
 import 'package:colonizethis_app/core/services/game_service/game_service.dart';
 import 'package:colonizethis_app/features/game/flame/map_state/map_state.dart';
 import 'package:colonizethis_app/features/game/flame/overlays/debug_console_overlay_panel.dart';
@@ -10,6 +11,8 @@ import 'package:colonizethis_app/providers/game_service_provider.dart';
 import 'package:colonizethis_app/providers/games_box_provider.dart';
 import 'package:colonizethis_app/providers/games_provider.dart';
 import 'package:colonizethis_app/providers/map_view_provider.dart';
+import 'package:colonizethis_data/colonizethis_data.dart'
+    show kTechIdCropRotation, techDisplayName;
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_map/colonizethis_map.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
@@ -166,6 +169,16 @@ List<LocateMapTileEvent> _listenLocateEvents(_EventFeedHarness harness) {
   return locateEvents;
 }
 
+List<NavigateToRouteEvent> _listenNavigateEvents(_EventFeedHarness harness) {
+  final navigateEvents = <NavigateToRouteEvent>[];
+  final sub = harness.bus.on<NavigateToRouteEvent>().listen(navigateEvents.add);
+  addTearDown(() async {
+    await sub.cancel();
+    harness.bus.dispose();
+  });
+  return navigateEvents;
+}
+
 Future<void> _openFeedToggle(WidgetTester tester) async {
   await tester.tap(find.byKey(kPlayerTurnFeedToggleButtonKey));
   await tester.pump();
@@ -252,16 +265,75 @@ void main() {
     await _commitTurnEvents(tester, harness, [
       AppResearchCompleteEvent(
         playerId: harness.humanId,
-        techId: 'agri_1',
+        techId: kTechIdCropRotation,
         turnNumber: 1,
       ),
     ], turnNumber: 2);
 
     expect(
-      find.textContaining('Research complete! agri_1 unlocked!'),
+      find.text(
+        'Research complete: ${techDisplayName(kTechIdCropRotation)} unlocked',
+      ),
       findsOneWidget,
     );
+    expect(find.textContaining(kTechIdCropRotation), findsNothing);
+    expect(find.byIcon(Icons.chevron_right), findsOneWidget);
   });
+
+  testWidgets(
+    'Player turn event feed research line emits NavigateToRouteEvent on tap',
+    (WidgetTester tester) async {
+      final harness = _newHarness(disposeBus: false);
+      final navigateEvents = _listenNavigateEvents(harness);
+
+      await _pumpMapArea(tester, gamesBox: gamesBox, harness: harness);
+      await _commitTurnEvents(tester, harness, [
+        AppResearchCompleteEvent(
+          playerId: harness.humanId,
+          techId: kTechIdCropRotation,
+          turnNumber: 1,
+        ),
+      ], turnNumber: 2);
+
+      final researchLine = find.text(
+        'Research complete: ${techDisplayName(kTechIdCropRotation)} unlocked',
+      );
+      expect(researchLine, findsOneWidget);
+      await tester.tap(researchLine);
+      await tester.pump();
+
+      expect(navigateEvents, hasLength(1));
+      expect(navigateEvents.single.route, Routes.technology);
+      final args = navigateEvents.single.arguments as Map<String, Object?>;
+      expect(args['humanPlayerId'], harness.humanId);
+    },
+  );
+
+  testWidgets(
+    'Player turn event feed unknown research tech is non-tappable',
+    (WidgetTester tester) async {
+      final harness = _newHarness(disposeBus: false);
+      final navigateEvents = _listenNavigateEvents(harness);
+
+      await _pumpMapArea(tester, gamesBox: gamesBox, harness: harness);
+      await _commitTurnEvents(tester, harness, [
+        AppResearchCompleteEvent(
+          playerId: harness.humanId,
+          techId: 'agri_1',
+          turnNumber: 1,
+        ),
+      ], turnNumber: 2);
+
+      const fallbackLine = 'Research complete — technology unlocked!';
+      expect(find.text(fallbackLine), findsOneWidget);
+      expect(find.textContaining('agri_1'), findsNothing);
+      expect(find.byIcon(Icons.chevron_right), findsNothing);
+
+      await tester.tap(find.text(fallbackLine));
+      await tester.pump();
+      expect(navigateEvents, isEmpty);
+    },
+  );
 
   testWidgets(
     'Player turn event feed naval line emits LocateMapTileEvent on tap',
@@ -399,7 +471,8 @@ void main() {
         harness: harness,
         mediaQuerySize: const Size(500, 900),
       );
-      const researchLine = 'Research complete! agri_1 unlocked!';
+      final researchLine =
+          'Research complete: ${techDisplayName(kTechIdCropRotation)} unlocked';
       final researchFinder = find.textContaining(researchLine);
 
       await _commitTurnEvents(
@@ -408,7 +481,7 @@ void main() {
         [
           AppResearchCompleteEvent(
             playerId: harness.humanId,
-            techId: 'agri_1',
+            techId: kTechIdCropRotation,
             turnNumber: 1,
           ),
         ],

--- a/app/test/player_turn_event_feed_chrome_test.dart
+++ b/app/test/player_turn_event_feed_chrome_test.dart
@@ -235,6 +235,60 @@ void main() {
         findsNothing,
       );
     });
+
+    testWidgets(
+      'link-affordance row shows trailing chevron and fires onTap',
+      (WidgetTester tester) async {
+        bool tapped = false;
+        await tester.pumpWidget(
+          hostFeedCard(
+            entries: <PlayerTurnEventFeedEntry>[
+              PlayerTurnEventFeedEntry(
+                text: 'Research complete: Crop Rotation unlocked',
+                linkAffordance: true,
+                onTap: () => tapped = true,
+              ),
+            ],
+          ),
+        );
+        await tester.pump();
+
+        expect(find.byIcon(Icons.chevron_right), findsOneWidget);
+        await tester.tap(find.text('Research complete: Crop Rotation unlocked'));
+        await tester.pump();
+        expect(tapped, isTrue);
+      },
+    );
+
+    testWidgets(
+      'tappable row on narrow viewport enforces 44 dp minimum height',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(
+          MediaQuery(
+            data: const MediaQueryData(size: Size(360, 800)),
+            child: hostFeedCard(
+              entries: <PlayerTurnEventFeedEntry>[
+                PlayerTurnEventFeedEntry(
+                  text: 'Research complete: Crop Rotation unlocked',
+                  linkAffordance: true,
+                  onTap: () {},
+                ),
+              ],
+            ),
+          ),
+        );
+        await tester.pump();
+
+        final inkWellFinder = find.descendant(
+          of: find.byKey(PlayerTurnEventFeedCard.surfaceKey),
+          matching: find.byType(InkWell),
+        );
+        expect(
+          tester.getSize(inkWellFinder).height,
+          greaterThanOrEqualTo(PlayerTurnEventFeedCard.narrowTappableRowMinHeight),
+        );
+      },
+    );
   });
 
   group('PlayerTurnEventsFeedToggleButton chrome', () {

--- a/docs/manual/14-passage-of-turns.md
+++ b/docs/manual/14-passage-of-turns.md
@@ -28,7 +28,7 @@ The game completes its phases in a fixed order. You see their combined consequen
 
 A completed turn’s principal report appears in `DLG50001` **Turn news dialog**, unless victory takes precedence. It lists major events from the resolved turn; if none qualify, it plainly says so. Close the report, inspect the map and your empire screens, and prepare the next turn.
 
-On the map chrome, the news toggle opens `OVL70001` **Player turn event feed** — a compact, human-scoped card of outcomes over the map. It replaces its entries each resolved turn and can be shown or hidden without leaving `GAME10001`. Use it with turn news: the dialog is the formal summary; the feed keeps relevant lines on the map while you inspect.
+On the map chrome, the news toggle opens `OVL70001` **Player turn event feed** — a compact, human-scoped card of outcomes over the map. It replaces its entries each resolved turn and can be shown or hidden without leaving `GAME10001`. Use it with turn news: the dialog is the formal summary; the feed keeps relevant lines on the map while you inspect. When a technology finishes researching, its feed line shows the tech by name; tap that line to open `GAME40001` **Technology** on the Slots tab and choose your next project.
 
 ### Pausing, saving, and loading
 

--- a/packages/colonizethis_app_ui_chrome/lib/colonizethis_app_ui_chrome.dart
+++ b/packages/colonizethis_app_ui_chrome/lib/colonizethis_app_ui_chrome.dart
@@ -5,5 +5,6 @@ library;
 export 'config/editorial_monocle_palette.dart';
 export 'widgets/ct_brass_divider.dart';
 export 'widgets/ct_compass_rose.dart';
+export 'widgets/ct_event_feed_entries_list.dart';
 export 'widgets/ct_fleur_de_lis_ornament.dart';
 export 'widgets/ct_main_menu_collage.dart';

--- a/packages/colonizethis_app_ui_chrome/lib/widgets/ct_event_feed_entries_list.dart
+++ b/packages/colonizethis_app_ui_chrome/lib/widgets/ct_event_feed_entries_list.dart
@@ -1,0 +1,103 @@
+import 'package:flutter/material.dart';
+
+import '../config/editorial_monocle_palette.dart';
+
+/// One scrollable row in a turn-event feed card (Refs #4144).
+class CtEventFeedEntry {
+  const CtEventFeedEntry({
+    required this.text,
+    this.onTap,
+    this.linkAffordance = false,
+  });
+
+  final String text;
+  final VoidCallback? onTap;
+
+  /// When true, the row shows a trailing chevron for screen-navigation taps.
+  final bool linkAffordance;
+}
+
+/// Scrollable event rows with optional map-focus or route-navigation taps.
+class CtEventFeedEntriesList extends StatelessWidget {
+  const CtEventFeedEntriesList({
+    super.key,
+    required this.entries,
+    required this.bodyStyle,
+    required this.narrowBreakpoint,
+    this.rowGap = rowGapDefault,
+    this.tappableRowVerticalPadding = tappableRowVerticalPaddingDefault,
+    this.narrowTappableRowMinHeight = narrowTappableRowMinHeightDefault,
+  });
+
+  final List<CtEventFeedEntry> entries;
+  final TextStyle bodyStyle;
+
+  /// Viewport widths below this use [narrowTappableRowMinHeight] tap targets.
+  final double narrowBreakpoint;
+  final double rowGap;
+  final double tappableRowVerticalPadding;
+  final double narrowTappableRowMinHeight;
+
+  static const double rowGapDefault = 6;
+  static const double tappableRowVerticalPaddingDefault = 2;
+
+  /// Minimum tap-target height on narrow viewports
+  /// (`SPEC/ui/mobile-adaptation.md` § 1).
+  static const double narrowTappableRowMinHeightDefault = 44;
+
+  @override
+  Widget build(BuildContext context) {
+    final bool narrowViewport =
+        MediaQuery.sizeOf(context).width < narrowBreakpoint;
+    return ListView.separated(
+      shrinkWrap: true,
+      itemCount: entries.length,
+      separatorBuilder: (_, _) => SizedBox(height: rowGap),
+      itemBuilder: (BuildContext context, int index) {
+        final CtEventFeedEntry entry = entries[index];
+        final Widget text = Text(entry.text, style: bodyStyle);
+        final Widget rowContent = entry.linkAffordance
+            ? Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Expanded(child: text),
+                  Icon(
+                    Icons.chevron_right,
+                    size: 16,
+                    color: EditorialMonoclePalette.accentDim,
+                  ),
+                ],
+              )
+            : text;
+        if (entry.onTap == null) {
+          return rowContent;
+        }
+        final Widget tappableChild = Padding(
+          padding: EdgeInsets.symmetric(vertical: tappableRowVerticalPadding),
+          child: rowContent,
+        );
+        final Widget inkChild = narrowViewport
+            ? ConstrainedBox(
+                constraints: BoxConstraints(
+                  minHeight: narrowTappableRowMinHeight,
+                ),
+                child: Align(
+                  alignment: Alignment.centerLeft,
+                  child: tappableChild,
+                ),
+              )
+            : tappableChild;
+        return Material(
+          color: Colors.transparent,
+          child: InkWell(
+            onTap: entry.onTap,
+            splashColor: EditorialMonoclePalette.surfaceLite,
+            highlightColor: EditorialMonoclePalette.surfaceLite,
+            hoverColor: EditorialMonoclePalette.surfaceLite,
+            child: inkChild,
+          ),
+        );
+      },
+    );
+  }
+}

--- a/widgetbook_host/lib/catalogs/catalog_event_feed.dart
+++ b/widgetbook_host/lib/catalogs/catalog_event_feed.dart
@@ -19,6 +19,23 @@ List<WidgetbookNode> get playerTurnEventFeedCardDirectories => [
     name: 'Player Turn Event Feed Card',
     children: [
       WidgetbookUseCase(
+        name: 'Research complete — tappable link to Technology',
+        builder: (context) => _playerTurnEventFeedCardStoryFrame(
+          child: PlayerTurnEventFeedCard(
+            entries: [
+              PlayerTurnEventFeedEntry(
+                // ignore: avoid_hardcoded_strings_in_widgets
+                text: 'Research complete: Crop Rotation unlocked',
+                linkAffordance: true,
+                onTap: () {},
+              ),
+            ],
+            // ignore: avoid_hardcoded_strings_in_widgets
+            emptyLabel: 'No events this turn.',
+          ),
+        ),
+      ),
+      WidgetbookUseCase(
         name: 'Populated — three entries (top entry tappable)',
         builder: (context) => _playerTurnEventFeedCardStoryFrame(
           child: PlayerTurnEventFeedCard(


### PR DESCRIPTION
## Summary

- Research-complete turn-feed rows show the catalog tech display name (never the raw `techId`), a trailing chevron link affordance, and tap through to `GAME40001` Technology on the Slots tab via `NavigateToRouteEvent`.
- Unknown catalog tech ids degrade to safe non-tappable fallback copy.
- Narrow-viewport tappable rows enforce a 44 dp minimum tap height.

## SPEC / docs

- Updated `SPEC/ui/player-turn-event-feed.md` interaction + ACs.
- Updated `docs/manual/14-passage-of-turns.md` (research-complete tap → Technology).
- Added Widgetbook story: "Research complete — tappable link to Technology".

## AC coverage

| AC | Status |
|----|--------|
| Catalog-known tech shows display name + chevron, no raw id | Covered (`game_map_area_event_feed_test.dart`) |
| Tap emits `NavigateToRouteEvent(Routes.technology, …)` | Covered |
| Unknown tech id → non-tappable fallback | Covered |
| Narrow viewport 44 dp tap target | Covered (`player_turn_event_feed_chrome_test.dart`) |
| Widget test / Widgetbook for tappable research row | Covered |

## Deferred

None — full issue scope implemented in this PR.

Refs #4144

## Test plan

- [x] `cd app && flutter test test/game_map_area_event_feed_test.dart test/player_turn_event_feed_chrome_test.dart`

Made with [Cursor](https://cursor.com)