### PR TITLE
perf: memoize Development panel projection via Riverpod (#4175)

### DIFF
--- a/SPEC/program/development-panel-read-model.md
+++ b/SPEC/program/development-panel-read-model.md
@@ -38,6 +38,7 @@ When `playerView` is supplied to `buildDevelopmentPanelModel`, improvable commod
 - `DevelopmentPanelMapPanel` caches `DevelopmentPanelMapSnapshot` (region view data + territory outline keys) across highlight-only rebuilds; invalidates when game turn, region, player, or per-region visibility digest changes.
 - First map paint is deferred to the frame after panel mount so overview/list can paint first (post-frame `mapReady` gate).
 - `DevelopmentScreenBody` defers read-model projection (`buildPlayerView`, `buildDevelopmentPanelBuildContext`, per-region models) to the frame after mount so the tab strip can paint before connectivity and improvable scans run (post-frame `readModelReady` gate).
+- `developmentPanelProjectionProvider` and `developmentPanelRegionModelProvider` memoize shared connectivity, [PlayerView], and per-region read models across unrelated [DevelopmentScreenBody] rebuilds; invalidate when game, orders, map data, or shell player context change.
 - `developmentPanelVisibilityByTile` accepts optional `regionId` so panel maps do not scan both regions when rendering one minimap.
 
 Cache invalidation: panel projections recompute when `game`, `currentOrders`, or `playerView` inputs change on rebuild; assign/cancel and fog updates remain live-immediate per Slice A–D ACs.

--- a/app/lib/features/game/screens/development/development_screen_body.dart
+++ b/app/lib/features/game/screens/development/development_screen_body.dart
@@ -2,16 +2,13 @@ import 'package:colonizethis_app_l10n/l10n/l10n.dart';
 import 'package:colonizethis_economy/colonizethis_economy.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_world/colonizethis_world.dart'
-    show
-        allProvinces,
-        buildPlayerView,
-        kRegionNewWorld,
-        kRegionOldWorld;
+    show kRegionNewWorld, kRegionOldWorld;
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../providers/app_event_bus_provider.dart';
+import '../../../../providers/development_panel_projection_provider.dart';
 import '../../../../providers/game_service_provider.dart';
 import '../../../../providers/games_provider.dart';
 import '../../../../widgets/ct_panel.dart';
@@ -60,7 +57,6 @@ class _DevelopmentScreenBodyState extends ConsumerState<DevelopmentScreenBody> {
   @override
   Widget build(BuildContext context) {
     final game = widget.game;
-    final humanPlayerId = widget.humanPlayerId;
     final mapData = ref.read(gameServiceProvider).getMapData(game.id);
     if (mapData == null) {
       return Center(child: Text(appL10n(context).development_mapDataUnavailable));
@@ -86,43 +82,22 @@ class _DevelopmentScreenBodyState extends ConsumerState<DevelopmentScreenBody> {
       );
     }
 
+    final projection = ref.watch(developmentPanelProjectionProvider);
+    if (projection == null) {
+      return Center(child: Text(l10n.development_mapDataUnavailable));
+    }
+
     final orders = ref.watch(currentOrdersProvider);
     final shell = ref.watch(shellPlayerContextProvider);
     final canEdit = shell.canMutateViaUi;
-    final provinceNames = <String, String>{};
-    for (final province in allProvinces(game.worldState)) {
-      provinceNames[province.id] = province.displayName ?? province.id;
-    }
-    final playerNames = {for (final p in game.players) p.id: p.displayName};
-    final playerView = buildPlayerView(
-      game,
-      mapData.combinedTopology,
-      humanPlayerId,
-    );
-    final shared = buildDevelopmentPanelBuildContext(
-      game: game,
-      playerId: humanPlayerId,
-      tileMapByRegion: mapData.tileMapByRegion,
-      topology: mapData.combinedTopology,
-      currentOrders: orders,
-    );
-    final connectedTileKeys = shared.connectedTileKeys;
+    final connectedTileKeys = projection.shared.connectedTileKeys;
 
     DevelopmentPanelRegionModel regionModelFor(String regionId) {
       if (!_visitedRegionIds.contains(regionId)) {
         return emptyDevelopmentPanelRegionModel(regionId);
       }
-      return buildDevelopmentPanelRegionModel(
-        shared: shared,
-        game: game,
-        playerId: humanPlayerId,
-        regionId: regionId,
-        tileMapByRegion: mapData.tileMapByRegion,
-        currentOrders: orders,
-        provinceDisplayNamesById: provinceNames,
-        playerDisplayNamesById: playerNames,
-        playerView: playerView,
-      );
+      return ref.watch(developmentPanelRegionModelProvider(regionId)) ??
+          emptyDevelopmentPanelRegionModel(regionId);
     }
 
     final bus = ref.read(appEventBusProvider);
@@ -138,50 +113,50 @@ class _DevelopmentScreenBodyState extends ConsumerState<DevelopmentScreenBody> {
           tabLabels: [l10n.region_oldWorld, l10n.region_newWorld],
           tabViews: [
             DevelopmentRegionTab(
-              game: game,
-              humanPlayerId: humanPlayerId,
+              game: projection.game,
+              humanPlayerId: projection.humanPlayerId,
               regionId: kRegionOldWorld,
               regionModel: regionModelFor(kRegionOldWorld),
-              playerView: playerView,
-              topology: mapData.combinedTopology,
-              tileMapByRegion: mapData.tileMapByRegion,
+              playerView: projection.playerView,
+              topology: projection.topology,
+              tileMapByRegion: projection.tileMapByRegion,
               currentOrders: orders,
               connectedTileKeys: connectedTileKeys,
-              provinceDisplayNamesById: provinceNames,
+              provinceDisplayNamesById: projection.provinceDisplayNamesById,
               canEdit: canEdit,
               onAssign: (candidate) => handleDevelopmentAssign(
                 context: context,
                 bus: bus,
-                game: game,
-                humanPlayerId: humanPlayerId,
+                game: projection.game,
+                humanPlayerId: projection.humanPlayerId,
                 canEdit: canEdit,
-                topology: mapData.combinedTopology,
-                tileMapByRegion: mapData.tileMapByRegion,
+                topology: projection.topology,
+                tileMapByRegion: projection.tileMapByRegion,
                 orders: orders,
                 connectedTileKeys: connectedTileKeys,
                 candidate: candidate,
               ),
             ),
             DevelopmentRegionTab(
-              game: game,
-              humanPlayerId: humanPlayerId,
+              game: projection.game,
+              humanPlayerId: projection.humanPlayerId,
               regionId: kRegionNewWorld,
               regionModel: regionModelFor(kRegionNewWorld),
-              playerView: playerView,
-              topology: mapData.combinedTopology,
-              tileMapByRegion: mapData.tileMapByRegion,
+              playerView: projection.playerView,
+              topology: projection.topology,
+              tileMapByRegion: projection.tileMapByRegion,
               currentOrders: orders,
               connectedTileKeys: connectedTileKeys,
-              provinceDisplayNamesById: provinceNames,
+              provinceDisplayNamesById: projection.provinceDisplayNamesById,
               canEdit: canEdit,
               onAssign: (candidate) => handleDevelopmentAssign(
                 context: context,
                 bus: bus,
-                game: game,
-                humanPlayerId: humanPlayerId,
+                game: projection.game,
+                humanPlayerId: projection.humanPlayerId,
                 canEdit: canEdit,
-                topology: mapData.combinedTopology,
-                tileMapByRegion: mapData.tileMapByRegion,
+                topology: projection.topology,
+                tileMapByRegion: projection.tileMapByRegion,
                 orders: orders,
                 connectedTileKeys: connectedTileKeys,
                 candidate: candidate,

--- a/app/lib/providers/development_panel_projection_provider.dart
+++ b/app/lib/providers/development_panel_projection_provider.dart
@@ -1,0 +1,107 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_economy/colonizethis_economy.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_world/colonizethis_world.dart'
+    show PlayerView, allProvinces, buildPlayerView;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../features/game/widgets/shell/shell_player_context.dart';
+import 'game_service_provider.dart';
+import 'games_provider.dart';
+
+/// Shared Development panel inputs memoized across [DevelopmentScreenBody] rebuilds.
+///
+/// Recomputes only when game, orders, map data, or shell player context change.
+/// Refs #4175 Slice E.
+class DevelopmentPanelProjection {
+  const DevelopmentPanelProjection({
+    required this.game,
+    required this.humanPlayerId,
+    required this.shared,
+    required this.playerView,
+    required this.provinceDisplayNamesById,
+    required this.playerDisplayNamesById,
+    required this.topology,
+    required this.tileMapByRegion,
+  });
+
+  final Game game;
+  final String humanPlayerId;
+  final DevelopmentPanelBuildContext shared;
+  final PlayerView playerView;
+  final Map<String, String> provinceDisplayNamesById;
+  final Map<String, String> playerDisplayNamesById;
+  final MapTopology topology;
+  final Map<String, TileMapResult> tileMapByRegion;
+}
+
+/// Connectivity, [PlayerView], and display-name maps — once per relevant input change.
+final developmentPanelProjectionProvider =
+    Provider<DevelopmentPanelProjection?>((ref) {
+      final game = ref.watch(currentGameProvider);
+      if (game == null) {
+        return null;
+      }
+      final mapData = ref.watch(gameServiceProvider).getMapData(game.id);
+      if (mapData == null) {
+        return null;
+      }
+      final orders = ref.watch(currentOrdersProvider);
+      final shell = ref.watch(shellPlayerContextProvider);
+      final humanPlayerId = resolveShellPanelPlayerId(shell, game);
+
+      final provinceDisplayNamesById = <String, String>{};
+      for (final province in allProvinces(game.worldState)) {
+        provinceDisplayNamesById[province.id] =
+            province.displayName ?? province.id;
+      }
+      final playerDisplayNamesById = {
+        for (final player in game.players) player.id: player.displayName,
+      };
+
+      final playerView = buildPlayerView(
+        game,
+        mapData.combinedTopology,
+        humanPlayerId,
+      );
+      final shared = buildDevelopmentPanelBuildContext(
+        game: game,
+        playerId: humanPlayerId,
+        tileMapByRegion: mapData.tileMapByRegion,
+        topology: mapData.combinedTopology,
+        currentOrders: orders,
+      );
+
+      return DevelopmentPanelProjection(
+        game: game,
+        humanPlayerId: humanPlayerId,
+        shared: shared,
+        playerView: playerView,
+        provinceDisplayNamesById: provinceDisplayNamesById,
+        playerDisplayNamesById: playerDisplayNamesById,
+        topology: mapData.combinedTopology,
+        tileMapByRegion: mapData.tileMapByRegion,
+      );
+    });
+
+/// Per-region read model; invalidates when [developmentPanelProjectionProvider]
+/// or [currentOrdersProvider] change.
+final developmentPanelRegionModelProvider =
+    Provider.family<DevelopmentPanelRegionModel?, String>((ref, regionId) {
+      final projection = ref.watch(developmentPanelProjectionProvider);
+      if (projection == null) {
+        return null;
+      }
+      final orders = ref.watch(currentOrdersProvider);
+      return buildDevelopmentPanelRegionModel(
+        shared: projection.shared,
+        game: projection.game,
+        playerId: projection.humanPlayerId,
+        regionId: regionId,
+        tileMapByRegion: projection.tileMapByRegion,
+        currentOrders: orders,
+        provinceDisplayNamesById: projection.provinceDisplayNamesById,
+        playerDisplayNamesById: projection.playerDisplayNamesById,
+        playerView: projection.playerView,
+      );
+    });

--- a/app/test/development_panel_projection_provider_test.dart
+++ b/app/test/development_panel_projection_provider_test.dart
@@ -5,6 +5,8 @@ import 'package:colonizethis_app/features/game/widgets/shell/shell_player_contex
 import 'package:colonizethis_app/providers/development_panel_projection_provider.dart';
 import 'package:colonizethis_app/providers/game_service_provider.dart';
 import 'package:colonizethis_app/providers/games_provider.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart'
+    show kWorkTargetBuildImprovement;
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_save/colonizethis_save.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
@@ -107,7 +109,7 @@ void main() {
           kPanelTestHumanPlayerId: const [
             WorkOrder(
               unitId: 'b1',
-              target: 'build_improvement',
+              target: kWorkTargetBuildImprovement,
               targetTileKey: 'oldWorld|p1|0|0',
             ),
           ],

--- a/app/test/development_panel_projection_provider_test.dart
+++ b/app/test/development_panel_projection_provider_test.dart
@@ -1,0 +1,124 @@
+import 'package:colonizethis_app/config/constants.dart';
+import 'package:colonizethis_app/features/game/flame/region_map/region_map.dart'
+    show CtMapVisibilityMode;
+import 'package:colonizethis_app/features/game/widgets/shell/shell_player_context.dart';
+import 'package:colonizethis_app/providers/development_panel_projection_provider.dart';
+import 'package:colonizethis_app/providers/game_service_provider.dart';
+import 'package:colonizethis_app/providers/games_provider.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_save/colonizethis_save.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:colonizethis_world/colonizethis_world.dart' show kRegionOldWorld;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart' show Override;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+
+import 'development_panel_test_support.dart';
+import 'panel_fixtures/core.dart';
+
+ShellPlayerContext _developmentPanelShellContext() {
+  return const ShellPlayerContext(
+    effectiveHumanPlayerId: kPanelTestHumanPlayerId,
+    viewingPlayerId: kPanelTestHumanPlayerId,
+    mapVisibilityMode: CtMapVisibilityMode.playerConstrained,
+    playerView: null,
+    omniscientDetail: false,
+    showPlayerChrome: true,
+    canMutateViaUi: true,
+    debugCommandTargetPlayerId: kPanelTestHumanPlayerId,
+    inObservePhase: false,
+    observeBannerLabel: null,
+    treasuryNotDefined: false,
+    cargoNotDefined: false,
+  );
+}
+
+List<Override> _developmentPanelProviderOverrides(
+  Game game, {
+  CurrentOrdersNotifier? ordersNotifier,
+}) {
+  return [
+    currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
+    currentOrdersProvider.overrideWith(
+      () => ordersNotifier ?? CurrentOrdersNotifier(const Orders()),
+    ),
+    shellPlayerContextProvider.overrideWithValue(_developmentPanelShellContext()),
+    gameServiceProvider.overrideWith(
+      (ref) => DevelopmentPanelMapGameService(
+        Hive.box<dynamic>(HiveBoxNames.games),
+        GameSaveAdapter(),
+      ),
+    ),
+  ];
+}
+
+void main() {
+  suppressLogsForTests();
+
+  late Box<dynamic> gamesBox;
+
+  setUpAll(() async {
+    gamesBox = await openDevelopmentPanelTestHiveBox();
+  });
+
+  tearDownAll(() async {
+    await gamesBox.close();
+  });
+
+  test(
+    'developmentPanelProjectionProvider caches across reads with stable inputs (Refs #4175 Slice E)',
+    () {
+      final game = buildDevelopmentPanelGoldenGame();
+      final container = ProviderContainer(
+        overrides: _developmentPanelProviderOverrides(game),
+      );
+      addTearDown(container.dispose);
+
+      final first = container.read(developmentPanelProjectionProvider);
+      final second = container.read(developmentPanelProjectionProvider);
+
+      expect(first, isNotNull);
+      expect(identical(first, second), isTrue);
+    },
+  );
+
+  test(
+    'developmentPanelRegionModelProvider invalidates when orders change (Refs #4175 Slice E)',
+    () {
+      final game = buildDevelopmentPanelGoldenGame();
+      final ordersNotifier = CurrentOrdersNotifier(const Orders());
+      final container = ProviderContainer(
+        overrides: _developmentPanelProviderOverrides(
+          game,
+          ordersNotifier: ordersNotifier,
+        ),
+      );
+      addTearDown(container.dispose);
+
+      final before = container.read(
+        developmentPanelRegionModelProvider(kRegionOldWorld),
+      );
+      expect(before, isNotNull);
+      expect(before!.idleBuilderCount, 1);
+
+      ordersNotifier.state = Orders(
+        workOrdersByPlayerId: {
+          kPanelTestHumanPlayerId: const [
+            WorkOrder(
+              unitId: 'b1',
+              target: 'build_improvement',
+              targetTileKey: 'oldWorld|p1|0|0',
+            ),
+          ],
+        },
+      );
+
+      final after = container.read(
+        developmentPanelRegionModelProvider(kRegionOldWorld),
+      );
+      expect(after, isNotNull);
+      expect(after!.idleBuilderCount, 0);
+    },
+  );
+}

--- a/app/test/development_panel_projection_rebuild_guard_test.dart
+++ b/app/test/development_panel_projection_rebuild_guard_test.dart
@@ -1,0 +1,136 @@
+// Guards Development panel projection memoization across unrelated rebuilds (Refs #4175 Slice E).
+
+import 'package:colonizethis_app/features/game/flame/region_map/region_map.dart'
+    show CtMapVisibilityMode;
+import 'package:colonizethis_app/features/game/screens/development/development_screen_body.dart';
+import 'package:colonizethis_app/features/game/widgets/shell/shell_player_context.dart';
+import 'package:colonizethis_app/providers/development_panel_projection_provider.dart';
+import 'package:colonizethis_app/providers/game_service_provider.dart';
+import 'package:colonizethis_app/providers/games_box_provider.dart';
+import 'package:colonizethis_app/providers/games_provider.dart';
+import 'package:colonizethis_app_l10n/l10n/l10n.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_save/colonizethis_save.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart' show Override;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+
+import 'app_shell_harness.dart';
+import 'development_panel_test_support.dart';
+import 'panel_fixtures/core.dart';
+
+class _RebuildTickHost extends StatefulWidget {
+  const _RebuildTickHost({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  State<_RebuildTickHost> createState() => _RebuildTickHostState();
+}
+
+class _RebuildTickHostState extends State<_RebuildTickHost> {
+  var _tick = 0;
+
+  void bump() => setState(() => _tick++);
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Text('tick:$_tick', key: const Key('rebuild_tick')),
+        Expanded(child: widget.child),
+      ],
+    );
+  }
+}
+
+List<Override> _developmentOverrides(Game game, Box<dynamic> gamesBox) => [
+  gamesBoxProvider.overrideWith((ref) => gamesBox),
+  gameServiceProvider.overrideWith(
+    (ref) => DevelopmentPanelMapGameService(gamesBox, GameSaveAdapter()),
+  ),
+  currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
+  currentOrdersProvider.overrideWith(() => CurrentOrdersNotifier(const Orders())),
+  shellPlayerContextProvider.overrideWithValue(
+    const ShellPlayerContext(
+      effectiveHumanPlayerId: kPanelTestHumanPlayerId,
+      viewingPlayerId: kPanelTestHumanPlayerId,
+      mapVisibilityMode: CtMapVisibilityMode.playerConstrained,
+      playerView: null,
+      omniscientDetail: false,
+      showPlayerChrome: true,
+      canMutateViaUi: true,
+      debugCommandTargetPlayerId: kPanelTestHumanPlayerId,
+      inObservePhase: false,
+      observeBannerLabel: null,
+      treasuryNotDefined: false,
+      cargoNotDefined: false,
+    ),
+  ),
+];
+
+void main() {
+  suppressLogsForTests();
+
+  late Box<dynamic> gamesBox;
+
+  setUpAll(() async {
+    gamesBox = await openDevelopmentPanelTestHiveBox();
+  });
+
+  tearDownAll(() async {
+    await gamesBox.close();
+  });
+
+  testWidgets(
+    'developmentPanelProjectionProvider survives unrelated parent rebuilds (Refs #4175 Slice E)',
+    (WidgetTester tester) async {
+      final game = buildDevelopmentPanelGoldenGame();
+      final container = ProviderContainer(
+        overrides: _developmentOverrides(game, gamesBox),
+      );
+      addTearDown(container.dispose);
+
+      var projectionNotifications = 0;
+      container.listen(
+        developmentPanelProjectionProvider,
+        (_, _) => projectionNotifications++,
+        fireImmediately: true,
+      );
+
+      final hostKey = GlobalKey<_RebuildTickHostState>();
+      await tester.pumpWidget(
+        buildAppShellWithContainer(
+          container: container,
+          child: _RebuildTickHost(
+            key: hostKey,
+            child: DevelopmentScreenBody(
+              game: game,
+              humanPlayerId: kPanelTestHumanPlayerId,
+            ),
+          ),
+          localizationsDelegates: AppLocalizationsBinding.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          locale: const Locale('en'),
+          viewport: const Size(900, 760),
+        ),
+      );
+
+      await pumpDevelopmentPanelReady(tester);
+
+      final projectionAfterOpen = container.read(developmentPanelProjectionProvider);
+      expect(projectionAfterOpen, isNotNull);
+      final notificationsAfterOpen = projectionNotifications;
+
+      hostKey.currentState!.bump();
+      await tester.pump();
+
+      final projectionAfterBump = container.read(developmentPanelProjectionProvider);
+      expect(identical(projectionAfterOpen, projectionAfterBump), isTrue);
+      expect(projectionNotifications, notificationsAfterOpen);
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Add `developmentPanelProjectionProvider` and `developmentPanelRegionModelProvider` to memoize connectivity, `PlayerView`, and per-region read models across unrelated `DevelopmentScreenBody` rebuilds.
- Refactor `DevelopmentScreenBody` to consume the providers while preserving post-frame deferral, lazy region tabs, and live assign/cancel updates.
- Document the caching contract in `SPEC/program/development-panel-read-model.md`.

## Done in this PR
- Riverpod memoization for shared + per-region Development panel projections (Slice E follow-up from #4322 deferred item)
- Provider unit tests: cache stability on stable inputs; idle-count invalidation when orders change
- Existing lazy-open and golden tests remain green

## Deferred
- Flutter DevTools before/after timeline on a representative mid-game save (owner qualitative sign-off per issue Slice E ACs)
- Issue remains open until owner confirms subjective open-path responsiveness

## Profiling notes
| Hotspot | Fix |
|---------|-----|
| Sync read-model recompute on every `DevelopmentScreenBody.build` | `developmentPanelProjectionProvider` + `developmentPanelRegionModelProvider` cache until game/orders/map/shell inputs change |
| Prior deferral/lazy-map work (#4321, #4322) | Unchanged — stacks with provider memoization |

## Test plan
- [x] `flutter test` — `development_panel_projection_provider_test.dart`
- [x] `flutter test` — `development_panel_lazy_open_test.dart`
- [x] `flutter test` — `development_panel_goldens_test.dart`
- [x] `dart analyze` — touched development panel modules

Refs #4175

Made with [Cursor](https://cursor.com)