### PR TITLE
refactor: app wave-15 Slice D allowlist densify (#4352)

### DIFF
--- a/app/test/app_event_handler_scope_fixtures.dart
+++ b/app/test/app_event_handler_scope_fixtures.dart
@@ -1,0 +1,166 @@
+// Shared Game fixtures for AppEventHandlerScope debug-apply tests (Refs #4352).
+
+import 'package:colonizethis_app_debug/colonizethis_app_debug.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+Game scopeGameWithCombatMode(CombatMode mode) {
+  return Game(
+    id: 'g1',
+    worldState: const WorldState(
+      turnState: TurnState(phase: TurnPhase.orders, turnNumber: 1),
+      oldWorld: RegionData(),
+      newWorld: RegionData(),
+    ),
+    players: const [
+      Player(id: 'p1', displayName: 'P1', isHuman: true),
+      Player(id: 'p2', displayName: 'P2', isHuman: false),
+    ],
+    defaultCombatMode: mode,
+  );
+}
+
+Game scopeCivilianCapitalGame({
+  required String id,
+  List<Unit> existingUnits = const [],
+  List<Player> extraPlayers = const [],
+}) {
+  return Game(
+    id: id,
+    worldState: WorldState(
+      turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+      oldWorld: RegionData(
+        provinces: [
+          Province(id: 'oldWorld|1', regionId: 'oldWorld', ownerId: 'p1'),
+        ],
+        units: existingUnits,
+      ),
+      newWorld: const RegionData(),
+    ),
+    players: [
+      const Player(
+        id: 'p1',
+        displayName: 'P1',
+        isHuman: true,
+        capitalProvinceId: 'oldWorld|1',
+        capitalTile: CapitalTile(
+          regionId: 'oldWorld',
+          provinceId: 'oldWorld|1',
+          x: 2,
+          y: 3,
+        ),
+      ),
+      ...extraPlayers,
+    ],
+  );
+}
+
+Game scopeCapitalProvinceOnlyGame({required String id}) {
+  return Game(
+    id: id,
+    worldState: WorldState(
+      turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+      oldWorld: RegionData(
+        provinces: [
+          Province(id: 'oldWorld|1', regionId: 'oldWorld', ownerId: 'p1'),
+        ],
+      ),
+      newWorld: const RegionData(),
+    ),
+    players: const [
+      Player(
+        id: 'p1',
+        displayName: 'P1',
+        isHuman: true,
+        capitalProvinceId: 'oldWorld|1',
+      ),
+    ],
+  );
+}
+
+Game scopeEmptyWorldGame({
+  required String id,
+  TurnPhase phase = TurnPhase.orders,
+  int turnNumber = 1,
+  required List<Player> players,
+}) {
+  return Game(
+    id: id,
+    worldState: WorldState(
+      turnState: TurnState(phase: phase, turnNumber: turnNumber),
+      oldWorld: const RegionData(),
+      newWorld: const RegionData(),
+    ),
+    players: players,
+  );
+}
+
+const scopeFlipHuman = Player(
+  id: 'human_1',
+  displayName: 'Human',
+  isHuman: true,
+);
+
+const scopeFlipAi = Player(id: 'ai_1', displayName: 'AI', isHuman: false);
+
+Game scopeFlipBaseGame({
+  required TurnPhase phase,
+  required String ownerId,
+  required String humanVisibility,
+}) {
+  return Game(
+    id: 'g-flip',
+    worldState: WorldState(
+      turnState: TurnState(phase: phase, turnNumber: 2),
+      oldWorld: RegionData(
+        provinces: [
+          Province(
+            id: 'oldWorld|P1',
+            regionId: 'oldWorld',
+            ownerId: ownerId,
+            displayName: 'New Bordeaux',
+          ),
+        ],
+        units: [
+          Unit(
+            id: 'r1',
+            type: 'musketeers',
+            ownerId: ownerId,
+            locationProvinceId: 'oldWorld|P1',
+          ),
+        ],
+      ),
+      newWorld: const RegionData(),
+      tileKeysByRegionAndProvince: const {
+        'oldWorld': {
+          'oldWorld|P1': ['oldWorld|P1|0|0'],
+        },
+      },
+      playerVisibilityByTile: {
+        'human_1': {'oldWorld|P1|0|0': humanVisibility},
+      },
+    ),
+    players: const [scopeFlipHuman, scopeFlipAi],
+  );
+}
+
+FlipDebugProvinceOwnershipEvent scopeFlipNameEvent([
+  String displayName = 'New Bordeaux',
+]) {
+  return FlipDebugProvinceOwnershipEvent(
+    humanPlayerId: 'human_1',
+    regionId: 'oldWorld',
+    provinceDisplayName: displayName,
+  );
+}
+
+({Game? game, String message}) scopeApplyFlip(
+  Game game,
+  FlipDebugProvinceOwnershipEvent event,
+) {
+  return applyDebugFlipProvinceOwnership(
+    currentGame: game,
+    event: event,
+    combinedTopology: const MapTopology(),
+  );
+}

--- a/app/test/app_event_handler_scope_part1_test.dart
+++ b/app/test/app_event_handler_scope_part1_test.dart
@@ -4,24 +4,10 @@ import 'package:colonizethis_app/core/services/app_event_handler/app_event_handl
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'app_event_handler_scope_fixtures.dart';
+
 void main() {
   suppressLogsForTests();
-
-  Game gameWithMode(CombatMode mode) {
-    return Game(
-      id: 'g1',
-      worldState: const WorldState(
-        turnState: TurnState(phase: TurnPhase.orders, turnNumber: 1),
-        oldWorld: RegionData(),
-        newWorld: RegionData(),
-      ),
-      players: const [
-        Player(id: 'p1', displayName: 'P1', isHuman: true),
-        Player(id: 'p2', displayName: 'P2', isHuman: false),
-      ],
-      defaultCombatMode: mode,
-    );
-  }
 
   group('applyCombatModeChoiceToGame', () {
     test('returns null when there is no active game', () {
@@ -30,13 +16,13 @@ void main() {
     });
 
     test('returns same instance when mode is unchanged', () {
-      final game = gameWithMode(CombatMode.quickBattle);
+      final game = scopeGameWithCombatMode(CombatMode.quickBattle);
       final updated = applyCombatModeChoiceToGame(game, CombatMode.quickBattle);
       expect(identical(updated, game), isTrue);
     });
 
     test('updates default combat mode when player picks a new mode', () {
-      final game = gameWithMode(CombatMode.autoResolve);
+      final game = scopeGameWithCombatMode(CombatMode.autoResolve);
       final updated = applyCombatModeChoiceToGame(game, CombatMode.quickBattle);
       expect(updated, isNotNull);
       expect(updated!.defaultCombatMode, CombatMode.quickBattle);
@@ -59,30 +45,9 @@ void main() {
     });
 
     test('spawns requested civilian count at human capital tile', () {
-      final game = Game(
+      final game = scopeCivilianCapitalGame(
         id: 'g2',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
-          oldWorld: RegionData(
-            provinces: [
-              Province(id: 'oldWorld|1', regionId: 'oldWorld', ownerId: 'p1'),
-            ],
-          ),
-          newWorld: const RegionData(),
-        ),
-        players: const [
-          Player(
-            id: 'p1',
-            displayName: 'P1',
-            isHuman: true,
-            capitalProvinceId: 'oldWorld|1',
-            capitalTile: CapitalTile(
-              regionId: 'oldWorld',
-              provinceId: 'oldWorld|1',
-              x: 2,
-              y: 3,
-            ),
-          ),
+        extraPlayers: const [
           Player(id: 'p2', displayName: 'P2', isHuman: false),
         ],
       );
@@ -106,32 +71,7 @@ void main() {
     });
 
     test('rejects unsupported unit type', () {
-      final game = Game(
-        id: 'g3',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
-          oldWorld: RegionData(
-            provinces: [
-              Province(id: 'oldWorld|1', regionId: 'oldWorld', ownerId: 'p1'),
-            ],
-          ),
-          newWorld: const RegionData(),
-        ),
-        players: const [
-          Player(
-            id: 'p1',
-            displayName: 'P1',
-            isHuman: true,
-            capitalProvinceId: 'oldWorld|1',
-            capitalTile: CapitalTile(
-              regionId: 'oldWorld',
-              provinceId: 'oldWorld|1',
-              x: 2,
-              y: 3,
-            ),
-          ),
-        ],
-      );
+      final game = scopeCivilianCapitalGame(id: 'g3');
       const event = SpawnDebugCivilianAtCapitalEvent(
         humanPlayerId: 'p1',
         unitType: 'InvalidType',
@@ -146,38 +86,15 @@ void main() {
     });
 
     test('continues deterministic canonical unit id sequence', () {
-      final game = Game(
+      final game = scopeCivilianCapitalGame(
         id: 'g4',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
-          oldWorld: RegionData(
-            provinces: [
-              Province(id: 'oldWorld|1', regionId: 'oldWorld', ownerId: 'p1'),
-            ],
-            units: [
-              Unit(
-                id: 'unit_7',
-                type: kUnitTypeBuilder,
-                ownerId: 'p1',
-                locationProvinceId: 'oldWorld|1',
-                tileKey: 'oldWorld|1|2|3',
-              ),
-            ],
-          ),
-          newWorld: const RegionData(),
-        ),
-        players: const [
-          Player(
-            id: 'p1',
-            displayName: 'P1',
-            isHuman: true,
-            capitalProvinceId: 'oldWorld|1',
-            capitalTile: CapitalTile(
-              regionId: 'oldWorld',
-              provinceId: 'oldWorld|1',
-              x: 2,
-              y: 3,
-            ),
+        existingUnits: [
+          Unit(
+            id: 'unit_7',
+            type: kUnitTypeBuilder,
+            ownerId: 'p1',
+            locationProvinceId: 'oldWorld|1',
+            tileKey: 'oldWorld|1|2|3',
           ),
         ],
       );
@@ -199,32 +116,7 @@ void main() {
     });
 
     test('caps oversized debug spawn count to 25', () {
-      final game = Game(
-        id: 'g5',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
-          oldWorld: RegionData(
-            provinces: [
-              Province(id: 'oldWorld|1', regionId: 'oldWorld', ownerId: 'p1'),
-            ],
-          ),
-          newWorld: const RegionData(),
-        ),
-        players: const [
-          Player(
-            id: 'p1',
-            displayName: 'P1',
-            isHuman: true,
-            capitalProvinceId: 'oldWorld|1',
-            capitalTile: CapitalTile(
-              regionId: 'oldWorld',
-              provinceId: 'oldWorld|1',
-              x: 2,
-              y: 3,
-            ),
-          ),
-        ],
-      );
+      final game = scopeCivilianCapitalGame(id: 'g5');
       const event = SpawnDebugCivilianAtCapitalEvent(
         humanPlayerId: 'p1',
         unitType: kUnitTypeExplorer,
@@ -241,32 +133,7 @@ void main() {
     });
 
     test('rejects zero or negative count', () {
-      final game = Game(
-        id: 'g6',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
-          oldWorld: RegionData(
-            provinces: [
-              Province(id: 'oldWorld|1', regionId: 'oldWorld', ownerId: 'p1'),
-            ],
-          ),
-          newWorld: const RegionData(),
-        ),
-        players: const [
-          Player(
-            id: 'p1',
-            displayName: 'P1',
-            isHuman: true,
-            capitalProvinceId: 'oldWorld|1',
-            capitalTile: CapitalTile(
-              regionId: 'oldWorld',
-              provinceId: 'oldWorld|1',
-              x: 2,
-              y: 3,
-            ),
-          ),
-        ],
-      );
+      final game = scopeCivilianCapitalGame(id: 'g6');
       const event = SpawnDebugCivilianAtCapitalEvent(
         humanPlayerId: 'p1',
         unitType: kUnitTypeExplorer,
@@ -297,26 +164,7 @@ void main() {
     });
 
     test('spawns regiment into region units and home army', () {
-      final game = Game(
-        id: 'g-reg-1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
-          oldWorld: RegionData(
-            provinces: [
-              Province(id: 'oldWorld|1', regionId: 'oldWorld', ownerId: 'p1'),
-            ],
-          ),
-          newWorld: const RegionData(),
-        ),
-        players: const [
-          Player(
-            id: 'p1',
-            displayName: 'P1',
-            isHuman: true,
-            capitalProvinceId: 'oldWorld|1',
-          ),
-        ],
-      );
+      final game = scopeCapitalProvinceOnlyGame(id: 'g-reg-1');
       const event = SpawnDebugRegimentAtCapitalEvent(
         humanPlayerId: 'p1',
         regimentTypeId: 'peasant_levies',
@@ -343,13 +191,8 @@ void main() {
     });
 
     test('fails on unknown player and keeps state unchanged', () {
-      final game = Game(
+      final game = scopeEmptyWorldGame(
         id: 'g-reg-2',
-        worldState: const WorldState(
-          turnState: TurnState(phase: TurnPhase.orders, turnNumber: 1),
-          oldWorld: RegionData(),
-          newWorld: RegionData(),
-        ),
         players: const [Player(id: 'p1', displayName: 'P1', isHuman: true)],
       );
       const event = SpawnDebugRegimentAtCapitalEvent(
@@ -365,13 +208,8 @@ void main() {
     });
 
     test('fails on missing capital and keeps state unchanged', () {
-      final game = Game(
+      final game = scopeEmptyWorldGame(
         id: 'g-reg-3',
-        worldState: const WorldState(
-          turnState: TurnState(phase: TurnPhase.orders, turnNumber: 1),
-          oldWorld: RegionData(),
-          newWorld: RegionData(),
-        ),
         players: const [Player(id: 'p1', displayName: 'P1', isHuman: true)],
       );
       const event = SpawnDebugRegimentAtCapitalEvent(
@@ -387,13 +225,8 @@ void main() {
     });
 
     test('fails when matched player is not human', () {
-      final game = Game(
+      final game = scopeEmptyWorldGame(
         id: 'g-reg-not-human',
-        worldState: const WorldState(
-          turnState: TurnState(phase: TurnPhase.orders, turnNumber: 1),
-          oldWorld: RegionData(),
-          newWorld: RegionData(),
-        ),
         players: const [
           Player(
             id: 'p2',
@@ -418,13 +251,8 @@ void main() {
     test(
       'fails on malformed capital province id and keeps state unchanged',
       () {
-        final game = Game(
+        final game = scopeEmptyWorldGame(
           id: 'g-reg-invalid-capital',
-          worldState: const WorldState(
-            turnState: TurnState(phase: TurnPhase.orders, turnNumber: 1),
-            oldWorld: RegionData(),
-            newWorld: RegionData(),
-          ),
           players: const [
             Player(
               id: 'p1',
@@ -448,13 +276,8 @@ void main() {
     );
 
     test('fails on unsupported regiment type and keeps state unchanged', () {
-      final game = Game(
+      final game = scopeEmptyWorldGame(
         id: 'g-reg-4',
-        worldState: const WorldState(
-          turnState: TurnState(phase: TurnPhase.orders, turnNumber: 1),
-          oldWorld: RegionData(),
-          newWorld: RegionData(),
-        ),
         players: const [
           Player(
             id: 'p1',

--- a/app/test/app_event_handler_scope_part2_test.dart
+++ b/app/test/app_event_handler_scope_part2_test.dart
@@ -1,28 +1,12 @@
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
-import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_app_debug/colonizethis_app_debug.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'app_event_handler_scope_fixtures.dart';
+
 void main() {
   suppressLogsForTests();
-
-  Game emptyWorldGame({
-    required String id,
-    TurnPhase phase = TurnPhase.orders,
-    int turnNumber = 1,
-    required List<Player> players,
-  }) {
-    return Game(
-      id: id,
-      worldState: WorldState(
-        turnState: TurnState(phase: phase, turnNumber: turnNumber),
-        oldWorld: const RegionData(),
-        newWorld: const RegionData(),
-      ),
-      players: players,
-    );
-  }
 
   group('applyDebugTreasuryCredit', () {
     test('returns message when there is no active game', () {
@@ -37,7 +21,7 @@ void main() {
     });
 
     test('adds credited amount to human player treasury', () {
-      final game = emptyWorldGame(
+      final game = scopeEmptyWorldGame(
         id: 'g-treasury',
         players: const [
           Player(id: 'p1', displayName: 'P1', isHuman: true, treasury: 100),
@@ -58,7 +42,7 @@ void main() {
     });
 
     test('clamped success message includes requested and credited amounts', () {
-      final game = emptyWorldGame(
+      final game = scopeEmptyWorldGame(
         id: 'g-treasury2',
         players: const [
           Player(id: 'p1', displayName: 'P1', isHuman: true, treasury: 0),
@@ -76,7 +60,7 @@ void main() {
     });
 
     test('rejects command outside human orders phase', () {
-      final game = emptyWorldGame(
+      final game = scopeEmptyWorldGame(
         id: 'g-treasury3',
         phase: TurnPhase.movement,
         players: const [
@@ -99,7 +83,7 @@ void main() {
 
   group('applyDebugStockpileCredit', () {
     test('adds credited amount to human player stockpile commodity', () {
-      final game = emptyWorldGame(
+      final game = scopeEmptyWorldGame(
         id: 'g-stockpile',
         players: const [
           Player(
@@ -126,7 +110,7 @@ void main() {
     });
 
     test('rejects add_resource command outside human orders phase', () {
-      final game = emptyWorldGame(
+      final game = scopeEmptyWorldGame(
         id: 'g-stockpile2',
         phase: TurnPhase.movement,
         players: const [Player(id: 'p1', displayName: 'P1', isHuman: true)],
@@ -146,7 +130,7 @@ void main() {
     });
 
     test('clamped success message includes requested and credited amounts', () {
-      final game = emptyWorldGame(
+      final game = scopeEmptyWorldGame(
         id: 'g-stockpile3',
         players: const [Player(id: 'p1', displayName: 'P1', isHuman: true)],
       );
@@ -168,83 +152,14 @@ void main() {
   });
 
   group('applyDebugFlipProvinceOwnership', () {
-    const flipHuman = Player(
-      id: 'human_1',
-      displayName: 'Human',
-      isHuman: true,
-    );
-    const flipAi = Player(id: 'ai_1', displayName: 'AI', isHuman: false);
-
-    Game baseGame({
-      required TurnPhase phase,
-      required String ownerId,
-      required String humanVisibility,
-    }) {
-      return Game(
-        id: 'g-flip',
-        worldState: WorldState(
-          turnState: TurnState(phase: phase, turnNumber: 2),
-          oldWorld: RegionData(
-            provinces: [
-              Province(
-                id: 'oldWorld|P1',
-                regionId: 'oldWorld',
-                ownerId: ownerId,
-                displayName: 'New Bordeaux',
-              ),
-            ],
-            units: [
-              Unit(
-                id: 'r1',
-                type: 'musketeers',
-                ownerId: ownerId,
-                locationProvinceId: 'oldWorld|P1',
-              ),
-            ],
-          ),
-          newWorld: const RegionData(),
-          tileKeysByRegionAndProvince: const {
-            'oldWorld': {
-              'oldWorld|P1': ['oldWorld|P1|0|0'],
-            },
-          },
-          playerVisibilityByTile: {
-            'human_1': {'oldWorld|P1|0|0': humanVisibility},
-          },
-        ),
-        players: const [flipHuman, flipAi],
-      );
-    }
-
-    FlipDebugProvinceOwnershipEvent nameEvent([
-      String displayName = 'New Bordeaux',
-    ]) {
-      return FlipDebugProvinceOwnershipEvent(
-        humanPlayerId: 'human_1',
-        regionId: 'oldWorld',
-        provinceDisplayName: displayName,
-      );
-    }
-
-    ({Game? game, String message}) flip(
-      Game game,
-      FlipDebugProvinceOwnershipEvent event,
-    ) {
-      return applyDebugFlipProvinceOwnership(
-        currentGame: game,
-        event: event,
-        combinedTopology: const MapTopology(),
-      );
-    }
-
     test('flips province through canonical transfer on valid command', () {
-      final result = flip(
-        baseGame(
+      final result = scopeApplyFlip(
+        scopeFlipBaseGame(
           phase: TurnPhase.orders,
           ownerId: 'ai_1',
           humanVisibility: 'fogged',
         ),
-        nameEvent(),
+        scopeFlipNameEvent(),
       );
 
       expect(result.game, isNotNull);
@@ -258,13 +173,13 @@ void main() {
     });
 
     test('rejects command outside human orders phase', () {
-      final result = flip(
-        baseGame(
+      final result = scopeApplyFlip(
+        scopeFlipBaseGame(
           phase: TurnPhase.movement,
           ownerId: 'ai_1',
           humanVisibility: 'fogged',
         ),
-        nameEvent(),
+        scopeFlipNameEvent(),
       );
 
       expect(result.game, isNull);
@@ -275,13 +190,13 @@ void main() {
     });
 
     test('rejects unknown province visibility to human', () {
-      final result = flip(
-        baseGame(
+      final result = scopeApplyFlip(
+        scopeFlipBaseGame(
           phase: TurnPhase.orders,
           ownerId: 'ai_1',
           humanVisibility: 'unknown',
         ),
-        nameEvent(),
+        scopeFlipNameEvent(),
       );
 
       expect(result.game, isNull);
@@ -289,13 +204,13 @@ void main() {
     });
 
     test('rejects already human-owned province', () {
-      final result = flip(
-        baseGame(
+      final result = scopeApplyFlip(
+        scopeFlipBaseGame(
           phase: TurnPhase.orders,
           ownerId: 'human_1',
           humanVisibility: 'fogged',
         ),
-        nameEvent(),
+        scopeFlipNameEvent(),
       );
 
       expect(result.game, isNull);
@@ -337,23 +252,23 @@ void main() {
             },
           },
         ),
-        players: const [flipHuman, flipAi],
+        players: const [scopeFlipHuman, scopeFlipAi],
       );
 
-      final result = flip(game, nameEvent());
+      final result = scopeApplyFlip(game, scopeFlipNameEvent());
 
       expect(result.game, isNull);
       expect(result.message, contains('ambiguous'));
     });
 
     test('rejects province display name not found in region', () {
-      final result = flip(
-        baseGame(
+      final result = scopeApplyFlip(
+        scopeFlipBaseGame(
           phase: TurnPhase.orders,
           ownerId: 'ai_1',
           humanVisibility: 'fogged',
         ),
-        nameEvent('Nonexistent Province'),
+        scopeFlipNameEvent('Nonexistent Province'),
       );
 
       expect(result.game, isNull);
@@ -385,23 +300,23 @@ void main() {
             'human_1': {'oldWorld|P1|0|0': 'fogged'},
           },
         ),
-        players: const [flipHuman, flipAi],
+        players: const [scopeFlipHuman, scopeFlipAi],
       );
 
-      final result = flip(game, nameEvent());
+      final result = scopeApplyFlip(game, scopeFlipNameEvent());
 
       expect(result.game, isNull);
       expect(result.message, contains('no current owner'));
     });
 
     test('JSON round-trip preserves flip outcome (persistence parity)', () {
-      final result = flip(
-        baseGame(
+      final result = scopeApplyFlip(
+        scopeFlipBaseGame(
           phase: TurnPhase.orders,
           ownerId: 'ai_1',
           humanVisibility: 'fogged',
         ),
-        nameEvent(),
+        scopeFlipNameEvent(),
       );
 
       expect(result.game, isNotNull);
@@ -447,9 +362,9 @@ void main() {
               },
             },
           ),
-          players: const [flipHuman, flipAi],
+          players: const [scopeFlipHuman, scopeFlipAi],
         );
-        final result = flip(game, nameEvent());
+        final result = scopeApplyFlip(game, scopeFlipNameEvent());
         expect(result.game, isNull);
         expect(
           result.message,
@@ -460,8 +375,8 @@ void main() {
     );
 
     test('flip resolves directly by full province id', () {
-      final result = flip(
-        baseGame(
+      final result = scopeApplyFlip(
+        scopeFlipBaseGame(
           phase: TurnPhase.orders,
           ownerId: 'ai_1',
           humanVisibility: 'fogged',

--- a/app/test/civilian_units_panel_part1_shortcut_support.dart
+++ b/app/test/civilian_units_panel_part1_shortcut_support.dart
@@ -1,0 +1,91 @@
+// Shortcut-commit helpers for CivilianUnitsPanel part1 (Refs #4352).
+
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'civilian_units_panel_test_support.dart';
+
+const civilianPanelPart1HumanId = 'h1';
+const civilianPanelPart1TileKey = 'oldWorld|p1|0|0';
+
+Future<void> expectCivilianShortcutCommit(
+  WidgetTester tester, {
+  required String gameId,
+  required String visibleType,
+  required String hiddenType,
+  required String unitId,
+  required String workTarget,
+  bool builderFirst = false,
+  bool explorerOnly = false,
+  bool builderOnly = false,
+  bool engineerOnly = false,
+  bool merchantOnly = false,
+  String? prospectShortcutTargetTileKey,
+  String? exploreShortcutTargetTileKey,
+  String? buildImprovementShortcutTargetTileKey,
+  String? buildRoadShortcutTargetTileKey,
+  String? purchaseLandShortcutTargetTileKey,
+  bool expectCloseBeforeUpsert = true,
+  Game Function(String id)? customGameBuilder,
+}) async {
+  const human = civilianPanelPart1HumanId;
+  const tileKey = civilianPanelPart1TileKey;
+  final bus = AppEventBus.create();
+  final events = <Type>[];
+  UpsertPendingCivilianWorkOrderRequestedEvent? upsertEvent;
+  bus.stream.listen((e) => events.add(e.runtimeType));
+  bus.on<UpsertPendingCivilianWorkOrderRequestedEvent>().listen(
+    (event) => upsertEvent = event,
+  );
+  await tester.pumpWidget(
+    buildCivilianPanel(
+      game: customGameBuilder != null
+          ? customGameBuilder(gameId)
+          : buildCivilianExplorerBuilderShortcutGame(
+              id: gameId,
+              humanId: human,
+              tileKey: tileKey,
+              builderFirst: builderFirst,
+            ),
+      humanPlayerId: human,
+      bus: bus,
+      explorerOnly: explorerOnly,
+      builderOnly: builderOnly,
+      engineerOnly: engineerOnly,
+      merchantOnly: merchantOnly,
+      prospectShortcutTargetTileKey: prospectShortcutTargetTileKey,
+      exploreShortcutTargetTileKey: exploreShortcutTargetTileKey,
+      buildImprovementShortcutTargetTileKey:
+          buildImprovementShortcutTargetTileKey,
+      buildRoadShortcutTargetTileKey: buildRoadShortcutTargetTileKey,
+      purchaseLandShortcutTargetTileKey: purchaseLandShortcutTargetTileKey,
+      availableWorkTargets: {
+        unitId: [workTarget],
+      },
+    ),
+  );
+  await tester.pumpAndSettle();
+
+  expect(find.text(visibleType), findsOneWidget);
+  expect(find.text(hiddenType), findsNothing);
+
+  await tester.tap(find.text('Assign'));
+  await tester.pump();
+  await tester.pumpAndSettle();
+
+  expect(find.textContaining('Assign work'), findsNothing);
+  expect(upsertEvent, isNotNull);
+  expect(upsertEvent!.playerId, human);
+  expect(upsertEvent!.workOrder.unitId, unitId);
+  expect(upsertEvent!.workOrder.target, workTarget);
+  expect(upsertEvent!.workOrder.targetTileKey, tileKey);
+  expect(events.contains(StartCivilianWorkTargetSelectionEvent), isFalse);
+  if (expectCloseBeforeUpsert) {
+    expect(
+      events.indexOf(ClosePanelEvent),
+      lessThan(
+        events.indexOf(UpsertPendingCivilianWorkOrderRequestedEvent),
+      ),
+    );
+  }
+}

--- a/app/test/civilian_units_panel_part1_test.dart
+++ b/app/test/civilian_units_panel_part1_test.dart
@@ -10,8 +10,14 @@ import 'package:colonizethis_app/core/services/app_event_handler/app_event_handl
 import 'package:colonizethis_app/features/game/widgets/units/civilian/civilian_units_panel.dart';
 import 'package:colonizethis_app/features/game/widgets/units/civilian/civilian_units_sort.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart'
-    show kWorkTargetBuildImprovement, kWorkTargetBuildRoad, kWorkTargetExplore, kWorkTargetProspect, kWorkTargetPurchaseLand;
+    show
+        kWorkTargetBuildImprovement,
+        kWorkTargetBuildRoad,
+        kWorkTargetExplore,
+        kWorkTargetProspect,
+        kWorkTargetPurchaseLand;
 
+import 'civilian_units_panel_part1_shortcut_support.dart';
 import 'civilian_units_panel_test_support.dart';
 
 void main() {
@@ -87,7 +93,6 @@ void main() {
     testWidgets(
       'work targets not in availableWorkTargets are grayed out (disabled)',
       (WidgetTester tester) async {
-        // Find an idle civilian unit
         final units = [
           ...game.worldState.oldWorld.units,
           ...game.worldState.newWorld.units,
@@ -102,11 +107,9 @@ void main() {
         if (idleCivilians.isEmpty) return;
         final idleCivilian = idleCivilians.first;
 
-        // Get allowed work targets for this unit type
         final allowed = workOrderTargetsByUnitType[idleCivilian.type] ?? [];
         if (allowed.isEmpty) return;
 
-        // Provide empty availableWorkTargets - ALL items should be disabled
         final availableWorkTargets = <String, List<String>>{};
 
         await tester.pumpWidget(
@@ -123,9 +126,6 @@ void main() {
 
         expect(find.textContaining('Assign work'), findsOneWidget);
 
-        // Get all target rows - all should be disabled. Work-target menu rows
-        // render through InkWell over palette-token chrome (Refs #2914 S8 —
-        // no Material ListTile); a disabled row has a null onTap.
         final targetRows = find
             .descendant(
               of: find.byType(BottomSheet),
@@ -135,7 +135,6 @@ void main() {
 
         expect(targetRows, isNotEmpty);
 
-        // All items should be disabled when availableWorkTargets is empty
         for (final row in targetRows) {
           final widget = row.widget as InkWell;
           expect(
@@ -165,7 +164,6 @@ void main() {
     });
 
     testWidgets('tap Assign opens order menu', (WidgetTester tester) async {
-      // Find an idle civilian unit
       final units = [
         ...game.worldState.oldWorld.units,
         ...game.worldState.newWorld.units,
@@ -177,15 +175,12 @@ void main() {
             isCivilianUnit(u) &&
             u.currentWork == null,
       );
-      // Skip if no idle civilians in test game
       if (idleCivilians.isEmpty) return;
 
       await tester.pumpWidget(
         buildCivilianPanel(
           game: game,
           humanPlayerId: humanPlayerIdWithUnits,
-          // Pass empty availableWorkTargets - all options will be disabled
-          // This tests the UI renders but callback won't fire on disabled items
           availableWorkTargets: const {},
         ),
       );
@@ -194,101 +189,17 @@ void main() {
       await tester.tap(find.text('Assign').first);
       await tester.pumpAndSettle();
 
-      // Menu opens but all items are disabled since no available targets provided
       expect(find.textContaining('Assign work'), findsOneWidget);
-      // Note: selectedUnit/selectedTarget remain null because items are disabled
 
       final scaffoldCtx = tester.element(find.byType(Scaffold));
       Navigator.of(scaffoldCtx, rootNavigator: true).pop();
       await tester.pumpAndSettle();
     });
 
-    Future<void> expectShortcutCommit(
-      WidgetTester tester, {
-      required String gameId,
-      required String visibleType,
-      required String hiddenType,
-      required String unitId,
-      required String workTarget,
-      bool builderFirst = false,
-      bool explorerOnly = false,
-      bool builderOnly = false,
-      bool engineerOnly = false,
-      bool merchantOnly = false,
-      String? prospectShortcutTargetTileKey,
-      String? exploreShortcutTargetTileKey,
-      String? buildImprovementShortcutTargetTileKey,
-      String? buildRoadShortcutTargetTileKey,
-      String? purchaseLandShortcutTargetTileKey,
-      bool expectCloseBeforeUpsert = true,
-      Game Function(String id)? customGameBuilder,
-    }) async {
-      const human = 'h1';
-      const tileKey = 'oldWorld|p1|0|0';
-      final bus = AppEventBus.create();
-      final events = <Type>[];
-      UpsertPendingCivilianWorkOrderRequestedEvent? upsertEvent;
-      bus.stream.listen((e) => events.add(e.runtimeType));
-      bus.on<UpsertPendingCivilianWorkOrderRequestedEvent>().listen(
-        (event) => upsertEvent = event,
-      );
-      await tester.pumpWidget(
-        buildCivilianPanel(
-          game: customGameBuilder != null
-              ? customGameBuilder(gameId)
-              : buildCivilianExplorerBuilderShortcutGame(
-                  id: gameId,
-                  humanId: human,
-                  tileKey: tileKey,
-                  builderFirst: builderFirst,
-                ),
-          humanPlayerId: human,
-          bus: bus,
-          explorerOnly: explorerOnly,
-          builderOnly: builderOnly,
-          engineerOnly: engineerOnly,
-          merchantOnly: merchantOnly,
-          prospectShortcutTargetTileKey: prospectShortcutTargetTileKey,
-          exploreShortcutTargetTileKey: exploreShortcutTargetTileKey,
-          buildImprovementShortcutTargetTileKey:
-              buildImprovementShortcutTargetTileKey,
-          buildRoadShortcutTargetTileKey: buildRoadShortcutTargetTileKey,
-          purchaseLandShortcutTargetTileKey: purchaseLandShortcutTargetTileKey,
-          availableWorkTargets: {
-            unitId: [workTarget],
-          },
-        ),
-      );
-      await tester.pumpAndSettle();
-
-      expect(find.text(visibleType), findsOneWidget);
-      expect(find.text(hiddenType), findsNothing);
-
-      await tester.tap(find.text('Assign'));
-      await tester.pump();
-      await tester.pumpAndSettle();
-
-      expect(find.textContaining('Assign work'), findsNothing);
-      expect(upsertEvent, isNotNull);
-      expect(upsertEvent!.playerId, human);
-      expect(upsertEvent!.workOrder.unitId, unitId);
-      expect(upsertEvent!.workOrder.target, workTarget);
-      expect(upsertEvent!.workOrder.targetTileKey, tileKey);
-      expect(events.contains(StartCivilianWorkTargetSelectionEvent), isFalse);
-      if (expectCloseBeforeUpsert) {
-        expect(
-          events.indexOf(ClosePanelEvent),
-          lessThan(
-            events.indexOf(UpsertPendingCivilianWorkOrderRequestedEvent),
-          ),
-        );
-      }
-    }
-
     testWidgets(
       'prospect shortcut mode filters explorers and commits prospect',
       (WidgetTester tester) async {
-        await expectShortcutCommit(
+        await expectCivilianShortcutCommit(
           tester,
           gameId: 'g_civ_prospect_shortcut',
           visibleType: kUnitTypeExplorer,
@@ -296,7 +207,7 @@ void main() {
           unitId: 'e1',
           workTarget: kWorkTargetProspect,
           explorerOnly: true,
-          prospectShortcutTargetTileKey: 'oldWorld|p1|0|0',
+          prospectShortcutTargetTileKey: civilianPanelPart1TileKey,
         );
       },
     );
@@ -304,7 +215,7 @@ void main() {
     testWidgets(
       'explore shortcut mode filters explorers and commits explore',
       (WidgetTester tester) async {
-        await expectShortcutCommit(
+        await expectCivilianShortcutCommit(
           tester,
           gameId: 'g_civ_explore_shortcut',
           visibleType: kUnitTypeExplorer,
@@ -312,7 +223,7 @@ void main() {
           unitId: 'e1',
           workTarget: kWorkTargetExplore,
           explorerOnly: true,
-          exploreShortcutTargetTileKey: 'oldWorld|p1|0|0',
+          exploreShortcutTargetTileKey: civilianPanelPart1TileKey,
         );
       },
     );
@@ -320,7 +231,7 @@ void main() {
     testWidgets(
       'build-improvement shortcut mode filters builders and commits',
       (WidgetTester tester) async {
-        await expectShortcutCommit(
+        await expectCivilianShortcutCommit(
           tester,
           gameId: 'g_civ_build_improvement_shortcut',
           visibleType: kUnitTypeBuilder,
@@ -329,7 +240,7 @@ void main() {
           workTarget: kWorkTargetBuildImprovement,
           builderFirst: true,
           builderOnly: true,
-          buildImprovementShortcutTargetTileKey: 'oldWorld|p1|0|0',
+          buildImprovementShortcutTargetTileKey: civilianPanelPart1TileKey,
           expectCloseBeforeUpsert: false,
         );
       },
@@ -338,7 +249,7 @@ void main() {
     testWidgets(
       'build-road shortcut mode filters engineers and commits',
       (WidgetTester tester) async {
-        await expectShortcutCommit(
+        await expectCivilianShortcutCommit(
           tester,
           gameId: 'g_civ_build_road_shortcut',
           visibleType: kUnitTypeEngineer,
@@ -346,7 +257,7 @@ void main() {
           unitId: 'e_eng',
           workTarget: kWorkTargetBuildRoad,
           engineerOnly: true,
-          buildRoadShortcutTargetTileKey: 'oldWorld|p1|0|0',
+          buildRoadShortcutTargetTileKey: civilianPanelPart1TileKey,
           expectCloseBeforeUpsert: false,
           customGameBuilder: (id) => buildCivilianEngineerBuilderShortcutGame(
             id: id,
@@ -359,7 +270,7 @@ void main() {
     testWidgets(
       'purchase-land shortcut mode filters merchants and commits',
       (WidgetTester tester) async {
-        await expectShortcutCommit(
+        await expectCivilianShortcutCommit(
           tester,
           gameId: 'g_civ_purchase_land_shortcut',
           visibleType: kUnitTypeMerchant,
@@ -367,7 +278,7 @@ void main() {
           unitId: 'm1',
           workTarget: kWorkTargetPurchaseLand,
           merchantOnly: true,
-          purchaseLandShortcutTargetTileKey: 'oldWorld|p1|0|0',
+          purchaseLandShortcutTargetTileKey: civilianPanelPart1TileKey,
           expectCloseBeforeUpsert: false,
           customGameBuilder: (id) => buildCivilianMerchantBuilderShortcutGame(
             id: id,

--- a/app/test/civilian_units_panel_part2_cancel_support.dart
+++ b/app/test/civilian_units_panel_part2_cancel_support.dart
@@ -1,0 +1,98 @@
+// Pending/in-progress cancel helpers for CivilianUnitsPanel part2 (Refs #4352).
+
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:colonizethis_app/widgets/ct_danger_text_button.dart';
+import 'package:colonizethis_app/features/game/widgets/units/civilian/civilian_units_panel.dart';
+import 'package:colonizethis_app/features/game/widgets/units/civilian/civilian_units_sort.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart'
+    show kWorkTargetExplore;
+
+import 'app_shell_harness.dart';
+import 'civilian_units_panel_test_support.dart';
+
+Unit? firstIdleCivilian(Game game, String humanId) {
+  final units = [
+    ...game.worldState.oldWorld.units,
+    ...game.worldState.newWorld.units,
+  ];
+  for (final u in units) {
+    if (u.ownerId == humanId &&
+        u.tileKey != null &&
+        isCivilianUnit(u) &&
+        u.currentWork == null) {
+      return u;
+    }
+  }
+  return null;
+}
+
+Orders pendingExploreOrders(String humanId, Unit unit) {
+  final pendingOrder = WorkOrder(
+    unitId: unit.id,
+    target: kWorkTargetExplore,
+    targetTileKey: '${unit.tileKey!.split('|').take(2).join('|')}|0|0',
+  );
+  return Orders(
+    workOrdersByPlayerId: {
+      humanId: [pendingOrder],
+    },
+  );
+}
+
+Future<void> invokePendingCancel(WidgetTester tester, Unit unit) async {
+  final pendingRow = find.byKey(
+    ValueKey('civilian-unit-card-${unit.id}'),
+    skipOffstage: false,
+  );
+  expect(pendingRow, findsOneWidget);
+  final cancelOnPendingRow = find.descendant(
+    of: pendingRow,
+    matching: find.byType(CtDangerTextButton, skipOffstage: false),
+  );
+  expect(cancelOnPendingRow, findsOneWidget);
+  final cancelBtn = tester.widget<CtDangerTextButton>(cancelOnPendingRow);
+  expect(cancelBtn.onPressed, isNotNull);
+  cancelBtn.onPressed!();
+  await tester.pumpAndSettle();
+}
+
+/// Cross-panel style watcher host: editorial [buildAppShell] + confirm-dialog
+/// bus leaf + a counter strip (Refs #4035 — no inline `MaterialApp`).
+Widget civilianPanelWatcherHost({
+  required AppEventBus bus,
+  required GlobalKey<NavigatorState> navigatorKey,
+  required ValueNotifier<int> counter,
+  required String labelPrefix,
+  required Game game,
+  required String humanId,
+  required Orders orders,
+}) {
+  return buildAppShell(
+    navigatorKey: navigatorKey,
+    child: Scaffold(
+      body: Column(
+        children: [
+          ValueListenableBuilder<int>(
+            valueListenable: counter,
+            builder: (_, count, _) => Text('$labelPrefix:$count'),
+          ),
+          Expanded(
+            child: CivilianPanelBusDialogHost(
+              bus: bus,
+              navigatorKey: navigatorKey,
+              child: CivilianUnitsPanel(
+                game: game,
+                humanPlayerId: humanId,
+                currentOrders: orders,
+                bus: bus,
+              ),
+            ),
+          ),
+        ],
+      ),
+    ),
+  );
+}

--- a/app/test/civilian_units_panel_part2_test.dart
+++ b/app/test/civilian_units_panel_part2_test.dart
@@ -7,101 +7,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:colonizethis_app/widgets/ct_circular_locate_button.dart';
-import 'package:colonizethis_app/widgets/ct_danger_text_button.dart';
 import 'package:colonizethis_app/features/game/widgets/units/civilian/civilian_units_panel.dart';
 import 'package:colonizethis_app/features/game/widgets/units/civilian/civilian_units_sort.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart'
-    show kWorkTargetBuildImprovement, kWorkTargetExplore;
+    show kWorkTargetBuildImprovement;
 
-import 'app_shell_harness.dart';
+import 'civilian_units_panel_part2_cancel_support.dart';
 import 'civilian_units_panel_test_support.dart';
-
-Unit? _firstIdleCivilian(Game game, String humanId) {
-  final units = [
-    ...game.worldState.oldWorld.units,
-    ...game.worldState.newWorld.units,
-  ];
-  for (final u in units) {
-    if (u.ownerId == humanId &&
-        u.tileKey != null &&
-        isCivilianUnit(u) &&
-        u.currentWork == null) {
-      return u;
-    }
-  }
-  return null;
-}
-
-Orders _pendingExploreOrders(String humanId, Unit unit) {
-  final pendingOrder = WorkOrder(
-    unitId: unit.id,
-    target: kWorkTargetExplore,
-    targetTileKey: '${unit.tileKey!.split('|').take(2).join('|')}|0|0',
-  );
-  return Orders(
-    workOrdersByPlayerId: {
-      humanId: [pendingOrder],
-    },
-  );
-}
-
-Future<void> _invokePendingCancel(
-  WidgetTester tester,
-  Unit unit,
-) async {
-  final pendingRow = find.byKey(
-    ValueKey('civilian-unit-card-${unit.id}'),
-    skipOffstage: false,
-  );
-  expect(pendingRow, findsOneWidget);
-  final cancelOnPendingRow = find.descendant(
-    of: pendingRow,
-    matching: find.byType(CtDangerTextButton, skipOffstage: false),
-  );
-  expect(cancelOnPendingRow, findsOneWidget);
-  final cancelBtn = tester.widget<CtDangerTextButton>(cancelOnPendingRow);
-  expect(cancelBtn.onPressed, isNotNull);
-  cancelBtn.onPressed!();
-  await tester.pumpAndSettle();
-}
-
-/// Cross-panel style watcher host: editorial [buildAppShell] + confirm-dialog
-/// bus leaf + a counter strip (Refs #4035 — no inline `MaterialApp`).
-Widget _watcherHost({
-  required AppEventBus bus,
-  required GlobalKey<NavigatorState> navigatorKey,
-  required ValueNotifier<int> counter,
-  required String labelPrefix,
-  required Game game,
-  required String humanId,
-  required Orders orders,
-}) {
-  return buildAppShell(
-    navigatorKey: navigatorKey,
-    child: Scaffold(
-      body: Column(
-        children: [
-          ValueListenableBuilder<int>(
-            valueListenable: counter,
-            builder: (_, count, _) => Text('$labelPrefix:$count'),
-          ),
-          Expanded(
-            child: CivilianPanelBusDialogHost(
-              bus: bus,
-              navigatorKey: navigatorKey,
-              child: CivilianUnitsPanel(
-                game: game,
-                humanPlayerId: humanId,
-                currentOrders: orders,
-                bus: bus,
-              ),
-            ),
-          ),
-        ],
-      ),
-    ),
-  );
-}
 
 void main() {
   suppressLogsForTests();
@@ -147,7 +59,6 @@ void main() {
           expect(locateEvent!.regionId, 'oldWorld');
         }
 
-        // Full-list: single Locate in the action cluster (R30 / #3514).
         await runLocateCase(
           host: (bus) => buildCivilianPanel(
             game: buildCivilianSingleUnitOwGame(
@@ -164,7 +75,6 @@ void main() {
           locateIndex: 0,
         );
 
-        // Tile-scoped: every visible row exposes Locate, including non-selected.
         await runLocateCase(
           host: (bus) => buildCivilianPanel(
             game: buildCivilianOwUnitsGame(
@@ -208,7 +118,7 @@ void main() {
           humanId: human,
           standingTile: standingTile,
         );
-        final orders = const Orders(
+        const orders = Orders(
           workOrdersByPlayerId: {
             human: [
               WorkOrder(
@@ -290,9 +200,6 @@ void main() {
         await tester.tap(assignButton.first);
         await tester.pumpAndSettle();
 
-        // Work-target menu rows render through InkWell over palette-token
-        // chrome (Refs #2914 S8 — no Material ListTile); an enabled row has a
-        // non-null onTap.
         final enabledTargetRow = find.descendant(
           of: find.byType(BottomSheet),
           matching: find.byWidgetPredicate(
@@ -316,7 +223,7 @@ void main() {
     testWidgets(
       'Cancel on pending row: Yes removes order; No dismisses without remove',
       (WidgetTester tester) async {
-        final idleCivilian = _firstIdleCivilian(game, humanPlayerIdWithUnits);
+        final idleCivilian = firstIdleCivilian(game, humanPlayerIdWithUnits);
         if (idleCivilian == null) return;
 
         Future<RemovePendingWorkOrderRequestedEvent?> confirmPending(
@@ -332,15 +239,14 @@ void main() {
               bus: bus,
               game: game,
               humanPlayerId: humanPlayerIdWithUnits,
-              currentOrders: _pendingExploreOrders(
+              currentOrders: pendingExploreOrders(
                 humanPlayerIdWithUnits,
                 idleCivilian,
               ),
             ),
           );
           await tester.pumpAndSettle();
-          // R30 (#3514): pending rows expose Cancel + circular Locate.
-          await _invokePendingCancel(tester, idleCivilian);
+          await invokePendingCancel(tester, idleCivilian);
           expect(find.text('Cancel work order?'), findsOneWidget);
           await tester.tap(find.text(answer));
           await tester.pumpAndSettle();
@@ -359,7 +265,7 @@ void main() {
     testWidgets(
       'pending cancel event can drive external watcher updates (cross-panel style)',
       (WidgetTester tester) async {
-        final idleCivilian = _firstIdleCivilian(game, humanPlayerIdWithUnits);
+        final idleCivilian = firstIdleCivilian(game, humanPlayerIdWithUnits);
         if (idleCivilian == null) return;
 
         final bus = AppEventBus.create();
@@ -374,20 +280,20 @@ void main() {
         });
 
         await tester.pumpWidget(
-          _watcherHost(
+          civilianPanelWatcherHost(
             bus: bus,
             navigatorKey: navigatorKey,
             counter: observedRemovals,
             labelPrefix: 'observed-removals',
             game: game,
             humanId: humanPlayerIdWithUnits,
-            orders: _pendingExploreOrders(humanPlayerIdWithUnits, idleCivilian),
+            orders: pendingExploreOrders(humanPlayerIdWithUnits, idleCivilian),
           ),
         );
         await tester.pumpAndSettle();
         expect(find.text('observed-removals:0'), findsOneWidget);
 
-        await _invokePendingCancel(tester, idleCivilian);
+        await invokePendingCancel(tester, idleCivilian);
         await tester.tap(find.text('Yes'));
         await tester.pumpAndSettle();
 
@@ -424,7 +330,7 @@ void main() {
         if (workingCivilians.isEmpty) return;
 
         await tester.pumpWidget(
-          _watcherHost(
+          civilianPanelWatcherHost(
             bus: bus,
             navigatorKey: navigatorKey,
             counter: observedCancels,

--- a/app/test/civilian_units_panel_part3_pending_support.dart
+++ b/app/test/civilian_units_panel_part3_pending_support.dart
@@ -1,0 +1,125 @@
+// Pending-turns + dual-shortfall helpers for CivilianUnitsPanel part3 (Refs #4352).
+
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:colonizethis_logic/colonizethis_logic.dart'
+    show
+        kWorkTargetBuildFort,
+        kWorkTargetBuildImprovement,
+        kWorkTargetBuildPort,
+        kWorkTargetBuildRail,
+        kWorkTargetBuildRoad,
+        kWorkTargetCounterSpy,
+        kWorkTargetExplore,
+        kWorkTargetProspect,
+        kWorkTargetPurchaseLand,
+        kWorkTargetUpgradeTown;
+
+import 'civilian_units_panel_part3_pump_support.dart';
+import 'civilian_units_panel_test_support.dart';
+
+const List<({String unitType, String target, int turns})>
+civilianPanelPendingTurnCases = [
+  (unitType: kUnitTypeExplorer, target: kWorkTargetExplore, turns: 3),
+  (unitType: kUnitTypeExplorer, target: kWorkTargetProspect, turns: 1),
+  (unitType: kUnitTypeBuilder, target: kWorkTargetBuildImprovement, turns: 1),
+  (unitType: kUnitTypeBuilder, target: kWorkTargetUpgradeTown, turns: 1),
+  (unitType: kUnitTypeEngineer, target: kWorkTargetBuildRoad, turns: 1),
+  (unitType: kUnitTypeEngineer, target: kWorkTargetBuildPort, turns: 1),
+  (unitType: kUnitTypeEngineer, target: kWorkTargetBuildFort, turns: 3),
+  (unitType: kUnitTypeRailBuilder, target: kWorkTargetBuildRail, turns: 1),
+  (unitType: kUnitTypeSpy, target: kWorkTargetCounterSpy, turns: 1),
+  (unitType: kUnitTypeMerchant, target: kWorkTargetPurchaseLand, turns: 1),
+];
+
+Future<void> pumpCivilianDualBuilderShortfall(WidgetTester tester) async {
+  const tileA = 'oldWorld|p1|0|0';
+  const tileB = 'oldWorld|p1|1|0';
+  await tester.pumpWidget(
+    buildCivilianPanel(
+      game: buildCivilianDualBuilderLowStockGame(id: 'g_civ_dual_shortfall'),
+      humanPlayerId: civilianPanelPart3HumanId,
+      currentOrders: civilianPendingWorkOrders(
+        humanId: civilianPanelPart3HumanId,
+        workOrders: [
+          WorkOrder(
+            unitId: 'b1',
+            target: kWorkTargetBuildImprovement,
+            targetTileKey: tileA,
+          ),
+          WorkOrder(
+            unitId: 'b2',
+            target: kWorkTargetBuildImprovement,
+            targetTileKey: tileB,
+          ),
+        ],
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+Future<void> expectCivilianPendingTurnLine(
+  WidgetTester tester, {
+  required int index,
+  required String unitType,
+  required String target,
+  required int turns,
+}) async {
+  const targetTileKey = 'oldWorld|p1|1|0';
+  final unitId = 'u_$index';
+  await tester.pumpWidget(
+    buildCivilianPanel(
+      game: buildCivilianOwUnitsGame(
+        id: 'g_civ_pending_turns_${target}_$index',
+        humanId: civilianPanelPart3HumanId,
+        fortLevel: 2,
+        resourceByTileKey: const {targetTileKey: 'grain'},
+        tileKeysByRegionAndProvince: const {
+          'oldWorld': {
+            'oldWorld|p1': [civilianPanelPart3TileKey, targetTileKey],
+          },
+        },
+        units: [
+          civilianIdleUnit(
+            id: unitId,
+            type: unitType,
+            ownerId: civilianPanelPart3HumanId,
+            provinceId: 'oldWorld|p1',
+            tileKey: civilianPanelPart3TileKey,
+          ),
+        ],
+      ),
+      humanPlayerId: civilianPanelPart3HumanId,
+      currentOrders: civilianSinglePendingWorkOrder(
+        humanId: civilianPanelPart3HumanId,
+        unitId: unitId,
+        target: target,
+        targetTileKey: targetTileKey,
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+
+  final lineFinder = find.textContaining('Assigned to:');
+  expect(
+    lineFinder,
+    findsOneWidget,
+    reason: 'Expected one Assigned to line for target $target',
+  );
+  final line = tester.widget<Text>(lineFinder).data ?? '';
+  final singular = '$turns turn';
+  final plural = '$turns turns';
+  expect(
+    line.contains(singular) || line.contains(plural),
+    isTrue,
+    reason: 'Expected target $target to show $singular/$plural, got: $line',
+  );
+  expect(
+    line.contains('# turn'),
+    isFalse,
+    reason: 'Target $target should not render placeholder text',
+  );
+}

--- a/app/test/civilian_units_panel_part3_test.dart
+++ b/app/test/civilian_units_panel_part3_test.dart
@@ -2,7 +2,6 @@
 
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:colonizethis_app/widgets/ct_action_text_button.dart';
@@ -12,17 +11,12 @@ import 'package:colonizethis_app/features/game/widgets/units/civilian/civilian_u
 import 'package:colonizethis_app/features/game/widgets/units/shared/units_panel_shell.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart'
     show
-        kWorkTargetBuildFort,
         kWorkTargetBuildImprovement,
-        kWorkTargetBuildPort,
         kWorkTargetBuildRail,
-        kWorkTargetBuildRoad,
-        kWorkTargetCounterSpy,
         kWorkTargetExplore,
-        kWorkTargetProspect,
-        kWorkTargetPurchaseLand,
-        kWorkTargetUpgradeTown;
+        kWorkTargetPurchaseLand;
 
+import 'civilian_units_panel_part3_pending_support.dart';
 import 'civilian_units_panel_part3_pump_support.dart';
 import 'civilian_units_panel_test_support.dart';
 
@@ -59,32 +53,7 @@ void main() {
     testWidgets(
       'AC #4262: second pending build_improvement shows muted shortfall line',
       (WidgetTester tester) async {
-        const tileA = 'oldWorld|p1|0|0';
-        const tileB = 'oldWorld|p1|1|0';
-        await tester.pumpWidget(
-          buildCivilianPanel(
-            game: buildCivilianDualBuilderLowStockGame(
-              id: 'g_civ_dual_shortfall',
-            ),
-            humanPlayerId: civilianPanelPart3HumanId,
-            currentOrders: civilianPendingWorkOrders(
-              humanId: civilianPanelPart3HumanId,
-              workOrders: [
-                WorkOrder(
-                  unitId: 'b1',
-                  target: kWorkTargetBuildImprovement,
-                  targetTileKey: tileA,
-                ),
-                WorkOrder(
-                  unitId: 'b2',
-                  target: kWorkTargetBuildImprovement,
-                  targetTileKey: tileB,
-                ),
-              ],
-            ),
-          ),
-        );
-        await tester.pumpAndSettle();
+        await pumpCivilianDualBuilderShortfall(tester);
 
         expect(find.textContaining('Assigned to:'), findsNWidgets(2));
         expect(civilianPanelResourceIcon('lumber'), findsNWidgets(2));
@@ -153,91 +122,14 @@ void main() {
     testWidgets(
       'AC: pending rows show faithful remaining-turn number for each work target',
       (WidgetTester tester) async {
-        const targetTileKey = 'oldWorld|p1|1|0';
-        final cases = <({String unitType, String target, int turns})>[
-          (unitType: kUnitTypeExplorer, target: kWorkTargetExplore, turns: 3),
-          (unitType: kUnitTypeExplorer, target: kWorkTargetProspect, turns: 1),
-          (
-            unitType: kUnitTypeBuilder,
-            target: kWorkTargetBuildImprovement,
-            turns: 1,
-          ),
-          (
-            unitType: kUnitTypeBuilder,
-            target: kWorkTargetUpgradeTown,
-            turns: 1,
-          ),
-          (unitType: kUnitTypeEngineer, target: kWorkTargetBuildRoad, turns: 1),
-          (unitType: kUnitTypeEngineer, target: kWorkTargetBuildPort, turns: 1),
-          (unitType: kUnitTypeEngineer, target: kWorkTargetBuildFort, turns: 3),
-          (
-            unitType: kUnitTypeRailBuilder,
-            target: kWorkTargetBuildRail,
-            turns: 1,
-          ),
-          (unitType: kUnitTypeSpy, target: kWorkTargetCounterSpy, turns: 1),
-          (
-            unitType: kUnitTypeMerchant,
-            target: kWorkTargetPurchaseLand,
-            turns: 1,
-          ),
-        ];
-
-        for (var i = 0; i < cases.length; i++) {
-          final c = cases[i];
-          final unitId = 'u_$i';
-          await tester.pumpWidget(
-            buildCivilianPanel(
-              game: buildCivilianOwUnitsGame(
-                id: 'g_civ_pending_turns_${c.target}_$i',
-                humanId: civilianPanelPart3HumanId,
-                fortLevel: 2,
-                resourceByTileKey: const {targetTileKey: 'grain'},
-                tileKeysByRegionAndProvince: const {
-                  'oldWorld': {
-                    'oldWorld|p1': [civilianPanelPart3TileKey, targetTileKey],
-                  },
-                },
-                units: [
-                  civilianIdleUnit(
-                    id: unitId,
-                    type: c.unitType,
-                    ownerId: civilianPanelPart3HumanId,
-                    provinceId: 'oldWorld|p1',
-                    tileKey: civilianPanelPart3TileKey,
-                  ),
-                ],
-              ),
-              humanPlayerId: civilianPanelPart3HumanId,
-              currentOrders: civilianSinglePendingWorkOrder(
-                humanId: civilianPanelPart3HumanId,
-                unitId: unitId,
-                target: c.target,
-                targetTileKey: targetTileKey,
-              ),
-            ),
-          );
-          await tester.pumpAndSettle();
-
-          final lineFinder = find.textContaining('Assigned to:');
-          expect(
-            lineFinder,
-            findsOneWidget,
-            reason: 'Expected one Assigned to line for target ${c.target}',
-          );
-          final line = tester.widget<Text>(lineFinder).data ?? '';
-          final singular = '${c.turns} turn';
-          final plural = '${c.turns} turns';
-          expect(
-            line.contains(singular) || line.contains(plural),
-            isTrue,
-            reason:
-                'Expected target ${c.target} to show $singular/$plural, got: $line',
-          );
-          expect(
-            line.contains('# turn'),
-            isFalse,
-            reason: 'Target ${c.target} should not render placeholder text',
+        for (var i = 0; i < civilianPanelPendingTurnCases.length; i++) {
+          final c = civilianPanelPendingTurnCases[i];
+          await expectCivilianPendingTurnLine(
+            tester,
+            index: i,
+            unitType: c.unitType,
+            target: c.target,
+            turns: c.turns,
           );
         }
       },
@@ -307,8 +199,6 @@ void main() {
         expect(find.text('Civilian Units (Tile)'), findsOneWidget);
         expect(find.text('Tile'), findsOneWidget);
 
-        // Header actions are compact primary pills (CtActionTextButton,
-        // not CtNinePatchButton) per #3514 owner decision #5.
         final shellButtons = find.descendant(
           of: find.byType(UnitsPanelShell),
           matching: find.byType(CtActionTextButton),
@@ -366,10 +256,6 @@ void main() {
           settle: false,
         );
 
-        // Scope to the header Train pill by label: row-action Assign pills are
-        // now also CtActionTextButton (#3514 row-action migration), so the
-        // header control is resolved via its 'Train' label rather than the
-        // first CtActionTextButton in the shell.
         final trainLabel = find.descendant(
           of: find.byType(UnitsPanelShell),
           matching: find.text('Train'),

--- a/app/test/ct_region_map_widget_part2_support.dart
+++ b/app/test/ct_region_map_widget_part2_support.dart
@@ -1,0 +1,185 @@
+// Marker / interaction helpers for CtRegionMap part2 widget tests (Refs #4352).
+
+import 'package:colonizethis_map/colonizethis_map.dart';
+import 'package:colonizethis_models/colonizethis_models.dart'
+    show OpenCivilianUnitsPanelEvent, OpenNavalMissionMenuEvent;
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:colonizethis_app/features/game/flame/region_map/region_map.dart'
+    show BaseLayerDisplayMode;
+
+import 'ct_region_map_test_support.dart';
+
+RegionMapViewData ctRegionMapCivilianMarkerRegion({
+  required String localProvinceId,
+  required String markerTileKey,
+  String displayName = 'Marker Province',
+}) {
+  return ctRegionMapMiniLandStrip(
+    base: ctRegionMapTestOldWorldRegion(),
+    width: 1,
+    height: 1,
+    cellSize: 24,
+    regionCellId: localProvinceId,
+    displayName: displayName,
+    civilianTileMarkers: [
+      ctRegionMapCivilianMarker(
+        tileKey: markerTileKey,
+        x: 0,
+        y: 0,
+        localProvinceId: localProvinceId,
+      ),
+    ],
+  );
+}
+
+RegionMapViewData ctRegionMapFleetMarkerRegion({
+  required String localSeaId,
+  required String markerTileKey,
+  String displayName = 'Marker Sea',
+}) {
+  return ctRegionMapMiniLandStrip(
+    base: ctRegionMapTestOldWorldRegion(),
+    width: 1,
+    height: 1,
+    cellSize: 24,
+    regionCellId: localSeaId,
+    displayName: displayName,
+    sea: true,
+    fleetTileMarkers: [
+      ctRegionMapFleetMarker(
+        tileKey: markerTileKey,
+        x: 0,
+        y: 0,
+        locationScopeKey: 'sea:oldWorld|fleet_scope',
+      ),
+    ],
+  );
+}
+
+RegionMapViewData ctRegionMapTownMarkerRegion({
+  required String localProvinceId,
+  String displayName = 'Town Province',
+}) {
+  return ctRegionMapMiniLandStrip(
+    base: ctRegionMapTestOldWorldRegion(),
+    width: 1,
+    height: 1,
+    cellSize: 24,
+    regionCellId: localProvinceId,
+    displayName: displayName,
+    townMarkers: [
+      TownMarkerView(
+        x: 0,
+        y: 0,
+        provinceId: localProvinceId,
+        isCoastal: false,
+        isPort: false,
+        touchesSea: false,
+        townDevelopmentLevel: 1,
+        townIconStyle: 'euro',
+      ),
+    ],
+  );
+}
+
+Future<(String?, List<OpenCivilianUnitsPanelEvent>)> pumpAndTapCivilianMarker(
+  WidgetTester tester,
+) async {
+  const markerTileKey = 'oldWorld|pMarker|0|0';
+  final region = ctRegionMapCivilianMarkerRegion(
+    localProvinceId: 'pMarker',
+    markerTileKey: markerTileKey,
+  );
+  String? tappedCivilianTileKey;
+  String? detailTileKey;
+  String? selectedProvinceId;
+  final (bus, openedPanels) =
+      ctRegionMapBusCapture<OpenCivilianUnitsPanelEvent>();
+  await pumpCtRegionMapTest(
+    tester,
+    region: region,
+    width: 64,
+    height: 64,
+    cellSizePx: 32,
+    bus: bus,
+    onCivilianTileStateChanged: (tileKey) => tappedCivilianTileKey = tileKey,
+    onMapTileTappedForDetail: (tileKey) => detailTileKey = tileKey,
+    onProvinceSelected: (id) => selectedProvinceId = id,
+  );
+  await tapCtRegionMap(tester);
+  expect(detailTileKey, isNull);
+  expect(selectedProvinceId, isNull);
+  return (tappedCivilianTileKey, openedPanels);
+}
+
+Future<List<OpenNavalMissionMenuEvent>> pumpAndTapFleetMarker(
+  WidgetTester tester,
+) async {
+  const markerTileKey = 'oldWorld|sMarker|0|0';
+  final region = ctRegionMapFleetMarkerRegion(
+    localSeaId: 'sMarker',
+    markerTileKey: markerTileKey,
+  );
+  final (bus, openedMenus) =
+      ctRegionMapBusCapture<OpenNavalMissionMenuEvent>();
+  await pumpCtRegionMapTest(
+    tester,
+    region: region,
+    width: 64,
+    height: 64,
+    cellSizePx: 32,
+    bus: bus,
+  );
+  await tapCtRegionMap(tester);
+  return openedMenus;
+}
+
+Future<(String?, String?)> pumpAndTapTownMarker(WidgetTester tester) async {
+  final region = ctRegionMapTownMarkerRegion(localProvinceId: 'pTown');
+  String? selectedId;
+  String? detailTileKey;
+  await pumpCtRegionMapTest(
+    tester,
+    region: region,
+    onProvinceSelected: (id) => selectedId = id,
+    onMapTileTappedForDetail: (tk) => detailTileKey = tk,
+    width: 64,
+    height: 64,
+    cellSizePx: 32,
+  );
+  await tapCtRegionMap(tester);
+  return (selectedId, detailTileKey);
+}
+
+Future<void> pumpCtRegionMapResourceBaseModes(WidgetTester tester) async {
+  await tester.runAsync(preloadCtRegionMapRoadAssets);
+  final region = ctRegionMapTestOldWorldRegion();
+  for (final mode in [
+    BaseLayerDisplayMode.terrainAndResources,
+    BaseLayerDisplayMode.terrainAndResourcesImprovementLabels,
+    BaseLayerDisplayMode.terrainAndResourcesImprovementsRoads,
+  ]) {
+    await pumpCtRegionMapTest(
+      tester,
+      region: region,
+      baseLayerDisplayMode: mode,
+    );
+    expect(ctRegionMapFinder(), findsOneWidget);
+  }
+}
+
+Future<void> pumpCtRegionMapRoadsCellSizes(WidgetTester tester) async {
+  await tester.runAsync(preloadCtRegionMapRoadAssets);
+  final region = ctRegionMapTestOldWorldRegion();
+  for (final cellSize in [16.0, 32.0, 96.0]) {
+    await pumpCtRegionMapTest(
+      tester,
+      region: region,
+      cellSizePx: cellSize,
+      baseLayerDisplayMode:
+          BaseLayerDisplayMode.terrainAndResourcesImprovementsRoads,
+    );
+    expect(ctRegionMapFinder(), findsOneWidget);
+  }
+}

--- a/app/test/ct_region_map_widget_part2_test.dart
+++ b/app/test/ct_region_map_widget_part2_test.dart
@@ -4,17 +4,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:colonizethis_map/colonizethis_map.dart';
-import 'package:colonizethis_models/colonizethis_models.dart'
-    show
-        OpenCivilianUnitsPanelEvent,
-        OpenNavalMissionMenuEvent;
-
 import 'package:colonizethis_app/features/game/flame/caches/resource_icon_cache.dart';
 import 'package:colonizethis_app/features/game/flame/region_map/region_map.dart'
-    show BaseLayerDisplayMode, CtMapVisibilityMode;
+    show CtMapVisibilityMode;
 import 'package:colonizethis_app/features/game/flame/tilesets/tilesets.dart';
 
 import 'ct_region_map_test_support.dart';
+import 'ct_region_map_widget_part2_support.dart';
 
 Finder get _map => ctRegionMapFinder();
 
@@ -170,45 +166,12 @@ void main() {
       'tap on civilian marker tile invokes civilian callback and suppresses detail tap callback',
       (WidgetTester tester) async {
         const markerTileKey = 'oldWorld|pMarker|0|0';
-        final region = ctRegionMapMiniLandStrip(
-          base: ctRegionMapTestOldWorldRegion(),
-          width: 1,
-          height: 1,
-          cellSize: 24,
-          regionCellId: 'pMarker',
-          displayName: 'Marker Province',
-          civilianTileMarkers: [
-            ctRegionMapCivilianMarker(
-              tileKey: markerTileKey,
-              x: 0,
-              y: 0,
-              localProvinceId: 'pMarker',
-            ),
-          ],
-        );
-        String? tappedCivilianTileKey;
-        String? detailTileKey;
-        String? selectedProvinceId;
-        final (bus, openedPanels) = ctRegionMapBusCapture<OpenCivilianUnitsPanelEvent>();
-        await pumpCtRegionMapTest(
-          tester,
-          region: region,
-          width: 64,
-          height: 64,
-          cellSizePx: 32,
-          bus: bus,
-          onCivilianTileStateChanged: (tileKey) =>
-              tappedCivilianTileKey = tileKey,
-          onMapTileTappedForDetail: (tileKey) => detailTileKey = tileKey,
-          onProvinceSelected: (id) => selectedProvinceId = id,
-        );
-        await tapCtRegionMap(tester);
+        final (tappedCivilianTileKey, openedPanels) =
+            await pumpAndTapCivilianMarker(tester);
         expect(tappedCivilianTileKey, equals(markerTileKey));
         expect(openedPanels, hasLength(1));
         expect(openedPanels.single.tileScopeTileKey, equals(markerTileKey));
         expect(openedPanels.single.initialSelectedUnitId, equals('u_builder'));
-        expect(detailTileKey, isNull);
-        expect(selectedProvinceId, isNull);
       },
       timeout: const Timeout(Duration(seconds: 5)),
     );
@@ -217,33 +180,7 @@ void main() {
       'tapping fleet marker emits naval mission menu event',
       (WidgetTester tester) async {
         const markerTileKey = 'oldWorld|sMarker|0|0';
-        final region = ctRegionMapMiniLandStrip(
-          base: ctRegionMapTestOldWorldRegion(),
-          width: 1,
-          height: 1,
-          cellSize: 24,
-          regionCellId: 'sMarker',
-          displayName: 'Marker Sea',
-          sea: true,
-          fleetTileMarkers: [
-            ctRegionMapFleetMarker(
-              tileKey: markerTileKey,
-              x: 0,
-              y: 0,
-              locationScopeKey: 'sea:oldWorld|fleet_scope',
-            ),
-          ],
-        );
-        final (bus, openedMenus) = ctRegionMapBusCapture<OpenNavalMissionMenuEvent>();
-        await pumpCtRegionMapTest(
-          tester,
-          region: region,
-          width: 64,
-          height: 64,
-          cellSizePx: 32,
-          bus: bus,
-        );
-        await tapCtRegionMap(tester);
+        final openedMenus = await pumpAndTapFleetMarker(tester);
         expect(openedMenus, hasLength(1));
         expect(
           openedMenus.single.locationScopeKey,
@@ -302,38 +239,7 @@ void main() {
     testWidgets(
       'tap on a town tile still invokes map tile and province selection callbacks',
       (WidgetTester tester) async {
-        final region = ctRegionMapMiniLandStrip(
-          base: ctRegionMapTestOldWorldRegion(),
-          width: 1,
-          height: 1,
-          cellSize: 24,
-          regionCellId: 'pTown',
-          displayName: 'Town Province',
-          townMarkers: const [
-            TownMarkerView(
-              x: 0,
-              y: 0,
-              provinceId: 'pTown',
-              isCoastal: false,
-              isPort: false,
-              touchesSea: false,
-              townDevelopmentLevel: 1,
-              townIconStyle: 'euro',
-            ),
-          ],
-        );
-        String? selectedId;
-        String? detailTileKey;
-        await pumpCtRegionMapTest(
-          tester,
-          region: region,
-          onProvinceSelected: (id) => selectedId = id,
-          onMapTileTappedForDetail: (tk) => detailTileKey = tk,
-          width: 64,
-          height: 64,
-          cellSizePx: 32,
-        );
-        await tapCtRegionMap(tester);
+        final (selectedId, detailTileKey) = await pumpAndTapTownMarker(tester);
         expect(selectedId, equals('oldWorld|pTown'));
         expect(detailTileKey, equals('oldWorld|pTown|0|0'));
       },
@@ -415,16 +321,7 @@ void main() {
       'map renders with resource icons across resource base-layer modes '
       '(SPEC/ui/map-widget.md § Base layer display mode)',
       (WidgetTester tester) async {
-        await tester.runAsync(preloadCtRegionMapRoadAssets);
-        final region = ctRegionMapTestOldWorldRegion();
-        for (final mode in [
-          BaseLayerDisplayMode.terrainAndResources,
-          BaseLayerDisplayMode.terrainAndResourcesImprovementLabels,
-          BaseLayerDisplayMode.terrainAndResourcesImprovementsRoads,
-        ]) {
-          await pumpCtRegionMapTest(tester, region: region, baseLayerDisplayMode: mode);
-          expect(_map, findsOneWidget);
-        }
+        await pumpCtRegionMapResourceBaseModes(tester);
       },
       timeout: const Timeout(Duration(seconds: 15)),
     );
@@ -432,18 +329,7 @@ void main() {
     testWidgets(
       'roads mode renders for non-64 cell sizes with transport overlay assets preloaded',
       (WidgetTester tester) async {
-        await tester.runAsync(preloadCtRegionMapRoadAssets);
-        final region = ctRegionMapTestOldWorldRegion();
-        for (final cellSize in [16.0, 32.0, 96.0]) {
-          await pumpCtRegionMapTest(
-            tester,
-            region: region,
-            cellSizePx: cellSize,
-            baseLayerDisplayMode:
-                BaseLayerDisplayMode.terrainAndResourcesImprovementsRoads,
-          );
-          expect(_map, findsOneWidget);
-        }
+        await pumpCtRegionMapRoadsCellSizes(tester);
       },
       timeout: const Timeout(Duration(seconds: 12)),
     );

--- a/app/test/production_panel_part1_test.dart
+++ b/app/test/production_panel_part1_test.dart
@@ -1,21 +1,19 @@
 // ProductionPanel chrome / allocation ACs (part1). SPEC/ui/production-panel.md.
 
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:colonizethis_app/features/game/widgets/production/production_recipe_affordance.dart';
 import 'package:colonizethis_app/widgets/ct_action_text_button.dart';
 import 'package:colonizethis_app/widgets/ct_danger_text_button.dart';
-import 'package:colonizethis_app_l10n/l10n/l10n.dart';
 import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
 import 'package:colonizethis_app/widgets/ct_resource_cell.dart';
 import 'package:colonizethis_app/widgets/ct_section_label.dart';
 import 'package:colonizethis_app/widgets/ct_slider.dart';
 import 'widget_test_pumps.dart';
+import 'production_panel_part_helpers.dart';
 import 'production_panel_test_support.dart';
 
 void main() {
@@ -31,21 +29,18 @@ void main() {
     testWidgets('Available header has no Breakdown button without callback', (
       WidgetTester tester,
     ) async {
-      await tester.pumpWidget(buildProductionPanel(player: fullPlayer));
-      await pumpSettleCapped(tester);
+      await pumpProductionPanelSettled(tester, player: fullPlayer);
       expect(find.text('Breakdown'), findsNothing);
     });
 
     testWidgets(
       'Available header shows Breakdown text button when callback set',
       (WidgetTester tester) async {
-        await tester.pumpWidget(
-          buildProductionPanel(
-            player: fullPlayer,
-            onOpenCommodityBreakdown: () {},
-          ),
+        await pumpProductionPanelSettled(
+          tester,
+          player: fullPlayer,
+          onOpenCommodityBreakdown: () {},
         );
-        await pumpSettleCapped(tester);
         expect(find.text('Breakdown'), findsOneWidget);
       },
     );
@@ -53,13 +48,11 @@ void main() {
     testWidgets(
       'Available header Breakdown renders as CtActionTextButton (Refs #2862 S10b / C11)',
       (WidgetTester tester) async {
-        await tester.pumpWidget(
-          buildProductionPanel(
-            player: fullPlayer,
-            onOpenCommodityBreakdown: () {},
-          ),
+        await pumpProductionPanelSettled(
+          tester,
+          player: fullPlayer,
+          onOpenCommodityBreakdown: () {},
         );
-        await pumpSettleCapped(tester);
 
         final breakdownFinder = find.widgetWithText(
           CtActionTextButton,
@@ -77,25 +70,16 @@ void main() {
       'negative: Available header Breakdown does not render as CtNinePatchButton '
       '(Refs #2862 S10b / C11)',
       (WidgetTester tester) async {
-        await tester.pumpWidget(
-          buildProductionPanel(
-            player: fullPlayer,
-            onOpenCommodityBreakdown: () {},
-          ),
+        await pumpProductionPanelSettled(
+          tester,
+          player: fullPlayer,
+          onOpenCommodityBreakdown: () {},
         );
-        await pumpSettleCapped(tester);
 
-        final ninePatchBreakdown = find.byWidgetPredicate((Widget w) {
-          if (w is! CtNinePatchButton) return false;
-          final child = w.child;
-          return child is Text && child.data == 'Breakdown';
-        });
         expect(
-          ninePatchBreakdown,
+          productionNinePatchLabeled('Breakdown'),
           findsNothing,
-          reason:
-              'Available header Breakdown must use CtActionTextButton per '
-              '#2862 C11, not a CtNinePatchButton labelled "Breakdown".',
+          reason: 'Breakdown must be CtActionTextButton (#2862 C11).',
         );
       },
     );
@@ -103,8 +87,7 @@ void main() {
     testWidgets('Available subpanel shows commodity groups', (
       WidgetTester tester,
     ) async {
-      await tester.pumpWidget(buildProductionPanel(player: fullPlayer));
-      await pumpSettleCapped(tester);
+      await pumpProductionPanelSettled(tester, player: fullPlayer);
 
       expect(find.text('Available'), findsOneWidget);
       expect(find.byType(CtSectionLabel), findsAtLeastNWidgets(4));
@@ -118,8 +101,7 @@ void main() {
     testWidgets('Available subpanel shows raw materials used as inputs', (
       WidgetTester tester,
     ) async {
-      await tester.pumpWidget(buildProductionPanel(player: fullPlayer));
-      await pumpSettleCapped(tester);
+      await pumpProductionPanelSettled(tester, player: fullPlayer);
 
       expect(find.byType(CtResourceCell), findsAtLeastNWidgets(3));
       expect(find.text('Timber'), findsOneWidget);
@@ -130,8 +112,7 @@ void main() {
     testWidgets('Allocation subpanel shows recipe labels with inputs', (
       WidgetTester tester,
     ) async {
-      await tester.pumpWidget(buildProductionPanel(player: fullPlayer));
-      await pumpSettleCapped(tester);
+      await pumpProductionPanelSettled(tester, player: fullPlayer);
 
       expect(find.text('Allocation'), findsOneWidget);
       expect(
@@ -145,8 +126,7 @@ void main() {
     testWidgets(
       'normalized recipe labels show updated input quantities (Refs #3873)',
       (WidgetTester tester) async {
-        await tester.pumpWidget(buildProductionPanel(player: fullPlayer));
-        await pumpSettleCapped(tester);
+        await pumpProductionPanelSettled(tester, player: fullPlayer);
 
         expect(find.textContaining('Tobacco ×2'), findsOneWidget);
         expect(find.textContaining('Timber ×2'), findsAtLeastNWidgets(2));
@@ -159,8 +139,7 @@ void main() {
     testWidgets(
       'Allocation rows show right-aligned affordance max · bottleneck',
       (WidgetTester tester) async {
-        await tester.pumpWidget(buildProductionPanel(player: fullPlayer));
-        await pumpSettleCapped(tester);
+        await pumpProductionPanelSettled(tester, player: fullPlayer);
 
         expect(
           find.textContaining('·'),
@@ -172,8 +151,7 @@ void main() {
     testWidgets(
       'Full availability: sliders enable comfort headroom at default allocation',
       (WidgetTester tester) async {
-        await tester.pumpWidget(buildProductionPanel(player: fullPlayer));
-        await pumpSettleCapped(tester);
+        await pumpProductionPanelSettled(tester, player: fullPlayer);
 
         final sliders = tester
             .widgetList<CtSlider>(find.byType(CtSlider))
@@ -187,14 +165,12 @@ void main() {
       WidgetTester tester,
     ) async {
       Map<String, int>? lastOutput;
-      await tester.pumpWidget(
-        buildProductionPanel(
-          player: fullPlayer,
-          desiredOutputByRecipe: {'lumber_from_timber': 5},
-          onDesiredOutputChanged: (next) => lastOutput = Map.from(next),
-        ),
+      await pumpProductionPanelSettled(
+        tester,
+        player: fullPlayer,
+        desiredOutputByRecipe: {'lumber_from_timber': 5},
+        onDesiredOutputChanged: (next) => lastOutput = Map.from(next),
       );
-      await pumpSettleCapped(tester);
 
       final resetFinder = find.byKey(
         const ValueKey<String>('production_allocation_reset_button'),
@@ -214,8 +190,7 @@ void main() {
     testWidgets(
       'Allocation header Reset renders as CtDangerTextButton (Refs #2862 S8d / C8)',
       (WidgetTester tester) async {
-        await tester.pumpWidget(buildProductionPanel(player: fullPlayer));
-        await pumpSettleCapped(tester);
+        await pumpProductionPanelSettled(tester, player: fullPlayer);
 
         final resetFinder = find.byKey(
           const ValueKey<String>('production_allocation_reset_button'),
@@ -242,22 +217,12 @@ void main() {
     testWidgets(
       'negative: production panel does not render Reset as CtNinePatchButton (Refs #2862 S8d / C8)',
       (WidgetTester tester) async {
-        await tester.pumpWidget(buildProductionPanel(player: fullPlayer));
-        await pumpSettleCapped(tester);
+        await pumpProductionPanelSettled(tester, player: fullPlayer);
 
-        final ninePatchButtonsWithResetLabel = find.byWidgetPredicate((
-          Widget w,
-        ) {
-          if (w is! CtNinePatchButton) return false;
-          final child = w.child;
-          return child is Text && child.data == 'Reset';
-        });
         expect(
-          ninePatchButtonsWithResetLabel,
+          productionNinePatchLabeled('Reset'),
           findsNothing,
-          reason:
-              'Allocation header Reset must use CtDangerTextButton per #2862 C8, '
-              'not a CtNinePatchButton labelled "Reset".',
+          reason: 'Reset must be CtDangerTextButton (#2862 C8).',
         );
       },
     );
@@ -267,15 +232,13 @@ void main() {
     ) async {
       Map<String, int>? lastOutput;
       final firstId = ProductionRecipesCatalog.all.first.id;
-      await tester.pumpWidget(
-        buildProductionPanel(
-          player: fullPlayer,
-          onDesiredOutputChanged: (next) =>
-              lastOutput = Map<String, int>.from(next),
-        ),
+      await pumpProductionPanelSettled(
+        tester,
+        player: fullPlayer,
+        onDesiredOutputChanged: (next) =>
+            lastOutput = Map<String, int>.from(next),
       );
-      await pumpSettleCapped(tester);
-      final l10n = lookupAppLocalizations(const Locale('en'));
+      final l10n = productionEnL10n();
       await tester.tap(
         find.bySemanticsLabel(l10n.production_allocationIncrementRecipe).first,
       );
@@ -289,26 +252,20 @@ void main() {
     ) async {
       Map<String, int>? lastOutput;
       const lumberId = 'lumber_from_timber';
-      final lumberIndex = ProductionRecipesCatalog.all.indexWhere(
-        (r) => r.id == lumberId,
+      final lumberIndex = productionRecipeIndex(lumberId);
+      final l10n = productionEnL10n();
+      await pumpProductionPanelSettled(
+        tester,
+        player: fullPlayer,
+        desiredOutputByRecipe: const {lumberId: 3},
+        onDesiredOutputChanged: (next) =>
+            lastOutput = Map<String, int>.from(next),
       );
-      expect(lumberIndex, greaterThanOrEqualTo(0));
-      final l10n = lookupAppLocalizations(const Locale('en'));
-      await tester.pumpWidget(
-        buildProductionPanel(
-          player: fullPlayer,
-          desiredOutputByRecipe: const {lumberId: 3},
-          onDesiredOutputChanged: (next) =>
-              lastOutput = Map<String, int>.from(next),
-        ),
+      await tapProductionAllocationSemantic(
+        tester,
+        semanticLabel: l10n.production_allocationDecrementRecipe,
+        recipeIndex: lumberIndex,
       );
-      await pumpSettleCapped(tester);
-      await tester.tap(
-        find
-            .bySemanticsLabel(l10n.production_allocationDecrementRecipe)
-            .at(lumberIndex),
-      );
-      await pumpSyncFrames(tester);
       expect(lastOutput, isNotNull);
       expect(lastOutput![lumberId], 2);
     });
@@ -318,25 +275,20 @@ void main() {
     ) async {
       Map<String, int>? lastOutput;
       const lumberId = 'lumber_from_timber';
-      final lumberIndex = ProductionRecipesCatalog.all.indexWhere(
-        (r) => r.id == lumberId,
+      final lumberIndex = productionRecipeIndex(lumberId);
+      final l10n = productionEnL10n();
+      await pumpProductionPanelSettled(
+        tester,
+        player: fullPlayer,
+        desiredOutputByRecipe: const {lumberId: 4},
+        onDesiredOutputChanged: (next) =>
+            lastOutput = Map<String, int>.from(next),
       );
-      final l10n = lookupAppLocalizations(const Locale('en'));
-      await tester.pumpWidget(
-        buildProductionPanel(
-          player: fullPlayer,
-          desiredOutputByRecipe: const {lumberId: 4},
-          onDesiredOutputChanged: (next) =>
-              lastOutput = Map<String, int>.from(next),
-        ),
+      await tapProductionAllocationSemantic(
+        tester,
+        semanticLabel: l10n.production_allocationClearRecipe,
+        recipeIndex: lumberIndex,
       );
-      await pumpSettleCapped(tester);
-      await tester.tap(
-        find
-            .bySemanticsLabel(l10n.production_allocationClearRecipe)
-            .at(lumberIndex),
-      );
-      await pumpSyncFrames(tester);
       expect(lastOutput, isNotNull);
       expect(lastOutput!.containsKey(lumberId), isFalse);
     });
@@ -346,48 +298,24 @@ void main() {
     ) async {
       Map<String, int>? lastOutput;
       const lumberId = 'lumber_from_timber';
-      final lumberIndex = ProductionRecipesCatalog.all.indexWhere(
-        (r) => r.id == lumberId,
-      );
-      final l10n = lookupAppLocalizations(const Locale('en'));
-      await tester.pumpWidget(
-        buildProductionPanel(
-          player: fullPlayer,
-          desiredOutputByRecipe: const {lumberId: 1},
-          onDesiredOutputChanged: (next) =>
-              lastOutput = Map<String, int>.from(next),
-        ),
-      );
-      await pumpSettleCapped(tester);
-      final displayGame = productionPanelTestGameFor(fullPlayer);
-      final regimentCounts = regimentTypeCountsForPlayer(
-        displayGame.worldState,
-        fullPlayer.id,
-      );
-      final shipCounts = shipTypeCountsForPlayer(
-        displayGame.worldState,
-        fullPlayer.id,
-      );
-      final effectiveLabour = effectiveLabourForWorkers(
-        workers: fullPlayer.workerPool,
-        stockpile: fullPlayer.stockpile,
-        foodCounts: MilitaryNavyFoodCounts(
-          regimentCountsById: regimentCounts,
-          shipCountsById: shipCounts,
-        ),
-      );
-      final expectedMax = computeRecipeAffordance(
-        recipe: ProductionRecipesCatalog.byId[lumberId]!,
-        stockpile: fullPlayer.stockpile,
+      final lumberIndex = productionRecipeIndex(lumberId);
+      final l10n = productionEnL10n();
+      await pumpProductionPanelSettled(
+        tester,
+        player: fullPlayer,
         desiredOutputByRecipe: const {lumberId: 1},
-        effectiveLabour: effectiveLabour,
-      ).maxDesiredOutput;
-      await tester.tap(
-        find
-            .bySemanticsLabel(l10n.production_allocationMaximizeRecipe)
-            .at(lumberIndex),
+        onDesiredOutputChanged: (next) =>
+            lastOutput = Map<String, int>.from(next),
       );
-      await pumpSyncFrames(tester);
+      final expectedMax = expectedLumberMaxForPlayer(
+        fullPlayer,
+        currentDesired: 1,
+      );
+      await tapProductionAllocationSemantic(
+        tester,
+        semanticLabel: l10n.production_allocationMaximizeRecipe,
+        recipeIndex: lumberIndex,
+      );
       expect(lastOutput, isNotNull);
       expect(lastOutput![lumberId], expectedMax);
     });
@@ -396,27 +324,21 @@ void main() {
       'allocation cross-row: lumber maxed disables cast iron increment',
       (WidgetTester tester) async {
         const castIronId = 'castIron_from_iron';
-        final castIronIndex = ProductionRecipesCatalog.all.indexWhere(
-          (r) => r.id == castIronId,
+        final castIronIndex = productionRecipeIndex(castIronId);
+        final l10n = productionEnL10n();
+        await pumpProductionPanelSettled(
+          tester,
+          player: fullPlayer,
+          desiredOutputByRecipe: const {'lumber_from_timber': 50},
         );
-        expect(castIronIndex, greaterThanOrEqualTo(0));
-        final l10n = lookupAppLocalizations(const Locale('en'));
-        await tester.pumpWidget(
-          buildProductionPanel(
-            player: fullPlayer,
-            desiredOutputByRecipe: const {'lumber_from_timber': 50},
-          ),
-        );
-        await pumpSettleCapped(tester);
         final before = tester
             .widget<CtSlider>(find.byType(CtSlider).at(castIronIndex))
             .value;
-        await tester.tap(
-          find
-              .bySemanticsLabel(l10n.production_allocationIncrementRecipe)
-              .at(castIronIndex),
+        await tapProductionAllocationSemantic(
+          tester,
+          semanticLabel: l10n.production_allocationIncrementRecipe,
+          recipeIndex: castIronIndex,
         );
-        await pumpSyncFrames(tester);
         final after = tester
             .widget<CtSlider>(find.byType(CtSlider).at(castIronIndex))
             .value;
@@ -428,13 +350,11 @@ void main() {
       WidgetTester tester,
     ) async {
       Map<String, int>? lastOutput;
-      await tester.pumpWidget(
-        buildProductionPanel(
-          player: fullPlayer,
-          onDesiredOutputChanged: (next) => lastOutput = Map.from(next),
-        ),
+      await pumpProductionPanelSettled(
+        tester,
+        player: fullPlayer,
+        onDesiredOutputChanged: (next) => lastOutput = Map.from(next),
       );
-      await pumpSettleCapped(tester);
 
       final sliders = find.byType(CtSlider);
       expect(sliders, findsNWidgets(ProductionRecipesCatalog.all.length));
@@ -448,10 +368,12 @@ void main() {
     testWidgets('Narrow viewport stacks subpanels and is scrollable', (
       WidgetTester tester,
     ) async {
-      await tester.pumpWidget(
-        buildProductionPanel(player: fullPlayer, width: 400, height: 600),
+      await pumpProductionPanelSettled(
+        tester,
+        player: fullPlayer,
+        width: 400,
+        height: 600,
       );
-      await pumpSettleCapped(tester);
 
       expect(find.byType(SingleChildScrollView), findsAtLeastNWidgets(1));
       expect(find.text('Available'), findsOneWidget);
@@ -461,10 +383,12 @@ void main() {
     testWidgets('Wide viewport shows subpanels in row', (
       WidgetTester tester,
     ) async {
-      await tester.pumpWidget(
-        buildProductionPanel(player: fullPlayer, width: 800, height: 500),
+      await pumpProductionPanelSettled(
+        tester,
+        player: fullPlayer,
+        width: 800,
+        height: 500,
       );
-      await pumpSettleCapped(tester);
 
       expect(find.byType(Row), findsWidgets);
       expect(find.text('Available'), findsOneWidget);

--- a/app/test/production_panel_part2_labour_support.dart
+++ b/app/test/production_panel_part2_labour_support.dart
@@ -1,0 +1,53 @@
+// Labour / chrome helpers for ProductionPanel part2 (Refs #4352).
+
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_app/features/game/widgets/production/production_labour_helpers.dart';
+import 'package:flutter/material.dart';
+
+import 'production_panel_test_support.dart';
+
+Game productionPanelIsolatedGame(Player player, {required String id}) {
+  return Game(
+    id: id,
+    worldState: WorldState(
+      turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+      oldWorld: const RegionData(),
+      newWorld: const RegionData(),
+    ),
+    players: [player],
+  );
+}
+
+Widget buildProductionPanelWithLabourCallbacks({
+  required Player player,
+  Orders currentOrders = const Orders(),
+  bool canEditLabour = true,
+}) {
+  return buildProductionPanel(
+    player: player,
+    currentOrders: currentOrders,
+    labourCallbacks: ProductionLabourCallbacks(
+      onAppendRecruitOrder: (_) {},
+      onPopLastRecruitOrder: (_) {},
+      onDisband: (_) {},
+    ),
+    canEditLabour: canEditLabour,
+    height: 700,
+  );
+}
+
+Orders productionPanelFabricOfferOrders(Player player, {int quantity = 4}) {
+  return Orders(
+    tradeOrdersByPlayerId: {
+      player.id: [
+        TradeOrder(
+          commodityId: CommodityCatalog.fabric.id,
+          type: TradeOrderType.offer,
+          quantity: quantity,
+          priority: 5,
+        ),
+      ],
+    },
+  );
+}

--- a/app/test/production_panel_part2_test.dart
+++ b/app/test/production_panel_part2_test.dart
@@ -18,6 +18,8 @@ import 'package:colonizethis_app/widgets/ct_section_label.dart';
 import 'package:colonizethis_app/widgets/ct_slider.dart';
 import 'widget_test_pumps.dart';
 import 'production_panel_test_support.dart';
+import 'production_panel_part_helpers.dart';
+import 'production_panel_part2_labour_support.dart';
 
 void main() {
   suppressLogsForTests();
@@ -32,8 +34,7 @@ void main() {
 
   group('ProductionPanel', () {
     testWidgets('Total labour displayed', (WidgetTester tester) async {
-      await tester.pumpWidget(buildProductionPanel(player: fullPlayer));
-      await pumpSettleCapped(tester);
+      await pumpProductionPanelSettled(tester, player: fullPlayer);
 
       expect(find.textContaining('Total labour:'), findsOneWidget);
     });
@@ -41,23 +42,15 @@ void main() {
     testWidgets('Net changes shown when allocations exist', (
       WidgetTester tester,
     ) async {
-      final isolatedGame = Game(
-        id: 'production-panel-net',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
-          oldWorld: const RegionData(),
-          newWorld: const RegionData(),
+      await pumpProductionPanelSettled(
+        tester,
+        player: fullPlayer,
+        gameOverride: productionPanelIsolatedGame(
+          fullPlayer,
+          id: 'production-panel-net',
         ),
-        players: [fullPlayer],
+        desiredOutputByRecipe: {'lumber_from_timber': 5},
       );
-      await tester.pumpWidget(
-        buildProductionPanel(
-          player: fullPlayer,
-          gameOverride: isolatedGame,
-          desiredOutputByRecipe: {'lumber_from_timber': 5},
-        ),
-      );
-      await pumpSettleCapped(tester);
 
       expect(find.text('Timber'), findsOneWidget);
       expect(find.text('-10'), findsOneWidget);
@@ -68,8 +61,7 @@ void main() {
     testWidgets('Partial availability: sliders capped by achievable runs', (
       WidgetTester tester,
     ) async {
-      await tester.pumpWidget(buildProductionPanel(player: partialPlayer));
-      await pumpSettleCapped(tester);
+      await pumpProductionPanelSettled(tester, player: partialPlayer);
 
       expect(
         find.byType(CtSlider),
@@ -82,16 +74,11 @@ void main() {
     testWidgets(
       'Over-allocating labour shows insufficient labour warning in summary',
       (WidgetTester tester) async {
-        await tester.pumpWidget(
-          buildProductionPanel(
-            player: fullPlayer,
-            desiredOutputByRecipe: {
-              // Choose a recipe and deliberately over-allocate beyond what labour allows.
-              'lumber_from_timber': 999,
-            },
-          ),
+        await pumpProductionPanelSettled(
+          tester,
+          player: fullPlayer,
+          desiredOutputByRecipe: {'lumber_from_timber': 999},
         );
-        await pumpSettleCapped(tester);
 
         // Summary line should turn into an error-coloured warning with explanatory text.
         expect(find.textContaining('Total labour:'), findsOneWidget);
@@ -107,16 +94,11 @@ void main() {
     testWidgets(
       'Unknown recipe ids are ignored when computing total labour (no warning)',
       (WidgetTester tester) async {
-        await tester.pumpWidget(
-          buildProductionPanel(
-            player: fullPlayer,
-            desiredOutputByRecipe: {
-              // Not a real production recipe id; should be ignored by the panel.
-              'definitely_not_a_recipe_id': 5,
-            },
-          ),
+        await pumpProductionPanelSettled(
+          tester,
+          player: fullPlayer,
+          desiredOutputByRecipe: {'definitely_not_a_recipe_id': 5},
         );
-        await pumpSettleCapped(tester);
 
         expect(find.textContaining('Total labour:'), findsOneWidget);
         expect(
@@ -131,8 +113,7 @@ void main() {
     testWidgets('Recipe labels show output with inputs in parentheses', (
       WidgetTester tester,
     ) async {
-      await tester.pumpWidget(buildProductionPanel(player: fullPlayer));
-      await pumpSettleCapped(tester);
+      await pumpProductionPanelSettled(tester, player: fullPlayer);
 
       expect(find.textContaining('('), findsWidgets);
       expect(find.textContaining('Lumber'), findsWidgets);
@@ -143,8 +124,7 @@ void main() {
       'Available section labels use CtSectionLabel for Food / Raw Materials / '
       'Manufactured / Workers (Refs #2862 S2)',
       (WidgetTester tester) async {
-        await tester.pumpWidget(buildProductionPanel(player: fullPlayer));
-        await pumpSettleCapped(tester);
+        await pumpProductionPanelSettled(tester, player: fullPlayer);
 
         Finder labelWithText(String text) => find.descendant(
           of: find.byType(CtSectionLabel),
@@ -161,23 +141,15 @@ void main() {
       'Available commodity cells use CtResourceCell with sign-prefixed '
       'positive deltas (Refs #2862 S2)',
       (WidgetTester tester) async {
-        final isolatedGame = Game(
-          id: 'production-panel-dark-positive',
-          worldState: WorldState(
-            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
-            oldWorld: const RegionData(),
-            newWorld: const RegionData(),
+        await pumpProductionPanelSettled(
+          tester,
+          player: fullPlayer,
+          gameOverride: productionPanelIsolatedGame(
+            fullPlayer,
+            id: 'production-panel-dark-positive',
           ),
-          players: [fullPlayer],
+          desiredOutputByRecipe: {'lumber_from_timber': 2},
         );
-        await tester.pumpWidget(
-          buildProductionPanel(
-            player: fullPlayer,
-            gameOverride: isolatedGame,
-            desiredOutputByRecipe: {'lumber_from_timber': 2},
-          ),
-        );
-        await pumpSettleCapped(tester);
 
         final lumberCell = find.byKey(
           const ValueKey<String>('production_available_cell_lumber'),
@@ -199,18 +171,7 @@ void main() {
       await tester.pumpWidget(
         buildProductionPanel(
           player: fullPlayer,
-          currentOrders: Orders(
-            tradeOrdersByPlayerId: {
-              fullPlayer.id: [
-                TradeOrder(
-                  commodityId: CommodityCatalog.fabric.id,
-                  type: TradeOrderType.offer,
-                  quantity: 4,
-                  priority: 5,
-                ),
-              ],
-            },
-          ),
+          currentOrders: productionPanelFabricOfferOrders(fullPlayer),
         ),
       );
       await pumpSettleCapped(tester);
@@ -227,8 +188,7 @@ void main() {
       'Available commodity cells omit delta region when net change is zero '
       '(Refs #2862 S2)',
       (WidgetTester tester) async {
-        await tester.pumpWidget(buildProductionPanel(player: fullPlayer));
-        await pumpSettleCapped(tester);
+        await pumpProductionPanelSettled(tester, player: fullPlayer);
 
         final timberCell = find.byKey(
           const ValueKey<String>('production_available_cell_timber'),
@@ -241,8 +201,7 @@ void main() {
 
     testWidgets('Workers section renders one CtResourceCell per worker tier '
         '(Refs #2862 S2)', (WidgetTester tester) async {
-      await tester.pumpWidget(buildProductionPanel(player: fullPlayer));
-      await pumpSettleCapped(tester);
+      await pumpProductionPanelSettled(tester, player: fullPlayer);
 
       for (final tier in const <String>[
         'peasant',
@@ -262,8 +221,7 @@ void main() {
         'ProductionAllocationRowChrome (Refs #2862 S3 / R13)', (
       WidgetTester tester,
     ) async {
-      await tester.pumpWidget(buildProductionPanel(player: fullPlayer));
-      await pumpSettleCapped(tester);
+      await pumpProductionPanelSettled(tester, player: fullPlayer);
 
       final recipeCount = ProductionRecipesCatalog.all.length;
       expect(recipeCount, greaterThan(1));
@@ -297,8 +255,7 @@ void main() {
       'Allocation row chrome paints CtGradients.rowGradient inside a 1px '
       'accent-dim border (Refs #2862 S3 / R13)',
       (WidgetTester tester) async {
-        await tester.pumpWidget(buildProductionPanel(player: fullPlayer));
-        await pumpSettleCapped(tester);
+        await pumpProductionPanelSettled(tester, player: fullPlayer);
 
         final chromes = tester.widgetList<ProductionAllocationRowChrome>(
           find.byType(ProductionAllocationRowChrome),
@@ -326,8 +283,7 @@ void main() {
 
     testWidgets('Allocation rows are separated by exactly N-1 CtBrassDividers '
         '(Refs #2862 S3 / R13)', (WidgetTester tester) async {
-      await tester.pumpWidget(buildProductionPanel(player: fullPlayer));
-      await pumpSettleCapped(tester);
+      await pumpProductionPanelSettled(tester, player: fullPlayer);
 
       final recipeCount = ProductionRecipesCatalog.all.length;
       expect(recipeCount, greaterThan(1));
@@ -355,29 +311,11 @@ void main() {
 
     // S7 — Labour Controls subsection placement (Refs #2862 S7a).
 
-    Widget buildPanelWithLabourCallbacks({
-      required Player player,
-      Orders currentOrders = const Orders(),
-      bool canEditLabour = true,
-    }) {
-      return buildProductionPanel(
-        player: player,
-        currentOrders: currentOrders,
-        labourCallbacks: ProductionLabourCallbacks(
-          onAppendRecruitOrder: (_) {},
-          onPopLastRecruitOrder: (_) {},
-          onDisband: (_) {},
-        ),
-        canEditLabour: canEditLabour,
-        height: 700,
-      );
-    }
-
     testWidgets(
       'Labour Controls CtSectionLabel appears below Effective Labour (Refs #2862 S7a)',
       (WidgetTester tester) async {
         await tester.pumpWidget(
-          buildPanelWithLabourCallbacks(player: fullPlayer),
+          buildProductionPanelWithLabourCallbacks(player: fullPlayer),
         );
         await pumpSettleCapped(tester);
 
@@ -407,8 +345,7 @@ void main() {
       '(no orphan section label; Refs #2862 S7a)',
       (WidgetTester tester) async {
         // `buildPanel` does not pass currentOrders / labourCallbacks.
-        await tester.pumpWidget(buildProductionPanel(player: fullPlayer));
-        await pumpSettleCapped(tester);
+        await pumpProductionPanelSettled(tester, player: fullPlayer);
 
         expect(
           find.descendant(
@@ -425,7 +362,7 @@ void main() {
       '(no action buttons above Effective Labour; Refs #2862 S7a)',
       (WidgetTester tester) async {
         await tester.pumpWidget(
-          buildPanelWithLabourCallbacks(player: fullPlayer),
+          buildProductionPanelWithLabourCallbacks(player: fullPlayer),
         );
         await pumpSettleCapped(tester);
 

--- a/app/test/production_panel_part_helpers.dart
+++ b/app/test/production_panel_part_helpers.dart
@@ -1,0 +1,87 @@
+// Shared ProductionPanel part1/part2 pump and finder helpers (Refs #4352).
+
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_app/features/game/widgets/production/production_recipe_affordance.dart';
+import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
+import 'package:colonizethis_app_l10n/l10n/l10n.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'production_panel_test_support.dart';
+import 'widget_test_pumps.dart';
+
+Finder productionNinePatchLabeled(String label) => find.byWidgetPredicate((
+  Widget w,
+) {
+  if (w is! CtNinePatchButton) return false;
+  final child = w.child;
+  return child is Text && child.data == label;
+});
+
+Future<void> pumpProductionPanelSettled(
+  WidgetTester tester, {
+  required Player player,
+  Game? gameOverride,
+  Map<String, int> desiredOutputByRecipe = const {},
+  ValueChanged<Map<String, int>>? onDesiredOutputChanged,
+  VoidCallback? onOpenCommodityBreakdown,
+  double width = 800,
+  double height = 500,
+}) async {
+  await tester.pumpWidget(
+    buildProductionPanel(
+      player: player,
+      gameOverride: gameOverride,
+      desiredOutputByRecipe: desiredOutputByRecipe,
+      onDesiredOutputChanged: onDesiredOutputChanged,
+      onOpenCommodityBreakdown: onOpenCommodityBreakdown,
+      width: width,
+      height: height,
+    ),
+  );
+  await pumpSettleCapped(tester);
+}
+
+int productionRecipeIndex(String recipeId) {
+  final index = ProductionRecipesCatalog.all.indexWhere((r) => r.id == recipeId);
+  expect(index, greaterThanOrEqualTo(0));
+  return index;
+}
+
+Future<void> tapProductionAllocationSemantic(
+  WidgetTester tester, {
+  required String semanticLabel,
+  required int recipeIndex,
+}) async {
+  await tester.tap(find.bySemanticsLabel(semanticLabel).at(recipeIndex));
+  await pumpSyncFrames(tester);
+}
+
+int expectedLumberMaxForPlayer(Player player, {required int currentDesired}) {
+  const lumberId = 'lumber_from_timber';
+  final displayGame = productionPanelTestGameFor(player);
+  final regimentCounts = regimentTypeCountsForPlayer(
+    displayGame.worldState,
+    player.id,
+  );
+  final shipCounts = shipTypeCountsForPlayer(displayGame.worldState, player.id);
+  final effectiveLabour = effectiveLabourForWorkers(
+    workers: player.workerPool,
+    stockpile: player.stockpile,
+    foodCounts: MilitaryNavyFoodCounts(
+      regimentCountsById: regimentCounts,
+      shipCountsById: shipCounts,
+    ),
+  );
+  return computeRecipeAffordance(
+    recipe: ProductionRecipesCatalog.byId[lumberId]!,
+    stockpile: player.stockpile,
+    desiredOutputByRecipe: {lumberId: currentDesired},
+    effectiveLabour: effectiveLabour,
+  ).maxDesiredOutput;
+}
+
+AppLocalizations productionEnL10n() =>
+    lookupAppLocalizations(const Locale('en'));

--- a/app/test/province_detail_overlay_host_support_fixtures.dart
+++ b/app/test/province_detail_overlay_host_support_fixtures.dart
@@ -1,0 +1,217 @@
+// Fixtures for province_detail_overlay_host_support_test (Refs #4352).
+
+import 'package:colonizethis_app/core/services/game_service/game_service.dart'
+    show GameMapData;
+import 'package:colonizethis_app/features/game/flame/caches/per_player_work_target_selection_cache.dart';
+import 'package:colonizethis_app/features/game/flame/overlays/province_detail_overlay_host_support.dart';
+import 'package:colonizethis_data/colonizethis_data.dart'
+    show
+        MapTopology,
+        Resource,
+        TileMapResult,
+        TopologyNode,
+        TopologyNodeType,
+        kTechIdMoldboardPlow;
+import 'package:colonizethis_logic/colonizethis_logic.dart'
+    show PlayerView, buildPlayerView;
+import 'package:colonizethis_map/colonizethis_map.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+const provinceDetailSupportPlayerId = 'gp1';
+const provinceDetailSupportTileKey = 'oldWorld|p1|0|0';
+const provinceDetailSupportProvinceId = 'oldWorld|p1';
+
+Game provinceDetailMinimalGame() => Game(
+  id: 'g_support',
+  worldState: const WorldState(
+    turnState: TurnState(phase: TurnPhase.orders, turnNumber: 1),
+    oldWorld: RegionData(provinces: [], units: []),
+    newWorld: RegionData(provinces: [], units: []),
+  ),
+  players: const [
+    Player(
+      id: provinceDetailSupportPlayerId,
+      displayName: 'Human',
+      isHuman: true,
+      capitalProvinceId: '',
+    ),
+  ],
+  minorNations: const [],
+  tribes: const [],
+);
+
+RegionMapViewData provinceDetailEmptyRegion() => const RegionMapViewData(
+  regionId: 'oldWorld',
+  width: 1,
+  height: 1,
+  cellSize: 16,
+  cells: [],
+  capitalMarkers: [],
+  portMarkers: [],
+  factionColors: {},
+  greatPowerFactionIds: {},
+  terrainColors: {},
+  provincePoliticalOwnerByPrefixedProvinceId: {},
+);
+
+PlayerView provinceDetailPlayerView(Game game) => buildPlayerView(
+  game,
+  const MapTopology(nodes: [], edges: []),
+  provinceDetailSupportPlayerId,
+);
+
+ProvinceDetailShortcutCallbacks provinceDetailCallbacks({
+  required Game game,
+  required String? selectedTileKey,
+  required bool exploreEnabled,
+  required bool prospectEnabled,
+  required bool buildImprovementEnabled,
+  required bool buildRoadEnabled,
+  required bool buildFortEnabled,
+  required bool buildPortEnabled,
+  required bool purchaseLandEnabled,
+  bool upgradeTownEnabled = false,
+  String? upgradeTownTargetTileKey,
+  String provinceId = provinceDetailSupportProvinceId,
+  required AppEventBus bus,
+}) => buildProvinceDetailShortcutCallbacks(
+  game: game,
+  humanPlayerId: provinceDetailSupportPlayerId,
+  region: provinceDetailEmptyRegion(),
+  playerView: provinceDetailPlayerView(game),
+  workTargetSelectionCache: PerPlayerWorkTargetSelectionCache(
+    strategies: const {},
+  ),
+  draftOrders: const Orders(),
+  mapData: null,
+  selectedTileKey: selectedTileKey,
+  exploreEnabled: exploreEnabled,
+  prospectEnabled: prospectEnabled,
+  buildImprovementEnabled: buildImprovementEnabled,
+  buildRoadEnabled: buildRoadEnabled,
+  buildFortEnabled: buildFortEnabled,
+  buildPortEnabled: buildPortEnabled,
+  purchaseLandEnabled: purchaseLandEnabled,
+  provinceId: provinceId,
+  upgradeTownEnabled: upgradeTownEnabled,
+  upgradeTownTargetTileKey: upgradeTownTargetTileKey,
+  bus: bus,
+);
+
+Game provinceDetailGameWithImprovedGrain({required String ownerId}) {
+  const provinceId = provinceDetailSupportProvinceId;
+  const tk = provinceDetailSupportTileKey;
+  return Game(
+    id: 'g_extraction_preview',
+    capitalTileGrainBonusPerTurn: 0,
+    worldState: WorldState(
+      turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 2),
+      oldWorld: RegionData(
+        provinces: [
+          Province(
+            id: provinceId,
+            regionId: 'oldWorld',
+            ownerId: ownerId,
+            townDevelopmentLevel: 4,
+          ),
+        ],
+      ),
+      newWorld: const RegionData(),
+      tileState: TileMapState().setImprovement(tk, 2).setRoadLevel(tk, 4),
+      resourceByTileKey: const {tk: 'grain'},
+      tileKeysByRegionAndProvince: const {
+        'oldWorld': {
+          'oldWorld|p1': [tk],
+        },
+      },
+    ),
+    players: [
+      Player(
+        id: ownerId,
+        displayName: 'GP',
+        isHuman: true,
+        capitalProvinceId: provinceId,
+        capitalTile: const CapitalTile(
+          regionId: 'oldWorld',
+          provinceId: 'oldWorld|p1',
+          x: 0,
+          y: 0,
+        ),
+        techUnlocked: const {kTechIdMoldboardPlow: true},
+      ),
+    ],
+  );
+}
+
+GameMapData provinceDetailMapDataForProjection() {
+  final tileMap = TileMapResult(
+    width: 1,
+    height: 1,
+    grid: const [
+      ['p1'],
+    ],
+    resourceGrid: const [
+      [Resource.grain],
+    ],
+  );
+  return (
+    combinedTopology: const MapTopology(
+      nodes: [
+        TopologyNode(
+          id: 'p1',
+          regionId: 'oldWorld',
+          type: TopologyNodeType.province,
+        ),
+      ],
+      edges: [],
+    ),
+    tileMapByRegion: {'oldWorld': tileMap},
+    topologyByRegion: const <String, MapTopology>{},
+    warpLinks: null,
+  );
+}
+
+Game provinceDetailUnresolvedExtractionGame() {
+  const provinceId = provinceDetailSupportProvinceId;
+  const tk = provinceDetailSupportTileKey;
+  return Game(
+    id: 'g_extraction_draft_ignore',
+    capitalTileGrainBonusPerTurn: 0,
+    worldState: WorldState(
+      turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 2),
+      oldWorld: RegionData(
+        provinces: [
+          Province(
+            id: provinceId,
+            regionId: 'oldWorld',
+            ownerId: 'gp1',
+            townDevelopmentLevel: 4,
+          ),
+        ],
+      ),
+      newWorld: const RegionData(),
+      tileState: const TileMapState(),
+      resourceByTileKey: const {tk: 'grain'},
+      tileKeysByRegionAndProvince: const {
+        'oldWorld': {
+          'oldWorld|p1': [tk],
+        },
+      },
+    ),
+    players: [
+      Player(
+        id: 'gp1',
+        displayName: 'GP',
+        isHuman: true,
+        capitalProvinceId: provinceId,
+        capitalTile: const CapitalTile(
+          regionId: 'oldWorld',
+          provinceId: 'oldWorld|p1',
+          x: 0,
+          y: 0,
+        ),
+        techUnlocked: const {kTechIdMoldboardPlow: true},
+      ),
+    ],
+  );
+}

--- a/app/test/province_detail_overlay_host_support_test.dart
+++ b/app/test/province_detail_overlay_host_support_test.dart
@@ -1,100 +1,13 @@
 // Unit pins for the shared province-detail overlay host support extracted in
 // Refs #3594 (work item 7 — resolve flame-host ↔ widget duplication/coupling).
-import 'package:colonizethis_app/core/services/game_service/game_service.dart'
-    show GameMapData;
-import 'package:colonizethis_app/features/game/flame/caches/per_player_work_target_selection_cache.dart';
 import 'package:colonizethis_app/features/game/flame/overlays/province_detail_overlay_host_support.dart';
-import 'package:colonizethis_data/colonizethis_data.dart'
-    show
-        MapTopology,
-        Resource,
-        TileMapResult,
-        TopologyNode,
-        TopologyNodeType,
-        kTechIdMoldboardPlow;
 import 'package:colonizethis_logic/colonizethis_logic.dart'
-    show PlayerView, buildPlayerView, kWorkTargetBuildImprovement;
-import 'package:colonizethis_map/colonizethis_map.dart';
+    show kWorkTargetBuildImprovement;
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter_test/flutter_test.dart';
 
-const String _kPlayerId = 'gp1';
-const String _kTileKey = 'oldWorld|p1|0|0';
-
-Game _minimalGame() => Game(
-      id: 'g_support',
-      worldState: const WorldState(
-        turnState: TurnState(phase: TurnPhase.orders, turnNumber: 1),
-        oldWorld: RegionData(provinces: [], units: []),
-        newWorld: RegionData(provinces: [], units: []),
-      ),
-      players: const [
-        Player(
-          id: _kPlayerId,
-          displayName: 'Human',
-          isHuman: true,
-          capitalProvinceId: '',
-        ),
-      ],
-      minorNations: const [],
-      tribes: const [],
-    );
-
-RegionMapViewData _emptyRegion() => const RegionMapViewData(
-      regionId: 'oldWorld',
-      width: 1,
-      height: 1,
-      cellSize: 16,
-      cells: [],
-      capitalMarkers: [],
-      portMarkers: [],
-      factionColors: {},
-      greatPowerFactionIds: {},
-      terrainColors: {},
-      provincePoliticalOwnerByPrefixedProvinceId: {},
-    );
-
-PlayerView _playerView(Game game) =>
-    buildPlayerView(game, const MapTopology(nodes: [], edges: []), _kPlayerId);
-
-ProvinceDetailShortcutCallbacks _callbacks({
-  required Game game,
-  required String? selectedTileKey,
-  required bool exploreEnabled,
-  required bool prospectEnabled,
-  required bool buildImprovementEnabled,
-  required bool buildRoadEnabled,
-  required bool buildFortEnabled,
-  required bool buildPortEnabled,
-  required bool purchaseLandEnabled,
-  bool upgradeTownEnabled = false,
-  String? upgradeTownTargetTileKey,
-  String provinceId = 'oldWorld|p1',
-  required AppEventBus bus,
-}) =>
-    buildProvinceDetailShortcutCallbacks(
-      game: game,
-      humanPlayerId: _kPlayerId,
-      region: _emptyRegion(),
-      playerView: _playerView(game),
-      workTargetSelectionCache:
-          PerPlayerWorkTargetSelectionCache(strategies: const {}),
-      draftOrders: const Orders(),
-      mapData: null,
-      selectedTileKey: selectedTileKey,
-      exploreEnabled: exploreEnabled,
-      prospectEnabled: prospectEnabled,
-      buildImprovementEnabled: buildImprovementEnabled,
-      buildRoadEnabled: buildRoadEnabled,
-      buildFortEnabled: buildFortEnabled,
-      buildPortEnabled: buildPortEnabled,
-      purchaseLandEnabled: purchaseLandEnabled,
-      provinceId: provinceId,
-      upgradeTownEnabled: upgradeTownEnabled,
-      upgradeTownTargetTileKey: upgradeTownTargetTileKey,
-      bus: bus,
-    );
+import 'province_detail_overlay_host_support_fixtures.dart';
 
 void main() {
   suppressLogsForTests();
@@ -102,14 +15,20 @@ void main() {
   group('resolveProvinceDetailDisplayId', () {
     test('returns empty string for a null tile key', () {
       expect(
-        resolveProvinceDetailDisplayId(region: _emptyRegion(), tileKey: null),
+        resolveProvinceDetailDisplayId(
+          region: provinceDetailEmptyRegion(),
+          tileKey: null,
+        ),
         isEmpty,
       );
     });
 
     test('returns empty string for an empty tile key', () {
       expect(
-        resolveProvinceDetailDisplayId(region: _emptyRegion(), tileKey: ''),
+        resolveProvinceDetailDisplayId(
+          region: provinceDetailEmptyRegion(),
+          tileKey: '',
+        ),
         isEmpty,
       );
     });
@@ -127,8 +46,8 @@ void main() {
     });
 
     test('returns all-null callbacks when no tile is selected', () {
-      final callbacks = _callbacks(
-        game: _minimalGame(),
+      final callbacks = provinceDetailCallbacks(
+        game: provinceDetailMinimalGame(),
         selectedTileKey: null,
         exploreEnabled: true,
         prospectEnabled: true,
@@ -148,9 +67,9 @@ void main() {
     });
 
     test('returns all-null callbacks when every action is disabled', () {
-      final callbacks = _callbacks(
-        game: _minimalGame(),
-        selectedTileKey: _kTileKey,
+      final callbacks = provinceDetailCallbacks(
+        game: provinceDetailMinimalGame(),
+        selectedTileKey: provinceDetailSupportTileKey,
         exploreEnabled: false,
         prospectEnabled: false,
         buildImprovementEnabled: false,
@@ -169,9 +88,9 @@ void main() {
     });
 
     test('exposes only the enabled action callback (per-action gating)', () {
-      final exploreOnly = _callbacks(
-        game: _minimalGame(),
-        selectedTileKey: _kTileKey,
+      final exploreOnly = provinceDetailCallbacks(
+        game: provinceDetailMinimalGame(),
+        selectedTileKey: provinceDetailSupportTileKey,
         exploreEnabled: true,
         prospectEnabled: false,
         buildImprovementEnabled: false,
@@ -187,9 +106,9 @@ void main() {
       expect(exploreOnly.onBuildRoadTap, isNull);
       expect(exploreOnly.onPurchaseLandTap, isNull);
 
-      final prospectOnly = _callbacks(
-        game: _minimalGame(),
-        selectedTileKey: _kTileKey,
+      final prospectOnly = provinceDetailCallbacks(
+        game: provinceDetailMinimalGame(),
+        selectedTileKey: provinceDetailSupportTileKey,
         exploreEnabled: false,
         prospectEnabled: true,
         buildImprovementEnabled: false,
@@ -205,9 +124,9 @@ void main() {
       expect(prospectOnly.onBuildRoadTap, isNull);
       expect(prospectOnly.onPurchaseLandTap, isNull);
 
-      final buildOnly = _callbacks(
-        game: _minimalGame(),
-        selectedTileKey: _kTileKey,
+      final buildOnly = provinceDetailCallbacks(
+        game: provinceDetailMinimalGame(),
+        selectedTileKey: provinceDetailSupportTileKey,
         exploreEnabled: false,
         prospectEnabled: false,
         buildImprovementEnabled: true,
@@ -223,9 +142,9 @@ void main() {
       expect(buildOnly.onBuildRoadTap, isNull);
       expect(buildOnly.onPurchaseLandTap, isNull);
 
-      final buildRoadOnly = _callbacks(
-        game: _minimalGame(),
-        selectedTileKey: _kTileKey,
+      final buildRoadOnly = provinceDetailCallbacks(
+        game: provinceDetailMinimalGame(),
+        selectedTileKey: provinceDetailSupportTileKey,
         exploreEnabled: false,
         prospectEnabled: false,
         buildImprovementEnabled: false,
@@ -241,9 +160,9 @@ void main() {
       expect(buildRoadOnly.onBuildRoadTap, isNotNull);
       expect(buildRoadOnly.onPurchaseLandTap, isNull);
 
-      final purchaseLandOnly = _callbacks(
-        game: _minimalGame(),
-        selectedTileKey: _kTileKey,
+      final purchaseLandOnly = provinceDetailCallbacks(
+        game: provinceDetailMinimalGame(),
+        selectedTileKey: provinceDetailSupportTileKey,
         exploreEnabled: false,
         prospectEnabled: false,
         buildImprovementEnabled: false,
@@ -262,86 +181,15 @@ void main() {
   });
 
   group('provinceExtractionSnapshotPreview projection (Refs #4064)', () {
-    const provinceId = 'oldWorld|p1';
-    const tk = 'oldWorld|p1|0|0';
-
-    Game gameWithImprovedGrain({required String ownerId}) {
-      return Game(
-        id: 'g_extraction_preview',
-        capitalTileGrainBonusPerTurn: 0,
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 2),
-          oldWorld: RegionData(
-            provinces: [
-              Province(
-                id: provinceId,
-                regionId: 'oldWorld',
-                ownerId: ownerId,
-                townDevelopmentLevel: 4,
-              ),
-            ],
-          ),
-          newWorld: const RegionData(),
-          tileState: TileMapState().setImprovement(tk, 2).setRoadLevel(tk, 4),
-          resourceByTileKey: const {tk: 'grain'},
-          tileKeysByRegionAndProvince: const {
-            'oldWorld': {
-              'oldWorld|p1': [tk],
-            },
-          },
-        ),
-        players: [
-          Player(
-            id: ownerId,
-            displayName: 'GP',
-            isHuman: true,
-            capitalProvinceId: provinceId,
-            capitalTile: const CapitalTile(
-              regionId: 'oldWorld',
-              provinceId: 'oldWorld|p1',
-              x: 0,
-              y: 0,
-            ),
-            techUnlocked: const {kTechIdMoldboardPlow: true},
-          ),
-        ],
-      );
-    }
-
-    GameMapData mapDataForProjection() {
-      final tileMap = TileMapResult(
-        width: 1,
-        height: 1,
-        grid: const [
-          ['p1'],
-        ],
-        resourceGrid: const [
-          [Resource.grain],
-        ],
-      );
-      return (
-        combinedTopology: const MapTopology(
-          nodes: [
-            TopologyNode(
-              id: 'p1',
-              regionId: 'oldWorld',
-              type: TopologyNodeType.province,
-            ),
-          ],
-          edges: [],
-        ),
-        tileMapByRegion: {'oldWorld': tileMap},
-        topologyByRegion: const <String, MapTopology>{},
-        warpLinks: null,
-      );
-    }
+    const provinceId = provinceDetailSupportProvinceId;
+    const tk = provinceDetailSupportTileKey;
 
     test('projects non-empty Extraction without last-turn history', () {
-      final game = gameWithImprovedGrain(ownerId: 'gp1');
+      final game = provinceDetailGameWithImprovedGrain(ownerId: 'gp1');
       final snap = provinceExtractionSnapshotPreview(
         game: game,
         provinceId: provinceId,
-        mapData: mapDataForProjection(),
+        mapData: provinceDetailMapDataForProjection(),
       );
       expect(snap, isNotNull);
       expect(snap!.ownerId, 'gp1');
@@ -351,9 +199,9 @@ void main() {
     test(
       'ownership change: preview attributes to new owner without Extraction write',
       () {
-        final mapData = mapDataForProjection();
+        final mapData = provinceDetailMapDataForProjection();
         final before = provinceExtractionSnapshotPreview(
-          game: gameWithImprovedGrain(ownerId: 'gp1'),
+          game: provinceDetailGameWithImprovedGrain(ownerId: 'gp1'),
           provinceId: provinceId,
           mapData: mapData,
         );
@@ -362,7 +210,7 @@ void main() {
         expect(before.byCommodity['grain']!.full, greaterThan(0));
 
         final after = provinceExtractionSnapshotPreview(
-          game: gameWithImprovedGrain(ownerId: 'gp2'),
+          game: provinceDetailGameWithImprovedGrain(ownerId: 'gp2'),
           provinceId: provinceId,
           mapData: mapData,
         );
@@ -374,7 +222,7 @@ void main() {
     );
 
     test('returns null when map data is missing', () {
-      final game = gameWithImprovedGrain(ownerId: 'gp1');
+      final game = provinceDetailGameWithImprovedGrain(ownerId: 'gp1');
       expect(
         provinceExtractionSnapshotPreview(
           game: game,
@@ -391,48 +239,8 @@ void main() {
       () {
         // Host preview has no draftOrders parameter; staged WorkOrders must not
         // invent yields until turn resolution updates Game.tileState.
-        final unresolved = Game(
-          id: 'g_extraction_draft_ignore',
-          capitalTileGrainBonusPerTurn: 0,
-          worldState: WorldState(
-            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 2),
-            oldWorld: RegionData(
-              provinces: [
-                Province(
-                  id: provinceId,
-                  regionId: 'oldWorld',
-                  ownerId: 'gp1',
-                  townDevelopmentLevel: 4,
-                ),
-              ],
-            ),
-            newWorld: const RegionData(),
-            // No improvement yet — draft build_improvement would raise this.
-            tileState: const TileMapState(),
-            resourceByTileKey: const {tk: 'grain'},
-            tileKeysByRegionAndProvince: const {
-              'oldWorld': {
-                'oldWorld|p1': [tk],
-              },
-            },
-          ),
-          players: [
-            Player(
-              id: 'gp1',
-              displayName: 'GP',
-              isHuman: true,
-              capitalProvinceId: provinceId,
-              capitalTile: const CapitalTile(
-                regionId: 'oldWorld',
-                provinceId: 'oldWorld|p1',
-                x: 0,
-                y: 0,
-              ),
-              techUnlocked: const {kTechIdMoldboardPlow: true},
-            ),
-          ],
-        );
-        final mapData = mapDataForProjection();
+        final unresolved = provinceDetailUnresolvedExtractionGame();
+        final mapData = provinceDetailMapDataForProjection();
         final beforeDraft = provinceExtractionSnapshotPreview(
           game: unresolved,
           provinceId: provinceId,
@@ -440,7 +248,6 @@ void main() {
         );
         expect(beforeDraft?.byCommodity['grain'], isNull);
 
-        // Local draft Orders exist mid-turn but are never passed into preview.
         final draftOrders = Orders(
           workOrdersByPlayerId: {
             'gp1': [
@@ -461,7 +268,7 @@ void main() {
         );
         expect(afterDraftPresence, beforeDraft);
 
-        final resolved = gameWithImprovedGrain(ownerId: 'gp1');
+        final resolved = provinceDetailGameWithImprovedGrain(ownerId: 'gp1');
         final afterResolution = provinceExtractionSnapshotPreview(
           game: resolved,
           provinceId: provinceId,

--- a/tool/check_app_test_file_size.dart
+++ b/tool/check_app_test_file_size.dart
@@ -18,13 +18,7 @@ const String _appTestsRelativePath = 'app/test';
 /// Oversized `app/test/**` files accepted as a shrink-only baseline (Refs #4352).
 /// Remove an entry only after the file is at or under [_maxPhysicalLines].
 const List<String> appTestFileSizeAllowlistForTests = <String>[
-  'app/test/app_event_handler_scope_part1_test.dart',
-  'app/test/app_event_handler_scope_part2_test.dart',
   'app/test/app_event_handler_test.dart',
-  'app/test/civilian_units_panel_part1_test.dart',
-  'app/test/civilian_units_panel_part2_test.dart',
-  'app/test/civilian_units_panel_part3_test.dart',
-  'app/test/ct_region_map_widget_part2_test.dart',
   'app/test/ct_spacing_features_adoption_test.dart',
   'app/test/ct_toggle_switch_test.dart',
   'app/test/debug_console_overlay_panel_test.dart',
@@ -46,9 +40,6 @@ const List<String> appTestFileSizeAllowlistForTests = <String>[
   'app/test/overture_dialogue_overlay_test.dart',
   'app/test/panels_320dp_min_viewport_test.dart',
   'app/test/pause_menu_side_menu_specs_test.dart',
-  'app/test/production_panel_part1_test.dart',
-  'app/test/production_panel_part2_test.dart',
-  'app/test/province_detail_overlay_host_support_test.dart',
   'app/test/province_overlay_extraction_available_test.dart',
   'app/test/screen_spec_acceptance_part2_test.dart',
   'app/test/trade_screen_deal_book_tab_e6_test.dart',


### PR DESCRIPTION
## Summary
- Continue #4352 Slice D: densify nine allowlisted `app/test/**` suites to ≤400 physical lines via shared fixture/support libraries (no new mechanical `*_partN` shards).
- Shrink `appTestFileSizeAllowlistForTests` accordingly (40 → 31).

## Done in this push
- Event-handler scope part1/2 + fixtures
- Civilian units panel part1–3 + shortcut/cancel/pending supports
- Production panel part1/2 + helpers/labour support
- CtRegionMap part2 + support
- Province detail overlay host support + fixtures
- Allowlist shrink in `tool/check_app_test_file_size.dart`

## Remaining for #4352
- Empty the remaining shrink-only allowlist (~31 files) for AC8
- Finish AC10 densify for remaining non-`_partN` dense suites (diplomacy/naval/trade/etc.)

## Manual
- N/A — structure/tests only (AC11)

## Test plan
- [x] `dart run tool/check_app_test_file_size.dart`
- [x] `flutter test` on densified suites listed above

Refs #4352

Made with [Cursor](https://cursor.com)