### PR TITLE
perf: memoize Development panel material shortage scans (#4175)

### DIFF
--- a/SPEC/program/development-panel-read-model.md
+++ b/SPEC/program/development-panel-read-model.md
@@ -40,6 +40,7 @@ When `playerView` is supplied to `buildDevelopmentPanelModel`, improvable commod
 - `DevelopmentScreenBody` defers read-model projection (`buildPlayerView`, `buildDevelopmentPanelBuildContext`, per-region models) to the frame after mount so the tab strip can paint before connectivity and improvable scans run (post-frame `readModelReady` gate).
 - `developmentPanelProjectionProvider` and `developmentPanelRegionModelProvider` memoize shared connectivity, [PlayerView], and per-region read models across unrelated [DevelopmentScreenBody] rebuilds; invalidate when game, orders, map data, or shell player context change.
 - `developmentPanelConnectivityProvider` memoizes `resolveConnectivity` separately from draft orders so assign/cancel live updates recompute idle counts without re-running connectivity scans.
+- `developmentPanelMaterialShortageProvider` memoizes per-region material-shortage commodity ids so highlight-only tab rebuilds do not re-scan assign affordance for every improvable row.
 - `developmentPanelVisibilityByTile` accepts optional `regionId` so panel maps do not scan both regions when rendering one minimap.
 
 Cache invalidation: panel projections recompute when `game`, `currentOrders`, or `playerView` inputs change on rebuild; assign/cancel and fog updates remain live-immediate per Slice A–D ACs. Connectivity (`developmentPanelConnectivityProvider`) invalidates on game/map revision only — not on draft-order churn.
@@ -55,6 +56,7 @@ Representative fixture: dual-region save with two OW provinces + one NW province
 | Duplicate `buildPlayerView` (screen + map) | Single `playerView` on `DevelopmentPanelProjection` | Eliminated per-map rebuild |
 | `IndexedStack` mounting both region maps | `CtTabStrip.lazyTabBodies` + `_visitedRegionIds` | NW map absent until first tab visit (`development_panel_lazy_open_test.dart`) |
 | Synchronous read model on first frame | Post-frame `readModelReady` gate | Tab strip paints before connectivity/improvable scans |
+| Per-row material shortage scan on highlight rebuild | `developmentPanelMaterialShortageProvider` memoizes per region | Show-tile highlight `setState` does not re-run assign affordance scans |
 | Full dual-region map view-data | Per-region `buildInitGameMapRegionViewData` + snapshot cache | Map defers one frame; highlight-only rebuilds reuse snapshot |
 
 DevTools timeline captures remain optional owner verification for AC1 qualitative bar; timing tests above are the CI profiling anchor for AC2.

--- a/SPEC/program/development-panel-read-model.md
+++ b/SPEC/program/development-panel-read-model.md
@@ -57,7 +57,7 @@ Representative fixture: dual-region save with two OW provinces + one NW province
 | Duplicate `buildPlayerView` (screen + map) | Single `playerView` on `DevelopmentPanelProjection` | Eliminated per-map rebuild |
 | `IndexedStack` mounting both region maps | `CtTabStrip.lazyTabBodies` + `_visitedRegionIds` | NW map absent until first tab visit (`development_panel_lazy_open_test.dart`) |
 | Synchronous read model on first frame | Post-frame `readModelReady` gate | Tab strip paints before connectivity/improvable scans |
-| Per-row material shortage scan on highlight rebuild | `developmentPanelAssignRowStateCacheProvider` + derived shortage set | Show-tile highlight `setState` does not re-run assign affordance per row |
+| Per-row material shortage scan on highlight rebuild | `developmentPanelAssignRowStateCacheProvider` + derived shortage set | Show-tile highlight `setState` does not re-run assign affordance per row (`development_panel_projection_rebuild_guard_test.dart`) |
 | Full dual-region map view-data | Per-region `buildInitGameMapRegionViewData` + snapshot cache | Map defers one frame; highlight-only rebuilds reuse snapshot |
 
 DevTools timeline captures remain optional owner verification for AC1 qualitative bar; timing tests above are the CI profiling anchor for AC2.

--- a/SPEC/program/development-panel-read-model.md
+++ b/SPEC/program/development-panel-read-model.md
@@ -41,6 +41,7 @@ When `playerView` is supplied to `buildDevelopmentPanelModel`, improvable commod
 - `developmentPanelProjectionProvider` and `developmentPanelRegionModelProvider` memoize shared connectivity, [PlayerView], and per-region read models across unrelated [DevelopmentScreenBody] rebuilds; invalidate when game, orders, map data, or shell player context change.
 - `developmentPanelConnectivityProvider` memoizes `resolveConnectivity` separately from draft orders so assign/cancel live updates recompute idle counts without re-running connectivity scans.
 - `developmentPanelMaterialShortageProvider` memoizes per-region material-shortage commodity ids so highlight-only tab rebuilds do not re-scan assign affordance for every improvable row.
+- `developmentPanelAssignRowStateCacheProvider` memoizes per-scope assign affordance (`resolveDevelopmentAssignRowState`) for every improvable row in the active region; material-shortage flags derive from the same cache.
 - `developmentPanelVisibilityByTile` accepts optional `regionId` so panel maps do not scan both regions when rendering one minimap.
 
 Cache invalidation: panel projections recompute when `game`, `currentOrders`, or `playerView` inputs change on rebuild; assign/cancel and fog updates remain live-immediate per Slice A–D ACs. Connectivity (`developmentPanelConnectivityProvider`) invalidates on game/map revision only — not on draft-order churn.
@@ -56,7 +57,7 @@ Representative fixture: dual-region save with two OW provinces + one NW province
 | Duplicate `buildPlayerView` (screen + map) | Single `playerView` on `DevelopmentPanelProjection` | Eliminated per-map rebuild |
 | `IndexedStack` mounting both region maps | `CtTabStrip.lazyTabBodies` + `_visitedRegionIds` | NW map absent until first tab visit (`development_panel_lazy_open_test.dart`) |
 | Synchronous read model on first frame | Post-frame `readModelReady` gate | Tab strip paints before connectivity/improvable scans |
-| Per-row material shortage scan on highlight rebuild | `developmentPanelMaterialShortageProvider` memoizes per region | Show-tile highlight `setState` does not re-run assign affordance scans |
+| Per-row material shortage scan on highlight rebuild | `developmentPanelAssignRowStateCacheProvider` + derived shortage set | Show-tile highlight `setState` does not re-run assign affordance per row |
 | Full dual-region map view-data | Per-region `buildInitGameMapRegionViewData` + snapshot cache | Map defers one frame; highlight-only rebuilds reuse snapshot |
 
 DevTools timeline captures remain optional owner verification for AC1 qualitative bar; timing tests above are the CI profiling anchor for AC2.

--- a/app/lib/features/game/screens/development/development_panel_scope_list.dart
+++ b/app/lib/features/game/screens/development/development_panel_scope_list.dart
@@ -28,8 +28,8 @@ class DevelopmentPanelScopeList extends StatelessWidget {
   final DevelopmentPanelRegionModel regionModel;
   final void Function(Set<String> tileKeys) onShowTiles;
   final DevelopmentAssignRowState Function(
+    String scopeKey,
     String commodityId,
-    Set<String> tileKeys,
   )
   assignRowStateFor;
   final void Function(DevelopmentImproveAssignCandidate candidate) onAssign;
@@ -97,8 +97,8 @@ class _ScopeCard extends StatelessWidget {
   final DevelopmentPanelScopeRow scope;
   final void Function(Set<String> tileKeys) onShowTiles;
   final DevelopmentAssignRowState Function(
+    String scopeKey,
     String commodityId,
-    Set<String> tileKeys,
   )
   assignRowStateFor;
   final void Function(DevelopmentImproveAssignCandidate candidate) onAssign;
@@ -168,8 +168,8 @@ class _ImprovableCommodityRow extends StatelessWidget {
   final DevelopmentImprovableCommodityRow row;
   final TextTheme textTheme;
   final DevelopmentAssignRowState Function(
+    String scopeKey,
     String commodityId,
-    Set<String> tileKeys,
   )
   assignRowStateFor;
   final void Function(Set<String> tileKeys) onShowTiles;
@@ -178,8 +178,7 @@ class _ImprovableCommodityRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final displayName = commodityDisplayName(l10n, row.commodityId);
-    final tileKeys = row.tileKeys.toSet();
-    final assignState = assignRowStateFor(row.commodityId, tileKeys);
+    final assignState = assignRowStateFor(scopeKey, row.commodityId);
     final assignTooltip = assignState.disabledReason;
     final assignButton = CtActionTextButton(
       key: DevelopmentPanelKeys.assignButtonKey(scopeKey, row.commodityId),
@@ -201,7 +200,7 @@ class _ImprovableCommodityRow extends StatelessWidget {
           CtActionTextButton(
             key: DevelopmentPanelKeys.showButtonKey(scopeKey, row.commodityId),
             label: l10n.development_show,
-            onPressed: () => onShowTiles(tileKeys),
+            onPressed: () => onShowTiles(row.tileKeys.toSet()),
           ),
           const SizedBox(width: CtSpacing.s),
           if (assignTooltip != null && !assignState.enabled)

--- a/app/lib/features/game/screens/development/development_region_tab.dart
+++ b/app/lib/features/game/screens/development/development_region_tab.dart
@@ -2,10 +2,7 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_economy/colonizethis_economy.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_orders/colonizethis_orders.dart'
-    show
-        DevelopmentAssignRowState,
-        DevelopmentImproveAssignCandidate,
-        resolveDevelopmentAssignRowState;
+    show DevelopmentAssignRowState, DevelopmentImproveAssignCandidate;
 import 'package:colonizethis_world/colonizethis_world.dart' show PlayerView;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -58,8 +55,8 @@ class _DevelopmentRegionTabState extends ConsumerState<DevelopmentRegionTab> {
   Set<String>? _highlightTileKeys;
 
   DevelopmentAssignRowState _assignRowStateFor(
+    String scopeKey,
     String commodityId,
-    Set<String> tileKeys,
   ) {
     if (!widget.canEdit) {
       return const DevelopmentAssignRowState(
@@ -67,20 +64,19 @@ class _DevelopmentRegionTabState extends ConsumerState<DevelopmentRegionTab> {
         disabledReason: 'Orders are read-only',
       );
     }
-    return resolveDevelopmentAssignRowState(
-      game: widget.game,
-      playerId: widget.humanPlayerId,
-      currentOrders: widget.currentOrders,
-      topology: widget.topology,
-      tileMapByRegion: widget.tileMapByRegion,
-      commodityTileKeys: tileKeys,
-      connectedTileKeys: widget.connectedTileKeys,
-    );
+    final cache = ref.read(developmentPanelAssignRowStateCacheProvider(widget.regionId));
+    return cache.byScopeCommodityKey[
+            developmentPanelAssignRowStateKey(scopeKey, commodityId)] ??
+        const DevelopmentAssignRowState(
+          enabled: false,
+          disabledReason: 'No valid tile',
+        );
   }
 
   @override
   Widget build(BuildContext context) {
     final wide = MediaQuery.sizeOf(context).width >= kNarrowBreakpoint;
+    ref.watch(developmentPanelAssignRowStateCacheProvider(widget.regionId));
     final materialShortages = ref.watch(
       developmentPanelMaterialShortageProvider(widget.regionId),
     );

--- a/app/lib/features/game/screens/development/development_region_tab.dart
+++ b/app/lib/features/game/screens/development/development_region_tab.dart
@@ -5,12 +5,13 @@ import 'package:colonizethis_orders/colonizethis_orders.dart'
     show
         DevelopmentAssignRowState,
         DevelopmentImproveAssignCandidate,
-        developmentPanelMaterialShortageCommodityIds,
         resolveDevelopmentAssignRowState;
 import 'package:colonizethis_world/colonizethis_world.dart' show PlayerView;
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../config/constants.dart';
+import '../../../../providers/development_panel_projection_provider.dart';
 import '../../../../widgets/ct_spacing.dart';
 import 'development_panel_keys.dart';
 import 'development_panel_map_panel.dart';
@@ -18,7 +19,7 @@ import 'development_panel_overview.dart';
 import 'development_panel_scope_list.dart';
 
 /// One region tab: overview, scope list, and panel map.
-class DevelopmentRegionTab extends StatefulWidget {
+class DevelopmentRegionTab extends ConsumerStatefulWidget {
   const DevelopmentRegionTab({
     super.key,
     required this.game,
@@ -49,23 +50,12 @@ class DevelopmentRegionTab extends StatefulWidget {
   final void Function(DevelopmentImproveAssignCandidate candidate) onAssign;
 
   @override
-  State<DevelopmentRegionTab> createState() => _DevelopmentRegionTabState();
+  ConsumerState<DevelopmentRegionTab> createState() =>
+      _DevelopmentRegionTabState();
 }
 
-class _DevelopmentRegionTabState extends State<DevelopmentRegionTab> {
+class _DevelopmentRegionTabState extends ConsumerState<DevelopmentRegionTab> {
   Set<String>? _highlightTileKeys;
-
-  Iterable<({String commodityId, Set<String> tileKeys})>
-  get _improvableRows sync* {
-    for (final scope in [
-      ...widget.regionModel.ownedScopes,
-      ...widget.regionModel.purchasedScopes,
-    ]) {
-      for (final row in scope.improvableCommodities) {
-        yield (commodityId: row.commodityId, tileKeys: row.tileKeys.toSet());
-      }
-    }
-  }
 
   DevelopmentAssignRowState _assignRowStateFor(
     String commodityId,
@@ -91,14 +81,8 @@ class _DevelopmentRegionTabState extends State<DevelopmentRegionTab> {
   @override
   Widget build(BuildContext context) {
     final wide = MediaQuery.sizeOf(context).width >= kNarrowBreakpoint;
-    final materialShortages = developmentPanelMaterialShortageCommodityIds(
-      game: widget.game,
-      playerId: widget.humanPlayerId,
-      currentOrders: widget.currentOrders,
-      topology: widget.topology,
-      tileMapByRegion: widget.tileMapByRegion,
-      improvableRows: _improvableRows,
-      connectedTileKeys: widget.connectedTileKeys,
+    final materialShortages = ref.watch(
+      developmentPanelMaterialShortageProvider(widget.regionId),
     );
     final list = DevelopmentPanelScopeList(
       key: DevelopmentPanelKeys.scopeListKey,

--- a/app/lib/providers/development_panel_projection_provider.dart
+++ b/app/lib/providers/development_panel_projection_provider.dart
@@ -1,6 +1,8 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_economy/colonizethis_economy.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_orders/colonizethis_orders.dart'
+    show developmentPanelMaterialShortageCommodityIds;
 import 'package:colonizethis_world/colonizethis_world.dart'
     show ConnectivityResult, PlayerView, allProvinces, buildPlayerView;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -124,5 +126,37 @@ final developmentPanelRegionModelProvider =
         provinceDisplayNamesById: projection.provinceDisplayNamesById,
         playerDisplayNamesById: projection.playerDisplayNamesById,
         playerView: projection.playerView,
+      );
+    });
+
+Iterable<({String commodityId, Set<String> tileKeys})>
+_improvableRowsFromRegionModel(DevelopmentPanelRegionModel regionModel) sync* {
+  for (final scope in [
+    ...regionModel.ownedScopes,
+    ...regionModel.purchasedScopes,
+  ]) {
+    for (final row in scope.improvableCommodities) {
+      yield (commodityId: row.commodityId, tileKeys: row.tileKeys.toSet());
+    }
+  }
+}
+
+/// Material-shortage flags per region — memoized across highlight-only tab rebuilds.
+final developmentPanelMaterialShortageProvider =
+    Provider.family<Set<String>, String>((ref, regionId) {
+      final projection = ref.watch(developmentPanelProjectionProvider);
+      final regionModel = ref.watch(developmentPanelRegionModelProvider(regionId));
+      if (projection == null || regionModel == null) {
+        return const {};
+      }
+      final orders = ref.watch(currentOrdersProvider);
+      return developmentPanelMaterialShortageCommodityIds(
+        game: projection.game,
+        playerId: projection.humanPlayerId,
+        currentOrders: orders,
+        topology: projection.topology,
+        tileMapByRegion: projection.tileMapByRegion,
+        improvableRows: _improvableRowsFromRegionModel(regionModel),
+        connectedTileKeys: projection.shared.connectedTileKeys,
       );
     });

--- a/app/lib/providers/development_panel_projection_provider.dart
+++ b/app/lib/providers/development_panel_projection_provider.dart
@@ -2,7 +2,7 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_economy/colonizethis_economy.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_orders/colonizethis_orders.dart'
-    show developmentPanelMaterialShortageCommodityIds;
+    show DevelopmentAssignRowState, resolveDevelopmentAssignRowState;
 import 'package:colonizethis_world/colonizethis_world.dart'
     show ConnectivityResult, PlayerView, allProvinces, buildPlayerView;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -129,34 +129,68 @@ final developmentPanelRegionModelProvider =
       );
     });
 
-Iterable<({String commodityId, Set<String> tileKeys})>
-_improvableRowsFromRegionModel(DevelopmentPanelRegionModel regionModel) sync* {
-  for (final scope in [
-    ...regionModel.ownedScopes,
-    ...regionModel.purchasedScopes,
-  ]) {
-    for (final row in scope.improvableCommodities) {
-      yield (commodityId: row.commodityId, tileKeys: row.tileKeys.toSet());
-    }
-  }
+/// Stable cache key for per-scope improvable commodity assign affordance.
+String developmentPanelAssignRowStateKey(String scopeKey, String commodityId) =>
+    '$scopeKey|$commodityId';
+
+/// Per-scope assign affordance + material-shortage flags for one region tab.
+///
+/// Memoized across highlight-only tab rebuilds so Show-tile [setState] does not
+/// re-run [resolveDevelopmentAssignRowState] for every improvable row.
+class DevelopmentPanelAssignRowStateCache {
+  const DevelopmentPanelAssignRowStateCache({
+    required this.byScopeCommodityKey,
+    required this.materialShortageCommodityIds,
+  });
+
+  final Map<String, DevelopmentAssignRowState> byScopeCommodityKey;
+  final Set<String> materialShortageCommodityIds;
 }
 
-/// Material-shortage flags per region — memoized across highlight-only tab rebuilds.
-final developmentPanelMaterialShortageProvider =
-    Provider.family<Set<String>, String>((ref, regionId) {
+final developmentPanelAssignRowStateCacheProvider =
+    Provider.family<DevelopmentPanelAssignRowStateCache, String>((ref, regionId) {
       final projection = ref.watch(developmentPanelProjectionProvider);
       final regionModel = ref.watch(developmentPanelRegionModelProvider(regionId));
       if (projection == null || regionModel == null) {
-        return const {};
+        return const DevelopmentPanelAssignRowStateCache(
+          byScopeCommodityKey: {},
+          materialShortageCommodityIds: {},
+        );
       }
       final orders = ref.watch(currentOrdersProvider);
-      return developmentPanelMaterialShortageCommodityIds(
-        game: projection.game,
-        playerId: projection.humanPlayerId,
-        currentOrders: orders,
-        topology: projection.topology,
-        tileMapByRegion: projection.tileMapByRegion,
-        improvableRows: _improvableRowsFromRegionModel(regionModel),
-        connectedTileKeys: projection.shared.connectedTileKeys,
+      final byKey = <String, DevelopmentAssignRowState>{};
+      final shortages = <String>{};
+      for (final scope in [
+        ...regionModel.ownedScopes,
+        ...regionModel.purchasedScopes,
+      ]) {
+        for (final row in scope.improvableCommodities) {
+          final state = resolveDevelopmentAssignRowState(
+            game: projection.game,
+            playerId: projection.humanPlayerId,
+            currentOrders: orders,
+            topology: projection.topology,
+            tileMapByRegion: projection.tileMapByRegion,
+            commodityTileKeys: row.tileKeys.toSet(),
+            connectedTileKeys: projection.shared.connectedTileKeys,
+          );
+          byKey[developmentPanelAssignRowStateKey(scope.scopeKey, row.commodityId)] =
+              state;
+          if (state.disabledReason == 'Insufficient materials') {
+            shortages.add(row.commodityId);
+          }
+        }
+      }
+      return DevelopmentPanelAssignRowStateCache(
+        byScopeCommodityKey: byKey,
+        materialShortageCommodityIds: shortages,
       );
+    });
+
+/// Material-shortage flags per region — derived from assign affordance cache.
+final developmentPanelMaterialShortageProvider =
+    Provider.family<Set<String>, String>((ref, regionId) {
+      return ref
+          .watch(developmentPanelAssignRowStateCacheProvider(regionId))
+          .materialShortageCommodityIds;
     });

--- a/app/test/development_panel_projection_provider_test.dart
+++ b/app/test/development_panel_projection_provider_test.dart
@@ -157,6 +157,63 @@ void main() {
   );
 
   test(
+    'developmentPanelAssignRowStateCacheProvider caches across reads with stable inputs (Refs #4175 Slice E)',
+    () {
+      final game = buildDevelopmentPanelGoldenGame();
+      final container = ProviderContainer(
+        overrides: _developmentPanelProviderOverrides(game),
+      );
+      addTearDown(container.dispose);
+
+      final first = container.read(
+        developmentPanelAssignRowStateCacheProvider(kRegionOldWorld),
+      );
+      final second = container.read(
+        developmentPanelAssignRowStateCacheProvider(kRegionOldWorld),
+      );
+
+      expect(identical(first, second), isTrue);
+      expect(first.byScopeCommodityKey, isNotEmpty);
+    },
+  );
+
+  test(
+    'developmentPanelAssignRowStateCacheProvider invalidates when orders change (Refs #4175 Slice E)',
+    () {
+      final game = buildDevelopmentPanelGoldenGame();
+      final ordersNotifier = CurrentOrdersNotifier(const Orders());
+      final container = ProviderContainer(
+        overrides: _developmentPanelProviderOverrides(
+          game,
+          ordersNotifier: ordersNotifier,
+        ),
+      );
+      addTearDown(container.dispose);
+
+      final before = container.read(
+        developmentPanelAssignRowStateCacheProvider(kRegionOldWorld),
+      );
+
+      ordersNotifier.state = Orders(
+        workOrdersByPlayerId: {
+          kPanelTestHumanPlayerId: const [
+            WorkOrder(
+              unitId: 'b1',
+              target: kWorkTargetBuildImprovement,
+              targetTileKey: 'oldWorld|p1|0|0',
+            ),
+          ],
+        },
+      );
+
+      final after = container.read(
+        developmentPanelAssignRowStateCacheProvider(kRegionOldWorld),
+      );
+      expect(identical(before, after), isFalse);
+    },
+  );
+
+  test(
     'developmentPanelMaterialShortageProvider caches across reads with stable inputs (Refs #4175 Slice E)',
     () {
       final game = buildDevelopmentPanelGoldenGame();

--- a/app/test/development_panel_projection_provider_test.dart
+++ b/app/test/development_panel_projection_provider_test.dart
@@ -155,4 +155,61 @@ void main() {
       expect(identical(connectivityBefore, connectivityAfter), isTrue);
     },
   );
+
+  test(
+    'developmentPanelMaterialShortageProvider caches across reads with stable inputs (Refs #4175 Slice E)',
+    () {
+      final game = buildDevelopmentPanelGoldenGame();
+      final container = ProviderContainer(
+        overrides: _developmentPanelProviderOverrides(game),
+      );
+      addTearDown(container.dispose);
+
+      final first = container.read(
+        developmentPanelMaterialShortageProvider(kRegionOldWorld),
+      );
+      final second = container.read(
+        developmentPanelMaterialShortageProvider(kRegionOldWorld),
+      );
+
+      expect(identical(first, second), isTrue);
+    },
+  );
+
+  test(
+    'developmentPanelMaterialShortageProvider invalidates when orders change (Refs #4175 Slice E)',
+    () {
+      final game = buildDevelopmentPanelGoldenGame();
+      final ordersNotifier = CurrentOrdersNotifier(const Orders());
+      final container = ProviderContainer(
+        overrides: _developmentPanelProviderOverrides(
+          game,
+          ordersNotifier: ordersNotifier,
+        ),
+      );
+      addTearDown(container.dispose);
+
+      final before = container.read(
+        developmentPanelMaterialShortageProvider(kRegionOldWorld),
+      );
+      expect(before, isEmpty);
+
+      ordersNotifier.state = Orders(
+        workOrdersByPlayerId: {
+          kPanelTestHumanPlayerId: const [
+            WorkOrder(
+              unitId: 'b1',
+              target: kWorkTargetBuildImprovement,
+              targetTileKey: 'oldWorld|p1|0|0',
+            ),
+          ],
+        },
+      );
+
+      final after = container.read(
+        developmentPanelMaterialShortageProvider(kRegionOldWorld),
+      );
+      expect(identical(before, after), isFalse);
+    },
+  );
 }

--- a/app/test/development_panel_projection_rebuild_guard_test.dart
+++ b/app/test/development_panel_projection_rebuild_guard_test.dart
@@ -12,11 +12,14 @@ import 'package:colonizethis_app_l10n/l10n/l10n.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_save/colonizethis_save.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:colonizethis_world/colonizethis_world.dart' show kRegionOldWorld;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/misc.dart' show Override;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
+
+import 'package:colonizethis_app/features/game/screens/development/development_panel_keys.dart';
 
 import 'app_shell_harness.dart';
 import 'development_panel_test_support.dart';
@@ -131,6 +134,59 @@ void main() {
       final projectionAfterBump = container.read(developmentPanelProjectionProvider);
       expect(identical(projectionAfterOpen, projectionAfterBump), isTrue);
       expect(projectionNotifications, notificationsAfterOpen);
+    },
+  );
+
+  testWidgets(
+    'developmentPanelAssignRowStateCacheProvider survives Show highlight setState (Refs #4175 Slice E)',
+    (WidgetTester tester) async {
+      final game = buildDevelopmentPanelGoldenGame();
+      final container = ProviderContainer(
+        overrides: _developmentOverrides(game, gamesBox),
+      );
+      addTearDown(container.dispose);
+
+      var assignCacheNotifications = 0;
+      container.listen(
+        developmentPanelAssignRowStateCacheProvider(kRegionOldWorld),
+        (_, _) => assignCacheNotifications++,
+        fireImmediately: true,
+      );
+
+      await tester.pumpWidget(
+        buildAppShellWithContainer(
+          container: container,
+          child: DevelopmentScreenBody(
+            game: game,
+            humanPlayerId: kPanelTestHumanPlayerId,
+          ),
+          localizationsDelegates: AppLocalizationsBinding.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          locale: const Locale('en'),
+          viewport: const Size(900, 760),
+        ),
+      );
+
+      await pumpDevelopmentPanelReady(tester);
+
+      final cacheAfterOpen = container.read(
+        developmentPanelAssignRowStateCacheProvider(kRegionOldWorld),
+      );
+      expect(cacheAfterOpen.byScopeCommodityKey, isNotEmpty);
+      final notificationsAfterOpen = assignCacheNotifications;
+
+      await tester.tap(
+        find.byKey(
+          DevelopmentPanelKeys.showButtonKey('oldWorld|p1', 'grain'),
+        ),
+      );
+      await tester.pump();
+
+      final cacheAfterShow = container.read(
+        developmentPanelAssignRowStateCacheProvider(kRegionOldWorld),
+      );
+      expect(identical(cacheAfterOpen, cacheAfterShow), isTrue);
+      expect(assignCacheNotifications, notificationsAfterOpen);
     },
   );
 }


### PR DESCRIPTION
## Summary
- Add `developmentPanelMaterialShortageProvider` to memoize per-region material-shortage commodity ids across highlight-only tab rebuilds.
- Convert `DevelopmentRegionTab` to `ConsumerStatefulWidget` and consume the provider instead of scanning assign affordance on every `build`.
- Document the caching contract in `SPEC/program/development-panel-read-model.md`.

## Done in this PR
- **Slice E (follow-up):** Avoid redundant `resolveDevelopmentAssignRowState` loops when the player taps **Show** on improvable rows (highlight `setState` only).
- Provider invalidates on game/orders/region-model changes; stable identity across repeated reads with unchanged inputs.

## Deferred
- **AC1 qualitative bar:** Owner manual verification on a mid-game save (compare open feel to Production panel) — still requires in-app check after merge.
- DevTools timeline captures (optional owner verification anchor for AC1).

## Test plan
- [x] `flutter test` — `app/test/development_panel_projection_provider_test.dart` (5/5)
- [x] `flutter test` — `app/test/development_panel_lazy_open_test.dart` (3/3)

Refs #4175

Made with [Cursor](https://cursor.com)