### PR TITLE
perf: cache Development panel map snapshot and defer first paint (#4175)

### DIFF
--- a/SPEC/program/development-panel-read-model.md
+++ b/SPEC/program/development-panel-read-model.md
@@ -35,6 +35,8 @@ When `playerView` is supplied to `buildDevelopmentPanelModel`, improvable commod
 - `DevelopmentScreenBody` builds `PlayerView` once per frame and passes it to the read model and each region map panel (no per-map `buildPlayerView`).
 - Region tabs use `CtTabStrip.lazyTabBodies` so the inactive region tab (including its map) is not built until first selection.
 - Panel maps call `buildInitGameMapRegionViewData` for the active region only (not full dual-region `buildInitGameMapViewData`).
+- `DevelopmentPanelMapPanel` caches `DevelopmentPanelMapSnapshot` (region view data + territory outline keys) across highlight-only rebuilds; invalidates when game turn, region, player, or per-region visibility digest changes.
+- First map paint is deferred to the frame after panel mount so overview/list can paint first (post-frame `mapReady` gate).
 - `developmentPanelVisibilityByTile` accepts optional `regionId` so panel maps do not scan both regions when rendering one minimap.
 
 Cache invalidation: panel projections recompute when `game`, `currentOrders`, or `playerView` inputs change on rebuild; assign/cancel and fog updates remain live-immediate per Slice A–D ACs.

--- a/app/lib/features/game/screens/development/development_panel_map_panel.dart
+++ b/app/lib/features/game/screens/development/development_panel_map_panel.dart
@@ -1,16 +1,17 @@
-import 'package:colonizethis_map/colonizethis_map.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_world/colonizethis_world.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../core/services/region_map/region_map_widget_bindings.dart';
 import '../../../../providers/game_service_provider.dart';
 import '../../../../widgets/ct_region_map.dart';
-import 'development_panel_map_visibility.dart';
+import 'development_panel_map_snapshot.dart';
 
 /// Pannable region map for the Development panel with multi-tile highlight.
-class DevelopmentPanelMapPanel extends ConsumerWidget {
+class DevelopmentPanelMapPanel extends ConsumerStatefulWidget {
   const DevelopmentPanelMapPanel({
     super.key,
     required this.game,
@@ -27,43 +28,95 @@ class DevelopmentPanelMapPanel extends ConsumerWidget {
   final Set<String>? highlightTileKeys;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final mapData = ref.read(gameServiceProvider).getMapData(game.id);
+  ConsumerState<DevelopmentPanelMapPanel> createState() =>
+      _DevelopmentPanelMapPanelState();
+}
+
+class _DevelopmentPanelMapPanelState
+    extends ConsumerState<DevelopmentPanelMapPanel> {
+  Object? _snapshotCacheKey;
+  DevelopmentPanelMapSnapshot? _snapshot;
+  bool _mapReady = false;
+
+  @override
+  void initState() {
+    super.initState();
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      setState(() => _mapReady = true);
+    });
+  }
+
+  @override
+  void didUpdateWidget(covariant DevelopmentPanelMapPanel oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final cacheKey = developmentPanelMapSnapshotCacheKey(
+      game: widget.game,
+      humanPlayerId: widget.humanPlayerId,
+      regionId: widget.regionId,
+      playerView: widget.playerView,
+    );
+    if (cacheKey != _snapshotCacheKey) {
+      _snapshotCacheKey = null;
+      _snapshot = null;
+    }
+  }
+
+  DevelopmentPanelMapSnapshot? _resolveSnapshot(
+    Map<String, TileMapResult> tileMapByRegion,
+    Map<String, MapTopology> topologyByRegion,
+  ) {
+    final cacheKey = developmentPanelMapSnapshotCacheKey(
+      game: widget.game,
+      humanPlayerId: widget.humanPlayerId,
+      regionId: widget.regionId,
+      playerView: widget.playerView,
+    );
+    if (_snapshotCacheKey == cacheKey && _snapshot != null) {
+      return _snapshot;
+    }
+    _snapshotCacheKey = cacheKey;
+    _snapshot = buildDevelopmentPanelMapSnapshot(
+      game: widget.game,
+      humanPlayerId: widget.humanPlayerId,
+      regionId: widget.regionId,
+      playerView: widget.playerView,
+      tileMapByRegion: tileMapByRegion,
+      topologyByRegion: topologyByRegion,
+    );
+    return _snapshot;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_mapReady) {
+      return const SizedBox.shrink();
+    }
+
+    final mapData = ref.read(gameServiceProvider).getMapData(widget.game.id);
     if (mapData == null) {
       return const SizedBox.shrink();
     }
 
-    final visibilityByTile = developmentPanelVisibilityByTile(
-      game: game,
-      playerView: playerView,
-      regionId: regionId,
+    final snapshot = _resolveSnapshot(
+      mapData.tileMapByRegion,
+      mapData.topologyByRegion,
     );
-    final region = buildInitGameMapRegionViewData(
-      regionId: regionId,
-      game: game,
-      tileMapByRegion: mapData.tileMapByRegion,
-      topologyByRegion: mapData.topologyByRegion,
-      cellSize: 12,
-      visibilityByTile: visibilityByTile,
-    );
-    final playerTerritoryTileKeys = developmentPanelPlayerTerritoryTileKeys(
-      game: game,
-      playerId: humanPlayerId,
-      regionId: regionId,
-      tileMapByRegion: mapData.tileMapByRegion,
-    );
+    if (snapshot == null) {
+      return const SizedBox.shrink();
+    }
 
     return CtRegionMap(
-      region: region,
+      region: snapshot.region,
       showPoliticalOverlay: false,
       showProvinceOverlay: true,
       showProvinceNamesLayer: false,
       cellSizePx: 12,
       visibilityMode: CtMapVisibilityMode.playerConstrained,
-      playerViewForResources: playerView,
+      playerViewForResources: widget.playerView,
       showPlayerTerritoryOutline: true,
-      playerTerritoryTileKeys: playerTerritoryTileKeys,
-      secondaryHighlightTileKeys: highlightTileKeys,
+      playerTerritoryTileKeys: snapshot.playerTerritoryTileKeys,
+      secondaryHighlightTileKeys: widget.highlightTileKeys,
     );
   }
 }

--- a/app/lib/features/game/screens/development/development_panel_map_snapshot.dart
+++ b/app/lib/features/game/screens/development/development_panel_map_snapshot.dart
@@ -1,0 +1,80 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_map/colonizethis_map.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_world/colonizethis_world.dart';
+
+import 'development_panel_map_visibility.dart';
+
+/// Immutable map payload for the Development panel minimap (Slice E).
+class DevelopmentPanelMapSnapshot {
+  const DevelopmentPanelMapSnapshot({
+    required this.region,
+    required this.playerTerritoryTileKeys,
+  });
+
+  final RegionMapViewData region;
+  final Set<String> playerTerritoryTileKeys;
+}
+
+/// Cache key for [DevelopmentPanelMapSnapshot]; excludes highlight-only inputs.
+Object developmentPanelMapSnapshotCacheKey({
+  required Game game,
+  required String humanPlayerId,
+  required String regionId,
+  required PlayerView playerView,
+}) {
+  final visibility = <String, VisibilityLevel>{};
+  for (final entry in playerView.visibilityByTile.entries) {
+    if (!entry.key.startsWith('$regionId|')) continue;
+    visibility[entry.key] = entry.value;
+  }
+  final visibilityDigest = Object.hashAll(
+    visibility.entries
+        .map((e) => Object.hash(e.key, e.value.index))
+        .toList()
+      ..sort(),
+  );
+  return (
+    game.id,
+    game.worldState.turnState.turnNumber,
+    humanPlayerId,
+    regionId,
+    visibilityDigest,
+    game.worldState.tileKeysByRegionAndProvince[regionId]?.length ?? 0,
+    game.worldState.purchasedTilesByTileKey.length,
+  );
+}
+
+/// Builds panel-map view data for one region (expensive; cache across highlights).
+DevelopmentPanelMapSnapshot buildDevelopmentPanelMapSnapshot({
+  required Game game,
+  required String humanPlayerId,
+  required String regionId,
+  required PlayerView playerView,
+  required Map<String, TileMapResult> tileMapByRegion,
+  required Map<String, MapTopology> topologyByRegion,
+}) {
+  final visibilityByTile = developmentPanelVisibilityByTile(
+    game: game,
+    playerView: playerView,
+    regionId: regionId,
+  );
+  final region = buildInitGameMapRegionViewData(
+    regionId: regionId,
+    game: game,
+    tileMapByRegion: tileMapByRegion,
+    topologyByRegion: topologyByRegion,
+    cellSize: 12,
+    visibilityByTile: visibilityByTile,
+  );
+  final playerTerritoryTileKeys = developmentPanelPlayerTerritoryTileKeys(
+    game: game,
+    playerId: humanPlayerId,
+    regionId: regionId,
+    tileMapByRegion: tileMapByRegion,
+  );
+  return DevelopmentPanelMapSnapshot(
+    region: region,
+    playerTerritoryTileKeys: playerTerritoryTileKeys,
+  );
+}

--- a/app/test/development_panel_map_snapshot_test.dart
+++ b/app/test/development_panel_map_snapshot_test.dart
@@ -1,0 +1,78 @@
+import 'package:colonizethis_app/features/game/screens/development/development_panel_map_snapshot.dart';
+import 'package:colonizethis_test/test.dart';
+import 'package:colonizethis_world/colonizethis_world.dart';
+
+import 'development_panel_test_support.dart';
+import 'panel_fixtures/core.dart';
+
+void main() {
+  suppressLogsForTests();
+
+  test(
+    'developmentPanelMapSnapshotCacheKey is stable for highlight-only inputs (Refs #4175 Slice E)',
+    () {
+      final game = buildDevelopmentPanelGoldenGame();
+      final playerView = buildPlayerView(
+        game,
+        developmentPanelMapCombinedTopology,
+        kPanelTestHumanPlayerId,
+      );
+      final baseKey = developmentPanelMapSnapshotCacheKey(
+        game: game,
+        humanPlayerId: kPanelTestHumanPlayerId,
+        regionId: kRegionOldWorld,
+        playerView: playerView,
+      );
+      expect(
+        developmentPanelMapSnapshotCacheKey(
+          game: game,
+          humanPlayerId: kPanelTestHumanPlayerId,
+          regionId: kRegionOldWorld,
+          playerView: playerView,
+        ),
+        baseKey,
+      );
+    },
+  );
+
+  test(
+    'developmentPanelMapSnapshotCacheKey changes when visibility changes (Refs #4175 Slice E)',
+    () {
+      final game = buildDevelopmentPanelGoldenGame();
+      final playerView = buildPlayerView(
+        game,
+        developmentPanelMapCombinedTopology,
+        kPanelTestHumanPlayerId,
+      );
+      final baseKey = developmentPanelMapSnapshotCacheKey(
+        game: game,
+        humanPlayerId: kPanelTestHumanPlayerId,
+        regionId: kRegionOldWorld,
+        playerView: playerView,
+      );
+      final alteredVisibility = Map<String, VisibilityLevel>.from(
+        playerView.visibilityByTile,
+      );
+      final firstKey = alteredVisibility.keys.first;
+      alteredVisibility[firstKey] = VisibilityLevel.unknown;
+      final alteredView = PlayerView(
+        playerId: playerView.playerId,
+        player: playerView.player,
+        ownUnitsById: playerView.ownUnitsById,
+        provincesById: playerView.provincesById,
+        visibilityByTile: alteredVisibility,
+        prospectedTiles: playerView.prospectedTiles,
+        diplomacyByOtherId: playerView.diplomacyByOtherId,
+      );
+      expect(
+        developmentPanelMapSnapshotCacheKey(
+          game: game,
+          humanPlayerId: kPanelTestHumanPlayerId,
+          regionId: kRegionOldWorld,
+          playerView: alteredView,
+        ),
+        isNot(baseKey),
+      );
+    },
+  );
+}

--- a/tool/check_app_main_line_budget.dart
+++ b/tool/check_app_main_line_budget.dart
@@ -39,13 +39,14 @@
 // raised for UNIT60001 Train Naval role and cargo/combat gist rows (Refs #4300).
 // raised for GAME80001 lazy per-region Development panel read model (Refs #4175 perf).
 // raised for OVL70001 realm economy turn-summary feed row (Refs #4308).
+// raised for GAME80001 Development panel map snapshot cache + deferred paint (Refs #4175 Slice E).
 import 'dart:convert';
 import 'dart:io';
 
 import 'package:path/path.dart' as p;
 
 const _packageName = 'colonizethis_app';
-const _maxMainLines = 70900;
+const _maxMainLines = 71100;
 
 int runCheckAppMainLineBudget(
   String repoRoot, {


### PR DESCRIPTION
## Summary
- Slice E follow-up for #4175: memoize `DevelopmentPanelMapSnapshot` (region view data + territory outline keys) so **Show** highlight updates skip redundant `buildInitGameMapRegionViewData` work.
- Defer minimap mount to the post-frame callback so overview/list paint on the first frame before map prep runs.

## Profiling notes (hotspot addressed)
- **Before:** every `_DevelopmentRegionTab` rebuild (including highlight-only `setState` from **Show**) synchronously rebuilt full region map view data in `DevelopmentPanelMapPanel.build`.
- **After:** map snapshot is cached until game turn, region, player, or per-region visibility digest changes; first open paints list/overview before map work.

## Done in this PR
- `development_panel_map_snapshot.dart` — snapshot builder + cache key
- `DevelopmentPanelMapPanel` — StatefulWidget with snapshot cache + post-frame `mapReady` gate
- Unit tests for cache-key stability and visibility invalidation
- SPEC `development-panel-read-model.md` — caching/defer contract

## Deferred
- DevTools before/after timeline capture on a representative mid-game save (owner qualitative sign-off still needed per verification comment)

## Test plan
- [x] `flutter test` — `development_panel_map_snapshot_test.dart`
- [x] `flutter test` — `development_panel_lazy_open_test.dart`
- [x] `flutter test` — `development_panel_goldens_test.dart`
- [x] `dart analyze` — development panel map modules

Refs #4175

Made with [Cursor](https://cursor.com)