### PR TITLE
perf: split Development panel static projection from order churn (#4175)

### DIFF
--- a/SPEC/program/development-panel-read-model.md
+++ b/SPEC/program/development-panel-read-model.md
@@ -38,7 +38,9 @@ When `playerView` is supplied to `buildDevelopmentPanelModel`, improvable commod
 - `DevelopmentPanelMapPanel` caches `DevelopmentPanelMapSnapshot` (region view data + territory outline keys) across highlight-only rebuilds; invalidates when game turn, region, player, or per-region visibility digest changes.
 - First map paint is deferred to the frame after panel mount so overview/list can paint first (post-frame `mapReady` gate).
 - `DevelopmentScreenBody` defers read-model projection (`buildPlayerView`, `buildDevelopmentPanelBuildContext`, per-region models) to the frame after mount so the tab strip can paint before connectivity and improvable scans run (post-frame `readModelReady` gate).
-- `developmentPanelProjectionProvider` and `developmentPanelRegionModelProvider` memoize shared connectivity, [PlayerView], and per-region read models across unrelated [DevelopmentScreenBody] rebuilds; invalidate when game, orders, map data, or shell player context change.
+- `developmentPanelStaticContextProvider` memoizes [PlayerView] and display-name maps across draft-order churn; invalidates on game, map data, or shell player context change only.
+- `developmentPanelSharedContextProvider` memoizes idle counts and connectivity slice; invalidates when draft orders change.
+- `developmentPanelProjectionProvider` and `developmentPanelRegionModelProvider` compose static + shared inputs across unrelated [DevelopmentScreenBody] rebuilds.
 - `developmentPanelConnectivityProvider` memoizes `resolveConnectivity` separately from draft orders so assign/cancel live updates recompute idle counts without re-running connectivity scans.
 - `developmentPanelMaterialShortageProvider` memoizes per-region material-shortage commodity ids so highlight-only tab rebuilds do not re-scan assign affordance for every improvable row.
 - `developmentPanelAssignRowStateCacheProvider` memoizes per-scope assign affordance (`resolveDevelopmentAssignRowState`) for every improvable row in the active region; material-shortage flags derive from the same cache.
@@ -54,7 +56,7 @@ Representative fixture: dual-region save with two OW provinces + one NW province
 |----------------------|------------|-------------------|
 | Eager dual-region `buildDevelopmentPanelModel` on open | Per-region `buildDevelopmentPanelRegionModel` + visited-tab gate | Lazy OW-only build faster than monolithic dual-region build on timing fixture (test-guarded) |
 | Duplicate `resolveConnectivity` on order churn | `developmentPanelConnectivityProvider` + `buildDevelopmentPanelBuildContextFromConnectivity` | Connectivity map identity stable across order-only updates (provider + unit tests) |
-| Duplicate `buildPlayerView` (screen + map) | Single `playerView` on `DevelopmentPanelProjection` | Eliminated per-map rebuild |
+| Duplicate `buildPlayerView` (screen + map) | Single `playerView` on `DevelopmentPanelStaticContext` | Eliminated per-map rebuild; [PlayerView] identity stable across order-only updates |
 | `IndexedStack` mounting both region maps | `CtTabStrip.lazyTabBodies` + `_visitedRegionIds` | NW map absent until first tab visit (`development_panel_lazy_open_test.dart`) |
 | Synchronous read model on first frame | Post-frame `readModelReady` gate | Tab strip paints before connectivity/improvable scans |
 | Per-row material shortage scan on highlight rebuild | `developmentPanelAssignRowStateCacheProvider` + derived shortage set | Show-tile highlight `setState` does not re-run assign affordance per row (`development_panel_projection_rebuild_guard_test.dart`) |

--- a/SPEC/program/development-panel-read-model.md
+++ b/SPEC/program/development-panel-read-model.md
@@ -42,8 +42,7 @@ When `playerView` is supplied to `buildDevelopmentPanelModel`, improvable commod
 - `developmentPanelSharedContextProvider` memoizes idle counts and connectivity slice; invalidates when draft orders change.
 - `developmentPanelProjectionProvider` and `developmentPanelRegionModelProvider` compose static + shared inputs across unrelated [DevelopmentScreenBody] rebuilds.
 - `developmentPanelConnectivityProvider` memoizes `resolveConnectivity` separately from draft orders so assign/cancel live updates recompute idle counts without re-running connectivity scans.
-- `developmentPanelMaterialShortageProvider` memoizes per-region material-shortage commodity ids so highlight-only tab rebuilds do not re-scan assign affordance for every improvable row.
-- `developmentPanelAssignRowStateCacheProvider` memoizes per-scope assign affordance (`resolveDevelopmentAssignRowState`) for every improvable row in the active region; material-shortage flags derive from the same cache.
+- `developmentPanelAssignRowStateCacheProvider` memoizes per-scope assign affordance (`resolveDevelopmentAssignRowState`) and per-region material-shortage commodity ids so highlight-only tab rebuilds do not re-scan assign affordance for every improvable row.
 - `developmentPanelVisibilityByTile` accepts optional `regionId` so panel maps do not scan both regions when rendering one minimap.
 
 Cache invalidation: panel projections recompute when `game`, `currentOrders`, or `playerView` inputs change on rebuild; assign/cancel and fog updates remain live-immediate per Slice A–D ACs. Connectivity (`developmentPanelConnectivityProvider`) invalidates on game/map revision only — not on draft-order churn.

--- a/SPEC/program/development-panel-read-model.md
+++ b/SPEC/program/development-panel-read-model.md
@@ -40,7 +40,8 @@ When `playerView` is supplied to `buildDevelopmentPanelModel`, improvable commod
 - `DevelopmentScreenBody` defers read-model projection (`buildPlayerView`, `buildDevelopmentPanelBuildContext`, per-region models) to the frame after mount so the tab strip can paint before connectivity and improvable scans run (post-frame `readModelReady` gate).
 - `developmentPanelStaticContextProvider` memoizes [PlayerView] and display-name maps across draft-order churn; invalidates on game, map data, or shell player context change only.
 - `developmentPanelSharedContextProvider` memoizes idle counts and connectivity slice; invalidates when draft orders change.
-- `developmentPanelProjectionProvider` and `developmentPanelRegionModelProvider` compose static + shared inputs across unrelated [DevelopmentScreenBody] rebuilds.
+- `developmentPanelRegionScopesProvider` memoizes improvable scope rows and land extraction per region; invalidates on game/map/shell changes only (not draft orders).
+- `developmentPanelRegionModelProvider` composes cached scopes with order-dependent idle counts and assigned civilians.
 - `developmentPanelConnectivityProvider` memoizes `resolveConnectivity` separately from draft orders so assign/cancel live updates recompute idle counts without re-running connectivity scans.
 - `developmentPanelAssignRowStateCacheProvider` memoizes per-scope assign affordance (`resolveDevelopmentAssignRowState`) and per-region material-shortage commodity ids so highlight-only tab rebuilds do not re-scan assign affordance for every improvable row.
 - `developmentPanelVisibilityByTile` accepts optional `regionId` so panel maps do not scan both regions when rendering one minimap.
@@ -59,6 +60,7 @@ Representative fixture: dual-region save with two OW provinces + one NW province
 | `IndexedStack` mounting both region maps | `CtTabStrip.lazyTabBodies` + `_visitedRegionIds` | NW map absent until first tab visit (`development_panel_lazy_open_test.dart`) |
 | Synchronous read model on first frame | Post-frame `readModelReady` gate | Tab strip paints before connectivity/improvable scans |
 | Per-row material shortage scan on highlight rebuild | `developmentPanelAssignRowStateCacheProvider` + derived shortage set | Show-tile highlight `setState` does not re-run assign affordance per row (`development_panel_projection_rebuild_guard_test.dart`) |
+| Full improvable scope scan on assign/cancel draft churn | `developmentPanelRegionScopesProvider` order-independent memoization | Scope rows and extraction projection identity stable across order-only updates (provider unit test) |
 | Full dual-region map view-data | Per-region `buildInitGameMapRegionViewData` + snapshot cache | Map defers one frame; highlight-only rebuilds reuse snapshot |
 
 DevTools timeline captures remain optional owner verification for AC1 qualitative bar; timing tests above are the CI profiling anchor for AC2.

--- a/app/lib/features/game/screens/development/development_region_tab.dart
+++ b/app/lib/features/game/screens/development/development_region_tab.dart
@@ -2,7 +2,10 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_economy/colonizethis_economy.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_orders/colonizethis_orders.dart'
-    show DevelopmentAssignRowState, DevelopmentImproveAssignCandidate;
+    show
+        DevelopmentAssignRowState,
+        DevelopmentImproveAssignCandidate,
+        developmentPanelAssignRowStateKey;
 import 'package:colonizethis_world/colonizethis_world.dart' show PlayerView;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -76,9 +79,8 @@ class _DevelopmentRegionTabState extends ConsumerState<DevelopmentRegionTab> {
   @override
   Widget build(BuildContext context) {
     final wide = MediaQuery.sizeOf(context).width >= kNarrowBreakpoint;
-    ref.watch(developmentPanelAssignRowStateCacheProvider(widget.regionId));
-    final materialShortages = ref.watch(
-      developmentPanelMaterialShortageProvider(widget.regionId),
+    final assignCache = ref.watch(
+      developmentPanelAssignRowStateCacheProvider(widget.regionId),
     );
     final list = DevelopmentPanelScopeList(
       key: DevelopmentPanelKeys.scopeListKey,
@@ -104,7 +106,7 @@ class _DevelopmentRegionTabState extends ConsumerState<DevelopmentRegionTab> {
         DevelopmentPanelOverview(
           key: DevelopmentPanelKeys.overviewKey,
           regionModel: widget.regionModel,
-          materialShortageCommodityIds: materialShortages,
+          materialShortageCommodityIds: assignCache.materialShortageCommodityIds,
           provinceDisplayNamesById: widget.provinceDisplayNamesById,
           game: widget.game,
           humanPlayerId: widget.humanPlayerId,

--- a/app/lib/providers/development_panel_projection_provider.dart
+++ b/app/lib/providers/development_panel_projection_provider.dart
@@ -2,7 +2,9 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_economy/colonizethis_economy.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_orders/colonizethis_orders.dart'
-    show DevelopmentAssignRowState, resolveDevelopmentAssignRowState;
+    show
+        DevelopmentPanelAssignRowStateCache,
+        buildDevelopmentPanelAssignRowStateCache;
 import 'package:colonizethis_world/colonizethis_world.dart'
     show ConnectivityResult, PlayerView, allProvinces, buildPlayerView;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -38,25 +40,15 @@ class DevelopmentPanelProjection {
 }
 
 /// Game/map/shell inputs that do not depend on draft orders.
-class DevelopmentPanelStaticContext {
-  const DevelopmentPanelStaticContext({
-    required this.game,
-    required this.humanPlayerId,
-    required this.playerView,
-    required this.provinceDisplayNamesById,
-    required this.playerDisplayNamesById,
-    required this.topology,
-    required this.tileMapByRegion,
-  });
-
-  final Game game;
-  final String humanPlayerId;
-  final PlayerView playerView;
-  final Map<String, String> provinceDisplayNamesById;
-  final Map<String, String> playerDisplayNamesById;
-  final MapTopology topology;
-  final Map<String, TileMapResult> tileMapByRegion;
-}
+typedef DevelopmentPanelStaticContext = ({
+  Game game,
+  String humanPlayerId,
+  PlayerView playerView,
+  Map<String, String> provinceDisplayNamesById,
+  Map<String, String> playerDisplayNamesById,
+  MapTopology topology,
+  Map<String, TileMapResult> tileMapByRegion,
+});
 
 /// Connectivity map — invalidates on game/map changes only (not draft orders).
 final developmentPanelConnectivityProvider =
@@ -106,7 +98,7 @@ final developmentPanelStaticContextProvider =
         humanPlayerId,
       );
 
-      return DevelopmentPanelStaticContext(
+      return (
         game: game,
         humanPlayerId: humanPlayerId,
         playerView: playerView,
@@ -179,69 +171,22 @@ final developmentPanelRegionModelProvider =
       );
     });
 
-/// Stable cache key for per-scope improvable commodity assign affordance.
-String developmentPanelAssignRowStateKey(String scopeKey, String commodityId) =>
-    '$scopeKey|$commodityId';
-
 /// Per-scope assign affordance + material-shortage flags for one region tab.
-///
-/// Memoized across highlight-only tab rebuilds so Show-tile [setState] does not
-/// re-run [resolveDevelopmentAssignRowState] for every improvable row.
-class DevelopmentPanelAssignRowStateCache {
-  const DevelopmentPanelAssignRowStateCache({
-    required this.byScopeCommodityKey,
-    required this.materialShortageCommodityIds,
-  });
-
-  final Map<String, DevelopmentAssignRowState> byScopeCommodityKey;
-  final Set<String> materialShortageCommodityIds;
-}
-
 final developmentPanelAssignRowStateCacheProvider =
     Provider.family<DevelopmentPanelAssignRowStateCache, String>((ref, regionId) {
       final staticContext = ref.watch(developmentPanelStaticContextProvider);
       final shared = ref.watch(developmentPanelSharedContextProvider);
       final regionModel = ref.watch(developmentPanelRegionModelProvider(regionId));
       if (staticContext == null || shared == null || regionModel == null) {
-        return const DevelopmentPanelAssignRowStateCache(
-          byScopeCommodityKey: {},
-          materialShortageCommodityIds: {},
-        );
+        return DevelopmentPanelAssignRowStateCache.empty;
       }
-      final orders = ref.watch(currentOrdersProvider);
-      final byKey = <String, DevelopmentAssignRowState>{};
-      final shortages = <String>{};
-      for (final scope in [
-        ...regionModel.ownedScopes,
-        ...regionModel.purchasedScopes,
-      ]) {
-        for (final row in scope.improvableCommodities) {
-          final state = resolveDevelopmentAssignRowState(
-            game: staticContext.game,
-            playerId: staticContext.humanPlayerId,
-            currentOrders: orders,
-            topology: staticContext.topology,
-            tileMapByRegion: staticContext.tileMapByRegion,
-            commodityTileKeys: row.tileKeys.toSet(),
-            connectedTileKeys: shared.connectedTileKeys,
-          );
-          byKey[developmentPanelAssignRowStateKey(scope.scopeKey, row.commodityId)] =
-              state;
-          if (state.disabledReason == 'Insufficient materials') {
-            shortages.add(row.commodityId);
-          }
-        }
-      }
-      return DevelopmentPanelAssignRowStateCache(
-        byScopeCommodityKey: byKey,
-        materialShortageCommodityIds: shortages,
+      return buildDevelopmentPanelAssignRowStateCache(
+        regionModel: regionModel,
+        game: staticContext.game,
+        playerId: staticContext.humanPlayerId,
+        currentOrders: ref.watch(currentOrdersProvider),
+        topology: staticContext.topology,
+        tileMapByRegion: staticContext.tileMapByRegion,
+        connectedTileKeys: shared.connectedTileKeys,
       );
-    });
-
-/// Material-shortage flags per region — derived from assign affordance cache.
-final developmentPanelMaterialShortageProvider =
-    Provider.family<Set<String>, String>((ref, regionId) {
-      return ref
-          .watch(developmentPanelAssignRowStateCacheProvider(regionId))
-          .materialShortageCommodityIds;
     });

--- a/app/lib/providers/development_panel_projection_provider.dart
+++ b/app/lib/providers/development_panel_projection_provider.dart
@@ -149,44 +149,57 @@ final developmentPanelProjectionProvider =
       );
     });
 
+/// Per-region scopes + extraction — invalidates on game/map/shell only (Slice E).
+final developmentPanelRegionScopesProvider =
+    Provider.family<DevelopmentPanelRegionScopes?, String>((ref, regionId) {
+      final ctx = ref.watch(developmentPanelStaticContextProvider);
+      final connectivity = ref.watch(developmentPanelConnectivityProvider);
+      if (ctx == null || connectivity == null) return null;
+      return buildDevelopmentPanelRegionScopesForPlayer(
+        game: ctx.game,
+        playerId: ctx.humanPlayerId,
+        regionId: regionId,
+        tileMapByRegion: ctx.tileMapByRegion,
+        provinceDisplayNamesById: ctx.provinceDisplayNamesById,
+        playerDisplayNamesById: ctx.playerDisplayNamesById,
+        connectivityByPlayer: connectivity,
+        playerView: ctx.playerView,
+      );
+    });
+
 /// Per-region read model; invalidates when static inputs, shared context, or orders change.
 final developmentPanelRegionModelProvider =
     Provider.family<DevelopmentPanelRegionModel?, String>((ref, regionId) {
-      final staticContext = ref.watch(developmentPanelStaticContextProvider);
+      final scopes = ref.watch(developmentPanelRegionScopesProvider(regionId));
       final shared = ref.watch(developmentPanelSharedContextProvider);
-      if (staticContext == null || shared == null) {
-        return null;
-      }
-      final orders = ref.watch(currentOrdersProvider);
-      return buildDevelopmentPanelRegionModel(
+      final ctx = ref.watch(developmentPanelStaticContextProvider);
+      if (scopes == null || shared == null || ctx == null) return null;
+      return composeDevelopmentPanelRegionModel(
+        scopes: scopes,
         shared: shared,
-        game: staticContext.game,
-        playerId: staticContext.humanPlayerId,
-        regionId: regionId,
-        tileMapByRegion: staticContext.tileMapByRegion,
-        currentOrders: orders,
-        provinceDisplayNamesById: staticContext.provinceDisplayNamesById,
-        playerDisplayNamesById: staticContext.playerDisplayNamesById,
-        playerView: staticContext.playerView,
+        game: ctx.game,
+        playerId: ctx.humanPlayerId,
+        currentOrders: ref.watch(currentOrdersProvider),
       );
     });
 
 /// Per-scope assign affordance + material-shortage flags for one region tab.
 final developmentPanelAssignRowStateCacheProvider =
     Provider.family<DevelopmentPanelAssignRowStateCache, String>((ref, regionId) {
-      final staticContext = ref.watch(developmentPanelStaticContextProvider);
+      final ctx = ref.watch(developmentPanelStaticContextProvider);
       final shared = ref.watch(developmentPanelSharedContextProvider);
-      final regionModel = ref.watch(developmentPanelRegionModelProvider(regionId));
-      if (staticContext == null || shared == null || regionModel == null) {
+      final scopes = ref.watch(developmentPanelRegionScopesProvider(regionId));
+      if (ctx == null || shared == null || scopes == null) {
         return DevelopmentPanelAssignRowStateCache.empty;
       }
       return buildDevelopmentPanelAssignRowStateCache(
-        regionModel: regionModel,
-        game: staticContext.game,
-        playerId: staticContext.humanPlayerId,
+        ownedScopes: scopes.ownedScopes,
+        purchasedScopes: scopes.purchasedScopes,
+        game: ctx.game,
+        playerId: ctx.humanPlayerId,
         currentOrders: ref.watch(currentOrdersProvider),
-        topology: staticContext.topology,
-        tileMapByRegion: staticContext.tileMapByRegion,
+        topology: ctx.topology,
+        tileMapByRegion: ctx.tileMapByRegion,
         connectedTileKeys: shared.connectedTileKeys,
       );
     });

--- a/app/lib/providers/development_panel_projection_provider.dart
+++ b/app/lib/providers/development_panel_projection_provider.dart
@@ -37,6 +37,27 @@ class DevelopmentPanelProjection {
   final Map<String, TileMapResult> tileMapByRegion;
 }
 
+/// Game/map/shell inputs that do not depend on draft orders.
+class DevelopmentPanelStaticContext {
+  const DevelopmentPanelStaticContext({
+    required this.game,
+    required this.humanPlayerId,
+    required this.playerView,
+    required this.provinceDisplayNamesById,
+    required this.playerDisplayNamesById,
+    required this.topology,
+    required this.tileMapByRegion,
+  });
+
+  final Game game;
+  final String humanPlayerId;
+  final PlayerView playerView;
+  final Map<String, String> provinceDisplayNamesById;
+  final Map<String, String> playerDisplayNamesById;
+  final MapTopology topology;
+  final Map<String, TileMapResult> tileMapByRegion;
+}
+
 /// Connectivity map — invalidates on game/map changes only (not draft orders).
 final developmentPanelConnectivityProvider =
     Provider<Map<String, ConnectivityResult>?>((ref) {
@@ -55,9 +76,10 @@ final developmentPanelConnectivityProvider =
       );
     });
 
-/// Connectivity, [PlayerView], and display-name maps — once per relevant input change.
-final developmentPanelProjectionProvider =
-    Provider<DevelopmentPanelProjection?>((ref) {
+/// [PlayerView], display-name maps, and map topology — invalidates on game/map/shell
+/// changes only (not draft orders).
+final developmentPanelStaticContextProvider =
+    Provider<DevelopmentPanelStaticContext?>((ref) {
       final game = ref.watch(currentGameProvider);
       if (game == null) {
         return null;
@@ -66,11 +88,6 @@ final developmentPanelProjectionProvider =
       if (mapData == null) {
         return null;
       }
-      final connectivity = ref.watch(developmentPanelConnectivityProvider);
-      if (connectivity == null) {
-        return null;
-      }
-      final orders = ref.watch(currentOrdersProvider);
       final shell = ref.watch(shellPlayerContextProvider);
       final humanPlayerId = resolveShellPanelPlayerId(shell, game);
 
@@ -88,17 +105,10 @@ final developmentPanelProjectionProvider =
         mapData.combinedTopology,
         humanPlayerId,
       );
-      final shared = buildDevelopmentPanelBuildContextFromConnectivity(
-        connectivity: connectivity,
-        game: game,
-        playerId: humanPlayerId,
-        currentOrders: orders,
-      );
 
-      return DevelopmentPanelProjection(
+      return DevelopmentPanelStaticContext(
         game: game,
         humanPlayerId: humanPlayerId,
-        shared: shared,
         playerView: playerView,
         provinceDisplayNamesById: provinceDisplayNamesById,
         playerDisplayNamesById: playerDisplayNamesById,
@@ -107,25 +117,65 @@ final developmentPanelProjectionProvider =
       );
     });
 
-/// Per-region read model; invalidates when [developmentPanelProjectionProvider]
-/// or [currentOrdersProvider] change.
+/// Idle counts and connectivity slice — invalidates when draft orders change.
+final developmentPanelSharedContextProvider =
+    Provider<DevelopmentPanelBuildContext?>((ref) {
+      final staticContext = ref.watch(developmentPanelStaticContextProvider);
+      if (staticContext == null) {
+        return null;
+      }
+      final connectivity = ref.watch(developmentPanelConnectivityProvider);
+      if (connectivity == null) {
+        return null;
+      }
+      final orders = ref.watch(currentOrdersProvider);
+      return buildDevelopmentPanelBuildContextFromConnectivity(
+        connectivity: connectivity,
+        game: staticContext.game,
+        playerId: staticContext.humanPlayerId,
+        currentOrders: orders,
+      );
+    });
+
+/// Combined projection for panel consumers.
+final developmentPanelProjectionProvider =
+    Provider<DevelopmentPanelProjection?>((ref) {
+      final staticContext = ref.watch(developmentPanelStaticContextProvider);
+      final shared = ref.watch(developmentPanelSharedContextProvider);
+      if (staticContext == null || shared == null) {
+        return null;
+      }
+      return DevelopmentPanelProjection(
+        game: staticContext.game,
+        humanPlayerId: staticContext.humanPlayerId,
+        shared: shared,
+        playerView: staticContext.playerView,
+        provinceDisplayNamesById: staticContext.provinceDisplayNamesById,
+        playerDisplayNamesById: staticContext.playerDisplayNamesById,
+        topology: staticContext.topology,
+        tileMapByRegion: staticContext.tileMapByRegion,
+      );
+    });
+
+/// Per-region read model; invalidates when static inputs, shared context, or orders change.
 final developmentPanelRegionModelProvider =
     Provider.family<DevelopmentPanelRegionModel?, String>((ref, regionId) {
-      final projection = ref.watch(developmentPanelProjectionProvider);
-      if (projection == null) {
+      final staticContext = ref.watch(developmentPanelStaticContextProvider);
+      final shared = ref.watch(developmentPanelSharedContextProvider);
+      if (staticContext == null || shared == null) {
         return null;
       }
       final orders = ref.watch(currentOrdersProvider);
       return buildDevelopmentPanelRegionModel(
-        shared: projection.shared,
-        game: projection.game,
-        playerId: projection.humanPlayerId,
+        shared: shared,
+        game: staticContext.game,
+        playerId: staticContext.humanPlayerId,
         regionId: regionId,
-        tileMapByRegion: projection.tileMapByRegion,
+        tileMapByRegion: staticContext.tileMapByRegion,
         currentOrders: orders,
-        provinceDisplayNamesById: projection.provinceDisplayNamesById,
-        playerDisplayNamesById: projection.playerDisplayNamesById,
-        playerView: projection.playerView,
+        provinceDisplayNamesById: staticContext.provinceDisplayNamesById,
+        playerDisplayNamesById: staticContext.playerDisplayNamesById,
+        playerView: staticContext.playerView,
       );
     });
 
@@ -149,9 +199,10 @@ class DevelopmentPanelAssignRowStateCache {
 
 final developmentPanelAssignRowStateCacheProvider =
     Provider.family<DevelopmentPanelAssignRowStateCache, String>((ref, regionId) {
-      final projection = ref.watch(developmentPanelProjectionProvider);
+      final staticContext = ref.watch(developmentPanelStaticContextProvider);
+      final shared = ref.watch(developmentPanelSharedContextProvider);
       final regionModel = ref.watch(developmentPanelRegionModelProvider(regionId));
-      if (projection == null || regionModel == null) {
+      if (staticContext == null || shared == null || regionModel == null) {
         return const DevelopmentPanelAssignRowStateCache(
           byScopeCommodityKey: {},
           materialShortageCommodityIds: {},
@@ -166,13 +217,13 @@ final developmentPanelAssignRowStateCacheProvider =
       ]) {
         for (final row in scope.improvableCommodities) {
           final state = resolveDevelopmentAssignRowState(
-            game: projection.game,
-            playerId: projection.humanPlayerId,
+            game: staticContext.game,
+            playerId: staticContext.humanPlayerId,
             currentOrders: orders,
-            topology: projection.topology,
-            tileMapByRegion: projection.tileMapByRegion,
+            topology: staticContext.topology,
+            tileMapByRegion: staticContext.tileMapByRegion,
             commodityTileKeys: row.tileKeys.toSet(),
-            connectedTileKeys: projection.shared.connectedTileKeys,
+            connectedTileKeys: shared.connectedTileKeys,
           );
           byKey[developmentPanelAssignRowStateKey(scope.scopeKey, row.commodityId)] =
               state;

--- a/app/test/development_panel_projection_provider_test.dart
+++ b/app/test/development_panel_projection_provider_test.dart
@@ -246,7 +246,7 @@ void main() {
   );
 
   test(
-    'developmentPanelMaterialShortageProvider caches across reads with stable inputs (Refs #4175 Slice E)',
+    'developmentPanelAssignRowStateCacheProvider exposes material shortages (Refs #4175 Slice E)',
     () {
       final game = buildDevelopmentPanelGoldenGame();
       final container = ProviderContainer(
@@ -254,19 +254,15 @@ void main() {
       );
       addTearDown(container.dispose);
 
-      final first = container.read(
-        developmentPanelMaterialShortageProvider(kRegionOldWorld),
+      final cache = container.read(
+        developmentPanelAssignRowStateCacheProvider(kRegionOldWorld),
       );
-      final second = container.read(
-        developmentPanelMaterialShortageProvider(kRegionOldWorld),
-      );
-
-      expect(identical(first, second), isTrue);
+      expect(cache.materialShortageCommodityIds, isEmpty);
     },
   );
 
   test(
-    'developmentPanelMaterialShortageProvider invalidates when orders change (Refs #4175 Slice E)',
+    'developmentPanelAssignRowStateCacheProvider material shortages invalidate on orders (Refs #4175 Slice E)',
     () {
       final game = buildDevelopmentPanelGoldenGame();
       final ordersNotifier = CurrentOrdersNotifier(const Orders());
@@ -279,9 +275,9 @@ void main() {
       addTearDown(container.dispose);
 
       final before = container.read(
-        developmentPanelMaterialShortageProvider(kRegionOldWorld),
+        developmentPanelAssignRowStateCacheProvider(kRegionOldWorld),
       );
-      expect(before, isEmpty);
+      expect(before.materialShortageCommodityIds, isEmpty);
 
       ordersNotifier.state = Orders(
         workOrdersByPlayerId: {
@@ -296,7 +292,7 @@ void main() {
       );
 
       final after = container.read(
-        developmentPanelMaterialShortageProvider(kRegionOldWorld),
+        developmentPanelAssignRowStateCacheProvider(kRegionOldWorld),
       );
       expect(identical(before, after), isFalse);
     },

--- a/app/test/development_panel_projection_provider_test.dart
+++ b/app/test/development_panel_projection_provider_test.dart
@@ -86,6 +86,42 @@ void main() {
   );
 
   test(
+    'developmentPanelRegionScopesProvider survives order-only changes (Refs #4175 Slice E)',
+    () {
+      final game = buildDevelopmentPanelGoldenGame();
+      final container = ProviderContainer(
+        overrides: _developmentPanelProviderOverrides(game),
+      );
+      addTearDown(container.dispose);
+
+      container.read(developmentPanelProjectionProvider);
+
+      final scopesBefore = container.read(
+        developmentPanelRegionScopesProvider(kRegionOldWorld),
+      );
+      expect(scopesBefore, isNotNull);
+      expect(scopesBefore!.ownedScopes, isNotEmpty);
+
+      container.read(currentOrdersProvider.notifier).state = Orders(
+        workOrdersByPlayerId: {
+          kPanelTestHumanPlayerId: const [
+            WorkOrder(
+              unitId: 'b1',
+              target: kWorkTargetBuildImprovement,
+              targetTileKey: 'oldWorld|p1|0|0',
+            ),
+          ],
+        },
+      );
+
+      final scopesAfter = container.read(
+        developmentPanelRegionScopesProvider(kRegionOldWorld),
+      );
+      expect(identical(scopesBefore, scopesAfter), isTrue);
+    },
+  );
+
+  test(
     'developmentPanelRegionModelProvider invalidates when orders change (Refs #4175 Slice E)',
     () {
       final game = buildDevelopmentPanelGoldenGame();

--- a/app/test/development_panel_projection_provider_test.dart
+++ b/app/test/development_panel_projection_provider_test.dart
@@ -125,6 +125,38 @@ void main() {
   );
 
   test(
+    'developmentPanelStaticContextProvider survives order-only changes (Refs #4175 Slice E)',
+    () {
+      final game = buildDevelopmentPanelGoldenGame();
+      final container = ProviderContainer(
+        overrides: _developmentPanelProviderOverrides(game),
+      );
+      addTearDown(container.dispose);
+
+      container.read(developmentPanelProjectionProvider);
+
+      final staticBefore = container.read(developmentPanelStaticContextProvider);
+      expect(staticBefore, isNotNull);
+
+      container.read(currentOrdersProvider.notifier).state = Orders(
+        workOrdersByPlayerId: {
+          kPanelTestHumanPlayerId: const [
+            WorkOrder(
+              unitId: 'b1',
+              target: kWorkTargetBuildImprovement,
+              targetTileKey: 'oldWorld|p1|0|0',
+            ),
+          ],
+        },
+      );
+
+      final staticAfter = container.read(developmentPanelStaticContextProvider);
+      expect(identical(staticBefore, staticAfter), isTrue);
+      expect(identical(staticBefore!.playerView, staticAfter!.playerView), isTrue);
+    },
+  );
+
+  test(
     'developmentPanelConnectivityProvider survives order-only changes (Refs #4175 Slice E)',
     () {
       final game = buildDevelopmentPanelGoldenGame();

--- a/packages/colonizethis_economy/lib/src/economy/development_panel_model.dart
+++ b/packages/colonizethis_economy/lib/src/economy/development_panel_model.dart
@@ -63,6 +63,21 @@ class DevelopmentAssignedCivilianRow {
   final int? totalTurns;
 }
 
+/// Order-independent region slice: scopes and land extraction (Slice E).
+class DevelopmentPanelRegionScopes {
+  const DevelopmentPanelRegionScopes({
+    required this.regionId,
+    required this.ownedScopes,
+    required this.purchasedScopes,
+    required this.landExtractionByCommodity,
+  });
+
+  final String regionId;
+  final List<DevelopmentPanelScopeRow> ownedScopes;
+  final List<DevelopmentPanelScopeRow> purchasedScopes;
+  final Map<String, int> landExtractionByCommodity;
+}
+
 /// Per-region Development panel projection.
 class DevelopmentPanelRegionModel {
   const DevelopmentPanelRegionModel({

--- a/packages/colonizethis_economy/lib/src/economy/development_panel_read_model.dart
+++ b/packages/colonizethis_economy/lib/src/economy/development_panel_read_model.dart
@@ -62,6 +62,75 @@ DevelopmentPanelModel buildDevelopmentPanelModel({
   );
 }
 
+/// Order-independent scopes + extraction for one region (Slice E).
+DevelopmentPanelRegionScopes buildDevelopmentPanelRegionScopes({
+  required Game game,
+  required String playerId,
+  required String regionId,
+  required Map<String, TileMapResult> tileMapByRegion,
+  required Map<String, String> provinceDisplayNamesById,
+  required Map<String, String> playerDisplayNamesById,
+  required ProvinceOwnerCache ownerCache,
+  required ConnectivityResult? playerConnectivity,
+  PlayerView? playerView,
+}) {
+  final ownedScopes = _buildOwnedScopes(
+    game: game,
+    playerId: playerId,
+    regionId: regionId,
+    tileMapByRegion: tileMapByRegion,
+    provinceDisplayNamesById: provinceDisplayNamesById,
+    ownerCache: ownerCache,
+    playerView: playerView,
+  );
+  final purchasedScopes = buildDevelopmentPurchasedScopes(
+    game: game,
+    playerId: playerId,
+    regionId: regionId,
+    tileMapByRegion: tileMapByRegion,
+    provinceDisplayNamesById: provinceDisplayNamesById,
+    playerDisplayNamesById: playerDisplayNamesById,
+    ownerCache: ownerCache,
+    playerView: playerView,
+  );
+  return DevelopmentPanelRegionScopes(
+    regionId: regionId,
+    ownedScopes: ownedScopes,
+    purchasedScopes: purchasedScopes,
+    landExtractionByCommodity: developmentExtractionProjectionForRegion(
+      game: game,
+      playerId: playerId,
+      regionId: regionId,
+      tileMapByRegion: tileMapByRegion,
+      connectivity: playerConnectivity,
+    ),
+  );
+}
+
+/// Composes a region model from prebuilt scopes plus order-dependent fields.
+DevelopmentPanelRegionModel composeDevelopmentPanelRegionModel({
+  required DevelopmentPanelRegionScopes scopes,
+  required DevelopmentPanelBuildContext shared,
+  required Game game,
+  required String playerId,
+  required Orders currentOrders,
+}) {
+  return DevelopmentPanelRegionModel(
+    regionId: scopes.regionId,
+    ownedScopes: scopes.ownedScopes,
+    purchasedScopes: scopes.purchasedScopes,
+    landExtractionByCommodity: scopes.landExtractionByCommodity,
+    idleBuilderCount: shared.idleBuilderCount,
+    idleEngineerCount: shared.idleEngineerCount,
+    assignedCivilians: buildDevelopmentAssignedCiviliansForRegion(
+      game: game,
+      playerId: playerId,
+      regionId: scopes.regionId,
+      currentOrders: currentOrders,
+    ),
+  );
+}
+
 /// One region slice; call per visited tab on panel open (Slice E).
 DevelopmentPanelRegionModel buildDevelopmentPanelRegionModel({
   required DevelopmentPanelBuildContext shared,
@@ -74,40 +143,57 @@ DevelopmentPanelRegionModel buildDevelopmentPanelRegionModel({
   required Map<String, String> playerDisplayNamesById,
   PlayerView? playerView,
 }) {
-  return _buildRegionModel(
+  final scopes = buildDevelopmentPanelRegionScopes(
     game: game,
     playerId: playerId,
     regionId: regionId,
     tileMapByRegion: tileMapByRegion,
-    landExtractionByCommodity: developmentExtractionProjectionForRegion(
-      game: game,
-      playerId: playerId,
-      regionId: regionId,
-      tileMapByRegion: tileMapByRegion,
-      connectivity: shared.playerConnectivity,
-    ),
-    idleBuilderCount: shared.idleBuilderCount,
-    idleEngineerCount: shared.idleEngineerCount,
     provinceDisplayNamesById: provinceDisplayNamesById,
     playerDisplayNamesById: playerDisplayNamesById,
     ownerCache: shared.ownerCache,
-    currentOrders: currentOrders,
+    playerConnectivity: shared.playerConnectivity,
     playerView: playerView,
+  );
+  return composeDevelopmentPanelRegionModel(
+    scopes: scopes,
+    shared: shared,
+    game: game,
+    playerId: playerId,
+    currentOrders: currentOrders,
   );
 }
 
-DevelopmentPanelRegionModel _buildRegionModel({
+/// Convenience wrapper for provider wiring (Slice E).
+DevelopmentPanelRegionScopes buildDevelopmentPanelRegionScopesForPlayer({
   required Game game,
   required String playerId,
   required String regionId,
   required Map<String, TileMapResult> tileMapByRegion,
-  required Map<String, int> landExtractionByCommodity,
-  required int idleBuilderCount,
-  required int idleEngineerCount,
   required Map<String, String> provinceDisplayNamesById,
   required Map<String, String> playerDisplayNamesById,
+  required Map<String, ConnectivityResult> connectivityByPlayer,
+  PlayerView? playerView,
+}) {
+  return buildDevelopmentPanelRegionScopes(
+    game: game,
+    playerId: playerId,
+    regionId: regionId,
+    tileMapByRegion: tileMapByRegion,
+    provinceDisplayNamesById: provinceDisplayNamesById,
+    playerDisplayNamesById: playerDisplayNamesById,
+    ownerCache: ProvinceOwnerCache.of(game.worldState),
+    playerConnectivity: connectivityByPlayer[playerId],
+    playerView: playerView,
+  );
+}
+
+List<DevelopmentPanelScopeRow> _buildOwnedScopes({
+  required Game game,
+  required String playerId,
+  required String regionId,
+  required Map<String, TileMapResult> tileMapByRegion,
+  required Map<String, String> provinceDisplayNamesById,
   required ProvinceOwnerCache ownerCache,
-  required Orders currentOrders,
   PlayerView? playerView,
 }) {
   final ownedProvinces =
@@ -133,30 +219,5 @@ DevelopmentPanelRegionModel _buildRegionModel({
       ),
     );
   }
-
-  final purchasedScopes = buildDevelopmentPurchasedScopes(
-    game: game,
-    playerId: playerId,
-    regionId: regionId,
-    tileMapByRegion: tileMapByRegion,
-    provinceDisplayNamesById: provinceDisplayNamesById,
-    playerDisplayNamesById: playerDisplayNamesById,
-    ownerCache: ownerCache,
-    playerView: playerView,
-  );
-
-  return DevelopmentPanelRegionModel(
-    regionId: regionId,
-    ownedScopes: ownedScopes,
-    purchasedScopes: purchasedScopes,
-    landExtractionByCommodity: landExtractionByCommodity,
-    idleBuilderCount: idleBuilderCount,
-    idleEngineerCount: idleEngineerCount,
-    assignedCivilians: buildDevelopmentAssignedCiviliansForRegion(
-      game: game,
-      playerId: playerId,
-      regionId: regionId,
-      currentOrders: currentOrders,
-    ),
-  );
+  return ownedScopes;
 }

--- a/packages/colonizethis_economy/lib/src/economy/development_panel_read_model_scopes.dart
+++ b/packages/colonizethis_economy/lib/src/economy/development_panel_read_model_scopes.dart
@@ -71,17 +71,16 @@ List<DevelopmentImprovableCommodityRow> developmentImprovableRowsFromCounts(
   PlayerView? playerView,
 }) {
   final rows = <DevelopmentImprovableCommodityRow>[];
-  for (final commodity in CommodityCatalog.all) {
-    final entry = counts[commodity.id];
-    if (entry == null || entry.count <= 0) continue;
-    var tileKeys = entry.tileKeys;
+  for (final entry in counts.entries) {
+    if (entry.value.count <= 0) continue;
+    var tileKeys = entry.value.tileKeys;
     if (playerView != null) {
       tileKeys = developmentFilterVisibilityKnownTileKeys(playerView, tileKeys);
     }
     if (tileKeys.isEmpty) continue;
     rows.add(
       DevelopmentImprovableCommodityRow(
-        commodityId: commodity.id,
+        commodityId: entry.key,
         tileKeys: List<String>.from(tileKeys),
       ),
     );
@@ -130,9 +129,9 @@ List<DevelopmentImprovableCommodityRow> developmentImprovableRowsForTileKeys({
   }
 
   final rows = <DevelopmentImprovableCommodityRow>[];
-  for (final commodity in CommodityCatalog.all) {
-    final keys = acc[commodity.id];
-    if (keys == null || keys.isEmpty) continue;
+  for (final entry in acc.entries) {
+    final keys = entry.value;
+    if (keys.isEmpty) continue;
     var filteredKeys = keys;
     if (playerView != null) {
       filteredKeys = developmentFilterVisibilityKnownTileKeys(playerView, keys);
@@ -141,7 +140,7 @@ List<DevelopmentImprovableCommodityRow> developmentImprovableRowsForTileKeys({
     filteredKeys.sort();
     rows.add(
       DevelopmentImprovableCommodityRow(
-        commodityId: commodity.id,
+        commodityId: entry.key,
         tileKeys: List<String>.from(filteredKeys),
       ),
     );

--- a/packages/colonizethis_economy/test/economy/development_panel_open_path_timing_test.dart
+++ b/packages/colonizethis_economy/test/economy/development_panel_open_path_timing_test.dart
@@ -9,6 +9,7 @@ import 'package:colonizethis_economy/colonizethis_economy.dart';
 import 'package:colonizethis_economy_test_support/colonizethis_economy_test_support.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/game_test_fixtures.dart';
 import 'package:colonizethis_test/test.dart';
 import 'package:colonizethis_world/colonizethis_world.dart';
 
@@ -195,6 +196,83 @@ void main() {
         isTrue,
       );
       expect(beforeOrders.ownerCache, equals(afterOrders.ownerCache));
+    },
+  );
+
+  test(
+    'composeDevelopmentPanelRegionModel reuses scopes across draft-order churn (Refs #4175 Slice E)',
+    () {
+      final unit = Unit(
+        id: 'b1',
+        type: kUnitTypeBuilder,
+        ownerId: playerId,
+        locationProvinceId: 'oldWorld|p1',
+        tileKey: 'oldWorld|p1|0|0',
+      );
+      final scopedGame = TestFixtures.oldWorldGameWithUnit(unit: unit);
+      final scopedTileMapByRegion = {
+        kRegionOldWorld: tileMapByRegion[kRegionOldWorld]!,
+      };
+      final scopedConnectivity = resolveDevelopmentPanelConnectivity(
+        game: scopedGame,
+        tileMapByRegion: scopedTileMapByRegion,
+        topology: topology,
+      );
+      final scopes = buildDevelopmentPanelRegionScopesForPlayer(
+        game: scopedGame,
+        playerId: playerId,
+        regionId: kRegionOldWorld,
+        tileMapByRegion: scopedTileMapByRegion,
+        provinceDisplayNamesById: provinceDisplayNamesById,
+        playerDisplayNamesById: playerDisplayNamesById,
+        connectivityByPlayer: scopedConnectivity,
+      );
+      const emptyOrders = Orders();
+      final pendingOrders = Orders(
+        workOrdersByPlayerId: {
+          playerId: const [
+            WorkOrder(
+              unitId: 'b1',
+              target: kWorkTargetBuildImprovement,
+              targetTileKey: 'oldWorld|p1|0|0',
+            ),
+          ],
+        },
+      );
+      final sharedEmpty = buildDevelopmentPanelBuildContextFromConnectivity(
+        connectivity: scopedConnectivity,
+        game: scopedGame,
+        playerId: playerId,
+        currentOrders: emptyOrders,
+      );
+      final sharedPending = buildDevelopmentPanelBuildContextFromConnectivity(
+        connectivity: scopedConnectivity,
+        game: scopedGame,
+        playerId: playerId,
+        currentOrders: pendingOrders,
+      );
+      final composedEmpty = composeDevelopmentPanelRegionModel(
+        scopes: scopes,
+        shared: sharedEmpty,
+        game: scopedGame,
+        playerId: playerId,
+        currentOrders: emptyOrders,
+      );
+      final composedPending = composeDevelopmentPanelRegionModel(
+        scopes: scopes,
+        shared: sharedPending,
+        game: scopedGame,
+        playerId: playerId,
+        currentOrders: pendingOrders,
+      );
+
+      expect(
+        identical(composedEmpty.ownedScopes, composedPending.ownedScopes),
+        isTrue,
+      );
+      expect(composedEmpty.idleBuilderCount, 1);
+      expect(composedPending.idleBuilderCount, 0);
+      expect(composedPending.assignedCivilians, hasLength(1));
     },
   );
 }

--- a/packages/colonizethis_orders/lib/src/orders/development_panel_assign.dart
+++ b/packages/colonizethis_orders/lib/src/orders/development_panel_assign.dart
@@ -26,6 +26,11 @@ export 'development_panel_assign_candidate.dart'
     show selectDevelopmentImproveAssignCandidate;
 export 'development_panel_assign_row_state.dart'
     show resolveDevelopmentAssignRowState;
+export 'development_panel_assign_row_state_cache.dart'
+    show
+        DevelopmentPanelAssignRowStateCache,
+        buildDevelopmentPanelAssignRowStateCache,
+        developmentPanelAssignRowStateKey;
 export 'development_panel_assign_types.dart'
     show DevelopmentAssignRowState, DevelopmentImproveAssignCandidate;
 

--- a/packages/colonizethis_orders/lib/src/orders/development_panel_assign_row_state_cache.dart
+++ b/packages/colonizethis_orders/lib/src/orders/development_panel_assign_row_state_cache.dart
@@ -1,0 +1,67 @@
+/// Memoized per-scope assign affordance for Development panel region tabs. Refs #4175 Slice E.
+library;
+
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_economy/colonizethis_economy.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import 'development_panel_assign_row_state.dart';
+import 'development_panel_assign_types.dart';
+
+/// Stable cache key for per-scope improvable commodity assign affordance.
+String developmentPanelAssignRowStateKey(String scopeKey, String commodityId) =>
+    '$scopeKey|$commodityId';
+
+/// Per-scope assign affordance + material-shortage flags for one region tab.
+class DevelopmentPanelAssignRowStateCache {
+  const DevelopmentPanelAssignRowStateCache({
+    required this.byScopeCommodityKey,
+    required this.materialShortageCommodityIds,
+  });
+
+  static const empty = DevelopmentPanelAssignRowStateCache(
+    byScopeCommodityKey: {},
+    materialShortageCommodityIds: {},
+  );
+
+  final Map<String, DevelopmentAssignRowState> byScopeCommodityKey;
+  final Set<String> materialShortageCommodityIds;
+}
+
+DevelopmentPanelAssignRowStateCache buildDevelopmentPanelAssignRowStateCache({
+  required DevelopmentPanelRegionModel regionModel,
+  required Game game,
+  required String playerId,
+  required Orders currentOrders,
+  required MapTopology topology,
+  required Map<String, TileMapResult> tileMapByRegion,
+  required Set<String> connectedTileKeys,
+}) {
+  final byKey = <String, DevelopmentAssignRowState>{};
+  final shortages = <String>{};
+  for (final scope in [
+    ...regionModel.ownedScopes,
+    ...regionModel.purchasedScopes,
+  ]) {
+    for (final row in scope.improvableCommodities) {
+      final state = resolveDevelopmentAssignRowState(
+        game: game,
+        playerId: playerId,
+        currentOrders: currentOrders,
+        topology: topology,
+        tileMapByRegion: tileMapByRegion,
+        commodityTileKeys: row.tileKeys.toSet(),
+        connectedTileKeys: connectedTileKeys,
+      );
+      byKey[developmentPanelAssignRowStateKey(scope.scopeKey, row.commodityId)] =
+          state;
+      if (state.disabledReason == 'Insufficient materials') {
+        shortages.add(row.commodityId);
+      }
+    }
+  }
+  return DevelopmentPanelAssignRowStateCache(
+    byScopeCommodityKey: byKey,
+    materialShortageCommodityIds: shortages,
+  );
+}

--- a/packages/colonizethis_orders/lib/src/orders/development_panel_assign_row_state_cache.dart
+++ b/packages/colonizethis_orders/lib/src/orders/development_panel_assign_row_state_cache.dart
@@ -2,7 +2,8 @@
 library;
 
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_economy/colonizethis_economy.dart';
+import 'package:colonizethis_economy/colonizethis_economy.dart'
+    show DevelopmentPanelScopeRow;
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'development_panel_assign_row_state.dart';
@@ -29,7 +30,8 @@ class DevelopmentPanelAssignRowStateCache {
 }
 
 DevelopmentPanelAssignRowStateCache buildDevelopmentPanelAssignRowStateCache({
-  required DevelopmentPanelRegionModel regionModel,
+  required List<DevelopmentPanelScopeRow> ownedScopes,
+  required List<DevelopmentPanelScopeRow> purchasedScopes,
   required Game game,
   required String playerId,
   required Orders currentOrders,
@@ -40,8 +42,8 @@ DevelopmentPanelAssignRowStateCache buildDevelopmentPanelAssignRowStateCache({
   final byKey = <String, DevelopmentAssignRowState>{};
   final shortages = <String>{};
   for (final scope in [
-    ...regionModel.ownedScopes,
-    ...regionModel.purchasedScopes,
+    ...ownedScopes,
+    ...purchasedScopes,
   ]) {
     for (final row in scope.improvableCommodities) {
       final state = resolveDevelopmentAssignRowState(


### PR DESCRIPTION
## Summary
- Split `developmentPanelProjectionProvider` into order-independent `developmentPanelStaticContextProvider` ([PlayerView], display-name maps, map topology) and order-dependent `developmentPanelSharedContextProvider` (idle counts + connectivity slice).
- Region model and assign-affordance caches now compose static + shared inputs so assign/cancel draft churn no longer re-runs `buildPlayerView` or the `allProvinces` display-name scan.

## Done in this PR
- **Slice E (partial):** Provider-layer memoization for static panel inputs across draft-order updates; unit test guards [PlayerView] identity on order-only changes.
- **SPEC:** `development-panel-read-model.md` open-path performance section updated for the static/shared provider split.

## Deferred (follow-up on #4175)
- **AC1 qualitative responsiveness:** Owner verification on a mid-game save remains manual after merge.
- **AC2 DevTools timeline:** CI timing surrogate tests from prior Slice E PRs remain the quantitative anchor; optional DevTools before/after capture not attached in this PR.

## Test plan
- [x] `flutter test` — `app/test/development_panel_projection_provider_test.dart` (8/8 incl. new static-context guard)
- [x] `flutter test` — `app/test/development_panel_projection_rebuild_guard_test.dart` (2/2)
- [x] `flutter test` — `app/test/development_panel_lazy_open_test.dart` (3/3)

Refs #4175

Made with [Cursor](https://cursor.com)