### PR TITLE
chore: sync AI suite-size lint titles to 400 (#4365)

### DIFF
--- a/test/check_ai_expand_peace_pin_suite_size_test.dart
+++ b/test/check_ai_expand_peace_pin_suite_size_test.dart
@@ -7,6 +7,10 @@ import '../tool/check_ai_expand_peace_pin_suite_size.dart';
 
 void main() {
   group('runCheckAiExpandPeacePinSuiteSize', () {
+    test('ceiling is 400 after #4365 Slice B', () {
+      expect(expandPeacePinSuitePhysicalLineCeiling, 400);
+    });
+
     test('fails when an oversize peace pin has no *_cases.dart import', () {
       final temp = Directory.systemTemp.createTempSync('ai-peace-size-');
       try {

--- a/test/check_ai_planning_cases_suite_size_test.dart
+++ b/test/check_ai_planning_cases_suite_size_test.dart
@@ -7,6 +7,10 @@ import '../tool/check_ai_planning_cases_suite_size.dart';
 
 void main() {
   group('runCheckAiPlanningCasesSuiteSize', () {
+    test('ceiling is 400 after #4365 Slice B', () {
+      expect(aiPlanningCasesSuitePhysicalLineCeiling, 400);
+    });
+
     test('fails when an in-scope *_cases.dart exceeds the ceiling', () {
       final temp = Directory.systemTemp.createTempSync('ai-cases-size-');
       try {
@@ -31,11 +35,7 @@ void main() {
     test('passes when an in-scope *_cases.dart is under the ceiling', () {
       final temp = Directory.systemTemp.createTempSync('ai-cases-size-ok-');
       try {
-        _writeCases(
-          temp,
-          'thin_cases.dart',
-          'void registerThin() {}\n',
-        );
+        _writeCases(temp, 'thin_cases.dart', 'void registerThin() {}\n');
         final exitCode = runCheckAiPlanningCasesSuiteSize(
           temp.path,
           info: (_) {},
@@ -53,9 +53,7 @@ void main() {
         final planning = Directory(
           p.join(temp.path, 'packages', 'colonizethis_ai', 'test', 'planning'),
         )..createSync(recursive: true);
-        File(
-          p.join(planning.path, 'fat_test.dart'),
-        ).writeAsStringSync(
+        File(p.join(planning.path, 'fat_test.dart')).writeAsStringSync(
           '${List.filled(700, '// pad').join('\n')}\nvoid main() {}\n',
         );
         final exitCode = runCheckAiPlanningCasesSuiteSize(

--- a/test/check_ai_residual_fat_pin_suite_size_test.dart
+++ b/test/check_ai_residual_fat_pin_suite_size_test.dart
@@ -7,6 +7,10 @@ import '../tool/check_ai_residual_fat_pin_suite_size.dart';
 
 void main() {
   group('runCheckAiResidualFatPinSuiteSize', () {
+    test('ceiling is 400 after #4365 Slice B', () {
+      expect(residualFatPinSuitePhysicalLineCeiling, 400);
+    });
+
     test('fails when gated residual fat pin is oversize without cases', () {
       final temp = Directory.systemTemp.createTempSync('ai-residual-fat-');
       try {
@@ -39,8 +43,8 @@ void main() {
           temp,
           'treasury_planner_treasury_budget_test.dart',
           "import 'treasury_planner_treasury_budget_deficit_clamp_cases.dart';\n"
-          '${List.filled(800, '// pad').join('\n')}\n'
-          'void main() {}\n',
+              '${List.filled(800, '// pad').join('\n')}\n'
+              'void main() {}\n',
         );
         final exitCode = runCheckAiResidualFatPinSuiteSize(
           temp.path,

--- a/test/check_ai_s7d_support_suite_size_test.dart
+++ b/test/check_ai_s7d_support_suite_size_test.dart
@@ -7,6 +7,10 @@ import '../tool/check_ai_s7d_support_suite_size.dart';
 
 void main() {
   group('runCheckAiS7dSupportSuiteSize', () {
+    test('ceiling is 400 after #4365 Slice B', () {
+      expect(aiS7dSupportSuitePhysicalLineCeiling, 400);
+    });
+
     test('fails when an S7D support module exceeds the soft ceiling', () {
       final temp = Directory.systemTemp.createTempSync('ai-s7d-over-');
       try {
@@ -58,14 +62,7 @@ void main() {
 
 void _writeS7dModule(Directory temp, String basename, String body) {
   final dir = Directory(
-    p.join(
-      temp.path,
-      'packages',
-      'colonizethis_ai',
-      'test',
-      'support',
-      's7d',
-    ),
+    p.join(temp.path, 'packages', 'colonizethis_ai', 'test', 'support', 's7d'),
   )..createSync(recursive: true);
   File(p.join(dir.path, basename)).writeAsStringSync(body);
 }

--- a/test/ct_repo_lint_test.dart
+++ b/test/ct_repo_lint_test.dart
@@ -124,6 +124,25 @@ void main() {
   });
 
   group('manifest file', () {
+    test('AI suite-size titles advertise 400 after #4365 Slice B', () {
+      final rules = loadRepoLintManifest(
+        repoRoot,
+        'tool/ct_repo_lint_manifest.yaml',
+      );
+      const ids = <String>[
+        'repo.ai_planning_cases_suite_size',
+        'repo.ai_expand_peace_pin_cases_required',
+        'repo.ai_residual_fat_pin_cases_required',
+        'repo.ai_s7d_support_suite_size',
+      ];
+      for (final id in ids) {
+        final title = rules.firstWhere((r) => r.ruleId == id).title;
+        expect(title, contains('400 physical lines'), reason: id);
+        expect(title, isNot(contains('450 physical lines')), reason: id);
+        expect(title, contains('#4365 Slice B'), reason: id);
+      }
+    });
+
     test('version and rules list are present', () {
       final f = File('$repoRoot/tool/ct_repo_lint_manifest.yaml');
       final doc = loadYaml(f.readAsStringSync()) as YamlMap;

--- a/tool/ct_repo_lint_manifest.yaml
+++ b/tool/ct_repo_lint_manifest.yaml
@@ -1664,7 +1664,7 @@ rules:
 
   - rule_id: repo.ai_expand_peace_pin_cases_required
     group: testing
-    title: colonizethis_ai expand_phase_planner_*peace*_test.dart contracts above 450 physical lines must import a sibling *_cases.dart (Refs #3977, #4104 Slice C, #4310 Slice D)
+    title: "colonizethis_ai expand_phase_planner_*peace*_test.dart contracts above 400 physical lines must import a sibling *_cases.dart (Refs #3977, #4104 Slice C, #4310 Slice D, #4365 Slice B)"
     spec: SPEC/program/repo-lint.md
     runner: dart
     script: tool/check_ai_expand_peace_pin_suite_size.dart
@@ -1902,21 +1902,21 @@ rules:
 
   - rule_id: repo.ai_planning_cases_suite_size
     group: testing
-    title: colonizethis_ai test/planning/*_cases.dart modules must stay at or under 450 physical lines unless registered as an indivisible allowlist entry with issue Ref (Refs #3997, #4104 Slice C, #4310 Slice D)
+    title: "colonizethis_ai test/planning/*_cases.dart modules must stay at or under 400 physical lines unless registered as an indivisible allowlist entry with issue Ref (Refs #3997, #4104 Slice C, #4310 Slice D, #4365 Slice B)"
     spec: SPEC/program/repo-lint.md
     runner: dart
     script: tool/check_ai_planning_cases_suite_size.dart
 
   - rule_id: repo.ai_residual_fat_pin_cases_required
     group: testing
-    title: colonizethis_ai residual fat-pin contracts (Phase-8/9/10 gated basenames) above 450 physical lines must import a sibling *_cases.dart (Refs #3997, #4079, #4104 Slice C, #4310 Slice D)
+    title: "colonizethis_ai residual fat-pin contracts (Phase-8/9/10 gated basenames) above 400 physical lines must import a sibling *_cases.dart (Refs #3997, #4079, #4104 Slice C, #4310 Slice D, #4365 Slice B)"
     spec: SPEC/program/repo-lint.md
     runner: dart
     script: tool/check_ai_residual_fat_pin_suite_size.dart
 
   - rule_id: repo.ai_s7d_support_suite_size
     group: testing
-    title: colonizethis_ai test/support/s7d/*.dart modules must stay at or under 450 physical lines (Refs #3997, #4079, #4104 Slice C, #4310 Slice A)
+    title: "colonizethis_ai test/support/s7d/*.dart modules must stay at or under 400 physical lines (Refs #3997, #4079, #4104 Slice C, #4310 Slice A, #4365 Slice B)"
     spec: SPEC/program/repo-lint.md
     runner: dart
     script: tool/check_ai_s7d_support_suite_size.dart


### PR DESCRIPTION
## Summary
- Close the remaining #4365 verification gap: `tool/ct_repo_lint_manifest.yaml` titles for the four Slice B suite-size rules still advertised **450** after PR #4376 ratcheted the Dart checkers to **400**.
- Quote those titles so YAML does not treat `(Refs #…)` as comments.

## Done in this push
- `repo.ai_planning_cases_suite_size`
- `repo.ai_expand_peace_pin_cases_required`
- `repo.ai_residual_fat_pin_cases_required`
- `repo.ai_s7d_support_suite_size`
- Title pin in `test/ct_repo_lint_test.dart` (400 present, 450 absent, `#4365 Slice B` present).
- Ceiling `== 400` pins on the four matching `test/check_ai_*_test.dart` files.

## Remaining / deferred
- Functional Slices A–C already merged in #4376.
- Leave the issue open for `verify-github-issue` after this PR merges.

## Manual
N/A — lint catalog titles and checker pins only; no player-visible UX/gameplay change.

## Test plan
- [x] `dart test test/ct_repo_lint_test.dart test/check_ai_planning_cases_suite_size_test.dart test/check_ai_expand_peace_pin_suite_size_test.dart test/check_ai_residual_fat_pin_suite_size_test.dart test/check_ai_s7d_support_suite_size_test.dart`
- [ ] CI Quality on this PR (do not wait in-agent)

Refs #4365

Made with [Cursor](https://cursor.com)