### PR TITLE
docs: teach capital and town plains placement at setup (#4065)

### DIFF
--- a/docs/manual/02-founding-your-reign.md
+++ b/docs/manual/02-founding-your-reign.md
@@ -49,6 +49,8 @@ Both auto-resolve and quick battle apply the same lookup for attacker and defend
 
 After provinces are assigned, each Great Power receives an **auto-chosen capital**: a **sea-bound** province plus capital tile, with capital ports and initial roads placed per capital rules. **Current product:** there is **no** in-game UI to confirm or override that choice after setup. Minor Nations and Tribes get capitals at setup without player choice. Province and capital **names** come from the naming ruleset.
 
+Setup places each capital tile on **plains** when the selection rules allow it — within each candidate class, plains tiles are preferred before other terrain. If the winning site is not plains (including when no plains exists among eligible candidates), setup **converts that selected tile to plains** and clears any resource or extraction improvement on it. The same plains preference and convert-if-needed rule applies to every province **town** tile (including neutral provinces without an owner): towns anchor on arable ground so roads and early extraction can grow from a predictable spine.
+
 ### Naming and identity
 
 Places you will see in the UI are named during setup, but their **identity** remains region-scoped (`regionId|localId`). Chapter 3 explains why that matters when the overlay titles a province.
@@ -56,6 +58,8 @@ Places you will see in the UI are named during setup, but their **identity** rem
 ## Counsel
 
 **Counsel.** Hark, my liege: pick a leader for the wars you expect, not for vanity — the bonus never feeds your stockpile.
+
+**Counsel.** Hark, my liege: capitals and towns are rooted on **plains** — arable ground where grain, roads, and your first extraction spine can take hold. A fortress on barren rock is a crown without a harvest.
 
 **Tip.** If you want a longer campaign past 1800, enable Infinite mode here; you cannot flip it mid-reign.
 
@@ -70,6 +74,7 @@ AI Great Powers receive leaders and optional blessed profiles from the same dial
 - A strong combat leader shortens some land wars and does nothing for fleets or factories.
 - Advanced start compresses early exploration and tech catch-up; rivals begin closer to mid-game posture.
 - Auto-chosen capitals fix your first ports and road spine — connectivity strategy starts from that seed, not from a blank map.
+- Capitals and province towns sit on **plains** tiles at setup; a converted site may have lost a surface resource that once sat on that tile.
 
 ## Acceptance criteria for this chapter
 
@@ -78,6 +83,7 @@ AI Great Powers receive leaders and optional blessed profiles from the same dial
 - [ ] Covers leader combat bonuses (Napoleon / Frederick / none).
 - [ ] Covers advanced start presets and when the control is disabled.
 - [ ] States capital is auto-chosen (sea-bound) with no post-setup override UI.
+- [ ] Explains capital and province town plains placement (prefer plains; convert selected tile and clear resource if needed).
 - [ ] Documents `SHEL30001` Game initializing as a real non-interactive wait-gate (no draft marker).
 - [ ] Sources match the chapter coverage map.
 
@@ -88,6 +94,7 @@ AI Great Powers receive leaders and optional blessed profiles from the same dial
 - `SPEC/game/leader-bonuses.md`
 - `SPEC/game/advanced-starts.md`
 - `SPEC/game/capital-choice-phase.md`
+- `SPEC/game/capital-and-connectivity.md`
 - `SPEC/game/naming.md`
 - `SPEC/ui/main-menu.md`
 - `SPEC/ui/shell-screen.md`

--- a/docs/manual/03-the-lay-of-the-land.md
+++ b/docs/manual/03-the-lay-of-the-land.md
@@ -16,7 +16,7 @@ Your decrees land on **provinces**, **sea zones**, and **tiles**. Reading the ma
 
 1. On `GAME10001` / `MAP10001`, select a land province or sea zone.
 2. `MAP20001` **Province / sea-zone detail overlay** shows the place’s display name, ownership, and local details (economic and military cues as implemented there).
-3. Town and port icons on the map mark development and seaboard access (`SPEC/ui/town-port-icons.md`). Layered terrain rendering paints the tile art beneath political ownership (`SPEC/ui/layered-terrain-rendering.md`).
+3. Town and port icons on the map mark development and seaboard access (`SPEC/ui/town-port-icons.md`). Expect those town sites to sit on **plains** terrain at setup — setup prefers plains among eligible candidates and converts the chosen town tile to plains (clearing any surface resource) when no natural plains exists. Layered terrain rendering paints the tile art beneath political ownership (`SPEC/ui/layered-terrain-rendering.md`).
 4. Political ownership glyphs and GP tinting (when present on the game) help you see who holds which province at a glance.
 
 ### Terrain, resources, and what is hidden
@@ -28,9 +28,10 @@ Tiles carry **terrain** and optional **resources**. Extraction only happens wher
 
 ### Capital and connectivity
 
-- Your **capital province** and **capital tile** are fixed at setup (Chapter 2). Great Power capital provinces start at high town development.
+- Your **capital province** and **capital tile** are fixed at setup (Chapter 2). Great Power capital provinces start at high town development. The capital tile is on **plains** — preferred among Class A/B/C candidates when possible, or converted to plains after selection if the winning site was another terrain (any resource on that tile is cleared).
+- Every province has exactly one **town** tile: the capital tile in a capital province, or a separate town site elsewhere. Neutral (ownerless) provinces receive a town tile under the same **plains-first** rule and convert-if-needed behavior. On `MAP10001`, town and port icons mark those sites on the plains beneath them.
 - **Connectivity** from the capital (roads/rails and town rules) decides which owned tiles contribute to your extraction network. Land-locked holdings without a path to the capital do not feed the stockpile the way connected tiles do.
-- Ports on seaboards matter for overseas links; capital setup places capital ports and initial roads so your first coast is usable.
+- Ports on seaboards matter for overseas links; capital setup places capital ports and initial roads so your first coast is usable. An overseas port tile chosen as a town site follows the same convert-to-plains rule when it is not already plains.
 
 ### Extraction discs on `MAP10001`
 
@@ -63,6 +64,7 @@ AI courts value capital-connected extraction and contested border provinces when
 - Building improvements on disconnected tiles spends treasury for little extraction.
 - An improved tile may show a resource icon and brown extraction discs even when nothing reaches your stockpile — read gold vs brown on `MAP10001` before you assume the tile is paying its way.
 - Ignoring New World vs Old World resource tables sends explorers and colonists to barren expectations.
+- A capital or town tile converted to plains at setup may no longer show the resource that generation placed there — the settlement spine takes priority over that surface deposit.
 - Confusing local ids across regions creates “wrong province” mistakes in army and work targeting.
 
 ## Acceptance criteria for this chapter
@@ -71,6 +73,7 @@ AI courts value capital-connected extraction and contested border provinces when
 - [ ] Documents map selection → `MAP20001` overlay and points to town/port and terrain rendering specs.
 - [ ] Summarizes region resource rules and prospect-required minerals (detail deferred to Ch. 4/6 as appropriate).
 - [ ] Explains capital connectivity’s effect on extraction usefulness.
+- [ ] Documents plains placement for capitals and per-province town tiles (including neutral provinces; prefer plains, convert-if-needed).
 - [ ] Explains gold vs brown extraction discs on `MAP10001` and ties brown discs on disconnected improved tiles to capital connectivity.
 - [ ] Explains prefixed province identity (`regionId|localId`) as the UI naming contract.
 - [ ] Sources match the chapter coverage map.
@@ -83,6 +86,7 @@ AI courts value capital-connected extraction and contested border provinces when
 - `SPEC/game/tile-map-and-generation.md`
 - `SPEC/game/resource-terrain-region-rules.md`
 - `SPEC/game/capital-and-connectivity.md`
+- `SPEC/game/capital-choice-phase.md`
 - `SPEC/ui/map-widget.md`
 - `SPEC/ui/empire-overview.md`
 - `SPEC/ui/province-sea-zone-detail-overlay.md`


### PR DESCRIPTION
## Summary

- Extends `docs/manual/02-founding-your-reign.md` **Capital auto-choice** with plains preference, select-then-convert semantics, and province town parity (including neutral provinces).
- Extends `docs/manual/03-the-lay-of-the-land.md` **Capital and connectivity** and map-reading bullets with the same plains rule, overseas port convert-if-needed, and visible plains under town/port icons.
- Adds Counsel on arable-ground settlement anchoring; Consequences bullets for converted tiles; chapter AC checklist items; Sources cross-refs to `capital-choice-phase.md` and `capital-and-connectivity.md`.

## AC coverage

| AC | Status |
|----|--------|
| Chapter 2 explains capital/town plains placement (prefer plains; convert + clear resource) | Covered |
| Chapter 3 explains same rule for capitals, town tiles, neutral provinces; map tie-in | Covered |
| Counsel line on arable-ground anchoring | Covered |
| Chapter AC checklists + Sources updated | Covered |

## Deferred

None — completes remaining manual work for #4065 (implementation landed in PR #4067).

Refs #4065

## Test plan

- [x] Manual prose reviewed against `SPEC/game/capital-choice-phase.md` and `SPEC/game/capital-and-connectivity.md`
- [x] Chapter template sections and Sources footers preserved

Made with [Cursor](https://cursor.com)