### PR TITLE
feat: Development panel Widgetbook fog and assigned-civilian stories (#4175)

### DIFF
--- a/SPEC/ui/development-panel.md
+++ b/SPEC/ui/development-panel.md
@@ -71,7 +71,9 @@ Road-step selection: BFS on owned land tiles from the improve target toward any 
 | Use case | Proves |
 |----------|--------|
 | Default — Old World | Overview + owned rows + map. |
-| Narrow (360 dp) | Stacked list/map. |
+| Default — Old World (mobile / wide) | Narrow stacked list/map and wide side-by-side layout. |
+| Fog map — player-constrained visibility | Panel map with `fullyVisible`, `fogged`, and unrevealed tiles; territory perimeter outline; improvable counts exclude unrevealed intel. |
+| Assigned civilians — overview rows | Overview lists pending Builder improve and in-progress Engineer road work with target + turn progress. |
 | Disconnected dialog | Road first disabled reason + Improve anyway affordance. |
 
 ---

--- a/widgetbook_host/lib/catalogs/catalog_data_screens.dart
+++ b/widgetbook_host/lib/catalogs/catalog_data_screens.dart
@@ -198,6 +198,9 @@ Widget _victoryScreenAnnotatedMinimapStory() {
 }
 
 const String _kDevelopmentPanelStoryGameId = 'wb_development_panel';
+const String _kDevelopmentPanelFogStoryGameId = 'wb_development_panel_fog';
+const String _kDevelopmentPanelAssignedStoryGameId =
+    'wb_development_panel_assigned';
 
 Game _developmentPanelStoryGame() {
   const human = 'gp1';
@@ -291,6 +294,216 @@ Game _developmentPanelStoryGame() {
   );
 }
 
+Game _developmentPanelFogVisibilityStoryGame() {
+  const human = 'gp1';
+  const p1 = 'oldWorld|p1';
+  const p2 = 'oldWorld|p2';
+  const tileA = 'oldWorld|p1|0|0';
+  const tileB = 'oldWorld|p1|1|0';
+  const tileHidden = 'oldWorld|p1|2|0';
+  const tileP2 = 'oldWorld|p2|0|1';
+  const tileP2Fog = 'oldWorld|p2|1|1';
+  const tileP2Visible = 'oldWorld|p2|2|1';
+
+  return Game(
+    id: _kDevelopmentPanelFogStoryGameId,
+    worldState: WorldState(
+      turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 5),
+      oldWorld: RegionData(
+        provinces: [
+          Province(
+            id: p1,
+            regionId: 'oldWorld',
+            ownerId: human,
+            displayName: 'Avalon',
+            townTileKey: tileA,
+          ),
+          Province(
+            id: p2,
+            regionId: 'oldWorld',
+            ownerId: human,
+            displayName: 'Barren',
+            townTileKey: tileP2,
+          ),
+        ],
+        units: [
+          Unit(
+            id: 'b1',
+            type: kUnitTypeBuilder,
+            ownerId: human,
+            locationProvinceId: p1,
+            tileKey: tileA,
+            status: UnitStatus.idle,
+          ),
+        ],
+      ),
+      newWorld: const RegionData(),
+      tileKeysByRegionAndProvince: {
+        'oldWorld': {
+          p1: [tileA, tileB, tileHidden],
+          p2: [tileP2, tileP2Fog, tileP2Visible],
+        },
+      },
+      resourceByTileKey: {
+        tileA: 'grain',
+        tileB: 'grain',
+        tileHidden: 'grain',
+      },
+      tileState: const TileMapState(
+        improvementByTile: {
+          tileA: 0,
+          tileB: 0,
+          tileHidden: 0,
+        },
+      ),
+      playerVisibilityByTile: {
+        human: {
+          tileA: 'fullyVisible',
+          tileB: 'fogged',
+          tileP2Fog: 'fogged',
+          tileP2Visible: 'fullyVisible',
+        },
+      },
+    ),
+    players: const [
+      Player(
+        id: human,
+        displayName: 'England',
+        isHuman: true,
+        capitalProvinceId: p1,
+        capitalTile: CapitalTile(
+          regionId: 'oldWorld',
+          provinceId: 'p1',
+          x: 0,
+          y: 0,
+        ),
+        stockpile: Stockpile(quantities: {'lumber': 20, 'castIron': 20}),
+        techUnlocked: {kTechIdCircularSaw: true},
+      ),
+    ],
+  );
+}
+
+Game _developmentPanelAssignedCiviliansStoryGame() {
+  const human = 'gp1';
+  const p1 = 'oldWorld|p1';
+  const p2 = 'oldWorld|p2';
+  const tileA = 'oldWorld|p1|0|0';
+  const tileB = 'oldWorld|p1|1|0';
+  const tileP2 = 'oldWorld|p2|0|1';
+
+  return Game(
+    id: _kDevelopmentPanelAssignedStoryGameId,
+    worldState: WorldState(
+      turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 5),
+      oldWorld: RegionData(
+        provinces: [
+          Province(
+            id: p1,
+            regionId: 'oldWorld',
+            ownerId: human,
+            displayName: 'Avalon',
+            townTileKey: tileA,
+          ),
+          Province(
+            id: p2,
+            regionId: 'oldWorld',
+            ownerId: human,
+            displayName: 'Barren',
+            townTileKey: tileP2,
+          ),
+        ],
+        units: [
+          Unit(
+            id: 'b1',
+            type: kUnitTypeBuilder,
+            ownerId: human,
+            locationProvinceId: p1,
+            tileKey: tileA,
+            status: UnitStatus.idle,
+          ),
+          Unit(
+            id: 'b2',
+            type: kUnitTypeBuilder,
+            ownerId: human,
+            locationProvinceId: p1,
+            tileKey: tileA,
+            status: UnitStatus.idle,
+          ),
+          Unit(
+            id: 'e1',
+            type: kUnitTypeEngineer,
+            ownerId: human,
+            locationProvinceId: p1,
+            tileKey: tileA,
+            status: UnitStatus.working,
+            currentWork: const CurrentWork(
+              workTarget: 'build_road',
+              tileKey: tileB,
+              totalTurns: 3,
+              remainingTurns: 2,
+            ),
+          ),
+        ],
+      ),
+      newWorld: const RegionData(),
+      tileKeysByRegionAndProvince: {
+        'oldWorld': {
+          p1: [tileA, tileB],
+          p2: [tileP2],
+        },
+      },
+      resourceByTileKey: {
+        tileA: 'grain',
+        tileB: 'grain',
+      },
+      tileState: const TileMapState(
+        improvementByTile: {
+          tileA: 0,
+          tileB: 0,
+        },
+      ),
+      playerVisibilityByTile: {
+        human: {
+          tileA: 'fullyVisible',
+          tileB: 'fullyVisible',
+          tileP2: 'fullyVisible',
+        },
+      },
+    ),
+    players: const [
+      Player(
+        id: human,
+        displayName: 'England',
+        isHuman: true,
+        capitalProvinceId: p1,
+        capitalTile: CapitalTile(
+          regionId: 'oldWorld',
+          provinceId: 'p1',
+          x: 0,
+          y: 0,
+        ),
+        stockpile: Stockpile(quantities: {'lumber': 20, 'castIron': 20}),
+        techUnlocked: {kTechIdCircularSaw: true},
+      ),
+    ],
+  );
+}
+
+Orders _developmentPanelAssignedCiviliansStoryOrders() {
+  return Orders(
+    workOrdersByPlayerId: {
+      'gp1': [
+        WorkOrder(
+          unitId: 'b1',
+          target: 'build_improvement',
+          targetTileKey: 'oldWorld|p1|0|0',
+        ),
+      ],
+    },
+  );
+}
+
 class _DevelopmentPanelStoryGameService extends StoryStubGameService {
   static final Map<String, MapTopology> _topologyByRegion = {
     'oldWorld': MapTopology(
@@ -311,7 +524,7 @@ class _DevelopmentPanelStoryGameService extends StoryStubGameService {
     'newWorld': const MapTopology(nodes: [], edges: []),
   };
 
-  static final Map<String, TileMapResult> _tileMapByRegion = {
+  static final Map<String, TileMapResult> _tileMapByRegion2x2 = {
     'oldWorld': TileMapResult(
       width: 2,
       height: 2,
@@ -326,6 +539,35 @@ class _DevelopmentPanelStoryGameService extends StoryStubGameService {
       resourceGrid: [
         [Resource.grain, Resource.grain],
         [null, null],
+      ],
+    ),
+    'newWorld': TileMapResult(
+      width: 1,
+      height: 1,
+      grid: const [
+        ['nw1'],
+      ],
+      terrainGrid: const [
+        [TerrainType.plains],
+      ],
+    ),
+  };
+
+  static final Map<String, TileMapResult> _tileMapByRegion3x2 = {
+    'oldWorld': TileMapResult(
+      width: 3,
+      height: 2,
+      grid: const [
+        ['p1', 'p1', 'p1'],
+        ['p2', 'p2', 'p2'],
+      ],
+      terrainGrid: const [
+        [TerrainType.plains, TerrainType.plains, TerrainType.plains],
+        [TerrainType.plains, TerrainType.plains, TerrainType.plains],
+      ],
+      resourceGrid: [
+        [Resource.grain, Resource.grain, Resource.grain],
+        [null, null, null],
       ],
     ),
     'newWorld': TileMapResult(
@@ -360,18 +602,28 @@ class _DevelopmentPanelStoryGameService extends StoryStubGameService {
 
   @override
   GameMapData? getMapData(String gameId) {
-    if (gameId != _kDevelopmentPanelStoryGameId) return null;
+    final tileMapByRegion = switch (gameId) {
+      _kDevelopmentPanelFogStoryGameId => _tileMapByRegion3x2,
+      _kDevelopmentPanelStoryGameId ||
+      _kDevelopmentPanelAssignedStoryGameId =>
+        _tileMapByRegion2x2,
+      _ => null,
+    };
+    if (tileMapByRegion == null) return null;
     return (
       combinedTopology: _combinedTopology,
-      tileMapByRegion: _tileMapByRegion,
+      tileMapByRegion: tileMapByRegion,
       topologyByRegion: _topologyByRegion,
       warpLinks: null,
     );
   }
 }
 
-Widget _developmentPanelStoryHost({required Widget child}) {
-  final game = _developmentPanelStoryGame();
+Widget _developmentPanelStoryHost({
+  required Game game,
+  required Orders orders,
+  required Widget child,
+}) {
   return ProviderScope(
     overrides: [
       appEventBusProvider.overrideWith((ref) {
@@ -381,7 +633,7 @@ Widget _developmentPanelStoryHost({required Widget child}) {
       }),
       currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
       currentOrdersProvider.overrideWith(
-        () => CurrentOrdersNotifier(const Orders()),
+        () => CurrentOrdersNotifier(orders),
       ),
       gameServiceProvider.overrideWith(
         (ref) => _DevelopmentPanelStoryGameService(),
@@ -396,10 +648,32 @@ Widget _developmentPanelStoryHost({required Widget child}) {
   );
 }
 
+Widget _developmentPanelStory({
+  required Game game,
+  required Orders orders,
+}) {
+  return _developmentPanelStoryHost(
+    game: game,
+    orders: orders,
+    child: DevelopmentScreen(game: game, humanPlayerId: 'gp1'),
+  );
+}
+
 Widget _developmentPanelDefaultStory() {
   final game = _developmentPanelStoryGame();
-  return _developmentPanelStoryHost(
-    child: DevelopmentScreen(game: game, humanPlayerId: 'gp1'),
+  return _developmentPanelStory(game: game, orders: const Orders());
+}
+
+Widget _developmentPanelFogVisibilityStory() {
+  final game = _developmentPanelFogVisibilityStoryGame();
+  return _developmentPanelStory(game: game, orders: const Orders());
+}
+
+Widget _developmentPanelAssignedCiviliansStory() {
+  final game = _developmentPanelAssignedCiviliansStoryGame();
+  return _developmentPanelStory(
+    game: game,
+    orders: _developmentPanelAssignedCiviliansStoryOrders(),
   );
 }
 
@@ -421,6 +695,24 @@ List<WidgetbookNode> get developmentScreenDirectories => [
         name: 'Default — Old World (wide)',
         builder: (context) =>
             wideViewport(context, _developmentPanelDefaultStory()),
+      ),
+      WidgetbookUseCase(
+        name: 'Fog map — player-constrained visibility',
+        builder: (context) => _developmentPanelFogVisibilityStory(),
+      ),
+      WidgetbookUseCase(
+        name: 'Fog map — player-constrained visibility (wide)',
+        builder: (context) =>
+            wideViewport(context, _developmentPanelFogVisibilityStory()),
+      ),
+      WidgetbookUseCase(
+        name: 'Assigned civilians — overview rows',
+        builder: (context) => _developmentPanelAssignedCiviliansStory(),
+      ),
+      WidgetbookUseCase(
+        name: 'Assigned civilians — overview rows (wide)',
+        builder: (context) =>
+            wideViewport(context, _developmentPanelAssignedCiviliansStory()),
       ),
     ],
   ),


### PR DESCRIPTION
## Summary

- Adds Widgetbook use cases for Slice D follow-up: **Fog map — player-constrained visibility** (mixed `fullyVisible` / `fogged` / unrevealed tiles, territory outline) and **Assigned civilians — overview rows** (pending Builder improve + in-progress Engineer road work).
- Extends development panel story fixtures with dedicated fog (3×2 map) and assigned-civilian game/orders hosts.
- Updates `SPEC/ui/development-panel.md` Widgetbook table to document the new use cases.

Refs #4175

## Scope

**Done in this PR:** Optional Widgetbook variant refresh deferred from #4203 (fog map + assigned-overview rows). Core panel behavior, goldens, and read-model tests were already merged on `dev`.

**Deferred:** None — this closes the issue’s optional follow-up.

## AC / SPEC coverage

| Area | Status |
|------|--------|
| Slice A–C (shell, assign, disconnected dialog) | Already on `dev` via #4177 |
| Slice D (fog parity, territory outline, assigned civilians) | Already on `dev` via #4203 |
| Widgetbook fog + assigned overview variants | This PR |

## Manual

N/A — Widgetbook/catalog-only; no player UX change.

## Tests

- `cd app && flutter test test/development_panel_goldens_test.dart` — pass (2/2)
- `dart analyze` on `catalog_data_screens.dart` — clean


Made with [Cursor](https://cursor.com)