### PR TITLE
perf: speed up Development panel open path (#4175 Slice E)

### DIFF
--- a/SPEC/program/development-panel-read-model.md
+++ b/SPEC/program/development-panel-read-model.md
@@ -28,6 +28,15 @@ When `playerView` is supplied to `buildDevelopmentPanelModel`, improvable commod
 
 `buildDevelopmentAssignedCiviliansForRegion` scans `oldWorld.units` / `newWorld.units` for `kUnitTypeBuilder` and `kUnitTypeEngineer` owned by the player in the active region. Include a unit when it has a pending `WorkOrder` in `currentOrders` for that unit id, or `status == working` with non-null `currentWork`. Pending takes precedence over in-progress when both exist.
 
+## Open-path performance (Slice E)
+
+- `buildDevelopmentPanelModel` performs a single `resolveConnectivity` pass and exposes `connectedTileKeys` on `DevelopmentPanelModel` for assign affordance (no duplicate connectivity resolution on panel open).
+- `DevelopmentScreenBody` builds `PlayerView` once per frame and passes it to the read model and each region map panel (no per-map `buildPlayerView`).
+- Region tabs use `CtTabStrip.lazyTabBodies` so the inactive region tab (including its map) is not built until first selection.
+- Panel maps call `buildInitGameMapRegionViewData` for the active region only (not full dual-region `buildInitGameMapViewData`).
+
+Cache invalidation: panel projections recompute when `game`, `currentOrders`, or `playerView` inputs change on rebuild; assign/cancel and fog updates remain live-immediate per Slice A–D ACs.
+
 ## Acceptance criteria
 
 - Given owned province P with three improvable grain tiles, when the read model builds, then P’s owned scope lists grain count 3 with sorted tile keys.

--- a/app/lib/features/game/screens/development/development_panel_map_panel.dart
+++ b/app/lib/features/game/screens/development/development_panel_map_panel.dart
@@ -16,12 +16,14 @@ class DevelopmentPanelMapPanel extends ConsumerWidget {
     required this.game,
     required this.humanPlayerId,
     required this.regionId,
+    required this.playerView,
     this.highlightTileKeys,
   });
 
   final Game game;
   final String humanPlayerId;
   final String regionId;
+  final PlayerView playerView;
   final Set<String>? highlightTileKeys;
 
   @override
@@ -31,25 +33,18 @@ class DevelopmentPanelMapPanel extends ConsumerWidget {
       return const SizedBox.shrink();
     }
 
-    final playerView = buildPlayerView(
-      game,
-      mapData.combinedTopology,
-      humanPlayerId,
-    );
     final visibilityByTile = developmentPanelVisibilityByTile(
       game: game,
       playerView: playerView,
     );
-    final viewData = buildInitGameMapViewData(
+    final region = buildInitGameMapRegionViewData(
+      regionId: regionId,
       game: game,
       tileMapByRegion: mapData.tileMapByRegion,
       topologyByRegion: mapData.topologyByRegion,
       cellSize: 12,
       visibilityByTile: visibilityByTile,
     );
-    final region = regionId == kRegionNewWorld
-        ? viewData.newWorld
-        : viewData.oldWorld;
     final playerTerritoryTileKeys = developmentPanelPlayerTerritoryTileKeys(
       game: game,
       playerId: humanPlayerId,

--- a/app/lib/features/game/screens/development/development_screen_body.dart
+++ b/app/lib/features/game/screens/development/development_screen_body.dart
@@ -17,7 +17,7 @@ import 'package:colonizethis_world/colonizethis_world.dart'
         buildPlayerView,
         kRegionNewWorld,
         kRegionOldWorld,
-        resolveConnectivity;
+        PlayerView;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -75,12 +75,7 @@ class DevelopmentScreenBody extends ConsumerWidget {
       playerDisplayNamesById: playerNames,
       playerView: playerView,
     );
-    final connectivity = resolveConnectivity(
-      game: game,
-      tileMapByRegion: mapData.tileMapByRegion,
-      topology: mapData.combinedTopology,
-    )[humanPlayerId];
-    final connectedTileKeys = connectivity?.connected ?? const <String>{};
+    final connectedTileKeys = model.connectedTileKeys;
     final bus = ref.read(appEventBusProvider);
     final l10n = appL10n(context);
 
@@ -90,6 +85,7 @@ class DevelopmentScreenBody extends ConsumerWidget {
         padding: const EdgeInsets.all(CtSpacing.l),
         child: CtTabStrip(
           key: DevelopmentPanelKeys.tabsBodyKey,
+          lazyTabBodies: true,
           tabLabels: [l10n.region_oldWorld, l10n.region_newWorld],
           tabViews: [
             _DevelopmentRegionTab(
@@ -97,6 +93,7 @@ class DevelopmentScreenBody extends ConsumerWidget {
               humanPlayerId: humanPlayerId,
               regionId: kRegionOldWorld,
               regionModel: model.oldWorld,
+              playerView: playerView,
               topology: mapData.combinedTopology,
               tileMapByRegion: mapData.tileMapByRegion,
               currentOrders: orders,
@@ -121,6 +118,7 @@ class DevelopmentScreenBody extends ConsumerWidget {
               humanPlayerId: humanPlayerId,
               regionId: kRegionNewWorld,
               regionModel: model.newWorld,
+              playerView: playerView,
               topology: mapData.combinedTopology,
               tileMapByRegion: mapData.tileMapByRegion,
               currentOrders: orders,
@@ -212,6 +210,7 @@ class _DevelopmentRegionTab extends StatefulWidget {
     required this.humanPlayerId,
     required this.regionId,
     required this.regionModel,
+    required this.playerView,
     required this.topology,
     required this.tileMapByRegion,
     required this.currentOrders,
@@ -225,6 +224,7 @@ class _DevelopmentRegionTab extends StatefulWidget {
   final String humanPlayerId;
   final String regionId;
   final DevelopmentPanelRegionModel regionModel;
+  final PlayerView playerView;
   final MapTopology topology;
   final Map<String, TileMapResult> tileMapByRegion;
   final Orders currentOrders;
@@ -299,6 +299,7 @@ class _DevelopmentRegionTabState extends State<_DevelopmentRegionTab> {
       game: widget.game,
       humanPlayerId: widget.humanPlayerId,
       regionId: widget.regionId,
+      playerView: widget.playerView,
       highlightTileKeys: _highlightTileKeys,
     );
 

--- a/app/lib/widgets/ct_tab_strip.dart
+++ b/app/lib/widgets/ct_tab_strip.dart
@@ -27,6 +27,7 @@ class CtTabStrip extends StatefulWidget {
     required this.tabViews,
     EdgeInsets? contentPadding,
     this.initialTabIndex = 0,
+    this.lazyTabBodies = false,
   })  : assert(tabLabels.length == tabViews.length),
         assert(tabLabels.isNotEmpty),
         assert(
@@ -48,6 +49,10 @@ class CtTabStrip extends StatefulWidget {
   /// dark-theme E4 contract for `TradeScreen` documents the default of
   /// `0` so callers must opt in explicitly.
   final int initialTabIndex;
+
+  /// When true, off-tab bodies are not built until their tab is selected
+  /// for the first time (reduces open-path work for heavy panel tabs).
+  final bool lazyTabBodies;
 
   /// Inner padding applied to every tab label container.
   static const EdgeInsets tabContentPadding =
@@ -104,7 +109,16 @@ class _CtTabStripState extends State<CtTabStrip> {
             child: IndexedStack(
               index: _selectedIndex,
               sizing: StackFit.expand,
-              children: widget.tabViews,
+              children: List<Widget>.generate(
+                widget.tabViews.length,
+                (int i) => widget.lazyTabBodies
+                    ? _CtLazyTabBody(
+                        index: i,
+                        selectedIndex: _selectedIndex,
+                        child: widget.tabViews[i],
+                      )
+                    : widget.tabViews[i],
+              ),
             ),
           ),
         ),
@@ -147,5 +161,36 @@ class _CtTabStripState extends State<CtTabStrip> {
         ),
       ),
     );
+  }
+}
+
+/// Defers building [child] until [index] is selected for the first time.
+class _CtLazyTabBody extends StatefulWidget {
+  const _CtLazyTabBody({
+    required this.index,
+    required this.selectedIndex,
+    required this.child,
+  });
+
+  final int index;
+  final int selectedIndex;
+  final Widget child;
+
+  @override
+  State<_CtLazyTabBody> createState() => _CtLazyTabBodyState();
+}
+
+class _CtLazyTabBodyState extends State<_CtLazyTabBody> {
+  bool _wasEverActive = false;
+
+  @override
+  Widget build(BuildContext context) {
+    if (widget.index == widget.selectedIndex) {
+      _wasEverActive = true;
+    }
+    if (!_wasEverActive) {
+      return const SizedBox.shrink();
+    }
+    return widget.child;
   }
 }

--- a/app/test/ct_tab_strip_test.dart
+++ b/app/test/ct_tab_strip_test.dart
@@ -282,4 +282,40 @@ void main() {
       },
     );
   });
+
+  testWidgets(
+    'lazyTabBodies defers off-tab body until first selection (Refs #4175 Slice E)',
+    (WidgetTester tester) async {
+      var secondaryBuilds = 0;
+      await tester.pumpWidget(
+        _host(
+          SizedBox(
+            height: 200,
+            child: CtTabStrip(
+              lazyTabBodies: true,
+              tabLabels: const ['First', 'Second'],
+              tabViews: [
+                const Text('View 1'),
+                Builder(
+                  builder: (context) {
+                    secondaryBuilds++;
+                    return const Text('View 2');
+                  },
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      expect(secondaryBuilds, 0);
+      expect(find.text('View 2'), findsNothing);
+
+      await tester.tap(find.text('Second'));
+      await tester.pump();
+
+      expect(secondaryBuilds, greaterThan(0));
+      expect(find.text('View 2'), findsOneWidget);
+    },
+  );
 }

--- a/packages/colonizethis_economy/lib/src/economy/development_panel_model.dart
+++ b/packages/colonizethis_economy/lib/src/economy/development_panel_model.dart
@@ -89,10 +89,14 @@ class DevelopmentPanelModel {
   const DevelopmentPanelModel({
     required this.oldWorld,
     required this.newWorld,
+    required this.connectedTileKeys,
   });
 
   final DevelopmentPanelRegionModel oldWorld;
   final DevelopmentPanelRegionModel newWorld;
+
+  /// Capital-connected tile keys for the human player (single connectivity pass).
+  final Set<String> connectedTileKeys;
 
   DevelopmentPanelRegionModel forRegion(String regionId) =>
       regionId == kRegionNewWorld ? newWorld : oldWorld;

--- a/packages/colonizethis_economy/lib/src/economy/development_panel_read_model.dart
+++ b/packages/colonizethis_economy/lib/src/economy/development_panel_read_model.dart
@@ -47,7 +47,10 @@ DevelopmentPanelModel buildDevelopmentPanelModel({
 
   final ownerCache = ProvinceOwnerCache.of(game.worldState);
 
+  final connectedTileKeys = connectivity[playerId]?.connected ?? const <String>{};
+
   return DevelopmentPanelModel(
+    connectedTileKeys: connectedTileKeys,
     oldWorld: _buildRegionModel(
       game: game,
       playerId: playerId,

--- a/packages/colonizethis_map/lib/src/view/init_game_map_view_builder.dart
+++ b/packages/colonizethis_map/lib/src/view/init_game_map_view_builder.dart
@@ -80,3 +80,23 @@ InitGameMapViewData buildInitGameMapViewData({
     configSummary: configSummary,
   );
 }
+
+/// Builds [RegionMapViewData] for one region without assembling the full
+/// dual-region [InitGameMapViewData] (lighter path for panel minimaps).
+RegionMapViewData buildInitGameMapRegionViewData({
+  required String regionId,
+  required Game game,
+  required Map<String, TileMapResult> tileMapByRegion,
+  required Map<String, MapTopology> topologyByRegion,
+  required int cellSize,
+  Map<String, TileVisibility>? visibilityByTile,
+}) {
+  return buildRegionViewData(
+    regionId: regionId,
+    tileMap: tileMapByRegion[regionId]!,
+    topology: topologyByRegion[regionId]!,
+    game: game,
+    cellSize: cellSize,
+    visibilityByTile: visibilityByTile,
+  );
+}


### PR DESCRIPTION
## Summary
- Remove duplicate `resolveConnectivity` on panel open by exposing `connectedTileKeys` from `buildDevelopmentPanelModel`.
- Build `PlayerView` once in `DevelopmentScreenBody` and pass it to region map panels (no per-map `buildPlayerView`).
- Enable `CtTabStrip.lazyTabBodies` for Development region tabs so the inactive region (and its map) is not built until first selection.
- Use new `buildInitGameMapRegionViewData` for panel minimaps (single region instead of full dual-region `buildInitGameMapViewData`).

## Profiling notes (code-review hotspots addressed)
| Hotspot | Fix |
|---------|-----|
| Duplicate `resolveConnectivity` | Single pass in read model; screen uses `model.connectedTileKeys` |
| Duplicate `buildPlayerView` | Hoisted to screen body; passed to map panel |
| `IndexedStack` mounts both region tabs on open | `lazyTabBodies: true` on Development `CtTabStrip` |
| `buildInitGameMapViewData` builds OW+NW per map | `buildInitGameMapRegionViewData` for active region only |

## Test plan
- [x] `dart test` — `packages/colonizethis_economy/test/economy/development_panel_read_model_test.dart`
- [x] `flutter test` — `app/test/ct_tab_strip_test.dart` (lazy tab guard)
- [x] `flutter test` — `app/test/development_panel_goldens_test.dart`

## Scope / deferred
- **Implemented:** Slice E performance ACs for lazy tab mount guard, duplicate-work elimination, SPEC contract in `development-panel-read-model.md`.
- **Deferred:** Flutter DevTools before/after timeline capture on a mid-game save (qualitative owner-reported symptom validation remains manual); Riverpod provider memoization for read model if further profiling shows rebuild churn.

Refs #4175

Made with [Cursor](https://cursor.com)