### PR TITLE
refactor: app wave 12 slice A — narrow logic imports for providers and trade/units/diplomacy (#4240)

### DIFF
--- a/SPEC/program/logic-package-barrel-contracts.md
+++ b/SPEC/program/logic-package-barrel-contracts.md
@@ -50,7 +50,18 @@ The rule is registered in `tool/ct_repo_lint_manifest.yaml` and dispatched in-pr
 - **Given** the `packages/colonizethis_logic/lib/ai_api.dart` file is missing, **when** `runCheckAiApiNarrowSurface` runs, **then** it returns exit code `1` and reports `Missing AI contract file`.
 - **Given** a domain referenced by an `ai_api.dart` deep export whose barrel file `lib/<domain>.dart` is missing, **when** `runCheckAiApiNarrowSurface` runs, **then** it returns exit code `1` and reports the missing barrel.
 
-## Enforcement: `repo.app_core_services_narrow_logic_import` (Refs #4224 Slice C)
+## Enforcement: `repo.app_narrow_logic_import` (Refs #4240 Slice A)
+
+`tool/check_app_narrow_logic_import.dart` (rule `repo.app_narrow_logic_import`) scans the wave-12 scoped app trees — `app/lib/core/services/**`, `app/lib/providers/**`, `app/lib/features/game/screens/trade/**`, `app/lib/features/game/screens/diplomacy/**`, `app/lib/features/game/widgets/units/**`, and `app/lib/features/game/widgets/diplomacy/**` — and flags any `import 'package:colonizethis_logic/colonizethis_logic.dart'` directive (with or without `show`/`hide` combinators). Consumers in these trees must import domain barrels (`colonizethis_world`, `colonizethis_orders`, `colonizethis_turn`, `colonizethis_combat`, `colonizethis_diplomacy`, `colonizethis_economy`, `colonizethis_setup`) or narrow logic contract entrypoints (`ai_api.dart`, `order_suggestion_api.dart`, `industry_counsel_api.dart`, `debug_console_api.dart`) instead of the broad logic barrel. Deep `package:colonizethis_<domain>/src/...` imports remain allowed when a symbol is not yet published by the domain barrel.
+
+The rule supersedes `repo.app_core_services_narrow_logic_import` (Slice C of #4224) by widening the same predicate to providers and high-churn feature subtrees. `tool/check_app_core_services_narrow_logic_import.dart` remains for Slice C unit tests. The rule is registered in `tool/ct_repo_lint_manifest.yaml`; repository tests `test/check_app_narrow_logic_import_test.dart` and `test/check_app_core_services_narrow_logic_import_test.dart` assert green fixtures.
+
+### Acceptance criteria (`repo.app_narrow_logic_import`)
+
+- **Given** Slice A of #4240 is merged, **when** `rg 'package:colonizethis_logic/colonizethis_logic.dart' app/lib/providers app/lib/features/game/screens/trade app/lib/features/game/widgets/units app/lib/features/game/widgets/diplomacy app/lib/features/game/screens/diplomacy` runs on `dev`, **then** zero matches are returned.
+- **Given** `repo.app_narrow_logic_import` is registered, **when** a file under any scoped tree adds a broad logic barrel import, **then** CI fails with a file:line violation.
+
+## Enforcement: `repo.app_core_services_narrow_logic_import` (Refs #4224 Slice C; superseded by `repo.app_narrow_logic_import`)
 
 `tool/check_app_core_services_narrow_logic_import.dart` (rule `repo.app_core_services_narrow_logic_import`) scans `app/lib/core/services/**` and flags any `import 'package:colonizethis_logic/colonizethis_logic.dart'` directive (with or without `show`/`hide` combinators). Consumers in this tree must import domain barrels (`colonizethis_world`, `colonizethis_orders`, `colonizethis_turn`, `colonizethis_combat`, `colonizethis_diplomacy`, `colonizethis_economy`, `colonizethis_setup`) or narrow logic contract entrypoints (`ai_api.dart`, `order_suggestion_api.dart`, `industry_counsel_api.dart`, `debug_console_api.dart`) instead of the broad logic barrel.
 

--- a/app/lib/features/game/screens/diplomacy/diplomacy_detail_screen.dart
+++ b/app/lib/features/game/screens/diplomacy/diplomacy_detail_screen.dart
@@ -1,6 +1,11 @@
 // Diplomacy detail: history + dossier for one faction. SPEC/ui/diplomacy-detail-screen.md.
 
-import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_diplomacy/colonizethis_diplomacy.dart'
+    show diplomaticHistoryForPair, getOverture, greatPowerPowerScore;
+import 'package:colonizethis_economy/colonizethis_economy.dart' show PurchasedTileIndex;
+import 'package:colonizethis_logic/src/turn_to_year.dart' show turnToYear;
+import 'package:colonizethis_world/colonizethis_world.dart' show Game;
+
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';

--- a/app/lib/features/game/screens/diplomacy/diplomacy_detail_screen_format.dart
+++ b/app/lib/features/game/screens/diplomacy/diplomacy_detail_screen_format.dart
@@ -1,4 +1,7 @@
-import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_diplomacy/colonizethis_diplomacy.dart'
+    show getRelation, relationScoreToDisplayLabel;
+import 'package:colonizethis_world/colonizethis_world.dart' show Game, GamePlayerLookup;
+
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 /// Human-readable sentence for a diplomatic event. Unknown factions shown as "Unknown faction".

--- a/app/lib/features/game/screens/diplomacy/diplomacy_detail_screen_widgets_relation.dart
+++ b/app/lib/features/game/screens/diplomacy/diplomacy_detail_screen_widgets_relation.dart
@@ -1,5 +1,7 @@
 import 'package:colonizethis_app_l10n/l10n/l10n.dart';
-import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_diplomacy/colonizethis_diplomacy.dart'
+    show relationScoreToDisplayLabel, relationScoreToMeterStep;
+
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 

--- a/app/lib/features/game/screens/diplomacy/diplomacy_detail_screen_widgets_sections.dart
+++ b/app/lib/features/game/screens/diplomacy/diplomacy_detail_screen_widgets_sections.dart
@@ -1,5 +1,6 @@
 import 'package:colonizethis_app_l10n/l10n/l10n.dart';
-import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_world/colonizethis_world.dart' show Game;
+
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 

--- a/app/lib/features/game/screens/trade/trade_screen_deal_book_panel.dart
+++ b/app/lib/features/game/screens/trade/trade_screen_deal_book_panel.dart
@@ -18,7 +18,9 @@ import 'package:colonizethis_app_l10n/l10n/l10n.dart';
 import 'package:colonizethis_app_ui_chrome/config/editorial_monocle_palette.dart';
 import 'package:flutter/material.dart';
 
-import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_economy/colonizethis_economy.dart' show WorldMarketState;
+import 'package:colonizethis_orders/colonizethis_orders.dart' show TradeOrder;
+
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../../../../widgets/ct_panel.dart';

--- a/app/lib/features/game/screens/trade/trade_screen_market_row.dart
+++ b/app/lib/features/game/screens/trade/trade_screen_market_row.dart
@@ -15,7 +15,8 @@
 
 import 'package:flutter/material.dart';
 
-import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_orders/colonizethis_orders.dart' show TradeOrder, TradeOrderType;
+
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'trade_screen_contract_market.dart';

--- a/app/lib/features/game/screens/trade/trade_screen_market_row_controls.dart
+++ b/app/lib/features/game/screens/trade/trade_screen_market_row_controls.dart
@@ -7,7 +7,8 @@
 
 import 'package:flutter/material.dart';
 
-import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_orders/colonizethis_orders.dart' show TradeOrder, TradeOrderType;
+
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../../../../widgets/ct_choice_chip.dart';

--- a/app/lib/features/game/screens/trade/trade_screen_market_tab.dart
+++ b/app/lib/features/game/screens/trade/trade_screen_market_tab.dart
@@ -45,7 +45,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_orders/colonizethis_orders.dart' show Orders, TradeOrder, TradeOrderType;
+import 'package:colonizethis_world/colonizethis_world.dart' show Game;
+
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../../../../providers/games_provider.dart';

--- a/app/lib/features/game/screens/trade/trade_screen_market_tab_build.dart
+++ b/app/lib/features/game/screens/trade/trade_screen_market_tab_build.dart
@@ -7,7 +7,10 @@ import 'package:colonizethis_app_l10n/l10n/l10n.dart';
 import 'package:flutter/material.dart';
 
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_economy/colonizethis_economy.dart';
+import 'package:colonizethis_orders/colonizethis_orders.dart' show Orders, TradeOrderType;
+import 'package:colonizethis_world/colonizethis_world.dart' show Game;
+
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../../../../providers/games_provider.dart';

--- a/app/lib/features/game/screens/trade/trade_screen_market_tab_build_sections.dart
+++ b/app/lib/features/game/screens/trade/trade_screen_market_tab_build_sections.dart
@@ -6,7 +6,9 @@ import 'package:colonizethis_app_l10n/l10n/l10n.dart';
 import 'package:colonizethis_app_ui_chrome/config/editorial_monocle_palette.dart';
 import 'package:flutter/material.dart';
 
-import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_economy/colonizethis_economy.dart' show WorldMarketState;
+import 'package:colonizethis_orders/colonizethis_orders.dart' show TradeOrderType;
+
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'trade_screen_contract_market.dart';

--- a/app/lib/features/game/screens/trade/trade_screen_market_tab_catalog.dart
+++ b/app/lib/features/game/screens/trade/trade_screen_market_tab_catalog.dart
@@ -7,7 +7,10 @@ import 'package:colonizethis_app_l10n/l10n/l10n.dart';
 import 'package:flutter/material.dart';
 
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_economy/colonizethis_economy.dart' show CommodityCatalog, WorldMarketState;
+import 'package:colonizethis_orders/colonizethis_orders.dart'
+    show Orders, TradeOrderType, tradeOrderForPlayerCommodity;
+
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../../../../widgets/ct_section_label.dart';

--- a/app/lib/features/game/screens/trade/trade_screen_market_tab_order_handlers.dart
+++ b/app/lib/features/game/screens/trade/trade_screen_market_tab_order_handlers.dart
@@ -2,7 +2,9 @@
 
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_economy/colonizethis_economy.dart';
-import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_orders/colonizethis_orders.dart'
+    show Orders, TradeOrder, TradeOrderType, removeTradeOrderForPlayer, tradeOrderForPlayerCommodity, applyTradeOrderForPlayer;
+
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../../../../providers/games_provider.dart';

--- a/app/lib/features/game/widgets/diplomacy/diplomacy_dialogs.dart
+++ b/app/lib/features/game/widgets/diplomacy/diplomacy_dialogs.dart
@@ -2,7 +2,8 @@
 // SPEC: SPEC/ui/grant-or-subsidy-dialog.md (DIPL20001),
 // SPEC/ui/diplomacy-panel.md.
 
-import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_world/colonizethis_world.dart' show Game;
+
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 import 'package:colonizethis_app_l10n/l10n/l10n.dart';

--- a/app/lib/features/game/widgets/diplomacy/diplomacy_dialogs_grant_subsidy_body.dart
+++ b/app/lib/features/game/widgets/diplomacy/diplomacy_dialogs_grant_subsidy_body.dart
@@ -1,4 +1,6 @@
-import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_diplomacy/colonizethis_diplomacy.dart';
+import 'package:colonizethis_world/colonizethis_world.dart';
+
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 import 'package:colonizethis_app_l10n/l10n/l10n.dart';

--- a/app/lib/features/game/widgets/diplomacy/diplomacy_order_helpers.dart
+++ b/app/lib/features/game/widgets/diplomacy/diplomacy_order_helpers.dart
@@ -1,5 +1,5 @@
-import 'package:colonizethis_logic/colonizethis_logic.dart'
-    show ordersWithAppendedDiplomaticOrder;
+import 'package:colonizethis_orders/colonizethis_orders.dart' show ordersWithAppendedDiplomaticOrder;
+
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 /// Shared short label for diplomacy action buttons and confirmation prompts.

--- a/app/lib/features/game/widgets/diplomacy/diplomacy_panel_constants.dart
+++ b/app/lib/features/game/widgets/diplomacy/diplomacy_panel_constants.dart
@@ -1,7 +1,8 @@
 // Diplomacy panel layout constants. SPEC/ui/diplomacy-panel.md.
 
 import 'package:colonizethis_app_ui_chrome/config/editorial_monocle_palette.dart';
-import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_diplomacy/colonizethis_diplomacy.dart' show relationScoreToMeterStep;
+
 import 'package:flutter/material.dart';
 
 import '../../../../widgets/relation_meter.dart';

--- a/app/lib/features/game/widgets/diplomacy/diplomacy_panel_order_actions.dart
+++ b/app/lib/features/game/widgets/diplomacy/diplomacy_panel_order_actions.dart
@@ -1,7 +1,9 @@
 /// Diplomatic order submission and negotiation-mood handlers.
 /// SPEC/ui/diplomacy-panel.md.
 
-import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_diplomacy/colonizethis_diplomacy.dart';
+import 'package:colonizethis_world/colonizethis_world.dart';
+
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 

--- a/app/lib/features/game/widgets/diplomacy/diplomacy_panel_row.dart
+++ b/app/lib/features/game/widgets/diplomacy/diplomacy_panel_row.dart
@@ -3,7 +3,9 @@
 
 import 'package:colonizethis_app_l10n/l10n/l10n.dart';
 import 'package:colonizethis_app_ui_chrome/config/editorial_monocle_palette.dart';
-import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_diplomacy/colonizethis_diplomacy.dart';
+import 'package:colonizethis_orders/src/orders/diplomatic_panel_actions.dart';
+
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 

--- a/app/lib/features/game/widgets/diplomacy/diplomacy_panel_rows.dart
+++ b/app/lib/features/game/widgets/diplomacy/diplomacy_panel_rows.dart
@@ -1,6 +1,7 @@
 // Row model and builder for diplomacy UI. SPEC/ui/diplomacy-panel.md.
 
-import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_orders/src/orders/diplomatic_panel_actions.dart';
+
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 export 'diplomacy_panel_rows_builder.dart';

--- a/app/lib/features/game/widgets/diplomacy/diplomacy_panel_rows_builder.dart
+++ b/app/lib/features/game/widgets/diplomacy/diplomacy_panel_rows_builder.dart
@@ -1,7 +1,12 @@
 /// Row-builder pipeline for diplomacy panel faction lists.
 
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_combat/colonizethis_combat.dart';
+import 'package:colonizethis_diplomacy/colonizethis_diplomacy.dart';
+import 'package:colonizethis_economy/colonizethis_economy.dart';
+import 'package:colonizethis_orders/src/orders/diplomatic_panel_actions.dart';
+import 'package:colonizethis_world/colonizethis_world.dart';
+
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'diplomacy_panel_rows.dart';

--- a/app/lib/features/game/widgets/diplomacy/diplomacy_panel_rows_builder_helpers.dart
+++ b/app/lib/features/game/widgets/diplomacy/diplomacy_panel_rows_builder_helpers.dart
@@ -1,6 +1,10 @@
 // Discovery and pending-order helpers for diplomacy row assembly.
 
-import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_diplomacy/colonizethis_diplomacy.dart';
+import 'package:colonizethis_economy/colonizethis_economy.dart';
+import 'package:colonizethis_orders/src/orders/diplomatic_panel_actions.dart';
+import 'package:colonizethis_world/colonizethis_world.dart';
+
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'diplomacy_panel_rows.dart';

--- a/app/lib/features/game/widgets/diplomacy/diplomacy_panel_rows_standing_chips.dart
+++ b/app/lib/features/game/widgets/diplomacy/diplomacy_panel_rows_standing_chips.dart
@@ -1,6 +1,9 @@
 /// Standing-chip derivation for diplomacy panel rows.
 
-import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_diplomacy/colonizethis_diplomacy.dart';
+import 'package:colonizethis_economy/colonizethis_economy.dart';
+import 'package:colonizethis_world/colonizethis_world.dart';
+
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'diplomacy_panel_rows.dart';

--- a/app/lib/features/game/widgets/diplomacy/grant_or_subsidy_listener.dart
+++ b/app/lib/features/game/widgets/diplomacy/grant_or_subsidy_listener.dart
@@ -1,7 +1,9 @@
 // Listens for GrantOrSubsidySubmittedEvent and shows a confirmation dialog.
 
 import 'package:colonizethis_ai/colonizethis_ai.dart';
-import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_diplomacy/colonizethis_diplomacy.dart';
+import 'package:colonizethis_world/colonizethis_world.dart';
+
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 

--- a/app/lib/features/game/widgets/units/civilian/civilian_units_panel_build.dart
+++ b/app/lib/features/game/widgets/units/civilian/civilian_units_panel_build.dart
@@ -2,7 +2,11 @@ import 'package:colonizethis_app_fixtures/config/ct_e2e.dart';
 import 'package:colonizethis_app_fixtures/config/ct_e2e_last_panel_snapshot.dart';
 import 'package:colonizethis_app_l10n/l10n/l10n.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_orders/colonizethis_orders.dart';
+import 'package:colonizethis_orders/src/orders/civilian_projected_tile.dart'
+    show projectedCivilianTileKey;
+import 'package:colonizethis_world/colonizethis_world.dart';
+
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';

--- a/app/lib/features/game/widgets/units/civilian/civilian_units_panel_list.dart
+++ b/app/lib/features/game/widgets/units/civilian/civilian_units_panel_list.dart
@@ -1,5 +1,9 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_orders/colonizethis_orders.dart';
+import 'package:colonizethis_orders/src/orders/civilian_projected_tile.dart'
+    show projectedCivilianTileKey;
+import 'package:colonizethis_world/colonizethis_world.dart';
+
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';

--- a/app/lib/features/game/widgets/units/civilian/civilian_units_panel_support_resolution.dart
+++ b/app/lib/features/game/widgets/units/civilian/civilian_units_panel_support_resolution.dart
@@ -1,7 +1,9 @@
 /// Pending work-order resolution helpers. SPEC/ui/civilian-units-panel.md.
 
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_orders/colonizethis_orders.dart';
+import 'package:colonizethis_world/colonizethis_world.dart';
+
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 

--- a/app/lib/features/game/widgets/units/civilian/civilian_units_panel_unit_row.dart
+++ b/app/lib/features/game/widgets/units/civilian/civilian_units_panel_unit_row.dart
@@ -3,7 +3,11 @@
 import 'dart:async';
 
 import 'package:colonizethis_app_l10n/l10n/l10n.dart';
-import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_logic/src/civilians/spy_relocate_intel.dart'
+    show isForeignProvinceForPlayer;
+import 'package:colonizethis_orders/colonizethis_orders.dart';
+import 'package:colonizethis_world/colonizethis_world.dart';
+
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';

--- a/app/lib/features/game/widgets/units/civilian/civilian_units_sort.dart
+++ b/app/lib/features/game/widgets/units/civilian/civilian_units_sort.dart
@@ -6,8 +6,9 @@
 
 import 'package:colonizethis_data/colonizethis_data.dart'
     show UnitRole, unitRoleForType;
-import 'package:colonizethis_logic/colonizethis_logic.dart'
-    show WorldStateProvinceLookup, projectedCivilianTileKey;
+import 'package:colonizethis_orders/src/orders/civilian_projected_tile.dart' show projectedCivilianTileKey;
+import 'package:colonizethis_world/colonizethis_world.dart' show Game, WorldStateProvinceLookup;
+
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 /// Builds prefixed province id (`regionId|provinceId`) → display name from

--- a/app/lib/features/game/widgets/units/military/general_command_capacity.dart
+++ b/app/lib/features/game/widgets/units/military/general_command_capacity.dart
@@ -3,11 +3,9 @@
 
 import 'package:colonizethis_data/colonizethis_data.dart'
     show generalCapForUnlockedTechs;
-import 'package:colonizethis_logic/colonizethis_logic.dart'
-    show resolveToFullProvinceId;
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_world/colonizethis_world.dart'
-    show GamePlayerLookup, WorldStateProvinceLookup;
+    show GamePlayerLookup, WorldStateProvinceLookup, resolveToFullProvinceId;
 
 /// Effective general cap for a Great Power (persisted cap or tech-derived).
 int effectiveGeneralCapForPlayer(Player player) =>

--- a/app/lib/features/game/widgets/units/military/military_units_panel_dialogs.dart
+++ b/app/lib/features/game/widgets/units/military/military_units_panel_dialogs.dart
@@ -1,8 +1,8 @@
 /// Dialog openers and combine mutations for military army actions.
 /// SPEC/ui/military-units-panel.md.
 
-import 'package:colonizethis_logic/colonizethis_logic.dart'
-    show buildPlayerView;
+import 'package:colonizethis_world/colonizethis_world.dart' show buildPlayerView;
+
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 

--- a/app/lib/features/game/widgets/units/naval/naval_units_panel_support_combine.dart
+++ b/app/lib/features/game/widgets/units/naval/naval_units_panel_support_combine.dart
@@ -1,6 +1,6 @@
 import 'package:colonizethis_app/core/utils/prefixed_id.dart';
-import 'package:colonizethis_logic/colonizethis_logic.dart'
-    show GamePlayerLookup, homeFleetIdFor;
+import 'package:colonizethis_world/colonizethis_world.dart' show GamePlayerLookup, homeFleetIdFor;
+
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 

--- a/app/lib/features/game/widgets/units/naval/naval_units_panel_support_dialogs.dart
+++ b/app/lib/features/game/widgets/units/naval/naval_units_panel_support_dialogs.dart
@@ -1,4 +1,5 @@
-import 'package:colonizethis_logic/colonizethis_logic.dart' show GamePlayerLookup;
+import 'package:colonizethis_world/colonizethis_world.dart' show GamePlayerLookup;
+
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 

--- a/app/lib/features/game/widgets/units/shared/region_labels.dart
+++ b/app/lib/features/game/widgets/units/shared/region_labels.dart
@@ -1,8 +1,8 @@
 // Region id → user-facing label for units panels and related UI.
 // SPEC/ui/military-units-panel.md, SPEC/ui/civilian-units-panel.md, SPEC/ui/naval-units-panel.md.
 
-import 'package:colonizethis_logic/colonizethis_logic.dart'
-    show kRegionNewWorld, kRegionOldWorld;
+import 'package:colonizethis_world/colonizethis_world.dart' show kRegionNewWorld, kRegionOldWorld;
+
 
 /// Maps a world [regionId] (`oldWorld`, `newWorld`, …) to a short display label.
 String regionDisplayLabel(String regionId) {

--- a/app/lib/providers/game_service_provider.dart
+++ b/app/lib/providers/game_service_provider.dart
@@ -1,4 +1,5 @@
-import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_world/colonizethis_world.dart' show DefaultGameEventBus;
+
 import 'package:colonizethis_save/colonizethis_save.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 

--- a/app/lib/providers/game_summary_support.dart
+++ b/app/lib/providers/game_summary_support.dart
@@ -1,6 +1,8 @@
 import 'package:colonizethis_app/package_logger.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_orders/colonizethis_orders.dart';
+import 'package:colonizethis_world/colonizethis_world.dart';
+
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../core/services/game_service/game_service.dart';

--- a/app/lib/providers/games_provider_diplomacy.dart
+++ b/app/lib/providers/games_provider_diplomacy.dart
@@ -1,5 +1,6 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_diplomacy/colonizethis_diplomacy.dart' show CallToArmsPending, FtpOffer, InterventionPrompt, OvertureOffer;
+
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 

--- a/app/lib/providers/games_provider_work_targets.dart
+++ b/app/lib/providers/games_provider_work_targets.dart
@@ -1,5 +1,7 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_orders/colonizethis_orders.dart';
+import 'package:colonizethis_world/colonizethis_world.dart';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../features/game/widgets/shell/shell_player_context.dart';

--- a/app/lib/providers/home_fleet_cargo_provider.dart
+++ b/app/lib/providers/home_fleet_cargo_provider.dart
@@ -1,6 +1,8 @@
 import 'package:colonizethis_app/package_logger.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_economy/colonizethis_economy.dart';
+import 'package:colonizethis_world/colonizethis_world.dart';
+
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 

--- a/app/lib/providers/map_view_provider_data.dart
+++ b/app/lib/providers/map_view_provider_data.dart
@@ -1,5 +1,7 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_economy/colonizethis_economy.dart';
+import 'package:colonizethis_world/colonizethis_world.dart';
+
 import 'package:colonizethis_map/colonizethis_map.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';

--- a/app/lib/providers/map_view_provider_extraction.dart
+++ b/app/lib/providers/map_view_provider_extraction.dart
@@ -1,6 +1,10 @@
 import 'package:colonizethis_app/core/utils/prefixed_id.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_economy/src/economy/economy_resource_constants.dart'
+    show kMineralResourceIds;
+import 'package:colonizethis_economy/colonizethis_economy.dart';
+import 'package:colonizethis_world/colonizethis_world.dart';
+
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 class MapResourceExtractionMaps {

--- a/app/lib/providers/production_allocation_provider.dart
+++ b/app/lib/providers/production_allocation_provider.dart
@@ -1,4 +1,6 @@
-import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_economy/colonizethis_economy.dart' show assignedRecipesFromDesiredOutput;
+import 'package:colonizethis_models/colonizethis_models.dart' show AssignedRecipe;
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 /// Desired output units per recipe (recipe id → units). Used by Production panel

--- a/app/lib/providers/treasury_summary_provider.dart
+++ b/app/lib/providers/treasury_summary_provider.dart
@@ -1,5 +1,7 @@
 import 'package:colonizethis_app/package_logger.dart';
-import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_turn/colonizethis_turn.dart';
+import 'package:colonizethis_world/colonizethis_world.dart';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'game_service_provider.dart';

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -28,6 +28,8 @@ dependencies:
   colonizethis_orders:
   colonizethis_turn:
   colonizethis_diplomacy:
+  colonizethis_economy:
+  colonizethis_combat:
   colonizethis_setup:
   colonizethis_world:
   colonizethis_ai:

--- a/test/check_app_narrow_logic_import_test.dart
+++ b/test/check_app_narrow_logic_import_test.dart
@@ -1,0 +1,104 @@
+// Refs #4240 — guards `repo.app_narrow_logic_import`: scoped app trees must not
+// import the broad colonizethis_logic barrel.
+
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+import '../tool/check_app_narrow_logic_import.dart';
+
+void main() {
+  group('repo.app_narrow_logic_import', () {
+    test('passes on real repo workspace', () {
+      final repoRoot = Directory.current.path;
+      final logs = <String>[];
+      final code = runCheckAppNarrowLogicImport(
+        repoRoot,
+        info: logs.add,
+        err: logs.add,
+      );
+      expect(code, 0, reason: logs.join('\n'));
+      expect(
+        logs.join('\n'),
+        contains(
+          'check_app_narrow_logic_import: no broad logic barrel imports found.',
+        ),
+      );
+    });
+
+    test('fails when a scoped file imports the broad logic barrel', () {
+      final temp = Directory.systemTemp.createTempSync(
+        'app_narrow_logic_import_fail_',
+      );
+      addTearDown(() => temp.deleteSync(recursive: true));
+
+      final targetDir = Directory(
+        p.join(temp.path, 'app', 'lib', 'providers'),
+      )..createSync(recursive: true);
+      File(
+        p.join(targetDir.path, 'sample_provider.dart'),
+      ).writeAsStringSync('''
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+
+class SampleProvider {}
+''');
+
+      for (final relativeDir in scopedRelativeDirs) {
+        if (relativeDir == 'app/lib/providers') {
+          continue;
+        }
+        Directory(p.join(temp.path, relativeDir)).createSync(recursive: true);
+      }
+
+      final errLogs = <String>[];
+      final code = runCheckAppNarrowLogicImport(
+        temp.path,
+        info: (_) {},
+        err: errLogs.add,
+      );
+
+      expect(code, 1);
+      expect(
+        errLogs.join('\n'),
+        contains('broad colonizethis_logic barrel import is disallowed'),
+      );
+      expect(
+        errLogs.join('\n'),
+        contains('sample_provider.dart:1'),
+      );
+    });
+
+    test('passes when scoped files use domain barrels only', () {
+      final temp = Directory.systemTemp.createTempSync(
+        'app_narrow_logic_import_pass_',
+      );
+      addTearDown(() => temp.deleteSync(recursive: true));
+
+      for (final relativeDir in scopedRelativeDirs) {
+        final targetDir = Directory(p.join(temp.path, relativeDir))
+          ..createSync(recursive: true);
+        if (relativeDir != 'app/lib/providers') {
+          continue;
+        }
+        File(
+          p.join(targetDir.path, 'sample_provider.dart'),
+        ).writeAsStringSync('''
+import 'package:colonizethis_turn/colonizethis_turn.dart';
+import 'package:colonizethis_logic/order_suggestion_api.dart';
+
+class SampleProvider {}
+''');
+      }
+
+      final logs = <String>[];
+      final code = runCheckAppNarrowLogicImport(
+        temp.path,
+        info: logs.add,
+        err: logs.add,
+      );
+
+      expect(code, 0, reason: logs.join('\n'));
+    });
+  });
+}

--- a/tool/check_app_core_services_narrow_logic_import.dart
+++ b/tool/check_app_core_services_narrow_logic_import.dart
@@ -1,37 +1,11 @@
 import 'dart:io';
 
-import 'package:path/path.dart' as p;
+import 'check_app_narrow_logic_import.dart';
 
 /// SPEC: SPEC/program/logic-package-barrel-contracts.md (Refs #4224 Slice C).
 /// Rule `repo.app_core_services_narrow_logic_import`.
 ///
-/// Forbids the broad `package:colonizethis_logic/colonizethis_logic.dart` barrel
-/// under `app/lib/core/services/**`. Domain barrels and narrow logic contract
-/// entrypoints remain allowed.
-const _servicesRelativeDir = 'app/lib/core/services';
-
-const _forbiddenImportNeedle =
-    'package:colonizethis_logic/colonizethis_logic.dart';
-
-/// Narrow logic contract libraries permitted under core services.
-const _allowedLogicContractNeedles = <String>[
-  'package:colonizethis_logic/ai_api.dart',
-  'package:colonizethis_logic/order_suggestion_api.dart',
-  'package:colonizethis_logic/industry_counsel_api.dart',
-  'package:colonizethis_logic/debug_console_api.dart',
-];
-
-/// Domain package barrels permitted under core services.
-const _allowedDomainBarrelNeedles = <String>[
-  'package:colonizethis_world/colonizethis_world.dart',
-  'package:colonizethis_orders/colonizethis_orders.dart',
-  'package:colonizethis_turn/colonizethis_turn.dart',
-  'package:colonizethis_combat/colonizethis_combat.dart',
-  'package:colonizethis_diplomacy/colonizethis_diplomacy.dart',
-  'package:colonizethis_economy/colonizethis_economy.dart',
-  'package:colonizethis_setup/colonizethis_setup.dart',
-];
-
+/// Legacy entrypoint retained for Slice C tests; scans only `app/lib/core/services`.
 int runCheckAppCoreServicesNarrowLogicImport(
   String repoRoot, {
   void Function(String line)? info,
@@ -39,57 +13,32 @@ int runCheckAppCoreServicesNarrowLogicImport(
 }) {
   final logI = info ?? stdout.writeln;
   final logE = err ?? stderr.writeln;
-  final servicesDir = Directory(p.join(repoRoot, _servicesRelativeDir));
-  if (!servicesDir.existsSync()) {
-    logE(
-      'check_app_core_services_narrow_logic_import: target not found: '
-      '$_servicesRelativeDir',
+
+  try {
+    final violations = scanAppNarrowLogicImportViolations(
+      repoRoot,
+      const [coreServicesRelativeDir],
     );
+    if (violations.isEmpty) {
+      logI(
+        'check_app_core_services_narrow_logic_import: no broad logic barrel '
+        'imports found.',
+      );
+      return 0;
+    }
+
+    logE(
+      'check_app_core_services_narrow_logic_import: found '
+      '${violations.length} violation(s):',
+    );
+    for (final violation in violations) {
+      logE(' - $violation');
+    }
+    return 1;
+  } on StateError catch (e) {
+    logE('check_app_core_services_narrow_logic_import: ${e.message}');
     return 1;
   }
-
-  final violations = <String>[];
-  for (final entity in servicesDir.listSync(recursive: true)) {
-    if (entity is! File || !entity.path.endsWith('.dart')) {
-      continue;
-    }
-    final relativePath = p.relative(entity.path, from: repoRoot);
-    final lines = entity.readAsLinesSync();
-    for (var i = 0; i < lines.length; i++) {
-      final trimmed = lines[i].trim();
-      if (trimmed.startsWith('//')) {
-        continue;
-      }
-      if (!trimmed.startsWith('import ')) {
-        continue;
-      }
-      if (!trimmed.contains(_forbiddenImportNeedle)) {
-        continue;
-      }
-      violations.add(
-        '$relativePath:${i + 1}: broad colonizethis_logic barrel import is '
-        'disallowed; use a domain barrel (${_allowedDomainBarrelNeedles.first}) '
-        'or a narrow logic contract (${_allowedLogicContractNeedles.first})',
-      );
-    }
-  }
-
-  if (violations.isEmpty) {
-    logI(
-      'check_app_core_services_narrow_logic_import: no broad logic barrel '
-      'imports found.',
-    );
-    return 0;
-  }
-
-  logE(
-    'check_app_core_services_narrow_logic_import: found '
-    '${violations.length} violation(s):',
-  );
-  for (final violation in violations) {
-    logE(' - $violation');
-  }
-  return 1;
 }
 
 void main() {

--- a/tool/check_app_narrow_logic_import.dart
+++ b/tool/check_app_narrow_logic_import.dart
@@ -1,0 +1,118 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+/// SPEC: SPEC/program/logic-package-barrel-contracts.md (Refs #4240 Slice A).
+/// Rule `repo.app_narrow_logic_import`.
+///
+/// Forbids the broad `package:colonizethis_logic/colonizethis_logic.dart` barrel
+/// under scoped app trees. Domain barrels and narrow logic contract entrypoints
+/// remain allowed.
+const forbiddenImportNeedle =
+    'package:colonizethis_logic/colonizethis_logic.dart';
+
+/// Scoped app trees migrated in wave 12 slice A (Refs #4240).
+const scopedRelativeDirs = <String>[
+  'app/lib/core/services',
+  'app/lib/providers',
+  'app/lib/features/game/screens/trade',
+  'app/lib/features/game/screens/diplomacy',
+  'app/lib/features/game/widgets/units',
+  'app/lib/features/game/widgets/diplomacy',
+];
+
+const coreServicesRelativeDir = 'app/lib/core/services';
+
+/// Narrow logic contract libraries permitted in scoped trees.
+const allowedLogicContractNeedles = <String>[
+  'package:colonizethis_logic/ai_api.dart',
+  'package:colonizethis_logic/order_suggestion_api.dart',
+  'package:colonizethis_logic/industry_counsel_api.dart',
+  'package:colonizethis_logic/debug_console_api.dart',
+];
+
+/// Domain package barrels permitted in scoped trees.
+const allowedDomainBarrelNeedles = <String>[
+  'package:colonizethis_world/colonizethis_world.dart',
+  'package:colonizethis_orders/colonizethis_orders.dart',
+  'package:colonizethis_turn/colonizethis_turn.dart',
+  'package:colonizethis_combat/colonizethis_combat.dart',
+  'package:colonizethis_diplomacy/colonizethis_diplomacy.dart',
+  'package:colonizethis_economy/colonizethis_economy.dart',
+  'package:colonizethis_setup/colonizethis_setup.dart',
+];
+
+List<String> scanAppNarrowLogicImportViolations(
+  String repoRoot,
+  List<String> relativeDirs,
+) {
+  final violations = <String>[];
+  for (final relativeDir in relativeDirs) {
+    final dir = Directory(p.join(repoRoot, relativeDir));
+    if (!dir.existsSync()) {
+      throw StateError('target not found: $relativeDir');
+    }
+    for (final entity in dir.listSync(recursive: true)) {
+      if (entity is! File || !entity.path.endsWith('.dart')) {
+        continue;
+      }
+      final relativePath = p.relative(entity.path, from: repoRoot);
+      final lines = entity.readAsLinesSync();
+      for (var i = 0; i < lines.length; i++) {
+        final trimmed = lines[i].trim();
+        if (trimmed.startsWith('//')) {
+          continue;
+        }
+        if (!trimmed.startsWith('import ')) {
+          continue;
+        }
+        if (!trimmed.contains(forbiddenImportNeedle)) {
+          continue;
+        }
+        violations.add(
+          '$relativePath:${i + 1}: broad colonizethis_logic barrel import is '
+          'disallowed; use a domain barrel (${allowedDomainBarrelNeedles.first}) '
+          'or a narrow logic contract (${allowedLogicContractNeedles.first})',
+        );
+      }
+    }
+  }
+  return violations;
+}
+
+int runCheckAppNarrowLogicImport(
+  String repoRoot, {
+  void Function(String line)? info,
+  void Function(String line)? err,
+}) {
+  final logI = info ?? stdout.writeln;
+  final logE = err ?? stderr.writeln;
+
+  try {
+    final violations = scanAppNarrowLogicImportViolations(
+      repoRoot,
+      scopedRelativeDirs,
+    );
+    if (violations.isEmpty) {
+      logI(
+        'check_app_narrow_logic_import: no broad logic barrel imports found.',
+      );
+      return 0;
+    }
+
+    logE(
+      'check_app_narrow_logic_import: found ${violations.length} violation(s):',
+    );
+    for (final violation in violations) {
+      logE(' - $violation');
+    }
+    return 1;
+  } on StateError catch (e) {
+    logE('check_app_narrow_logic_import: ${e.message}');
+    return 1;
+  }
+}
+
+void main() {
+  exit(runCheckAppNarrowLogicImport(Directory.current.path));
+}

--- a/tool/ct_repo_lint_lib.dart
+++ b/tool/ct_repo_lint_lib.dart
@@ -5,6 +5,7 @@ import 'package:path/path.dart' as p;
 import 'package:yaml/yaml.dart';
 
 import 'check_app_core_services_narrow_logic_import.dart';
+import 'check_app_narrow_logic_import.dart';
 import 'check_app_editorial_monocle_colors.dart';
 import 'check_app_event_bus_decoupling.dart';
 import 'check_app_event_handler_scope_logic_boundary.dart';
@@ -830,6 +831,8 @@ int? _tryRunDartRuleInProcess({
       return runCheckDebugConsoleSharedHelpers(repoRoot);
     case 'repo.app_event_handler_scope_logic_boundary':
       return runCheckAppEventHandlerScopeLogicBoundary(repoRoot);
+    case 'repo.app_narrow_logic_import':
+      return runCheckAppNarrowLogicImport(repoRoot);
     case 'repo.app_core_services_narrow_logic_import':
       return runCheckAppCoreServicesNarrowLogicImport(repoRoot);
     case 'repo.app_event_bus_decoupling':

--- a/tool/ct_repo_lint_manifest.yaml
+++ b/tool/ct_repo_lint_manifest.yaml
@@ -538,12 +538,12 @@ rules:
     runner: dart
     script: tool/check_app_event_handler_scope_logic_boundary.dart
 
-  - rule_id: repo.app_core_services_narrow_logic_import
+  - rule_id: repo.app_narrow_logic_import
     group: architecture
-    title: app core services must not import the broad colonizethis_logic barrel (Refs #4224 Slice C)
+    title: scoped app trees must not import the broad colonizethis_logic barrel (Refs #4240 Slice A)
     spec: SPEC/program/logic-package-barrel-contracts.md
     runner: dart
-    script: tool/check_app_core_services_narrow_logic_import.dart
+    script: tool/check_app_narrow_logic_import.dart
 
   - rule_id: repo.app_no_part_directives
     group: structure


### PR DESCRIPTION
## Summary

Slice A for #4240: generalize the app narrow-import CI gate to `repo.app_narrow_logic_import` and migrate **42** scoped files off `package:colonizethis_logic/colonizethis_logic.dart` onto domain barrels (`colonizethis_world`, `colonizethis_orders`, `colonizethis_economy`, `colonizethis_diplomacy`, `colonizethis_turn`, `colonizethis_combat`) and a small set of permitted narrow/deep imports.

**Done in this PR**
- New `tool/check_app_narrow_logic_import.dart` + `test/check_app_narrow_logic_import_test.dart`; manifest dispatch via `repo.app_narrow_logic_import` (supersedes `repo.app_core_services_narrow_logic_import` in CI manifest).
- Migrated `app/lib/providers/**` (9 files) and high-churn `features/game/{trade,units,diplomacy}` + `screens/diplomacy` (33 files).
- Added direct `colonizethis_economy` / `colonizethis_combat` app dependencies where newly imported.
- SPEC update: `SPEC/program/logic-package-barrel-contracts.md` § `repo.app_narrow_logic_import`.

**Deferred (later slices on #4240)**
- Slice B: Trade staging controller extraction
- Slice C: Civilian unit row decomposition
- Slice D: Draft projection shared helpers
- Slice E: Trade test harness densify
- Remaining broad logic imports outside the scoped trees (~110+ files in other `app/lib/features/**` paths)

## Test plan

- [x] `dart run tool/check_app_narrow_logic_import.dart`
- [x] `dart test test/check_app_narrow_logic_import_test.dart`
- [x] `dart test test/check_app_core_services_narrow_logic_import_test.dart`
- [x] `cd app && flutter analyze` on migrated subtrees (no errors)

Refs #4240

Made with [Cursor](https://cursor.com)