### PR TITLE
feat: connectivity-aware AI civilian work ordering (#4176)

### DIFF
--- a/SPEC/ai/civilian-work-planner.md
+++ b/SPEC/ai/civilian-work-planner.md
@@ -190,6 +190,28 @@ in [economy-planner.md](economy-planner.md) (seller / supplier feedstock
 extraction) and [growth-stage-planner.md](growth-stage-planner.md) (fabric /
 infrastructure feedstock routing).
 
+## Connectivity-aware development targets (Refs #4176)
+
+When `suggestWorkOrders` receives `tileMapByRegion`, the pass builds one
+[ConnectivityDevSnapshot](../program/order-suggestions.md) per player via
+`resolveConnectivity` and applies deterministic candidate reordering for
+`build_road`, `build_rail`, `build_improvement`, and `build_port` before the
+worker probe loop. Selection-layer scoring in
+`selectFullAiCivilianWorkOrders` mirrors the same connectivity signals via
+GA-tunable bonuses (`kEngineerFrontierRoadExtensionBonus`,
+`kBuildImprovementConnectedBonus`, `kBuildRailBottleneckYieldBonus`,
+`kEngineerPortOverseasLinkageBonus`, etc.).
+
+### GA-tunable connectivity parameters
+
+| Parameter | Default | Applies to |
+|-----------|---------|------------|
+| `kEngineerFrontierRoadExtensionBonus` | 280 | `build_road` on a frontier-extension tile when unconnected dev targets exist |
+| `kBuildImprovementConnectedBonus` | 240 | `build_improvement` on a capital-connected tile |
+| `kBuildImprovementAdjacentToConnectedBonus` | 80 | `build_improvement` on a tile 4-adjacent to the connected set |
+| `kBuildRailBottleneckYieldBonus` | 260 | `build_rail` on a connected bottleneck path tile |
+| `kEngineerPortOverseasLinkageBonus` | 220 | `build_port` in a province with unconnected dev targets and capital-reachable sea |
+
 ## Acceptance criteria
 
 - **AC1 (parameters registered):**

--- a/SPEC/program/order-suggestions.md
+++ b/SPEC/program/order-suggestions.md
@@ -252,6 +252,31 @@ This ordering change is **gated**: for every ordinary player the feedstock set i
 
 ---
 
+## Connectivity-aware development target ordering (Refs #4176)
+
+When `suggestWorkOrders` is called with non-null `tileMapByRegion`, the pass builds one `ConnectivityDevSnapshot` per player (`buildConnectivityDevSnapshot` in `colonizethis_orders`) from `resolveConnectivity(game, tileMapByRegion, topology)` plus an owned-land multi-source BFS toward unconnected resource/improved tiles. The snapshot is shared by all worker units in that pass.
+
+Candidate lists for `build_road`, `build_rail`, `build_improvement`, and `build_port` are **stable-partitioned** by connectivity tier before the worker probe loop (feedstock `build_improvement` partitioning from § Feedstock-extraction priority runs first and keeps precedence). When no unconnected dev targets exist, ordering is unchanged (negative control).
+
+| Target | Promotion rule | Demotion rule |
+|--------|----------------|---------------|
+| `build_road` | Tiles in `frontierExtensionTiles` (4-adjacent to connected set), ascending extension distance | Non-frontier candidates sort after every frontier candidate |
+| `build_rail` | Connected `bottleneckRailTiles` | Disconnected candidates sort last |
+| `build_improvement` | Connected → adjacent-to-connected → far | Never hard-forbidden |
+| `build_port` | Coastal tiles in provinces with unconnected dev targets and capital-reachable sea zones | Sea-unreachable or no-unconnected-resource provinces sort last |
+
+Human suggestion passes using the same pure helpers (`applyConnectivityDevTargetOrdering`) when `tileMapByRegion` is supplied. Selection-layer scoring mirrors are normative in `SPEC/ai/civilian-work-planner.md` § Connectivity-aware development targets.
+
+**Acceptance criteria (connectivity-aware ordering)**
+
+- Given unconnected dev targets and `build_road` candidates `R1` (frontier-extending) and `R2` (not adjacent to the connected set), when candidate ordering runs, then `R1` sorts before `R2` regardless of lexicographic order.
+- Given two frontier `build_road` candidates at extension distances 1 and 3 from their nearest unconnected target, when ordering runs, then the distance-1 candidate sorts first.
+- Given no unconnected resource/improved tiles, when ordering runs for any of the four targets, then the candidate order equals the pre-change deterministic order.
+- Given unimproved resource tiles `C` (connected), `A` (adjacent to connected), and `F` (far), when `build_improvement` ordering runs, then `C` sorts before `A` before `F`.
+- Given an active feedstock-extraction gate, an unconnected unimproved feedstock tile, and a connected non-feedstock tile, when `build_improvement` ordering runs, then the feedstock tile still sorts first (no regression of #2847 H8).
+
+---
+
 ## Mineral feedstock prospecting priority (Refs #2847 H8-extraction mineral feedstock prospecting)
 
 `build_improvement` on a **mineral** resource tile (resource id in `kMineralResourceIds`, e.g. `iron`, `coal`) is rejected by `precheckBuildImprovement` (`work_order_target_prechecks.dart`) with `Mineral tile must be prospected first` until the tile is in the player's `playerProspectedTiles` set. Prospecting is an **Explorer** target (`prospect`), while `build_improvement` is a **Builder** target (`workOrderTargetsByUnitType`). The Builder feedstock-extraction boost (§ economy-planner.md H8-extraction) therefore cannot extract a mineral feedstock until a separate Explorer prospects it. On seed 42 this is the binding `castIron` co-availability blocker: a supplier freely improves its **surface** `timber` tile (no prospecting needed) but never prospects its `iron` mineral tile, so `iron` stays `0`, the `castIron_from_iron` recipe never becomes feasible, and the conquest economy never recovers.

--- a/packages/colonizethis_ai/lib/src/planning/domain_planner_orchestrator_economy.dart
+++ b/packages/colonizethis_ai/lib/src/planning/domain_planner_orchestrator_economy.dart
@@ -253,6 +253,7 @@ EconomyDomainPlannersResult runEconomyDomainPlanners({
       view: ctx.view,
       game: ctx.game,
       tileMapByRegion: tileMapByRegion,
+      topology: ctx.topology,
       growthStageFabricFeedstockResourceIds:
           feedstockPreference.fabricFeedstockResourceIds,
       growthStageInfraFeedstockResourceIds:

--- a/packages/colonizethis_ai_contracts/lib/src/ai/full_ai_civilian_work_selection.dart
+++ b/packages/colonizethis_ai_contracts/lib/src/ai/full_ai_civilian_work_selection.dart
@@ -1,6 +1,7 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
+import 'package:colonizethis_orders/src/orders/connectivity_dev_snapshot.dart';
 import 'package:colonizethis_orders/src/orders/feedstock_extraction_targets.dart';
 import 'package:colonizethis_world/colonizethis_world.dart';
 
@@ -40,6 +41,7 @@ FullAiCivilianWorkSelectionResult selectFullAiCivilianWorkOrders({
   required PlayerView view,
   required Game game,
   Map<String, TileMapResult>? tileMapByRegion,
+  MapTopology? topology,
   Set<String> growthStageFabricFeedstockResourceIds = const <String>{},
   Set<String> growthStageInfraFeedstockResourceIds = const <String>{},
   bool spyDevelopPhase = false,
@@ -70,6 +72,14 @@ FullAiCivilianWorkSelectionResult selectFullAiCivilianWorkOrders({
     game,
     feedstockExtractionResourceIds,
   );
+  final connectivityDev = topology == null
+      ? null
+      : buildConnectivityDevSnapshot(
+          game: game,
+          playerId: view.playerId,
+          topology: topology,
+          tileMapByRegion: tileMapByRegion,
+        );
 
   for (final unitId in allUnitIds) {
     appendSelectionForUnitId(
@@ -88,6 +98,7 @@ FullAiCivilianWorkSelectionResult selectFullAiCivilianWorkOrders({
           growthStageInfraFeedstockResourceIds,
       reservation: reservation,
       spyDevelopPhase: spyDevelopPhase,
+      connectivityDev: connectivityDev,
     );
   }
 

--- a/packages/colonizethis_ai_contracts/lib/src/ai/full_ai_civilian_work_selection_build_purchase.dart
+++ b/packages/colonizethis_ai_contracts/lib/src/ai/full_ai_civilian_work_selection_build_purchase.dart
@@ -1,5 +1,6 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_orders/src/orders/connectivity_dev_snapshot.dart';
 
 import 'package:colonizethis_world/colonizethis_world.dart';
 
@@ -27,6 +28,7 @@ int buildImprovementWorkScore(
   Set<String> feedstockExtractionResourceIds = const <String>{},
   Set<String> growthStageFabricFeedstockResourceIds = const <String>{},
   Set<String> growthStageInfraFeedstockResourceIds = const <String>{},
+  ConnectivityDevSnapshot? connectivityDev,
 }) {
   if (w.target != kWorkTargetBuildImprovement) return 0;
   final level = game.worldState.tileState.improvementLevel(w.targetTileKey);
@@ -34,6 +36,15 @@ int buildImprovementWorkScore(
   final resourceId = game.worldState.resourceByTileKey[w.targetTileKey];
   if (resourceId == null || resourceId.isEmpty) return 2;
   var score = kBuildImprovementExtractableResourceScore;
+  if (connectivityDev != null && connectivityDev.hasUnconnectedDevTargets) {
+    if (connectivityDev.connected.contains(w.targetTileKey)) {
+      score += kBuildImprovementConnectedBonus;
+    } else if (connectivityDev.adjacentToConnectedTiles.contains(
+      w.targetTileKey,
+    )) {
+      score += kBuildImprovementAdjacentToConnectedBonus;
+    }
+  }
   if (Unit.regionIdFromTileKey(w.targetTileKey) == kNewWorldRegionId) {
     score += kBuildImprovementNewWorldResourceBonus;
     final provId = Unit.provinceIdFromTileKey(w.targetTileKey);
@@ -148,6 +159,7 @@ WorkOrder? bestBuildImprovementRow(
   Set<String> feedstockExtractionResourceIds = const <String>{},
   Set<String> growthStageFabricFeedstockResourceIds = const <String>{},
   Set<String> growthStageInfraFeedstockResourceIds = const <String>{},
+  ConnectivityDevSnapshot? connectivityDev,
 }) {
   final improvements = candidates
       .where((w) => w.target == kWorkTargetBuildImprovement)
@@ -162,6 +174,7 @@ WorkOrder? bestBuildImprovementRow(
     growthStageFabricFeedstockResourceIds:
         growthStageFabricFeedstockResourceIds,
     growthStageInfraFeedstockResourceIds: growthStageInfraFeedstockResourceIds,
+    connectivityDev: connectivityDev,
   );
   for (var i = 1; i < improvements.length; i++) {
     final w = improvements[i];
@@ -174,6 +187,7 @@ WorkOrder? bestBuildImprovementRow(
           growthStageFabricFeedstockResourceIds,
       growthStageInfraFeedstockResourceIds:
           growthStageInfraFeedstockResourceIds,
+      connectivityDev: connectivityDev,
     );
     if (s > bestScore) {
       bestScore = s;

--- a/packages/colonizethis_ai_contracts/lib/src/ai/full_ai_civilian_work_selection_engineer.dart
+++ b/packages/colonizethis_ai_contracts/lib/src/ai/full_ai_civilian_work_selection_engineer.dart
@@ -1,5 +1,6 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_orders/src/orders/connectivity_dev_snapshot.dart';
 
 import '../constants.dart';
 import 'full_ai_civilian_work_selection.dart' show FullAiCivilianWorkIdle;
@@ -30,6 +31,7 @@ int _engineerWorkScore(
   WorkOrder w,
   Game game, {
   required String playerId,
+  ConnectivityDevSnapshot? connectivityDev,
 }) {
   final resourceId = game.worldState.resourceByTileKey[w.targetTileKey];
   final hasResource = resourceId != null && resourceId.isNotEmpty;
@@ -46,11 +48,24 @@ int _engineerWorkScore(
       var score = kEngineerBuildRoadBaseWorkScore;
       if (hasResource) score += kEngineerRoadResourceConnectivityBonus;
       if (inCapital) score += kEngineerRoadCapitalLogisticsBonus;
+      if (connectivityDev != null &&
+          connectivityDev.hasUnconnectedDevTargets &&
+          connectivityDev.frontierExtensionTiles.contains(w.targetTileKey)) {
+        score += kEngineerFrontierRoadExtensionBonus;
+      }
       return score;
     case kWorkTargetBuildPort:
       var score = kEngineerBuildPortBaseWorkScore;
       if (hasResource) score += kEngineerPortResourceExtractionBonus;
       if (inNewWorld) score += kEngineerPortNewWorldCoastalBonus;
+      if (connectivityDev != null &&
+          connectivityDev.hasUnconnectedDevTargets &&
+          provinceId != null &&
+          connectivityDev.provincesWithUnconnectedDevTargets.contains(
+            provinceId,
+          )) {
+        score += kEngineerPortOverseasLinkageBonus;
+      }
       return score;
     case kWorkTargetBuildFort:
       var score = kEngineerBuildFortBaseWorkScore;
@@ -84,16 +99,27 @@ WorkOrder? _bestEngineerRow(
   List<WorkOrder> candidates,
   Game game, {
   required String playerId,
+  ConnectivityDevSnapshot? connectivityDev,
 }) {
   final engineerCandidates = candidates
       .where((w) => _isEngineerWorkTarget(w.target))
       .toList();
   if (engineerCandidates.isEmpty) return null;
   var best = engineerCandidates.first;
-  var bestScore = _engineerWorkScore(best, game, playerId: playerId);
+  var bestScore = _engineerWorkScore(
+    best,
+    game,
+    playerId: playerId,
+    connectivityDev: connectivityDev,
+  );
   for (var i = 1; i < engineerCandidates.length; i++) {
     final w = engineerCandidates[i];
-    final s = _engineerWorkScore(w, game, playerId: playerId);
+    final s = _engineerWorkScore(
+      w,
+      game,
+      playerId: playerId,
+      connectivityDev: connectivityDev,
+    );
     if (s > bestScore) {
       bestScore = s;
       best = w;
@@ -113,9 +139,16 @@ void appendEngineerPathResult({
   required String playerId,
   required List<WorkOrder> workOrders,
   required List<FullAiCivilianWorkIdle> idleEvents,
+  ConnectivityDevSnapshot? connectivityDev,
 }) {
   final chosen =
-      _bestEngineerRow(w, game, playerId: playerId) ?? pickLexicographic(w);
+      _bestEngineerRow(
+        w,
+        game,
+        playerId: playerId,
+        connectivityDev: connectivityDev,
+      ) ??
+      pickLexicographic(w);
   if (chosen != null) {
     workOrders.add(chosen);
     return;

--- a/packages/colonizethis_ai_contracts/lib/src/ai/full_ai_civilian_work_selection_rail.dart
+++ b/packages/colonizethis_ai_contracts/lib/src/ai/full_ai_civilian_work_selection_rail.dart
@@ -1,5 +1,6 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_orders/src/orders/connectivity_dev_snapshot.dart';
 
 import '../constants.dart';
 import 'full_ai_civilian_work_selection.dart' show FullAiCivilianWorkIdle;
@@ -28,6 +29,7 @@ int _buildRailWorkScore(
   WorkOrder w,
   Game game, {
   required String playerId,
+  ConnectivityDevSnapshot? connectivityDev,
 }) {
   if (w.target != kWorkTargetBuildRail) return 0;
   var score = kBuildRailBaseWorkScore;
@@ -44,6 +46,11 @@ int _buildRailWorkScore(
   }
   if (Unit.regionIdFromTileKey(w.targetTileKey) == kNewWorldRegionId) {
     score += kBuildRailNewWorldBonus;
+  }
+  if (connectivityDev != null &&
+      connectivityDev.hasUnconnectedDevTargets &&
+      connectivityDev.bottleneckRailTiles.contains(w.targetTileKey)) {
+    score += kBuildRailBottleneckYieldBonus;
   }
   return score;
 }
@@ -64,16 +71,27 @@ WorkOrder? _bestBuildRailRow(
   List<WorkOrder> candidates,
   Game game, {
   required String playerId,
+  ConnectivityDevSnapshot? connectivityDev,
 }) {
   final rails = candidates
       .where((w) => w.target == kWorkTargetBuildRail)
       .toList();
   if (rails.isEmpty) return null;
   var best = rails.first;
-  var bestScore = _buildRailWorkScore(best, game, playerId: playerId);
+  var bestScore = _buildRailWorkScore(
+    best,
+    game,
+    playerId: playerId,
+    connectivityDev: connectivityDev,
+  );
   for (var i = 1; i < rails.length; i++) {
     final w = rails[i];
-    final s = _buildRailWorkScore(w, game, playerId: playerId);
+    final s = _buildRailWorkScore(
+      w,
+      game,
+      playerId: playerId,
+      connectivityDev: connectivityDev,
+    );
     if (s > bestScore) {
       bestScore = s;
       best = w;
@@ -93,9 +111,16 @@ void appendRailBuilderPathResult({
   required String playerId,
   required List<WorkOrder> workOrders,
   required List<FullAiCivilianWorkIdle> idleEvents,
+  ConnectivityDevSnapshot? connectivityDev,
 }) {
   final chosen =
-      _bestBuildRailRow(w, game, playerId: playerId) ?? pickLexicographic(w);
+      _bestBuildRailRow(
+        w,
+        game,
+        playerId: playerId,
+        connectivityDev: connectivityDev,
+      ) ??
+      pickLexicographic(w);
   if (chosen != null) {
     workOrders.add(chosen);
     return;

--- a/packages/colonizethis_ai_contracts/lib/src/ai/full_ai_civilian_work_selection_unit_paths.dart
+++ b/packages/colonizethis_ai_contracts/lib/src/ai/full_ai_civilian_work_selection_unit_paths.dart
@@ -12,6 +12,7 @@ import 'full_ai_civilian_work_selection_rail.dart';
 import 'full_ai_civilian_work_selection_shared.dart';
 import 'full_ai_civilian_work_selection_spy.dart';
 import 'full_ai_civilian_work_selection_upgrade_town.dart';
+import 'package:colonizethis_orders/src/orders/connectivity_dev_snapshot.dart';
 
 // Per-unit civilian-work path selection: the Builder / Merchant / Explorer /
 // lexicographic appenders and the per-unit dispatcher that routes each unit's
@@ -29,6 +30,7 @@ void _appendBuilderPathResult({
   Set<String> feedstockExtractionResourceIds = const <String>{},
   Set<String> growthStageFabricFeedstockResourceIds = const <String>{},
   Set<String> growthStageInfraFeedstockResourceIds = const <String>{},
+  ConnectivityDevSnapshot? connectivityDev,
 }) {
   final chosen =
       bestBuilderRow(
@@ -40,6 +42,7 @@ void _appendBuilderPathResult({
             growthStageFabricFeedstockResourceIds,
         growthStageInfraFeedstockResourceIds:
             growthStageInfraFeedstockResourceIds,
+        connectivityDev: connectivityDev,
       ) ??
       pickLexicographic(w);
   if (chosen != null) {
@@ -175,6 +178,7 @@ void appendSelectionForUnitId({
   Set<String> growthStageInfraFeedstockResourceIds = const <String>{},
   OwFeedstockReservation reservation = OwFeedstockReservation.none,
   bool spyDevelopPhase = false,
+  ConnectivityDevSnapshot? connectivityDev,
 }) {
   final W = List<WorkOrder>.from(byUnit[unitId] ?? const <WorkOrder>[]);
   sortWorkOrdersLex(W);
@@ -226,6 +230,7 @@ void appendSelectionForUnitId({
           growthStageFabricFeedstockResourceIds,
       growthStageInfraFeedstockResourceIds:
           growthStageInfraFeedstockResourceIds,
+      connectivityDev: connectivityDev,
     );
     return;
   }
@@ -238,6 +243,7 @@ void appendSelectionForUnitId({
       playerId: view.playerId,
       workOrders: workOrders,
       idleEvents: idleEvents,
+      connectivityDev: connectivityDev,
     );
     return;
   }
@@ -250,6 +256,7 @@ void appendSelectionForUnitId({
       playerId: view.playerId,
       workOrders: workOrders,
       idleEvents: idleEvents,
+      connectivityDev: connectivityDev,
     );
     return;
   }

--- a/packages/colonizethis_ai_contracts/lib/src/ai/full_ai_civilian_work_selection_upgrade_town.dart
+++ b/packages/colonizethis_ai_contracts/lib/src/ai/full_ai_civilian_work_selection_upgrade_town.dart
@@ -2,6 +2,7 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';
+import 'package:colonizethis_orders/src/orders/connectivity_dev_snapshot.dart';
 import 'full_ai_civilian_work_selection_build_purchase.dart';
 
 // Builder `upgrade_town` candidate scoring / row selection. Adds the
@@ -109,6 +110,7 @@ WorkOrder? bestBuilderRow(
   Set<String> feedstockExtractionResourceIds = const <String>{},
   Set<String> growthStageFabricFeedstockResourceIds = const <String>{},
   Set<String> growthStageInfraFeedstockResourceIds = const <String>{},
+  ConnectivityDevSnapshot? connectivityDev,
 }) {
   final improvement = bestBuildImprovementRow(
     candidates,
@@ -117,6 +119,7 @@ WorkOrder? bestBuilderRow(
     feedstockExtractionResourceIds: feedstockExtractionResourceIds,
     growthStageFabricFeedstockResourceIds: growthStageFabricFeedstockResourceIds,
     growthStageInfraFeedstockResourceIds: growthStageInfraFeedstockResourceIds,
+    connectivityDev: connectivityDev,
   );
   final upgrade = _bestUpgradeTownRow(candidates, game, playerId: playerId);
   if (improvement == null) return upgrade;
@@ -128,6 +131,7 @@ WorkOrder? bestBuilderRow(
     feedstockExtractionResourceIds: feedstockExtractionResourceIds,
     growthStageFabricFeedstockResourceIds: growthStageFabricFeedstockResourceIds,
     growthStageInfraFeedstockResourceIds: growthStageInfraFeedstockResourceIds,
+    connectivityDev: connectivityDev,
   );
   final uScore = _upgradeTownWorkScore(upgrade, game, playerId: playerId);
   if (uScore > iScore) return upgrade;

--- a/packages/colonizethis_ai_contracts/test/full_ai_civilian_work_connectivity_selection_test.dart
+++ b/packages/colonizethis_ai_contracts/test/full_ai_civilian_work_connectivity_selection_test.dart
@@ -4,7 +4,7 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_orders/src/orders/connectivity_dev_snapshot.dart';
 import 'package:colonizethis_orders/src/orders/order_work_constants.dart';
-import 'package:test/test.dart';
+import 'package:colonizethis_test/test.dart';
 
 /// Connectivity-aware Engineer selection mirrors (Refs #4176 AC-E1).
 void main() {

--- a/packages/colonizethis_ai_contracts/test/full_ai_civilian_work_connectivity_selection_test.dart
+++ b/packages/colonizethis_ai_contracts/test/full_ai_civilian_work_connectivity_selection_test.dart
@@ -1,5 +1,6 @@
 import 'package:colonizethis_ai_contracts/src/ai/full_ai_civilian_work_selection.dart';
 import 'package:colonizethis_ai_contracts/src/ai/full_ai_civilian_work_selection_engineer.dart';
+import 'package:colonizethis_ai_contracts/src/ai/full_ai_civilian_work_selection_build_purchase.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_orders/src/orders/connectivity_dev_snapshot.dart';
@@ -71,5 +72,89 @@ void main() {
     );
     expect(workOrders.single.target, kWorkTargetBuildRoad);
     expect(workOrders.single.targetTileKey, roadTile);
+  });
+
+  test('AC-C4 selection mirror prefers connected > adjacent > far', () {
+    const connectedTile = 'oldWorld|p1|c';
+    const adjacentTile = 'oldWorld|p1|a';
+    const farTile = 'oldWorld|p1|f';
+    final game = Game(
+      id: 'g',
+      worldState: WorldState(
+        turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+        oldWorld: const RegionData(),
+        newWorld: const RegionData(),
+        resourceByTileKey: {
+          connectedTile: 'grain',
+          adjacentTile: 'grain',
+          farTile: 'grain',
+        },
+      ),
+      players: [
+        Player(
+          id: playerId,
+          displayName: 'GP',
+          isHuman: false,
+          capitalProvinceId: 'oldWorld|p1',
+        ),
+      ],
+    );
+    final snapshot = ConnectivityDevSnapshot(
+      connected: {connectedTile},
+      pathTransportCap: const {},
+      extensionDistanceByTile: const {},
+      seaZonesReachableFromCapital: const {},
+      provincesWithUnconnectedDevTargets: {adjacentTile, farTile},
+      hasUnconnectedDevTargets: true,
+      frontierExtensionTiles: const {},
+      bottleneckRailTiles: const {},
+      adjacentToConnectedTiles: {adjacentTile},
+    );
+    final selected = bestBuildImprovementRow(
+      [
+        WorkOrder(
+          unitId: 'b1',
+          target: kWorkTargetBuildImprovement,
+          targetTileKey: farTile,
+        ),
+        WorkOrder(
+          unitId: 'b1',
+          target: kWorkTargetBuildImprovement,
+          targetTileKey: adjacentTile,
+        ),
+        WorkOrder(
+          unitId: 'b1',
+          target: kWorkTargetBuildImprovement,
+          targetTileKey: connectedTile,
+        ),
+      ],
+      game,
+      playerId: playerId,
+      connectivityDev: snapshot,
+    );
+    expect(selected?.targetTileKey, connectedTile);
+  });
+
+  group('Connectivity GA tunability (AC-G1)', () {
+    test('connectivity scoring constants are registered in the registry', () {
+      for (final name in const [
+        'kEngineerFrontierRoadExtensionBonus',
+        'kBuildImprovementConnectedBonus',
+        'kBuildImprovementAdjacentToConnectedBonus',
+        'kBuildRailBottleneckYieldBonus',
+        'kEngineerPortOverseasLinkageBonus',
+      ]) {
+        final p = AiParameterRegistry.byName(name);
+        expect(p, isNotNull, reason: name);
+        expect(p!.category, AiParameterCategory.victoryConfig, reason: name);
+        expect(p.isInteger, isTrue, reason: name);
+        expect(p.minValue, 0, reason: name);
+        expect(
+          p.maxValue,
+          greaterThanOrEqualTo(2000),
+          reason: name,
+        );
+      }
+    });
   });
 }

--- a/packages/colonizethis_ai_contracts/test/full_ai_civilian_work_connectivity_selection_test.dart
+++ b/packages/colonizethis_ai_contracts/test/full_ai_civilian_work_connectivity_selection_test.dart
@@ -1,0 +1,75 @@
+import 'package:colonizethis_ai_contracts/src/ai/full_ai_civilian_work_selection.dart';
+import 'package:colonizethis_ai_contracts/src/ai/full_ai_civilian_work_selection_engineer.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_orders/src/orders/connectivity_dev_snapshot.dart';
+import 'package:colonizethis_orders/src/orders/order_work_constants.dart';
+import 'package:test/test.dart';
+
+/// Connectivity-aware Engineer selection mirrors (Refs #4176 AC-E1).
+void main() {
+  const playerId = 'gp1';
+  const roadTile = 'oldWorld|p1|0|1';
+  const fortTile = 'oldWorld|p1|5|5';
+
+  final game = Game(
+    id: 'g',
+    worldState: WorldState(
+      turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+      oldWorld: const RegionData(),
+      newWorld: const RegionData(),
+    ),
+    players: [
+      Player(
+        id: playerId,
+        displayName: 'GP',
+        isHuman: false,
+        capitalProvinceId: 'oldWorld|p1',
+      ),
+    ],
+  );
+
+  final snapshot = ConnectivityDevSnapshot(
+    connected: {'oldWorld|p1|0|0'},
+    pathTransportCap: const {},
+    extensionDistanceByTile: const {roadTile: 1},
+    seaZonesReachableFromCapital: const {},
+    provincesWithUnconnectedDevTargets: const {'oldWorld|p1'},
+    hasUnconnectedDevTargets: true,
+    frontierExtensionTiles: {roadTile},
+    bottleneckRailTiles: const {},
+    adjacentToConnectedTiles: {roadTile},
+  );
+
+  test('AC-E1 frontier road beats fort when unconnected targets exist', () {
+    final workOrders = <WorkOrder>[];
+    final idleEvents = <FullAiCivilianWorkIdle>[];
+    appendEngineerPathResult(
+      unit: Unit(
+        id: 'e1',
+        type: kUnitTypeEngineer,
+        ownerId: playerId,
+        locationProvinceId: 'oldWorld|p1',
+      ),
+      w: [
+        WorkOrder(
+          unitId: 'e1',
+          target: kWorkTargetBuildFort,
+          targetTileKey: fortTile,
+        ),
+        WorkOrder(
+          unitId: 'e1',
+          target: kWorkTargetBuildRoad,
+          targetTileKey: roadTile,
+        ),
+      ],
+      game: game,
+      playerId: playerId,
+      workOrders: workOrders,
+      idleEvents: idleEvents,
+      connectivityDev: snapshot,
+    );
+    expect(workOrders.single.target, kWorkTargetBuildRoad);
+    expect(workOrders.single.targetTileKey, roadTile);
+  });
+}

--- a/packages/colonizethis_data/lib/src/ai_parameter_victory_config_params_work.dart
+++ b/packages/colonizethis_data/lib/src/ai_parameter_victory_config_params_work.dart
@@ -364,4 +364,29 @@ final List<AiParameter> victoryConfigParamsWork = <AiParameter>[
     kSpyPhaseCounterSpyBonus,
     'Phase bonus added to Spy counter_spy scores in the DEVELOP phase.',
   ),
+  victoryConfigIntParam(
+    'kEngineerFrontierRoadExtensionBonus',
+    kEngineerFrontierRoadExtensionBonus,
+    'Extra Engineer build_road score for frontier network extension.',
+  ),
+  victoryConfigIntParam(
+    'kBuildImprovementConnectedBonus',
+    kBuildImprovementConnectedBonus,
+    'Extra build_improvement score on capital-connected tiles.',
+  ),
+  victoryConfigIntParam(
+    'kBuildImprovementAdjacentToConnectedBonus',
+    kBuildImprovementAdjacentToConnectedBonus,
+    'Extra build_improvement score on tiles adjacent to the connected set.',
+  ),
+  victoryConfigIntParam(
+    'kBuildRailBottleneckYieldBonus',
+    kBuildRailBottleneckYieldBonus,
+    'Extra build_rail score on connected bottleneck path tiles.',
+  ),
+  victoryConfigIntParam(
+    'kEngineerPortOverseasLinkageBonus',
+    kEngineerPortOverseasLinkageBonus,
+    'Extra build_port score for overseas dev-target linkage.',
+  ),
 ];

--- a/packages/colonizethis_data/lib/src/ai_victory_config_work.dart
+++ b/packages/colonizethis_data/lib/src/ai_victory_config_work.dart
@@ -158,3 +158,23 @@ const int kSpyCounterSpyBorderBonus = 90;
 /// Phase bonus added to Spy `counter_spy` scores in the DEVELOP phase
 /// (Refs #3794 § Spy, AC24; steal_tech retired Refs #3834).
 const int kSpyPhaseCounterSpyBonus = 2000;
+
+/// Extra Engineer `build_road` score when the tile extends the connected
+/// network frontier toward an unconnected dev target (Refs #4176).
+const int kEngineerFrontierRoadExtensionBonus = 280;
+
+/// Extra `build_improvement` score when the target tile is capital-connected
+/// (Refs #4176).
+const int kBuildImprovementConnectedBonus = 240;
+
+/// Extra `build_improvement` score when the target tile is unconnected but
+/// 4-adjacent to the connected set (Refs #4176).
+const int kBuildImprovementAdjacentToConnectedBonus = 80;
+
+/// Extra Rail Builder `build_rail` score on a connected bottleneck path tile
+/// (Refs #4176).
+const int kBuildRailBottleneckYieldBonus = 260;
+
+/// Extra Engineer `build_port` score in a province with unconnected dev targets
+/// and a capital-reachable sea zone (Refs #4176).
+const int kEngineerPortOverseasLinkageBonus = 220;

--- a/packages/colonizethis_orders/lib/src/orders/connectivity_dev_snapshot.dart
+++ b/packages/colonizethis_orders/lib/src/orders/connectivity_dev_snapshot.dart
@@ -1,0 +1,314 @@
+import 'dart:collection';
+
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_world/colonizethis_world.dart';
+
+/// Plan-time connectivity snapshot for development-target candidate ordering
+/// and Full-AI civilian-work scoring (Refs #4176).
+///
+/// Built once per `suggestWorkOrders` pass when [tileMapByRegion] is supplied.
+/// Pure over `(game, playerId, topology, tileMapByRegion)`.
+class ConnectivityDevSnapshot {
+  const ConnectivityDevSnapshot({
+    required this.connected,
+    required this.pathTransportCap,
+    required this.extensionDistanceByTile,
+    required this.seaZonesReachableFromCapital,
+    required this.provincesWithUnconnectedDevTargets,
+    required this.hasUnconnectedDevTargets,
+    required this.frontierExtensionTiles,
+    required this.bottleneckRailTiles,
+    required this.adjacentToConnectedTiles,
+  });
+
+  /// Capital-connected tile set from [resolveConnectivity] (includes Town rule).
+  final Set<String> connected;
+
+  /// Per-tile path transport cap along connectivity paths from the capital.
+  final Map<String, int> pathTransportCap;
+
+  /// Minimum owned-land steps from each tile to the nearest unconnected
+  /// resource/improved dev target; absent when unreachable over owned land.
+  final Map<String, int> extensionDistanceByTile;
+
+  /// Sea zones reachable from the player's capital by sea path.
+  final Set<String> seaZonesReachableFromCapital;
+
+  /// Full prefixed province ids holding at least one unconnected dev target.
+  final Set<String> provincesWithUnconnectedDevTargets;
+
+  /// When false, connectivity reordering is a no-op (baseline lex order).
+  final bool hasUnconnectedDevTargets;
+
+  /// Owned land tiles 4-adjacent to [connected] but not in [connected].
+  final Set<String> frontierExtensionTiles;
+
+  /// Connected road tiles whose path cap bottlenecks served improvements.
+  final Set<String> bottleneckRailTiles;
+
+  /// Unconnected tiles 4-adjacent to [connected] (improvement tier-1).
+  final Set<String> adjacentToConnectedTiles;
+}
+
+/// Returns null when [tileMapByRegion] is null (connectivity ordering skipped).
+ConnectivityDevSnapshot? buildConnectivityDevSnapshot({
+  required Game game,
+  required String playerId,
+  required MapTopology topology,
+  required Map<String, TileMapResult>? tileMapByRegion,
+}) {
+  if (tileMapByRegion == null || tileMapByRegion.isEmpty) return null;
+  final player = game.playerById(playerId);
+  final capital = player?.capitalTile;
+  if (player == null || capital == null) return null;
+
+  final connectivity = resolveConnectivity(
+    game: game,
+    tileMapByRegion: tileMapByRegion,
+    topology: topology,
+  );
+  final result = connectivity[playerId];
+  if (result == null) {
+    return const ConnectivityDevSnapshot(
+      connected: {},
+      pathTransportCap: {},
+      extensionDistanceByTile: {},
+      seaZonesReachableFromCapital: {},
+      provincesWithUnconnectedDevTargets: {},
+      hasUnconnectedDevTargets: false,
+      frontierExtensionTiles: {},
+      bottleneckRailTiles: {},
+      adjacentToConnectedTiles: {},
+    );
+  }
+
+  final connected = result.connected;
+  final pathTransportCap = result.pathTransportCap;
+  final landProvinceIds = provinceNodeIds(topology);
+  final ownedProvinceIds = _ownedProvinceIdsForPlayer(game, playerId);
+  final purchasedTiles = game.worldState.purchasedTilesByTileKey.keys.toSet();
+  final ownedLandTiles = _ownedLandTileKeys(
+    game: game,
+    ownedProvinceIds: ownedProvinceIds,
+    purchasedTiles: purchasedTiles,
+  );
+
+  final frontierExtensionTiles = <String>{};
+  final adjacentToConnectedTiles = <String>{};
+  for (final tileKey in ownedLandTiles) {
+    if (connected.contains(tileKey)) continue;
+    if (!isTileAdjacentToConnectedSet(
+      tileKey,
+      connected,
+      tileMapByRegion: tileMapByRegion,
+      landProvinceIds: landProvinceIds,
+    )) {
+      continue;
+    }
+    adjacentToConnectedTiles.add(tileKey);
+    frontierExtensionTiles.add(tileKey);
+  }
+
+  final bottleneckRailTiles = _bottleneckRailTiles(
+    game: game,
+    connected: connected,
+    pathTransportCap: pathTransportCap,
+  );
+
+  final unconnectedTargets = <String>{};
+  final provincesWithUnconnected = <String>{};
+  for (final tileKey in ownedLandTiles) {
+    if (!_isDevTargetTile(game, tileKey)) continue;
+    if (connected.contains(tileKey)) continue;
+    unconnectedTargets.add(tileKey);
+    final provinceId = Unit.provinceIdFromTileKey(tileKey);
+    if (provinceId != null) provincesWithUnconnected.add(provinceId);
+  }
+
+  final extensionDistanceByTile = unconnectedTargets.isEmpty
+      ? const <String, int>{}
+      : _extensionDistancesOverOwnedLand(
+          startTargets: unconnectedTargets,
+          ownedLandTiles: ownedLandTiles,
+          tileMapByRegion: tileMapByRegion,
+          landProvinceIds: landProvinceIds,
+        );
+
+  final seaReachable = _seaZonesReachableFromCapital(
+    topology: topology,
+    capital: capital,
+  );
+
+  return ConnectivityDevSnapshot(
+    connected: connected,
+    pathTransportCap: pathTransportCap,
+    extensionDistanceByTile: extensionDistanceByTile,
+    seaZonesReachableFromCapital: seaReachable,
+    provincesWithUnconnectedDevTargets: provincesWithUnconnected,
+    hasUnconnectedDevTargets: unconnectedTargets.isNotEmpty,
+    frontierExtensionTiles: frontierExtensionTiles,
+    bottleneckRailTiles: bottleneckRailTiles,
+    adjacentToConnectedTiles: adjacentToConnectedTiles,
+  );
+}
+
+Set<String> _ownedProvinceIdsForPlayer(Game game, String playerId) {
+  final out = <String>{};
+  for (final province in game.worldState.oldWorld.provinces) {
+    if (province.ownerId == playerId) out.add(province.id);
+  }
+  for (final province in game.worldState.newWorld.provinces) {
+    if (province.ownerId == playerId) out.add(province.id);
+  }
+  return out;
+}
+
+Set<String> _ownedLandTileKeys({
+  required Game game,
+  required Set<String> ownedProvinceIds,
+  required Set<String> purchasedTiles,
+}) {
+  final out = <String>{};
+  final tileKeysByRegion = game.worldState.tileKeysByRegionAndProvince;
+  for (final regionEntry in tileKeysByRegion.entries) {
+    final regionId = regionEntry.key;
+    for (final provinceEntry in regionEntry.value.entries) {
+      final localProvinceId = provinceEntry.key;
+      final fullProvinceId = ProvinceId.full(regionId, localProvinceId);
+      if (!ownedProvinceIds.contains(fullProvinceId)) continue;
+      out.addAll(provinceEntry.value);
+    }
+  }
+  out.addAll(purchasedTiles);
+  return out;
+}
+
+bool _isDevTargetTile(Game game, String tileKey) {
+  final resourceId = game.worldState.resourceByTileKey[tileKey];
+  final level = game.worldState.tileState.improvementLevel(tileKey);
+  return (resourceId != null && resourceId.isNotEmpty) || level >= 1;
+}
+
+Map<String, int> _extensionDistancesOverOwnedLand({
+  required Set<String> startTargets,
+  required Set<String> ownedLandTiles,
+  required Map<String, TileMapResult> tileMapByRegion,
+  required Set<String> landProvinceIds,
+}) {
+  final distances = <String, int>{};
+  final queue = Queue<String>();
+  for (final tk in startTargets) {
+    distances[tk] = 0;
+    queue.add(tk);
+  }
+  while (queue.isNotEmpty) {
+    final current = queue.removeFirst();
+    final currentDist = distances[current]!;
+    for (final neighbor in _cardinalNeighborTileKeys(
+      current,
+      tileMapByRegion: tileMapByRegion,
+      landProvinceIds: landProvinceIds,
+    )) {
+      if (!ownedLandTiles.contains(neighbor)) continue;
+      if (distances.containsKey(neighbor)) continue;
+      distances[neighbor] = currentDist + 1;
+      queue.add(neighbor);
+    }
+  }
+  return distances;
+}
+
+List<String> _cardinalNeighborTileKeys(
+  String tileKey, {
+  required Map<String, TileMapResult> tileMapByRegion,
+  required Set<String> landProvinceIds,
+}) {
+  final coords = parseTileKeyCoordinates(tileKey);
+  if (coords == null) return const [];
+  if (coords.x < 0 || coords.y < 0) return const [];
+  final map = tileMapByRegion[coords.regionId];
+  if (map == null) return const [];
+  final out = <String>[];
+  final w = map.width;
+  final h = map.height;
+  for (final d in kGridNeighborsCardinal4) {
+    final nx = coords.x + d.$1;
+    final ny = coords.y + d.$2;
+    if (nx < 0 || nx >= w || ny < 0 || ny >= h) continue;
+    final cellId = map.cell(nx, ny);
+    final fullProvinceId = '$coords.regionId|$cellId';
+    if (!landProvinceIds.contains(cellId) &&
+        !landProvinceIds.contains(fullProvinceId)) {
+      continue;
+    }
+    out.add(CapitalTile.tileKey(coords.regionId, fullProvinceId, nx, ny));
+  }
+  return out;
+}
+
+Set<String> _seaZonesReachableFromCapital({
+  required MapTopology topology,
+  required CapitalTile capital,
+}) {
+  final prefixedTopology = topologyUsesPrefixedIds(topology);
+  final provinceIdForLookup = prefixedTopology
+      ? capital.provinceId
+      : (ProvinceId.isPrefixed(capital.provinceId)
+            ? ProvinceId.localIdFrom(capital.provinceId)
+            : capital.provinceId);
+  final capitalSeaZones = seaZoneIdsAdjacentToProvince(
+    topology,
+    provinceIdForLookup,
+    regionId: ProvinceId.isPrefixed(capital.provinceId)
+        ? ProvinceId.regionIdFrom(capital.provinceId)
+        : null,
+  );
+  if (capitalSeaZones.isEmpty) return const {};
+  return seaZonesReachableBySeaPath(topology, capitalSeaZones);
+}
+
+Set<String> _bottleneckRailTiles({
+  required Game game,
+  required Set<String> connected,
+  required Map<String, int> pathTransportCap,
+}) {
+  final out = <String>{};
+  final tileState = game.worldState.tileState;
+  final resourceByTile = game.worldState.resourceByTileKey;
+  for (final tileKey in connected) {
+    final cap = pathTransportCap[tileKey] ?? 0;
+    if (cap >= 4) continue;
+    var servesBottleneck = false;
+    for (final servedTile in connected) {
+      final resourceId = resourceByTile[servedTile];
+      if (resourceId == null || resourceId.isEmpty) continue;
+      final level = tileState.improvementLevel(servedTile);
+      if (level < 1) continue;
+      final servedCap = pathTransportCap[servedTile] ?? 0;
+      if (servedCap <= cap && level > cap) {
+        servesBottleneck = true;
+        break;
+      }
+    }
+    if (servesBottleneck) out.add(tileKey);
+  }
+  return out;
+}
+
+/// True when [tileKey] is 4-adjacent to any tile in [connected].
+bool isTileAdjacentToConnectedSet(
+  String tileKey,
+  Set<String> connected, {
+  required Map<String, TileMapResult> tileMapByRegion,
+  required Set<String> landProvinceIds,
+}) {
+  for (final neighbor in _cardinalNeighborTileKeys(
+    tileKey,
+    tileMapByRegion: tileMapByRegion,
+    landProvinceIds: landProvinceIds,
+  )) {
+    if (connected.contains(neighbor)) return true;
+  }
+  return false;
+}

--- a/packages/colonizethis_orders/lib/src/orders/connectivity_dev_targets.dart
+++ b/packages/colonizethis_orders/lib/src/orders/connectivity_dev_targets.dart
@@ -1,0 +1,172 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_world/colonizethis_world.dart';
+
+import 'connectivity_dev_snapshot.dart';
+import 'order_work_constants.dart';
+
+/// Stable-partitions [sortedVisible] by connectivity tier without crossing
+/// partition boundaries (feedstock front/back precedence preserved).
+List<String> stablePartitionByConnectivityTier(
+  List<String> sortedVisible,
+  int Function(String tileKey) tierFor,
+) {
+  if (sortedVisible.length < 2) return sortedVisible;
+  final buckets = <int, List<String>>{};
+  for (final tileKey in sortedVisible) {
+    buckets.putIfAbsent(tierFor(tileKey), () => <String>[]).add(tileKey);
+  }
+  final tiers = buckets.keys.toList()..sort();
+  return [for (final tier in tiers) ...buckets[tier]!];
+}
+
+List<String> prioritizeBuildRoadCandidatesByConnectivity({
+  required ConnectivityDevSnapshot snapshot,
+  required List<String> sortedVisible,
+}) {
+  if (!snapshot.hasUnconnectedDevTargets) return sortedVisible;
+  final frontier = <String>[];
+  final nonFrontier = <String>[];
+  for (final tileKey in sortedVisible) {
+    if (snapshot.frontierExtensionTiles.contains(tileKey)) {
+      frontier.add(tileKey);
+    } else {
+      nonFrontier.add(tileKey);
+    }
+  }
+  int distance(String tileKey) =>
+      snapshot.extensionDistanceByTile[tileKey] ?? (1 << 30);
+  frontier.sort((a, b) {
+    final d = distance(a).compareTo(distance(b));
+    if (d != 0) return d;
+    return a.compareTo(b);
+  });
+  return <String>[...frontier, ...nonFrontier];
+}
+
+List<String> prioritizeBuildRailCandidatesByConnectivity({
+  required ConnectivityDevSnapshot snapshot,
+  required List<String> sortedVisible,
+}) {
+  if (!snapshot.hasUnconnectedDevTargets) return sortedVisible;
+  return stablePartitionByConnectivityTier(
+    sortedVisible,
+    (tileKey) {
+      if (!snapshot.connected.contains(tileKey)) return 2;
+      if (snapshot.bottleneckRailTiles.contains(tileKey)) return 0;
+      return 1;
+    },
+  );
+}
+
+List<String> prioritizeBuildImprovementCandidatesByConnectivity({
+  required ConnectivityDevSnapshot snapshot,
+  required List<String> sortedVisible,
+}) {
+  if (!snapshot.hasUnconnectedDevTargets) return sortedVisible;
+  return stablePartitionByConnectivityTier(
+    sortedVisible,
+    (tileKey) {
+      if (snapshot.connected.contains(tileKey)) return 0;
+      if (snapshot.adjacentToConnectedTiles.contains(tileKey)) return 1;
+      return 2;
+    },
+  );
+}
+
+List<String> prioritizeBuildPortCandidatesByConnectivity({
+  required ConnectivityDevSnapshot snapshot,
+  required List<String> sortedVisible,
+  required Game game,
+  required MapTopology topology,
+}) {
+  if (!snapshot.hasUnconnectedDevTargets) return sortedVisible;
+  return stablePartitionByConnectivityTier(
+    sortedVisible,
+    (tileKey) => _buildPortConnectivityTier(
+      tileKey: tileKey,
+      snapshot: snapshot,
+      game: game,
+      topology: topology,
+    ),
+  );
+}
+
+int _buildPortConnectivityTier({
+  required String tileKey,
+  required ConnectivityDevSnapshot snapshot,
+  required Game game,
+  required MapTopology topology,
+}) {
+  final provinceId = Unit.provinceIdFromTileKey(tileKey);
+  if (provinceId == null) return 2;
+  if (!snapshot.provincesWithUnconnectedDevTargets.contains(provinceId)) {
+    return 2;
+  }
+  final seaZoneId = _seaZoneIdForProvincePort(
+    game: game,
+    topology: topology,
+    fullProvinceId: provinceId,
+  );
+  if (seaZoneId == null) return 2;
+  final prefixedTopology = topologyUsesPrefixedIds(topology);
+  final regionId = ProvinceId.regionIdFrom(provinceId);
+  final reachableId = prefixedTopology ? '$regionId|$seaZoneId' : seaZoneId;
+  if (!snapshot.seaZonesReachableFromCapital.contains(reachableId) &&
+      !snapshot.seaZonesReachableFromCapital.contains(seaZoneId)) {
+    return 2;
+  }
+  return 0;
+}
+
+String? _seaZoneIdForProvincePort({
+  required Game game,
+  required MapTopology topology,
+  required String fullProvinceId,
+}) {
+  final localId = ProvinceId.localIdFrom(fullProvinceId);
+  final regionId = ProvinceId.regionIdFrom(fullProvinceId);
+  final zones = seaZoneIdsAdjacentToProvince(
+    topology,
+    topologyUsesPrefixedIds(topology) ? fullProvinceId : localId,
+    regionId: regionId,
+  );
+  if (zones.isEmpty) return null;
+  return zones.first;
+}
+
+List<String> applyConnectivityDevTargetOrdering({
+  required String workTarget,
+  required List<String> sortedVisible,
+  required ConnectivityDevSnapshot snapshot,
+  required Game game,
+  required MapTopology topology,
+  required Map<String, TileMapResult> tileMapByRegion,
+}) {
+  switch (workTarget) {
+    case kWorkTargetBuildRoad:
+      return prioritizeBuildRoadCandidatesByConnectivity(
+        snapshot: snapshot,
+        sortedVisible: sortedVisible,
+      );
+    case kWorkTargetBuildRail:
+      return prioritizeBuildRailCandidatesByConnectivity(
+        snapshot: snapshot,
+        sortedVisible: sortedVisible,
+      );
+    case kWorkTargetBuildImprovement:
+      return prioritizeBuildImprovementCandidatesByConnectivity(
+        snapshot: snapshot,
+        sortedVisible: sortedVisible,
+      );
+    case kWorkTargetBuildPort:
+      return prioritizeBuildPortCandidatesByConnectivity(
+        snapshot: snapshot,
+        sortedVisible: sortedVisible,
+        game: game,
+        topology: topology,
+      );
+    default:
+      return sortedVisible;
+  }
+}

--- a/packages/colonizethis_orders/lib/src/orders/connectivity_dev_targets.dart
+++ b/packages/colonizethis_orders/lib/src/orders/connectivity_dev_targets.dart
@@ -3,6 +3,8 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_world/colonizethis_world.dart';
 
 import 'connectivity_dev_snapshot.dart';
+import 'feedstock_extraction_targets.dart'
+    show feedstockExtractionResourceIdsForPlayer;
 import 'order_work_constants.dart';
 
 /// Stable-partitions [sortedVisible] by connectivity tier without crossing
@@ -72,6 +74,52 @@ List<String> prioritizeBuildImprovementCandidatesByConnectivity({
       return 2;
     },
   );
+}
+
+/// Applies connectivity tiers to `build_improvement` candidates without crossing
+/// the feedstock-extraction front/back partition (Refs #4176 AC-C3, #2847 H8).
+List<String> applyBuildImprovementConnectivityPreservingFeedstock({
+  required Game game,
+  required String playerId,
+  required List<String> sortedVisible,
+  required ConnectivityDevSnapshot snapshot,
+}) {
+  final feedstockIds = feedstockExtractionResourceIdsForPlayer(game, playerId);
+  if (feedstockIds.isEmpty) {
+    return prioritizeBuildImprovementCandidatesByConnectivity(
+      snapshot: snapshot,
+      sortedVisible: sortedVisible,
+    );
+  }
+  final resourceByTile = game.worldState.resourceByTileKey;
+  final tileState = game.worldState.tileState;
+  final front = <String>[];
+  final back = <String>[];
+  for (final tileKey in sortedVisible) {
+    final resourceId = resourceByTile[tileKey];
+    if (resourceId != null &&
+        feedstockIds.contains(resourceId) &&
+        tileState.improvementLevel(tileKey) < 1) {
+      front.add(tileKey);
+    } else {
+      back.add(tileKey);
+    }
+  }
+  if (front.isEmpty) {
+    return prioritizeBuildImprovementCandidatesByConnectivity(
+      snapshot: snapshot,
+      sortedVisible: sortedVisible,
+    );
+  }
+  final orderedFront = prioritizeBuildImprovementCandidatesByConnectivity(
+    snapshot: snapshot,
+    sortedVisible: front,
+  );
+  final orderedBack = prioritizeBuildImprovementCandidatesByConnectivity(
+    snapshot: snapshot,
+    sortedVisible: back,
+  );
+  return <String>[...orderedFront, ...orderedBack];
 }
 
 List<String> prioritizeBuildPortCandidatesByConnectivity({

--- a/packages/colonizethis_orders/lib/src/orders/order_suggestion_work.dart
+++ b/packages/colonizethis_orders/lib/src/orders/order_suggestion_work.dart
@@ -12,6 +12,7 @@ import 'order_suggestion_work_explorer.dart';
 import 'order_suggestion_work_merchant.dart';
 import 'order_suggestion_work_spy.dart';
 import 'order_suggestion_work_worker.dart';
+import 'connectivity_dev_snapshot.dart';
 import 'order_visibility.dart';
 import 'work_suggestion_pipeline.dart';
 import 'partial_province_reveal.dart';
@@ -151,6 +152,13 @@ List<WorkOrder> suggestWorkOrders(
 
   final workProbeBudget = WorkSuggestionProbeBudget();
 
+  final connectivityDev = buildConnectivityDevSnapshot(
+    game: game,
+    playerId: playerId,
+    topology: topology,
+    tileMapByRegion: tileMapByRegion,
+  );
+
   for (final unit in view.ownUnits) {
     _addWorkSuggestionsForUnit(
       view: view,
@@ -173,6 +181,7 @@ List<WorkOrder> suggestWorkOrders(
       candidateValidator: candidateValidator,
       factionMembership: factionMembership,
       workProbeBudget: workProbeBudget,
+      connectivityDev: connectivityDev,
     );
   }
 
@@ -241,6 +250,7 @@ void _addWorkSuggestionsForUnit({
   required DiplomacyFactionMembership factionMembership,
   required WorkSuggestionProbeBudget workProbeBudget,
   Map<String, TileMapResult>? tileMapByRegion,
+  ConnectivityDevSnapshot? connectivityDev,
 }) {
   if (unit.currentWork != null) return;
 
@@ -299,6 +309,7 @@ void _addWorkSuggestionsForUnit({
       tileMapByRegion: tileMapByRegion,
       factionMembership: factionMembership,
       workProbeBudget: workProbeBudget,
+      connectivityDev: connectivityDev,
     );
   }
 

--- a/packages/colonizethis_orders/lib/src/orders/order_suggestion_work_worker.dart
+++ b/packages/colonizethis_orders/lib/src/orders/order_suggestion_work_worker.dart
@@ -2,6 +2,8 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_world/colonizethis_world.dart';
 
+import 'connectivity_dev_snapshot.dart';
+import 'connectivity_dev_targets.dart';
 import 'feedstock_extraction_targets.dart'
     show feedstockExtractionResourceIdsForPlayer;
 import 'incremental_candidate_validator.dart';
@@ -30,6 +32,7 @@ void addWorkerSuggestionsForUnit({
   required DiplomacyFactionMembership factionMembership,
   required WorkSuggestionProbeBudget workProbeBudget,
   Map<String, TileMapResult>? tileMapByRegion,
+  ConnectivityDevSnapshot? connectivityDev,
 }) {
   final allowedTargets = workOrderTargetsByUnitType[type];
   if (allowedTargets == null) return;
@@ -46,12 +49,22 @@ void addWorkerSuggestionsForUnit({
           playerOwnedProvinceIds: playerOwnedProvinceIds,
           factionMembership: factionMembership,
         );
-        final visible = sortedVisibleWorkTargetCandidates(view, raw);
+        var visible = sortedVisibleWorkTargetCandidates(view, raw);
         if (target == kWorkTargetBuildImprovement) {
-          return _prioritizeFeedstockBuildImprovementCandidates(
+          visible = _prioritizeFeedstockBuildImprovementCandidates(
             game: game,
             playerId: playerId,
             sortedVisible: visible,
+          );
+        }
+        if (connectivityDev != null && tileMapByRegion != null) {
+          visible = applyConnectivityDevTargetOrdering(
+            workTarget: target,
+            sortedVisible: visible,
+            snapshot: connectivityDev,
+            game: game,
+            topology: topology,
+            tileMapByRegion: tileMapByRegion,
           );
         }
         return visible;

--- a/packages/colonizethis_orders/lib/src/orders/order_suggestion_work_worker.dart
+++ b/packages/colonizethis_orders/lib/src/orders/order_suggestion_work_worker.dart
@@ -56,8 +56,15 @@ void addWorkerSuggestionsForUnit({
             playerId: playerId,
             sortedVisible: visible,
           );
-        }
-        if (connectivityDev != null && tileMapByRegion != null) {
+          if (connectivityDev != null && tileMapByRegion != null) {
+            visible = applyBuildImprovementConnectivityPreservingFeedstock(
+              game: game,
+              playerId: playerId,
+              sortedVisible: visible,
+              snapshot: connectivityDev,
+            );
+          }
+        } else if (connectivityDev != null && tileMapByRegion != null) {
           visible = applyConnectivityDevTargetOrdering(
             workTarget: target,
             sortedVisible: visible,

--- a/packages/colonizethis_orders/test/orders/connectivity_dev_snapshot_test.dart
+++ b/packages/colonizethis_orders/test/orders/connectivity_dev_snapshot_test.dart
@@ -6,10 +6,12 @@ import 'package:colonizethis_orders/src/orders/order_work_constants.dart';
 import 'package:colonizethis_orders/src/orders/work_suggestion_pipeline.dart';
 import 'package:colonizethis_test/test.dart';
 
+import 'support/scenario_runner.dart';
+
 /// ConnectivityDevSnapshot builder pins (Refs #4176 AC-A5, AC-A7).
 void main() {
-  group('buildConnectivityDevSnapshot', () {
-    test('AC-A5 owned-land traversal only for extension distances', () {
+  runLabeledScenarioGroup('buildConnectivityDevSnapshot', [
+    rs('AC-A5 owned-land traversal only for extension distances', () {
       const ow = 'oldWorld';
       const pCapital = '$ow|pCap';
       const pForeign = '$ow|pFor';
@@ -107,73 +109,76 @@ void main() {
         reason: 'foreign-province barrier must block owned-land extension '
             'distance toward the isolated resource province',
       );
-    });
-  });
+    }),
+  ], runRunnableScenario);
 
-  group('build_road connectivity ordering with probe cap', () {
-    test('AC-A7 frontier tile is first accepted despite lex-smaller non-frontier', () {
-      const frontierTile = 'oldWorld|p1|2|4';
-      final lexSorted = <String>[
-        for (var y = 0; y < 5; y++)
-          for (var x = 0; x < 5; x++) 'oldWorld|p1|$x|$y',
-      ];
-      final snapshot = ConnectivityDevSnapshot(
-        connected: {'oldWorld|p1|4|4', 'oldWorld|p1|3|4', 'oldWorld|p1|4|3'},
-        pathTransportCap: const {},
-        extensionDistanceByTile: {
-          frontierTile: 6,
-          'oldWorld|p1|3|3': 6,
-          'oldWorld|p1|4|2': 6,
-        },
-        seaZonesReachableFromCapital: const {},
-        provincesWithUnconnectedDevTargets: {'oldWorld|p1'},
-        hasUnconnectedDevTargets: true,
-        frontierExtensionTiles: {
-          frontierTile,
-          'oldWorld|p1|3|3',
-          'oldWorld|p1|4|2',
-        },
-        bottleneckRailTiles: const {},
-        adjacentToConnectedTiles: {
-          frontierTile,
-          'oldWorld|p1|3|3',
-          'oldWorld|p1|4|2',
-        },
-      );
-      final ordered = prioritizeBuildRoadCandidatesByConnectivity(
-        snapshot: snapshot,
-        sortedVisible: lexSorted,
-      );
-      expect(ordered.first, frontierTile);
+  runLabeledScenarioGroup('build_road connectivity ordering with probe cap', [
+    rs(
+      'AC-A7 frontier tile is first accepted despite lex-smaller non-frontier',
+      () {
+        const frontierTile = 'oldWorld|p1|2|4';
+        final lexSorted = <String>[
+          for (var y = 0; y < 5; y++)
+            for (var x = 0; x < 5; x++) 'oldWorld|p1|$x|$y',
+        ];
+        final snapshot = ConnectivityDevSnapshot(
+          connected: {'oldWorld|p1|4|4', 'oldWorld|p1|3|4', 'oldWorld|p1|4|3'},
+          pathTransportCap: const {},
+          extensionDistanceByTile: {
+            frontierTile: 6,
+            'oldWorld|p1|3|3': 6,
+            'oldWorld|p1|4|2': 6,
+          },
+          seaZonesReachableFromCapital: const {},
+          provincesWithUnconnectedDevTargets: {'oldWorld|p1'},
+          hasUnconnectedDevTargets: true,
+          frontierExtensionTiles: {
+            frontierTile,
+            'oldWorld|p1|3|3',
+            'oldWorld|p1|4|2',
+          },
+          bottleneckRailTiles: const {},
+          adjacentToConnectedTiles: {
+            frontierTile,
+            'oldWorld|p1|3|3',
+            'oldWorld|p1|4|2',
+          },
+        );
+        final ordered = prioritizeBuildRoadCandidatesByConnectivity(
+          snapshot: snapshot,
+          sortedVisible: lexSorted,
+        );
+        expect(ordered.first, frontierTile);
 
-      final unit = Unit(
-        id: 'e1',
-        type: kUnitTypeEngineer,
-        ownerId: 'gp1',
-        locationProvinceId: 'oldWorld|p1',
-      );
-      final suggestions = <WorkOrder>[];
-      WorkSuggestionPipeline.run(
-        unit: unit,
-        unitType: unit.type,
-        unitRegionId: 'oldWorld',
-        atProvinceId: 'oldWorld|p1',
-        workTarget: kWorkTargetBuildRoad,
-        existingTargetsByUnit: {},
-        suggestions: suggestions,
-        candidatesProvider: () sync* {
-          for (final tileKey in ordered) {
-            yield WorkOrder(
-              unitId: unit.id,
-              target: kWorkTargetBuildRoad,
-              targetTileKey: tileKey,
-            );
-          }
-        },
-        candidateAcceptor: (_) => true,
-        noCandidateReason: 'no_valid_tile',
-      );
-      expect(suggestions.single.targetTileKey, frontierTile);
-    });
-  });
+        final unit = Unit(
+          id: 'e1',
+          type: kUnitTypeEngineer,
+          ownerId: 'gp1',
+          locationProvinceId: 'oldWorld|p1',
+        );
+        final suggestions = <WorkOrder>[];
+        WorkSuggestionPipeline.run(
+          unit: unit,
+          unitType: unit.type,
+          unitRegionId: 'oldWorld',
+          atProvinceId: 'oldWorld|p1',
+          workTarget: kWorkTargetBuildRoad,
+          existingTargetsByUnit: {},
+          suggestions: suggestions,
+          candidatesProvider: () sync* {
+            for (final tileKey in ordered) {
+              yield WorkOrder(
+                unitId: unit.id,
+                target: kWorkTargetBuildRoad,
+                targetTileKey: tileKey,
+              );
+            }
+          },
+          candidateAcceptor: (_) => true,
+          noCandidateReason: 'no_valid_tile',
+        );
+        expect(suggestions.single.targetTileKey, frontierTile);
+      },
+    ),
+  ], runRunnableScenario);
 }

--- a/packages/colonizethis_orders/test/orders/connectivity_dev_snapshot_test.dart
+++ b/packages/colonizethis_orders/test/orders/connectivity_dev_snapshot_test.dart
@@ -1,0 +1,179 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_orders/src/orders/connectivity_dev_snapshot.dart';
+import 'package:colonizethis_orders/src/orders/connectivity_dev_targets.dart';
+import 'package:colonizethis_orders/src/orders/order_work_constants.dart';
+import 'package:colonizethis_orders/src/orders/work_suggestion_pipeline.dart';
+import 'package:colonizethis_test/test.dart';
+
+/// ConnectivityDevSnapshot builder pins (Refs #4176 AC-A5, AC-A7).
+void main() {
+  group('buildConnectivityDevSnapshot', () {
+    test('AC-A5 owned-land traversal only for extension distances', () {
+      const ow = 'oldWorld';
+      const pCapital = '$ow|pCap';
+      const pForeign = '$ow|pFor';
+      const pResource = '$ow|pRes';
+      const capTile = '$pCapital|2|0';
+      const resourceTile = '$pResource|0|2';
+      const grid = [
+        ['pCap', 'pCap', 'pCap'],
+        ['pFor', 'pFor', 'pFor'],
+        ['pRes', 'pRes', 'pRes'],
+      ];
+      final tileMap = TileMapResult(
+        width: grid.first.length,
+        height: grid.length,
+        grid: grid,
+      );
+      const topology = MapTopology(
+        nodes: [
+          TopologyNode(
+            id: pCapital,
+            regionId: ow,
+            type: TopologyNodeType.province,
+          ),
+          TopologyNode(
+            id: pForeign,
+            regionId: ow,
+            type: TopologyNodeType.province,
+          ),
+          TopologyNode(
+            id: pResource,
+            regionId: ow,
+            type: TopologyNodeType.province,
+          ),
+        ],
+        edges: [
+          TopologyEdge(id1: pCapital, id2: pForeign),
+          TopologyEdge(id1: pForeign, id2: pResource),
+        ],
+      );
+      final capTiles = [
+        for (var x = 0; x < 3; x++) '$pCapital|$x|0',
+      ];
+      final resTiles = [
+        for (var x = 0; x < 3; x++) '$pResource|$x|2',
+      ];
+      final game = Game(
+        id: 'g',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: RegionData(
+            provinces: [
+              Province(id: pCapital, regionId: ow, ownerId: 'gp1'),
+              Province(id: pForeign, regionId: ow, ownerId: 'minor1'),
+              Province(id: pResource, regionId: ow, ownerId: 'gp1'),
+            ],
+          ),
+          newWorld: const RegionData(),
+          tileKeysByRegionAndProvince: {
+            ow: {
+              'pCap': capTiles,
+              'pRes': resTiles,
+            },
+          },
+          resourceByTileKey: {resourceTile: 'iron'},
+          tileState: const TileMapState(
+            improvementByTile: {resourceTile: 1},
+          ),
+        ),
+        players: [
+          Player(
+            id: 'gp1',
+            displayName: 'GP',
+            isHuman: false,
+            capitalProvinceId: pCapital,
+            capitalTile: CapitalTile(
+              regionId: ow,
+              provinceId: pCapital,
+              x: 2,
+              y: 0,
+            ),
+          ),
+        ],
+      );
+      final snapshot = buildConnectivityDevSnapshot(
+        game: game,
+        playerId: 'gp1',
+        topology: topology,
+        tileMapByRegion: {ow: tileMap},
+      );
+      expect(snapshot, isNotNull);
+      expect(snapshot!.hasUnconnectedDevTargets, isTrue);
+      expect(
+        snapshot.extensionDistanceByTile[capTile],
+        isNull,
+        reason: 'foreign-province barrier must block owned-land extension '
+            'distance toward the isolated resource province',
+      );
+    });
+  });
+
+  group('build_road connectivity ordering with probe cap', () {
+    test('AC-A7 frontier tile is first accepted despite lex-smaller non-frontier', () {
+      const frontierTile = 'oldWorld|p1|2|4';
+      final lexSorted = <String>[
+        for (var y = 0; y < 5; y++)
+          for (var x = 0; x < 5; x++) 'oldWorld|p1|$x|$y',
+      ];
+      final snapshot = ConnectivityDevSnapshot(
+        connected: {'oldWorld|p1|4|4', 'oldWorld|p1|3|4', 'oldWorld|p1|4|3'},
+        pathTransportCap: const {},
+        extensionDistanceByTile: {
+          frontierTile: 6,
+          'oldWorld|p1|3|3': 6,
+          'oldWorld|p1|4|2': 6,
+        },
+        seaZonesReachableFromCapital: const {},
+        provincesWithUnconnectedDevTargets: {'oldWorld|p1'},
+        hasUnconnectedDevTargets: true,
+        frontierExtensionTiles: {
+          frontierTile,
+          'oldWorld|p1|3|3',
+          'oldWorld|p1|4|2',
+        },
+        bottleneckRailTiles: const {},
+        adjacentToConnectedTiles: {
+          frontierTile,
+          'oldWorld|p1|3|3',
+          'oldWorld|p1|4|2',
+        },
+      );
+      final ordered = prioritizeBuildRoadCandidatesByConnectivity(
+        snapshot: snapshot,
+        sortedVisible: lexSorted,
+      );
+      expect(ordered.first, frontierTile);
+
+      final unit = Unit(
+        id: 'e1',
+        type: kUnitTypeEngineer,
+        ownerId: 'gp1',
+        locationProvinceId: 'oldWorld|p1',
+      );
+      final suggestions = <WorkOrder>[];
+      WorkSuggestionPipeline.run(
+        unit: unit,
+        unitType: unit.type,
+        unitRegionId: 'oldWorld',
+        atProvinceId: 'oldWorld|p1',
+        workTarget: kWorkTargetBuildRoad,
+        existingTargetsByUnit: {},
+        suggestions: suggestions,
+        candidatesProvider: () sync* {
+          for (final tileKey in ordered) {
+            yield WorkOrder(
+              unitId: unit.id,
+              target: kWorkTargetBuildRoad,
+              targetTileKey: tileKey,
+            );
+          }
+        },
+        candidateAcceptor: (_) => true,
+        noCandidateReason: 'no_valid_tile',
+      );
+      expect(suggestions.single.targetTileKey, frontierTile);
+    });
+  });
+}

--- a/packages/colonizethis_orders/test/orders/connectivity_dev_targets_test.dart
+++ b/packages/colonizethis_orders/test/orders/connectivity_dev_targets_test.dart
@@ -6,6 +6,7 @@ import 'package:colonizethis_orders/src/orders/feedstock_extraction_targets.dart
 import 'package:colonizethis_orders/src/orders/order_work_constants.dart';
 import 'package:colonizethis_test/test.dart';
 
+import 'support/scenario_runner.dart';
 import 'support/suggestion/order_suggestion_work_feedstock_priority_fixtures.dart';
 
 ConnectivityDevSnapshot _snapshot({
@@ -30,8 +31,8 @@ ConnectivityDevSnapshot _snapshot({
 }
 
 void main() {
-  group('prioritizeBuildRoadCandidatesByConnectivity', () {
-    test('AC-A2 frontier hard demotion', () {
+  runLabeledScenarioGroup('prioritizeBuildRoadCandidatesByConnectivity', [
+    rs('AC-A2 frontier hard demotion', () {
       final snapshot = _snapshot(
         frontier: {'oldWorld|p1|0|1'},
         extensionDistance: {'oldWorld|p1|0|1': 2},
@@ -41,9 +42,8 @@ void main() {
         sortedVisible: ['oldWorld|p1|9|9', 'oldWorld|p1|0|1'],
       );
       expect(ordered.first, 'oldWorld|p1|0|1');
-    });
-
-    test('AC-A3 nearest-target-first within frontier', () {
+    }),
+    rs('AC-A3 nearest-target-first within frontier', () {
       final snapshot = _snapshot(
         frontier: {'oldWorld|p1|0|1', 'oldWorld|p1|0|3'},
         extensionDistance: {'oldWorld|p1|0|1': 1, 'oldWorld|p1|0|3': 3},
@@ -53,9 +53,8 @@ void main() {
         sortedVisible: ['oldWorld|p1|0|3', 'oldWorld|p1|0|1'],
       );
       expect(ordered, ['oldWorld|p1|0|1', 'oldWorld|p1|0|3']);
-    });
-
-    test('AC-A4 baseline when no unconnected targets', () {
+    }),
+    rs('AC-A4 baseline when no unconnected targets', () {
       final snapshot = _snapshot(hasTargets: false);
       const input = ['oldWorld|p1|9|9', 'oldWorld|p1|0|1'];
       expect(
@@ -65,11 +64,11 @@ void main() {
         ),
         input,
       );
-    });
-  });
+    }),
+  ], runRunnableScenario);
 
-  group('prioritizeBuildImprovementCandidatesByConnectivity', () {
-    test('AC-C1 connected > adjacent > far', () {
+  runLabeledScenarioGroup('prioritizeBuildImprovementCandidatesByConnectivity', [
+    rs('AC-C1 connected > adjacent > far', () {
       final snapshot = _snapshot(
         connected: {'c'},
         adjacent: {'a'},
@@ -79,38 +78,42 @@ void main() {
         sortedVisible: ['f', 'a', 'c'],
       );
       expect(ordered, ['c', 'a', 'f']);
-    });
-  });
+    }),
+  ], runRunnableScenario);
 
-  group('applyBuildImprovementConnectivityPreservingFeedstock', () {
-    test('AC-C3 feedstock tile precedes connected non-feedstock tile', () {
-      final game = feedstockPriorityGame();
-      expect(
-        feedstockExtractionResourceIdsForPlayer(
-          game,
-          feedstockPrioritySupplierId,
-        ),
-        contains('iron'),
-      );
-      final snapshot = _snapshot(
-        connected: {feedstockPrioritySupplierGrainTile},
-        adjacent: const {},
-      );
-      final ordered = applyBuildImprovementConnectivityPreservingFeedstock(
-        game: game,
-        playerId: feedstockPrioritySupplierId,
-        sortedVisible: [
-          feedstockPrioritySupplierGrainTile,
-          feedstockPrioritySupplierIronTile,
-        ],
-        snapshot: snapshot,
-      );
-      expect(ordered.first, feedstockPrioritySupplierIronTile);
-    });
-  });
+  runLabeledScenarioGroup(
+    'applyBuildImprovementConnectivityPreservingFeedstock',
+    [
+      rs('AC-C3 feedstock tile precedes connected non-feedstock tile', () {
+        final game = feedstockPriorityGame();
+        expect(
+          feedstockExtractionResourceIdsForPlayer(
+            game,
+            feedstockPrioritySupplierId,
+          ),
+          contains('iron'),
+        );
+        final snapshot = _snapshot(
+          connected: {feedstockPrioritySupplierGrainTile},
+          adjacent: const {},
+        );
+        final ordered = applyBuildImprovementConnectivityPreservingFeedstock(
+          game: game,
+          playerId: feedstockPrioritySupplierId,
+          sortedVisible: [
+            feedstockPrioritySupplierGrainTile,
+            feedstockPrioritySupplierIronTile,
+          ],
+          snapshot: snapshot,
+        );
+        expect(ordered.first, feedstockPrioritySupplierIronTile);
+      }),
+    ],
+    runRunnableScenario,
+  );
 
-  group('prioritizeBuildRailCandidatesByConnectivity', () {
-    test('AC-B1 bottleneck promotion', () {
+  runLabeledScenarioGroup('prioritizeBuildRailCandidatesByConnectivity', [
+    rs('AC-B1 bottleneck promotion', () {
       final snapshot = _snapshot(
         connected: {'bottleneck', 'plain'},
         bottleneck: {'bottleneck'},
@@ -120,9 +123,8 @@ void main() {
         sortedVisible: ['plain', 'bottleneck'],
       );
       expect(ordered.first, 'bottleneck');
-    });
-
-    test('AC-B2 no-yield-gain demotion', () {
+    }),
+    rs('AC-B2 no-yield-gain demotion', () {
       final snapshot = _snapshot(
         connected: {'bottleneck', 'satisfied'},
         bottleneck: {'bottleneck'},
@@ -132,11 +134,11 @@ void main() {
         sortedVisible: ['satisfied', 'bottleneck'],
       );
       expect(ordered.first, 'bottleneck');
-    });
-  });
+    }),
+  ], runRunnableScenario);
 
-  group('prioritizeBuildPortCandidatesByConnectivity', () {
-    test('AC-D1 overseas resource province promotion', () {
+  runLabeledScenarioGroup('prioritizeBuildPortCandidatesByConnectivity', [
+    rs('AC-D1 overseas resource province promotion', () {
       const ow = 'oldWorld';
       const provinceId = '$ow|nw1';
       const linkedPort = '$provinceId|0|0';
@@ -215,9 +217,8 @@ void main() {
         topology: topology,
       );
       expect(ordered.first, linkedPort);
-    });
-
-    test('AC-D2 sea-unreachable demotion', () {
+    }),
+    rs('AC-D2 sea-unreachable demotion', () {
       const ow = 'oldWorld';
       const reachableProvince = '$ow|nwReach';
       const unreachableProvince = '$ow|nwBlock';
@@ -310,21 +311,21 @@ void main() {
         topology: topology,
       );
       expect(ordered.first, reachablePort);
-    });
-  });
+    }),
+  ], runRunnableScenario);
 
-  group('stablePartitionByConnectivityTier', () {
-    test('preserves relative order within tier', () {
+  runLabeledScenarioGroup('stablePartitionByConnectivityTier', [
+    rs('preserves relative order within tier', () {
       final ordered = stablePartitionByConnectivityTier(
         ['b2', 'a2', 'b1', 'a1'],
         (k) => k.endsWith('1') ? 0 : 1,
       );
       expect(ordered, ['b1', 'a1', 'b2', 'a2']);
-    });
-  });
+    }),
+  ], runRunnableScenario);
 
-  group('applyConnectivityDevTargetOrdering', () {
-    test('unknown target unchanged', () {
+  runLabeledScenarioGroup('applyConnectivityDevTargetOrdering', [
+    rs('unknown target unchanged', () {
       final snapshot = _snapshot();
       const input = ['t1', 't2'];
       expect(
@@ -346,6 +347,6 @@ void main() {
         ),
         input,
       );
-    });
-  });
+    }),
+  ], runRunnableScenario);
 }

--- a/packages/colonizethis_orders/test/orders/connectivity_dev_targets_test.dart
+++ b/packages/colonizethis_orders/test/orders/connectivity_dev_targets_test.dart
@@ -3,7 +3,7 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_orders/src/orders/connectivity_dev_snapshot.dart';
 import 'package:colonizethis_orders/src/orders/connectivity_dev_targets.dart';
 import 'package:colonizethis_orders/src/orders/order_work_constants.dart';
-import 'package:test/test.dart';
+import 'package:colonizethis_test/test.dart';
 
 ConnectivityDevSnapshot _snapshot({
   Set<String> connected = const {},

--- a/packages/colonizethis_orders/test/orders/connectivity_dev_targets_test.dart
+++ b/packages/colonizethis_orders/test/orders/connectivity_dev_targets_test.dart
@@ -1,0 +1,117 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_orders/src/orders/connectivity_dev_snapshot.dart';
+import 'package:colonizethis_orders/src/orders/connectivity_dev_targets.dart';
+import 'package:colonizethis_orders/src/orders/order_work_constants.dart';
+import 'package:test/test.dart';
+
+ConnectivityDevSnapshot _snapshot({
+  Set<String> connected = const {},
+  Set<String> frontier = const {},
+  Set<String> adjacent = const {},
+  Set<String> bottleneck = const {},
+  Map<String, int> extensionDistance = const {},
+  bool hasTargets = true,
+}) {
+  return ConnectivityDevSnapshot(
+    connected: connected,
+    pathTransportCap: const {},
+    extensionDistanceByTile: extensionDistance,
+    seaZonesReachableFromCapital: const {},
+    provincesWithUnconnectedDevTargets: const {},
+    hasUnconnectedDevTargets: hasTargets,
+    frontierExtensionTiles: frontier,
+    bottleneckRailTiles: bottleneck,
+    adjacentToConnectedTiles: adjacent,
+  );
+}
+
+void main() {
+  group('prioritizeBuildRoadCandidatesByConnectivity', () {
+    test('AC-A2 frontier hard demotion', () {
+      final snapshot = _snapshot(
+        frontier: {'oldWorld|p1|0|1'},
+        extensionDistance: {'oldWorld|p1|0|1': 2},
+      );
+      final ordered = prioritizeBuildRoadCandidatesByConnectivity(
+        snapshot: snapshot,
+        sortedVisible: ['oldWorld|p1|9|9', 'oldWorld|p1|0|1'],
+      );
+      expect(ordered.first, 'oldWorld|p1|0|1');
+    });
+
+    test('AC-A3 nearest-target-first within frontier', () {
+      final snapshot = _snapshot(
+        frontier: {'oldWorld|p1|0|1', 'oldWorld|p1|0|3'},
+        extensionDistance: {'oldWorld|p1|0|1': 1, 'oldWorld|p1|0|3': 3},
+      );
+      final ordered = prioritizeBuildRoadCandidatesByConnectivity(
+        snapshot: snapshot,
+        sortedVisible: ['oldWorld|p1|0|3', 'oldWorld|p1|0|1'],
+      );
+      expect(ordered, ['oldWorld|p1|0|1', 'oldWorld|p1|0|3']);
+    });
+
+    test('AC-A4 baseline when no unconnected targets', () {
+      final snapshot = _snapshot(hasTargets: false);
+      const input = ['oldWorld|p1|9|9', 'oldWorld|p1|0|1'];
+      expect(
+        prioritizeBuildRoadCandidatesByConnectivity(
+          snapshot: snapshot,
+          sortedVisible: input,
+        ),
+        input,
+      );
+    });
+  });
+
+  group('prioritizeBuildImprovementCandidatesByConnectivity', () {
+    test('AC-C1 connected > adjacent > far', () {
+      final snapshot = _snapshot(
+        connected: {'c'},
+        adjacent: {'a'},
+      );
+      final ordered = prioritizeBuildImprovementCandidatesByConnectivity(
+        snapshot: snapshot,
+        sortedVisible: ['f', 'a', 'c'],
+      );
+      expect(ordered, ['c', 'a', 'f']);
+    });
+  });
+
+  group('stablePartitionByConnectivityTier', () {
+    test('preserves relative order within tier', () {
+      final ordered = stablePartitionByConnectivityTier(
+        ['b2', 'a2', 'b1', 'a1'],
+        (k) => k.endsWith('1') ? 0 : 1,
+      );
+      expect(ordered, ['b1', 'a1', 'b2', 'a2']);
+    });
+  });
+
+  group('applyConnectivityDevTargetOrdering', () {
+    test('unknown target unchanged', () {
+      final snapshot = _snapshot();
+      const input = ['t1', 't2'];
+      expect(
+        applyConnectivityDevTargetOrdering(
+          workTarget: kWorkTargetExplore,
+          sortedVisible: input,
+          snapshot: snapshot,
+          game: Game(
+            id: 'g',
+            worldState: WorldState(
+              turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+              oldWorld: const RegionData(),
+              newWorld: const RegionData(),
+            ),
+            players: const [],
+          ),
+          topology: const MapTopology(nodes: [], edges: []),
+          tileMapByRegion: const {},
+        ),
+        input,
+      );
+    });
+  });
+}

--- a/packages/colonizethis_orders/test/orders/connectivity_dev_targets_test.dart
+++ b/packages/colonizethis_orders/test/orders/connectivity_dev_targets_test.dart
@@ -2,8 +2,11 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_orders/src/orders/connectivity_dev_snapshot.dart';
 import 'package:colonizethis_orders/src/orders/connectivity_dev_targets.dart';
+import 'package:colonizethis_orders/src/orders/feedstock_extraction_targets.dart';
 import 'package:colonizethis_orders/src/orders/order_work_constants.dart';
 import 'package:colonizethis_test/test.dart';
+
+import 'support/suggestion/order_suggestion_work_feedstock_priority_fixtures.dart';
 
 ConnectivityDevSnapshot _snapshot({
   Set<String> connected = const {},
@@ -76,6 +79,237 @@ void main() {
         sortedVisible: ['f', 'a', 'c'],
       );
       expect(ordered, ['c', 'a', 'f']);
+    });
+  });
+
+  group('applyBuildImprovementConnectivityPreservingFeedstock', () {
+    test('AC-C3 feedstock tile precedes connected non-feedstock tile', () {
+      final game = feedstockPriorityGame();
+      expect(
+        feedstockExtractionResourceIdsForPlayer(
+          game,
+          feedstockPrioritySupplierId,
+        ),
+        contains('iron'),
+      );
+      final snapshot = _snapshot(
+        connected: {feedstockPrioritySupplierGrainTile},
+        adjacent: const {},
+      );
+      final ordered = applyBuildImprovementConnectivityPreservingFeedstock(
+        game: game,
+        playerId: feedstockPrioritySupplierId,
+        sortedVisible: [
+          feedstockPrioritySupplierGrainTile,
+          feedstockPrioritySupplierIronTile,
+        ],
+        snapshot: snapshot,
+      );
+      expect(ordered.first, feedstockPrioritySupplierIronTile);
+    });
+  });
+
+  group('prioritizeBuildRailCandidatesByConnectivity', () {
+    test('AC-B1 bottleneck promotion', () {
+      final snapshot = _snapshot(
+        connected: {'bottleneck', 'plain'},
+        bottleneck: {'bottleneck'},
+      );
+      final ordered = prioritizeBuildRailCandidatesByConnectivity(
+        snapshot: snapshot,
+        sortedVisible: ['plain', 'bottleneck'],
+      );
+      expect(ordered.first, 'bottleneck');
+    });
+
+    test('AC-B2 no-yield-gain demotion', () {
+      final snapshot = _snapshot(
+        connected: {'bottleneck', 'satisfied'},
+        bottleneck: {'bottleneck'},
+      );
+      final ordered = prioritizeBuildRailCandidatesByConnectivity(
+        snapshot: snapshot,
+        sortedVisible: ['satisfied', 'bottleneck'],
+      );
+      expect(ordered.first, 'bottleneck');
+    });
+  });
+
+  group('prioritizeBuildPortCandidatesByConnectivity', () {
+    test('AC-D1 overseas resource province promotion', () {
+      const ow = 'oldWorld';
+      const provinceId = '$ow|nw1';
+      const linkedPort = '$provinceId|0|0';
+      const plainPort = 'oldWorld|ow1|0|0';
+      final snapshot = ConnectivityDevSnapshot(
+        connected: const {},
+        pathTransportCap: const {},
+        extensionDistanceByTile: const {},
+        seaZonesReachableFromCapital: {'$ow|sea1'},
+        provincesWithUnconnectedDevTargets: {provinceId},
+        hasUnconnectedDevTargets: true,
+        frontierExtensionTiles: const {},
+        bottleneckRailTiles: const {},
+        adjacentToConnectedTiles: const {},
+      );
+      final game = Game(
+        id: 'g',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: RegionData(
+            provinces: [
+              Province(id: 'oldWorld|ow1', regionId: ow, ownerId: 'gp1'),
+              Province(id: provinceId, regionId: ow, ownerId: 'gp1'),
+            ],
+          ),
+          newWorld: const RegionData(),
+        ),
+        players: [
+          Player(
+            id: 'gp1',
+            displayName: 'GP',
+            isHuman: false,
+            capitalProvinceId: 'oldWorld|ow1',
+            capitalTile: CapitalTile(
+              regionId: ow,
+              provinceId: 'oldWorld|ow1',
+              x: 0,
+              y: 0,
+            ),
+          ),
+        ],
+      );
+      const topology = MapTopology(
+        nodes: [
+          TopologyNode(
+            id: 'oldWorld|ow1',
+            regionId: ow,
+            type: TopologyNodeType.province,
+          ),
+          TopologyNode(
+            id: provinceId,
+            regionId: ow,
+            type: TopologyNodeType.province,
+          ),
+          TopologyNode(
+            id: '$ow|sea1',
+            regionId: ow,
+            type: TopologyNodeType.seaZone,
+          ),
+        ],
+        edges: [
+          TopologyEdge(
+            id1: 'oldWorld|ow1',
+            id2: '$ow|sea1',
+          ),
+          TopologyEdge(
+            id1: provinceId,
+            id2: '$ow|sea1',
+          ),
+        ],
+      );
+      final ordered = prioritizeBuildPortCandidatesByConnectivity(
+        snapshot: snapshot,
+        sortedVisible: [plainPort, linkedPort],
+        game: game,
+        topology: topology,
+      );
+      expect(ordered.first, linkedPort);
+    });
+
+    test('AC-D2 sea-unreachable demotion', () {
+      const ow = 'oldWorld';
+      const reachableProvince = '$ow|nwReach';
+      const unreachableProvince = '$ow|nwBlock';
+      const reachablePort = '$reachableProvince|0|0';
+      const unreachablePort = '$unreachableProvince|0|0';
+      final snapshot = ConnectivityDevSnapshot(
+        connected: const {},
+        pathTransportCap: const {},
+        extensionDistanceByTile: const {},
+        seaZonesReachableFromCapital: {'$ow|seaReach'},
+        provincesWithUnconnectedDevTargets: {
+          reachableProvince,
+          unreachableProvince,
+        },
+        hasUnconnectedDevTargets: true,
+        frontierExtensionTiles: const {},
+        bottleneckRailTiles: const {},
+        adjacentToConnectedTiles: const {},
+      );
+      final game = Game(
+        id: 'g',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: RegionData(
+            provinces: [
+              Province(
+                id: 'oldWorld|ow1',
+                regionId: ow,
+                ownerId: 'gp1',
+              ),
+              Province(id: reachableProvince, regionId: ow, ownerId: 'gp1'),
+              Province(id: unreachableProvince, regionId: ow, ownerId: 'gp1'),
+            ],
+          ),
+          newWorld: const RegionData(),
+        ),
+        players: [
+          Player(
+            id: 'gp1',
+            displayName: 'GP',
+            isHuman: false,
+            capitalProvinceId: 'oldWorld|ow1',
+            capitalTile: CapitalTile(
+              regionId: ow,
+              provinceId: 'oldWorld|ow1',
+              x: 0,
+              y: 0,
+            ),
+          ),
+        ],
+      );
+      const topology = MapTopology(
+        nodes: [
+          TopologyNode(
+            id: 'oldWorld|ow1',
+            regionId: ow,
+            type: TopologyNodeType.province,
+          ),
+          TopologyNode(
+            id: reachableProvince,
+            regionId: ow,
+            type: TopologyNodeType.province,
+          ),
+          TopologyNode(
+            id: unreachableProvince,
+            regionId: ow,
+            type: TopologyNodeType.province,
+          ),
+          TopologyNode(
+            id: '$ow|seaReach',
+            regionId: ow,
+            type: TopologyNodeType.seaZone,
+          ),
+          TopologyNode(
+            id: '$ow|seaBlock',
+            regionId: ow,
+            type: TopologyNodeType.seaZone,
+          ),
+        ],
+        edges: [
+          TopologyEdge(id1: 'oldWorld|ow1', id2: '$ow|seaReach'),
+          TopologyEdge(id1: reachableProvince, id2: '$ow|seaReach'),
+          TopologyEdge(id1: unreachableProvince, id2: '$ow|seaBlock'),
+        ],
+      );
+      final ordered = prioritizeBuildPortCandidatesByConnectivity(
+        snapshot: snapshot,
+        sortedVisible: [unreachablePort, reachablePort],
+        game: game,
+        topology: topology,
+      );
+      expect(ordered.first, reachablePort);
     });
   });
 


### PR DESCRIPTION
## Summary
- Adds **ConnectivityDevSnapshot** (one per `suggestWorkOrders` pass when `tileMapByRegion` is supplied) from `resolveConnectivity` plus owned-land extension-distance BFS toward unconnected resource/improved tiles.
- **Suggestion layer:** stable-partition reordering for `build_road`, `build_rail`, `build_improvement`, and `build_port` (feedstock `build_improvement` partition keeps precedence via `applyBuildImprovementConnectivityPreservingFeedstock`).
- **Selection layer:** GA-tunable connectivity scoring mirrors for Engineer/Rail Builder/Builder paths; orchestrator passes `topology` into `selectFullAiCivilianWorkOrders`.
- **SPEC:** `SPEC/ai/civilian-work-planner.md` and `SPEC/program/order-suggestions.md` document ordering rules and new parameters.

## Done in this PR
- Core snapshot + reordering helpers (`connectivity_dev_snapshot.dart`, `connectivity_dev_targets.dart`)
- Wired into `suggestWorkOrders` / worker suggestion pipeline
- Selection-layer bonuses + registry params (`kEngineerFrontierRoadExtensionBonus`, etc.)
- Feedstock precedence fix: connectivity tiers apply within feedstock front/back partitions (AC-C3)
- Unit tests: AC-A2/A3/A4/A5/A7, AC-B1/B2, AC-C1/C3/C4, AC-D1/D2, AC-E1, AC-G1

## Deferred
- End-to-end multi-turn observer ACs (AC-A1, AC-A6, AC-D3, AC-F1–F3, AC-F5–F7)
- Full `suggestWorkOrders` integration fixture for AC-A7 (pipeline-level probe-cap test covers ordering + cap interaction)

## Manual
N/A — AI-internal behavior; player-facing connectivity rules in `docs/manual/06-bounty-of-the-earth.md` unchanged.

## Test plan
- [x] `cd packages/colonizethis_orders && dart test test/orders/connectivity_dev_targets_test.dart test/orders/connectivity_dev_snapshot_test.dart`
- [x] `cd packages/colonizethis_ai_contracts && dart test test/full_ai_civilian_work_connectivity_selection_test.dart`
- [x] `cd packages/colonizethis_ai_contracts && dart test test/full_ai_civilian_work_engineer_scoring_test.dart test/full_ai_civilian_work_selection_test.dart`

Refs #4176

Made with [Cursor](https://cursor.com)