### PR TITLE
test: multi-turn connectivity dev ACs and late-turn budget (#4176)

### DIFF
--- a/packages/colonizethis_ai/test/connectivity_dev_multi_turn_chain_test.dart
+++ b/packages/colonizethis_ai/test/connectivity_dev_multi_turn_chain_test.dart
@@ -1,0 +1,84 @@
+// Multi-turn connectivity-aware civilian-work chain pins (Refs #4176 AC-A1, AC-A6).
+import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_test/test.dart';
+import 'package:logger/logger.dart';
+
+import 'support/connectivity_dev_chain_fixture.dart';
+import 'support/connectivity_dev_multi_turn_harness.dart';
+
+void main() {
+  setUpAll(() {
+    CtLogger.level = Level.off;
+  });
+
+  test(
+    'AC-A1 Engineer extends road frontier each turn until isolated resource '
+    'connects',
+    () {
+      final scenario = ConnectivityDevChainFixture.threeTileGap();
+      var game = scenario.game;
+      for (var turn = 0; turn < 3; turn++) {
+        final selection = selectConnectivityDevCivilianWork(
+          game: game,
+          topology: scenario.topology,
+          tileMapByRegion: scenario.tileMapByRegion,
+          playerId: kConnectivityDevChainPlayerId,
+        );
+        final road = engineerBuildRoadOrder(selection);
+        expect(road, isNotNull);
+        expect(
+          road!.targetTileKey,
+          scenario.expectedFrontierRoadTiles[turn],
+        );
+        game = resolveConnectivityDevSelectionTurn(
+          game: game,
+          topology: scenario.topology,
+          tileMapByRegion: scenario.tileMapByRegion,
+          playerId: kConnectivityDevChainPlayerId,
+        );
+      }
+      final connected = connectedTilesForPlayer(
+        game: game,
+        playerId: kConnectivityDevChainPlayerId,
+        topology: scenario.topology,
+        tileMapByRegion: scenario.tileMapByRegion,
+      );
+      expect(connected, contains(scenario.resourceTiles.single));
+    },
+  );
+
+  test(
+    'AC-A6 nearer improved resource connects before farther resource',
+    () {
+      final scenario = ConnectivityDevChainFixture.dualResourceSequencing();
+      final nearResource = scenario.resourceTiles.first;
+      final farResource = scenario.resourceTiles.last;
+      var game = scenario.game;
+      var nearConnectedTurn = -1;
+      var farConnectedTurn = -1;
+      for (var turn = 0; turn < 8; turn++) {
+        final connected = connectedTilesForPlayer(
+          game: game,
+          playerId: kConnectivityDevChainPlayerId,
+          topology: scenario.topology,
+          tileMapByRegion: scenario.tileMapByRegion,
+        );
+        if (nearConnectedTurn < 0 && connected.contains(nearResource)) {
+          nearConnectedTurn = turn;
+        }
+        if (farConnectedTurn < 0 && connected.contains(farResource)) {
+          farConnectedTurn = turn;
+        }
+        if (nearConnectedTurn >= 0 && farConnectedTurn >= 0) break;
+        game = resolveConnectivityDevSelectionTurn(
+          game: game,
+          topology: scenario.topology,
+          tileMapByRegion: scenario.tileMapByRegion,
+          playerId: kConnectivityDevChainPlayerId,
+        );
+      }
+      expect(nearConnectedTurn, greaterThanOrEqualTo(0));
+      expect(farConnectedTurn, greaterThan(nearConnectedTurn));
+    },
+  );
+}

--- a/packages/colonizethis_ai/test/connectivity_dev_overseas_port_test.dart
+++ b/packages/colonizethis_ai/test/connectivity_dev_overseas_port_test.dart
@@ -1,0 +1,81 @@
+// Overseas port linkage end-to-end pin (Refs #4176 AC-D3).
+import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_orders/src/orders/order_work_constants.dart';
+import 'package:colonizethis_test/test.dart';
+import 'package:logger/logger.dart';
+
+import 'support/connectivity_dev_multi_turn_harness.dart';
+import 'support/connectivity_dev_overseas_fixture.dart';
+
+void main() {
+  setUpAll(() {
+    CtLogger.level = Level.off;
+  });
+
+  test(
+    'AC-D3 Engineer builds overseas port then in-province roads connect '
+    'improved resource',
+    () {
+      final scenario = ConnectivityDevOverseasFixture.overseasPortLinkage();
+      final resourceTile = scenario.resourceTile;
+      var game = scenario.game;
+      var sawPortOrder = false;
+
+      final startConnected = connectedTilesForPlayer(
+        game: game,
+        playerId: kConnectivityDevOverseasPlayerId,
+        topology: scenario.topology,
+        tileMapByRegion: scenario.tileMapByRegion,
+      );
+      expect(startConnected, isNot(contains(resourceTile)));
+
+      for (var turn = 0; turn < 8; turn++) {
+        final connected = connectedTilesForPlayer(
+          game: game,
+          playerId: kConnectivityDevOverseasPlayerId,
+          topology: scenario.topology,
+          tileMapByRegion: scenario.tileMapByRegion,
+        );
+        if (connected.contains(resourceTile)) {
+          expect(sawPortOrder, isTrue, reason: 'resource connected without port');
+          return;
+        }
+
+        final selection = selectConnectivityDevCivilianWork(
+          game: game,
+          topology: scenario.topology,
+          tileMapByRegion: scenario.tileMapByRegion,
+          playerId: kConnectivityDevOverseasPlayerId,
+        );
+        final portOrder = engineerWorkOrderForTarget(
+          selection,
+          kWorkTargetBuildPort,
+          engineerId: kConnectivityDevOverseasEngineerId,
+        );
+        if (portOrder != null) {
+          expect(portOrder.targetTileKey, scenario.portTile);
+          sawPortOrder = true;
+        }
+
+        game = resolveConnectivityDevSelectionTurn(
+          game: game,
+          topology: scenario.topology,
+          tileMapByRegion: scenario.tileMapByRegion,
+          playerId: kConnectivityDevOverseasPlayerId,
+        );
+      }
+
+      final finalConnected = connectedTilesForPlayer(
+        game: game,
+        playerId: kConnectivityDevOverseasPlayerId,
+        topology: scenario.topology,
+        tileMapByRegion: scenario.tileMapByRegion,
+      );
+      expect(
+        finalConnected,
+        contains(resourceTile),
+        reason: 'resource tile $resourceTile not connected after 8 turns',
+      );
+    },
+  );
+}

--- a/packages/colonizethis_ai/test/connectivity_dev_reconquest_test.dart
+++ b/packages/colonizethis_ai/test/connectivity_dev_reconquest_test.dart
@@ -1,0 +1,48 @@
+// Reconquest reconnection pin for connectivity-aware civilian work (Refs #4176 AC-F2).
+import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_test/test.dart';
+import 'package:logger/logger.dart';
+
+import 'support/connectivity_dev_chain_fixture.dart';
+import 'support/connectivity_dev_multi_turn_harness.dart';
+
+void main() {
+  setUpAll(() {
+    CtLogger.level = Level.off;
+  });
+
+  test(
+    'AC-F2 Engineer extends network to reconnect pre-built improvements',
+    () {
+      final scenario = ConnectivityDevChainFixture.reconquestImprovements();
+      final resourceTile = scenario.resourceTiles.single;
+      var game = scenario.game;
+      final startConnected = connectedTilesForPlayer(
+        game: game,
+        playerId: kConnectivityDevChainPlayerId,
+        topology: scenario.topology,
+        tileMapByRegion: scenario.tileMapByRegion,
+      );
+      expect(startConnected, isNot(contains(resourceTile)));
+
+      for (var turn = 0; turn < 4; turn++) {
+        final connected = connectedTilesForPlayer(
+          game: game,
+          playerId: kConnectivityDevChainPlayerId,
+          topology: scenario.topology,
+          tileMapByRegion: scenario.tileMapByRegion,
+        );
+        if (connected.contains(resourceTile)) {
+          return;
+        }
+        game = resolveConnectivityDevSelectionTurn(
+          game: game,
+          topology: scenario.topology,
+          tileMapByRegion: scenario.tileMapByRegion,
+          playerId: kConnectivityDevChainPlayerId,
+        );
+      }
+      fail('resource tile $resourceTile never reconnected within 4 turns');
+    },
+  );
+}

--- a/packages/colonizethis_ai/test/perf/connectivity_dev_late_turn_wall_clock_budget_test.dart
+++ b/packages/colonizethis_ai/test/perf/connectivity_dev_late_turn_wall_clock_budget_test.dart
@@ -1,0 +1,89 @@
+// Late-turn Full AI wall-clock budget with connectivity-aware civilian work
+// (Refs #4176 AC-F5).
+import 'package:colonizethis_ai/colonizethis_ai.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+import 'package:logger/logger.dart';
+
+import '../support/seed42_observer_campaign.dart';
+
+const int kConnectivityDevBudgetProbeTurn = 60;
+
+void main() {
+  setUpAll(() {
+    CtLogger.level = Level.off;
+  });
+
+  suppressLogsForTests();
+
+  group('connectivity dev late-turn wall-clock budget (Refs #4176 AC-F5)', () {
+    test(
+      'seed 42 turn $kConnectivityDevBudgetProbeTurn Full AI + resolve stays '
+      'within kTurnProcessingWallClockBudgetMs',
+      () {
+        final init = runInitGame(
+          config: GameSetupConfig(seed: 42),
+          options: const InitGameOptions(
+            cellSize: 24,
+            renderPng: false,
+            skipFillLakes: false,
+          ),
+        );
+        final topology = init.combinedTopology;
+        final tileMapByRegion = init.tileMapByRegion;
+        final campaign = runSeed42ObserverCampaign(
+          turns: kConnectivityDevBudgetProbeTurn - 1,
+        );
+        final game = campaign.finalGame;
+
+        final total = Stopwatch()..start();
+        final fullAiSw = Stopwatch()..start();
+        final fullAi = generateOrdersForGameFullAI(
+          game,
+          topology,
+          tileMapByRegion: tileMapByRegion,
+        );
+        fullAiSw.stop();
+
+        final mergedOrders = mergeOrderLists(
+          humanOrders: const Orders(),
+          aiOrders: fullAi.orders,
+        );
+        final defaultAssignmentsByPlayerId =
+            fullAi.economyPlansByPlayerId.map(
+          (pid, plan) => MapEntry(pid, plan.productionAssignments),
+        );
+
+        final resolveSw = Stopwatch()..start();
+        final result = validateOrdersAndResolveTurnFromTrustedOrders(
+          game: fullAi.game,
+          topology: topology,
+          orders: mergedOrders,
+          tileMapByRegion: tileMapByRegion,
+          defaultAssignmentsByPlayerId: defaultAssignmentsByPlayerId,
+        );
+        resolveSw.stop();
+        total.stop();
+
+        requireTurnResolutionComplete(result);
+
+        final fullAiMs = fullAiSw.elapsedMilliseconds;
+        final resolveMs = resolveSw.elapsedMilliseconds;
+        final totalMs = total.elapsedMilliseconds;
+
+        expect(
+          totalMs,
+          lessThanOrEqualTo(kTurnProcessingWallClockBudgetMs),
+          reason:
+              'turn $kConnectivityDevBudgetProbeTurn processing exceeded budget: '
+              'total_ms=$totalMs full_ai_ms=$fullAiMs resolve_ms=$resolveMs '
+              'budget_ms=$kTurnProcessingWallClockBudgetMs',
+        );
+      },
+      timeout: Timeout.none,
+    );
+  });
+}

--- a/packages/colonizethis_ai/test/support/connectivity_dev_chain_fixture.dart
+++ b/packages/colonizethis_ai/test/support/connectivity_dev_chain_fixture.dart
@@ -1,0 +1,306 @@
+/// Crafted connectivity chain scenarios for multi-turn civilian-work pins (Refs #4176).
+library;
+
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/game_test_fixtures.dart';
+
+const String kConnectivityDevChainOw = 'oldWorld';
+const String kConnectivityDevChainPlayerId = 'gp1';
+const String kConnectivityDevChainEngineerId = 'e1';
+
+/// Horizontal chain scenario: capital road at x=0, optional improved resources,
+/// idle Engineer, materials for repeated `build_road`.
+class ConnectivityDevChainFixture {
+  ConnectivityDevChainFixture._({
+    required this.game,
+    required this.topology,
+    required this.tileMapByRegion,
+    required this.resourceTiles,
+    required this.expectedFrontierRoadTiles,
+  });
+
+  final Game game;
+  final MapTopology topology;
+  final Map<String, TileMapResult> tileMapByRegion;
+  final List<String> resourceTiles;
+  final List<String> expectedFrontierRoadTiles;
+
+  static String tileKey(String provinceId, int x) => '$provinceId|$x|0';
+
+  /// AC-A1: improved resource three owned tiles beyond the capital network.
+  static ConnectivityDevChainFixture threeTileGap() {
+    const p1 = '$kConnectivityDevChainOw|p1';
+    const width = 5;
+    final grid = [
+      List.generate(width, (_) => 'p1'),
+    ];
+    final tileMap = TileMapResult(
+      width: width,
+      height: 1,
+      grid: grid,
+    );
+    final tiles = [for (var x = 0; x < width; x++) tileKey(p1, x)];
+    final capTile = tileKey(p1, 0);
+    final resourceTile = tileKey(p1, 4);
+    final visibility = {
+      for (final t in tiles) t: 'fullyVisible',
+    };
+    final game = TestFixtures.minimalGame(
+      players: [
+        Player(
+          id: kConnectivityDevChainPlayerId,
+          displayName: 'GP',
+          isHuman: false,
+          capitalProvinceId: p1,
+          capitalTile: CapitalTile(
+            regionId: kConnectivityDevChainOw,
+            provinceId: p1,
+            x: 0,
+            y: 0,
+          ),
+          stockpile: const Stockpile(
+            quantities: {'lumber': 50, 'castIron': 50},
+          ),
+        ),
+      ],
+      oldWorld: RegionData(
+        provinces: [
+          Province(
+            id: p1,
+            regionId: kConnectivityDevChainOw,
+            ownerId: kConnectivityDevChainPlayerId,
+          ),
+        ],
+        units: [
+          Unit(
+            id: kConnectivityDevChainEngineerId,
+            type: kUnitTypeEngineer,
+            ownerId: kConnectivityDevChainPlayerId,
+            locationProvinceId: p1,
+            tileKey: capTile,
+          ),
+        ],
+      ),
+      tileKeysByRegionAndProvince: {
+        kConnectivityDevChainOw: {
+          p1: tiles,
+        },
+      },
+      playerVisibilityByTile: {
+        kConnectivityDevChainPlayerId: visibility,
+      },
+      resourceByTileKey: {resourceTile: 'grain'},
+      tileState: TileMapState(
+        improvementByTile: {resourceTile: 1},
+        roadLevelByTile: {capTile: 1},
+      ),
+    );
+    const topology = MapTopology(
+      nodes: [
+        TopologyNode(
+          id: p1,
+          regionId: kConnectivityDevChainOw,
+          type: TopologyNodeType.province,
+        ),
+      ],
+      edges: [],
+    );
+    return ConnectivityDevChainFixture._(
+      game: game,
+      topology: topology,
+      tileMapByRegion: {kConnectivityDevChainOw: tileMap},
+      resourceTiles: [resourceTile],
+      expectedFrontierRoadTiles: [
+        tileKey(p1, 1),
+        tileKey(p1, 2),
+        tileKey(p1, 3),
+      ],
+    );
+  }
+
+  /// AC-A6: nearer improved resource at x=2, farther at x=4 on one province row.
+  static ConnectivityDevChainFixture dualResourceSequencing() {
+    const p1 = '$kConnectivityDevChainOw|p1';
+    const width = 5;
+    final grid = [
+      List.generate(width, (_) => 'p1'),
+    ];
+    final tileMap = TileMapResult(
+      width: width,
+      height: 1,
+      grid: grid,
+    );
+    final tiles = [for (var x = 0; x < width; x++) tileKey(p1, x)];
+    final capTile = tileKey(p1, 0);
+    final nearResource = tileKey(p1, 2);
+    final farResource = tileKey(p1, 4);
+    final visibility = {
+      for (final t in tiles) t: 'fullyVisible',
+    };
+    final game = TestFixtures.minimalGame(
+      players: [
+        Player(
+          id: kConnectivityDevChainPlayerId,
+          displayName: 'GP',
+          isHuman: false,
+          capitalProvinceId: p1,
+          capitalTile: CapitalTile(
+            regionId: kConnectivityDevChainOw,
+            provinceId: p1,
+            x: 0,
+            y: 0,
+          ),
+          stockpile: const Stockpile(
+            quantities: {'lumber': 80, 'castIron': 80},
+          ),
+        ),
+      ],
+      oldWorld: RegionData(
+        provinces: [
+          Province(
+            id: p1,
+            regionId: kConnectivityDevChainOw,
+            ownerId: kConnectivityDevChainPlayerId,
+          ),
+        ],
+        units: [
+          Unit(
+            id: kConnectivityDevChainEngineerId,
+            type: kUnitTypeEngineer,
+            ownerId: kConnectivityDevChainPlayerId,
+            locationProvinceId: p1,
+            tileKey: capTile,
+          ),
+        ],
+      ),
+      tileKeysByRegionAndProvince: {
+        kConnectivityDevChainOw: {
+          p1: tiles,
+        },
+      },
+      playerVisibilityByTile: {
+        kConnectivityDevChainPlayerId: visibility,
+      },
+      resourceByTileKey: {
+        nearResource: 'grain',
+        farResource: 'timber',
+      },
+      tileState: TileMapState(
+        improvementByTile: {
+          nearResource: 1,
+          farResource: 1,
+        },
+        roadLevelByTile: {capTile: 1},
+      ),
+    );
+    const topology = MapTopology(
+      nodes: [
+        TopologyNode(
+          id: p1,
+          regionId: kConnectivityDevChainOw,
+          type: TopologyNodeType.province,
+        ),
+      ],
+      edges: [],
+    );
+    return ConnectivityDevChainFixture._(
+      game: game,
+      topology: topology,
+      tileMapByRegion: {kConnectivityDevChainOw: tileMap},
+      resourceTiles: [nearResource, farResource],
+      expectedFrontierRoadTiles: const [],
+    );
+  }
+
+  /// AC-F2: pre-built improvements outside the capital network on a distant tile.
+  static ConnectivityDevChainFixture reconquestImprovements() {
+    const p1 = '$kConnectivityDevChainOw|p1';
+    const width = 5;
+    final grid = [
+      List.generate(width, (_) => 'p1'),
+    ];
+    final tileMap = TileMapResult(
+      width: width,
+      height: 1,
+      grid: grid,
+    );
+    final tiles = [for (var x = 0; x < width; x++) tileKey(p1, x)];
+    final capTile = tileKey(p1, 0);
+    final resourceTile = tileKey(p1, 4);
+    final visibility = {
+      for (final t in tiles) t: 'fullyVisible',
+    };
+    final game = TestFixtures.minimalGame(
+      players: [
+        Player(
+          id: kConnectivityDevChainPlayerId,
+          displayName: 'GP',
+          isHuman: false,
+          capitalProvinceId: p1,
+          capitalTile: CapitalTile(
+            regionId: kConnectivityDevChainOw,
+            provinceId: p1,
+            x: 0,
+            y: 0,
+          ),
+          stockpile: const Stockpile(
+            quantities: {'lumber': 50, 'castIron': 50},
+          ),
+        ),
+      ],
+      oldWorld: RegionData(
+        provinces: [
+          Province(
+            id: p1,
+            regionId: kConnectivityDevChainOw,
+            ownerId: kConnectivityDevChainPlayerId,
+          ),
+        ],
+        units: [
+          Unit(
+            id: kConnectivityDevChainEngineerId,
+            type: kUnitTypeEngineer,
+            ownerId: kConnectivityDevChainPlayerId,
+            locationProvinceId: p1,
+            tileKey: capTile,
+          ),
+        ],
+      ),
+      tileKeysByRegionAndProvince: {
+        kConnectivityDevChainOw: {
+          p1: tiles,
+        },
+      },
+      playerVisibilityByTile: {
+        kConnectivityDevChainPlayerId: visibility,
+      },
+      resourceByTileKey: {resourceTile: 'grain'},
+      tileState: TileMapState(
+        improvementByTile: {resourceTile: 2},
+        roadLevelByTile: {capTile: 1},
+      ),
+    );
+    const topology = MapTopology(
+      nodes: [
+        TopologyNode(
+          id: p1,
+          regionId: kConnectivityDevChainOw,
+          type: TopologyNodeType.province,
+        ),
+      ],
+      edges: [],
+    );
+    return ConnectivityDevChainFixture._(
+      game: game,
+      topology: topology,
+      tileMapByRegion: {kConnectivityDevChainOw: tileMap},
+      resourceTiles: [resourceTile],
+      expectedFrontierRoadTiles: [
+        tileKey(p1, 1),
+        tileKey(p1, 2),
+        tileKey(p1, 3),
+      ],
+    );
+  }
+}

--- a/packages/colonizethis_ai/test/support/connectivity_dev_multi_turn_harness.dart
+++ b/packages/colonizethis_ai/test/support/connectivity_dev_multi_turn_harness.dart
@@ -1,0 +1,85 @@
+/// Multi-turn civilian-work selection + trusted resolve harness (Refs #4176).
+library;
+
+import 'package:colonizethis_ai_contracts/colonizethis_ai_contracts.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_orders/src/orders/order_suggestion_work.dart';
+import 'package:colonizethis_test/test.dart';
+
+import 'connectivity_dev_chain_fixture.dart';
+
+FullAiCivilianWorkSelectionResult selectConnectivityDevCivilianWork({
+  required Game game,
+  required MapTopology topology,
+  required Map<String, TileMapResult> tileMapByRegion,
+  required String playerId,
+}) {
+  final view = buildPlayerView(game, topology, playerId);
+  final suggestions = suggestWorkOrders(
+    view,
+    game,
+    topology,
+    const Orders(),
+    tileMapByRegion: tileMapByRegion,
+  );
+  return selectFullAiCivilianWorkOrders(
+    workSuggestions: suggestions,
+    view: view,
+    game: game,
+    tileMapByRegion: tileMapByRegion,
+    topology: topology,
+  );
+}
+
+WorkOrder? engineerBuildRoadOrder(FullAiCivilianWorkSelectionResult selection) {
+  for (final order in selection.workOrders) {
+    if (order.unitId == kConnectivityDevChainEngineerId &&
+        order.target == kWorkTargetBuildRoad) {
+      return order;
+    }
+  }
+  return null;
+}
+
+Game resolveConnectivityDevSelectionTurn({
+  required Game game,
+  required MapTopology topology,
+  required Map<String, TileMapResult> tileMapByRegion,
+  required String playerId,
+}) {
+  final selection = selectConnectivityDevCivilianWork(
+    game: game,
+    topology: topology,
+    tileMapByRegion: tileMapByRegion,
+    playerId: playerId,
+  );
+  final orders = Orders(
+    workOrdersByPlayerId: {
+      playerId: selection.workOrders,
+    },
+  );
+  final result = validateOrdersAndResolveTurnFromTrustedOrders(
+    game: game,
+    topology: topology,
+    orders: orders,
+    tileMapByRegion: tileMapByRegion,
+  );
+  expect(result, isA<TurnResolutionComplete>());
+  return (result as TurnResolutionComplete).game;
+}
+
+Set<String> connectedTilesForPlayer({
+  required Game game,
+  required String playerId,
+  required MapTopology topology,
+  required Map<String, TileMapResult> tileMapByRegion,
+}) {
+  final connectivity = resolveConnectivity(
+    game: game,
+    tileMapByRegion: tileMapByRegion,
+    topology: topology,
+  );
+  return connectivity[playerId]?.connected ?? const {};
+}

--- a/packages/colonizethis_ai/test/support/connectivity_dev_multi_turn_harness.dart
+++ b/packages/colonizethis_ai/test/support/connectivity_dev_multi_turn_harness.dart
@@ -8,6 +8,8 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_orders/src/orders/order_suggestion_work.dart';
 import 'package:colonizethis_test/test.dart';
 
+import 'package:colonizethis_orders/src/orders/order_work_constants.dart';
+
 import 'connectivity_dev_chain_fixture.dart';
 
 FullAiCivilianWorkSelectionResult selectConnectivityDevCivilianWork({
@@ -34,9 +36,20 @@ FullAiCivilianWorkSelectionResult selectConnectivityDevCivilianWork({
 }
 
 WorkOrder? engineerBuildRoadOrder(FullAiCivilianWorkSelectionResult selection) {
+  return engineerWorkOrderForTarget(selection, kWorkTargetBuildRoad);
+}
+
+WorkOrder? engineerBuildPortOrder(FullAiCivilianWorkSelectionResult selection) {
+  return engineerWorkOrderForTarget(selection, kWorkTargetBuildPort);
+}
+
+WorkOrder? engineerWorkOrderForTarget(
+  FullAiCivilianWorkSelectionResult selection,
+  String target, {
+  String engineerId = kConnectivityDevChainEngineerId,
+}) {
   for (final order in selection.workOrders) {
-    if (order.unitId == kConnectivityDevChainEngineerId &&
-        order.target == kWorkTargetBuildRoad) {
+    if (order.unitId == engineerId && order.target == target) {
       return order;
     }
   }

--- a/packages/colonizethis_ai/test/support/connectivity_dev_overseas_fixture.dart
+++ b/packages/colonizethis_ai/test/support/connectivity_dev_overseas_fixture.dart
@@ -1,0 +1,165 @@
+/// Multi-region overseas port linkage scenario for AC-D3 (Refs #4176).
+library;
+
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/game_test_fixtures.dart';
+
+const String kConnectivityDevOverseasOw = 'oldWorld';
+const String kConnectivityDevOverseasNw = 'newWorld';
+const String kConnectivityDevOverseasPlayerId = 'gp1';
+const String kConnectivityDevOverseasEngineerId = 'e1';
+
+const String _owHome = '$kConnectivityDevOverseasOw|home';
+const String _nwColony = '$kConnectivityDevOverseasNw|colony';
+const String _owSeaLocal = 'owSea';
+const String _nwSeaLocal = 'nwSea';
+
+/// AC-D3: OW capital with seaboard port, NW colony with unconnected improved
+/// resource, sea path linking regions; idle Engineer and materials for port +
+/// in-province roads.
+class ConnectivityDevOverseasFixture {
+  ConnectivityDevOverseasFixture._({
+    required this.game,
+    required this.topology,
+    required this.tileMapByRegion,
+    required this.resourceTile,
+    required this.portTile,
+  });
+
+  final Game game;
+  final MapTopology topology;
+  final Map<String, TileMapResult> tileMapByRegion;
+  final String resourceTile;
+  final String portTile;
+
+  static ConnectivityDevOverseasFixture overseasPortLinkage() {
+    const owCapTile = '$_owHome|0|0';
+    const nwPortTile = '$_nwColony|0|0';
+    const nwResourceTile = '$_nwColony|0|1';
+
+    final owTiles = [owCapTile, '$_owHome|1|0'];
+    final nwTiles = [nwPortTile, nwResourceTile];
+    final visibility = {
+      for (final t in [...owTiles, ...nwTiles]) t: 'fullyVisible',
+    };
+
+    final game = TestFixtures.minimalGame(
+      players: [
+        Player(
+          id: kConnectivityDevOverseasPlayerId,
+          displayName: 'GP',
+          isHuman: false,
+          capitalProvinceId: _owHome,
+          capitalTile: CapitalTile(
+            regionId: kConnectivityDevOverseasOw,
+            provinceId: _owHome,
+            x: 0,
+            y: 0,
+          ),
+          stockpile: const Stockpile(
+            quantities: {'lumber': 100, 'castIron': 100},
+          ),
+        ),
+      ],
+      oldWorld: RegionData(
+        provinces: [
+          Province(
+            id: _owHome,
+            regionId: kConnectivityDevOverseasOw,
+            ownerId: kConnectivityDevOverseasPlayerId,
+          ),
+        ],
+        units: const [],
+      ),
+      newWorld: RegionData(
+        provinces: [
+          Province(
+            id: _nwColony,
+            regionId: kConnectivityDevOverseasNw,
+            ownerId: kConnectivityDevOverseasPlayerId,
+          ),
+        ],
+        units: [
+          Unit(
+            id: kConnectivityDevOverseasEngineerId,
+            type: kUnitTypeEngineer,
+            ownerId: kConnectivityDevOverseasPlayerId,
+            locationProvinceId: _nwColony,
+            tileKey: nwPortTile,
+          ),
+        ],
+      ),
+      tileKeysByRegionAndProvince: {
+        kConnectivityDevOverseasOw: {_owHome: owTiles},
+        kConnectivityDevOverseasNw: {_nwColony: nwTiles},
+      },
+      playerVisibilityByTile: {
+        kConnectivityDevOverseasPlayerId: visibility,
+      },
+      resourceByTileKey: {nwResourceTile: 'grain'},
+      portsByProvinceSeaboard: {'$_owHome|$_owSeaLocal': owCapTile},
+      tileState: TileMapState(
+        improvementByTile: {nwResourceTile: 1},
+        roadLevelByTile: {owCapTile: 4},
+      ),
+    );
+
+    const topology = MapTopology(
+      nodes: [
+        TopologyNode(
+          id: 'home',
+          regionId: kConnectivityDevOverseasOw,
+          type: TopologyNodeType.province,
+        ),
+        TopologyNode(
+          id: _owSeaLocal,
+          regionId: kConnectivityDevOverseasOw,
+          type: TopologyNodeType.seaZone,
+        ),
+        TopologyNode(
+          id: _nwSeaLocal,
+          regionId: kConnectivityDevOverseasNw,
+          type: TopologyNodeType.seaZone,
+        ),
+        TopologyNode(
+          id: 'colony',
+          regionId: kConnectivityDevOverseasNw,
+          type: TopologyNodeType.province,
+        ),
+      ],
+      edges: [
+        TopologyEdge(id1: 'home', id2: _owSeaLocal),
+        TopologyEdge(id1: _owSeaLocal, id2: _nwSeaLocal),
+        TopologyEdge(id1: 'colony', id2: _nwSeaLocal),
+      ],
+    );
+
+    final owTileMap = TileMapResult(
+      width: 2,
+      height: 1,
+      grid: [
+        ['home', 'home'],
+      ],
+    );
+    final nwTileMap = TileMapResult(
+      width: 1,
+      height: 2,
+      grid: [
+        ['colony'],
+        ['colony'],
+      ],
+    );
+
+    return ConnectivityDevOverseasFixture._(
+      game: game,
+      topology: topology,
+      tileMapByRegion: {
+        kConnectivityDevOverseasOw: owTileMap,
+        kConnectivityDevOverseasNw: nwTileMap,
+      },
+      resourceTile: nwResourceTile,
+      portTile: nwPortTile,
+    );
+  }
+}

--- a/tool/check_ai_test_mirrors_lib.dart
+++ b/tool/check_ai_test_mirrors_lib.dart
@@ -45,6 +45,8 @@ const Set<String> aiTestMirrorsLibAllowlist = <String>{
   'seed42_observer_colonial_regression_test.dart',
   'seed42_observer_connectivity_dev_closure_test.dart',
   'seed42_observer_connectivity_dev_heartland_baseline_test.dart',
+  'connectivity_dev_multi_turn_chain_test.dart',
+  'connectivity_dev_reconquest_test.dart',
   'seed42_observer_conquest_regression_test.dart',
   'seed42_observer_conquest_s7d_conquest_geography_diagnostic_test.dart',
   'seed42_observer_conquest_s7d_diagnostic_test.dart',

--- a/tool/check_ai_test_mirrors_lib.dart
+++ b/tool/check_ai_test_mirrors_lib.dart
@@ -46,6 +46,7 @@ const Set<String> aiTestMirrorsLibAllowlist = <String>{
   'seed42_observer_connectivity_dev_closure_test.dart',
   'seed42_observer_connectivity_dev_heartland_baseline_test.dart',
   'connectivity_dev_multi_turn_chain_test.dart',
+  'connectivity_dev_overseas_port_test.dart',
   'connectivity_dev_reconquest_test.dart',
   'seed42_observer_conquest_regression_test.dart',
   'seed42_observer_conquest_s7d_conquest_geography_diagnostic_test.dart',


### PR DESCRIPTION
## Summary
- Adds crafted-scenario fixtures and a civilian-work selection + trusted-resolve harness for multi-turn road-chain pins.
- Closes remaining deferred acceptance tests: **AC-A1**, **AC-A6**, **AC-F2**, and **AC-F5** (seed-42 turn 60 wall-clock budget).
- Registers new root-level integration tests on the AI test mirror allowlist.

## Done in this PR
- AC-A1 end-to-end three-turn road chain connects an isolated improved resource
- AC-A6 nearer improved resource connects before a farther one on the same province row
- AC-F2 Engineer reconnects pre-built improvements stranded outside the capital network
- AC-F5 seed-42 turn 60 `generateOrdersForGameFullAI` + resolve within `kTurnProcessingWallClockBudgetMs`

## Deferred
- AC-D3 overseas port + in-province road end-to-end (multi-region crafted scenario)
- Full `generateOrdersForGameFullAI` pins for AC-A1/A6/F2 (harness uses suggestion + selection + resolve slice; behavior is the civilian-work path Full AI uses)

## Manual
N/A — test-only follow-up; player-facing connectivity rules unchanged.

## Test plan
- [x] `cd packages/colonizethis_ai && dart test test/connectivity_dev_multi_turn_chain_test.dart test/connectivity_dev_reconquest_test.dart`
- [x] `cd packages/colonizethis_ai && dart test test/perf/connectivity_dev_late_turn_wall_clock_budget_test.dart`

Refs #4176

Made with [Cursor](https://cursor.com)