### PR TITLE
docs: teach advanced-start bootstrap prospecting (#3918)

### DIFF
--- a/docs/manual/02-founding-your-reign.md
+++ b/docs/manual/02-founding-your-reign.md
@@ -49,6 +49,24 @@ Both auto-resolve and quick battle apply the same lookup for attacker and defend
 
 After provinces are assigned, each Great Power receives an **auto-chosen capital**: a **sea-bound** province plus capital tile, with capital ports and initial roads placed per capital rules. **Current product:** there is **no** in-game UI to confirm or override that choice after setup. Minor Nations and Tribes get capitals at setup without player choice. Province and capital **names** come from the naming ruleset.
 
+### Advanced start bootstrap (prospecting and development)
+
+When you pick **turns50** or **turns100** on the locked profile, setup runs a mid-century bootstrap after world generation — tech, treasury, civilians, fleets, diplomacy, and (at 100-turn) New World colonization — before your first Orders phase.
+
+**Bootstrap prospecting** is a dedicated setup pass that runs **after** any 100-turn NW colonization assigns ownership and **before** the improvements-and-roads pass:
+
+1. For each Great Power, setup collects **prospect-required mineral tiles** in provinces you **own** at that moment into **one combined pool** per GP (not separate per region).
+2. Setup marks a **tier fraction** of that pool as already prospected in your `playerProspectedTiles` record:
+   - **turns50:** at least **50%** of prospect-required minerals in your combined **Old World owned** pool.
+   - **turns100:** at least **75%** in your combined **Old World + New World owned** pool (NW minerals count only after colonization assigns those provinces to you).
+3. **Minor nations** receive the same tier fraction on minerals in their **OW-owned** provinces; those entries are recorded in buyer Great Powers' prospected sets (round-robin assignment).
+4. **Development** (improvement level 1 and roads on developable tiles) runs **after** prospecting so prospected minerals are eligible alongside grain, timber, wool, and other non-mineral resources.
+
+**What this is not:**
+
+- **NW reveal** (contiguous flood-fill visibility from the warp entry) is separate — seeing New World coasts does **not** prospect minerals for you.
+- Bootstrap prospecting is **not** Explorer **prospect** work during play. Minerals you already know on owned tiles at turn 50 or 100 may have been marked at setup, not by an Explorer you trained. Chapter 4 **Charting the Unknown** covers in-game explore and prospect orders.
+
 ### Naming and identity
 
 Places you will see in the UI are named during setup, but their **identity** remains region-scoped (`regionId|localId`). Chapter 3 explains why that matters when the overlay titles a province.
@@ -61,6 +79,8 @@ Places you will see in the UI are named during setup, but their **identity** rem
 
 **Warning.** Advanced starts assume the locked full-init profile. On atypical configs the control is inert — do not assume mid-game infrastructure appeared if Start ran with advanced start disabled.
 
+**Tip.** Do not confuse New World **visibility** with mineral **prospecting** on advanced starts — flood-fill reveal opens the map; bootstrap prospecting marks owned minerals before Builders improve them.
+
 ## The other courts
 
 AI Great Powers receive leaders and optional blessed profiles from the same dialog. Their planners still obey the same order and diplomacy rules; profiles bias temperament and priorities (`SPEC/ai/ai-personalities.md`, `SPEC/ai/ai-profile-overrides.md`), not alternate victory conditions. Fully-AI observer games are a setup tool path (empty human slot set) — the standard New Game flow keeps you as slot 0.
@@ -69,6 +89,7 @@ AI Great Powers receive leaders and optional blessed profiles from the same dial
 
 - A strong combat leader shortens some land wars and does nothing for fleets or factories.
 - Advanced start compresses early exploration and tech catch-up; rivals begin closer to mid-game posture.
+- Bootstrap prospecting on advanced starts means some owned minerals are already known when you take the throne — that knowledge came from setup, not from Explorer turns you issued.
 - Auto-chosen capitals fix your first ports and road spine — connectivity strategy starts from that seed, not from a blank map.
 
 ## Acceptance criteria for this chapter
@@ -77,6 +98,7 @@ AI Great Powers receive leaders and optional blessed profiles from the same dial
 - [ ] Explains human slot 0 vs AI slots, nation uniqueness, leader pick, AI profiles.
 - [ ] Covers leader combat bonuses (Napoleon / Frederick / none).
 - [ ] Covers advanced start presets and when the control is disabled.
+- [ ] Explains advanced-start bootstrap prospecting (tier fractions, OW vs NW owned scope, prospect-before-development order) and distinguishes it from NW reveal and Explorer prospect work (cross-ref Ch. 4).
 - [ ] States capital is auto-chosen (sea-bound) with no post-setup override UI.
 - [ ] Documents `SHEL30001` Game initializing as a real non-interactive wait-gate (no draft marker).
 - [ ] Sources match the chapter coverage map.

--- a/docs/manual/04-charting-the-unknown.md
+++ b/docs/manual/04-charting-the-unknown.md
@@ -20,6 +20,12 @@ Political ownership on the map remains authoritative even when a province is fog
 
 **Setup defaults:** Old World fogged (owned tiles fully visible); New World unknown. Sea zones adjacent to coasts you **fully own** become fully visible at setup and again each end of turn.
 
+### Bootstrap prospecting (advanced start)
+
+**turns50** and **turns100** presets run a **setup-only** prospecting pass on **owned** provinces before the first Orders phase — separate from Explorer **prospect** work below. Setup marks a tier fraction of prospect-required minerals in your combined owned pool (50% OW-only at 50-turn; 75% OW+NW after 100-turn colonization). Minor OW minerals receive the same fraction and are recorded in buyer Great Power prospected sets.
+
+That bootstrap step is **not** NW flood-fill **reveal** and **not** in-game Explorer labor. Chapter 2 **Founding Your Reign** documents tier fractions, OW vs NW scope, and the prospect-before-development bootstrap order.
+
 ### Explorer work: explore and prospect
 
 Use `UNIT10001` **Civilian units panel** (or tile shortcuts on `MAP20001` **Province / sea-zone detail overlay**) with an **Explorer**:
@@ -67,6 +73,7 @@ Rival courts race the same fog. AI civilian planners score Explorer **explore** 
 ## Acceptance criteria for this chapter
 
 - [ ] Documents unknown / fogged / fully visible and own-province never-decay rule.
+- [ ] Documents bootstrap prospecting on advanced starts vs in-game Explorer `prospect` (cross-ref Ch. 2).
 - [ ] Documents Explorer `explore` (partial-reveal gate, free, ≤3 turns, province reveal on complete) and `prospect` (eligible terrain, free, 1 turn, completion-only).
 - [ ] Documents Consulate gate for Minor/Tribe explore/prospect.
 - [ ] Documents fleet enter → coastal/sea reveal and end-of-turn re-fog conditions.
@@ -75,6 +82,7 @@ Rival courts race the same fog. AI civilian planners score Explorer **explore** 
 
 ## Sources
 
+- `SPEC/game/advanced-starts.md`
 - `SPEC/game/fog-and-exploration.md`
 - `SPEC/game/civilian-units.md`
 - `SPEC/game/ships-and-naval.md`


### PR DESCRIPTION
## Summary

- Adds **Advanced start bootstrap (prospecting and development)** to `docs/manual/02-founding-your-reign.md`: tier fractions (50% OW at turns50, 75% OW+NW at turns100 after colonization), minor OW parity, prospect-before-development order, and clear separation from NW reveal and Explorer work.
- Adds reciprocal **Bootstrap prospecting (advanced start)** subsection to `docs/manual/04-charting-the-unknown.md` with cross-link back to Chapter 2.
- Updates chapter AC checklists; adds `SPEC/game/advanced-starts.md` to Chapter 4 Sources.

## AC coverage

| AC | Status |
|----|--------|
| Chapter 2 explains turns50/turns100 bootstrap prospecting fractions and owned-pool scope | Covered |
| Chapter 2 clarifies known minerals at turn 50/100 come from bootstrap, not NW reveal or Explorer work | Covered |
| Chapter 2 cross-links Chapter 4 for in-game prospecting | Covered |
| Chapter 4 reciprocal cross-link to Chapter 2 advanced starts | Covered |

## Deferred

None — completes remaining manual deliverable for #3918 (implementation landed in PR #3920).

Refs #3918

## Test plan

- [x] Manual prose reviewed against `SPEC/game/advanced-starts.md` tier table and bootstrap step 10
- [x] Chapter template sections and Sources footers preserved


Made with [Cursor](https://cursor.com)