### PR TITLE
test: connectivity-aware AI observer and selection coverage (#4176)

### DIFF
--- a/packages/colonizethis_ai/test/seed42_observer_connectivity_dev_closure_test.dart
+++ b/packages/colonizethis_ai/test/seed42_observer_connectivity_dev_closure_test.dart
@@ -1,0 +1,75 @@
+// Seed-42 Full-AI observer connectivity closure gate (Refs #4176 AC-F1).
+//
+// After connectivity-aware civilian-work ordering lands, every improved resource
+// tile that is geographically reachable over owned land from the capital network
+// must be extraction-connected. Overseas tiles separated by sea (not reachable
+// via owned-land BFS from the OW network) are exempt per AC-F1.
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_test/test.dart';
+import 'package:logger/logger.dart';
+
+import 'support/connectivity_dev_observer_verify.dart';
+import 'support/seed42_observer_campaign.dart';
+
+/// Turn count for the late-game connectivity closure pin.
+const int kConnectivityClosureTurns = 60;
+
+const Set<String> kConnectivityClosureGreatPowerIds = {
+  'gp1',
+  'gp2',
+  'gp3',
+  'gp4',
+  'gp5',
+  'gp6',
+};
+
+void main() {
+  setUpAll(() {
+    CtLogger.level = Level.off;
+  });
+
+  test(
+    'seed 42 turn $kConnectivityClosureTurns: improved resource tiles '
+    'reachable over owned land are capital-connected (AC-F1)',
+    () {
+      final init = runInitGame(
+        config: GameSetupConfig(seed: 42),
+        options: const InitGameOptions(
+          cellSize: 24,
+          renderPng: false,
+          skipFillLakes: false,
+        ),
+      );
+      final topo = init.combinedTopology;
+      final tileMap = init.tileMapByRegion;
+
+      final campaign = runSeed42ObserverCampaign(
+        turns: kConnectivityClosureTurns,
+      );
+      final game = campaign.finalGame;
+
+      final allViolations = <String, List<String>>{};
+      for (final gpId in kConnectivityClosureGreatPowerIds) {
+        final violations = connectivityClosureViolations(
+          game: game,
+          playerId: gpId,
+          topology: topo,
+          tileMapByRegion: tileMap,
+        );
+        if (violations.isNotEmpty) {
+          allViolations[gpId] = violations;
+        }
+      }
+
+      expect(
+        allViolations,
+        isEmpty,
+        reason: 'connectivity closure violations at turn '
+            '$kConnectivityClosureTurns: $allViolations',
+      );
+    },
+    timeout: const Timeout(Duration(minutes: 5)),
+  );
+}

--- a/packages/colonizethis_ai/test/seed42_observer_connectivity_dev_heartland_baseline_test.dart
+++ b/packages/colonizethis_ai/test/seed42_observer_connectivity_dev_heartland_baseline_test.dart
@@ -1,0 +1,64 @@
+// Seed-42 heartland connectivity baseline pin (Refs #4176 AC-F3).
+//
+// Pins per-GP connected-tile counts after 10 resolved turns so connectivity-
+// aware civilian-work changes cannot silently regress early-game network growth.
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_test/test.dart';
+import 'package:logger/logger.dart';
+
+import 'support/connectivity_dev_observer_verify.dart';
+import 'support/seed42_observer_campaign.dart';
+
+const int kHeartlandBaselineTurns = 10;
+
+/// Connected-tile counts per GP after seed-42 turn [kHeartlandBaselineTurns].
+/// Captured on `dev` after PR #4178 merged (connectivity-aware civilian work).
+const Map<String, int> kSeed42Turn10ConnectedTileCounts = {
+  'gp1': 203,
+  'gp2': 202,
+  'gp3': 144,
+  'gp4': 207,
+  'gp5': 117,
+  'gp6': 169,
+};
+
+void main() {
+  setUpAll(() {
+    CtLogger.level = Level.off;
+  });
+
+  test(
+    'seed 42 turn $kHeartlandBaselineTurns: connected tile counts match '
+    'post-connectivity baseline (AC-F3)',
+    () {
+      final init = runInitGame(
+        config: GameSetupConfig(seed: 42),
+        options: const InitGameOptions(
+          cellSize: 24,
+          renderPng: false,
+          skipFillLakes: false,
+        ),
+      );
+      final topo = init.combinedTopology;
+      final tileMap = init.tileMapByRegion;
+
+      final campaign = runSeed42ObserverCampaign(turns: kHeartlandBaselineTurns);
+      final game = campaign.finalGame;
+
+      final actual = <String, int>{};
+      for (final gpId in kSeed42Turn10ConnectedTileCounts.keys) {
+        actual[gpId] = connectedTileCountForPlayer(
+          game: game,
+          playerId: gpId,
+          topology: topo,
+          tileMapByRegion: tileMap,
+        );
+      }
+
+      expect(actual, kSeed42Turn10ConnectedTileCounts);
+    },
+    timeout: const Timeout(Duration(minutes: 3)),
+  );
+}

--- a/packages/colonizethis_ai/test/support/connectivity_dev_observer_verify.dart
+++ b/packages/colonizethis_ai/test/support/connectivity_dev_observer_verify.dart
@@ -19,29 +19,39 @@ Iterable<String> improvedResourceTilesForPlayer(Game game, String playerId) sync
   for (final regionEntry in ws.tileKeysByRegionAndProvince.entries) {
     final regionId = regionEntry.key;
     for (final provinceEntry in regionEntry.value.entries) {
-      final localProvinceId = provinceEntry.key;
-      final fullProvinceId = ProvinceId.full(regionId, localProvinceId);
-      final provinceOwner = provinceOwnerById[fullProvinceId];
-      for (final tileKey in provinceEntry.value) {
-        if (seen.contains(tileKey)) continue;
-        if (!_playerControlsTile(
-          tileKey: tileKey,
-          playerId: playerId,
-          provinceOwner: provinceOwner,
-          purchasedBy: ws.purchasedTilesByTileKey[tileKey],
-        )) {
-          continue;
-        }
-        final resourceId = ws.resourceByTileKey[tileKey];
-        final level = ws.tileState.improvementLevel(tileKey);
-        if (resourceId != null &&
-            resourceId.isNotEmpty &&
-            level >= 1 &&
-            seen.add(tileKey)) {
-          yield tileKey;
-        }
-      }
+      final fullProvinceId = ProvinceId.full(regionId, provinceEntry.key);
+      yield* _improvedResourceTilesInProvince(
+        ws: ws,
+        playerId: playerId,
+        provinceOwner: provinceOwnerById[fullProvinceId],
+        tileKeys: provinceEntry.value,
+        seen: seen,
+      );
     }
+  }
+}
+
+Iterable<String> _improvedResourceTilesInProvince({
+  required WorldState ws,
+  required String playerId,
+  required String? provinceOwner,
+  required Iterable<String> tileKeys,
+  required Set<String> seen,
+}) sync* {
+  for (final tileKey in tileKeys) {
+    if (seen.contains(tileKey)) continue;
+    if (!_playerControlsTile(
+      tileKey: tileKey,
+      playerId: playerId,
+      provinceOwner: provinceOwner,
+      purchasedBy: ws.purchasedTilesByTileKey[tileKey],
+    )) {
+      continue;
+    }
+    final resourceId = ws.resourceByTileKey[tileKey];
+    final level = ws.tileState.improvementLevel(tileKey);
+    if (resourceId == null || resourceId.isEmpty || level < 1) continue;
+    if (seen.add(tileKey)) yield tileKey;
   }
 }
 

--- a/packages/colonizethis_ai/test/support/connectivity_dev_observer_verify.dart
+++ b/packages/colonizethis_ai/test/support/connectivity_dev_observer_verify.dart
@@ -1,0 +1,175 @@
+/// Observer-game verification helpers for connectivity-aware civilian work
+/// (Refs #4176 AC-F1, AC-F3).
+library;
+
+import 'dart:collection';
+
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+/// Improved resource tiles controlled by [playerId] (owned province or purchase).
+Iterable<String> improvedResourceTilesForPlayer(Game game, String playerId) sync* {
+  final ws = game.worldState;
+  final provinceOwnerById = <String, String?>{
+    for (final p in ws.oldWorld.provinces) p.id: p.ownerId,
+    for (final p in ws.newWorld.provinces) p.id: p.ownerId,
+  };
+  final seen = <String>{};
+  for (final regionEntry in ws.tileKeysByRegionAndProvince.entries) {
+    final regionId = regionEntry.key;
+    for (final provinceEntry in regionEntry.value.entries) {
+      final localProvinceId = provinceEntry.key;
+      final fullProvinceId = ProvinceId.full(regionId, localProvinceId);
+      final provinceOwner = provinceOwnerById[fullProvinceId];
+      for (final tileKey in provinceEntry.value) {
+        if (seen.contains(tileKey)) continue;
+        if (!_playerControlsTile(
+          tileKey: tileKey,
+          playerId: playerId,
+          provinceOwner: provinceOwner,
+          purchasedBy: ws.purchasedTilesByTileKey[tileKey],
+        )) {
+          continue;
+        }
+        final resourceId = ws.resourceByTileKey[tileKey];
+        final level = ws.tileState.improvementLevel(tileKey);
+        if (resourceId != null &&
+            resourceId.isNotEmpty &&
+            level >= 1 &&
+            seen.add(tileKey)) {
+          yield tileKey;
+        }
+      }
+    }
+  }
+}
+
+bool _playerControlsTile({
+  required String tileKey,
+  required String playerId,
+  required String? provinceOwner,
+  required String? purchasedBy,
+}) {
+  if (purchasedBy == playerId) return true;
+  if (provinceOwner == playerId && purchasedBy == null) return true;
+  return false;
+}
+
+Set<String> _ownedLandTilesForPlayer(Game game, String playerId) {
+  final ownedProvinceIds = <String>{};
+  for (final province in game.worldState.oldWorld.provinces) {
+    if (province.ownerId == playerId) ownedProvinceIds.add(province.id);
+  }
+  for (final province in game.worldState.newWorld.provinces) {
+    if (province.ownerId == playerId) ownedProvinceIds.add(province.id);
+  }
+  final purchased =
+      game.worldState.purchasedTilesByTileKey.keys.toSet();
+  final out = <String>{};
+  for (final regionEntry
+      in game.worldState.tileKeysByRegionAndProvince.entries) {
+    final regionId = regionEntry.key;
+    for (final provinceEntry in regionEntry.value.entries) {
+      final fullProvinceId =
+          ProvinceId.full(regionId, provinceEntry.key);
+      if (!ownedProvinceIds.contains(fullProvinceId)) continue;
+      out.addAll(provinceEntry.value);
+    }
+  }
+  out.addAll(purchased);
+  return out;
+}
+
+Set<String> _reachableOverOwnedLandFromNetwork({
+  required Set<String> connected,
+  required Set<String> ownedLandTiles,
+  required Map<String, TileMapResult> tileMapByRegion,
+  required Set<String> landProvinceIds,
+}) {
+  final reached = Set<String>.from(connected);
+  final queue = Queue<String>.from(connected);
+  while (queue.isNotEmpty) {
+    final current = queue.removeFirst();
+    for (final neighbor in _cardinalNeighbors(
+      current,
+      tileMapByRegion: tileMapByRegion,
+      landProvinceIds: landProvinceIds,
+    )) {
+      if (!ownedLandTiles.contains(neighbor)) continue;
+      if (reached.add(neighbor)) queue.add(neighbor);
+    }
+  }
+  return reached;
+}
+
+List<String> _cardinalNeighbors(
+  String tileKey, {
+  required Map<String, TileMapResult> tileMapByRegion,
+  required Set<String> landProvinceIds,
+}) {
+  final coords = parseTileKeyCoordinates(tileKey);
+  if (coords == null || coords.x < 0 || coords.y < 0) return const [];
+  final map = tileMapByRegion[coords.regionId];
+  if (map == null) return const [];
+  final out = <String>[];
+  for (final d in kGridNeighborsCardinal4) {
+    final nx = coords.x + d.$1;
+    final ny = coords.y + d.$2;
+    if (nx < 0 || nx >= map.width || ny < 0 || ny >= map.height) continue;
+    final cellId = map.cell(nx, ny);
+    final fullProvinceId = '${coords.regionId}|$cellId';
+    if (!landProvinceIds.contains(cellId) &&
+        !landProvinceIds.contains(fullProvinceId)) {
+      continue;
+    }
+    out.add(CapitalTile.tileKey(coords.regionId, fullProvinceId, nx, ny));
+  }
+  return out;
+}
+
+/// Improved resource tiles that are reachable over owned land from the
+/// capital-connected network but not yet in [connected] (Refs #4176 AC-F1).
+List<String> connectivityClosureViolations({
+  required Game game,
+  required String playerId,
+  required MapTopology topology,
+  required Map<String, TileMapResult> tileMapByRegion,
+}) {
+  final connectivity = resolveConnectivity(
+    game: game,
+    tileMapByRegion: tileMapByRegion,
+    topology: topology,
+  );
+  final connected = connectivity[playerId]?.connected ?? const {};
+  final ownedLand = _ownedLandTilesForPlayer(game, playerId);
+  final landProvinceIds = provinceNodeIds(topology);
+  final reachable = _reachableOverOwnedLandFromNetwork(
+    connected: connected,
+    ownedLandTiles: ownedLand,
+    tileMapByRegion: tileMapByRegion,
+    landProvinceIds: landProvinceIds,
+  );
+  final violations = <String>[];
+  for (final tileKey in improvedResourceTilesForPlayer(game, playerId)) {
+    if (connected.contains(tileKey)) continue;
+    if (!reachable.contains(tileKey)) continue;
+    violations.add(tileKey);
+  }
+  return violations;
+}
+
+/// Count of capital-connected tiles for [playerId] after extraction connectivity.
+int connectedTileCountForPlayer({
+  required Game game,
+  required String playerId,
+  required MapTopology topology,
+  required Map<String, TileMapResult> tileMapByRegion,
+}) {
+  final connectivity = resolveConnectivity(
+    game: game,
+    tileMapByRegion: tileMapByRegion,
+    topology: topology,
+  );
+  return connectivity[playerId]?.connected.length ?? 0;
+}

--- a/packages/colonizethis_ai_contracts/test/full_ai_civilian_work_connectivity_selection_test.dart
+++ b/packages/colonizethis_ai_contracts/test/full_ai_civilian_work_connectivity_selection_test.dart
@@ -42,6 +42,53 @@ void main() {
     adjacentToConnectedTiles: {roadTile},
   );
 
+  test('AC-C2 never hard-forbids unconnected improve when only far tiles', () {
+    const farTile = 'oldWorld|p1|f';
+    final game = Game(
+      id: 'g',
+      worldState: WorldState(
+        turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+        oldWorld: const RegionData(),
+        newWorld: const RegionData(),
+        resourceByTileKey: {farTile: 'grain'},
+      ),
+      players: [
+        Player(
+          id: playerId,
+          displayName: 'GP',
+          isHuman: false,
+          capitalProvinceId: 'oldWorld|p1',
+        ),
+      ],
+    );
+    final snapshot = ConnectivityDevSnapshot(
+      connected: {'oldWorld|p1|c'},
+      pathTransportCap: const {},
+      extensionDistanceByTile: const {},
+      seaZonesReachableFromCapital: const {},
+      provincesWithUnconnectedDevTargets: {farTile},
+      hasUnconnectedDevTargets: true,
+      frontierExtensionTiles: const {},
+      bottleneckRailTiles: const {},
+      adjacentToConnectedTiles: const {},
+    );
+    final selected = bestBuildImprovementRow(
+      [
+        WorkOrder(
+          unitId: 'b1',
+          target: kWorkTargetBuildImprovement,
+          targetTileKey: farTile,
+        ),
+      ],
+      game,
+      playerId: playerId,
+      connectivityDev: snapshot,
+    );
+    expect(selected, isNotNull);
+    expect(selected!.target, kWorkTargetBuildImprovement);
+    expect(selected.targetTileKey, farTile);
+  });
+
   test('AC-E1 frontier road beats fort when unconnected targets exist', () {
     final workOrders = <WorkOrder>[];
     final idleEvents = <FullAiCivilianWorkIdle>[];
@@ -72,6 +119,65 @@ void main() {
     );
     expect(workOrders.single.target, kWorkTargetBuildRoad);
     expect(workOrders.single.targetTileKey, roadTile);
+  });
+
+  test('AC-E2 legacy Engineer ordering when nothing to connect', () {
+    final idleSnapshot = ConnectivityDevSnapshot(
+      connected: {'oldWorld|p1|0|0', roadTile},
+      pathTransportCap: const {},
+      extensionDistanceByTile: const {},
+      seaZonesReachableFromCapital: const {},
+      provincesWithUnconnectedDevTargets: const {},
+      hasUnconnectedDevTargets: false,
+      frontierExtensionTiles: const {},
+      bottleneckRailTiles: const {},
+      adjacentToConnectedTiles: const {},
+    );
+    final workOrdersWithSnapshot = <WorkOrder>[];
+    final workOrdersWithout = <WorkOrder>[];
+    final idleA = <FullAiCivilianWorkIdle>[];
+    final idleB = <FullAiCivilianWorkIdle>[];
+    final candidates = [
+      WorkOrder(
+        unitId: 'e1',
+        target: kWorkTargetBuildFort,
+        targetTileKey: fortTile,
+      ),
+      WorkOrder(
+        unitId: 'e1',
+        target: kWorkTargetBuildRoad,
+        targetTileKey: roadTile,
+      ),
+    ];
+    appendEngineerPathResult(
+      unit: Unit(
+        id: 'e1',
+        type: kUnitTypeEngineer,
+        ownerId: playerId,
+        locationProvinceId: 'oldWorld|p1',
+      ),
+      w: candidates,
+      game: game,
+      playerId: playerId,
+      workOrders: workOrdersWithSnapshot,
+      idleEvents: idleA,
+      connectivityDev: idleSnapshot,
+    );
+    appendEngineerPathResult(
+      unit: Unit(
+        id: 'e1',
+        type: kUnitTypeEngineer,
+        ownerId: playerId,
+        locationProvinceId: 'oldWorld|p1',
+      ),
+      w: candidates,
+      game: game,
+      playerId: playerId,
+      workOrders: workOrdersWithout,
+      idleEvents: idleB,
+      connectivityDev: null,
+    );
+    expect(workOrdersWithSnapshot.single, workOrdersWithout.single);
   });
 
   test('AC-C4 selection mirror prefers connected > adjacent > far', () {

--- a/packages/colonizethis_orders/test/orders/connectivity_dev_determinism_test.dart
+++ b/packages/colonizethis_orders/test/orders/connectivity_dev_determinism_test.dart
@@ -1,0 +1,71 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_orders/src/orders/order_suggestion_work.dart';
+import 'package:colonizethis_test/test.dart';
+
+import 'support/suggestion/order_suggestion_work_feedstock_priority_fixtures.dart';
+
+/// Determinism pin for connectivity-aware work suggestions (Refs #4176 AC-F4).
+void main() {
+  test('suggestWorkOrders is byte-identical across two passes (AC-F4)', () {
+    final game = feedstockPriorityGame();
+    final topology = feedstockPriorityTopology(game);
+    final view = buildPlayerView(game, topology, feedstockPrioritySupplierId);
+    final tileMapByRegion = <String, TileMapResult>{
+      for (final regionEntry
+          in game.worldState.tileKeysByRegionAndProvince.entries)
+        regionEntry.key: _tileMapForRegion(regionEntry.key, regionEntry.value),
+    };
+
+    final first = suggestWorkOrders(
+      view,
+      game,
+      topology,
+      const Orders(),
+      tileMapByRegion: tileMapByRegion,
+    );
+    final second = suggestWorkOrders(
+      view,
+      game,
+      topology,
+      const Orders(),
+      tileMapByRegion: tileMapByRegion,
+    );
+
+    expect(
+      second.map((o) => (o.unitId, o.target, o.targetTileKey)).toList(),
+      first.map((o) => (o.unitId, o.target, o.targetTileKey)).toList(),
+    );
+  });
+}
+
+TileMapResult _tileMapForRegion(
+  String regionId,
+  Map<String, List<String>> provinces,
+) {
+  var maxX = 0;
+  var maxY = 0;
+  for (final tiles in provinces.values) {
+    for (final tileKey in tiles) {
+      final coords = parseTileKeyCoordinates(tileKey);
+      if (coords == null) continue;
+      if (coords.x > maxX) maxX = coords.x;
+      if (coords.y > maxY) maxY = coords.y;
+    }
+  }
+  final w = maxX + 1;
+  final h = maxY + 1;
+  final grid = List.generate(
+    h,
+    (_) => List.filled(w, provinces.keys.first),
+  );
+  for (final provinceEntry in provinces.entries) {
+    for (final tileKey in provinceEntry.value) {
+      final coords = parseTileKeyCoordinates(tileKey);
+      if (coords == null) continue;
+      grid[coords.y][coords.x] = provinceEntry.key;
+    }
+  }
+  return TileMapResult(width: w, height: h, grid: grid);
+}

--- a/packages/colonizethis_orders/test/orders/connectivity_dev_determinism_test.dart
+++ b/packages/colonizethis_orders/test/orders/connectivity_dev_determinism_test.dart
@@ -4,40 +4,44 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_orders/src/orders/order_suggestion_work.dart';
 import 'package:colonizethis_test/test.dart';
 
+import 'support/scenario_runner.dart';
 import 'support/suggestion/order_suggestion_work_feedstock_priority_fixtures.dart';
 
 /// Determinism pin for connectivity-aware work suggestions (Refs #4176 AC-F4).
 void main() {
-  test('suggestWorkOrders is byte-identical across two passes (AC-F4)', () {
-    final game = feedstockPriorityGame();
-    final topology = feedstockPriorityTopology(game);
-    final view = buildPlayerView(game, topology, feedstockPrioritySupplierId);
-    final tileMapByRegion = <String, TileMapResult>{
-      for (final regionEntry
-          in game.worldState.tileKeysByRegionAndProvince.entries)
-        regionEntry.key: _tileMapForRegion(regionEntry.key, regionEntry.value),
-    };
+  runLabeledScenarioGroup('suggestWorkOrders determinism (AC-F4)', [
+    rs('byte-identical across two passes', () {
+      final game = feedstockPriorityGame();
+      final topology = feedstockPriorityTopology(game);
+      final view = buildPlayerView(game, topology, feedstockPrioritySupplierId);
+      final tileMapByRegion = <String, TileMapResult>{
+        for (final regionEntry
+            in game.worldState.tileKeysByRegionAndProvince.entries)
+          regionEntry.key:
+              _tileMapForRegion(regionEntry.key, regionEntry.value),
+      };
 
-    final first = suggestWorkOrders(
-      view,
-      game,
-      topology,
-      const Orders(),
-      tileMapByRegion: tileMapByRegion,
-    );
-    final second = suggestWorkOrders(
-      view,
-      game,
-      topology,
-      const Orders(),
-      tileMapByRegion: tileMapByRegion,
-    );
+      final first = suggestWorkOrders(
+        view,
+        game,
+        topology,
+        const Orders(),
+        tileMapByRegion: tileMapByRegion,
+      );
+      final second = suggestWorkOrders(
+        view,
+        game,
+        topology,
+        const Orders(),
+        tileMapByRegion: tileMapByRegion,
+      );
 
-    expect(
-      second.map((o) => (o.unitId, o.target, o.targetTileKey)).toList(),
-      first.map((o) => (o.unitId, o.target, o.targetTileKey)).toList(),
-    );
-  });
+      expect(
+        second.map((o) => (o.unitId, o.target, o.targetTileKey)).toList(),
+        first.map((o) => (o.unitId, o.target, o.targetTileKey)).toList(),
+      );
+    }),
+  ], runRunnableScenario);
 }
 
 TileMapResult _tileMapForRegion(

--- a/packages/colonizethis_orders/test/orders/connectivity_dev_snapshot_test.dart
+++ b/packages/colonizethis_orders/test/orders/connectivity_dev_snapshot_test.dart
@@ -181,4 +181,28 @@ void main() {
       },
     ),
   ], runRunnableScenario);
+
+  runLabeledScenarioGroup('Town-rule awareness (AC-F7)', [
+    rs('town-connected resource tile is not a frontier extension target', () {
+      const townResourceTile = 'oldWorld|p1|2|2';
+      const frontierTile = 'oldWorld|p1|3|2';
+      final snapshot = ConnectivityDevSnapshot(
+        connected: {townResourceTile, 'oldWorld|p1|0|0'},
+        pathTransportCap: const {},
+        extensionDistanceByTile: const {frontierTile: 1},
+        seaZonesReachableFromCapital: const {},
+        provincesWithUnconnectedDevTargets: const {'oldWorld|p1'},
+        hasUnconnectedDevTargets: true,
+        frontierExtensionTiles: {frontierTile},
+        bottleneckRailTiles: const {},
+        adjacentToConnectedTiles: {frontierTile},
+      );
+      expect(snapshot.frontierExtensionTiles, isNot(contains(townResourceTile)));
+      final ordered = prioritizeBuildRoadCandidatesByConnectivity(
+        snapshot: snapshot,
+        sortedVisible: [townResourceTile, frontierTile],
+      );
+      expect(ordered.first, frontierTile);
+    }),
+  ], runRunnableScenario);
 }

--- a/packages/colonizethis_orders/test/orders/connectivity_dev_suggestion_parity_test.dart
+++ b/packages/colonizethis_orders/test/orders/connectivity_dev_suggestion_parity_test.dart
@@ -1,0 +1,134 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_orders/src/orders/connectivity_dev_snapshot.dart';
+import 'package:colonizethis_orders/src/orders/connectivity_dev_targets.dart';
+import 'package:colonizethis_orders/src/orders/order_suggestion_work.dart';
+import 'package:colonizethis_orders/src/orders/order_work_constants.dart';
+import 'package:colonizethis_test/test.dart';
+
+/// Human suggestion parity pin (Refs #4176 AC-F6).
+void main() {
+  test(
+    'suggestWorkOrders applies connectivity ordering for build_improvement',
+    () {
+      const ow = 'oldWorld';
+      const p1 = '$ow|p1';
+      const playerId = 'gp1';
+      const capTile = '$p1|2|2';
+      const connectedGrain = '$p1|0|0';
+      const farGrain = '$p1|4|0';
+      const grid = [
+        ['p1', 'p1', 'p1', 'p1', 'p1'],
+        ['p1', 'p1', 'p1', 'p1', 'p1'],
+        ['p1', 'p1', 'p1', 'p1', 'p1'],
+        ['p1', 'p1', 'p1', 'p1', 'p1'],
+        ['p1', 'p1', 'p1', 'p1', 'p1'],
+      ];
+      final tileMap = TileMapResult(
+        width: grid.first.length,
+        height: grid.length,
+        grid: grid,
+      );
+      const topology = MapTopology(
+        nodes: [
+          TopologyNode(
+            id: p1,
+            regionId: ow,
+            type: TopologyNodeType.province,
+          ),
+        ],
+        edges: [],
+      );
+      final tileState = TileMapState(
+        improvementByTile: const {connectedGrain: 0, farGrain: 0},
+        roadLevelByTile: {
+          capTile: 1,
+          '$p1|2|1': 1,
+          '$p1|1|1': 1,
+          '$p1|1|0': 1,
+          connectedGrain: 1,
+        },
+      );
+      final tiles = <String>[
+        for (var y = 0; y < 5; y++)
+          for (var x = 0; x < 5; x++) '$p1|$x|$y',
+      ];
+      final game = Game(
+        id: 'g',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: RegionData(
+            provinces: [Province(id: p1, regionId: ow, ownerId: playerId)],
+            units: [
+              Unit(
+                id: 'b1',
+                type: kUnitTypeBuilder,
+                ownerId: playerId,
+                locationProvinceId: p1,
+                tileKey: capTile,
+              ),
+            ],
+          ),
+          newWorld: const RegionData(),
+          tileKeysByRegionAndProvince: {ow: {p1: tiles}},
+          resourceByTileKey: {connectedGrain: 'grain', farGrain: 'grain'},
+          tileState: tileState,
+          playerVisibilityByTile: {
+            playerId: {for (final t in tiles) t: 'fullyVisible'},
+          },
+        ),
+        players: [
+          Player(
+            id: playerId,
+            displayName: 'Human',
+            isHuman: true,
+            capitalProvinceId: p1,
+            capitalTile: CapitalTile(
+              regionId: ow,
+              provinceId: p1,
+              x: 2,
+              y: 2,
+            ),
+            stockpile: const Stockpile(
+              quantities: {'lumber': 20, 'castIron': 20},
+            ),
+          ),
+        ],
+      );
+      final tileMapByRegion = {ow: tileMap};
+      final view = buildPlayerView(game, topology, playerId);
+      final snapshot = buildConnectivityDevSnapshot(
+        game: game,
+        playerId: playerId,
+        topology: topology,
+        tileMapByRegion: tileMapByRegion,
+      );
+      expect(snapshot, isNotNull);
+      expect(snapshot!.connected, contains(connectedGrain));
+      expect(snapshot.connected, isNot(contains(farGrain)));
+
+      final rawSorted = [farGrain, connectedGrain]..sort();
+      final expectedOrder = prioritizeBuildImprovementCandidatesByConnectivity(
+        snapshot: snapshot,
+        sortedVisible: rawSorted,
+      );
+      expect(expectedOrder.first, connectedGrain);
+
+      final suggestions = suggestWorkOrders(
+        view,
+        game,
+        topology,
+        const Orders(),
+        tileMapByRegion: tileMapByRegion,
+      );
+      final improve = suggestions
+          .where(
+            (o) => o.unitId == 'b1' && o.target == kWorkTargetBuildImprovement,
+          )
+          .toList();
+      expect(improve, hasLength(1));
+      expect(improve.single.targetTileKey, connectedGrain);
+    },
+  );
+}

--- a/tool/check_ai_test_mirrors_lib.dart
+++ b/tool/check_ai_test_mirrors_lib.dart
@@ -43,6 +43,8 @@ const Set<String> aiTestMirrorsLibAllowlist = <String>{
   'seed42_observer_colonial_c0_diagnostic_test.dart',
   'seed42_observer_colonial_phase_entry_budget_test.dart',
   'seed42_observer_colonial_regression_test.dart',
+  'seed42_observer_connectivity_dev_closure_test.dart',
+  'seed42_observer_connectivity_dev_heartland_baseline_test.dart',
   'seed42_observer_conquest_regression_test.dart',
   'seed42_observer_conquest_s7d_conquest_geography_diagnostic_test.dart',
   'seed42_observer_conquest_s7d_diagnostic_test.dart',


### PR DESCRIPTION
## Summary
- Adds observer verification helpers and seed-42 integration tests for connectivity closure (AC-F1 at turn 60) and heartland connected-tile baseline (AC-F3 at turn 10).
- Adds selection-layer pins for AC-C2 (never hard-forbid unconnected improve) and AC-E2 (legacy Engineer ordering when nothing to connect).
- Adds orders-package pins for AC-F4 (suggestWorkOrders determinism) and AC-F7 (Town-rule: town-connected resources are not frontier road targets).

## Done in this PR
- AC-F1, AC-F3, AC-F4, AC-F7, AC-C2, AC-E2

## Deferred
- AC-A1, AC-A6, AC-D3 (multi-turn crafted scenarios)
- AC-F2 (reconquest reconnection), AC-F5 (15s budget perf harness), AC-F6 (human suggestion parity integration fixture)

## Manual
N/A — test-only follow-up to AI-internal behavior from PR #4178.

## Test plan
- [x] `cd packages/colonizethis_orders && dart test test/orders/connectivity_dev_determinism_test.dart test/orders/connectivity_dev_snapshot_test.dart`
- [x] `cd packages/colonizethis_ai_contracts && dart test test/full_ai_civilian_work_connectivity_selection_test.dart`
- [x] `cd packages/colonizethis_ai && dart test test/seed42_observer_connectivity_dev_heartland_baseline_test.dart`
- [x] `cd packages/colonizethis_ai && dart test test/seed42_observer_connectivity_dev_closure_test.dart`

Refs #4176

Made with [Cursor](https://cursor.com)