### PR TITLE
test: turn-feed deep-link AC coverage for overture and spy rows (#4145)

### DIFF
--- a/app/test/game_map_area_event_feed_test.dart
+++ b/app/test/game_map_area_event_feed_test.dart
@@ -480,6 +480,181 @@ void main() {
     },
   );
 
+  testWidgets(
+    'Player turn event feed overture line opens diplomacy detail on tap',
+    (WidgetTester tester) async {
+      final harness = _newHarness(disposeBus: false);
+      final navigateEvents = _listenNavigateEvents(harness);
+
+      await _pumpMapArea(tester, gamesBox: gamesBox, harness: harness);
+      await _commitTurnEvents(tester, harness, [
+        AppOvertureAdvancedEvent(
+          offererGpId: harness.humanId,
+          targetFactionId: harness.opponentId,
+          newStage: 'embassy',
+          turnNumber: 1,
+        ),
+      ], turnNumber: 2);
+
+      final line = find.textContaining('Overture advanced!');
+      expect(line, findsOneWidget);
+      expect(find.textContaining(': Embassy!'), findsOneWidget);
+      expect(find.byIcon(Icons.chevron_right), findsOneWidget);
+      await tester.tap(line);
+      await tester.pump();
+
+      expect(navigateEvents, hasLength(1));
+      expect(navigateEvents.single.route, Routes.diplomacyDetail);
+      final args = navigateEvents.single.arguments as Map<String, Object?>;
+      expect(args['factionId'], harness.opponentId);
+      expect(args['humanPlayerId'], harness.humanId);
+    },
+  );
+
+  testWidgets(
+    'Player turn event feed spy caught line opens diplomacy detail on tap',
+    (WidgetTester tester) async {
+      final harness = _newHarness(disposeBus: false);
+      final navigateEvents = _listenNavigateEvents(harness);
+
+      await _pumpMapArea(tester, gamesBox: gamesBox, harness: harness);
+      await _commitTurnEvents(tester, harness, [
+        AppSpyCaughtEvent(
+          unitId: 'spy_1',
+          spyOwnerId: harness.opponentId,
+          territoryOwnerId: harness.humanId,
+          provinceId: 'oldWorld|cap',
+          turnNumber: 1,
+        ),
+      ], turnNumber: 2);
+
+      final line = find.textContaining('enemy spy from');
+      expect(line, findsOneWidget);
+      expect(find.byIcon(Icons.chevron_right), findsOneWidget);
+      await tester.tap(line);
+      await tester.pump();
+
+      expect(navigateEvents, hasLength(1));
+      expect(navigateEvents.single.route, Routes.diplomacyDetail);
+      final args = navigateEvents.single.arguments as Map<String, Object?>;
+      expect(args['factionId'], harness.opponentId);
+    },
+  );
+
+  testWidgets(
+    'Player turn event feed spy defected line opens diplomacy detail on tap',
+    (WidgetTester tester) async {
+      final harness = _newHarness(disposeBus: false);
+      final navigateEvents = _listenNavigateEvents(harness);
+
+      await _pumpMapArea(tester, gamesBox: gamesBox, harness: harness);
+      await _commitTurnEvents(tester, harness, [
+        AppSpyDefectedEvent(
+          unitId: 'spy_1',
+          previousOwnerId: harness.opponentId,
+          newOwnerId: harness.humanId,
+          provinceId: 'oldWorld|cap',
+          turnNumber: 1,
+        ),
+      ], turnNumber: 2);
+
+      final line = find.textContaining('defected to your side');
+      expect(line, findsOneWidget);
+      expect(find.byIcon(Icons.chevron_right), findsOneWidget);
+      await tester.tap(line);
+      await tester.pump();
+
+      expect(navigateEvents, hasLength(1));
+      expect(navigateEvents.single.route, Routes.diplomacyDetail);
+      final args = navigateEvents.single.arguments as Map<String, Object?>;
+      expect(args['factionId'], harness.opponentId);
+    },
+  );
+
+  testWidgets(
+    'Player turn event feed unresolved spy counterpart is non-tappable',
+    (WidgetTester tester) async {
+      final harness = _newHarness(disposeBus: false);
+      final navigateEvents = _listenNavigateEvents(harness);
+
+      await _pumpMapArea(tester, gamesBox: gamesBox, harness: harness);
+      await _commitTurnEvents(tester, harness, [
+        AppSpyCaughtEvent(
+          unitId: 'spy_1',
+          spyOwnerId: 'unknown_spy_owner',
+          territoryOwnerId: harness.humanId,
+          provinceId: 'oldWorld|cap',
+          turnNumber: 1,
+        ),
+      ], turnNumber: 2);
+
+      final line = find.textContaining('enemy spy from');
+      expect(line, findsOneWidget);
+      expect(find.byIcon(Icons.chevron_right), findsNothing);
+      await tester.tap(line);
+      await tester.pump();
+      expect(navigateEvents, isEmpty);
+    },
+  );
+
+  testWidgets(
+    'Player turn event feed land combat line emits locate and overlay on tap',
+    (WidgetTester tester) async {
+      final harness = _newHarness(disposeBus: false);
+      final locateEvents = _listenLocateEvents(harness);
+      final overlayEvents = _listenOpenMapTileDetailEvents(harness);
+
+      await _pumpMapArea(tester, gamesBox: gamesBox, harness: harness);
+      await _commitTurnEvents(tester, harness, [
+        AppCombatResultEvent(
+          provinceId: 'oldWorld|cap',
+          attackerId: harness.humanId,
+          defenderId: harness.opponentId,
+          winnerId: harness.humanId,
+          turnNumber: 1,
+        ),
+      ], turnNumber: 2);
+
+      final line = find.textContaining('battle resolved!');
+      expect(line, findsOneWidget);
+      expect(find.byIcon(Icons.chevron_right), findsNothing);
+      await tester.tap(line);
+      await tester.pump();
+
+      expect(locateEvents, hasLength(1));
+      expect(overlayEvents, hasLength(1));
+      expect(overlayEvents.single.tileKey, locateEvents.single.tileKey);
+    },
+  );
+
+  testWidgets(
+    'Player turn event feed province captured line emits locate and overlay on tap',
+    (WidgetTester tester) async {
+      final harness = _newHarness(disposeBus: false);
+      final locateEvents = _listenLocateEvents(harness);
+      final overlayEvents = _listenOpenMapTileDetailEvents(harness);
+
+      await _pumpMapArea(tester, gamesBox: gamesBox, harness: harness);
+      await _commitTurnEvents(tester, harness, [
+        AppProvinceCapturedEvent(
+          provinceId: 'oldWorld|cap',
+          previousOwnerId: harness.opponentId,
+          newOwnerId: harness.humanId,
+          turnNumber: 1,
+        ),
+      ], turnNumber: 2);
+
+      final line = find.textContaining('captured!');
+      expect(line, findsOneWidget);
+      await tester.tap(line);
+      await tester.pump();
+
+      expect(locateEvents, hasLength(1));
+      expect(overlayEvents, hasLength(1));
+      expect(overlayEvents.single.tileKey, locateEvents.single.tileKey);
+    },
+  );
+
   testWidgets('Player turn event feed renders diplomacy/discovery/overture copy', (
     WidgetTester tester,
   ) async {


### PR DESCRIPTION
## Summary

- Closes verification gaps left after PR #4148 merged the turn-feed deep-link implementation.
- Adds widget tests for overture tap → diplomacy detail, spy caught/defected tap → diplomacy detail, unresolved spy counterpart non-tappable fallback, and land combat / province capture locate + overlay taps.

## AC coverage (this PR)

| AC | Status |
|----|--------|
| Overture stage human-readable + tap opens detail | Covered (tap test added) |
| Spy rows open detail / non-tappable when unresolved | Covered (caught, defected, unresolved tests) |
| Land combat / province capture locate + overlay | Covered (explicit tap tests) |
| All other ACs from #4145 | Already covered on `dev` via #4148 |

## Deferred

- None — issue ACs should be fully satisfied once this PR merges.

Refs #4145

## Test plan

- [x] `cd app && flutter test test/game_map_area_event_feed_test.dart` (17/17 passed)


Made with [Cursor](https://cursor.com)