### PR TITLE
refactor: app wave 12 slice B — TradeMarketStagingContext (#4240)

### DIFF
--- a/app/lib/features/game/screens/trade/trade_market_staging_context.dart
+++ b/app/lib/features/game/screens/trade/trade_market_staging_context.dart
@@ -1,0 +1,109 @@
+// Shared per-build Market tab staging state (Refs #4240 Slice B).
+//
+// Bundles offer caps, staged-offer quantities, bid-type cap, and the
+// direction/quantity mutation handlers so catalog/build/row modules do
+// not thread the same parameters in parallel.
+
+import 'package:colonizethis_economy/colonizethis_economy.dart';
+import 'package:colonizethis_orders/colonizethis_orders.dart'
+    show Orders, TradeOrder, TradeOrderType, tradeOrderForPlayerCommodity;
+import 'package:colonizethis_world/colonizethis_world.dart';
+
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import 'trade_screen_market_tab_order_handlers.dart';
+import 'trade_section_handlers.dart';
+
+/// Immutable per-build view of Market tab order-staging inputs.
+class TradeMarketStagingContext {
+  const TradeMarketStagingContext({
+    required this.playerId,
+    required this.offerCap,
+    required this.stagedOffers,
+    required this.bidTypeCap,
+    required this.orders,
+    required this.market,
+    required this.handlers,
+    required this.firstRightCommodityIds,
+  });
+
+  final String playerId;
+  final Map<CommodityId, int> offerCap;
+  final Map<CommodityId, int> stagedOffers;
+  final int bidTypeCap;
+  final Orders orders;
+  final WorldMarketState market;
+  final TradeSectionHandlers handlers;
+  final Set<CommodityId> firstRightCommodityIds;
+
+  /// Builds staging maps and caps once per Market tab build.
+  static TradeMarketStagingContext forMarketBuild({
+    required Game game,
+    required String playerId,
+    required Orders orders,
+    required Map<CommodityId, int> productionInputConsumption,
+    required TradeSectionHandlers handlers,
+  }) {
+    return TradeMarketStagingContext(
+      playerId: playerId,
+      offerCap: offerCapByCommodityId(
+        game: game,
+        playerId: playerId,
+        productionInputConsumptionByCommodityId: productionInputConsumption,
+      ),
+      stagedOffers: stagedOfferQuantitiesByCommodityId(
+        orders: orders,
+        playerId: playerId,
+      ),
+      bidTypeCap: worldMarketBidTypeCap(game, playerId),
+      orders: orders,
+      market: game.worldMarketState,
+      handlers: handlers,
+      firstRightCommodityIds: firstRightCommodityIdsForPlayer(game, playerId),
+    );
+  }
+
+  TradeOrder? stagedOrderFor(CommodityId commodityId) {
+    return tradeOrderForPlayerCommodity(orders, playerId, commodityId);
+  }
+
+  int sellableHeadroomFor(CommodityId commodityId) {
+    return sellableHeadroomForMaps(
+      offerCap: offerCap,
+      stagedOffers: stagedOffers,
+      commodityId: commodityId,
+    );
+  }
+
+  bool canSelectBidOn(CommodityId commodityId) {
+    return canStageBidOnCommodity(
+      orders: orders,
+      playerId: playerId,
+      commodityId: commodityId,
+      bidTypeCap: bidTypeCap,
+    );
+  }
+
+  void onDirectionChanged(CommodityId commodityId, TradeOrderType? next) {
+    handlers.onDirectionChanged(commodityId, next);
+  }
+
+  void onQuantityDelta(CommodityId commodityId, int delta) {
+    handlers.onQuantityDelta(commodityId, delta);
+  }
+}
+
+/// Returns the per-row sellable headroom shown as `(N)` next to the
+/// commodity name on the Trade Market tab (Refs #3093 — sellable
+/// clamp slice). Equals `max(0, offerCap[c] − stagedOffer[c])` for
+/// the row's commodity.
+int sellableHeadroomForMaps({
+  required Map<CommodityId, int> offerCap,
+  required Map<CommodityId, int> stagedOffers,
+  required CommodityId commodityId,
+}) {
+  final int cap = offerCap[commodityId] ?? 0;
+  final int staged = stagedOffers[commodityId] ?? 0;
+  final int headroom = cap - staged;
+  return headroom < 0 ? 0 : headroom;
+}

--- a/app/lib/features/game/screens/trade/trade_screen_market_tab_build.dart
+++ b/app/lib/features/game/screens/trade/trade_screen_market_tab_build.dart
@@ -15,6 +15,7 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../../../../providers/games_provider.dart';
 
+import 'trade_market_staging_context.dart';
 import 'trade_screen_contract_market.dart';
 import 'trade_screen_market_tab.dart';
 import 'trade_screen_market_tab_build_sections.dart';
@@ -51,62 +52,10 @@ extension MarketTabContentBuild on MarketTabContent {
     final SectionedTradeableCommodities sectioned =
         tradeableCommoditiesByCategory();
     final AppLocalizations l10n = appL10n(context);
-    final WorldMarketState market = game.worldMarketState;
-    final Set<CommodityId> firstRightCommodityIds =
-        firstRightCommodityIdsForPlayer(game, playerId);
 
-    final int tradeCargoCapacity = cargoHoldsForHomeFleet(game, playerId);
-    final int totalStagedBid = totalStagedBidQuantity(orders, playerId);
-    final int stagedDistinctBidCount =
-        stagedDistinctBidCommodityCount(orders, playerId);
-    final int bidTypeCap = worldMarketBidTypeCap(game, playerId);
-    final int remainingCargo = tradeCargoCapacity - totalStagedBid;
-    final int clampedRemaining = remainingCargo < 0 ? 0 : remainingCargo;
-    final bool warningVisible =
-        clampedRemaining == 0 && totalStagedBid > 0;
-
-    final ({
-      int budgetTotal,
-      int budgetRemaining,
-      bool warningVisible,
-    }) bidBudgetHeader = marketTabBidBudgetHeaderState(
-      game: game,
-      playerId: playerId,
-      orders: orders,
-      projectedTreasuryDelta: readProjectedTreasuryDelta(),
-      resourceRules: ResourceRules.defaultRules,
-    );
-
-    // Refs #3093 — sellable clamp slice. Compute the per-commodity offer
-    // cap and the player's already-staged offer quantities once per
-    // build so the rows below render `(headroom)` and clamp Offer
-    // toggles / `+` increments consistently. The helpers live in
-    // `colonizethis_logic` (pure functions) and are safe to call per
-    // frame. Industry-allocation reservations come from the player's
-    // current production assignments (derived from
-    // `productionDesiredOutputProvider`); subtracting them from the
-    // raw stockpile makes the sellable readout match
-    // `SPEC/game/world-market.md` § Per-commodity quantity cap. We
-    // `watch` the provider so allocation changes (e.g. the user
-    // returning from the Production screen) immediately refresh the
-    // sellable readouts without leaving the Market tab.
     final Map<CommodityId, int> productionInputConsumption =
         _consumptionForDesiredOutput(desiredOutputByRecipe);
-    final Map<CommodityId, int> offerCap = offerCapByCommodityId(
-      game: game,
-      playerId: playerId,
-      productionInputConsumptionByCommodityId: productionInputConsumption,
-    );
-    final Map<CommodityId, int> stagedOffers =
-        stagedOfferQuantitiesByCommodityId(
-      orders: orders,
-      playerId: playerId,
-    );
 
-    // Refs #3546 — collapse the three verbatim per-section closure pairs into a
-    // single factory call. The shared per-build order context is bound once;
-    // the projected treasury delta is still read lazily per interaction inside
-    // the factory (behaviour-preserving).
     final TradeSectionHandlers sectionHandlers = buildTradeSectionHandlers(
       readProjectedTreasuryDelta: readProjectedTreasuryDelta,
       handleDirectionChanged: ({
@@ -136,6 +85,35 @@ extension MarketTabContentBuild on MarketTabContent {
             delta: delta,
           ),
     );
+    final TradeMarketStagingContext staging = TradeMarketStagingContext.forMarketBuild(
+      game: game,
+      playerId: playerId,
+      orders: orders,
+      productionInputConsumption: productionInputConsumption,
+      handlers: sectionHandlers,
+    );
+
+    final int tradeCargoCapacity = cargoHoldsForHomeFleet(game, playerId);
+    final int totalStagedBid = totalStagedBidQuantity(orders, playerId);
+    final int stagedDistinctBidCount =
+        stagedDistinctBidCommodityCount(orders, playerId);
+    final int bidTypeCap = staging.bidTypeCap;
+    final int remainingCargo = tradeCargoCapacity - totalStagedBid;
+    final int clampedRemaining = remainingCargo < 0 ? 0 : remainingCargo;
+    final bool warningVisible =
+        clampedRemaining == 0 && totalStagedBid > 0;
+
+    final ({
+      int budgetTotal,
+      int budgetRemaining,
+      bool warningVisible,
+    }) bidBudgetHeader = marketTabBidBudgetHeaderState(
+      game: game,
+      playerId: playerId,
+      orders: orders,
+      projectedTreasuryDelta: readProjectedTreasuryDelta(),
+      resourceRules: ResourceRules.defaultRules,
+    );
 
     // SingleChildScrollView + Column (instead of ListView.builder) so
     // every commodity row is built up-front. Widget tests pin all 22
@@ -161,17 +139,11 @@ extension MarketTabContentBuild on MarketTabContent {
         final List<Widget> sectionWidgets = buildMarketTabSectionWidgets(
           l10n: l10n,
           sectioned: sectioned,
-          market: market,
-          orders: orders,
-          offerCap: offerCap,
-          stagedOffers: stagedOffers,
-          bidTypeCap: bidTypeCap,
-          firstRightCommodityIds: firstRightCommodityIds,
+          staging: staging,
           nameStyle: nameStyle,
           priceStyle: priceStyle,
           volumeStyle: volumeStyle,
           quantityStyle: quantityStyle,
-          sectionHandlers: sectionHandlers,
           wideLayout: wideLayout,
         );
         return SingleChildScrollView(

--- a/app/lib/features/game/screens/trade/trade_screen_market_tab_build_sections.dart
+++ b/app/lib/features/game/screens/trade/trade_screen_market_tab_build_sections.dart
@@ -6,15 +6,10 @@ import 'package:colonizethis_app_l10n/l10n/l10n.dart';
 import 'package:colonizethis_app_ui_chrome/config/editorial_monocle_palette.dart';
 import 'package:flutter/material.dart';
 
-import 'package:colonizethis_economy/colonizethis_economy.dart' show WorldMarketState;
-import 'package:colonizethis_orders/colonizethis_orders.dart' show TradeOrderType;
-
-import 'package:colonizethis_models/colonizethis_models.dart';
-
+import 'trade_market_staging_context.dart';
 import 'trade_screen_contract_market.dart';
 import 'trade_screen_market_tab.dart';
 import 'trade_screen_market_tab_catalog.dart';
-import 'trade_section_handlers.dart';
 
 extension MarketTabContentBuildSections on MarketTabContent {
   ({
@@ -61,17 +56,11 @@ extension MarketTabContentBuildSections on MarketTabContent {
   List<Widget> buildMarketTabSectionWidgets({
     required AppLocalizations l10n,
     required SectionedTradeableCommodities sectioned,
-    required WorldMarketState market,
-    required Orders orders,
-    required Map<CommodityId, int> offerCap,
-    required Map<CommodityId, int> stagedOffers,
-    required int bidTypeCap,
-    required Set<CommodityId> firstRightCommodityIds,
+    required TradeMarketStagingContext staging,
     required TextStyle nameStyle,
     required TextStyle priceStyle,
     required TextStyle volumeStyle,
     required TextStyle quantityStyle,
-    required TradeSectionHandlers sectionHandlers,
     bool wideLayout = false,
   }) {
     return <Widget>[
@@ -79,18 +68,11 @@ extension MarketTabContentBuildSections on MarketTabContent {
         sectionKey: TradeScreenMarketKeys.marketSectionFoodKey,
         sectionLabel: l10n.production_food,
         commodities: sectioned.food,
-        offerCap: offerCap,
-        stagedOffers: stagedOffers,
-        bidTypeCap: bidTypeCap,
-        market: market,
-        orders: orders,
+        staging: staging,
         nameStyle: nameStyle,
         priceStyle: priceStyle,
         volumeStyle: volumeStyle,
         quantityStyle: quantityStyle,
-        onDirectionChanged: sectionHandlers.onDirectionChanged,
-        onQuantityDelta: sectionHandlers.onQuantityDelta,
-        firstRightCommodityIds: firstRightCommodityIds,
         l10n: l10n,
         wideLayout: wideLayout,
       ),
@@ -98,19 +80,12 @@ extension MarketTabContentBuildSections on MarketTabContent {
         sectionKey: TradeScreenMarketKeys.marketSectionRawMaterialsKey,
         sectionLabel: l10n.production_rawMaterials,
         commodities: sectioned.rawMaterials,
-        offerCap: offerCap,
-        stagedOffers: stagedOffers,
-        bidTypeCap: bidTypeCap,
-        market: market,
-        orders: orders,
+        staging: staging,
         nameStyle: nameStyle,
         priceStyle: priceStyle,
         volumeStyle: volumeStyle,
         quantityStyle: quantityStyle,
-        onDirectionChanged: sectionHandlers.onDirectionChanged,
-        onQuantityDelta: sectionHandlers.onQuantityDelta,
         isFirstSection: false,
-        firstRightCommodityIds: firstRightCommodityIds,
         l10n: l10n,
         wideLayout: wideLayout,
       ),
@@ -118,19 +93,12 @@ extension MarketTabContentBuildSections on MarketTabContent {
         sectionKey: TradeScreenMarketKeys.marketSectionManufacturedKey,
         sectionLabel: l10n.production_manufactured,
         commodities: sectioned.manufactured,
-        offerCap: offerCap,
-        stagedOffers: stagedOffers,
-        bidTypeCap: bidTypeCap,
-        market: market,
-        orders: orders,
+        staging: staging,
         nameStyle: nameStyle,
         priceStyle: priceStyle,
         volumeStyle: volumeStyle,
         quantityStyle: quantityStyle,
-        onDirectionChanged: sectionHandlers.onDirectionChanged,
-        onQuantityDelta: sectionHandlers.onQuantityDelta,
         isFirstSection: false,
-        firstRightCommodityIds: firstRightCommodityIds,
         l10n: l10n,
         wideLayout: wideLayout,
       ),

--- a/app/lib/features/game/screens/trade/trade_screen_market_tab_catalog.dart
+++ b/app/lib/features/game/screens/trade/trade_screen_market_tab_catalog.dart
@@ -8,17 +8,16 @@ import 'package:flutter/material.dart';
 
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_economy/colonizethis_economy.dart' show CommodityCatalog, WorldMarketState;
-import 'package:colonizethis_orders/colonizethis_orders.dart'
-    show Orders, TradeOrderType, tradeOrderForPlayerCommodity;
+import 'package:colonizethis_orders/colonizethis_orders.dart' show TradeOrderType;
 
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../../../../widgets/ct_section_label.dart';
 import '../../widgets/production/commodity_ui_helpers.dart';
+import 'trade_market_staging_context.dart';
 import 'trade_screen_contract_market.dart';
 import 'trade_screen_market_row.dart';
 import 'trade_screen_market_tab.dart';
-import 'trade_screen_market_tab_order_handlers.dart';
 
 extension MarketTabContentCatalog on MarketTabContent {
   /// Builds the widget list that renders one Market commodity category
@@ -41,20 +40,12 @@ extension MarketTabContentCatalog on MarketTabContent {
     required Key sectionKey,
     required String sectionLabel,
     required List<Commodity> commodities,
-    required Map<CommodityId, int> offerCap,
-    required Map<CommodityId, int> stagedOffers,
-    required int bidTypeCap,
-    required WorldMarketState market,
-    required Orders orders,
+    required TradeMarketStagingContext staging,
     required TextStyle nameStyle,
     required TextStyle priceStyle,
     required TextStyle volumeStyle,
     required TextStyle quantityStyle,
-    required void Function(CommodityId commodityId, TradeOrderType? next)
-        onDirectionChanged,
-    required void Function(CommodityId commodityId, int delta) onQuantityDelta,
     required AppLocalizations l10n,
-    required Set<CommodityId> firstRightCommodityIds,
     bool isFirstSection = true,
     bool wideLayout = false,
   }) {
@@ -66,56 +57,34 @@ extension MarketTabContentCatalog on MarketTabContent {
       if (wideLayout)
         ..._buildWideCommodityGrid(
           commodities: commodities,
-          offerCap: offerCap,
-          stagedOffers: stagedOffers,
-          bidTypeCap: bidTypeCap,
-          market: market,
-          orders: orders,
+          staging: staging,
           nameStyle: nameStyle,
           priceStyle: priceStyle,
           volumeStyle: volumeStyle,
           quantityStyle: quantityStyle,
-          onDirectionChanged: onDirectionChanged,
-          onQuantityDelta: onQuantityDelta,
           l10n: l10n,
-          firstRightCommodityIds: firstRightCommodityIds,
         )
       else
         ..._buildNarrowCommodityList(
           commodities: commodities,
-          offerCap: offerCap,
-          stagedOffers: stagedOffers,
-          bidTypeCap: bidTypeCap,
-          market: market,
-          orders: orders,
+          staging: staging,
           nameStyle: nameStyle,
           priceStyle: priceStyle,
           volumeStyle: volumeStyle,
           quantityStyle: quantityStyle,
-          onDirectionChanged: onDirectionChanged,
-          onQuantityDelta: onQuantityDelta,
           l10n: l10n,
-          firstRightCommodityIds: firstRightCommodityIds,
         ),
     ];
   }
 
   List<Widget> _buildNarrowCommodityList({
     required List<Commodity> commodities,
-    required Map<CommodityId, int> offerCap,
-    required Map<CommodityId, int> stagedOffers,
-    required int bidTypeCap,
-    required WorldMarketState market,
-    required Orders orders,
+    required TradeMarketStagingContext staging,
     required TextStyle nameStyle,
     required TextStyle priceStyle,
     required TextStyle volumeStyle,
     required TextStyle quantityStyle,
-    required void Function(CommodityId commodityId, TradeOrderType? next)
-        onDirectionChanged,
-    required void Function(CommodityId commodityId, int delta) onQuantityDelta,
     required AppLocalizations l10n,
-    required Set<CommodityId> firstRightCommodityIds,
   }) {
     return <Widget>[
       for (int index = 0; index < commodities.length; index++)
@@ -125,19 +94,12 @@ extension MarketTabContentCatalog on MarketTabContent {
           child: _buildCommodityRow(
             commodity: commodities[index],
             compact: false,
-            offerCap: offerCap,
-            stagedOffers: stagedOffers,
-            bidTypeCap: bidTypeCap,
-            market: market,
-            orders: orders,
+            staging: staging,
             nameStyle: nameStyle,
             priceStyle: priceStyle,
             volumeStyle: volumeStyle,
             quantityStyle: quantityStyle,
-            onDirectionChanged: onDirectionChanged,
-            onQuantityDelta: onQuantityDelta,
             l10n: l10n,
-            firstRightCommodityIds: firstRightCommodityIds,
           ),
         ),
     ];
@@ -145,20 +107,12 @@ extension MarketTabContentCatalog on MarketTabContent {
 
   List<Widget> _buildWideCommodityGrid({
     required List<Commodity> commodities,
-    required Map<CommodityId, int> offerCap,
-    required Map<CommodityId, int> stagedOffers,
-    required int bidTypeCap,
-    required WorldMarketState market,
-    required Orders orders,
+    required TradeMarketStagingContext staging,
     required TextStyle nameStyle,
     required TextStyle priceStyle,
     required TextStyle volumeStyle,
     required TextStyle quantityStyle,
-    required void Function(CommodityId commodityId, TradeOrderType? next)
-        onDirectionChanged,
-    required void Function(CommodityId commodityId, int delta) onQuantityDelta,
     required AppLocalizations l10n,
-    required Set<CommodityId> firstRightCommodityIds,
   }) {
     final List<Widget> rows = <Widget>[];
     for (int index = 0; index < commodities.length; index += 2) {
@@ -180,19 +134,12 @@ extension MarketTabContentCatalog on MarketTabContent {
                   child: _buildCommodityRow(
                     commodity: left,
                     compact: true,
-                    offerCap: offerCap,
-                    stagedOffers: stagedOffers,
-                    bidTypeCap: bidTypeCap,
-                    market: market,
-                    orders: orders,
+                    staging: staging,
                     nameStyle: nameStyle,
                     priceStyle: priceStyle,
                     volumeStyle: volumeStyle,
                     quantityStyle: quantityStyle,
-                    onDirectionChanged: onDirectionChanged,
-                    onQuantityDelta: onQuantityDelta,
                     l10n: l10n,
-                    firstRightCommodityIds: firstRightCommodityIds,
                   ),
                 ),
               ),
@@ -206,19 +153,12 @@ extension MarketTabContentCatalog on MarketTabContent {
                         child: _buildCommodityRow(
                           commodity: right,
                           compact: true,
-                          offerCap: offerCap,
-                          stagedOffers: stagedOffers,
-                          bidTypeCap: bidTypeCap,
-                          market: market,
-                          orders: orders,
+                          staging: staging,
                           nameStyle: nameStyle,
                           priceStyle: priceStyle,
                           volumeStyle: volumeStyle,
                           quantityStyle: quantityStyle,
-                          onDirectionChanged: onDirectionChanged,
-                          onQuantityDelta: onQuantityDelta,
                           l10n: l10n,
-                          firstRightCommodityIds: firstRightCommodityIds,
                         ),
                       ),
               ),
@@ -233,54 +173,38 @@ extension MarketTabContentCatalog on MarketTabContent {
   Widget _buildCommodityRow({
     required Commodity commodity,
     required bool compact,
-    required Map<CommodityId, int> offerCap,
-    required Map<CommodityId, int> stagedOffers,
-    required int bidTypeCap,
-    required WorldMarketState market,
-    required Orders orders,
+    required TradeMarketStagingContext staging,
     required TextStyle nameStyle,
     required TextStyle priceStyle,
     required TextStyle volumeStyle,
     required TextStyle quantityStyle,
-    required void Function(CommodityId commodityId, TradeOrderType? next)
-        onDirectionChanged,
-    required void Function(CommodityId commodityId, int delta) onQuantityDelta,
     required AppLocalizations l10n,
-    required Set<CommodityId> firstRightCommodityIds,
   }) {
     final CommodityId commodityId = commodity.id;
-    final bool showFirstRightChip = firstRightCommodityIds.contains(commodityId);
+    final bool showFirstRightChip =
+        staging.firstRightCommodityIds.contains(commodityId);
     final rowParams = (
       commodityId: commodityId,
       commodityDisplayName: commodityDisplayName(l10n, commodityId),
       priceText: formatMarketPrice(
-        market.prices[commodityId],
+        staging.market.prices[commodityId],
         commodityId: commodityId,
       ),
       volumeText: volumeText(
-        market.lastTurnActivity[commodityId] ?? MarketActivity.empty,
+        staging.market.lastTurnActivity[commodityId] ?? MarketActivity.empty,
       ),
-      stagedOrder: tradeOrderForPlayerCommodity(orders, playerId, commodityId),
-      sellableHeadroom: sellableHeadroomFor(
-        offerCap: offerCap,
-        stagedOffers: stagedOffers,
-        commodityId: commodityId,
-      ),
-      offerCap: offerCap[commodityId] ?? 0,
-      canSelectBid: canStageBidOnCommodity(
-        orders: orders,
-        playerId: playerId,
-        commodityId: commodityId,
-        bidTypeCap: bidTypeCap,
-      ),
+      stagedOrder: staging.stagedOrderFor(commodityId),
+      sellableHeadroom: staging.sellableHeadroomFor(commodityId),
+      offerCap: staging.offerCap[commodityId] ?? 0,
+      canSelectBid: staging.canSelectBidOn(commodityId),
       nameStyle: nameStyle,
       priceStyle: priceStyle,
       volumeStyle: volumeStyle,
       quantityStyle: quantityStyle,
       onDirectionChanged: (TradeOrderType? next) =>
-          onDirectionChanged(commodityId, next),
-      onIncrement: () => onQuantityDelta(commodityId, 1),
-      onDecrement: () => onQuantityDelta(commodityId, -1),
+          staging.onDirectionChanged(commodityId, next),
+      onIncrement: () => staging.onQuantityDelta(commodityId, 1),
+      onDecrement: () => staging.onQuantityDelta(commodityId, -1),
     );
     if (compact) {
       return MarketCommodityRowCompact(
@@ -325,24 +249,6 @@ extension MarketTabContentCatalog on MarketTabContent {
       firstRightTooltip: l10n.tradeMarket_firstRightTooltip,
     );
   }
-}
-
-/// Returns the per-row sellable headroom shown as `(N)` next to the
-/// commodity name on the Trade Market tab (Refs #3093 — sellable
-/// clamp slice). Equals `max(0, offerCap[c] − stagedOffer[c])` for
-/// the row's commodity. Mirrors
-/// `sellableHeadroomByCommodityId` but with per-row resolution so
-/// the build path passes one int per row instead of rebuilding the
-/// full map per child.
-int sellableHeadroomFor({
-  required Map<CommodityId, int> offerCap,
-  required Map<CommodityId, int> stagedOffers,
-  required CommodityId commodityId,
-}) {
-  final int cap = offerCap[commodityId] ?? 0;
-  final int staged = stagedOffers[commodityId] ?? 0;
-  final int headroom = cap - staged;
-  return headroom < 0 ? 0 : headroom;
 }
 
 String volumeText(MarketActivity activity) {

--- a/app/test/trade_market_staging_context_test.dart
+++ b/app/test/trade_market_staging_context_test.dart
@@ -1,0 +1,45 @@
+import 'package:colonizethis_app/features/game/screens/trade/trade_market_staging_context.dart';
+import 'package:colonizethis_app/features/game/screens/trade/trade_section_handlers.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('TradeMarketStagingContext', () {
+    test('sellableHeadroomForMaps clamps negative headroom to zero', () {
+      expect(
+        sellableHeadroomForMaps(
+          offerCap: const {'grain': 5},
+          stagedOffers: const {'grain': 8},
+          commodityId: 'grain',
+        ),
+        0,
+      );
+    });
+
+    test('onDirectionChanged delegates to handlers', () {
+      CommodityId? capturedId;
+      var captured = false;
+      final staging = TradeMarketStagingContext(
+        playerId: 'gp1',
+        offerCap: const {},
+        stagedOffers: const {},
+        bidTypeCap: 3,
+        orders: const Orders(),
+        market: WorldMarketState.empty,
+        handlers: (
+          onDirectionChanged: (CommodityId id, TradeOrderType? _) {
+            capturedId = id;
+            captured = true;
+          },
+          onQuantityDelta: (_, __) {},
+        ),
+        firstRightCommodityIds: const {},
+      );
+
+      staging.onDirectionChanged('grain', TradeOrderType.bid);
+
+      expect(captured, isTrue);
+      expect(capturedId, 'grain');
+    });
+  });
+}

--- a/app/test/trade_market_staging_context_test.dart
+++ b/app/test/trade_market_staging_context_test.dart
@@ -1,3 +1,5 @@
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+
 import 'package:colonizethis_app/features/game/screens/trade/trade_market_staging_context.dart';
 import 'package:colonizethis_app/features/game/screens/trade/trade_section_handlers.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';


### PR DESCRIPTION
## Summary

- Introduce `TradeMarketStagingContext` bundling offer caps, staged-offer quantities, bid-type cap, market state, first-right commodity ids, and direction/quantity mutation handlers.
- Refactor `trade_screen_market_tab_catalog.dart`, `trade_screen_market_tab_build_sections.dart`, and `trade_screen_market_tab_build.dart` to pass the context instead of 10+ parallel parameters per section/row.

## Deferred (issue #4240)

- Slice C — civilian unit row decomposition
- Slice D — draft projection shared helpers
- Slice E — trade test harness densify
- Remaining features/providers narrow-import migration beyond slice A scope

## Tests

- `flutter test app/test/trade_market_staging_context_test.dart`
- `flutter test app/test/trade_screen_market_tab_commodity_table_test.dart`
- `flutter test app/test/trade_screen_market_tab_sellable_clamp_test.dart`
- `flutter test app/test/trade_screen_market_tab_bid_type_cap_test.dart`
- `flutter test app/test/trade_screen_market_tab_e5b_interactive_controls_test.dart`
- `flutter test app/test/trade_screen_market_tab_wide_layout_test.dart`

Refs #4240


Made with [Cursor](https://cursor.com)