### PR TITLE
refactor: extract Game.copyWith for wave-3 headroom (#4334)

### DIFF
--- a/packages/colonizethis_models/lib/src/game.dart
+++ b/packages/colonizethis_models/lib/src/game.dart
@@ -2,6 +2,7 @@ import 'advanced_start_type.dart';
 import 'combat_mode.dart';
 import 'dossier_evidence.dart';
 import 'diplomacy.dart';
+import 'game_copy_with.dart';
 import 'game_equality.dart';
 import 'game_serialization.dart';
 import 'general.dart';
@@ -218,59 +219,48 @@ class Game {
     Set<String>? ftpPartnershipKeys,
     Set<String>? debugDiplomacyUsedPairKeys,
     AdvancedStartType? advancedStartType,
-  }) {
-    return Game(
-      id: id ?? this.id,
-      worldState: worldState ?? this.worldState,
-      players: players ?? this.players,
-      minorNations: minorNations ?? this.minorNations,
-      tribes: tribes ?? this.tribes,
-      generals: generals ?? this.generals,
-      turnTimeMapping: turnTimeMapping ?? this.turnTimeMapping,
-      defaultCombatMode: defaultCombatMode ?? this.defaultCombatMode,
-      combatModeByProvinceId:
-          combatModeByProvinceId ?? this.combatModeByProvinceId,
-      diplomacyRelations: diplomacyRelations ?? this.diplomacyRelations,
-      overtureStates: overtureStates ?? this.overtureStates,
-      subsidyStates: subsidyStates ?? this.subsidyStates,
-      colonyStates: colonyStates ?? this.colonyStates,
-      boycottStates: boycottStates ?? this.boycottStates,
-      allianceBreakCooldowns:
-          allianceBreakCooldowns ?? this.allianceBreakCooldowns,
-      aiControlByGpId: aiControlByGpId ?? this.aiControlByGpId,
-      aiSeedByGpId: aiSeedByGpId ?? this.aiSeedByGpId,
-      aiProfileByGpId: aiProfileByGpId ?? this.aiProfileByGpId,
-      hiddenAgendaByGpId: hiddenAgendaByGpId ?? this.hiddenAgendaByGpId,
-      dossierEvidenceEntries:
-          dossierEvidenceEntries ?? this.dossierEvidenceEntries,
-      diplomaticHistoryEvents:
-          diplomaticHistoryEvents ?? this.diplomaticHistoryEvents,
-      globalGameSeed: globalGameSeed ?? this.globalGameSeed,
-      greatPowerColorOverride:
-          greatPowerColorOverride ?? this.greatPowerColorOverride,
-      victory: victory ?? this.victory,
-      calendarCampaignHalted:
-          calendarCampaignHalted ?? this.calendarCampaignHalted,
-      infiniteMode: infiniteMode ?? this.infiniteMode,
-      richesCashMultiplier: richesCashMultiplier ?? this.richesCashMultiplier,
-      capitalTileGrainBonusPerTurn:
-          capitalTileGrainBonusPerTurn ?? this.capitalTileGrainBonusPerTurn,
-      politicalGlyphByPlayerId:
-          politicalGlyphByPlayerId ?? this.politicalGlyphByPlayerId,
-      lastHumanCompletedResearchCategory:
-          lastHumanCompletedResearchCategory ??
-          this.lastHumanCompletedResearchCategory,
-      lastHumanResearchCategoryCompletionTurn:
-          lastHumanResearchCategoryCompletionTurn ??
-          this.lastHumanResearchCategoryCompletionTurn,
-      mapViewState: mapViewState ?? this.mapViewState,
-      worldMarketState: worldMarketState ?? this.worldMarketState,
-      ftpPartnershipKeys: ftpPartnershipKeys ?? this.ftpPartnershipKeys,
-      debugDiplomacyUsedPairKeys:
-          debugDiplomacyUsedPairKeys ?? this.debugDiplomacyUsedPairKeys,
-      advancedStartType: advancedStartType ?? this.advancedStartType,
-    );
-  }
+  }) =>
+      gameCopyWith(
+        this,
+        id: id,
+        worldState: worldState,
+        players: players,
+        minorNations: minorNations,
+        tribes: tribes,
+        generals: generals,
+        turnTimeMapping: turnTimeMapping,
+        defaultCombatMode: defaultCombatMode,
+        combatModeByProvinceId: combatModeByProvinceId,
+        diplomacyRelations: diplomacyRelations,
+        overtureStates: overtureStates,
+        subsidyStates: subsidyStates,
+        colonyStates: colonyStates,
+        boycottStates: boycottStates,
+        allianceBreakCooldowns: allianceBreakCooldowns,
+        aiControlByGpId: aiControlByGpId,
+        aiSeedByGpId: aiSeedByGpId,
+        aiProfileByGpId: aiProfileByGpId,
+        hiddenAgendaByGpId: hiddenAgendaByGpId,
+        dossierEvidenceEntries: dossierEvidenceEntries,
+        diplomaticHistoryEvents: diplomaticHistoryEvents,
+        globalGameSeed: globalGameSeed,
+        greatPowerColorOverride: greatPowerColorOverride,
+        victory: victory,
+        calendarCampaignHalted: calendarCampaignHalted,
+        infiniteMode: infiniteMode,
+        richesCashMultiplier: richesCashMultiplier,
+        capitalTileGrainBonusPerTurn: capitalTileGrainBonusPerTurn,
+        politicalGlyphByPlayerId: politicalGlyphByPlayerId,
+        lastHumanCompletedResearchCategory:
+            lastHumanCompletedResearchCategory,
+        lastHumanResearchCategoryCompletionTurn:
+            lastHumanResearchCategoryCompletionTurn,
+        mapViewState: mapViewState,
+        worldMarketState: worldMarketState,
+        ftpPartnershipKeys: ftpPartnershipKeys,
+        debugDiplomacyUsedPairKeys: debugDiplomacyUsedPairKeys,
+        advancedStartType: advancedStartType,
+      );
 
   @override
   bool operator ==(Object other) => gameEquals(this, other);

--- a/packages/colonizethis_models/lib/src/game_copy_with.dart
+++ b/packages/colonizethis_models/lib/src/game_copy_with.dart
@@ -1,0 +1,110 @@
+/// [Game.copyWith] implementation extracted so [Game] stays under the models
+/// wave-3 physical-line cap (Refs #4334).
+library;
+
+import 'advanced_start_type.dart';
+import 'combat_mode.dart';
+import 'diplomacy.dart';
+import 'dossier_evidence.dart';
+import 'game.dart';
+import 'general.dart';
+import 'map_view_state.dart';
+import 'minor_nation.dart';
+import 'player.dart';
+import 'tribe.dart';
+import 'turn_time_mapping.dart';
+import 'victory.dart';
+import 'world_market.dart';
+import 'world_state.dart';
+
+Game gameCopyWith(
+  Game game, {
+  String? id,
+  WorldState? worldState,
+  List<Player>? players,
+  List<MinorNation>? minorNations,
+  List<Tribe>? tribes,
+  List<General>? generals,
+  TurnTimeMapping? turnTimeMapping,
+  CombatMode? defaultCombatMode,
+  Map<String, CombatMode>? combatModeByProvinceId,
+  List<DiplomacyRelation>? diplomacyRelations,
+  List<OvertureState>? overtureStates,
+  List<SubsidyState>? subsidyStates,
+  List<ColonyState>? colonyStates,
+  List<BoycottState>? boycottStates,
+  List<AllianceBreakCooldownState>? allianceBreakCooldowns,
+  Map<String, bool>? aiControlByGpId,
+  Map<String, int>? aiSeedByGpId,
+  Map<String, String?>? aiProfileByGpId,
+  Map<String, String>? hiddenAgendaByGpId,
+  List<DossierEvidenceEntry>? dossierEvidenceEntries,
+  List<DiplomaticEvent>? diplomaticHistoryEvents,
+  int? globalGameSeed,
+  Map<String, List<int>>? greatPowerColorOverride,
+  VictoryState? victory,
+  bool? calendarCampaignHalted,
+  bool? infiniteMode,
+  double? richesCashMultiplier,
+  int? capitalTileGrainBonusPerTurn,
+  Map<String, String>? politicalGlyphByPlayerId,
+  String? lastHumanCompletedResearchCategory,
+  int? lastHumanResearchCategoryCompletionTurn,
+  MapViewState? mapViewState,
+  WorldMarketState? worldMarketState,
+  Set<String>? ftpPartnershipKeys,
+  Set<String>? debugDiplomacyUsedPairKeys,
+  AdvancedStartType? advancedStartType,
+}) {
+  return Game(
+    id: id ?? game.id,
+    worldState: worldState ?? game.worldState,
+    players: players ?? game.players,
+    minorNations: minorNations ?? game.minorNations,
+    tribes: tribes ?? game.tribes,
+    generals: generals ?? game.generals,
+    turnTimeMapping: turnTimeMapping ?? game.turnTimeMapping,
+    defaultCombatMode: defaultCombatMode ?? game.defaultCombatMode,
+    combatModeByProvinceId:
+        combatModeByProvinceId ?? game.combatModeByProvinceId,
+    diplomacyRelations: diplomacyRelations ?? game.diplomacyRelations,
+    overtureStates: overtureStates ?? game.overtureStates,
+    subsidyStates: subsidyStates ?? game.subsidyStates,
+    colonyStates: colonyStates ?? game.colonyStates,
+    boycottStates: boycottStates ?? game.boycottStates,
+    allianceBreakCooldowns:
+        allianceBreakCooldowns ?? game.allianceBreakCooldowns,
+    aiControlByGpId: aiControlByGpId ?? game.aiControlByGpId,
+    aiSeedByGpId: aiSeedByGpId ?? game.aiSeedByGpId,
+    aiProfileByGpId: aiProfileByGpId ?? game.aiProfileByGpId,
+    hiddenAgendaByGpId: hiddenAgendaByGpId ?? game.hiddenAgendaByGpId,
+    dossierEvidenceEntries:
+        dossierEvidenceEntries ?? game.dossierEvidenceEntries,
+    diplomaticHistoryEvents:
+        diplomaticHistoryEvents ?? game.diplomaticHistoryEvents,
+    globalGameSeed: globalGameSeed ?? game.globalGameSeed,
+    greatPowerColorOverride:
+        greatPowerColorOverride ?? game.greatPowerColorOverride,
+    victory: victory ?? game.victory,
+    calendarCampaignHalted:
+        calendarCampaignHalted ?? game.calendarCampaignHalted,
+    infiniteMode: infiniteMode ?? game.infiniteMode,
+    richesCashMultiplier: richesCashMultiplier ?? game.richesCashMultiplier,
+    capitalTileGrainBonusPerTurn:
+        capitalTileGrainBonusPerTurn ?? game.capitalTileGrainBonusPerTurn,
+    politicalGlyphByPlayerId:
+        politicalGlyphByPlayerId ?? game.politicalGlyphByPlayerId,
+    lastHumanCompletedResearchCategory:
+        lastHumanCompletedResearchCategory ??
+        game.lastHumanCompletedResearchCategory,
+    lastHumanResearchCategoryCompletionTurn:
+        lastHumanResearchCategoryCompletionTurn ??
+        game.lastHumanResearchCategoryCompletionTurn,
+    mapViewState: mapViewState ?? game.mapViewState,
+    worldMarketState: worldMarketState ?? game.worldMarketState,
+    ftpPartnershipKeys: ftpPartnershipKeys ?? game.ftpPartnershipKeys,
+    debugDiplomacyUsedPairKeys:
+        debugDiplomacyUsedPairKeys ?? game.debugDiplomacyUsedPairKeys,
+    advancedStartType: advancedStartType ?? game.advancedStartType,
+  );
+}


### PR DESCRIPTION
## Summary

Closes the remaining AC1 gap from verification on #4334: `game.dart` was at 280 physical lines (20 lines headroom under the 300 ceiling; required ≥30).

- Extract `Game.copyWith` body to `game_copy_with.dart` (mirrors existing `game_equality.dart` pattern from #4136).
- `game.dart` now 270 physical lines (30 headroom under 300 ceiling).

## Done in this push

- **AC1 (lib physical ceiling + headroom):** `game.dart` 280 → 270 phys; all analysis-time near-cap modules now have ≥30 headroom under 300.
- **AC2–AC7:** Already satisfied by merged PR #4337; unchanged in this PR.

## Deferred

None — issue should be fully complete once this PR merges.

## Tests

- `dart test` in `packages/colonizethis_models` — 351 passed
- `dart run tool/check_models_lib_physical_file_size.dart` — green (ceiling 300, empty grandfather)

Refs #4334

Made with [Cursor](https://cursor.com)