### PR TITLE
refactor: densify nine more app-test allowlist suites under 400 lines (#4352)

### DIFF
--- a/app/test/app_event_handler_test.dart
+++ b/app/test/app_event_handler_test.dart
@@ -3,7 +3,6 @@
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/misc.dart' show Override;
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:colonizethis_app/config/route_paths.dart';
@@ -14,6 +13,7 @@ import 'package:colonizethis_app/features/game/widgets/combat/quick_battle_resul
 import 'package:colonizethis_app/features/game/widgets/panels/pause_menu_panel.dart';
 import 'package:colonizethis_app/providers/turn_resolution_blocking_provider.dart';
 
+import 'app_event_handler_test_support.dart';
 import 'app_shell_harness.dart';
 
 void main() {
@@ -28,18 +28,7 @@ void main() {
       AppEventBus.reset();
       bus = AppEventBus.create();
       navKey = GlobalKey<NavigatorState>();
-      handler = AppEventHandler(
-        bus: bus,
-        navigatorKey: navKey,
-        dialogBuilders: {
-          'test_dialog': (ctx, params) =>
-              Material(child: Text('dialog:${params?['id'] ?? 'default'}')),
-        },
-        panelBuilders: {
-          'test_panel': (ctx, params) =>
-              Material(child: Text('panel:${params?['id'] ?? 'default'}')),
-        },
-      );
+      handler = buildTestAppEventHandler(bus: bus, navigatorKey: navKey);
     });
 
     tearDown(() {
@@ -47,46 +36,16 @@ void main() {
       AppEventBus.reset();
     });
 
-    Future<void> pumpEmitButton(
-      WidgetTester tester, {
-      required String label,
-      required VoidCallback onPressed,
-      RouteFactory? onGenerateRoute,
-      Widget? home,
-      List<Override> overrides = const <Override>[],
-    }) async {
-      // Editorial shell via buildAppShell (Refs #4035 — no inline MaterialApp).
-      await tester.pumpWidget(
-        buildAppShell(
-          navigatorKey: navKey,
-          onGenerateRoute: onGenerateRoute,
-          overrides: overrides,
-          child: home ??
-              Builder(
-                builder: (ctx) => TextButton(
-                  onPressed: onPressed,
-                  child: Text(label),
-                ),
-              ),
-        ),
-      );
-      await tester.pumpAndSettle();
-    }
-
-    Future<void> tapLabel(WidgetTester tester, String label) async {
-      await tester.tap(find.text(label));
-      await tester.pumpAndSettle();
-    }
-
     testWidgets('OpenDialogEvent opens registered dialog', (tester) async {
       handler.bind();
-      await pumpEmitButton(
+      await pumpAppEventHandlerEmitButton(
         tester,
+        navigatorKey: navKey,
         label: 'open',
         onPressed: () =>
             bus.emit(const OpenDialogEvent('test_dialog', {'id': '42'})),
       );
-      await tapLabel(tester, 'open');
+      await tapAppEventHandlerLabel(tester, 'open');
       expect(find.text('dialog:42'), findsOneWidget);
     });
 
@@ -94,20 +53,22 @@ void main() {
       tester,
     ) async {
       handler.bind();
-      await pumpEmitButton(
+      await pumpAppEventHandlerEmitButton(
         tester,
+        navigatorKey: navKey,
         label: 'open',
         onPressed: () => bus.emit(const OpenDialogEvent('unknown_dialog')),
       );
-      await tapLabel(tester, 'open');
+      await tapAppEventHandlerLabel(tester, 'open');
       expect(find.byType(AlertDialog), findsNothing);
     });
 
     testWidgets('NavigateToRouteEvent calls pushNamed', (tester) async {
       handler.bind();
       final pushed = <RouteSettings?>[];
-      await pumpEmitButton(
+      await pumpAppEventHandlerEmitButton(
         tester,
+        navigatorKey: navKey,
         label: 'navigate',
         onGenerateRoute: (settings) {
           pushed.add(settings);
@@ -119,7 +80,7 @@ void main() {
         onPressed: () =>
             bus.emit(const NavigateToRouteEvent('/target', {'x': 1})),
       );
-      await tapLabel(tester, 'navigate');
+      await tapAppEventHandlerLabel(tester, 'navigate');
       expect(pushed, hasLength(1));
       expect(pushed[0]?.name, '/target');
       expect(pushed[0]?.arguments, {'x': 1});
@@ -163,64 +124,63 @@ void main() {
       expect(find.text('base_route'), findsOneWidget);
     });
 
-    testWidgets(
-      'OpenPauseMenuPanelEvent opens centered PauseMenuPanel modal '
-      'with five action buttons',
-      (tester) async {
-        handler.bind();
-        await pumpEmitButton(
-          tester,
-          label: 'open',
-          overrides: [
-            turnResolutionBlockingProvider.overrideWith(
-              () => StateToggleNotifier(false),
-            ),
-          ],
-          home: Scaffold(
-            body: Builder(
-              builder: (context) => TextButton(
-                onPressed: () => bus.emit(const OpenPauseMenuPanelEvent()),
-                child: const Text('open'),
-              ),
+    testWidgets('OpenPauseMenuPanelEvent opens centered PauseMenuPanel modal '
+        'with five action buttons', (tester) async {
+      handler.bind();
+      await pumpAppEventHandlerEmitButton(
+        tester,
+        navigatorKey: navKey,
+        label: 'open',
+        overrides: [
+          turnResolutionBlockingProvider.overrideWith(
+            () => StateToggleNotifier(false),
+          ),
+        ],
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => TextButton(
+              onPressed: () => bus.emit(const OpenPauseMenuPanelEvent()),
+              child: const Text('open'),
             ),
           ),
-          onPressed: () {},
-        );
-        await tapLabel(tester, 'open');
-        expect(find.byType(PauseMenuPanel), findsOneWidget);
-        expect(find.text('Resume'), findsOneWidget);
-        expect(find.text('Save Game'), findsOneWidget);
-        expect(find.text('Load Game'), findsOneWidget);
-        expect(find.text('Settings'), findsOneWidget);
-        expect(find.text('Exit to Main Menu'), findsOneWidget);
-        // Debug log was moved to GameSideMenu in the redesign.
-        expect(find.text('Debug log'), findsNothing);
-      },
-    );
+        ),
+        onPressed: () {},
+      );
+      await tapAppEventHandlerLabel(tester, 'open');
+      expect(find.byType(PauseMenuPanel), findsOneWidget);
+      expect(find.text('Resume'), findsOneWidget);
+      expect(find.text('Save Game'), findsOneWidget);
+      expect(find.text('Load Game'), findsOneWidget);
+      expect(find.text('Settings'), findsOneWidget);
+      expect(find.text('Exit to Main Menu'), findsOneWidget);
+      // Debug log was moved to GameSideMenu in the redesign.
+      expect(find.text('Debug log'), findsNothing);
+    });
 
     testWidgets('OpenPanelEvent opens registered bottom sheet panel', (
       tester,
     ) async {
       handler.bind();
-      await pumpEmitButton(
+      await pumpAppEventHandlerEmitButton(
         tester,
+        navigatorKey: navKey,
         label: 'open panel',
-        onPressed: () => bus.emit(
-          const OpenPanelEvent('test_panel', {'id': 'panel42'}),
-        ),
+        onPressed: () =>
+            bus.emit(const OpenPanelEvent('test_panel', {'id': 'panel42'})),
       );
-      await tapLabel(tester, 'open panel');
+      await tapAppEventHandlerLabel(tester, 'open panel');
       expect(find.text('panel:panel42'), findsOneWidget);
     });
 
     testWidgets('OpenPanelEvent with unknown id shows nothing', (tester) async {
       handler.bind();
-      await pumpEmitButton(
+      await pumpAppEventHandlerEmitButton(
         tester,
+        navigatorKey: navKey,
         label: 'open',
         onPressed: () => bus.emit(const OpenPanelEvent('unknown_panel')),
       );
-      await tapLabel(tester, 'open');
+      await tapAppEventHandlerLabel(tester, 'open');
       expect(find.text('open'), findsOneWidget);
     });
 
@@ -228,14 +188,15 @@ void main() {
       tester,
     ) async {
       handler.bind();
-      await pumpEmitButton(
+      await pumpAppEventHandlerEmitButton(
         tester,
+        navigatorKey: navKey,
         label: 'trigger',
         onPressed: () => bus.emit(
           const ConfirmDialogEvent(title: 'Confirm', message: 'Proceed?'),
         ),
       );
-      await tapLabel(tester, 'trigger');
+      await tapAppEventHandlerLabel(tester, 'trigger');
       expect(find.text('Confirm'), findsOneWidget);
       expect(find.text('Proceed?'), findsOneWidget);
       expect(find.text('OK'), findsOneWidget);
@@ -247,8 +208,9 @@ void main() {
       (tester) async {
         handler.bind();
         bool? dialogResult;
-        await pumpEmitButton(
+        await pumpAppEventHandlerEmitButton(
           tester,
+          navigatorKey: navKey,
           label: 'open sheet',
           onPressed: () {},
           home: Builder(
@@ -274,11 +236,11 @@ void main() {
             ),
           ),
         );
-        await tapLabel(tester, 'open sheet');
-        await tapLabel(tester, 'emit from sheet');
+        await tapAppEventHandlerLabel(tester, 'open sheet');
+        await tapAppEventHandlerLabel(tester, 'emit from sheet');
         expect(find.text('Sheet confirm'), findsOneWidget);
         expect(find.text('From bottom sheet'), findsOneWidget);
-        await tapLabel(tester, 'OK');
+        await tapAppEventHandlerLabel(tester, 'OK');
         expect(dialogResult, isTrue);
       },
     );
@@ -293,8 +255,9 @@ void main() {
         onShowSnackBar: (e) => received = e,
       );
       handler.bind();
-      await pumpEmitButton(
+      await pumpAppEventHandlerEmitButton(
         tester,
+        navigatorKey: navKey,
         label: 'home',
         home: const Text('home'),
         onPressed: () {},
@@ -317,8 +280,9 @@ void main() {
         onDismissOverlay: (e) => received = e,
       );
       handler.bind();
-      await pumpEmitButton(
+      await pumpAppEventHandlerEmitButton(
         tester,
+        navigatorKey: navKey,
         label: 'home',
         home: const Text('home'),
         onPressed: () {},
@@ -372,8 +336,9 @@ void main() {
       'ClosePanelEvent then OpenDialogEvent opens dialog (handler ordering)',
       (tester) async {
         handler.bind();
-        await pumpEmitButton(
+        await pumpAppEventHandlerEmitButton(
           tester,
+          navigatorKey: navKey,
           label: 'home',
           home: const Scaffold(body: Text('home')),
           onPressed: () {},
@@ -402,8 +367,9 @@ void main() {
         handler.bind();
         CombatModeChosenEvent? chosen;
         bus.on<CombatModeChosenEvent>().listen((e) => chosen = e);
-        await pumpEmitButton(
+        await pumpAppEventHandlerEmitButton(
           tester,
+          navigatorKey: navKey,
           label: 'open',
           onPressed: () => bus.emit(
             const OpenDialogEvent('combat_mode_choice', {
@@ -412,8 +378,8 @@ void main() {
             }),
           ),
         );
-        await tapLabel(tester, 'open');
-        await tapLabel(tester, 'Quick Battle');
+        await tapAppEventHandlerLabel(tester, 'open');
+        await tapAppEventHandlerLabel(tester, 'Quick Battle');
         expect(chosen?.mode, CombatMode.quickBattle);
         expect(find.text('Combat at TestProv'), findsNothing);
       },
@@ -440,14 +406,14 @@ void main() {
         defenderCasualties: const [],
         provinceFlips: false,
       );
-      await pumpEmitButton(
+      await pumpAppEventHandlerEmitButton(
         tester,
+        navigatorKey: navKey,
         label: 'open',
-        onPressed: () => bus.emit(
-          OpenDialogEvent('quick_battle_result', {'result': qb}),
-        ),
+        onPressed: () =>
+            bus.emit(OpenDialogEvent('quick_battle_result', {'result': qb})),
       );
-      await tapLabel(tester, 'open');
+      await tapAppEventHandlerLabel(tester, 'open');
       expect(find.textContaining('Battle Result'), findsOneWidget);
       expect(find.textContaining('A wins'), findsOneWidget);
     });

--- a/app/test/app_event_handler_test_support.dart
+++ b/app/test/app_event_handler_test_support.dart
@@ -1,0 +1,69 @@
+// Pump helpers for AppEventHandler widget tests (Refs #4352).
+
+import 'package:colonizethis_app/core/services/app_event_handler/app_event_handler.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/misc.dart' show Override;
+import 'package:flutter_test/flutter_test.dart';
+
+import 'app_shell_harness.dart';
+
+AppEventHandler buildTestAppEventHandler({
+  required AppEventBus bus,
+  required GlobalKey<NavigatorState> navigatorKey,
+  Map<String, Widget Function(BuildContext, Map<String, Object?>?)>?
+  dialogBuilders,
+  Map<String, Widget Function(BuildContext, Map<String, Object?>?)>?
+  panelBuilders,
+  void Function(ShowSnackBarEvent event)? onShowSnackBar,
+  void Function(DismissOverlayEvent event)? onDismissOverlay,
+}) {
+  return AppEventHandler(
+    bus: bus,
+    navigatorKey: navigatorKey,
+    dialogBuilders:
+        dialogBuilders ??
+        {
+          'test_dialog': (ctx, params) =>
+              Material(child: Text('dialog:${params?['id'] ?? 'default'}')),
+        },
+    panelBuilders:
+        panelBuilders ??
+        {
+          'test_panel': (ctx, params) =>
+              Material(child: Text('panel:${params?['id'] ?? 'default'}')),
+        },
+    onShowSnackBar: onShowSnackBar,
+    onDismissOverlay: onDismissOverlay,
+  );
+}
+
+Future<void> pumpAppEventHandlerEmitButton(
+  WidgetTester tester, {
+  required GlobalKey<NavigatorState> navigatorKey,
+  required String label,
+  required VoidCallback onPressed,
+  RouteFactory? onGenerateRoute,
+  Widget? home,
+  List<Override> overrides = const <Override>[],
+}) async {
+  await tester.pumpWidget(
+    buildAppShell(
+      navigatorKey: navigatorKey,
+      onGenerateRoute: onGenerateRoute,
+      overrides: overrides,
+      child:
+          home ??
+          Builder(
+            builder: (ctx) =>
+                TextButton(onPressed: onPressed, child: Text(label)),
+          ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+Future<void> tapAppEventHandlerLabel(WidgetTester tester, String label) async {
+  await tester.tap(find.text(label));
+  await tester.pumpAndSettle();
+}

--- a/app/test/debug_console_overlay_panel_chrome_test.dart
+++ b/app/test/debug_console_overlay_panel_chrome_test.dart
@@ -1,0 +1,148 @@
+// DebugConsoleOverlayPanel editorial-monocle chrome pins (Refs #4352).
+
+import 'package:colonizethis_app/features/game/flame/overlays/debug_console_overlay_panel.dart';
+import 'package:colonizethis_app/widgets/ct_icon_action.dart';
+import 'package:colonizethis_app_ui_chrome/config/editorial_monocle_palette.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'debug_console_overlay_panel_test_support.dart';
+
+void main() {
+  suppressLogsForTests();
+
+  group('DebugConsoleOverlayPanel dark editorial-monocle chrome (Refs #2914 '
+      'S3 + S8)', () {
+    testWidgets(
+      'panel close affordance is a CtIconAction (no Material IconButton)',
+      (tester) async {
+        final bus = debugConsoleBus();
+        await pumpDebugConsolePanel(tester, bus: bus);
+
+        final closeFinder = find.byKey(DebugConsoleOverlayPanel.closeButtonKey);
+        expect(
+          closeFinder,
+          findsOneWidget,
+          reason:
+              'Refs #2914 S8 requires the catalog CtIconAction primitive '
+              '(not the banned Material IconButton) for the close affordance.',
+        );
+        expect(tester.widget(closeFinder), isA<CtIconAction>());
+        expect(
+          find.descendant(
+            of: find.byType(DebugConsoleOverlayPanel),
+            matching: find.byType(CtIconAction),
+          ),
+          findsOneWidget,
+        );
+        expect(
+          find.descendant(
+            of: find.byType(DebugConsoleOverlayPanel),
+            matching: find.byType(IconButton),
+          ),
+          findsNothing,
+          reason:
+              'Banned Material IconButton must not appear in the panel '
+              'subtree (Refs #2914 S8 / SPEC/ui/pixel-art-ui-catalog.md '
+              '§ Material design ban).',
+        );
+      },
+    );
+
+    testWidgets('tapping the CtIconAction close affordance invokes onClose', (
+      tester,
+    ) async {
+      final bus = debugConsoleBus();
+      var closeCount = 0;
+      await pumpDebugConsolePanel(
+        tester,
+        bus: bus,
+        onClose: () => closeCount += 1,
+      );
+
+      await tester.tap(find.byKey(DebugConsoleOverlayPanel.closeButtonKey));
+      await tester.pump();
+
+      expect(closeCount, 1);
+    });
+
+    testWidgets('header title text style colour resolves to '
+        'EditorialMonoclePalette.fg (no Material Colors.white)', (
+      tester,
+    ) async {
+      final bus = debugConsoleBus();
+      await pumpDebugConsolePanel(tester, bus: bus);
+
+      final headerText = tester.widget<Text>(find.text('Debug Console'));
+      expect(headerText.style?.color, EditorialMonoclePalette.fg);
+      expect(headerText.style?.fontWeight, FontWeight.w700);
+    });
+
+    testWidgets('TextField input style colour resolves to '
+        'EditorialMonoclePalette.fg (no Material Colors.white)', (
+      tester,
+    ) async {
+      final bus = debugConsoleBus();
+      await pumpDebugConsolePanel(tester, bus: bus);
+
+      final input = tester.widget<TextField>(find.byKey(debugConsoleInputKey));
+      expect(input.style?.color, EditorialMonoclePalette.fg);
+    });
+
+    testWidgets(
+      'TextField hint style colour resolves to EditorialMonoclePalette.muted '
+      'with the documented hint alpha (no Material Colors.white)',
+      (tester) async {
+        final bus = debugConsoleBus();
+        await pumpDebugConsolePanel(tester, bus: bus);
+
+        final input = tester.widget<TextField>(
+          find.byKey(debugConsoleInputKey),
+        );
+        final hintColor = input.decoration?.hintStyle?.color;
+        final expectedHint = EditorialMonoclePalette.muted.withValues(
+          alpha: DebugConsoleOverlayPanel.hintTextAlpha,
+        );
+        expect(hintColor, expectedHint);
+      },
+    );
+
+    testWidgets(
+      'TextField fill colour resolves to EditorialMonoclePalette.dialogScrim',
+      (tester) async {
+        final bus = debugConsoleBus();
+        await pumpDebugConsolePanel(tester, bus: bus);
+
+        final input = tester.widget<TextField>(
+          find.byKey(debugConsoleInputKey),
+        );
+        expect(input.decoration?.filled, isTrue);
+        expect(
+          input.decoration?.fillColor,
+          EditorialMonoclePalette.dialogScrim,
+        );
+      },
+    );
+
+    testWidgets('outer Material surface colour resolves to '
+        'EditorialMonoclePalette.bgDeep at the documented panel alpha '
+        '(no Material Colors.black)', (tester) async {
+      final bus = debugConsoleBus();
+      await pumpDebugConsolePanel(tester, bus: bus);
+
+      final panelMaterial = tester.widget<Material>(
+        find
+            .descendant(
+              of: find.byType(DebugConsoleOverlayPanel),
+              matching: find.byType(Material),
+            )
+            .first,
+      );
+      final expectedSurface = EditorialMonoclePalette.bgDeep.withValues(
+        alpha: DebugConsoleOverlayPanel.panelBackgroundAlpha,
+      );
+      expect(panelMaterial.color, expectedSurface);
+    });
+  });
+}

--- a/app/test/debug_console_overlay_panel_test.dart
+++ b/app/test/debug_console_overlay_panel_test.dart
@@ -1,6 +1,3 @@
-import 'package:colonizethis_app_ui_chrome/config/editorial_monocle_palette.dart';
-import 'package:colonizethis_app/features/game/flame/overlays/debug_console_overlay_panel.dart';
-import 'package:colonizethis_app/widgets/ct_icon_action.dart';
 import 'package:colonizethis_debug_console/colonizethis_debug_console.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
@@ -8,69 +5,24 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'app_shell_harness.dart';
-
-const _debugConsoleInputKey = ValueKey<String>('debug-console-input');
-
-AppEventBus _debugConsoleBus() {
-  final bus = AppEventBus.create();
-  addTearDown(bus.dispose);
-  return bus;
-}
-
-List<T> _listenDebugEvents<T extends AppEvent>(AppEventBus bus) {
-  final events = <T>[];
-  final sub = bus.on<T>().listen(events.add);
-  addTearDown(sub.cancel);
-  return events;
-}
-
-Future<void> _pumpDebugConsolePanel(
-  WidgetTester tester, {
-  required AppEventBus bus,
-  VoidCallback? onClose,
-  DebugConsoleReadOnlyContext Function()? readOnlyContextProvider,
-}) async {
-  // Editorial shell via buildAppShell (Refs #4035 — no inline MaterialApp).
-  await tester.pumpWidget(
-    buildAppShell(
-      child: Scaffold(
-        body: DebugConsoleOverlayPanel(
-          bus: bus,
-          humanPlayerId: 'human_1',
-          readOnlyContextProvider:
-              readOnlyContextProvider ??
-              () => const DebugConsoleReadOnlyContext(),
-          onClose: onClose ?? () {},
-        ),
-      ),
-    ),
-  );
-  await tester.pump();
-}
-
-Future<void> _submitDebugCommand(WidgetTester tester, String command) async {
-  await tester.enterText(find.byKey(_debugConsoleInputKey), command);
-  await tester.testTextInput.receiveAction(TextInputAction.done);
-  await tester.pump();
-}
+import 'debug_console_overlay_panel_test_support.dart';
 
 void main() {
   suppressLogsForTests();
 
   group('DebugConsoleOverlayPanel', () {
     testWidgets('submitting valid command emits spawn event', (tester) async {
-      final bus = _debugConsoleBus();
-      final events = _listenDebugEvents<SpawnDebugCivilianAtCapitalEvent>(bus);
-      final snackbars = _listenDebugEvents<ShowSnackBarEvent>(bus);
+      final bus = debugConsoleBus();
+      final events = listenDebugEvents<SpawnDebugCivilianAtCapitalEvent>(bus);
+      final snackbars = listenDebugEvents<ShowSnackBarEvent>(bus);
       var closed = false;
 
-      await _pumpDebugConsolePanel(
+      await pumpDebugConsolePanel(
         tester,
         bus: bus,
         onClose: () => closed = true,
       );
-      await _submitDebugCommand(tester, '/spawn_civilian explorer 2');
+      await submitDebugCommand(tester, '/spawn_civilian explorer 2');
 
       expect(events, hasLength(1));
       expect(events.single.humanPlayerId, 'human_1');
@@ -87,12 +39,12 @@ void main() {
     testWidgets('submitting valid add_money emits treasury credit event', (
       tester,
     ) async {
-      final bus = _debugConsoleBus();
-      final events = _listenDebugEvents<CreditDebugTreasuryEvent>(bus);
-      final snackbars = _listenDebugEvents<ShowSnackBarEvent>(bus);
+      final bus = debugConsoleBus();
+      final events = listenDebugEvents<CreditDebugTreasuryEvent>(bus);
+      final snackbars = listenDebugEvents<ShowSnackBarEvent>(bus);
 
-      await _pumpDebugConsolePanel(tester, bus: bus);
-      await _submitDebugCommand(tester, '/add_money 42');
+      await pumpDebugConsolePanel(tester, bus: bus);
+      await submitDebugCommand(tester, '/add_money 42');
 
       expect(events, hasLength(1));
       expect(events.single.humanPlayerId, 'human_1');
@@ -104,11 +56,11 @@ void main() {
     testWidgets('submitting valid spawn_regiment emits regiment event', (
       tester,
     ) async {
-      final bus = _debugConsoleBus();
-      final events = _listenDebugEvents<SpawnDebugRegimentAtCapitalEvent>(bus);
+      final bus = debugConsoleBus();
+      final events = listenDebugEvents<SpawnDebugRegimentAtCapitalEvent>(bus);
 
-      await _pumpDebugConsolePanel(tester, bus: bus);
-      await _submitDebugCommand(tester, '/spawn_regiment peasant_levies 2');
+      await pumpDebugConsolePanel(tester, bus: bus);
+      await submitDebugCommand(tester, '/spawn_regiment peasant_levies 2');
 
       expect(events, hasLength(1));
       expect(events.single.humanPlayerId, 'human_1');
@@ -119,12 +71,13 @@ void main() {
     testWidgets('submitting valid spawn_ship emits ship spawn event', (
       tester,
     ) async {
-      final bus = _debugConsoleBus();
-      final events =
-          _listenDebugEvents<SpawnDebugShipAtCapitalHomeFleetEvent>(bus);
+      final bus = debugConsoleBus();
+      final events = listenDebugEvents<SpawnDebugShipAtCapitalHomeFleetEvent>(
+        bus,
+      );
 
-      await _pumpDebugConsolePanel(tester, bus: bus);
-      await _submitDebugCommand(tester, '/spawn_ship carrack 2');
+      await pumpDebugConsolePanel(tester, bus: bus);
+      await submitDebugCommand(tester, '/spawn_ship carrack 2');
 
       expect(events, hasLength(1));
       expect(events.single.humanPlayerId, 'human_1');
@@ -133,11 +86,11 @@ void main() {
     });
 
     testWidgets('invalid command does not emit spawn event', (tester) async {
-      final bus = _debugConsoleBus();
-      final events = _listenDebugEvents<SpawnDebugCivilianAtCapitalEvent>(bus);
+      final bus = debugConsoleBus();
+      final events = listenDebugEvents<SpawnDebugCivilianAtCapitalEvent>(bus);
 
-      await _pumpDebugConsolePanel(tester, bus: bus);
-      await _submitDebugCommand(tester, '/spawn_civilian unknown_type');
+      await pumpDebugConsolePanel(tester, bus: bus);
+      await submitDebugCommand(tester, '/spawn_civilian unknown_type');
 
       expect(events, isEmpty);
     });
@@ -145,14 +98,11 @@ void main() {
     testWidgets('submitting flip_province emits ownership flip event', (
       tester,
     ) async {
-      final bus = _debugConsoleBus();
-      final events = _listenDebugEvents<FlipDebugProvinceOwnershipEvent>(bus);
+      final bus = debugConsoleBus();
+      final events = listenDebugEvents<FlipDebugProvinceOwnershipEvent>(bus);
 
-      await _pumpDebugConsolePanel(tester, bus: bus);
-      await _submitDebugCommand(
-        tester,
-        '/flip_province oldWorld New Bordeaux',
-      );
+      await pumpDebugConsolePanel(tester, bus: bus);
+      await submitDebugCommand(tester, '/flip_province oldWorld New Bordeaux');
 
       expect(events, hasLength(1));
       expect(events.single.humanPlayerId, 'human_1');
@@ -163,12 +113,11 @@ void main() {
     testWidgets(
       'submitting rail_builder command emits rail builder spawn event',
       (tester) async {
-        final bus = _debugConsoleBus();
-        final events =
-            _listenDebugEvents<SpawnDebugCivilianAtCapitalEvent>(bus);
+        final bus = debugConsoleBus();
+        final events = listenDebugEvents<SpawnDebugCivilianAtCapitalEvent>(bus);
 
-        await _pumpDebugConsolePanel(tester, bus: bus);
-        await _submitDebugCommand(tester, '/spawn_civilian rail_builder 3');
+        await pumpDebugConsolePanel(tester, bus: bus);
+        await submitDebugCommand(tester, '/spawn_civilian rail_builder 3');
 
         expect(events, hasLength(1));
         expect(events.single.unitType, kUnitTypeRailBuilder);
@@ -179,11 +128,11 @@ void main() {
     testWidgets('invalid command emits deterministic snackbar message', (
       tester,
     ) async {
-      final bus = _debugConsoleBus();
-      final snackbars = _listenDebugEvents<ShowSnackBarEvent>(bus);
+      final bus = debugConsoleBus();
+      final snackbars = listenDebugEvents<ShowSnackBarEvent>(bus);
 
-      await _pumpDebugConsolePanel(tester, bus: bus);
-      await _submitDebugCommand(tester, '/spawn_civilian unknown_type');
+      await pumpDebugConsolePanel(tester, bus: bus);
+      await submitDebugCommand(tester, '/spawn_civilian unknown_type');
 
       expect(snackbars, isNotEmpty);
       expect(
@@ -193,16 +142,16 @@ void main() {
     });
 
     testWidgets('escape key triggers panel close callback', (tester) async {
-      final bus = _debugConsoleBus();
+      final bus = debugConsoleBus();
       var closeCount = 0;
 
-      await _pumpDebugConsolePanel(
+      await pumpDebugConsolePanel(
         tester,
         bus: bus,
         onClose: () => closeCount += 1,
       );
 
-      await tester.tap(find.byKey(_debugConsoleInputKey));
+      await tester.tap(find.byKey(debugConsoleInputKey));
       await tester.pump();
       await tester.sendKeyEvent(LogicalKeyboardKey.escape);
       await tester.pump();
@@ -213,14 +162,14 @@ void main() {
     testWidgets('arrow up and down navigate submitted command history', (
       tester,
     ) async {
-      final bus = _debugConsoleBus();
+      final bus = debugConsoleBus();
 
-      await _pumpDebugConsolePanel(tester, bus: bus);
+      await pumpDebugConsolePanel(tester, bus: bus);
 
-      await _submitDebugCommand(tester, '/spawn_civilian explorer 1');
-      await _submitDebugCommand(tester, '/spawn_civilian builder 2');
+      await submitDebugCommand(tester, '/spawn_civilian explorer 1');
+      await submitDebugCommand(tester, '/spawn_civilian builder 2');
 
-      await tester.tap(find.byKey(_debugConsoleInputKey));
+      await tester.tap(find.byKey(debugConsoleInputKey));
       await tester.pump();
 
       await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
@@ -244,25 +193,25 @@ void main() {
     testWidgets('/get_tile_basic_info reads selectedTileKey at submit-time', (
       tester,
     ) async {
-      final bus = _debugConsoleBus();
-      final events = _listenDebugEvents<SessionCommandEvent>(bus);
-      final snackbars = _listenDebugEvents<ShowSnackBarEvent>(bus);
+      final bus = debugConsoleBus();
+      final events = listenDebugEvents<SessionCommandEvent>(bus);
+      final snackbars = listenDebugEvents<ShowSnackBarEvent>(bus);
       String? selectedTileKey = 'oldWorld|P12|34|21';
 
-      await _pumpDebugConsolePanel(
+      await pumpDebugConsolePanel(
         tester,
         bus: bus,
         readOnlyContextProvider: () =>
             DebugConsoleReadOnlyContext(selectedTileKey: selectedTileKey),
       );
 
-      await _submitDebugCommand(tester, '/get_tile_basic_info');
+      await submitDebugCommand(tester, '/get_tile_basic_info');
       expect(snackbars.last.message, contains('tile_id: oldWorld|P12|34|21'));
       expect(snackbars.last.message, contains('province_id: oldWorld|P12'));
       expect(events, isEmpty);
 
       selectedTileKey = 'oldWorld|P1|2|3';
-      await _submitDebugCommand(tester, '/get_tile_basic_info');
+      await submitDebugCommand(tester, '/get_tile_basic_info');
       expect(snackbars.last.message, contains('tile_id: oldWorld|P1|2|3'));
       expect(snackbars.last.message, contains('province_id: oldWorld|P1'));
       expect(events, isEmpty);
@@ -271,11 +220,11 @@ void main() {
     testWidgets('/list_players appends output and emits no session events', (
       tester,
     ) async {
-      final bus = _debugConsoleBus();
-      final events = _listenDebugEvents<SessionCommandEvent>(bus);
-      final snackbars = _listenDebugEvents<ShowSnackBarEvent>(bus);
+      final bus = debugConsoleBus();
+      final events = listenDebugEvents<SessionCommandEvent>(bus);
+      final snackbars = listenDebugEvents<ShowSnackBarEvent>(bus);
 
-      await _pumpDebugConsolePanel(
+      await pumpDebugConsolePanel(
         tester,
         bus: bus,
         readOnlyContextProvider: () => DebugConsoleReadOnlyContext(
@@ -290,163 +239,11 @@ void main() {
         ),
       );
 
-      await _submitDebugCommand(tester, '/list_players');
+      await submitDebugCommand(tester, '/list_players');
 
       expect(snackbars.last.message, contains('players_count: 1'));
       expect(snackbars.last.message, contains('player_id: p1'));
       expect(events, isEmpty);
     });
-  });
-
-  group('DebugConsoleOverlayPanel dark editorial-monocle chrome (Refs #2914 '
-      'S3 + S8)', () {
-    testWidgets(
-      'panel close affordance is a CtIconAction (no Material IconButton)',
-      (tester) async {
-        final bus = _debugConsoleBus();
-        await _pumpDebugConsolePanel(tester, bus: bus);
-
-        final closeFinder = find.byKey(
-          DebugConsoleOverlayPanel.closeButtonKey,
-        );
-        expect(
-          closeFinder,
-          findsOneWidget,
-          reason:
-              'Refs #2914 S8 requires the catalog CtIconAction primitive '
-              '(not the banned Material IconButton) for the close affordance.',
-        );
-        // The keyed widget itself must be the CtIconAction catalog primitive.
-        expect(
-          tester.widget(closeFinder),
-          isA<CtIconAction>(),
-        );
-        expect(
-          find.descendant(
-            of: find.byType(DebugConsoleOverlayPanel),
-            matching: find.byType(CtIconAction),
-          ),
-          findsOneWidget,
-        );
-        expect(
-          find.descendant(
-            of: find.byType(DebugConsoleOverlayPanel),
-            matching: find.byType(IconButton),
-          ),
-          findsNothing,
-          reason:
-              'Banned Material IconButton must not appear in the panel '
-              'subtree (Refs #2914 S8 / SPEC/ui/pixel-art-ui-catalog.md '
-              '\u00a7 Material design ban).',
-        );
-      },
-    );
-
-    testWidgets(
-      'tapping the CtIconAction close affordance invokes onClose',
-      (tester) async {
-        final bus = _debugConsoleBus();
-        var closeCount = 0;
-        await _pumpDebugConsolePanel(
-          tester,
-          bus: bus,
-          onClose: () => closeCount += 1,
-        );
-
-        await tester.tap(
-          find.byKey(DebugConsoleOverlayPanel.closeButtonKey),
-        );
-        await tester.pump();
-
-        expect(closeCount, 1);
-      },
-    );
-
-    testWidgets(
-      'header title text style colour resolves to '
-      'EditorialMonoclePalette.fg (no Material Colors.white)',
-      (tester) async {
-        final bus = _debugConsoleBus();
-        await _pumpDebugConsolePanel(tester, bus: bus);
-
-        final headerText = tester.widget<Text>(
-          find.text('Debug Console'),
-        );
-        expect(headerText.style?.color, EditorialMonoclePalette.fg);
-        expect(headerText.style?.fontWeight, FontWeight.w700);
-      },
-    );
-
-    testWidgets(
-      'TextField input style colour resolves to '
-      'EditorialMonoclePalette.fg (no Material Colors.white)',
-      (tester) async {
-        final bus = _debugConsoleBus();
-        await _pumpDebugConsolePanel(tester, bus: bus);
-
-        final input = tester.widget<TextField>(
-          find.byKey(_debugConsoleInputKey),
-        );
-        expect(input.style?.color, EditorialMonoclePalette.fg);
-      },
-    );
-
-    testWidgets(
-      'TextField hint style colour resolves to EditorialMonoclePalette.muted '
-      'with the documented hint alpha (no Material Colors.white)',
-      (tester) async {
-        final bus = _debugConsoleBus();
-        await _pumpDebugConsolePanel(tester, bus: bus);
-
-        final input = tester.widget<TextField>(
-          find.byKey(_debugConsoleInputKey),
-        );
-        final hintColor = input.decoration?.hintStyle?.color;
-        final expectedHint = EditorialMonoclePalette.muted.withValues(
-          alpha: DebugConsoleOverlayPanel.hintTextAlpha,
-        );
-        expect(hintColor, expectedHint);
-      },
-    );
-
-    testWidgets(
-      'TextField fill colour resolves to EditorialMonoclePalette.dialogScrim',
-      (tester) async {
-        final bus = _debugConsoleBus();
-        await _pumpDebugConsolePanel(tester, bus: bus);
-
-        final input = tester.widget<TextField>(
-          find.byKey(_debugConsoleInputKey),
-        );
-        expect(input.decoration?.filled, isTrue);
-        expect(
-          input.decoration?.fillColor,
-          EditorialMonoclePalette.dialogScrim,
-        );
-      },
-    );
-
-    testWidgets(
-      'outer Material surface colour resolves to '
-      'EditorialMonoclePalette.bgDeep at the documented panel alpha '
-      '(no Material Colors.black)',
-      (tester) async {
-        final bus = _debugConsoleBus();
-        await _pumpDebugConsolePanel(tester, bus: bus);
-
-        final panelMaterial = tester.widget<Material>(
-          find
-              .descendant(
-                of: find.byType(DebugConsoleOverlayPanel),
-                matching: find.byType(Material),
-              )
-              .first,
-        );
-        final expectedSurface = EditorialMonoclePalette.bgDeep.withValues(
-          alpha: DebugConsoleOverlayPanel.panelBackgroundAlpha,
-        );
-        expect(panelMaterial.color, expectedSurface);
-      },
-    );
   });
 }

--- a/app/test/debug_console_overlay_panel_test_support.dart
+++ b/app/test/debug_console_overlay_panel_test_support.dart
@@ -1,0 +1,53 @@
+// Pump/listen helpers for DebugConsoleOverlayPanel widget tests (Refs #4352).
+
+import 'package:colonizethis_app/features/game/flame/overlays/debug_console_overlay_panel.dart';
+import 'package:colonizethis_debug_console/colonizethis_debug_console.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'app_shell_harness.dart';
+
+const debugConsoleInputKey = ValueKey<String>('debug-console-input');
+
+AppEventBus debugConsoleBus() {
+  final bus = AppEventBus.create();
+  addTearDown(bus.dispose);
+  return bus;
+}
+
+List<T> listenDebugEvents<T extends AppEvent>(AppEventBus bus) {
+  final events = <T>[];
+  final sub = bus.on<T>().listen(events.add);
+  addTearDown(sub.cancel);
+  return events;
+}
+
+Future<void> pumpDebugConsolePanel(
+  WidgetTester tester, {
+  required AppEventBus bus,
+  VoidCallback? onClose,
+  DebugConsoleReadOnlyContext Function()? readOnlyContextProvider,
+}) async {
+  await tester.pumpWidget(
+    buildAppShell(
+      child: Scaffold(
+        body: DebugConsoleOverlayPanel(
+          bus: bus,
+          humanPlayerId: 'human_1',
+          readOnlyContextProvider:
+              readOnlyContextProvider ??
+              () => const DebugConsoleReadOnlyContext(),
+          onClose: onClose ?? () {},
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+Future<void> submitDebugCommand(WidgetTester tester, String command) async {
+  await tester.enterText(find.byKey(debugConsoleInputKey), command);
+  await tester.testTextInput.receiveAction(TextInputAction.done);
+  await tester.pump();
+}

--- a/app/test/diplomacy_panel_chrome_test.dart
+++ b/app/test/diplomacy_panel_chrome_test.dart
@@ -1,328 +1,159 @@
-// DiplomacyPanel chrome tests: row chrome, relation-state badges, and the
-// danger-variant war action button. Split from `diplomacy_panel_test.dart`
-// to keep each file under `repo.dart_file_non_comment_line_size` (1000
-// non-comment lines). SPEC/ui/diplomacy-panel.md § Per-faction row.
+// DiplomacyPanel editorial-monocle chrome pins (Refs #4352).
+// SPEC: SPEC/ui/diplomacy-panel.md.
 
-import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_app_ui_chrome/config/editorial_monocle_palette.dart';
+import 'package:colonizethis_app/features/game/widgets/diplomacy/diplomacy_panel.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:colonizethis_app_ui_chrome/config/editorial_monocle_palette.dart';
-import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
-
-import 'diplomacy_panel_test_support.dart';
-import 'panel_test_fixtures.dart';
+import 'diplomacy_panel_widget_harness.dart';
 import 'widget_test_assets.dart';
 
 void main() {
   suppressLogsForTests();
 
-  late Game gameWithFactions;
-  late String humanPlayerId;
-  late MapTopology topology;
+  late DiplomacyPanelRichFixture fixture;
 
-  setUp(() {
-    AppEventBus.reset();
-  });
+  setUp(() => AppEventBus.reset());
 
   setUpAll(() async {
     await preloadNinePatchImage();
-    // Refs #3656: lightweight discovered-GP fixture replaces the ~7-11s
-    // getDebugInitGameResult() map generation. These chrome suites only read a
-    // discovered Great Power row (relation badges + action buttons), which the
-    // fixture's at-peace gp1↔gp2 relation provides; no generated map/topology
-    // data is consumed.
-    gameWithFactions = buildDiplomacyPanelTestGame();
-    topology = const MapTopology();
-    humanPlayerId = gameWithFactions.players.isNotEmpty
-        ? gameWithFactions.players.first.id
-        : 'gp1';
+    fixture = DiplomacyPanelRichFixture.create();
   });
 
-  group('DiplomacyPanel relation-state badge (editorial-monocle)', () {
-    Game gameWithWarRelation(Game source, String otherFactionId) {
-      // Replace any existing relation between humanPlayerId ↔ otherFactionId
-      // with an at-war pair so the panel always renders at least one WAR
-      // badge for the assertion.
-      bool involvesPair(DiplomacyRelation r) =>
-          (r.factionId1 == humanPlayerId && r.factionId2 == otherFactionId) ||
-          (r.factionId1 == otherFactionId && r.factionId2 == humanPlayerId);
-      final updated = [
-        for (final r in source.diplomacyRelations)
-          if (!involvesPair(r)) r,
-        DiplomacyRelation(
-          factionId1: humanPlayerId,
-          factionId2: otherFactionId,
-          score: 10,
-          state: RelationState.atWar,
-          sinceTurn: 0,
-        ),
-      ];
-      return source.copyWith(diplomacyRelations: updated);
+  Future<void> pumpDefault(WidgetTester tester) =>
+      pumpDiplomacyPanelOnTallSurface(
+        tester,
+        game: fixture.gameWithFactions,
+        humanPlayerId: fixture.humanPlayerId,
+        topology: fixture.topology,
+      );
+
+  group('DiplomacyPanel section headings (editorial-monocle)', () {
+    testWidgets('AC: Section heading text resolves to --accent color', (
+      WidgetTester tester,
+    ) async {
+      await pumpDefault(tester);
+      final heading = tester.widget<Text>(find.text('Great Powers'));
+      expect(heading.style?.color, EditorialMonoclePalette.accent);
+      expect(heading.style?.fontFamily, 'Cinzel');
+    });
+
+    testWidgets(
+      'AC: Section heading container exposes a 2 px --accent-dim bottom border',
+      (WidgetTester tester) async {
+        await pumpDefault(tester);
+        final decorated = find.ancestor(
+          of: find.text('Great Powers'),
+          matching: find.byType(DecoratedBox),
+        );
+        expect(decorated, findsAtLeastNWidgets(1));
+        final box = tester.widget<DecoratedBox>(decorated.first);
+        final decoration = box.decoration as BoxDecoration;
+        expect(
+          decoration.border!.bottom.color,
+          EditorialMonoclePalette.accentDim,
+        );
+        expect(decoration.border!.bottom.width, 2);
+      },
+    );
+  });
+
+  group('DiplomacyPanel faction kind badges (editorial-monocle)', () {
+    Future<List<DiplomacyRowData>> rows(WidgetTester tester) async {
+      await pumpDefault(tester);
+      return buildDiplomacyRows(
+        fixture.gameWithFactions,
+        fixture.topology,
+        fixture.humanPlayerId,
+        const Orders(),
+      );
     }
 
     testWidgets(
-      'AC: WAR badge foreground resolves to --danger',
+      'AC: GP badge background --accent-dim and foreground --bg-deep',
       (WidgetTester tester) async {
-        await bindDiplomacyTallTestSurface(tester);
-        final otherGp = gameWithFactions.players.firstWhere(
-          (p) => p.id != humanPlayerId,
-        );
-        final warGame = gameWithWarRelation(gameWithFactions, otherGp.id);
-        await tester.pumpWidget(
-          buildDiplomacyPanel(
-            game: warGame,
-            humanPlayerId: humanPlayerId,
-            topology: topology,
-          ),
-        );
-        await pumpDiplomacyPanelBuilt(tester);
-
-        final warText = find.text('WAR');
-        expect(warText, findsAtLeastNWidgets(1));
-        final widget = tester.widget<Text>(warText.first);
-        expect(
-          widget.style?.color,
-          EditorialMonoclePalette.danger,
-          reason: 'WAR badge foreground must resolve to --danger.',
-        );
-        expect(
-          widget.style?.fontFamily,
-          'monospace',
-          reason: 'WAR badge label must use the mono font stack.',
-        );
-      },
-    );
-
-    testWidgets(
-      'AC: PEACE badge foreground resolves to --success',
-      (WidgetTester tester) async {
-        await bindDiplomacyTallTestSurface(tester);
-        await tester.pumpWidget(
-          buildDiplomacyPanel(
-            game: gameWithFactions,
-            humanPlayerId: humanPlayerId,
-            topology: topology,
-          ),
-        );
-        await pumpDiplomacyPanelBuilt(tester);
-
-        final peaceText = find.text('PEACE');
-        if (peaceText.evaluate().isEmpty) {
-          // Debug-init game may have all relations at-war by default;
-          // skip rather than fail.
-          return;
-        }
-        final widget = tester.widget<Text>(peaceText.first);
-        expect(
-          widget.style?.color,
-          EditorialMonoclePalette.success,
-          reason: 'PEACE badge foreground must resolve to --success.',
-        );
-        expect(
-          widget.style?.fontFamily,
-          'monospace',
-          reason: 'PEACE badge label must use the mono font stack.',
-        );
-      },
-    );
-
-    testWidgets(
-      'AC: WAR badge background derives from --danger hue at alpha 0.40',
-      (WidgetTester tester) async {
-        await bindDiplomacyTallTestSurface(tester);
-        final otherGp = gameWithFactions.players.firstWhere(
-          (p) => p.id != humanPlayerId,
-        );
-        final warGame = gameWithWarRelation(gameWithFactions, otherGp.id);
-        await tester.pumpWidget(
-          buildDiplomacyPanel(
-            game: warGame,
-            humanPlayerId: humanPlayerId,
-            topology: topology,
-          ),
-        );
-        await pumpDiplomacyPanelBuilt(tester);
-
-        // Mockup token: oklch(40% 0.06 20 / 0.4).
-        final Color expectedBg =
-            oklchToColor(const OklchToken(0.40, 0.06, 20))
-                .withValues(alpha: 0.4);
-        final warText = find.text('WAR');
-        expect(warText, findsAtLeastNWidgets(1));
+        final panelRows = await rows(tester);
+        if (!panelRows.any((r) => r.kind == FactionKind.greatPower)) return;
+        final gpText = find.text('GP').first;
         final container = tester.widget<Container>(
-          find.ancestor(of: warText.first, matching: find.byType(Container))
-              .first,
+          find.ancestor(of: gpText, matching: find.byType(Container)).first,
         );
         final decoration = container.decoration as BoxDecoration;
+        expect(decoration.color, EditorialMonoclePalette.accentDim);
+        expect(decoration.border, isNull);
         expect(
-          decoration.color,
-          expectedBg,
-          reason:
-              'WAR badge background must derive from the danger hue at alpha 0.4.',
+          tester.widget<Text>(gpText).style?.color,
+          EditorialMonoclePalette.bgDeep,
         );
-        expect(decoration.border, isNull,
-            reason: 'WAR badge must not draw an outline border.');
       },
     );
 
-    testWidgets(
-      'AC: PEACE badge background derives from --success hue at alpha 0.20',
-      (WidgetTester tester) async {
-        await bindDiplomacyTallTestSurface(tester);
-        await tester.pumpWidget(
-          buildDiplomacyPanel(
-            game: gameWithFactions,
-            humanPlayerId: humanPlayerId,
-            topology: topology,
-          ),
-        );
-        await pumpDiplomacyPanelBuilt(tester);
+    testWidgets('AC: Minor badge background --muted and foreground --bg-deep', (
+      WidgetTester tester,
+    ) async {
+      final panelRows = await rows(tester);
+      if (!panelRows.any((r) => r.kind == FactionKind.minor)) return;
+      final minorText = find.text('Minor').first;
+      final container = tester.widget<Container>(
+        find.ancestor(of: minorText, matching: find.byType(Container)).first,
+      );
+      final decoration = container.decoration as BoxDecoration;
+      expect(decoration.color, EditorialMonoclePalette.muted);
+      expect(decoration.border, isNull);
+      expect(
+        tester.widget<Text>(minorText).style?.color,
+        EditorialMonoclePalette.bgDeep,
+      );
+    });
 
-        final peaceText = find.text('PEACE');
-        if (peaceText.evaluate().isEmpty) return;
-        final Color expectedBg =
-            oklchToColor(const OklchToken(0.40, 0.06, 150))
-                .withValues(alpha: 0.2);
+    testWidgets(
+      'AC: Tribe badge outlined with --muted border, transparent background',
+      (WidgetTester tester) async {
+        final panelRows = await rows(tester);
+        final tribeRows = panelRows
+            .where((r) => r.kind == FactionKind.tribe)
+            .toList();
+        if (tribeRows.isEmpty) return;
+        final tribeRow = tribeRows.first;
+        final tribeText = find.descendant(
+          of: find.byKey(
+            ValueKey('$kDiplomacyRowBodyKeyPrefix${tribeRow.factionId}'),
+          ),
+          matching: find.text('Tribe'),
+        );
+        await tester.scrollUntilVisible(
+          tribeText,
+          120,
+          scrollable: find.byType(Scrollable).first,
+        );
+        await tester.pump();
         final container = tester.widget<Container>(
-          find.ancestor(of: peaceText.first, matching: find.byType(Container))
-              .first,
+          find.ancestor(of: tribeText, matching: find.byType(Container)).first,
         );
         final decoration = container.decoration as BoxDecoration;
+        expect(decoration.color, isNull);
+        expect(decoration.border!.top.color, EditorialMonoclePalette.muted);
         expect(
-          decoration.color,
-          expectedBg,
-          reason:
-              'PEACE badge background must derive from the success hue at alpha 0.2.',
-        );
-        expect(decoration.border, isNull,
-            reason: 'PEACE badge must not draw an outline border.');
-      },
-    );
-  });
-
-  group('DiplomacyPanel faction-row chrome (editorial-monocle)', () {
-    testWidgets(
-      'AC: Faction row paints --bg-deep → --surface vertical gradient and --border outline',
-      (WidgetTester tester) async {
-        await bindDiplomacyTallTestSurface(tester);
-        await tester.pumpWidget(
-          buildDiplomacyPanel(
-            game: gameWithFactions,
-            humanPlayerId: humanPlayerId,
-            topology: topology,
-          ),
-        );
-        await pumpDiplomacyPanelBuilt(tester);
-
-        // Locate the first AnimatedContainer that wraps a faction row
-        // (the row chrome lives inside _DiplomacyRowChrome → MouseRegion →
-        // AnimatedContainer per diplomacy_panel_chrome.dart).
-        final containers = find.byType(AnimatedContainer);
-        BoxDecoration? rowDecoration;
-        for (final element in containers.evaluate()) {
-          final w = element.widget as AnimatedContainer;
-          final deco = w.decoration;
-          if (deco is! BoxDecoration) continue;
-          final gradient = deco.gradient;
-          if (gradient is! LinearGradient) continue;
-          if (gradient.colors.length != 2) continue;
-          // Match against the canonical row gradient (bg-deep → surface).
-          if (gradient.colors[0] == EditorialMonoclePalette.bgDeep &&
-              gradient.colors[1] == EditorialMonoclePalette.surface) {
-            rowDecoration = deco;
-            break;
-          }
-        }
-        expect(
-          rowDecoration,
-          isNotNull,
-          reason:
-              'At least one faction row must paint the canonical --bg-deep → --surface vertical gradient.',
-        );
-        final LinearGradient gradient = rowDecoration!.gradient as LinearGradient;
-        expect(gradient.begin, Alignment.topCenter,
-            reason: 'Row gradient must flow top → bottom (180deg).');
-        expect(gradient.end, Alignment.bottomCenter);
-        expect(rowDecoration.border, isNotNull,
-            reason: 'Row chrome must draw a 1 px outline.');
-        final BorderSide side = rowDecoration.border!.top;
-        expect(side.width, 1);
-        expect(
-          side.color,
-          EditorialMonoclePalette.border,
-          reason: 'Idle row outline must resolve to --border.',
-        );
-      },
-    );
-  });
-
-  group('DiplomacyPanel war-action button (editorial-monocle danger variant)',
-      () {
-    testWidgets(
-      'AC: Declare War button resolves border and label to --danger',
-      (WidgetTester tester) async {
-        await bindDiplomacyTallTestSurface(tester);
-        await tester.pumpWidget(
-          buildDiplomacyPanel(
-            game: gameWithFactions,
-            humanPlayerId: humanPlayerId,
-            topology: topology,
-          ),
-        );
-        await pumpDiplomacyPanelBuilt(tester);
-
-        final warBtn = find.text('Declare War');
-        if (warBtn.evaluate().isEmpty) return;
-        final button = tester.widget<CtNinePatchButton>(
-          find
-              .ancestor(of: warBtn, matching: find.byType(CtNinePatchButton))
-              .first,
-        );
-        expect(
-          button.dangerVariant,
-          isTrue,
-          reason:
-              'Declare War button must opt into the CtNinePatchButton danger variant.',
+          tester.widget<Text>(tribeText).style?.color,
+          EditorialMonoclePalette.muted,
         );
       },
     );
 
     testWidgets(
-      'AC: Non-war action buttons do not opt into the danger variant',
+      'AC: No badge uses raw Material chrome (Colors.blue/grey/orange)',
       (WidgetTester tester) async {
-        await bindDiplomacyTallTestSurface(tester);
-        await tester.pumpWidget(
-          buildDiplomacyPanel(
-            game: gameWithFactions,
-            humanPlayerId: humanPlayerId,
-            topology: topology,
-          ),
-        );
-        await pumpDiplomacyPanelBuilt(tester);
-
-        const nonWarLabels = [
-          'Offer Peace',
-          'Alliance',
-          'Grant Aid',
-          'Set Subsidy',
-        ];
-        for (final label in nonWarLabels) {
+        await pumpDefault(tester);
+        for (final label in ['GP', 'Minor', 'Tribe']) {
           final finder = find.text(label);
           if (finder.evaluate().isEmpty) continue;
-          final button = tester.widget<CtNinePatchButton>(
-            find
-                .ancestor(of: finder, matching: find.byType(CtNinePatchButton))
-                .first,
-          );
-          expect(
-            button.dangerVariant,
-            isFalse,
-            reason:
-                'Non-war action button "$label" must keep the default brass variant.',
-          );
+          final color = tester.widget<Text>(finder.first).style?.color;
+          expect(color, isNot(equals(Colors.blue)));
+          expect(color, isNot(equals(Colors.grey)));
+          expect(color, isNot(equals(Colors.orange)));
         }
       },
     );

--- a/app/test/diplomacy_panel_orders_pump_support.dart
+++ b/app/test/diplomacy_panel_orders_pump_support.dart
@@ -74,6 +74,33 @@ Orders diplomacyPendingOrders(DiplomaticOrder order) {
   );
 }
 
+Game diplomacyColonyGame({List<BoycottState> boycotts = const []}) {
+  return buildDiplomacyPanelTestGame().copyWith(
+    colonyStates: const [
+      ColonyState(
+        tribeId: 't1',
+        colonyOfGpId: diplomacyOrdersHumanId,
+        sinceTurn: 1,
+      ),
+    ],
+    tribes: const [Tribe(id: 't1', displayName: 'Aztec')],
+    boycottStates: boycotts,
+  );
+}
+
+Game diplomacyMinorEmbassyGame({List<SubsidyState> subsidies = const []}) {
+  return buildDiplomacyRichPanelTestGame().copyWith(
+    overtureStates: const [
+      OvertureState(
+        gpId: diplomacyOrdersHumanId,
+        targetId: diplomacyOrdersMinorId,
+        stage: OvertureStage.embassy,
+      ),
+    ],
+    subsidyStates: subsidies,
+  );
+}
+
 Future<ConfirmDialogEvent> awaitConfirmOnDiplomacyActionTap(
   WidgetTester tester, {
   required Game game,
@@ -83,10 +110,9 @@ Future<ConfirmDialogEvent> awaitConfirmOnDiplomacyActionTap(
   bool tall = false,
 }) async {
   final eventBus = bus ?? AppEventBus.create();
-  final confirmFuture = eventBus
-      .on<ConfirmDialogEvent>()
-      .first
-      .timeout(const Duration(seconds: 2));
+  final confirmFuture = eventBus.on<ConfirmDialogEvent>().first.timeout(
+    const Duration(seconds: 2),
+  );
   await pumpDiplomacyOrdersPanel(
     tester,
     game: game,

--- a/app/test/diplomacy_panel_orders_test.dart
+++ b/app/test/diplomacy_panel_orders_test.dart
@@ -11,29 +11,6 @@ import 'diplomacy_panel_orders_pump_support.dart';
 import 'panel_test_fixtures.dart';
 import 'widget_test_assets.dart';
 
-Game _colonyGame({List<BoycottState> boycotts = const []}) {
-  return buildDiplomacyPanelTestGame().copyWith(
-    colonyStates: const [
-      ColonyState(tribeId: 't1', colonyOfGpId: diplomacyOrdersHumanId, sinceTurn: 1),
-    ],
-    tribes: const [Tribe(id: 't1', displayName: 'Aztec')],
-    boycottStates: boycotts,
-  );
-}
-
-Game _minorEmbassyGame({List<SubsidyState> subsidies = const []}) {
-  return buildDiplomacyRichPanelTestGame().copyWith(
-    overtureStates: const [
-      OvertureState(
-        gpId: diplomacyOrdersHumanId,
-        targetId: diplomacyOrdersMinorId,
-        stage: OvertureStage.embassy,
-      ),
-    ],
-    subsidyStates: subsidies,
-  );
-}
-
 void main() {
   suppressLogsForTests();
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -72,12 +49,16 @@ void main() {
       final game = buildDiplomacyPanelTestGame();
       final humanId = game.players.firstWhere((p) => p.isHuman).id;
       final bus = AppEventBus.create();
-      final appendFuture = awaitDiplomacyBusEvent<AppendDiplomaticOrderRequestedEvent>(
-        bus,
-      );
+      final appendFuture =
+          awaitDiplomacyBusEvent<AppendDiplomaticOrderRequestedEvent>(bus);
       autoConfirmDiplomacyDialogs(bus);
 
-      await pumpDiplomacyOrdersPanel(tester, game: game, humanId: humanId, bus: bus);
+      await pumpDiplomacyOrdersPanel(
+        tester,
+        game: game,
+        humanId: humanId,
+        bus: bus,
+      );
 
       const actionLabels = <String>['Declare War', 'Offer Peace', 'Alliance'];
       Finder? actionFinder;
@@ -115,10 +96,17 @@ void main() {
       );
       final humanId = game.players.firstWhere((p) => p.isHuman).id;
       final bus = AppEventBus.create();
-      final breakFuture = awaitDiplomacyBusEvent<BreakAllianceImmediatelyEvent>(bus);
+      final breakFuture = awaitDiplomacyBusEvent<BreakAllianceImmediatelyEvent>(
+        bus,
+      );
       autoConfirmDiplomacyDialogs(bus);
 
-      await pumpDiplomacyOrdersPanel(tester, game: game, humanId: humanId, bus: bus);
+      await pumpDiplomacyOrdersPanel(
+        tester,
+        game: game,
+        humanId: humanId,
+        bus: bus,
+      );
       await tapVisibleDiplomacy(tester, find.text('Break Alliance'));
 
       final event = await breakFuture;
@@ -134,9 +122,8 @@ void main() {
       final humanId = game.players.firstWhere((p) => p.isHuman).id;
       final target = game.players.firstWhere((p) => p.id != humanId).id;
       final bus = AppEventBus.create();
-      final removeFuture = awaitDiplomacyBusEvent<RemoveDiplomaticOrderRequestedEvent>(
-        bus,
-      );
+      final removeFuture =
+          awaitDiplomacyBusEvent<RemoveDiplomaticOrderRequestedEvent>(bus);
 
       await pumpDiplomacyOrdersPanel(
         tester,
@@ -160,73 +147,41 @@ void main() {
   );
 
   group('Boycott controls (Refs #3753 S14)', () {
-    testWidgets(
-      'colony holder shows Boycott enabled on GP row',
-      (WidgetTester tester) async {
-        final bus = AppEventBus.create();
-        final appendFuture =
-            awaitDiplomacyBusEvent<AppendDiplomaticOrderRequestedEvent>(bus);
-        autoConfirmDiplomacyDialogs(bus);
+    testWidgets('colony holder shows Boycott enabled on GP row', (
+      WidgetTester tester,
+    ) async {
+      final bus = AppEventBus.create();
+      final appendFuture =
+          awaitDiplomacyBusEvent<AppendDiplomaticOrderRequestedEvent>(bus);
+      autoConfirmDiplomacyDialogs(bus);
 
-        await pumpDiplomacyOrdersPanel(tester, game: _colonyGame(), bus: bus);
-        expect(find.text('Boycott'), findsOneWidget);
-        // Revoke Boycott is disabled until a boycott is active (Refs #4265 More).
-        expect(find.text('Revoke Boycott'), findsNothing);
+      await pumpDiplomacyOrdersPanel(
+        tester,
+        game: diplomacyColonyGame(),
+        bus: bus,
+      );
+      expect(find.text('Boycott'), findsOneWidget);
+      // Revoke Boycott is disabled until a boycott is active (Refs #4265 More).
+      expect(find.text('Revoke Boycott'), findsNothing);
 
-        await tapVisibleDiplomacy(tester, find.text('Boycott'));
-        final event = await appendFuture;
-        expect(event.playerId, diplomacyOrdersHumanId);
-        expect(event.order.type, DiplomaticOrderType.boycott);
-        expect(event.order.targetFactionId, diplomacyOrdersGp2);
-      },
-    );
+      await tapVisibleDiplomacy(tester, find.text('Boycott'));
+      final event = await appendFuture;
+      expect(event.playerId, diplomacyOrdersHumanId);
+      expect(event.order.type, DiplomaticOrderType.boycott);
+      expect(event.order.targetFactionId, diplomacyOrdersGp2);
+    });
 
-    testWidgets(
-      'active boycott shows Revoke Boycott enabled on GP row',
-      (WidgetTester tester) async {
-        final bus = AppEventBus.create();
-        final appendFuture =
-            awaitDiplomacyBusEvent<AppendDiplomaticOrderRequestedEvent>(bus);
-        autoConfirmDiplomacyDialogs(bus);
+    testWidgets('active boycott shows Revoke Boycott enabled on GP row', (
+      WidgetTester tester,
+    ) async {
+      final bus = AppEventBus.create();
+      final appendFuture =
+          awaitDiplomacyBusEvent<AppendDiplomaticOrderRequestedEvent>(bus);
+      autoConfirmDiplomacyDialogs(bus);
 
-        await pumpDiplomacyOrdersPanel(
-          tester,
-          game: _colonyGame(
-            boycotts: const [
-              BoycottState(
-                gpId: diplomacyOrdersHumanId,
-                targetGpId: diplomacyOrdersGp2,
-                sinceTurn: 1,
-              ),
-            ],
-          ),
-          bus: bus,
-        );
-        expect(find.text('Revoke Boycott'), findsOneWidget);
-
-        await tapVisibleDiplomacy(tester, find.text('Revoke Boycott'));
-        final event = await appendFuture;
-        expect(event.playerId, diplomacyOrdersHumanId);
-        expect(event.order.type, DiplomaticOrderType.revokeBoycott);
-        expect(event.order.targetFactionId, diplomacyOrdersGp2);
-      },
-    );
-
-    for (final c in <({
-      String name,
-      Game Function() game,
-      DiplomaticOrderType type,
-      String hiddenLabel,
-    })>[
-      (
-        name: 'pending boycott shows Cancel and removes on tap',
-        game: _colonyGame,
-        type: DiplomaticOrderType.boycott,
-        hiddenLabel: 'Boycott',
-      ),
-      (
-        name: 'pending revokeBoycott shows Cancel and removes on tap',
-        game: () => _colonyGame(
+      await pumpDiplomacyOrdersPanel(
+        tester,
+        game: diplomacyColonyGame(
           boycotts: const [
             BoycottState(
               gpId: diplomacyOrdersHumanId,
@@ -235,10 +190,47 @@ void main() {
             ),
           ],
         ),
-        type: DiplomaticOrderType.revokeBoycott,
-        hiddenLabel: 'Revoke Boycott',
-      ),
-    ]) {
+        bus: bus,
+      );
+      expect(find.text('Revoke Boycott'), findsOneWidget);
+
+      await tapVisibleDiplomacy(tester, find.text('Revoke Boycott'));
+      final event = await appendFuture;
+      expect(event.playerId, diplomacyOrdersHumanId);
+      expect(event.order.type, DiplomaticOrderType.revokeBoycott);
+      expect(event.order.targetFactionId, diplomacyOrdersGp2);
+    });
+
+    for (final c
+        in <
+          ({
+            String name,
+            Game Function() game,
+            DiplomaticOrderType type,
+            String hiddenLabel,
+          })
+        >[
+          (
+            name: 'pending boycott shows Cancel and removes on tap',
+            game: diplomacyColonyGame,
+            type: DiplomaticOrderType.boycott,
+            hiddenLabel: 'Boycott',
+          ),
+          (
+            name: 'pending revokeBoycott shows Cancel and removes on tap',
+            game: () => diplomacyColonyGame(
+              boycotts: const [
+                BoycottState(
+                  gpId: diplomacyOrdersHumanId,
+                  targetGpId: diplomacyOrdersGp2,
+                  sinceTurn: 1,
+                ),
+              ],
+            ),
+            type: DiplomaticOrderType.revokeBoycott,
+            hiddenLabel: 'Revoke Boycott',
+          ),
+        ]) {
       testWidgets(c.name, (WidgetTester tester) async {
         final bus = AppEventBus.create();
         final removeFuture =
@@ -262,153 +254,147 @@ void main() {
       });
     }
 
-    testWidgets(
-      'Boycott disabled when human holds no colony',
-      (WidgetTester tester) async {
-        await pumpDiplomacyOrdersPanel(tester, game: buildDiplomacyPanelTestGame());
+    testWidgets('Boycott disabled when human holds no colony', (
+      WidgetTester tester,
+    ) async {
+      await pumpDiplomacyOrdersPanel(
+        tester,
+        game: buildDiplomacyPanelTestGame(),
+      );
 
-        await tapVisibleDiplomacy(tester, find.text('More actions'));
-        final boycottButton = find.widgetWithText(CtNinePatchButton, 'Boycott');
-        expect(boycottButton, findsOneWidget);
-        expect(tester.widget<CtNinePatchButton>(boycottButton).enabled, isFalse);
-      },
-    );
+      await tapVisibleDiplomacy(tester, find.text('More actions'));
+      final boycottButton = find.widgetWithText(CtNinePatchButton, 'Boycott');
+      expect(boycottButton, findsOneWidget);
+      expect(tester.widget<CtNinePatchButton>(boycottButton).enabled, isFalse);
+    });
 
-    testWidgets(
-      'Minor row omits Boycott controls (negative)',
-      (WidgetTester tester) async {
-        await pumpDiplomacyOrdersPanel(
-          tester,
-          game: buildDiplomacyRichPanelTestGame(),
-          tall: true,
-          minorsTab: true,
-        );
+    testWidgets('Minor row omits Boycott controls (negative)', (
+      WidgetTester tester,
+    ) async {
+      await pumpDiplomacyOrdersPanel(
+        tester,
+        game: buildDiplomacyRichPanelTestGame(),
+        tall: true,
+        minorsTab: true,
+      );
 
-        expect(find.text('Free City'), findsOneWidget);
-        expect(find.text('Boycott'), findsNothing);
-        expect(find.text('Revoke Boycott'), findsNothing);
-      },
-    );
+      expect(find.text('Free City'), findsOneWidget);
+      expect(find.text('Boycott'), findsNothing);
+      expect(find.text('Revoke Boycott'), findsNothing);
+    });
   });
 
   group('Minor subsidy / grant aid (Refs #3753 S15 / R2)', () {
-    testWidgets(
-      'pending setSubsidy shows percent line and Cancel',
-      (WidgetTester tester) async {
-        const percent = 15;
-        final bus = AppEventBus.create();
-        final removeFuture =
-            awaitDiplomacyBusEvent<RemoveDiplomaticOrderRequestedEvent>(bus);
+    testWidgets('pending setSubsidy shows percent line and Cancel', (
+      WidgetTester tester,
+    ) async {
+      const percent = 15;
+      final bus = AppEventBus.create();
+      final removeFuture =
+          awaitDiplomacyBusEvent<RemoveDiplomaticOrderRequestedEvent>(bus);
 
-        await pumpDiplomacyOrdersPanel(
-          tester,
-          game: buildDiplomacyRichPanelTestGame(),
-          bus: bus,
-          tall: true,
-          minorsTab: true,
-          currentOrders: diplomacyPendingOrders(
-            DiplomaticOrder(
-              type: DiplomaticOrderType.setSubsidy,
-              targetFactionId: diplomacyOrdersMinorId,
-              amount: percent,
+      await pumpDiplomacyOrdersPanel(
+        tester,
+        game: buildDiplomacyRichPanelTestGame(),
+        bus: bus,
+        tall: true,
+        minorsTab: true,
+        currentOrders: diplomacyPendingOrders(
+          DiplomaticOrder(
+            type: DiplomaticOrderType.setSubsidy,
+            targetFactionId: diplomacyOrdersMinorId,
+            amount: percent,
+          ),
+        ),
+      );
+
+      expect(
+        find.text('Pending subsidy: $percent% (resolves end of turn)'),
+        findsOneWidget,
+      );
+      expect(find.text('Set Subsidy ($percent%)'), findsNothing);
+
+      await tapVisibleDiplomacy(tester, find.text('Cancel').first);
+      final event = await removeFuture;
+      expect(event.playerId, diplomacyOrdersHumanId);
+      expect(event.type, DiplomaticOrderType.setSubsidy);
+      expect(event.targetFactionId, diplomacyOrdersMinorId);
+    });
+
+    testWidgets('active subsidy shows outgoing percent line', (
+      WidgetTester tester,
+    ) async {
+      const percent = 10;
+      await pumpDiplomacyOrdersPanel(
+        tester,
+        game: diplomacyMinorEmbassyGame(
+          subsidies: const [
+            SubsidyState(
+              payerId: diplomacyOrdersHumanId,
+              targetId: diplomacyOrdersMinorId,
+              percent: percent,
             ),
+          ],
+        ),
+        tall: true,
+        minorsTab: true,
+      );
+
+      expect(
+        find.text('Outgoing subsidy: $percent% to Free City'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('pending grantAid shows amount line and Cancel', (
+      WidgetTester tester,
+    ) async {
+      const amount = 2000;
+      final bus = AppEventBus.create();
+      final removeFuture =
+          awaitDiplomacyBusEvent<RemoveDiplomaticOrderRequestedEvent>(bus);
+
+      await pumpDiplomacyOrdersPanel(
+        tester,
+        game: buildDiplomacyRichPanelTestGame(),
+        bus: bus,
+        tall: true,
+        minorsTab: true,
+        currentOrders: diplomacyPendingOrders(
+          DiplomaticOrder(
+            type: DiplomaticOrderType.grantAid,
+            targetFactionId: diplomacyOrdersMinorId,
+            amount: amount,
           ),
-        );
+        ),
+      );
 
-        expect(
-          find.text('Pending subsidy: $percent% (resolves end of turn)'),
-          findsOneWidget,
-        );
-        expect(find.text('Set Subsidy ($percent%)'), findsNothing);
-
-        await tapVisibleDiplomacy(tester, find.text('Cancel').first);
-        final event = await removeFuture;
-        expect(event.playerId, diplomacyOrdersHumanId);
-        expect(event.type, DiplomaticOrderType.setSubsidy);
-        expect(event.targetFactionId, diplomacyOrdersMinorId);
-      },
-    );
-
-    testWidgets(
-      'active subsidy shows outgoing percent line',
-      (WidgetTester tester) async {
-        const percent = 10;
-        await pumpDiplomacyOrdersPanel(
-          tester,
-          game: _minorEmbassyGame(
-            subsidies: const [
-              SubsidyState(
-                payerId: diplomacyOrdersHumanId,
-                targetId: diplomacyOrdersMinorId,
-                percent: percent,
-              ),
-            ],
+      final minorRow = diplomacyMinorRow();
+      expect(
+        find.descendant(
+          of: minorRow,
+          matching: find.text(
+            'Pending grant aid: £$amount (resolves end of turn)',
           ),
-          tall: true,
-          minorsTab: true,
-        );
+        ),
+        findsOneWidget,
+      );
+      expect(
+        find.descendant(of: minorRow, matching: find.text('Grant Aid')),
+        findsNothing,
+      );
 
-        expect(
-          find.text('Outgoing subsidy: $percent% to Free City'),
-          findsOneWidget,
-        );
-      },
-    );
+      await tapVisibleDiplomacy(
+        tester,
+        find.descendant(of: minorRow, matching: find.text('Cancel')),
+      );
+      final event = await removeFuture;
+      expect(event.playerId, diplomacyOrdersHumanId);
+      expect(event.type, DiplomaticOrderType.grantAid);
+      expect(event.targetFactionId, diplomacyOrdersMinorId);
+    });
 
-    testWidgets(
-      'pending grantAid shows amount line and Cancel',
-      (WidgetTester tester) async {
-        const amount = 2000;
-        final bus = AppEventBus.create();
-        final removeFuture =
-            awaitDiplomacyBusEvent<RemoveDiplomaticOrderRequestedEvent>(bus);
-
-        await pumpDiplomacyOrdersPanel(
-          tester,
-          game: buildDiplomacyRichPanelTestGame(),
-          bus: bus,
-          tall: true,
-          minorsTab: true,
-          currentOrders: diplomacyPendingOrders(
-            DiplomaticOrder(
-              type: DiplomaticOrderType.grantAid,
-              targetFactionId: diplomacyOrdersMinorId,
-              amount: amount,
-            ),
-          ),
-        );
-
-        final minorRow = diplomacyMinorRow();
-        expect(
-          find.descendant(
-            of: minorRow,
-            matching: find.text(
-              'Pending grant aid: £$amount (resolves end of turn)',
-            ),
-          ),
-          findsOneWidget,
-        );
-        expect(
-          find.descendant(of: minorRow, matching: find.text('Grant Aid')),
-          findsNothing,
-        );
-
-        await tapVisibleDiplomacy(
-          tester,
-          find.descendant(of: minorRow, matching: find.text('Cancel')),
-        );
-        final event = await removeFuture;
-        expect(event.playerId, diplomacyOrdersHumanId);
-        expect(event.type, DiplomaticOrderType.grantAid);
-        expect(event.targetFactionId, diplomacyOrdersMinorId);
-      },
-    );
-
-    for (final c in <({
-      String name,
-      String buttonLabel,
-      bool isSubsidy,
-    })>[
+    for (final c in <({String name, String buttonLabel, bool isSubsidy})>[
       (
         name: 'Grant Aid emits grantOrSubsidy dialog',
         buttonLabel: 'Grant Aid',
@@ -426,7 +412,7 @@ void main() {
 
         await pumpDiplomacyOrdersPanel(
           tester,
-          game: _minorEmbassyGame(),
+          game: diplomacyMinorEmbassyGame(),
           bus: bus,
           tall: true,
           minorsTab: true,

--- a/app/test/diplomacy_panel_test.dart
+++ b/app/test/diplomacy_panel_test.dart
@@ -8,11 +8,9 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:colonizethis_app_ui_chrome/config/editorial_monocle_palette.dart';
 import 'package:colonizethis_app/features/game/widgets/diplomacy/diplomacy_panel.dart';
-import 'package:colonizethis_app/features/game/widgets/diplomacy/diplomacy_panel_constants.dart';
 import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
 
 import 'diplomacy_panel_test_scenarios.dart';
-import 'diplomacy_panel_test_support.dart';
 import 'panel_test_fixtures.dart';
 import 'diplomacy_panel_widget_harness.dart';
 import 'widget_test_assets.dart';
@@ -251,18 +249,19 @@ void main() {
       WidgetTester tester,
     ) async {
       await pumpAndRows(tester);
-      final stronger = buildDiplomacyRows(
-        fixture.gameWithFactions,
-        fixture.topology,
-        fixture.humanPlayerId,
-        const Orders(),
-      ).where(
-        (r) =>
-            r.kind == FactionKind.greatPower &&
-            r.powerScore != null &&
-            r.playerPowerScore != null &&
-            powerComparisonPercent(r.powerScore!, r.playerPowerScore!) > 0,
-      );
+      final stronger =
+          buildDiplomacyRows(
+            fixture.gameWithFactions,
+            fixture.topology,
+            fixture.humanPlayerId,
+            const Orders(),
+          ).where(
+            (r) =>
+                r.kind == FactionKind.greatPower &&
+                r.powerScore != null &&
+                r.playerPowerScore != null &&
+                powerComparisonPercent(r.powerScore!, r.playerPowerScore!) > 0,
+          );
       if (stronger.isEmpty) return;
       for (final r in stronger) {
         final colors = relativePowerSpanColors(tester, r.factionId);
@@ -275,18 +274,20 @@ void main() {
       'AC: weaker/equal GP relative-power line renders in --success',
       (WidgetTester tester) async {
         await pumpAndRows(tester);
-        final weakerOrEqual = buildDiplomacyRows(
-          fixture.gameWithFactions,
-          fixture.topology,
-          fixture.humanPlayerId,
-          const Orders(),
-        ).where(
-          (r) =>
-              r.kind == FactionKind.greatPower &&
-              r.powerScore != null &&
-              r.playerPowerScore != null &&
-              powerComparisonPercent(r.powerScore!, r.playerPowerScore!) <= 0,
-        );
+        final weakerOrEqual =
+            buildDiplomacyRows(
+              fixture.gameWithFactions,
+              fixture.topology,
+              fixture.humanPlayerId,
+              const Orders(),
+            ).where(
+              (r) =>
+                  r.kind == FactionKind.greatPower &&
+                  r.powerScore != null &&
+                  r.playerPowerScore != null &&
+                  powerComparisonPercent(r.powerScore!, r.playerPowerScore!) <=
+                      0,
+            );
         if (weakerOrEqual.isEmpty) return;
         for (final r in weakerOrEqual) {
           final colors = relativePowerSpanColors(tester, r.factionId);
@@ -317,130 +318,6 @@ void main() {
       (WidgetTester tester) async {
         await pumpAndRows(tester);
         expect(find.textContaining('Power: '), findsNothing);
-      },
-    );
-  });
-
-  group('DiplomacyPanel section headings (editorial-monocle)', () {
-    testWidgets('AC: Section heading text resolves to --accent color', (
-      WidgetTester tester,
-    ) async {
-      await pumpDefault(tester);
-      final heading = tester.widget<Text>(find.text('Great Powers'));
-      expect(heading.style?.color, EditorialMonoclePalette.accent);
-      expect(heading.style?.fontFamily, 'Cinzel');
-    });
-
-    testWidgets(
-      'AC: Section heading container exposes a 2 px --accent-dim bottom border',
-      (WidgetTester tester) async {
-        await pumpDefault(tester);
-        final decorated = find.ancestor(
-          of: find.text('Great Powers'),
-          matching: find.byType(DecoratedBox),
-        );
-        expect(decorated, findsAtLeastNWidgets(1));
-        final box = tester.widget<DecoratedBox>(decorated.first);
-        final decoration = box.decoration as BoxDecoration;
-        expect(decoration.border!.bottom.color, EditorialMonoclePalette.accentDim);
-        expect(decoration.border!.bottom.width, 2);
-      },
-    );
-  });
-
-  group('DiplomacyPanel faction kind badges (editorial-monocle)', () {
-    Future<List<DiplomacyRowData>> rows(WidgetTester tester) async {
-      await pumpDefault(tester);
-      return buildDiplomacyRows(
-        fixture.gameWithFactions,
-        fixture.topology,
-        fixture.humanPlayerId,
-        const Orders(),
-      );
-    }
-
-    testWidgets(
-      'AC: GP badge background --accent-dim and foreground --bg-deep',
-      (WidgetTester tester) async {
-        final panelRows = await rows(tester);
-        if (!panelRows.any((r) => r.kind == FactionKind.greatPower)) return;
-        final gpText = find.text('GP').first;
-        final container = tester.widget<Container>(
-          find.ancestor(of: gpText, matching: find.byType(Container)).first,
-        );
-        final decoration = container.decoration as BoxDecoration;
-        expect(decoration.color, EditorialMonoclePalette.accentDim);
-        expect(decoration.border, isNull);
-        expect(
-          tester.widget<Text>(gpText).style?.color,
-          EditorialMonoclePalette.bgDeep,
-        );
-      },
-    );
-
-    testWidgets('AC: Minor badge background --muted and foreground --bg-deep', (
-      WidgetTester tester,
-    ) async {
-      final panelRows = await rows(tester);
-      if (!panelRows.any((r) => r.kind == FactionKind.minor)) return;
-      final minorText = find.text('Minor').first;
-      final container = tester.widget<Container>(
-        find.ancestor(of: minorText, matching: find.byType(Container)).first,
-      );
-      final decoration = container.decoration as BoxDecoration;
-      expect(decoration.color, EditorialMonoclePalette.muted);
-      expect(decoration.border, isNull);
-      expect(
-        tester.widget<Text>(minorText).style?.color,
-        EditorialMonoclePalette.bgDeep,
-      );
-    });
-
-    testWidgets(
-      'AC: Tribe badge outlined with --muted border, transparent background',
-      (WidgetTester tester) async {
-        final panelRows = await rows(tester);
-        final tribeRows =
-            panelRows.where((r) => r.kind == FactionKind.tribe).toList();
-        if (tribeRows.isEmpty) return;
-        final tribeRow = tribeRows.first;
-        final tribeText = find.descendant(
-          of: find.byKey(
-            ValueKey('$kDiplomacyRowBodyKeyPrefix${tribeRow.factionId}'),
-          ),
-          matching: find.text('Tribe'),
-        );
-        await tester.scrollUntilVisible(
-          tribeText,
-          120,
-          scrollable: find.byType(Scrollable).first,
-        );
-        await tester.pump();
-        final container = tester.widget<Container>(
-          find.ancestor(of: tribeText, matching: find.byType(Container)).first,
-        );
-        final decoration = container.decoration as BoxDecoration;
-        expect(decoration.color, isNull);
-        expect(decoration.border!.top.color, EditorialMonoclePalette.muted);
-        expect(
-          tester.widget<Text>(tribeText).style?.color,
-          EditorialMonoclePalette.muted,
-        );
-      },
-    );
-
-    testWidgets(
-      'AC: No badge uses raw Material chrome (Colors.blue/grey/orange)',
-      (WidgetTester tester) async {
-        await pumpDefault(tester);
-        for (final label in ['GP', 'Minor', 'Tribe']) {
-          final finder = find.text(label);
-          if (finder.evaluate().isEmpty) continue;
-          final color = tester.widget<Text>(finder.first).style?.color;
-          expect(color, isNot(equals(Colors.blue)));
-          expect(color, isNot(equals(Colors.grey)));
-          expect(color, isNot(equals(Colors.orange)));
-        }
       },
     );
   });

--- a/app/test/game_side_menu_specs_test.dart
+++ b/app/test/game_side_menu_specs_test.dart
@@ -1,0 +1,253 @@
+// Pins SPEC/ui/game-side-menu.md (extracted from pause-menu suite, Refs #4352).
+
+import 'package:colonizethis_app/app.dart';
+import 'package:colonizethis_app/config/constants.dart';
+import 'package:colonizethis_app/config/routes.dart';
+import 'package:colonizethis_app/core/services/app_event_handler/app_event_handler_scope.dart';
+import 'package:colonizethis_app/core/services/game_service/game_service.dart';
+import 'package:colonizethis_app/features/game/flame/controls/game_side_menu.dart';
+import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
+import 'package:colonizethis_app/providers/app_event_bus_provider.dart';
+import 'package:colonizethis_app/providers/game_service_provider.dart';
+import 'package:colonizethis_app/providers/games_box_provider.dart';
+import 'package:colonizethis_app/providers/games_provider.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_save/colonizethis_save.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+
+import 'app_shell_harness.dart';
+import 'panel_test_fixtures.dart';
+
+void main() {
+  suppressLogsForTests();
+
+  group('GameSideMenu (SPEC/ui/game-side-menu.md)', () {
+    late Game game;
+    late Box<dynamic> gamesBox;
+
+    setUpAll(() async {
+      game = buildSideMenuTestGame();
+      Hive.init('./.dart_tool/test_hive_game_side_menu_specs');
+      gamesBox = await Hive.openBox<dynamic>(HiveBoxNames.games);
+    });
+
+    Widget wrap({
+      required Game? activeGame,
+      required AppEventBus bus,
+      bool sideMenuOpen = true,
+      required VoidCallback onClose,
+      Map<String, Widget Function(BuildContext)> routes = const {},
+    }) {
+      return buildAppShell(
+        overrides: [
+          gamesBoxProvider.overrideWith((ref) => gamesBox),
+          gameServiceProvider.overrideWith(
+            (ref) => GameService(gamesBox, GameSaveAdapter()),
+          ),
+          currentGameProvider.overrideWith(
+            () => CurrentGameNotifier(activeGame),
+          ),
+          currentOrdersProvider.overrideWith(
+            () => CurrentOrdersNotifier(const Orders()),
+          ),
+          appEventBusProvider.overrideWith((ref) => bus),
+        ],
+        navigatorKey: appNavigatorKey,
+        onGenerateRoute: routes.isEmpty
+            ? null
+            : (settings) {
+                final builder = routes[settings.name];
+                if (builder == null) {
+                  return null;
+                }
+                return MaterialPageRoute<void>(
+                  settings: settings,
+                  builder: builder,
+                );
+              },
+        shellWrapper: (app) => AppEventHandlerScope(child: app),
+        child: Scaffold(
+          body: Stack(
+            children: [
+              GameSideMenu(sideMenuOpen: sideMenuOpen, onClose: onClose),
+            ],
+          ),
+        ),
+      );
+    }
+
+    testWidgets(
+      'AC: renders close, Game Parameters, and Debug log entries with a non-null game',
+      (WidgetTester tester) async {
+        final bus = AppEventBus.create();
+        addTearDown(bus.dispose);
+
+        await tester.pumpWidget(
+          wrap(activeGame: game, bus: bus, onClose: () {}),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('Game Parameters'), findsOneWidget);
+        expect(find.text('Debug log'), findsOneWidget);
+        expect(find.text('×'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'AC: close button invokes onClose exactly once and emits no bus events',
+      (WidgetTester tester) async {
+        final bus = AppEventBus.create();
+        addTearDown(bus.dispose);
+        final events = <AppEvent>[];
+        final sub = bus.stream.listen(events.add);
+        addTearDown(sub.cancel);
+
+        var closes = 0;
+        await tester.pumpWidget(
+          wrap(activeGame: game, bus: bus, onClose: () => closes++),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('×'));
+        await tester.pumpAndSettle();
+
+        expect(closes, 1);
+        expect(events, isEmpty);
+      },
+    );
+
+    testWidgets(
+      'AC: Game Parameters with non-null game closes menu and opens dialog without bus event',
+      (WidgetTester tester) async {
+        final bus = AppEventBus.create();
+        addTearDown(bus.dispose);
+        final events = <AppEvent>[];
+        final sub = bus.stream.listen(events.add);
+        addTearDown(sub.cancel);
+
+        var closes = 0;
+        await tester.pumpWidget(
+          wrap(
+            activeGame: game.copyWith(infiniteMode: true),
+            bus: bus,
+            onClose: () => closes++,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Game Parameters'));
+        await tester.pumpAndSettle();
+
+        expect(closes, 1);
+        expect(find.text('Infinite mode: On'), findsOneWidget);
+        expect(
+          events.whereType<OpenDialogEvent>(),
+          isEmpty,
+          reason: 'Game Parameters must not emit an OpenDialogEvent.',
+        );
+      },
+    );
+
+    testWidgets('Negative AC: Game Parameters with null game is a no-op', (
+      WidgetTester tester,
+    ) async {
+      final bus = AppEventBus.create();
+      addTearDown(bus.dispose);
+      final events = <AppEvent>[];
+      final sub = bus.stream.listen(events.add);
+      addTearDown(sub.cancel);
+
+      var closes = 0;
+      await tester.pumpWidget(
+        wrap(activeGame: null, bus: bus, onClose: () => closes++),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Game Parameters'));
+      await tester.pumpAndSettle();
+
+      expect(closes, 0, reason: 'onClose must not run when game is null.');
+      expect(find.text('Infinite mode: On'), findsNothing);
+      expect(find.text('Infinite mode: Off'), findsNothing);
+      expect(events, isEmpty);
+    });
+
+    testWidgets(
+      'AC: Debug log calls onClose and emits exactly one NavigateToRouteEvent(debugLog)',
+      (WidgetTester tester) async {
+        final bus = AppEventBus.create();
+        addTearDown(bus.dispose);
+        final events = <AppEvent>[];
+        final sub = bus.stream.listen(events.add);
+        addTearDown(sub.cancel);
+
+        var closes = 0;
+        await tester.pumpWidget(
+          wrap(
+            activeGame: game,
+            bus: bus,
+            onClose: () => closes++,
+            routes: {
+              Routes.debugLog: (_) => const Scaffold(
+                body: Center(child: Text('debug-route-marker')),
+              ),
+            },
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Debug log'));
+        await tester.pumpAndSettle();
+
+        expect(closes, 1);
+        final navEvents = events.whereType<NavigateToRouteEvent>().toList();
+        expect(navEvents, hasLength(1));
+        expect(navEvents.single.route, Routes.debugLog);
+        expect(
+          events.whereType<OpenDialogEvent>(),
+          isEmpty,
+          reason: 'Debug log must not emit an OpenDialogEvent.',
+        );
+      },
+    );
+
+    testWidgets('AC: horizontal drag left invokes onClose', (
+      WidgetTester tester,
+    ) async {
+      final bus = AppEventBus.create();
+      addTearDown(bus.dispose);
+
+      var closes = 0;
+      await tester.pumpWidget(
+        wrap(activeGame: game, bus: bus, onClose: () => closes++),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.drag(find.byType(GameSideMenu), const Offset(-40, 0));
+      await tester.pumpAndSettle();
+
+      expect(closes, greaterThanOrEqualTo(1));
+    });
+
+    testWidgets(
+      'Negative AC: menu contains zero Navigator.pushNamed equivalents '
+      '(only CtNinePatchButton rows host actions)',
+      (WidgetTester tester) async {
+        final bus = AppEventBus.create();
+        addTearDown(bus.dispose);
+
+        await tester.pumpWidget(
+          wrap(activeGame: game, bus: bus, onClose: () {}),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.byType(CtNinePatchButton), findsWidgets);
+        expect(find.byType(ElevatedButton), findsNothing);
+        expect(find.byType(TextButton), findsNothing);
+      },
+    );
+  });
+}

--- a/app/test/mobile_320dp_min_viewport_test.dart
+++ b/app/test/mobile_320dp_min_viewport_test.dart
@@ -5,113 +5,17 @@
 // scope here per the existing `SPEC/ui/mobile-adaptation.md` § 1 carve-out
 // SPEC: `SPEC/ui/mobile-adaptation.md` § 7 (Minimum-viewport pin).
 // Refs #2870 S10. Shared pumps densify residual mid-500 cases (Refs #4021).
+import 'package:colonizethis_app/config/constants.dart';
+import 'package:colonizethis_app/features/shell/new_game_leader_selection_dialog.dart';
+import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
+import 'package:colonizethis_app/widgets/main_menu.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:colonizethis_app_fixtures/runtime/app_display_strings.dart';
-import 'package:colonizethis_app/config/constants.dart';
-import 'package:colonizethis_app/features/shell/new_game_leader_selection_dialog.dart';
-import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
-import 'package:colonizethis_app/widgets/main_menu.dart';
-
 import 'dialogs_320dp_min_viewport_support.dart';
-import 'min_viewport_harness.dart';
-
-/// Minimum supported viewport dimensions for SPEC/ui/mobile-adaptation.md
-/// § 7. Width matches [kMinViewportWidth]; height (640 dp) is the lower end
-/// of the iPhone SE-class mobile envelope mockups target.
-const Size _kMinViewport = Size(kMinViewportWidth, 640);
-
-/// Viewport used by the negative-regression pin: comfortably wider than
-/// every per-screen breakpoint so the same screens render their wide layout
-/// without any responsive concessions. If a future refactor flips the
-/// overflow contract upstream, this control still passes — the contrast
-/// with the 320 dp positive pins keeps the regression signal honest.
-const Size _kWideRegressionViewport = Size(1024, 768);
-
-Widget _wrapMainMenu({
-  MainMenuVariant variant = MainMenuVariant.plain,
-  MainMenuState state = MainMenuState.default_,
-}) {
-  return CtMainMenu(
-    variant: variant,
-    state: state,
-    version: formatDebugAwareVersion('v1.0.0'),
-    onNewGame: () {},
-    onLoadGame: () {},
-    onSettings: () {},
-    onQuit: () {},
-  );
-}
-
-/// Pumps [screen] at [size] and asserts the framework emitted no
-/// exception. We deliberately treat any caught exception as a failure
-/// because Flutter surfaces `RenderFlex` overflows as
-/// `FlutterError`s with `"RenderFlex overflowed"` messages via the
-/// `FlutterError.onError` channel, which `WidgetTester` collects through
-/// `takeException`. This is the same contract several existing tests in
-/// the repo rely on (see `unit_panels_widgetbook_dark_chrome_test.dart`).
-///
-/// When [settleAnimations] is `true` (default) the helper drives
-/// `pumpAndSettle()` to completion. When `false` it pumps a small finite
-/// number of frames instead so screens with **continuous** animations can
-/// still be exercised against the layout overflow contract without the
-/// framework's settle-loop timing out.
-Future<void> _pumpNarrow(
-  WidgetTester tester,
-  Widget screen, {
-  required Size size,
-  bool settleAnimations = true,
-}) async {
-  if (settleAnimations) {
-    await pumpAtMinViewport(tester, size: size, child: screen, settle: true);
-    return;
-  }
-  // Two frames are enough for the layout pass and any one-frame
-  // post-build microtasks to surface a `RenderFlex` overflow exception
-  // through `WidgetTester.takeException()`: the harness pumps the first,
-  // and a second framed pump follows.
-  await pumpAtMinViewport(tester, size: size, child: screen);
-  await tester.pump();
-}
-
-/// Returns the rendered height (logical pixels) of every visible
-/// [CtNinePatchButton] descendant of the current widget tree.
-List<double> _renderedNinePatchButtonHeights(WidgetTester tester) {
-  final Iterable<Element> elements = find.byType(CtNinePatchButton).evaluate();
-  final List<double> heights = <double>[];
-  for (final Element element in elements) {
-    final RenderBox? box = element.renderObject as RenderBox?;
-    if (box == null || !box.hasSize) continue;
-    heights.add(box.size.height);
-  }
-  return heights;
-}
-
-void _expectTouchTargets(WidgetTester tester, {required bool requireButtons}) {
-  expect(tester.takeException(), isNull);
-  final heights = _renderedNinePatchButtonHeights(tester);
-  if (requireButtons) {
-    expect(
-      heights,
-      isNotEmpty,
-      reason:
-          'CtMainMenu must render at least one CtNinePatchButton '
-          '(New Game / Load Game / Settings / Quit).',
-    );
-  }
-  for (final h in heights) {
-    expect(
-      h,
-      greaterThanOrEqualTo(kMinTouchTargetSize),
-      reason:
-          'CtNinePatchButton height $h dp violates the 44 dp '
-          'touch-target minimum at the 320 dp viewport.',
-    );
-  }
-}
+import 'mobile_320dp_min_viewport_test_support.dart';
 
 void main() {
   suppressLogsForTests();
@@ -152,12 +56,12 @@ void main() {
             ),
           ]) {
         testWidgets(c.name, (WidgetTester tester) async {
-          await _pumpNarrow(
+          await pumpMobileNarrow(
             tester,
-            _wrapMainMenu(variant: c.variant, state: c.state),
-            size: _kMinViewport,
+            wrapMainMenuForMinViewport(variant: c.variant, state: c.state),
+            size: kMobileMinViewport,
           );
-          _expectTouchTargets(tester, requireButtons: c.requireButtons);
+          expectMobileTouchTargets(tester, requireButtons: c.requireButtons);
         });
       }
 
@@ -174,7 +78,11 @@ void main() {
         'AC1 (positive) CtMainMenu plain @ 320×640: menu body padding is the '
         'compact kMainMenuBodyPaddingNarrow (≤ 430 dp narrow contract)',
         (WidgetTester tester) async {
-          await _pumpNarrow(tester, _wrapMainMenu(), size: _kMinViewport);
+          await pumpMobileNarrow(
+            tester,
+            wrapMainMenuForMinViewport(),
+            size: kMobileMinViewport,
+          );
 
           expect(tester.takeException(), isNull);
           final Padding bodyPadding = tester.widget<Padding>(
@@ -202,10 +110,10 @@ void main() {
         'AC1 (positive) CtMainMenu pixelArt @ 320×640: compact padding plus '
         'narrow button letter-spacing (≤ 430 dp narrow contract)',
         (WidgetTester tester) async {
-          await _pumpNarrow(
+          await pumpMobileNarrow(
             tester,
-            _wrapMainMenu(variant: MainMenuVariant.pixelArt),
-            size: _kMinViewport,
+            wrapMainMenuForMinViewport(variant: MainMenuVariant.pixelArt),
+            size: kMobileMinViewport,
           );
 
           expect(tester.takeException(), isNull);
@@ -243,10 +151,10 @@ void main() {
         'Negative control: CtMainMenu plain @ 1024×768 also pumps without '
         'exception (regression sentinel for the overflow contract)',
         (WidgetTester tester) async {
-          await _pumpNarrow(
+          await pumpMobileNarrow(
             tester,
-            _wrapMainMenu(),
-            size: _kWideRegressionViewport,
+            wrapMainMenuForMinViewport(),
+            size: kMobileWideRegressionViewport,
           );
 
           expect(tester.takeException(), isNull);
@@ -314,7 +222,7 @@ void main() {
     testWidgets('AC3 (positive) NewGameLeaderSelectionDialog @ 320×640: no '
         'RenderFlex overflow exception, six stacked slot bodies render, '
         'side-by-side row body is not mounted', (WidgetTester tester) async {
-      await pumpDialog(tester, size: _kMinViewport);
+      await pumpDialog(tester, size: kMobileMinViewport);
 
       expect(
         tester.takeException(),
@@ -353,7 +261,7 @@ void main() {
       'six slot labels + Cancel + Start labels render within the '
       '~288 dp content column',
       (WidgetTester tester) async {
-        await pumpDialog(tester, size: _kMinViewport);
+        await pumpDialog(tester, size: kMobileMinViewport);
 
         expect(tester.takeException(), isNull);
         expect(find.text('Choose nations and leaders'), findsOneWidget);
@@ -391,10 +299,10 @@ void main() {
         'kMinTouchTargetSize (SPEC/ui/mobile-adaptation.md § 1)', (
       WidgetTester tester,
     ) async {
-      await pumpDialog(tester, size: _kMinViewport);
+      await pumpDialog(tester, size: kMobileMinViewport);
 
       expect(tester.takeException(), isNull);
-      final List<double> heights = _renderedNinePatchButtonHeights(tester);
+      final List<double> heights = renderedNinePatchButtonHeights(tester);
       // The dialog footer renders exactly two CtNinePatchButtons
       // (Cancel + Start) per the SPEC layout / wireframe. Asserting
       // ≥ 2 keeps the AC robust against future button additions
@@ -425,7 +333,7 @@ void main() {
       '(regression sentinel for the narrow-stacking branch — keeps '
       'the 320 dp positive pins meaningful)',
       (WidgetTester tester) async {
-        await pumpDialog(tester, size: _kWideRegressionViewport);
+        await pumpDialog(tester, size: kMobileWideRegressionViewport);
 
         expect(tester.takeException(), isNull);
         expect(

--- a/app/test/mobile_320dp_min_viewport_test_support.dart
+++ b/app/test/mobile_320dp_min_viewport_test_support.dart
@@ -1,0 +1,93 @@
+// Shared 320 dp main-menu / leader-dialog pumps (Refs #4352).
+// SPEC: SPEC/ui/mobile-adaptation.md § 7.
+
+import 'package:colonizethis_app/config/constants.dart';
+import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
+import 'package:colonizethis_app/widgets/main_menu.dart';
+import 'package:colonizethis_app_fixtures/runtime/app_display_strings.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'min_viewport_harness.dart';
+
+/// Minimum supported viewport dimensions for SPEC/ui/mobile-adaptation.md
+/// § 7. Width matches [kMinViewportWidth]; height (640 dp) is the lower end
+/// of the iPhone SE-class mobile envelope mockups target.
+const Size kMobileMinViewport = Size(kMinViewportWidth, 640);
+
+/// Viewport used by the negative-regression pin: comfortably wider than
+/// every per-screen breakpoint so the same screens render their wide layout
+/// without any responsive concessions.
+const Size kMobileWideRegressionViewport = Size(1024, 768);
+
+Widget wrapMainMenuForMinViewport({
+  MainMenuVariant variant = MainMenuVariant.plain,
+  MainMenuState state = MainMenuState.default_,
+}) {
+  return CtMainMenu(
+    variant: variant,
+    state: state,
+    version: formatDebugAwareVersion('v1.0.0'),
+    onNewGame: () {},
+    onLoadGame: () {},
+    onSettings: () {},
+    onQuit: () {},
+  );
+}
+
+/// Pumps [screen] at [size] and asserts the framework emitted no exception.
+///
+/// When [settleAnimations] is `true` (default) the helper drives
+/// `pumpAndSettle()` to completion. When `false` it pumps a small finite
+/// number of frames instead so screens with **continuous** animations can
+/// still be exercised against the layout overflow contract.
+Future<void> pumpMobileNarrow(
+  WidgetTester tester,
+  Widget screen, {
+  required Size size,
+  bool settleAnimations = true,
+}) async {
+  if (settleAnimations) {
+    await pumpAtMinViewport(tester, size: size, child: screen, settle: true);
+    return;
+  }
+  await pumpAtMinViewport(tester, size: size, child: screen);
+  await tester.pump();
+}
+
+List<double> renderedNinePatchButtonHeights(WidgetTester tester) {
+  final Iterable<Element> elements = find.byType(CtNinePatchButton).evaluate();
+  final List<double> heights = <double>[];
+  for (final Element element in elements) {
+    final RenderBox? box = element.renderObject as RenderBox?;
+    if (box == null || !box.hasSize) continue;
+    heights.add(box.size.height);
+  }
+  return heights;
+}
+
+void expectMobileTouchTargets(
+  WidgetTester tester, {
+  required bool requireButtons,
+}) {
+  expect(tester.takeException(), isNull);
+  final heights = renderedNinePatchButtonHeights(tester);
+  if (requireButtons) {
+    expect(
+      heights,
+      isNotEmpty,
+      reason:
+          'CtMainMenu must render at least one CtNinePatchButton '
+          '(New Game / Load Game / Settings / Quit).',
+    );
+  }
+  for (final h in heights) {
+    expect(
+      h,
+      greaterThanOrEqualTo(kMinTouchTargetSize),
+      reason:
+          'CtNinePatchButton height $h dp violates the 44 dp '
+          'touch-target minimum at the 320 dp viewport.',
+    );
+  }
+}

--- a/app/test/move_army_invasion_intel_test.dart
+++ b/app/test/move_army_invasion_intel_test.dart
@@ -4,129 +4,49 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:colonizethis_app/features/game/widgets/unit_orders/move_army_dialog.dart';
 import 'package:colonizethis_app/features/game/widgets/unit_orders/move_army_invasion_intel.dart';
 
-import 'move_dialogs_specs_test_support.dart';
+import 'move_army_invasion_intel_test_support.dart';
 
 void main() {
   suppressLogsForTests();
 
-  const humanId = 'gp_intel';
-  const rivalId = 'gp_rival';
-  const from = 'oldWorld|p_from';
-  const invasionDest = 'oldWorld|p_invade';
-
-  Game buildBaseGame({
-    required Map<String, String> visibilityByTile,
-    int fortLevel = 0,
-    List<Unit> invasionUnits = const [],
-  }) {
-    return Game(
-      id: 'g_intel',
-      worldState: WorldState(
-        turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
-        oldWorld: RegionData(
-          provinces: [
-            Province(
-              id: from,
-              regionId: 'oldWorld',
-              ownerId: humanId,
-              displayName: 'Origin',
-            ),
-            Province(
-              id: invasionDest,
-              regionId: 'oldWorld',
-              ownerId: rivalId,
-              displayName: 'Invade Dest',
-              fortLevel: fortLevel,
-            ),
-          ],
-          units: [
-            Unit(
-              id: 'u_mover',
-              type: 'musketeers',
-              ownerId: humanId,
-              locationProvinceId: from,
-            ),
-            ...invasionUnits,
-          ],
-        ),
-        newWorld: const RegionData(),
-        armies: const [
-          Army(
-            id: 'a_intel',
-            ownerId: humanId,
-            regionId: 'oldWorld',
-            stationedProvinceId: from,
-            regimentUnitIds: ['u_mover'],
-            isHomeArmy: false,
-          ),
-        ],
-        tileKeysByRegionAndProvince: const {
-          'oldWorld': {
-            from: ['oldWorld|p_from|0|0'],
-            invasionDest: ['oldWorld|p_invade|0|0'],
-          },
-        },
-        playerVisibilityByTile: {humanId: visibilityByTile},
-      ),
-      players: const [
-        Player(
-          id: humanId,
-          displayName: 'Human',
-          isHuman: true,
-          capitalProvinceId: from,
-        ),
-        Player(
-          id: rivalId,
-          displayName: 'Rival',
-          isHuman: false,
-          capitalProvinceId: invasionDest,
-        ),
-      ],
-    );
-  }
-
   group('computeMoveArmyInvasionIntelSummary', () {
     test('unknown when playerView is null', () {
-      final game = buildBaseGame(
-        visibilityByTile: {
-          'oldWorld|p_invade|0|0': 'fullyVisible',
-        },
+      final game = buildMoveArmyInvasionIntelBaseGame(
+        visibilityByTile: {'oldWorld|p_invade|0|0': 'fullyVisible'},
       );
       final summary = computeMoveArmyInvasionIntelSummary(
         game: game,
         playerView: null,
-        humanPlayerId: humanId,
-        destinationProvinceId: invasionDest,
+        humanPlayerId: kMoveArmyIntelHumanId,
+        destinationProvinceId: kMoveArmyIntelInvasionDest,
       );
       expect(summary.intelLevel, MoveArmyInvasionIntelLevel.unknown);
     });
 
     test('unknown when invasion tiles are not fully visible', () {
-      final game = buildBaseGame(
+      final game = buildMoveArmyInvasionIntelBaseGame(
         visibilityByTile: {
           'oldWorld|p_from|0|0': 'fullyVisible',
           'oldWorld|p_invade|0|0': 'fogged',
         },
       );
       final topology = const MapTopology(nodes: [], edges: []);
-      final view = buildPlayerView(game, topology, humanId);
+      final view = buildPlayerView(game, topology, kMoveArmyIntelHumanId);
       final summary = computeMoveArmyInvasionIntelSummary(
         game: game,
         playerView: view,
-        humanPlayerId: humanId,
-        destinationProvinceId: invasionDest,
+        humanPlayerId: kMoveArmyIntelHumanId,
+        destinationProvinceId: kMoveArmyIntelInvasionDest,
       );
       expect(summary.intelLevel, MoveArmyInvasionIntelLevel.unknown);
     });
 
     test('full intel counts combat-capable defenders and fort level', () {
-      final game = buildBaseGame(
+      final game = buildMoveArmyInvasionIntelBaseGame(
         visibilityByTile: {
           'oldWorld|p_from|0|0': 'fullyVisible',
           'oldWorld|p_invade|0|0': 'fullyVisible',
@@ -136,30 +56,30 @@ void main() {
           Unit(
             id: 'd1',
             type: 'musketeers',
-            ownerId: rivalId,
-            locationProvinceId: invasionDest,
+            ownerId: kMoveArmyIntelRivalId,
+            locationProvinceId: kMoveArmyIntelInvasionDest,
           ),
           Unit(
             id: 'd2',
             type: 'pikemen',
-            ownerId: rivalId,
-            locationProvinceId: invasionDest,
+            ownerId: kMoveArmyIntelRivalId,
+            locationProvinceId: kMoveArmyIntelInvasionDest,
           ),
           Unit(
             id: 'spy1',
             type: 'spy',
-            ownerId: rivalId,
-            locationProvinceId: invasionDest,
+            ownerId: kMoveArmyIntelRivalId,
+            locationProvinceId: kMoveArmyIntelInvasionDest,
           ),
         ],
       );
       final topology = const MapTopology(nodes: [], edges: []);
-      final view = buildPlayerView(game, topology, humanId);
+      final view = buildPlayerView(game, topology, kMoveArmyIntelHumanId);
       final summary = computeMoveArmyInvasionIntelSummary(
         game: game,
         playerView: view,
-        humanPlayerId: humanId,
-        destinationProvinceId: invasionDest,
+        humanPlayerId: kMoveArmyIntelHumanId,
+        destinationProvinceId: kMoveArmyIntelInvasionDest,
       );
       expect(summary.intelLevel, MoveArmyInvasionIntelLevel.full);
       expect(summary.defenderCombatCapableCount, 2);
@@ -170,7 +90,7 @@ void main() {
     });
 
     test('full intel with zero combat-capable defenders is unopposed', () {
-      final game = buildBaseGame(
+      final game = buildMoveArmyInvasionIntelBaseGame(
         visibilityByTile: {
           'oldWorld|p_from|0|0': 'fullyVisible',
           'oldWorld|p_invade|0|0': 'fullyVisible',
@@ -179,18 +99,18 @@ void main() {
           Unit(
             id: 'spy1',
             type: 'spy',
-            ownerId: rivalId,
-            locationProvinceId: invasionDest,
+            ownerId: kMoveArmyIntelRivalId,
+            locationProvinceId: kMoveArmyIntelInvasionDest,
           ),
         ],
       );
       final topology = const MapTopology(nodes: [], edges: []);
-      final view = buildPlayerView(game, topology, humanId);
+      final view = buildPlayerView(game, topology, kMoveArmyIntelHumanId);
       final summary = computeMoveArmyInvasionIntelSummary(
         game: game,
         playerView: view,
-        humanPlayerId: humanId,
-        destinationProvinceId: invasionDest,
+        humanPlayerId: kMoveArmyIntelHumanId,
+        destinationProvinceId: kMoveArmyIntelInvasionDest,
       );
       expect(summary.unopposed, isTrue);
       expect(summary.defenderCombatCapableCount, 0);
@@ -200,9 +120,9 @@ void main() {
   test('moveArmyOwnRegimentCount matches army regiment ids', () {
     final army = Army(
       id: 'a',
-      ownerId: humanId,
+      ownerId: kMoveArmyIntelHumanId,
       regionId: 'oldWorld',
-      stationedProvinceId: from,
+      stationedProvinceId: kMoveArmyIntelFrom,
       regimentUnitIds: ['u1', 'u2'],
       isHomeArmy: false,
     );
@@ -210,163 +130,28 @@ void main() {
   });
 
   group('MoveArmyDialog invasion intel UI', () {
-    const playerId = 'gp_intel_ui';
-    const rivalId = 'gp_rival_ui';
-    const from = 'oldWorld|p_from';
-    const playerDest = 'oldWorld|p_owned';
-    const invasionDest = 'oldWorld|p_invade';
-
-    MapTopology buildTopology() {
-      return const MapTopology(
-        nodes: [
-          TopologyNode(
-            id: from,
-            regionId: 'oldWorld',
-            type: TopologyNodeType.province,
-          ),
-          TopologyNode(
-            id: playerDest,
-            regionId: 'oldWorld',
-            type: TopologyNodeType.province,
-          ),
-          TopologyNode(
-            id: invasionDest,
-            regionId: 'oldWorld',
-            type: TopologyNodeType.province,
-          ),
-        ],
-        edges: [
-          TopologyEdge(id1: from, id2: playerDest),
-          TopologyEdge(id1: from, id2: invasionDest),
-        ],
-      );
-    }
-
-    Game buildUiGame({
-      required Map<String, String> visibilityByTile,
-      int fortLevel = 0,
-      List<Unit> extraUnits = const [],
-    }) {
-      return Game(
-        id: 'g_intel_ui',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
-          oldWorld: RegionData(
-            provinces: [
-              Province(
-                id: from,
-                regionId: 'oldWorld',
-                ownerId: playerId,
-                displayName: 'Origin',
-              ),
-              Province(
-                id: playerDest,
-                regionId: 'oldWorld',
-                ownerId: playerId,
-                displayName: 'Owned Dest',
-              ),
-              Province(
-                id: invasionDest,
-                regionId: 'oldWorld',
-                ownerId: rivalId,
-                displayName: 'Invade Dest',
-                fortLevel: fortLevel,
-              ),
-            ],
-            units: [
-              Unit(
-                id: 'u_mover',
-                type: 'musketeers',
-                ownerId: playerId,
-                locationProvinceId: from,
-              ),
-              ...extraUnits,
-            ],
-          ),
-          newWorld: const RegionData(),
-          armies: const [
-            Army(
-              id: 'a_ui',
-              ownerId: playerId,
-              regionId: 'oldWorld',
-              stationedProvinceId: from,
-              regimentUnitIds: ['u_mover'],
-              isHomeArmy: false,
-            ),
-          ],
-          tileKeysByRegionAndProvince: const {
-            'oldWorld': {
-              from: ['oldWorld|p_from|0|0'],
-              playerDest: ['oldWorld|p_owned|0|0'],
-              invasionDest: ['oldWorld|p_invade|0|0'],
-            },
-          },
-          playerVisibilityByTile: {playerId: visibilityByTile},
-        ),
-        players: const [
-          Player(
-            id: playerId,
-            displayName: 'Human',
-            isHuman: true,
-            capitalProvinceId: from,
-          ),
-          Player(
-            id: rivalId,
-            displayName: 'Rival',
-            isHuman: false,
-            capitalProvinceId: invasionDest,
-          ),
-        ],
-      );
-    }
-
-    Future<void> pumpDialog(
-      WidgetTester tester, {
-      required Game game,
-      required MapTopology topology,
-    }) async {
-      final army = game.worldState.armies.first;
-      final view = buildPlayerView(game, topology, playerId);
-      await tester.pumpWidget(
-        moveDialogsSpecsFrameWithOpener(
-          (context) => () {
-            showDialog<void>(
-              context: context,
-              builder: (_) => MoveArmyDialog(
-                army: army,
-                game: game,
-                humanPlayerId: playerId,
-                bus: AppEventBus.create(),
-                topology: topology,
-                draftOrders: const Orders(),
-                playerView: view,
-              ),
-            );
-          },
-        ),
-      );
-      await tester.tap(find.text('open'));
-      await tester.pumpAndSettle();
-    }
-
     testWidgets('shows own army count on dialog body', (tester) async {
-      final topology = buildTopology();
-      final game = buildUiGame(
+      final topology = buildMoveArmyInvasionIntelUiTopology();
+      final game = buildMoveArmyInvasionIntelUiGame(
         visibilityByTile: {
           'oldWorld|p_from|0|0': 'fullyVisible',
           'oldWorld|p_owned|0|0': 'fullyVisible',
           'oldWorld|p_invade|0|0': 'fullyVisible',
         },
       );
-      await pumpDialog(tester, game: game, topology: topology);
+      await pumpMoveArmyInvasionIntelDialog(
+        tester,
+        game: game,
+        topology: topology,
+      );
       expect(find.text('Your army: 1 regiments'), findsOneWidget);
     });
 
     testWidgets('full intel invasion row shows defender count and fort label', (
       tester,
     ) async {
-      final topology = buildTopology();
-      final game = buildUiGame(
+      final topology = buildMoveArmyInvasionIntelUiTopology();
+      final game = buildMoveArmyInvasionIntelUiGame(
         visibilityByTile: {
           'oldWorld|p_from|0|0': 'fullyVisible',
           'oldWorld|p_owned|0|0': 'fullyVisible',
@@ -377,12 +162,16 @@ void main() {
           Unit(
             id: 'd1',
             type: 'pikemen',
-            ownerId: rivalId,
-            locationProvinceId: invasionDest,
+            ownerId: kMoveArmyIntelUiRivalId,
+            locationProvinceId: kMoveArmyIntelUiInvasionDest,
           ),
         ],
       );
-      await pumpDialog(tester, game: game, topology: topology);
+      await pumpMoveArmyInvasionIntelDialog(
+        tester,
+        game: game,
+        topology: topology,
+      );
       expect(find.text('Defenders: 1 regiments'), findsOneWidget);
       expect(find.text('Wood fort siege'), findsOneWidget);
       expect(find.text('Defenders unknown'), findsNothing);
@@ -391,15 +180,19 @@ void main() {
     testWidgets('unknown intel invasion row shows defenders unknown', (
       tester,
     ) async {
-      final topology = buildTopology();
-      final game = buildUiGame(
+      final topology = buildMoveArmyInvasionIntelUiTopology();
+      final game = buildMoveArmyInvasionIntelUiGame(
         visibilityByTile: {
           'oldWorld|p_from|0|0': 'fullyVisible',
           'oldWorld|p_owned|0|0': 'fullyVisible',
           'oldWorld|p_invade|0|0': 'fogged',
         },
       );
-      await pumpDialog(tester, game: game, topology: topology);
+      await pumpMoveArmyInvasionIntelDialog(
+        tester,
+        game: game,
+        topology: topology,
+      );
       expect(find.text('Defenders unknown'), findsOneWidget);
       expect(find.textContaining('Defenders:'), findsNothing);
       expect(find.text('Unopposed capture'), findsNothing);
@@ -408,15 +201,19 @@ void main() {
     testWidgets('owned destination row has no invasion intel lines', (
       tester,
     ) async {
-      final topology = buildTopology();
-      final game = buildUiGame(
+      final topology = buildMoveArmyInvasionIntelUiTopology();
+      final game = buildMoveArmyInvasionIntelUiGame(
         visibilityByTile: {
           'oldWorld|p_from|0|0': 'fullyVisible',
           'oldWorld|p_owned|0|0': 'fullyVisible',
           'oldWorld|p_invade|0|0': 'fullyVisible',
         },
       );
-      await pumpDialog(tester, game: game, topology: topology);
+      await pumpMoveArmyInvasionIntelDialog(
+        tester,
+        game: game,
+        topology: topology,
+      );
       final ownedRow = find.ancestor(
         of: find.text('Owned Dest'),
         matching: find.byWidgetPredicate(
@@ -433,8 +230,8 @@ void main() {
     testWidgets('selected invasion row shows regiment type breakdown', (
       tester,
     ) async {
-      final topology = buildTopology();
-      final game = buildUiGame(
+      final topology = buildMoveArmyInvasionIntelUiTopology();
+      final game = buildMoveArmyInvasionIntelUiGame(
         visibilityByTile: {
           'oldWorld|p_from|0|0': 'fullyVisible',
           'oldWorld|p_owned|0|0': 'fullyVisible',
@@ -444,12 +241,16 @@ void main() {
           Unit(
             id: 'd1',
             type: 'pikemen',
-            ownerId: rivalId,
-            locationProvinceId: invasionDest,
+            ownerId: kMoveArmyIntelUiRivalId,
+            locationProvinceId: kMoveArmyIntelUiInvasionDest,
           ),
         ],
       );
-      await pumpDialog(tester, game: game, topology: topology);
+      await pumpMoveArmyInvasionIntelDialog(
+        tester,
+        game: game,
+        topology: topology,
+      );
       await tester.tap(find.text('Invade Dest'));
       await tester.pump();
       expect(find.textContaining('Musketeers'), findsWidgets);

--- a/app/test/move_army_invasion_intel_test_support.dart
+++ b/app/test/move_army_invasion_intel_test_support.dart
@@ -1,0 +1,228 @@
+// Shared Game/topology fixtures for move-army invasion intel tests (Refs #4352).
+
+import 'package:colonizethis_app/features/game/widgets/unit_orders/move_army_dialog.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'move_dialogs_specs_test_support.dart';
+
+const kMoveArmyIntelHumanId = 'gp_intel';
+const kMoveArmyIntelRivalId = 'gp_rival';
+const kMoveArmyIntelFrom = 'oldWorld|p_from';
+const kMoveArmyIntelInvasionDest = 'oldWorld|p_invade';
+
+const kMoveArmyIntelUiHumanId = 'gp_intel_ui';
+const kMoveArmyIntelUiRivalId = 'gp_rival_ui';
+const kMoveArmyIntelUiFrom = 'oldWorld|p_from';
+const kMoveArmyIntelUiOwnedDest = 'oldWorld|p_owned';
+const kMoveArmyIntelUiInvasionDest = 'oldWorld|p_invade';
+
+Game buildMoveArmyInvasionIntelBaseGame({
+  required Map<String, String> visibilityByTile,
+  int fortLevel = 0,
+  List<Unit> invasionUnits = const [],
+}) {
+  return Game(
+    id: 'g_intel',
+    worldState: WorldState(
+      turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+      oldWorld: RegionData(
+        provinces: [
+          Province(
+            id: kMoveArmyIntelFrom,
+            regionId: 'oldWorld',
+            ownerId: kMoveArmyIntelHumanId,
+            displayName: 'Origin',
+          ),
+          Province(
+            id: kMoveArmyIntelInvasionDest,
+            regionId: 'oldWorld',
+            ownerId: kMoveArmyIntelRivalId,
+            displayName: 'Invade Dest',
+            fortLevel: fortLevel,
+          ),
+        ],
+        units: [
+          Unit(
+            id: 'u_mover',
+            type: 'musketeers',
+            ownerId: kMoveArmyIntelHumanId,
+            locationProvinceId: kMoveArmyIntelFrom,
+          ),
+          ...invasionUnits,
+        ],
+      ),
+      newWorld: const RegionData(),
+      armies: const [
+        Army(
+          id: 'a_intel',
+          ownerId: kMoveArmyIntelHumanId,
+          regionId: 'oldWorld',
+          stationedProvinceId: kMoveArmyIntelFrom,
+          regimentUnitIds: ['u_mover'],
+          isHomeArmy: false,
+        ),
+      ],
+      tileKeysByRegionAndProvince: const {
+        'oldWorld': {
+          kMoveArmyIntelFrom: ['oldWorld|p_from|0|0'],
+          kMoveArmyIntelInvasionDest: ['oldWorld|p_invade|0|0'],
+        },
+      },
+      playerVisibilityByTile: {kMoveArmyIntelHumanId: visibilityByTile},
+    ),
+    players: const [
+      Player(
+        id: kMoveArmyIntelHumanId,
+        displayName: 'Human',
+        isHuman: true,
+        capitalProvinceId: kMoveArmyIntelFrom,
+      ),
+      Player(
+        id: kMoveArmyIntelRivalId,
+        displayName: 'Rival',
+        isHuman: false,
+        capitalProvinceId: kMoveArmyIntelInvasionDest,
+      ),
+    ],
+  );
+}
+
+MapTopology buildMoveArmyInvasionIntelUiTopology() {
+  return const MapTopology(
+    nodes: [
+      TopologyNode(
+        id: kMoveArmyIntelUiFrom,
+        regionId: 'oldWorld',
+        type: TopologyNodeType.province,
+      ),
+      TopologyNode(
+        id: kMoveArmyIntelUiOwnedDest,
+        regionId: 'oldWorld',
+        type: TopologyNodeType.province,
+      ),
+      TopologyNode(
+        id: kMoveArmyIntelUiInvasionDest,
+        regionId: 'oldWorld',
+        type: TopologyNodeType.province,
+      ),
+    ],
+    edges: [
+      TopologyEdge(id1: kMoveArmyIntelUiFrom, id2: kMoveArmyIntelUiOwnedDest),
+      TopologyEdge(
+        id1: kMoveArmyIntelUiFrom,
+        id2: kMoveArmyIntelUiInvasionDest,
+      ),
+    ],
+  );
+}
+
+Game buildMoveArmyInvasionIntelUiGame({
+  required Map<String, String> visibilityByTile,
+  int fortLevel = 0,
+  List<Unit> extraUnits = const [],
+}) {
+  return Game(
+    id: 'g_intel_ui',
+    worldState: WorldState(
+      turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+      oldWorld: RegionData(
+        provinces: [
+          Province(
+            id: kMoveArmyIntelUiFrom,
+            regionId: 'oldWorld',
+            ownerId: kMoveArmyIntelUiHumanId,
+            displayName: 'Origin',
+          ),
+          Province(
+            id: kMoveArmyIntelUiOwnedDest,
+            regionId: 'oldWorld',
+            ownerId: kMoveArmyIntelUiHumanId,
+            displayName: 'Owned Dest',
+          ),
+          Province(
+            id: kMoveArmyIntelUiInvasionDest,
+            regionId: 'oldWorld',
+            ownerId: kMoveArmyIntelUiRivalId,
+            displayName: 'Invade Dest',
+            fortLevel: fortLevel,
+          ),
+        ],
+        units: [
+          Unit(
+            id: 'u_mover',
+            type: 'musketeers',
+            ownerId: kMoveArmyIntelUiHumanId,
+            locationProvinceId: kMoveArmyIntelUiFrom,
+          ),
+          ...extraUnits,
+        ],
+      ),
+      newWorld: const RegionData(),
+      armies: const [
+        Army(
+          id: 'a_ui',
+          ownerId: kMoveArmyIntelUiHumanId,
+          regionId: 'oldWorld',
+          stationedProvinceId: kMoveArmyIntelUiFrom,
+          regimentUnitIds: ['u_mover'],
+          isHomeArmy: false,
+        ),
+      ],
+      tileKeysByRegionAndProvince: const {
+        'oldWorld': {
+          kMoveArmyIntelUiFrom: ['oldWorld|p_from|0|0'],
+          kMoveArmyIntelUiOwnedDest: ['oldWorld|p_owned|0|0'],
+          kMoveArmyIntelUiInvasionDest: ['oldWorld|p_invade|0|0'],
+        },
+      },
+      playerVisibilityByTile: {kMoveArmyIntelUiHumanId: visibilityByTile},
+    ),
+    players: const [
+      Player(
+        id: kMoveArmyIntelUiHumanId,
+        displayName: 'Human',
+        isHuman: true,
+        capitalProvinceId: kMoveArmyIntelUiFrom,
+      ),
+      Player(
+        id: kMoveArmyIntelUiRivalId,
+        displayName: 'Rival',
+        isHuman: false,
+        capitalProvinceId: kMoveArmyIntelUiInvasionDest,
+      ),
+    ],
+  );
+}
+
+Future<void> pumpMoveArmyInvasionIntelDialog(
+  WidgetTester tester, {
+  required Game game,
+  required MapTopology topology,
+}) async {
+  final army = game.worldState.armies.first;
+  final view = buildPlayerView(game, topology, kMoveArmyIntelUiHumanId);
+  await tester.pumpWidget(
+    moveDialogsSpecsFrameWithOpener(
+      (context) => () {
+        showDialog<void>(
+          context: context,
+          builder: (_) => MoveArmyDialog(
+            army: army,
+            game: game,
+            humanPlayerId: kMoveArmyIntelUiHumanId,
+            bus: AppEventBus.create(),
+            topology: topology,
+            draftOrders: const Orders(),
+            playerView: view,
+          ),
+        );
+      },
+    ),
+  );
+  await tester.tap(find.text('open'));
+  await tester.pumpAndSettle();
+}

--- a/app/test/move_dialogs_specs_army_support.dart
+++ b/app/test/move_dialogs_specs_army_support.dart
@@ -1,0 +1,258 @@
+// Army-dialog fixtures for move_dialogs_specs_part1 (Refs #4352).
+
+import 'dart:async';
+
+import 'package:colonizethis_app/features/game/widgets/unit_orders/move_army_dialog.dart';
+import 'package:colonizethis_app/widgets/ct_dialog_shell.dart';
+import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'move_dialogs_specs_test_support.dart';
+
+const kMoveArmySpecsPlayerId = 'gp_specs_army';
+const kMoveArmySpecsRivalId = 'gp_specs_rival';
+const kMoveArmySpecsFrom = 'oldWorld|p_from';
+const kMoveArmySpecsOwnedDest = 'oldWorld|p_owned';
+const kMoveArmySpecsInvasionDest = 'oldWorld|p_invade';
+const kMoveArmySpecsIsolatedPlayerId = 'gp_isolated';
+const kMoveArmySpecsIsolatedFrom = 'oldWorld|p_isolated';
+
+MapTopology buildMoveArmySpecsTopology() {
+  return const MapTopology(
+    nodes: [
+      TopologyNode(
+        id: kMoveArmySpecsFrom,
+        regionId: 'oldWorld',
+        type: TopologyNodeType.province,
+      ),
+      TopologyNode(
+        id: kMoveArmySpecsOwnedDest,
+        regionId: 'oldWorld',
+        type: TopologyNodeType.province,
+      ),
+      TopologyNode(
+        id: kMoveArmySpecsInvasionDest,
+        regionId: 'oldWorld',
+        type: TopologyNodeType.province,
+      ),
+    ],
+    edges: [
+      TopologyEdge(id1: kMoveArmySpecsFrom, id2: kMoveArmySpecsOwnedDest),
+      TopologyEdge(id1: kMoveArmySpecsFrom, id2: kMoveArmySpecsInvasionDest),
+    ],
+  );
+}
+
+Game buildMoveArmySpecsGame() {
+  return Game(
+    id: 'g_specs_army',
+    worldState: WorldState(
+      turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+      oldWorld: RegionData(
+        provinces: const [
+          Province(
+            id: kMoveArmySpecsFrom,
+            regionId: 'oldWorld',
+            ownerId: kMoveArmySpecsPlayerId,
+            displayName: 'Origin',
+          ),
+          Province(
+            id: kMoveArmySpecsOwnedDest,
+            regionId: 'oldWorld',
+            ownerId: kMoveArmySpecsPlayerId,
+            displayName: 'Owned Dest',
+          ),
+          Province(
+            id: kMoveArmySpecsInvasionDest,
+            regionId: 'oldWorld',
+            ownerId: kMoveArmySpecsRivalId,
+            displayName: 'Invade Dest',
+          ),
+        ],
+        units: [
+          Unit(
+            id: 'u_specs',
+            type: 'musketeers',
+            ownerId: kMoveArmySpecsPlayerId,
+            locationProvinceId: kMoveArmySpecsFrom,
+          ),
+        ],
+      ),
+      newWorld: const RegionData(),
+      armies: const [
+        Army(
+          id: 'aspecs',
+          ownerId: kMoveArmySpecsPlayerId,
+          regionId: 'oldWorld',
+          stationedProvinceId: kMoveArmySpecsFrom,
+          regimentUnitIds: ['u_specs'],
+          isHomeArmy: false,
+        ),
+      ],
+      tileKeysByRegionAndProvince: const {
+        'oldWorld': {
+          kMoveArmySpecsFrom: ['oldWorld|p_from|0|0'],
+          kMoveArmySpecsOwnedDest: ['oldWorld|p_owned|0|0'],
+          kMoveArmySpecsInvasionDest: ['oldWorld|p_invade|0|0'],
+        },
+      },
+      playerVisibilityByTile: const {
+        kMoveArmySpecsPlayerId: {
+          'oldWorld|p_from|0|0': 'fullyVisible',
+          'oldWorld|p_owned|0|0': 'fullyVisible',
+          'oldWorld|p_invade|0|0': 'fullyVisible',
+        },
+      },
+    ),
+    players: const [
+      Player(
+        id: kMoveArmySpecsPlayerId,
+        displayName: 'Specs Player',
+        isHuman: true,
+        capitalProvinceId: kMoveArmySpecsFrom,
+      ),
+      Player(
+        id: kMoveArmySpecsRivalId,
+        displayName: 'Specs Rival',
+        isHuman: false,
+        capitalProvinceId: kMoveArmySpecsInvasionDest,
+      ),
+    ],
+  );
+}
+
+Game buildMoveArmySpecsIsolatedGame() {
+  return Game(
+    id: 'g_isolated_army',
+    worldState: WorldState(
+      turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+      oldWorld: RegionData(
+        provinces: const [
+          Province(
+            id: kMoveArmySpecsIsolatedFrom,
+            regionId: 'oldWorld',
+            ownerId: kMoveArmySpecsIsolatedPlayerId,
+            displayName: 'Lonely',
+          ),
+        ],
+        units: [
+          Unit(
+            id: 'u_isolated',
+            type: 'musketeers',
+            ownerId: kMoveArmySpecsIsolatedPlayerId,
+            locationProvinceId: kMoveArmySpecsIsolatedFrom,
+          ),
+        ],
+      ),
+      newWorld: const RegionData(),
+      armies: const [
+        Army(
+          id: 'aisolated',
+          ownerId: kMoveArmySpecsIsolatedPlayerId,
+          regionId: 'oldWorld',
+          stationedProvinceId: kMoveArmySpecsIsolatedFrom,
+          regimentUnitIds: ['u_isolated'],
+          isHomeArmy: false,
+        ),
+      ],
+      tileKeysByRegionAndProvince: const {
+        'oldWorld': {
+          kMoveArmySpecsIsolatedFrom: ['oldWorld|p_isolated|0|0'],
+        },
+      },
+    ),
+    players: const [
+      Player(
+        id: kMoveArmySpecsIsolatedPlayerId,
+        displayName: 'Isolated',
+        isHuman: true,
+        capitalProvinceId: kMoveArmySpecsIsolatedFrom,
+      ),
+    ],
+  );
+}
+
+const isolatedMoveArmySpecsTopology = MapTopology(
+  nodes: [
+    TopologyNode(
+      id: kMoveArmySpecsIsolatedFrom,
+      regionId: 'oldWorld',
+      type: TopologyNodeType.province,
+    ),
+  ],
+  edges: [],
+);
+
+Future<void> pumpMoveArmySpecsDialog(
+  WidgetTester tester, {
+  required AppEventBus bus,
+  Game? game,
+  MapTopology? topology,
+  String humanPlayerId = kMoveArmySpecsPlayerId,
+}) async {
+  final resolvedGame = game ?? buildMoveArmySpecsGame();
+  final resolvedTopology = topology ?? buildMoveArmySpecsTopology();
+  final army = resolvedGame.worldState.armies.first;
+  await tester.pumpWidget(
+    moveDialogsSpecsFrameWithOpener(
+      (context) => () {
+        showDialog<void>(
+          context: context,
+          builder: (_) => MoveArmyDialog(
+            army: army,
+            game: resolvedGame,
+            humanPlayerId: humanPlayerId,
+            bus: bus,
+            topology: resolvedTopology,
+            draftOrders: const Orders(),
+          ),
+        );
+      },
+    ),
+  );
+  await tester.tap(find.text('open'));
+  await tester.pumpAndSettle();
+}
+
+(
+  AppEventBus bus,
+  ArmyMoveRequestedEvent? Function() getCaptured,
+  StreamSubscription<ArmyMoveRequestedEvent> sub,
+)
+subscribeArmyMoveRequested() {
+  ArmyMoveRequestedEvent? captured;
+  final bus = AppEventBus.create();
+  final sub = bus.on<ArmyMoveRequestedEvent>().listen((e) {
+    captured = e;
+  });
+  return (bus, () => captured, sub);
+}
+
+Future<void> openInvasionWarConfirm(
+  WidgetTester tester,
+  AppEventBus bus,
+) async {
+  await pumpMoveArmySpecsDialog(tester, bus: bus);
+  await tester.tap(find.text('Invade Dest'));
+  await tester.pump();
+  await tester.tap(find.widgetWithText(CtNinePatchButton, 'Confirm'));
+  await tester.pumpAndSettle();
+  expect(find.text('Declare war?'), findsOneWidget);
+}
+
+Future<TextStyle?> invasionDeclareWarTriggerStyle(WidgetTester tester) async {
+  await pumpMoveArmySpecsDialog(tester, bus: AppEventBus.create());
+  final triggerFinder = find.text('declare war on Specs Rival');
+  expect(triggerFinder, findsOneWidget);
+  return tester.widget<Text>(triggerFinder).style;
+}
+
+Finder warConfirmSubShell() {
+  return find.ancestor(
+    of: find.text('Declare war?'),
+    matching: find.byType(CtDialogShell),
+  );
+}

--- a/app/test/move_dialogs_specs_part1_test.dart
+++ b/app/test/move_dialogs_specs_part1_test.dart
@@ -2,15 +2,12 @@
 // - SPEC/ui/move-army-dialog.md
 // Split under repo.app_test_file_size (Refs #4013).
 
-import 'dart:async';
-
 import 'package:colonizethis_app_ui_chrome/config/editorial_monocle_palette.dart';
 import 'package:colonizethis_app/config/themes.dart'
     show editorialMonocleDisplayFontFamily;
 import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
 import 'package:colonizethis_app/widgets/ct_dialog_shell.dart';
 import 'package:colonizethis_app/widgets/ct_section_label.dart';
-import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
@@ -18,196 +15,16 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:colonizethis_app/features/game/widgets/unit_orders/move_army_dialog.dart';
 
-import 'move_dialogs_specs_test_support.dart';
+import 'move_dialogs_specs_army_support.dart';
 
 void main() {
   suppressLogsForTests();
 
   group('MoveArmyDialog (SPEC/ui/move-army-dialog.md)', () {
-    const playerId = 'gp_specs_army';
-    const otherFactionId = 'gp_specs_rival';
-    const from = 'oldWorld|p_from';
-    const playerDest = 'oldWorld|p_owned';
-    const invasionDest = 'oldWorld|p_invade';
-
-    MapTopology buildTopology() {
-      return const MapTopology(
-        nodes: [
-          TopologyNode(
-            id: from,
-            regionId: 'oldWorld',
-            type: TopologyNodeType.province,
-          ),
-          TopologyNode(
-            id: playerDest,
-            regionId: 'oldWorld',
-            type: TopologyNodeType.province,
-          ),
-          TopologyNode(
-            id: invasionDest,
-            regionId: 'oldWorld',
-            type: TopologyNodeType.province,
-          ),
-        ],
-        edges: [
-          TopologyEdge(id1: from, id2: playerDest),
-          TopologyEdge(id1: from, id2: invasionDest),
-        ],
-      );
-    }
-
-    Game buildGame() {
-      return Game(
-        id: 'g_specs_army',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
-          oldWorld: RegionData(
-            provinces: const [
-              Province(
-                id: from,
-                regionId: 'oldWorld',
-                ownerId: playerId,
-                displayName: 'Origin',
-              ),
-              Province(
-                id: playerDest,
-                regionId: 'oldWorld',
-                ownerId: playerId,
-                displayName: 'Owned Dest',
-              ),
-              Province(
-                id: invasionDest,
-                regionId: 'oldWorld',
-                ownerId: otherFactionId,
-                displayName: 'Invade Dest',
-              ),
-            ],
-            units: [
-              Unit(
-                id: 'u_specs',
-                type: 'musketeers',
-                ownerId: playerId,
-                locationProvinceId: from,
-              ),
-            ],
-          ),
-          newWorld: const RegionData(),
-          armies: const [
-            Army(
-              id: 'aspecs',
-              ownerId: playerId,
-              regionId: 'oldWorld',
-              stationedProvinceId: from,
-              regimentUnitIds: ['u_specs'],
-              isHomeArmy: false,
-            ),
-          ],
-          tileKeysByRegionAndProvince: const {
-            'oldWorld': {
-              from: ['oldWorld|p_from|0|0'],
-              playerDest: ['oldWorld|p_owned|0|0'],
-              invasionDest: ['oldWorld|p_invade|0|0'],
-            },
-          },
-          playerVisibilityByTile: const {
-            playerId: {
-              'oldWorld|p_from|0|0': 'fullyVisible',
-              'oldWorld|p_owned|0|0': 'fullyVisible',
-              'oldWorld|p_invade|0|0': 'fullyVisible',
-            },
-          },
-        ),
-        players: const [
-          Player(
-            id: playerId,
-            displayName: 'Specs Player',
-            isHuman: true,
-            capitalProvinceId: from,
-          ),
-          Player(
-            id: otherFactionId,
-            displayName: 'Specs Rival',
-            isHuman: false,
-            capitalProvinceId: invasionDest,
-          ),
-        ],
-      );
-    }
-
-    Future<void> pumpDialog(
-      WidgetTester tester, {
-      required AppEventBus bus,
-    }) async {
-      final game = buildGame();
-      final topology = buildTopology();
-      final army = game.worldState.armies.first;
-      await tester.pumpWidget(
-        moveDialogsSpecsFrameWithOpener(
-          (context) => () {
-            showDialog<void>(
-              context: context,
-              builder: (_) => MoveArmyDialog(
-                army: army,
-                game: game,
-                humanPlayerId: playerId,
-                bus: bus,
-                topology: topology,
-                draftOrders: const Orders(),
-              ),
-            );
-          },
-        ),
-      );
-      await tester.tap(find.text('open'));
-      await tester.pumpAndSettle();
-    }
-
-    (
-      AppEventBus bus,
-      ArmyMoveRequestedEvent? Function() getCaptured,
-      StreamSubscription<ArmyMoveRequestedEvent> sub,
-    )
-    subscribeArmyMoveRequested() {
-      ArmyMoveRequestedEvent? captured;
-      final bus = AppEventBus.create();
-      final sub = bus.on<ArmyMoveRequestedEvent>().listen((e) {
-        captured = e;
-      });
-      return (bus, () => captured, sub);
-    }
-
-    Future<void> openInvasionWarConfirm(
-      WidgetTester tester,
-      AppEventBus bus,
-    ) async {
-      await pumpDialog(tester, bus: bus);
-      await tester.tap(find.text('Invade Dest'));
-      await tester.pump();
-      await tester.tap(find.widgetWithText(CtNinePatchButton, 'Confirm'));
-      await tester.pumpAndSettle();
-      expect(find.text('Declare war?'), findsOneWidget);
-    }
-
-    Future<TextStyle?> invasionDeclareWarTriggerStyle(
-      WidgetTester tester,
-    ) async {
-      await pumpDialog(tester, bus: AppEventBus.create());
-      final triggerFinder = find.text('declare war on Specs Rival');
-      expect(triggerFinder, findsOneWidget);
-      return tester.widget<Text>(triggerFinder).style;
-    }
-
-    Finder warConfirmSubShell() {
-      return find.ancestor(
-        of: find.text('Declare war?'),
-        matching: find.byType(CtDialogShell),
-      );
-    }
-
     testWidgets(
       'renders CtDialogShell with section labels and no Material dropdown (Refs #2867 S1)',
       (WidgetTester tester) async {
-        await pumpDialog(tester, bus: AppEventBus.create());
+        await pumpMoveArmySpecsDialog(tester, bus: AppEventBus.create());
         expect(find.byType(MoveArmyDialog), findsOneWidget);
         expect(find.byType(CtDialogShell), findsOneWidget);
         expect(find.byType(CtSectionLabel), findsAtLeastNWidgets(2));
@@ -231,13 +48,13 @@ void main() {
         final (bus, getCaptured, sub) = subscribeArmyMoveRequested();
         addTearDown(sub.cancel);
 
-        await pumpDialog(tester, bus: bus);
+        await pumpMoveArmySpecsDialog(tester, bus: bus);
         await tester.tap(find.widgetWithText(CtNinePatchButton, 'Confirm'));
         await tester.pumpAndSettle();
 
         final captured = getCaptured();
         expect(captured, isNotNull);
-        expect(captured!.humanPlayerId, playerId);
+        expect(captured!.humanPlayerId, kMoveArmySpecsPlayerId);
         expect(captured.moveOrder.armyId, 'aspecs');
         expect(captured.declareWarTargetFactionId, isNull);
         expect(find.byType(MoveArmyDialog), findsNothing);
@@ -272,8 +89,11 @@ void main() {
 
         final captured = getCaptured();
         expect(captured, isNotNull);
-        expect(captured!.declareWarTargetFactionId, otherFactionId);
-        expect(captured.moveOrder.destinationProvinceId, invasionDest);
+        expect(captured!.declareWarTargetFactionId, kMoveArmySpecsRivalId);
+        expect(
+          captured.moveOrder.destinationProvinceId,
+          kMoveArmySpecsInvasionDest,
+        );
       },
     );
 
@@ -354,7 +174,7 @@ void main() {
         final (bus, getCaptured, sub) = subscribeArmyMoveRequested();
         addTearDown(sub.cancel);
 
-        await pumpDialog(tester, bus: bus);
+        await pumpMoveArmySpecsDialog(tester, bus: bus);
         await tester.tap(find.widgetWithText(CtNinePatchButton, 'Cancel'));
         await tester.pumpAndSettle();
 
@@ -366,86 +186,13 @@ void main() {
     testWidgets(
       'with zero offered destinations renders the empty-state copy and disables Confirm',
       (WidgetTester tester) async {
-        const isolatedPlayerId = 'gp_isolated';
-        const isolatedFrom = 'oldWorld|p_isolated';
-        final isolatedGame = Game(
-          id: 'g_isolated_army',
-          worldState: WorldState(
-            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
-            oldWorld: RegionData(
-              provinces: const [
-                Province(
-                  id: isolatedFrom,
-                  regionId: 'oldWorld',
-                  ownerId: isolatedPlayerId,
-                  displayName: 'Lonely',
-                ),
-              ],
-              units: [
-                Unit(
-                  id: 'u_isolated',
-                  type: 'musketeers',
-                  ownerId: isolatedPlayerId,
-                  locationProvinceId: isolatedFrom,
-                ),
-              ],
-            ),
-            newWorld: const RegionData(),
-            armies: const [
-              Army(
-                id: 'aisolated',
-                ownerId: isolatedPlayerId,
-                regionId: 'oldWorld',
-                stationedProvinceId: isolatedFrom,
-                regimentUnitIds: ['u_isolated'],
-                isHomeArmy: false,
-              ),
-            ],
-            tileKeysByRegionAndProvince: const {
-              'oldWorld': {
-                isolatedFrom: ['oldWorld|p_isolated|0|0'],
-              },
-            },
-          ),
-          players: const [
-            Player(
-              id: isolatedPlayerId,
-              displayName: 'Isolated',
-              isHuman: true,
-              capitalProvinceId: isolatedFrom,
-            ),
-          ],
+        await pumpMoveArmySpecsDialog(
+          tester,
+          bus: AppEventBus.create(),
+          game: buildMoveArmySpecsIsolatedGame(),
+          topology: isolatedMoveArmySpecsTopology,
+          humanPlayerId: kMoveArmySpecsIsolatedPlayerId,
         );
-        const isolatedTopology = MapTopology(
-          nodes: [
-            TopologyNode(
-              id: isolatedFrom,
-              regionId: 'oldWorld',
-              type: TopologyNodeType.province,
-            ),
-          ],
-          edges: [],
-        );
-
-        await tester.pumpWidget(
-          moveDialogsSpecsFrameWithOpener(
-            (context) => () {
-              showDialog<void>(
-                context: context,
-                builder: (_) => MoveArmyDialog(
-                  army: isolatedGame.worldState.armies.first,
-                  game: isolatedGame,
-                  humanPlayerId: isolatedPlayerId,
-                  bus: AppEventBus.create(),
-                  topology: isolatedTopology,
-                  draftOrders: const Orders(),
-                ),
-              );
-            },
-          ),
-        );
-        await tester.tap(find.text('open'));
-        await tester.pumpAndSettle();
 
         expect(find.text('No valid destinations.'), findsOneWidget);
         expect(find.byType(DropdownButtonFormField<String>), findsNothing);

--- a/app/test/panels_320dp_min_viewport_test.dart
+++ b/app/test/panels_320dp_min_viewport_test.dart
@@ -9,9 +9,7 @@ import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:colonizethis_app/config/constants.dart';
 import 'package:colonizethis_app/features/game/widgets/diplomacy/diplomacy_panel.dart';
-import 'package:colonizethis_app/features/game/widgets/production/production_panel.dart';
 import 'package:colonizethis_app_fixtures/demo/province_overlay_demo_data.dart'
     show
         demoGameForOverlay,
@@ -22,415 +20,310 @@ import 'package:colonizethis_app_fixtures/demo/province_overlay_demo_data.dart'
 import 'package:colonizethis_app/features/game/widgets/province_overlay/province_sea_zone_detail_overlay.dart';
 import 'package:colonizethis_app/features/game/widgets/technology/technology_panel.dart';
 
-import 'production_panel_test_support.dart';
-import 'min_viewport_harness.dart';
 import 'panel_test_fixtures.dart';
 import 'widget_test_assets.dart';
-
-/// Minimum supported viewport dimensions for SPEC/ui/mobile-adaptation.md
-/// § 7. Width matches [kMinViewportWidth]; height (640 dp) mirrors the
-/// existing screen-level pin file.
-const Size _kMinViewport = Size(kMinViewportWidth, 640);
-
-/// Wide regression sentinel — comfortably above every per-screen breakpoint
-/// so the same panel renders its wide layout. If a future refactor flips
-/// the overflow contract upstream, the contrast with the 320 dp positive
-/// pins keeps the regression signal honest. Mirrors the same pattern in
-/// `mobile_320dp_min_viewport_test.dart`.
-const Size _kWideRegressionViewport = Size(1024, 768);
-
-/// Pumps [child] at [size] under the running editorial-monocle theme.
-/// Sets the surface size (so the binding's render flex math sees the
-/// minimum viewport) and overrides MediaQuery so widget code that reads
-/// `MediaQuery.sizeOf(context).width` resolves to the same value — the
-/// pattern used by `mobile_320dp_min_viewport_test.dart` and
-/// `victory_overlay_narrow_test.dart`.
-Future<void> _pumpNarrow(
-  WidgetTester tester,
-  Widget child, {
-  required Size size,
-  bool settle = true,
-}) async {
-  if (settle) {
-    await pumpAtMinViewport(
-      tester,
-      size: size,
-      child: Scaffold(body: child),
-      settle: true,
-    );
-    return;
-  }
-  // DiplomacyPanel's hover-aware row chrome animates the border color via
-  // `AnimatedContainer`; `pumpAndSettle` would block on that animation.
-  // The harness pumps one frame; a second short timed pump lays out the
-  // body without entering the animation steady-state loop.
-  await pumpAtMinViewport(tester, size: size, child: Scaffold(body: child));
-  await tester.pump(const Duration(milliseconds: 16));
-}
-
-Widget _buildProductionPanel(Player player) {
-  return ProductionPanel(
-    game: productionPanelTestGameFor(player),
-    player: player,
-    desiredOutputByRecipe: const <String, int>{},
-    netDeltasByCommodity: const <String, int>{},
-    labourReadiness: labourReadinessForPlayer(player),
-    forcesFeeding: forcesFeedingForPlayer(player),
-    onDesiredOutputChanged: (_) {},
-  );
-}
-
-Widget _buildDiplomacyPanel({
-  required Game game,
-  required MapTopology topology,
-  required String humanPlayerId,
-}) {
-  return DiplomacyPanel(
-    game: game,
-    humanPlayerId: humanPlayerId,
-    topology: topology,
-    currentOrders: const Orders(),
-    bus: AppEventBus.create(),
-  );
-}
-
-/// Mirrors [TechnologyScreen] `_SlotsBody`: scroll host + panel so the 320 dp
-/// pin exercises the same vertical-scroll contract as production.
-Widget _buildTechnologyPanelSlotsBody({
-  required Game game,
-  required Player player,
-}) {
-  return SingleChildScrollView(
-    padding: const EdgeInsets.all(16),
-    child: TechnologyPanel(
-      game: game,
-      player: player,
-    ),
-  );
-}
+import 'panels_320dp_min_viewport_test_support.dart';
 
 void main() {
   suppressLogsForTests();
 
-  group(
-    'SPEC/ui/mobile-adaptation.md § 7 — ProductionPanel @ 320 dp '
-    '(Refs #2870 S10)',
-    () {
-      late Player fullPlayer;
-      late Player partialPlayer;
+  group('SPEC/ui/mobile-adaptation.md § 7 — ProductionPanel @ 320 dp '
+      '(Refs #2870 S10)', () {
+    late Player fullPlayer;
+    late Player partialPlayer;
 
-      setUpAll(() {
-        fullPlayer = productionPanelTestFullPlayer();
-        partialPlayer = productionPanelTestPartialPlayer();
-      });
+    setUpAll(() {
+      fullPlayer = productionPanelTestFullPlayer();
+      partialPlayer = productionPanelTestPartialPlayer();
+    });
 
-      testWidgets(
-        'AC (positive) ProductionPanel (full player) @ 320×640: no '
+    testWidgets('AC (positive) ProductionPanel (full player) @ 320×640: no '
         'RenderFlex overflow exception, Available + Allocation labels both '
-        'render',
-        (WidgetTester tester) async {
-          await _pumpNarrow(
-            tester,
-            _buildProductionPanel(fullPlayer),
-            size: _kMinViewport,
-          );
-
-          expect(
-            tester.takeException(),
-            isNull,
-            reason:
-                'SPEC/ui/mobile-adaptation.md § 7: ProductionPanel must not '
-                'emit a RenderFlex overflow exception at kMinViewportWidth '
-                '(320 dp). The wide layout (Padding + Row with Expanded '
-                'flex 1 + Expanded flex 2) would overflow at 320 dp; the '
-                'narrow `_ProductionPanelNarrowLayout` (SingleChildScrollView '
-                '> Column) is selected at < kNarrowBreakpoint (600 dp) and '
-                'must lay out without overflowing.',
-          );
-          expect(find.text('Available'), findsOneWidget);
-          expect(find.text('Allocation'), findsOneWidget);
-        },
+        'render', (WidgetTester tester) async {
+      await pumpPanelsNarrow(
+        tester,
+        buildPanelsProductionPanel(fullPlayer),
+        size: kPanelsMinViewport,
       );
 
-      testWidgets(
-        'AC (positive) ProductionPanel (partial player) @ 320×640: no '
+      expect(
+        tester.takeException(),
+        isNull,
+        reason:
+            'SPEC/ui/mobile-adaptation.md § 7: ProductionPanel must not '
+            'emit a RenderFlex overflow exception at kMinViewportWidth '
+            '(320 dp). The wide layout (Padding + Row with Expanded '
+            'flex 1 + Expanded flex 2) would overflow at 320 dp; the '
+            'narrow `_ProductionPanelNarrowLayout` (SingleChildScrollView '
+            '> Column) is selected at < kNarrowBreakpoint (600 dp) and '
+            'must lay out without overflowing.',
+      );
+      expect(find.text('Available'), findsOneWidget);
+      expect(find.text('Allocation'), findsOneWidget);
+    });
+
+    testWidgets('AC (positive) ProductionPanel (partial player) @ 320×640: no '
         'exception (regression guard for the partial-stockpile path the '
-        'existing production_panel_test exercises at wider widths)',
-        (WidgetTester tester) async {
-          await _pumpNarrow(
-            tester,
-            _buildProductionPanel(partialPlayer),
-            size: _kMinViewport,
-          );
-
-          expect(tester.takeException(), isNull);
-          expect(find.text('Available'), findsOneWidget);
-          expect(find.text('Allocation'), findsOneWidget);
-        },
+        'existing production_panel_test exercises at wider widths)', (
+      WidgetTester tester,
+    ) async {
+      await pumpPanelsNarrow(
+        tester,
+        buildPanelsProductionPanel(partialPlayer),
+        size: kPanelsMinViewport,
       );
 
-      testWidgets(
-        'Negative control: ProductionPanel (full player) @ 1024×768 also '
-        'pumps without exception (regression sentinel for the overflow '
-        'contract — keeps the 320 dp positive pins meaningful)',
-        (WidgetTester tester) async {
-          await _pumpNarrow(
-            tester,
-            _buildProductionPanel(fullPlayer),
-            size: _kWideRegressionViewport,
-          );
+      expect(tester.takeException(), isNull);
+      expect(find.text('Available'), findsOneWidget);
+      expect(find.text('Allocation'), findsOneWidget);
+    });
 
-          expect(tester.takeException(), isNull);
-          expect(find.text('Available'), findsOneWidget);
-          expect(find.text('Allocation'), findsOneWidget);
-        },
+    testWidgets(
+      'Negative control: ProductionPanel (full player) @ 1024×768 also '
+      'pumps without exception (regression sentinel for the overflow '
+      'contract — keeps the 320 dp positive pins meaningful)',
+      (WidgetTester tester) async {
+        await pumpPanelsNarrow(
+          tester,
+          buildPanelsProductionPanel(fullPlayer),
+          size: kPanelsWideRegressionViewport,
+        );
+
+        expect(tester.takeException(), isNull);
+        expect(find.text('Available'), findsOneWidget);
+        expect(find.text('Allocation'), findsOneWidget);
+      },
+    );
+  });
+
+  group('SPEC/ui/mobile-adaptation.md § 7 — DiplomacyPanel @ 320 dp '
+      '(Refs #2870 S10)', () {
+    late Game game;
+    late MapTopology topology;
+    late String humanPlayerId;
+    late String firstNonHumanFactionId;
+
+    setUp(() => AppEventBus.reset());
+
+    setUpAll(() async {
+      await preloadNinePatchImage();
+      // Lightweight fixture (Refs #3656): a single discovered Great Power is
+      // enough to exercise the narrow faction-row body; no generated
+      // map/topology data is read, so an empty `MapTopology` suffices.
+      game = buildDiplomacyPanelTestGame();
+      topology = const MapTopology();
+      humanPlayerId = game.players.first.id;
+      final rows = buildDiplomacyRows(
+        game,
+        topology,
+        humanPlayerId,
+        const Orders(),
       );
-    },
-  );
+      expect(
+        rows,
+        isNotEmpty,
+        reason:
+            'Lightweight diplomacy fixture must seed at least one discovered '
+            'faction so a 320 dp render exercises the narrow faction-row body.',
+      );
+      firstNonHumanFactionId = rows.first.factionId;
+    });
 
-  group(
-    'SPEC/ui/mobile-adaptation.md § 7 — DiplomacyPanel @ 320 dp '
-    '(Refs #2870 S10)',
-    () {
-      late Game game;
-      late MapTopology topology;
-      late String humanPlayerId;
-      late String firstNonHumanFactionId;
+    testWidgets(
+      'AC (positive) DiplomacyPanel @ 320×640: no RenderFlex overflow '
+      'exception, narrow Column body selected for the first discovered '
+      'faction row',
+      (WidgetTester tester) async {
+        await pumpPanelsNarrow(
+          tester,
+          buildPanelsDiplomacyPanel(
+            game: game,
+            topology: topology,
+            humanPlayerId: humanPlayerId,
+          ),
+          size: kPanelsMinViewport,
+          settle: false,
+        );
 
-      setUp(() => AppEventBus.reset());
-
-      setUpAll(() async {
-        await preloadNinePatchImage();
-        // Lightweight fixture (Refs #3656): a single discovered Great Power is
-        // enough to exercise the narrow faction-row body; no generated
-        // map/topology data is read, so an empty `MapTopology` suffices.
-        game = buildDiplomacyPanelTestGame();
-        topology = const MapTopology();
-        humanPlayerId = game.players.first.id;
-        final rows = buildDiplomacyRows(
-          game,
-          topology,
-          humanPlayerId,
-          const Orders(),
+        expect(
+          tester.takeException(),
+          isNull,
+          reason:
+              'SPEC/ui/mobile-adaptation.md § 7: DiplomacyPanel must not '
+              'emit a RenderFlex overflow exception at kMinViewportWidth '
+              '(320 dp). The faction-row header/relation Rows and action '
+              'Wrap must lay out within the narrow row body.',
+        );
+        final Key bodyKey = ValueKey(
+          '$kDiplomacyRowBodyKeyPrefix$firstNonHumanFactionId',
         );
         expect(
-          rows,
-          isNotEmpty,
+          find.byKey(bodyKey),
+          findsOneWidget,
           reason:
-              'Lightweight diplomacy fixture must seed at least one discovered '
-              'faction so a 320 dp render exercises the narrow faction-row body.',
+              'Narrow body must exist for the first discovered faction so '
+              'the 320 dp pin actually exercises the narrow layout path.',
         );
-        firstNonHumanFactionId = rows.first.factionId;
-      });
+        expect(
+          tester.widget(find.byKey(bodyKey)),
+          isA<Column>(),
+          reason:
+              'At kMinViewportWidth (320 dp) ≤ kDiplomacyRowNarrowMaxWidth '
+              '(500 dp), SPEC/ui/diplomacy-panel.md § Responsive layout '
+              'selects the narrow Column body.',
+        );
+      },
+    );
 
-      testWidgets(
-        'AC (positive) DiplomacyPanel @ 320×640: no RenderFlex overflow '
-        'exception, narrow Column body selected for the first discovered '
-        'faction row',
-        (WidgetTester tester) async {
-          await _pumpNarrow(
-            tester,
-            _buildDiplomacyPanel(
-              game: game,
-              topology: topology,
-              humanPlayerId: humanPlayerId,
-            ),
-            size: _kMinViewport,
-            settle: false,
-          );
-
-          expect(
-            tester.takeException(),
-            isNull,
-            reason:
-                'SPEC/ui/mobile-adaptation.md § 7: DiplomacyPanel must not '
-                'emit a RenderFlex overflow exception at kMinViewportWidth '
-                '(320 dp). The faction-row header/relation Rows and action '
-                'Wrap must lay out within the narrow row body.',
-          );
-          final Key bodyKey = ValueKey(
-            '$kDiplomacyRowBodyKeyPrefix$firstNonHumanFactionId',
-          );
-          expect(
-            find.byKey(bodyKey),
-            findsOneWidget,
-            reason:
-                'Narrow body must exist for the first discovered faction so '
-                'the 320 dp pin actually exercises the narrow layout path.',
-          );
-          expect(
-            tester.widget(find.byKey(bodyKey)),
-            isA<Column>(),
-            reason:
-                'At kMinViewportWidth (320 dp) ≤ kDiplomacyRowNarrowMaxWidth '
-                '(500 dp), SPEC/ui/diplomacy-panel.md § Responsive layout '
-                'selects the narrow Column body.',
-          );
-        },
-      );
-
-      testWidgets(
-        'Negative control: DiplomacyPanel @ 1024×768 pumps without '
+    testWidgets('Negative control: DiplomacyPanel @ 1024×768 pumps without '
         'exception (regression sentinel against future narrow-only fixes '
-        'breaking the wide layout)',
-        (WidgetTester tester) async {
-          await _pumpNarrow(
-            tester,
-            _buildDiplomacyPanel(
-              game: game,
-              topology: topology,
-              humanPlayerId: humanPlayerId,
-            ),
-            size: _kWideRegressionViewport,
-            settle: false,
-          );
-
-          expect(tester.takeException(), isNull);
-        },
+        'breaking the wide layout)', (WidgetTester tester) async {
+      await pumpPanelsNarrow(
+        tester,
+        buildPanelsDiplomacyPanel(
+          game: game,
+          topology: topology,
+          humanPlayerId: humanPlayerId,
+        ),
+        size: kPanelsWideRegressionViewport,
+        settle: false,
       );
-    },
-  );
 
-  group(
-    'SPEC/ui/mobile-adaptation.md § 7 — TechnologyPanel @ 320 dp '
-    '(Refs #2870 S10)',
-    () {
-      late Game game;
-      late Player player;
+      expect(tester.takeException(), isNull);
+    });
+  });
 
-      setUpAll(() {
-        // Lightweight fixture (Refs #3656): the Technology panel reads only
-        // `game.players`; the single human starts with the default research-slot
-        // count (3 active + 1 locked), matching the assertions below.
-        game = buildTechnologyPanelTestGame();
-        player = game.players.first;
-      });
+  group('SPEC/ui/mobile-adaptation.md § 7 — TechnologyPanel @ 320 dp '
+      '(Refs #2870 S10)', () {
+    late Game game;
+    late Player player;
 
-      testWidgets(
-        'AC (positive) TechnologyPanel (Slots body host) @ 320×640: no '
+    setUpAll(() {
+      // Lightweight fixture (Refs #3656): the Technology panel reads only
+      // `game.players`; the single human starts with the default research-slot
+      // count (3 active + 1 locked), matching the assertions below.
+      game = buildTechnologyPanelTestGame();
+      player = game.players.first;
+    });
+
+    testWidgets('AC (positive) TechnologyPanel (Slots body host) @ 320×640: no '
         'RenderFlex overflow exception, four slot cards + researched heading '
-        'render',
-        (WidgetTester tester) async {
-          await _pumpNarrow(
-            tester,
-            _buildTechnologyPanelSlotsBody(game: game, player: player),
-            size: _kMinViewport,
-          );
-
-          expect(
-            tester.takeException(),
-            isNull,
-            reason:
-                'SPEC/ui/mobile-adaptation.md § 7: TechnologyPanel inside '
-                'the TechnologyScreen Slots scroll host must not emit a '
-                'RenderFlex overflow exception at kMinViewportWidth (320 dp). '
-                'Slot cards and the researched grid rely on vertical scroll '
-                'instead of clipping.',
-          );
-          expect(find.byType(SingleChildScrollView), findsOneWidget);
-          // Debug-init player has three active slots + locked slot 4 (University).
-          expect(find.byType(ResearchSlotCard), findsNWidgets(3));
-          expect(find.byType(LockedResearchSlotCard), findsOneWidget);
-          expect(find.text('Researched Techs'), findsOneWidget);
-        },
+        'render', (WidgetTester tester) async {
+      await pumpPanelsNarrow(
+        tester,
+        buildPanelsTechnologySlotsBody(game: game, player: player),
+        size: kPanelsMinViewport,
       );
 
-      testWidgets(
-        'Negative control: TechnologyPanel (Slots body host) @ 1024×768 '
-        'pumps without exception',
-        (WidgetTester tester) async {
-          await _pumpNarrow(
-            tester,
-            _buildTechnologyPanelSlotsBody(game: game, player: player),
-            size: _kWideRegressionViewport,
-          );
-
-          expect(tester.takeException(), isNull);
-          expect(find.byType(ResearchSlotCard), findsNWidgets(3));
-          expect(find.byType(LockedResearchSlotCard), findsOneWidget);
-        },
+      expect(
+        tester.takeException(),
+        isNull,
+        reason:
+            'SPEC/ui/mobile-adaptation.md § 7: TechnologyPanel inside '
+            'the TechnologyScreen Slots scroll host must not emit a '
+            'RenderFlex overflow exception at kMinViewportWidth (320 dp). '
+            'Slot cards and the researched grid rely on vertical scroll '
+            'instead of clipping.',
       );
-    },
-  );
+      expect(find.byType(SingleChildScrollView), findsOneWidget);
+      // Debug-init player has three active slots + locked slot 4 (University).
+      expect(find.byType(ResearchSlotCard), findsNWidgets(3));
+      expect(find.byType(LockedResearchSlotCard), findsOneWidget);
+      expect(find.text('Researched Techs'), findsOneWidget);
+    });
 
-  group(
-    'SPEC/ui/mobile-adaptation.md § 7 — ProvinceSeaZoneDetailOverlay '
-    '@ 320 dp (Refs #2870 S10)',
-    () {
-      // Constructed lazily inside each test so the demo-data getters resolve
-      // against the running test binding (matches game_map_narrow_detail_
-      // overlay_test.dart).
-      Widget buildOverlay({double? heightPx}) {
-        final overlay = ProvinceSeaZoneDetailOverlay(
-          game: demoGameForOverlay,
-          region: demoRegionForOverlay,
-          displayId: sampleProvinceIdForOverlay,
-          selectedTileKey: sampleTileKeyForProvinceOverlay,
-          humanPlayerId: demoGameForOverlay.players.first.id,
-          playerView: demoHumanPlayerViewForOverlay,
+    testWidgets(
+      'Negative control: TechnologyPanel (Slots body host) @ 1024×768 '
+      'pumps without exception',
+      (WidgetTester tester) async {
+        await pumpPanelsNarrow(
+          tester,
+          buildPanelsTechnologySlotsBody(game: game, player: player),
+          size: kPanelsWideRegressionViewport,
         );
-        // Mirrors GameMapNarrowDetailOverlaySlot's bottom-anchored
-        // `SizedBox(height: viewport.height * 0.33)` host so the overlay
-        // sees the same ~33 vh ceiling it would in the running game per
-        // SPEC/ui/in-game-shell-narrow.md § Province/sea zone detail overlay.
-        if (heightPx != null) {
-          return Align(
-            alignment: Alignment.bottomCenter,
-            child: SizedBox(height: heightPx, child: overlay),
-          );
-        }
-        return overlay;
+
+        expect(tester.takeException(), isNull);
+        expect(find.byType(ResearchSlotCard), findsNWidgets(3));
+        expect(find.byType(LockedResearchSlotCard), findsOneWidget);
+      },
+    );
+  });
+
+  group('SPEC/ui/mobile-adaptation.md § 7 — ProvinceSeaZoneDetailOverlay '
+      '@ 320 dp (Refs #2870 S10)', () {
+    // Constructed lazily inside each test so the demo-data getters resolve
+    // against the running test binding (matches game_map_narrow_detail_
+    // overlay_test.dart).
+    Widget buildOverlay({double? heightPx}) {
+      final overlay = ProvinceSeaZoneDetailOverlay(
+        game: demoGameForOverlay,
+        region: demoRegionForOverlay,
+        displayId: sampleProvinceIdForOverlay,
+        selectedTileKey: sampleTileKeyForProvinceOverlay,
+        humanPlayerId: demoGameForOverlay.players.first.id,
+        playerView: demoHumanPlayerViewForOverlay,
+      );
+      // Mirrors GameMapNarrowDetailOverlaySlot's bottom-anchored
+      // `SizedBox(height: viewport.height * 0.33)` host so the overlay
+      // sees the same ~33 vh ceiling it would in the running game per
+      // SPEC/ui/in-game-shell-narrow.md § Province/sea zone detail overlay.
+      if (heightPx != null) {
+        return Align(
+          alignment: Alignment.bottomCenter,
+          child: SizedBox(height: heightPx, child: overlay),
+        );
       }
+      return overlay;
+    }
 
-      testWidgets(
-        'AC (positive) ProvinceSeaZoneDetailOverlay @ 320×640 hosted in '
-        'bottom-anchored ~33 vh slot: no RenderFlex overflow exception, '
-        'Province header + Tile tab label render',
-        (WidgetTester tester) async {
-          await _pumpNarrow(
-            tester,
-            buildOverlay(heightPx: _kMinViewport.height * 0.33),
-            size: _kMinViewport,
-          );
+    testWidgets(
+      'AC (positive) ProvinceSeaZoneDetailOverlay @ 320×640 hosted in '
+      'bottom-anchored ~33 vh slot: no RenderFlex overflow exception, '
+      'Province header + Tile tab label render',
+      (WidgetTester tester) async {
+        await pumpPanelsNarrow(
+          tester,
+          buildOverlay(heightPx: kPanelsMinViewport.height * 0.33),
+          size: kPanelsMinViewport,
+        );
 
-          expect(
-            tester.takeException(),
-            isNull,
-            reason:
-                'SPEC/ui/mobile-adaptation.md § 7 + § 4 (Province / sea '
-                'detail narrow row): ProvinceSeaZoneDetailOverlay must not '
-                'emit a RenderFlex overflow exception at kMinViewportWidth '
-                '(320 dp) when hosted inside the bottom-anchored ~33 vh '
-                'slot used by GameMapNarrowDetailOverlaySlot. The narrow '
-                'CtTabStrip body (Tile / Political / Economic / Military / '
-                'Civilian / Naval) must lay out within the 320 dp column '
-                'without horizontal overflow.',
-          );
-          expect(find.byType(ProvinceSeaZoneDetailOverlay), findsOneWidget);
-          expect(find.text('Province'), findsOneWidget);
-          // Narrow body renders a CtTabStrip with six tabs; the first
-          // ("Tile") is selected by default per SPEC § Tabs.
-          expect(find.text('Tile'), findsOneWidget);
-        },
-      );
+        expect(
+          tester.takeException(),
+          isNull,
+          reason:
+              'SPEC/ui/mobile-adaptation.md § 7 + § 4 (Province / sea '
+              'detail narrow row): ProvinceSeaZoneDetailOverlay must not '
+              'emit a RenderFlex overflow exception at kMinViewportWidth '
+              '(320 dp) when hosted inside the bottom-anchored ~33 vh '
+              'slot used by GameMapNarrowDetailOverlaySlot. The narrow '
+              'CtTabStrip body (Tile / Political / Economic / Military / '
+              'Civilian / Naval) must lay out within the 320 dp column '
+              'without horizontal overflow.',
+        );
+        expect(find.byType(ProvinceSeaZoneDetailOverlay), findsOneWidget);
+        expect(find.text('Province'), findsOneWidget);
+        // Narrow body renders a CtTabStrip with six tabs; the first
+        // ("Tile") is selected by default per SPEC § Tabs.
+        expect(find.text('Tile'), findsOneWidget);
+      },
+    );
 
-      testWidgets(
-        'Negative control: ProvinceSeaZoneDetailOverlay @ 1024×768 (wide '
-        'side-panel host) pumps without exception',
-        (WidgetTester tester) async {
-          // Wide layout: side-panel host gives the overlay full available
-          // height; no bottom-sheet 33 vh clamp.
-          await _pumpNarrow(
-            tester,
-            buildOverlay(),
-            size: _kWideRegressionViewport,
-          );
+    testWidgets(
+      'Negative control: ProvinceSeaZoneDetailOverlay @ 1024×768 (wide '
+      'side-panel host) pumps without exception',
+      (WidgetTester tester) async {
+        // Wide layout: side-panel host gives the overlay full available
+        // height; no bottom-sheet 33 vh clamp.
+        await pumpPanelsNarrow(
+          tester,
+          buildOverlay(),
+          size: kPanelsWideRegressionViewport,
+        );
 
-          expect(tester.takeException(), isNull);
-          expect(find.byType(ProvinceSeaZoneDetailOverlay), findsOneWidget);
-          expect(find.text('Province'), findsOneWidget);
-        },
-      );
-    },
-  );
+        expect(tester.takeException(), isNull);
+        expect(find.byType(ProvinceSeaZoneDetailOverlay), findsOneWidget);
+        expect(find.text('Province'), findsOneWidget);
+      },
+    );
+  });
 }

--- a/app/test/panels_320dp_min_viewport_test_support.dart
+++ b/app/test/panels_320dp_min_viewport_test_support.dart
@@ -1,0 +1,97 @@
+// Shared 320 dp panel pumps (Refs #4352).
+// SPEC: SPEC/ui/mobile-adaptation.md § 7.
+
+import 'package:colonizethis_app/config/constants.dart';
+import 'package:colonizethis_app/features/game/widgets/diplomacy/diplomacy_panel.dart';
+import 'package:colonizethis_app/features/game/widgets/production/production_panel.dart';
+import 'package:colonizethis_app/features/game/widgets/technology/technology_panel.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'min_viewport_harness.dart';
+import 'production_panel_test_support.dart';
+
+/// Minimum supported viewport dimensions for SPEC/ui/mobile-adaptation.md
+/// § 7. Width matches [kMinViewportWidth]; height (640 dp) mirrors the
+/// existing screen-level pin file.
+const Size kPanelsMinViewport = Size(kMinViewportWidth, 640);
+
+/// Wide regression sentinel — comfortably above every per-screen breakpoint
+/// so the same panel renders its wide layout. If a future refactor flips
+/// the overflow contract upstream, the contrast with the 320 dp positive
+/// pins keeps the regression signal honest. Mirrors the same pattern in
+/// `mobile_320dp_min_viewport_test.dart`.
+const Size kPanelsWideRegressionViewport = Size(1024, 768);
+
+/// Pumps [child] at [size] under the running editorial-monocle theme.
+/// Sets the surface size (so the binding's render flex math sees the
+/// minimum viewport) and overrides MediaQuery so widget code that reads
+/// `MediaQuery.sizeOf(context).width` resolves to the same value — the
+/// pattern used by `mobile_320dp_min_viewport_test.dart` and
+/// `victory_overlay_narrow_test.dart`.
+Future<void> pumpPanelsNarrow(
+  WidgetTester tester,
+  Widget child, {
+  required Size size,
+  bool settle = true,
+}) async {
+  if (settle) {
+    await pumpAtMinViewport(
+      tester,
+      size: size,
+      child: Scaffold(body: child),
+      settle: true,
+    );
+    return;
+  }
+  // DiplomacyPanel's hover-aware row chrome animates the border color via
+  // `AnimatedContainer`; `pumpAndSettle` would block on that animation.
+  // The harness pumps one frame; a second short timed pump lays out the
+  // body without entering the animation steady-state loop.
+  await pumpAtMinViewport(
+    tester,
+    size: size,
+    child: Scaffold(body: child),
+  );
+  await tester.pump(const Duration(milliseconds: 16));
+}
+
+Widget buildPanelsProductionPanel(Player player) {
+  return ProductionPanel(
+    game: productionPanelTestGameFor(player),
+    player: player,
+    desiredOutputByRecipe: const <String, int>{},
+    netDeltasByCommodity: const <String, int>{},
+    labourReadiness: labourReadinessForPlayer(player),
+    forcesFeeding: forcesFeedingForPlayer(player),
+    onDesiredOutputChanged: (_) {},
+  );
+}
+
+Widget buildPanelsDiplomacyPanel({
+  required Game game,
+  required MapTopology topology,
+  required String humanPlayerId,
+}) {
+  return DiplomacyPanel(
+    game: game,
+    humanPlayerId: humanPlayerId,
+    topology: topology,
+    currentOrders: const Orders(),
+    bus: AppEventBus.create(),
+  );
+}
+
+/// Mirrors [TechnologyScreen] `_SlotsBody`: scroll host + panel so the 320 dp
+/// pin exercises the same vertical-scroll contract as production.
+Widget buildPanelsTechnologySlotsBody({
+  required Game game,
+  required Player player,
+}) {
+  return SingleChildScrollView(
+    padding: const EdgeInsets.all(16),
+    child: TechnologyPanel(game: game, player: player),
+  );
+}

--- a/app/test/pause_menu_side_menu_specs_test.dart
+++ b/app/test/pause_menu_side_menu_specs_test.dart
@@ -1,30 +1,15 @@
-// Pins SPEC/ui contracts for the in-game pause and side menus:
-// - SPEC/ui/pause-menu-panel.md
-// - SPEC/ui/game-side-menu.md
+// Pins SPEC/ui/pause-menu-panel.md (Refs #4352).
 
-import 'package:colonizethis_app/app.dart';
-import 'package:colonizethis_app/config/constants.dart';
-import 'package:colonizethis_app/config/routes.dart';
-import 'package:colonizethis_app/core/services/app_event_handler/app_event_handler_scope.dart';
-import 'package:colonizethis_app/core/services/game_service/game_service.dart';
 import 'package:colonizethis_app/core/utils/state_toggle_notifier.dart';
-import 'package:colonizethis_app/features/game/flame/controls/game_side_menu.dart';
-import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
 import 'package:colonizethis_app/features/game/widgets/panels/pause_menu_panel.dart';
-import 'package:colonizethis_app/providers/app_event_bus_provider.dart';
-import 'package:colonizethis_app/providers/game_service_provider.dart';
-import 'package:colonizethis_app/providers/games_box_provider.dart';
-import 'package:colonizethis_app/providers/games_provider.dart';
 import 'package:colonizethis_app/providers/turn_resolution_blocking_provider.dart';
+import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
-import 'package:colonizethis_save/colonizethis_save.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:hive/hive.dart';
 
 import 'app_shell_harness.dart';
-import 'panel_test_fixtures.dart';
 
 void main() {
   suppressLogsForTests();
@@ -58,16 +43,13 @@ void main() {
             .widgetList<CtNinePatchButton>(find.byType(CtNinePatchButton))
             .toList();
         expect(buttons, hasLength(5));
-        expect(
-          buttons.map((b) => b.key).toList(),
-          const <Key>[
-            PauseMenuPanel.resumeButtonKey,
-            PauseMenuPanel.saveGameButtonKey,
-            PauseMenuPanel.loadGameButtonKey,
-            PauseMenuPanel.settingsButtonKey,
-            PauseMenuPanel.exitToMainMenuButtonKey,
-          ],
-        );
+        expect(buttons.map((b) => b.key).toList(), const <Key>[
+          PauseMenuPanel.resumeButtonKey,
+          PauseMenuPanel.saveGameButtonKey,
+          PauseMenuPanel.loadGameButtonKey,
+          PauseMenuPanel.settingsButtonKey,
+          PauseMenuPanel.exitToMainMenuButtonKey,
+        ]);
       },
     );
 
@@ -96,44 +78,37 @@ void main() {
         expect(
           events.whereType<RequestExitToMainMenuFlowEvent>(),
           isEmpty,
-          reason:
-              'Resume must not emit RequestExitToMainMenuFlowEvent.',
+          reason: 'Resume must not emit RequestExitToMainMenuFlowEvent.',
         );
       },
     );
 
-    testWidgets(
-      'AC: Exit to Main Menu emits ClosePanelEvent before '
-      'RequestExitToMainMenuFlowEvent',
-      (WidgetTester tester) async {
-        final bus = AppEventBus.create();
-        addTearDown(bus.dispose);
-        final events = <AppEvent>[];
-        final sub = bus.stream.listen(events.add);
-        addTearDown(sub.cancel);
+    testWidgets('AC: Exit to Main Menu emits ClosePanelEvent before '
+        'RequestExitToMainMenuFlowEvent', (WidgetTester tester) async {
+      final bus = AppEventBus.create();
+      addTearDown(bus.dispose);
+      final events = <AppEvent>[];
+      final sub = bus.stream.listen(events.add);
+      addTearDown(sub.cancel);
 
-        await tester.pumpWidget(pauseHost(bus));
-        await tester.pumpAndSettle();
+      await tester.pumpWidget(pauseHost(bus));
+      await tester.pumpAndSettle();
 
-        await tester.tap(
-          find.byKey(PauseMenuPanel.exitToMainMenuButtonKey),
-        );
-        await tester.pumpAndSettle();
+      await tester.tap(find.byKey(PauseMenuPanel.exitToMainMenuButtonKey));
+      await tester.pumpAndSettle();
 
-        final closeIndex = events.indexWhere((e) => e is ClosePanelEvent);
-        final flowIndex = events.indexWhere(
-          (e) => e is RequestExitToMainMenuFlowEvent,
-        );
-        expect(closeIndex, isNonNegative);
-        expect(flowIndex, isNonNegative);
-        expect(
-          closeIndex,
-          lessThan(flowIndex),
-          reason:
-              'ClosePanelEvent must precede RequestExitToMainMenuFlowEvent.',
-        );
-      },
-    );
+      final closeIndex = events.indexWhere((e) => e is ClosePanelEvent);
+      final flowIndex = events.indexWhere(
+        (e) => e is RequestExitToMainMenuFlowEvent,
+      );
+      expect(closeIndex, isNonNegative);
+      expect(flowIndex, isNonNegative);
+      expect(
+        closeIndex,
+        lessThan(flowIndex),
+        reason: 'ClosePanelEvent must precede RequestExitToMainMenuFlowEvent.',
+      );
+    });
 
     testWidgets(
       'AC: when not blocking, Save/Load/Settings are enabled and emit dialogs',
@@ -178,10 +153,7 @@ void main() {
         events.clear();
         await tester.tap(find.byKey(PauseMenuPanel.settingsButtonKey));
         await tester.pumpAndSettle();
-        expect(
-          events.whereType<OpenDialogEvent>().single.dialogId,
-          'settings',
-        );
+        expect(events.whereType<OpenDialogEvent>().single.dialogId, 'settings');
       },
     );
 
@@ -201,243 +173,6 @@ void main() {
         expect(find.byType(AlertDialog), findsNothing);
         expect(find.byType(Divider), findsNothing);
         expect(find.byType(AppBar), findsNothing);
-      },
-    );
-  });
-
-  group('GameSideMenu (SPEC/ui/game-side-menu.md)', () {
-    late Game game;
-    late Box<dynamic> gamesBox;
-
-    setUpAll(() async {
-      // Refs #3656: lightweight fixture replaces the ~11s procedural map
-      // generation; the side menu only reads the active Game.
-      game = buildSideMenuTestGame();
-      Hive.init('./.dart_tool/test_hive_game_side_menu_specs');
-      gamesBox = await Hive.openBox<dynamic>(HiveBoxNames.games);
-    });
-
-    Widget wrap({
-      required Game? activeGame,
-      required AppEventBus bus,
-      bool sideMenuOpen = true,
-      required VoidCallback onClose,
-      Map<String, Widget Function(BuildContext)> routes = const {},
-    }) {
-      // Editorial shell via buildAppShell (Refs #4035 — no inline MaterialApp).
-      return buildAppShell(
-        overrides: [
-          gamesBoxProvider.overrideWith((ref) => gamesBox),
-          gameServiceProvider.overrideWith(
-            (ref) => GameService(gamesBox, GameSaveAdapter()),
-          ),
-          currentGameProvider.overrideWith(
-            () => CurrentGameNotifier(activeGame),
-          ),
-          currentOrdersProvider.overrideWith(
-            () => CurrentOrdersNotifier(const Orders()),
-          ),
-          appEventBusProvider.overrideWith((ref) => bus),
-        ],
-        navigatorKey: appNavigatorKey,
-        onGenerateRoute: routes.isEmpty
-            ? null
-            : (settings) {
-                final builder = routes[settings.name];
-                if (builder == null) {
-                  return null;
-                }
-                return MaterialPageRoute<void>(
-                  settings: settings,
-                  builder: builder,
-                );
-              },
-        shellWrapper: (app) => AppEventHandlerScope(child: app),
-        child: Scaffold(
-          body: Stack(
-            children: [
-              GameSideMenu(
-                sideMenuOpen: sideMenuOpen,
-                onClose: onClose,
-              ),
-            ],
-          ),
-        ),
-      );
-    }
-
-    testWidgets(
-      'AC: renders close, Game Parameters, and Debug log entries with a non-null game',
-      (WidgetTester tester) async {
-        final bus = AppEventBus.create();
-        addTearDown(bus.dispose);
-
-        await tester.pumpWidget(
-          wrap(activeGame: game, bus: bus, onClose: () {}),
-        );
-        await tester.pumpAndSettle();
-
-        expect(find.text('Game Parameters'), findsOneWidget);
-        expect(find.text('Debug log'), findsOneWidget);
-        expect(find.text('×'), findsOneWidget);
-      },
-    );
-
-    testWidgets(
-      'AC: close button invokes onClose exactly once and emits no bus events',
-      (WidgetTester tester) async {
-        final bus = AppEventBus.create();
-        addTearDown(bus.dispose);
-        final events = <AppEvent>[];
-        final sub = bus.stream.listen(events.add);
-        addTearDown(sub.cancel);
-
-        var closes = 0;
-        await tester.pumpWidget(
-          wrap(activeGame: game, bus: bus, onClose: () => closes++),
-        );
-        await tester.pumpAndSettle();
-
-        await tester.tap(find.text('×'));
-        await tester.pumpAndSettle();
-
-        expect(closes, 1);
-        expect(events, isEmpty);
-      },
-    );
-
-    testWidgets(
-      'AC: Game Parameters with non-null game closes menu and opens dialog without bus event',
-      (WidgetTester tester) async {
-        final bus = AppEventBus.create();
-        addTearDown(bus.dispose);
-        final events = <AppEvent>[];
-        final sub = bus.stream.listen(events.add);
-        addTearDown(sub.cancel);
-
-        var closes = 0;
-        await tester.pumpWidget(
-          wrap(
-            activeGame: game.copyWith(infiniteMode: true),
-            bus: bus,
-            onClose: () => closes++,
-          ),
-        );
-        await tester.pumpAndSettle();
-
-        await tester.tap(find.text('Game Parameters'));
-        await tester.pumpAndSettle();
-
-        expect(closes, 1);
-        expect(find.text('Infinite mode: On'), findsOneWidget);
-        expect(
-          events.whereType<OpenDialogEvent>(),
-          isEmpty,
-          reason: 'Game Parameters must not emit an OpenDialogEvent.',
-        );
-      },
-    );
-
-    testWidgets(
-      'Negative AC: Game Parameters with null game is a no-op',
-      (WidgetTester tester) async {
-        final bus = AppEventBus.create();
-        addTearDown(bus.dispose);
-        final events = <AppEvent>[];
-        final sub = bus.stream.listen(events.add);
-        addTearDown(sub.cancel);
-
-        var closes = 0;
-        await tester.pumpWidget(
-          wrap(activeGame: null, bus: bus, onClose: () => closes++),
-        );
-        await tester.pumpAndSettle();
-
-        await tester.tap(find.text('Game Parameters'));
-        await tester.pumpAndSettle();
-
-        expect(closes, 0, reason: 'onClose must not run when game is null.');
-        expect(find.text('Infinite mode: On'), findsNothing);
-        expect(find.text('Infinite mode: Off'), findsNothing);
-        expect(events, isEmpty);
-      },
-    );
-
-    testWidgets(
-      'AC: Debug log calls onClose and emits exactly one NavigateToRouteEvent(debugLog)',
-      (WidgetTester tester) async {
-        final bus = AppEventBus.create();
-        addTearDown(bus.dispose);
-        final events = <AppEvent>[];
-        final sub = bus.stream.listen(events.add);
-        addTearDown(sub.cancel);
-
-        var closes = 0;
-        await tester.pumpWidget(
-          wrap(
-            activeGame: game,
-            bus: bus,
-            onClose: () => closes++,
-            routes: {
-              Routes.debugLog: (_) => const Scaffold(
-                body: Center(child: Text('debug-route-marker')),
-              ),
-            },
-          ),
-        );
-        await tester.pumpAndSettle();
-
-        await tester.tap(find.text('Debug log'));
-        await tester.pumpAndSettle();
-
-        expect(closes, 1);
-        final navEvents = events.whereType<NavigateToRouteEvent>().toList();
-        expect(navEvents, hasLength(1));
-        expect(navEvents.single.route, Routes.debugLog);
-        expect(
-          events.whereType<OpenDialogEvent>(),
-          isEmpty,
-          reason: 'Debug log must not emit an OpenDialogEvent.',
-        );
-      },
-    );
-
-    testWidgets(
-      'AC: horizontal drag left invokes onClose',
-      (WidgetTester tester) async {
-        final bus = AppEventBus.create();
-        addTearDown(bus.dispose);
-
-        var closes = 0;
-        await tester.pumpWidget(
-          wrap(activeGame: game, bus: bus, onClose: () => closes++),
-        );
-        await tester.pumpAndSettle();
-
-        await tester.drag(find.byType(GameSideMenu), const Offset(-40, 0));
-        await tester.pumpAndSettle();
-
-        expect(closes, greaterThanOrEqualTo(1));
-      },
-    );
-
-    testWidgets(
-      'Negative AC: menu contains zero Navigator.pushNamed equivalents '
-      '(only CtNinePatchButton rows host actions)',
-      (WidgetTester tester) async {
-        final bus = AppEventBus.create();
-        addTearDown(bus.dispose);
-
-        await tester.pumpWidget(
-          wrap(activeGame: game, bus: bus, onClose: () {}),
-        );
-        await tester.pumpAndSettle();
-
-        // The menu must render CtNinePatchButton entries (no Material buttons
-        // such as ElevatedButton / TextButton wired into navigation).
-        expect(find.byType(CtNinePatchButton), findsWidgets);
-        expect(find.byType(ElevatedButton), findsNothing);
-        expect(find.byType(TextButton), findsNothing);
       },
     );
   });

--- a/app/test/province_overlay_extraction_available_test.dart
+++ b/app/test/province_overlay_extraction_available_test.dart
@@ -4,7 +4,7 @@ import 'package:colonizethis_app_fixtures/demo/province_overlay_demo_data.dart'
 import 'package:colonizethis_app_ui_chrome/config/editorial_monocle_palette.dart';
 import 'package:colonizethis_data/colonizethis_data.dart' show MapTopology;
 import 'package:colonizethis_logic/colonizethis_logic.dart'
-    show ProvinceImprovableCommodityCount, buildPlayerView;
+    show buildPlayerView;
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/gestures.dart';
@@ -13,55 +13,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'province_overlay_test_harness.dart';
-
-String _foreignOwnedProvinceId({
-  required Game game,
-  required String humanPlayerId,
-}) {
-  for (final province in game.worldState.oldWorld.provinces) {
-    final ownerId = province.ownerId;
-    if (ownerId != null && ownerId.isNotEmpty && ownerId != humanPlayerId) {
-      return province.id;
-    }
-  }
-  fail(
-    'Test setup: demo game has no foreign-owned Old World province for '
-    'intel-gate pins.',
-  );
-}
-
-ProvinceExtractionSnapshot _sampleExtractionSnapshot(
-  String ownerId, {
-  int capitalGrainBonus = 0,
-}) {
-  return ProvinceExtractionSnapshot(
-    ownerId: ownerId,
-    capitalGrainBonus: capitalGrainBonus,
-    byCommodity: {
-      'grain': const ProvinceExtractionCommodityTotals(
-        effective: 1,
-        full: 5,
-        tileKeys: ['oldWorld|p1|0|0', 'oldWorld|p1|0|1'],
-      ),
-      'iron': const ProvinceExtractionCommodityTotals(
-        effective: 5,
-        full: 5,
-        tileKeys: ['oldWorld|p1|1|0'],
-      ),
-    },
-  );
-}
-
-const Map<String, ProvinceImprovableCommodityCount> _sampleAvailable = {
-  'grain': ProvinceImprovableCommodityCount(
-    count: 3,
-    tileKeys: ['oldWorld|p1|0|0', 'oldWorld|p1|2|0'],
-  ),
-  'timber': ProvinceImprovableCommodityCount(
-    count: 2,
-    tileKeys: ['oldWorld|p1|0|1'],
-  ),
-};
+import 'province_overlay_extraction_available_test_support.dart';
 
 void main() {
   suppressLogsForTests();
@@ -85,8 +37,8 @@ void main() {
         humanPlayerId: humanId,
         playerView: playerView,
         omniscientDetail: true,
-        extractionSnapshot: _sampleExtractionSnapshot(humanId),
-        availableByCommodity: _sampleAvailable,
+        extractionSnapshot: sampleProvinceExtractionSnapshot(humanId),
+        availableByCommodity: sampleProvinceImprovableAvailable,
       );
 
       expect(find.text('Extraction'), findsOneWidget);
@@ -124,8 +76,8 @@ void main() {
         humanPlayerId: humanId,
         playerView: playerView,
         omniscientDetail: true,
-        extractionSnapshot: _sampleExtractionSnapshot(humanId),
-        availableByCommodity: _sampleAvailable,
+        extractionSnapshot: sampleProvinceExtractionSnapshot(humanId),
+        availableByCommodity: sampleProvinceImprovableAvailable,
       );
 
       expect(
@@ -137,79 +89,71 @@ void main() {
     },
   );
 
-  testWidgets(
-    'full-yield Extraction omits partial reason line (Refs #4150)',
-    (tester) async {
-      final game = demoGameForOverlay;
-      final humanId = game.players.first.id;
-      final provinceId = ownedProvinceIdInOldWorld(
-        game: game,
+  testWidgets('full-yield Extraction omits partial reason line (Refs #4150)', (
+    tester,
+  ) async {
+    final game = demoGameForOverlay;
+    final humanId = game.players.first.id;
+    final provinceId = ownedProvinceIdInOldWorld(game: game, ownerId: humanId);
+    final playerView = buildPlayerView(game, const MapTopology(), humanId);
+
+    await pumpProvinceOverlayAtDarkTheme(
+      tester,
+      game: game,
+      displayId: provinceId,
+      region: demoRegionForOverlay,
+      humanPlayerId: humanId,
+      playerView: playerView,
+      omniscientDetail: true,
+      extractionSnapshot: ProvinceExtractionSnapshot(
         ownerId: humanId,
-      );
-      final playerView = buildPlayerView(game, const MapTopology(), humanId);
+        byCommodity: {
+          'grain': const ProvinceExtractionCommodityTotals(
+            effective: 5,
+            full: 5,
+            tileKeys: ['oldWorld|p1|0|0'],
+          ),
+        },
+      ),
+    );
 
-      await pumpProvinceOverlayAtDarkTheme(
-        tester,
-        game: game,
-        displayId: provinceId,
-        region: demoRegionForOverlay,
-        humanPlayerId: humanId,
-        playerView: playerView,
-        omniscientDetail: true,
-        extractionSnapshot: ProvinceExtractionSnapshot(
-          ownerId: humanId,
-          byCommodity: {
-            'grain': const ProvinceExtractionCommodityTotals(
-              effective: 5,
-              full: 5,
-              tileKeys: ['oldWorld|p1|0|0'],
-            ),
-          },
-        ),
-      );
+    expect(
+      find.text(
+        'Some improved tiles are not linked to your capital, or the road/port path is too weak.',
+      ),
+      findsNothing,
+    );
+  });
 
-      expect(
-        find.text(
-          'Some improved tiles are not linked to your capital, or the road/port path is too weak.',
-        ),
-        findsNothing,
-      );
-    },
-  );
+  testWidgets('empty Extraction shows dash placeholders (Refs #4002)', (
+    tester,
+  ) async {
+    final game = demoGameForOverlay;
+    final humanId = game.players.first.id;
+    final provinceId = ownedProvinceIdInOldWorld(game: game, ownerId: humanId);
+    final playerView = buildPlayerView(game, const MapTopology(), humanId);
 
-  testWidgets(
-    'empty Extraction shows dash placeholders (Refs #4002)',
-    (tester) async {
-      final game = demoGameForOverlay;
-      final humanId = game.players.first.id;
-      final provinceId = ownedProvinceIdInOldWorld(
-        game: game,
-        ownerId: humanId,
-      );
-      final playerView = buildPlayerView(game, const MapTopology(), humanId);
+    await pumpProvinceOverlayAtDarkTheme(
+      tester,
+      game: game,
+      displayId: provinceId,
+      region: demoRegionForOverlay,
+      humanPlayerId: humanId,
+      playerView: playerView,
+      omniscientDetail: true,
+    );
 
-      await pumpProvinceOverlayAtDarkTheme(
-        tester,
-        game: game,
-        displayId: provinceId,
-        region: demoRegionForOverlay,
-        humanPlayerId: humanId,
-        playerView: playerView,
-        omniscientDetail: true,
-      );
-
-      expect(find.text('Extraction'), findsOneWidget);
-      expect(find.text('Available'), findsOneWidget);
-      expect(find.text('—'), findsWidgets);
-    },
-  );
+    expect(find.text('Extraction'), findsOneWidget);
+    expect(find.text('Available'), findsOneWidget);
+    expect(find.text('—'), findsWidgets);
+  });
 
   testWidgets(
     'intel gate hides Extraction/Available quantities behind ??? (Refs #4002)',
     (tester) async {
       final game = demoGameForOverlay;
       final humanId = game.players.first.id;
-      final foreignProvinceId = _foreignOwnedProvinceId(
+      final foreignProvinceId = foreignOwnedProvinceIdForOverlay(
         game: game,
         humanPlayerId: humanId,
       );
@@ -223,8 +167,8 @@ void main() {
         humanPlayerId: humanId,
         playerView: playerView,
         omniscientDetail: false,
-        extractionSnapshot: _sampleExtractionSnapshot(humanId),
-        availableByCommodity: _sampleAvailable,
+        extractionSnapshot: sampleProvinceExtractionSnapshot(humanId),
+        availableByCommodity: sampleProvinceImprovableAvailable,
       );
 
       expect(find.text('Extraction'), findsNothing);
@@ -255,8 +199,8 @@ void main() {
         humanPlayerId: humanId,
         playerView: playerView,
         omniscientDetail: true,
-        extractionSnapshot: _sampleExtractionSnapshot(humanId),
-        availableByCommodity: _sampleAvailable,
+        extractionSnapshot: sampleProvinceExtractionSnapshot(humanId),
+        availableByCommodity: sampleProvinceImprovableAvailable,
         onHighlightTiles: (keys) {
           highlighted = keys;
         },
@@ -271,10 +215,7 @@ void main() {
       expect(mouseRegions, findsWidgets);
       final region = tester.widget<MouseRegion>(mouseRegions.first);
       region.onEnter!(const PointerEnterEvent());
-      expect(
-        highlighted,
-        ['oldWorld|p1|0|0', 'oldWorld|p1|0|1'],
-      );
+      expect(highlighted, ['oldWorld|p1|0|0', 'oldWorld|p1|0|1']);
       region.onExit!(const PointerExitEvent());
       expect(highlighted, isNull);
     },
@@ -353,11 +294,11 @@ void main() {
         humanPlayerId: humanId,
         playerView: playerView,
         omniscientDetail: true,
-        extractionSnapshot: _sampleExtractionSnapshot(
+        extractionSnapshot: sampleProvinceExtractionSnapshot(
           humanId,
           capitalGrainBonus: 2,
         ),
-        availableByCommodity: _sampleAvailable,
+        availableByCommodity: sampleProvinceImprovableAvailable,
       );
 
       expect(
@@ -371,57 +312,51 @@ void main() {
     },
   );
 
-  testWidgets(
-    'capital grain bonus annotation is not a hover-highlight target '
-    '(Refs #4064)',
-    (tester) async {
-      final game = demoGameForOverlay;
-      final humanId = game.players.first.id;
-      final provinceId = ownedProvinceIdInOldWorld(
-        game: game,
-        ownerId: humanId,
-      );
-      final playerView = buildPlayerView(game, const MapTopology(), humanId);
-      Iterable<String>? highlighted;
+  testWidgets('capital grain bonus annotation is not a hover-highlight target '
+      '(Refs #4064)', (tester) async {
+    final game = demoGameForOverlay;
+    final humanId = game.players.first.id;
+    final provinceId = ownedProvinceIdInOldWorld(game: game, ownerId: humanId);
+    final playerView = buildPlayerView(game, const MapTopology(), humanId);
+    Iterable<String>? highlighted;
 
-      await pumpProvinceOverlayAtDarkTheme(
-        tester,
-        game: game,
-        displayId: provinceId,
-        region: demoRegionForOverlay,
-        humanPlayerId: humanId,
-        playerView: playerView,
-        omniscientDetail: true,
-        extractionSnapshot: _sampleExtractionSnapshot(
-          humanId,
-          capitalGrainBonus: 2,
-        ),
-        availableByCommodity: _sampleAvailable,
-        onHighlightTiles: (keys) {
-          highlighted = keys;
-        },
-      );
+    await pumpProvinceOverlayAtDarkTheme(
+      tester,
+      game: game,
+      displayId: provinceId,
+      region: demoRegionForOverlay,
+      humanPlayerId: humanId,
+      playerView: playerView,
+      omniscientDetail: true,
+      extractionSnapshot: sampleProvinceExtractionSnapshot(
+        humanId,
+        capitalGrainBonus: 2,
+      ),
+      availableByCommodity: sampleProvinceImprovableAvailable,
+      onHighlightTiles: (keys) {
+        highlighted = keys;
+      },
+    );
 
-      final bonus = find.textContaining('incl. +2 capital grain bonus');
-      expect(bonus, findsOneWidget);
-      expect(
-        find.ancestor(of: bonus, matching: find.byType(MouseRegion)),
-        findsNothing,
-      );
+    final bonus = find.textContaining('incl. +2 capital grain bonus');
+    expect(bonus, findsOneWidget);
+    expect(
+      find.ancestor(of: bonus, matching: find.byType(MouseRegion)),
+      findsNothing,
+    );
 
-      final grainSegment = find.textContaining('1 (5)');
-      expect(grainSegment, findsOneWidget);
-      final grainRegions = find.ancestor(
-        of: grainSegment,
-        matching: find.byType(MouseRegion),
-      );
-      expect(grainRegions, findsWidgets);
-      tester.widget<MouseRegion>(grainRegions.first).onEnter!(
-        const PointerEnterEvent(),
-      );
-      expect(highlighted, ['oldWorld|p1|0|0', 'oldWorld|p1|0|1']);
-    },
-  );
+    final grainSegment = find.textContaining('1 (5)');
+    expect(grainSegment, findsOneWidget);
+    final grainRegions = find.ancestor(
+      of: grainSegment,
+      matching: find.byType(MouseRegion),
+    );
+    expect(grainRegions, findsWidgets);
+    tester.widget<MouseRegion>(grainRegions.first).onEnter!(
+      const PointerEnterEvent(),
+    );
+    expect(highlighted, ['oldWorld|p1|0|0', 'oldWorld|p1|0|1']);
+  });
 
   test(
     'setSecondaryHighlights stores multi keys and clears single (Refs #4002)',

--- a/app/test/province_overlay_extraction_available_test_support.dart
+++ b/app/test/province_overlay_extraction_available_test_support.dart
@@ -1,0 +1,56 @@
+// Fixtures for province overlay extraction/available pins (Refs #4352).
+
+import 'package:colonizethis_logic/colonizethis_logic.dart'
+    show ProvinceImprovableCommodityCount;
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+String foreignOwnedProvinceIdForOverlay({
+  required Game game,
+  required String humanPlayerId,
+}) {
+  for (final province in game.worldState.oldWorld.provinces) {
+    final ownerId = province.ownerId;
+    if (ownerId != null && ownerId.isNotEmpty && ownerId != humanPlayerId) {
+      return province.id;
+    }
+  }
+  fail(
+    'Test setup: demo game has no foreign-owned Old World province for '
+    'intel-gate pins.',
+  );
+}
+
+ProvinceExtractionSnapshot sampleProvinceExtractionSnapshot(
+  String ownerId, {
+  int capitalGrainBonus = 0,
+}) {
+  return ProvinceExtractionSnapshot(
+    ownerId: ownerId,
+    capitalGrainBonus: capitalGrainBonus,
+    byCommodity: {
+      'grain': const ProvinceExtractionCommodityTotals(
+        effective: 1,
+        full: 5,
+        tileKeys: ['oldWorld|p1|0|0', 'oldWorld|p1|0|1'],
+      ),
+      'iron': const ProvinceExtractionCommodityTotals(
+        effective: 5,
+        full: 5,
+        tileKeys: ['oldWorld|p1|1|0'],
+      ),
+    },
+  );
+}
+
+const Map<String, ProvinceImprovableCommodityCount>
+sampleProvinceImprovableAvailable = {
+  'grain': ProvinceImprovableCommodityCount(
+    count: 3,
+    tileKeys: ['oldWorld|p1|0|0', 'oldWorld|p1|2|0'],
+  ),
+  'timber': ProvinceImprovableCommodityCount(
+    count: 2,
+    tileKeys: ['oldWorld|p1|0|1'],
+  ),
+};

--- a/app/test/trade_screen_deal_book_tab_e6_support.dart
+++ b/app/test/trade_screen_deal_book_tab_e6_support.dart
@@ -1,0 +1,73 @@
+// Deal Book tab ledger fixtures (Refs #4352).
+
+import 'package:colonizethis_app/features/game/screens/trade/trade_screen.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'trade_screen_test_support.dart';
+
+const List<Player> dealBookTestPlayers = <Player>[
+  // ignore: avoid_hardcoded_strings_in_widgets
+  Player(
+    id: kTradeTestHumanPlayerId,
+    displayName: 'England',
+    isHuman: true,
+    treasury: 500,
+  ),
+  // ignore: avoid_hardcoded_strings_in_widgets
+  Player(id: 'gp_a', displayName: 'Aragon', isHuman: false, treasury: 500),
+];
+
+FilledDeal dealBookFilledDeal({
+  required String seller,
+  required String buyer,
+  required String commodity,
+  required int qty,
+  required double price,
+  bool frr = false,
+  bool ftp = false,
+  String? sellerOriginTileKey,
+}) {
+  return FilledDeal(
+    sellerFactionId: seller,
+    buyerFactionId: buyer,
+    commodityId: commodity,
+    quantity: qty,
+    pricePerUnit: price,
+    isFirstRightOfRefusalMatch: frr,
+    isFtpMatch: ftp,
+    sellerOriginTileKey: sellerOriginTileKey,
+  );
+}
+
+MarketActivity dealBookActivity(String commodity, List<FilledDeal> deals) {
+  final qty = deals.fold<int>(0, (sum, d) => sum + d.quantity);
+  return MarketActivity(
+    totalBidQuantity: qty,
+    totalOfferQuantity: qty,
+    filledQuantity: qty,
+    deals: deals,
+  );
+}
+
+void expectDealBookTotals(WidgetTester tester, {int? bids, int? offers}) {
+  if (bids != null) {
+    final bidsTotals = tester.widget<Text>(
+      find.byKey(TradeScreenDealBookKeys.dealBookBidsTotalsKey),
+    );
+    expect(
+      bidsTotals.data,
+      '${TradeScreenDealBookKeys.dealBookTotalSpentLabel}: $bids',
+    );
+  }
+  if (offers != null) {
+    final offersTotals = tester.widget<Text>(
+      find.byKey(TradeScreenDealBookKeys.dealBookOffersTotalsKey),
+    );
+    expect(
+      offersTotals.data,
+      '${TradeScreenDealBookKeys.dealBookTotalReceivedLabel}: $offers',
+    );
+  }
+}

--- a/app/test/trade_screen_deal_book_tab_e6_test.dart
+++ b/app/test/trade_screen_deal_book_tab_e6_test.dart
@@ -7,68 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'trade_screen_test_support.dart';
-
-const List<Player> _players = <Player>[
-  // ignore: avoid_hardcoded_strings_in_widgets
-  Player(
-    id: kTradeTestHumanPlayerId,
-    displayName: 'England',
-    isHuman: true,
-    treasury: 500,
-  ),
-  // ignore: avoid_hardcoded_strings_in_widgets
-  Player(id: 'gp_a', displayName: 'Aragon', isHuman: false, treasury: 500),
-];
-
-FilledDeal _deal({
-  required String seller,
-  required String buyer,
-  required String commodity,
-  required int qty,
-  required double price,
-  bool frr = false,
-  bool ftp = false,
-  String? sellerOriginTileKey,
-}) {
-  return FilledDeal(
-    sellerFactionId: seller,
-    buyerFactionId: buyer,
-    commodityId: commodity,
-    quantity: qty,
-    pricePerUnit: price,
-    isFirstRightOfRefusalMatch: frr,
-    isFtpMatch: ftp,
-    sellerOriginTileKey: sellerOriginTileKey,
-  );
-}
-
-MarketActivity _activity(String commodity, List<FilledDeal> deals) {
-  final qty = deals.fold<int>(0, (sum, d) => sum + d.quantity);
-  return MarketActivity(
-    totalBidQuantity: qty,
-    totalOfferQuantity: qty,
-    filledQuantity: qty,
-    deals: deals,
-  );
-}
-
-void _expectTotals(WidgetTester tester, {int? bids, int? offers}) {
-  if (bids != null) {
-    final bidsTotals = tester.widget<Text>(
-      find.byKey(TradeScreenDealBookKeys.dealBookBidsTotalsKey),
-    );
-    expect(bidsTotals.data, '${TradeScreenDealBookKeys.dealBookTotalSpentLabel}: $bids');
-  }
-  if (offers != null) {
-    final offersTotals = tester.widget<Text>(
-      find.byKey(TradeScreenDealBookKeys.dealBookOffersTotalsKey),
-    );
-    expect(
-      offersTotals.data,
-      '${TradeScreenDealBookKeys.dealBookTotalReceivedLabel}: $offers',
-    );
-  }
-}
+import 'trade_screen_deal_book_tab_e6_support.dart';
 
 void main() {
   suppressLogsForTests();
@@ -80,15 +19,27 @@ void main() {
       (tester) async {
         await pumpTradeScreen(
           tester,
-          game: buildTradeTestGame(players: _players),
+          game: buildTradeTestGame(players: dealBookTestPlayers),
           selectDealBookTab: true,
         );
 
-        expect(find.byKey(TradeScreenDealBookKeys.dealBookBidsEmptyKey), findsOneWidget);
-        expect(find.byKey(TradeScreenDealBookKeys.dealBookOffersEmptyKey), findsOneWidget);
-        expect(find.text(TradeScreenDealBookKeys.dealBookBidsEmptyText), findsOneWidget);
-        expect(find.text(TradeScreenDealBookKeys.dealBookOffersEmptyText), findsOneWidget);
-        _expectTotals(tester, bids: 0, offers: 0);
+        expect(
+          find.byKey(TradeScreenDealBookKeys.dealBookBidsEmptyKey),
+          findsOneWidget,
+        );
+        expect(
+          find.byKey(TradeScreenDealBookKeys.dealBookOffersEmptyKey),
+          findsOneWidget,
+        );
+        expect(
+          find.text(TradeScreenDealBookKeys.dealBookBidsEmptyText),
+          findsOneWidget,
+        );
+        expect(
+          find.text(TradeScreenDealBookKeys.dealBookOffersEmptyText),
+          findsOneWidget,
+        );
+        expectDealBookTotals(tester, bids: 0, offers: 0);
       },
     );
 
@@ -97,10 +48,10 @@ void main() {
       'display (Refs #3093)',
       (tester) async {
         final game = buildTradeTestGame(
-          players: _players,
+          players: dealBookTestPlayers,
           lastTurnActivity: {
-            'timber': _activity('timber', [
-              _deal(
+            'timber': dealBookActivity('timber', [
+              dealBookFilledDeal(
                 seller: 'gp_a',
                 buyer: 'gp_h',
                 commodity: 'timber',
@@ -114,7 +65,7 @@ void main() {
 
         // ignore: avoid_hardcoded_strings_in_widgets
         expect(find.text('timber — qty 5 × 30 = 150'), findsOneWidget);
-        _expectTotals(tester, bids: 150);
+        expectDealBookTotals(tester, bids: 150);
       },
     );
 
@@ -123,10 +74,10 @@ void main() {
       'to the bids panel total spent; unrelated deal is excluded',
       (tester) async {
         final game = buildTradeTestGame(
-          players: _players,
+          players: dealBookTestPlayers,
           lastTurnActivity: {
-            'timber': _activity('timber', [
-              _deal(
+            'timber': dealBookActivity('timber', [
+              dealBookFilledDeal(
                 seller: 'gp_a',
                 buyer: 'gp_h',
                 commodity: 'timber',
@@ -134,8 +85,8 @@ void main() {
                 price: 30.0,
               ),
             ]),
-            'iron': _activity('iron', [
-              _deal(
+            'iron': dealBookActivity('iron', [
+              dealBookFilledDeal(
                 seller: 'gp_a',
                 buyer: 'gp_b',
                 commodity: 'iron',
@@ -149,22 +100,34 @@ void main() {
 
         expect(
           find.byKey(
-            TradeScreenDealBookKeys.dealBookFilledRowKey(TradeScreenDealBookKeys.dealBookSideBids, 0),
+            TradeScreenDealBookKeys.dealBookFilledRowKey(
+              TradeScreenDealBookKeys.dealBookSideBids,
+              0,
+            ),
           ),
           findsOneWidget,
         );
         expect(
           find.byKey(
-            TradeScreenDealBookKeys.dealBookFilledRowKey(TradeScreenDealBookKeys.dealBookSideBids, 1),
+            TradeScreenDealBookKeys.dealBookFilledRowKey(
+              TradeScreenDealBookKeys.dealBookSideBids,
+              1,
+            ),
           ),
           findsNothing,
         );
-        expect(find.byKey(TradeScreenDealBookKeys.dealBookBidsEmptyKey), findsNothing);
+        expect(
+          find.byKey(TradeScreenDealBookKeys.dealBookBidsEmptyKey),
+          findsNothing,
+        );
 
         // ignore: avoid_hardcoded_strings_in_widgets
         expect(find.text('timber — qty 5 × 30 = 150'), findsOneWidget);
-        _expectTotals(tester, bids: 150, offers: 0);
-        expect(find.byKey(TradeScreenDealBookKeys.dealBookOffersEmptyKey), findsOneWidget);
+        expectDealBookTotals(tester, bids: 150, offers: 0);
+        expect(
+          find.byKey(TradeScreenDealBookKeys.dealBookOffersEmptyKey),
+          findsOneWidget,
+        );
       },
     );
 
@@ -174,10 +137,10 @@ void main() {
       'a combined total',
       (tester) async {
         final game = buildTradeTestGame(
-          players: _players,
+          players: dealBookTestPlayers,
           lastTurnActivity: {
-            'timber': _activity('timber', [
-              _deal(
+            'timber': dealBookActivity('timber', [
+              dealBookFilledDeal(
                 seller: 'gp_h',
                 buyer: 'gp_a',
                 commodity: 'timber',
@@ -185,8 +148,8 @@ void main() {
                 price: 30.0,
               ),
             ]),
-            'iron': _activity('iron', [
-              _deal(
+            'iron': dealBookActivity('iron', [
+              dealBookFilledDeal(
                 seller: 'gp_h',
                 buyer: 'gp_a',
                 commodity: 'iron',
@@ -200,19 +163,28 @@ void main() {
 
         expect(
           find.byKey(
-            TradeScreenDealBookKeys.dealBookFilledRowKey(TradeScreenDealBookKeys.dealBookSideOffers, 0),
+            TradeScreenDealBookKeys.dealBookFilledRowKey(
+              TradeScreenDealBookKeys.dealBookSideOffers,
+              0,
+            ),
           ),
           findsOneWidget,
         );
         expect(
           find.byKey(
-            TradeScreenDealBookKeys.dealBookFilledRowKey(TradeScreenDealBookKeys.dealBookSideOffers, 1),
+            TradeScreenDealBookKeys.dealBookFilledRowKey(
+              TradeScreenDealBookKeys.dealBookSideOffers,
+              1,
+            ),
           ),
           findsOneWidget,
         );
 
-        _expectTotals(tester, offers: 390);
-        expect(find.byKey(TradeScreenDealBookKeys.dealBookBidsEmptyKey), findsOneWidget);
+        expectDealBookTotals(tester, offers: 390);
+        expect(
+          find.byKey(TradeScreenDealBookKeys.dealBookBidsEmptyKey),
+          findsOneWidget,
+        );
       },
     );
 
@@ -221,7 +193,7 @@ void main() {
       'to the total spent (they have not cleared)',
       (tester) async {
         final game = buildTradeTestGame(
-          players: _players,
+          players: dealBookTestPlayers,
           carryForwardBids: <String, List<TradeOrder>>{
             'gp_h': <TradeOrder>[
               TradeOrder(
@@ -237,7 +209,10 @@ void main() {
 
         expect(
           find.byKey(
-            TradeScreenDealBookKeys.dealBookUnfilledRowKey(TradeScreenDealBookKeys.dealBookSideBids, 0),
+            TradeScreenDealBookKeys.dealBookUnfilledRowKey(
+              TradeScreenDealBookKeys.dealBookSideBids,
+              0,
+            ),
           ),
           findsOneWidget,
         );
@@ -245,13 +220,22 @@ void main() {
         expect(find.text('timber — qty 8 (priority 2)'), findsOneWidget);
         expect(
           find.byKey(
-            TradeScreenDealBookKeys.dealBookFilledRowKey(TradeScreenDealBookKeys.dealBookSideBids, 0),
+            TradeScreenDealBookKeys.dealBookFilledRowKey(
+              TradeScreenDealBookKeys.dealBookSideBids,
+              0,
+            ),
           ),
           findsNothing,
         );
-        _expectTotals(tester, bids: 0);
-        expect(find.byKey(TradeScreenDealBookKeys.dealBookBidsEmptyKey), findsNothing);
-        expect(find.byKey(TradeScreenDealBookKeys.dealBookOffersEmptyKey), findsOneWidget);
+        expectDealBookTotals(tester, bids: 0);
+        expect(
+          find.byKey(TradeScreenDealBookKeys.dealBookBidsEmptyKey),
+          findsNothing,
+        );
+        expect(
+          find.byKey(TradeScreenDealBookKeys.dealBookOffersEmptyKey),
+          findsOneWidget,
+        );
       },
     );
 
@@ -260,7 +244,7 @@ void main() {
       'isolation: another player\'s carry-forwards never appear',
       (tester) async {
         final game = buildTradeTestGame(
-          players: _players,
+          players: dealBookTestPlayers,
           carryForwardOffers: <String, List<TradeOrder>>{
             'gp_h': <TradeOrder>[
               TradeOrder(
@@ -316,10 +300,10 @@ void main() {
       'the deal so players can audit how a fill cleared',
       (tester) async {
         final game = buildTradeTestGame(
-          players: _players,
+          players: dealBookTestPlayers,
           lastTurnActivity: {
-            'timber': _activity('timber', [
-              _deal(
+            'timber': dealBookActivity('timber', [
+              dealBookFilledDeal(
                 seller: 'M1',
                 buyer: 'gp_h',
                 commodity: 'timber',
@@ -328,7 +312,7 @@ void main() {
                 frr: true,
                 sellerOriginTileKey: 'oldWorld|M1|0|0',
               ),
-              _deal(
+              dealBookFilledDeal(
                 seller: 'gp_a',
                 buyer: 'gp_h',
                 commodity: 'timber',
@@ -343,19 +327,25 @@ void main() {
 
         expect(
           find.byKey(
-            TradeScreenDealBookKeys.dealBookFilledRowKey(TradeScreenDealBookKeys.dealBookSideBids, 0),
+            TradeScreenDealBookKeys.dealBookFilledRowKey(
+              TradeScreenDealBookKeys.dealBookSideBids,
+              0,
+            ),
           ),
           findsOneWidget,
         );
         expect(
           find.byKey(
-            TradeScreenDealBookKeys.dealBookFilledRowKey(TradeScreenDealBookKeys.dealBookSideBids, 1),
+            TradeScreenDealBookKeys.dealBookFilledRowKey(
+              TradeScreenDealBookKeys.dealBookSideBids,
+              1,
+            ),
           ),
           findsOneWidget,
         );
         expect(find.text('First right'), findsOneWidget);
         expect(find.text('Favored partner'), findsOneWidget);
-        _expectTotals(tester, bids: 180);
+        expectDealBookTotals(tester, bids: 180);
       },
     );
 
@@ -371,7 +361,7 @@ void main() {
 
       await pumpTradeScreen(
         tester,
-        game: buildTradeTestGame(players: _players),
+        game: buildTradeTestGame(players: dealBookTestPlayers),
         selectDealBookTab: true,
       );
 
@@ -412,7 +402,7 @@ void main() {
 
         await pumpTradeScreen(
           tester,
-          game: buildTradeTestGame(players: _players),
+          game: buildTradeTestGame(players: dealBookTestPlayers),
           selectDealBookTab: true,
         );
 

--- a/app/test/units_panel_shared_widgets_test.dart
+++ b/app/test/units_panel_shared_widgets_test.dart
@@ -17,54 +17,7 @@ import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
 import 'package:colonizethis_app/widgets/ct_section_label.dart';
 import 'package:colonizethis_app/widgets/ct_top_bar.dart';
 
-import 'app_shell_harness.dart';
-
-Future<void> _pumpBody(WidgetTester tester, Widget body) async {
-  await tester.pumpWidget(
-    buildAppShell(child: Scaffold(body: body)),
-  );
-}
-
-Border _headerBorder(WidgetTester tester, Type headerType) {
-  final DecoratedBox decoratedBox = tester.widget<DecoratedBox>(
-    find.descendant(
-      of: find.byType(headerType),
-      matching: find.byType(DecoratedBox),
-    ),
-  );
-  return (decoratedBox.decoration as BoxDecoration).border! as Border;
-}
-
-UnitsPanelShell _emptyShell({
-  String title = 'Civilian Units',
-  String emptyMessage = 'No civilian units',
-  List<Widget> actions = const [],
-}) {
-  return UnitsPanelShell(
-    title: title,
-    actions: actions,
-    hasContent: false,
-    listChildren: const [],
-    emptyMessage: emptyMessage,
-  );
-}
-
-Future<void> _pumpActionRow(
-  WidgetTester tester, {
-  double width = 420,
-  required List<UnitsEntityAction> actions,
-}) async {
-  await _pumpBody(
-    tester,
-    SizedBox(
-      width: width,
-      child: UnitsEntityActionRow(
-        details: const Text('Left details'),
-        actions: actions,
-      ),
-    ),
-  );
-}
+import 'units_panel_shared_widgets_test_support.dart';
 
 void main() {
   suppressLogsForTests();
@@ -84,7 +37,7 @@ void main() {
     testWidgets('renders label via CtSectionLabel (#2866)', (
       WidgetTester tester,
     ) async {
-      await _pumpBody(
+      await pumpUnitsSharedBody(
         tester,
         const RegionSectionHeader(label: 'Old World'),
       );
@@ -96,7 +49,7 @@ void main() {
       'leftBar variant renders a left accent-dim bar without CtSectionLabel '
       '(Refs #3514)',
       (WidgetTester tester) async {
-        await _pumpBody(
+        await pumpUnitsSharedBody(
           tester,
           const RegionSectionHeader(
             label: 'New World',
@@ -109,7 +62,10 @@ void main() {
         expect(find.text('NEW WORLD'), findsOneWidget);
         expect(find.byType(CtSectionLabel), findsNothing);
 
-        final Border border = _headerBorder(tester, RegionSectionHeader);
+        final Border border = unitsSharedHeaderBorder(
+          tester,
+          RegionSectionHeader,
+        );
         expect(border.left.width, RegionSectionHeader.leftBarWidth);
         expect(border.left.color, EditorialMonoclePalette.accentDim);
         expect(border.bottom, BorderSide.none);
@@ -120,7 +76,7 @@ void main() {
       'bottomBorderMuted variant renders a 1dp --border bottom border '
       'without CtSectionLabel (Refs #3514)',
       (WidgetTester tester) async {
-        await _pumpBody(
+        await pumpUnitsSharedBody(
           tester,
           const RegionSectionHeader(
             label: 'Old World',
@@ -138,7 +94,10 @@ void main() {
         expect(label.style?.color, EditorialMonoclePalette.muted);
         expect(label.style?.fontWeight, FontWeight.w600);
 
-        final Border border = _headerBorder(tester, RegionSectionHeader);
+        final Border border = unitsSharedHeaderBorder(
+          tester,
+          RegionSectionHeader,
+        );
         expect(border.bottom.width, RegionSectionHeader.bottomBorderWidth);
         expect(border.bottom.color, EditorialMonoclePalette.border);
         expect(border.left, BorderSide.none);
@@ -148,7 +107,7 @@ void main() {
 
   group('LocationSectionHeader', () {
     testWidgets('shows label and region', (WidgetTester tester) async {
-      await _pumpBody(
+      await pumpUnitsSharedBody(
         tester,
         const LocationSectionHeader(
           label: 'Province A',
@@ -158,39 +117,36 @@ void main() {
       expect(find.text('Province A — New World'), findsOneWidget);
     });
 
-    testWidgets(
-      'renders semi-bold fg-at-0.8 chrome per mockup .province-label '
-      '(Refs #3514)',
-      (WidgetTester tester) async {
-        await _pumpBody(
-          tester,
-          const LocationSectionHeader(
-            label: 'Province A',
-            regionLabel: 'New World',
-          ),
-        );
+    testWidgets('renders semi-bold fg-at-0.8 chrome per mockup .province-label '
+        '(Refs #3514)', (WidgetTester tester) async {
+      await pumpUnitsSharedBody(
+        tester,
+        const LocationSectionHeader(
+          label: 'Province A',
+          regionLabel: 'New World',
+        ),
+      );
 
-        final Text text = tester.widget<Text>(
-          find.text('Province A — New World'),
-        );
-        expect(text.style?.fontWeight, FontWeight.w600);
-        expect(
-          text.style?.color,
-          EditorialMonoclePalette.fg.withValues(
-            alpha: LocationSectionHeader.labelOpacity,
-          ),
-        );
-      },
-    );
+      final Text text = tester.widget<Text>(
+        find.text('Province A — New World'),
+      );
+      expect(text.style?.fontWeight, FontWeight.w600);
+      expect(
+        text.style?.color,
+        EditorialMonoclePalette.fg.withValues(
+          alpha: LocationSectionHeader.labelOpacity,
+        ),
+      );
+    });
   });
 
   group('UnitsPanelShell', () {
     testWidgets('shows title and empty message when no content', (
       WidgetTester tester,
     ) async {
-      await _pumpBody(
+      await pumpUnitsSharedBody(
         tester,
-        _emptyShell(title: 'Test Panel', emptyMessage: 'Nothing here'),
+        emptyUnitsPanelShell(title: 'Test Panel', emptyMessage: 'Nothing here'),
       );
       expect(find.text('Test Panel'), findsOneWidget);
       expect(find.text('Nothing here'), findsOneWidget);
@@ -199,7 +155,7 @@ void main() {
     testWidgets('shows list children when hasContent', (
       WidgetTester tester,
     ) async {
-      await _pumpBody(
+      await pumpUnitsSharedBody(
         tester,
         UnitsPanelShell(
           title: 'With rows',
@@ -217,14 +173,12 @@ void main() {
     });
 
     testWidgets('forwards trailing actions', (WidgetTester tester) async {
-      await _pumpBody(
+      await pumpUnitsSharedBody(
         tester,
-        _emptyShell(
+        emptyUnitsPanelShell(
           title: 'T',
           emptyMessage: 'E',
-          actions: [
-            TextButton(onPressed: () {}, child: const Text('Action')),
-          ],
+          actions: [TextButton(onPressed: () {}, child: const Text('Action'))],
         ),
       );
       expect(find.text('Action'), findsOneWidget);
@@ -233,7 +187,7 @@ void main() {
     testWidgets(
       'renders title via CtTopBar (showBackButton: false; #2866 S1 chrome)',
       (WidgetTester tester) async {
-        await _pumpBody(tester, _emptyShell());
+        await pumpUnitsSharedBody(tester, emptyUnitsPanelShell());
 
         final Finder topBarFinder = find.byType(CtTopBar);
         expect(topBarFinder, findsOneWidget);
@@ -258,7 +212,10 @@ void main() {
 
         // Title text colour resolves to the canonical --accent token.
         final Text titleText = tester.widget(
-          find.descendant(of: topBarFinder, matching: find.text('Civilian Units')),
+          find.descendant(
+            of: topBarFinder,
+            matching: find.text('Civilian Units'),
+          ),
         );
         expect(titleText.style?.color, EditorialMonoclePalette.accent);
       },
@@ -267,9 +224,9 @@ void main() {
     testWidgets(
       'wraps multiple trailing actions in a Row inside CtTopBar trailing slot',
       (WidgetTester tester) async {
-        await _pumpBody(
+        await pumpUnitsSharedBody(
           tester,
-          _emptyShell(
+          emptyUnitsPanelShell(
             actions: [
               TextButton(onPressed: () {}, child: const Text('Tile')),
               TextButton(onPressed: () {}, child: const Text('Train')),
@@ -300,9 +257,9 @@ void main() {
           onPressed: () {},
           child: const Text('Train'),
         );
-        await _pumpBody(
+        await pumpUnitsSharedBody(
           tester,
-          _emptyShell(actions: [soloAction], emptyMessage: 'E'),
+          emptyUnitsPanelShell(actions: [soloAction], emptyMessage: 'E'),
         );
 
         final CtTopBar topBar = tester.widget(find.byType(CtTopBar));
@@ -313,7 +270,7 @@ void main() {
     testWidgets(
       'renders empty message in italic --muted (#2866 S1 dark-theme palette)',
       (WidgetTester tester) async {
-        await _pumpBody(tester, _emptyShell());
+        await pumpUnitsSharedBody(tester, emptyUnitsPanelShell());
 
         final Text emptyText = tester.widget(find.text('No civilian units'));
         expect(emptyText.style?.color, EditorialMonoclePalette.muted);
@@ -321,32 +278,29 @@ void main() {
       },
     );
 
-    testWidgets(
-      'omits the empty message when hasContent is true',
-      (WidgetTester tester) async {
-        await _pumpBody(
-          tester,
-          const UnitsPanelShell(
-            title: 'Civilian Units',
-            hasContent: true,
-            listChildren: [
-              ListTile(title: Text('Row one')),
-            ],
-            emptyMessage: 'No civilian units',
-          ),
-        );
+    testWidgets('omits the empty message when hasContent is true', (
+      WidgetTester tester,
+    ) async {
+      await pumpUnitsSharedBody(
+        tester,
+        const UnitsPanelShell(
+          title: 'Civilian Units',
+          hasContent: true,
+          listChildren: [ListTile(title: Text('Row one'))],
+          emptyMessage: 'No civilian units',
+        ),
+      );
 
-        expect(find.text('Row one'), findsOneWidget);
-        expect(find.text('No civilian units'), findsNothing);
-      },
-    );
+      expect(find.text('Row one'), findsOneWidget);
+      expect(find.text('No civilian units'), findsNothing);
+    });
   });
 
   group('UnitsEntityActionRow', () {
     testWidgets('renders details with text action label on wide width', (
       WidgetTester tester,
     ) async {
-      await _pumpActionRow(
+      await pumpUnitsEntityActionRow(
         tester,
         actions: [
           UnitsEntityAction(
@@ -366,7 +320,7 @@ void main() {
     testWidgets('switches action button to icon-only on narrow width', (
       WidgetTester tester,
     ) async {
-      await _pumpActionRow(
+      await pumpUnitsEntityActionRow(
         tester,
         width: 220,
         actions: [
@@ -388,7 +342,7 @@ void main() {
       'neutral -> CtActionTextButton, danger -> CtDangerTextButton, '
       'iconOnly -> CtCircularLocateButton, and no CtNinePatchButton',
       (WidgetTester tester) async {
-        await _pumpActionRow(
+        await pumpUnitsEntityActionRow(
           tester,
           actions: [
             UnitsEntityAction(
@@ -426,7 +380,7 @@ void main() {
     testWidgets(
       'disabled action (onPressed == null) renders a disabled pill (#3514)',
       (WidgetTester tester) async {
-        await _pumpActionRow(
+        await pumpUnitsEntityActionRow(
           tester,
           actions: const [
             UnitsEntityAction(

--- a/app/test/units_panel_shared_widgets_test_support.dart
+++ b/app/test/units_panel_shared_widgets_test_support.dart
@@ -1,0 +1,53 @@
+// Pump helpers for units-panel shared-widget tests (Refs #4352).
+
+import 'package:colonizethis_app/features/game/widgets/units/shared/units_entity_action_row.dart';
+import 'package:colonizethis_app/features/game/widgets/units/shared/units_panel_shell.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'app_shell_harness.dart';
+
+Future<void> pumpUnitsSharedBody(WidgetTester tester, Widget body) async {
+  await tester.pumpWidget(buildAppShell(child: Scaffold(body: body)));
+}
+
+Border unitsSharedHeaderBorder(WidgetTester tester, Type headerType) {
+  final DecoratedBox decoratedBox = tester.widget<DecoratedBox>(
+    find.descendant(
+      of: find.byType(headerType),
+      matching: find.byType(DecoratedBox),
+    ),
+  );
+  return (decoratedBox.decoration as BoxDecoration).border! as Border;
+}
+
+UnitsPanelShell emptyUnitsPanelShell({
+  String title = 'Civilian Units',
+  String emptyMessage = 'No civilian units',
+  List<Widget> actions = const [],
+}) {
+  return UnitsPanelShell(
+    title: title,
+    actions: actions,
+    hasContent: false,
+    listChildren: const [],
+    emptyMessage: emptyMessage,
+  );
+}
+
+Future<void> pumpUnitsEntityActionRow(
+  WidgetTester tester, {
+  double width = 420,
+  required List<UnitsEntityAction> actions,
+}) async {
+  await pumpUnitsSharedBody(
+    tester,
+    SizedBox(
+      width: width,
+      child: UnitsEntityActionRow(
+        details: const Text('Left details'),
+        actions: actions,
+      ),
+    ),
+  );
+}

--- a/app/test/widgets/ct_nine_patch_button_dark_test.dart
+++ b/app/test/widgets/ct_nine_patch_button_dark_test.dart
@@ -4,167 +4,54 @@ import 'package:colonizethis_app_ui_chrome/config/editorial_monocle_palette.dart
 import 'package:colonizethis_app/widgets/ct_gradients.dart';
 import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
-import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../app_shell_harness.dart';
-
-Future<void> _pumpButton(
-  WidgetTester tester, {
-  required VoidCallback? onPressed,
-  bool enabled = true,
-  bool dangerVariant = false,
-  bool mutedVariant = false,
-  double? disabledOpacityOverride,
-  LinearGradient? gradient,
-  LinearGradient? pressedGradient,
-  Widget child = const Text('Confirm'),
-}) async {
-  await pumpAppShell(
-    tester,
-    settle: true,
-    child: Scaffold(
-      body: Center(
-        child: SizedBox(
-          width: 200,
-          child: CtNinePatchButton(
-            onPressed: onPressed,
-            enabled: enabled,
-            dangerVariant: dangerVariant,
-            mutedVariant: mutedVariant,
-            disabledOpacityOverride: disabledOpacityOverride,
-            gradient: gradient,
-            pressedGradient: pressedGradient,
-            child: child,
-          ),
-        ),
-      ),
-    ),
-  );
-}
-
-DecoratedBox _findButtonSurfaceDecoratedBox(WidgetTester tester) {
-  final Finder boxes = find.descendant(
-    of: find.byType(CtNinePatchButton),
-    matching: find.byWidgetPredicate(
-      (Widget widget) =>
-          widget is DecoratedBox &&
-          (widget.decoration is BoxDecoration) &&
-          (widget.decoration as BoxDecoration).gradient != null,
-    ),
-  );
-  expect(boxes, findsAtLeastNWidgets(1));
-  return tester.widget<DecoratedBox>(boxes.first);
-}
-
-BoxDecoration _surfaceDecoration(WidgetTester tester) =>
-    _findButtonSurfaceDecoratedBox(tester).decoration as BoxDecoration;
-
-TextSpan _labelSpan(WidgetTester tester, String label) {
-  final RichText rich = tester.widget<RichText>(
-    find.descendant(of: find.text(label), matching: find.byType(RichText)),
-  );
-  return rich.text as TextSpan;
-}
-
-Finder _opacityFinder(double opacity) => find.descendant(
-      of: find.byType(CtNinePatchButton),
-      matching: find.byWidgetPredicate(
-        (Widget w) => w is Opacity && w.opacity == opacity,
-      ),
-    );
-
-void _expectGradientColors(
-  WidgetTester tester,
-  List<Color> colors, {
-  String? reason,
-}) {
-  final LinearGradient gradient =
-      _surfaceDecoration(tester).gradient! as LinearGradient;
-  expect(gradient.colors, colors, reason: reason);
-}
-
-void _expectBorderColor(WidgetTester tester, Color color, {String? reason}) {
-  final Border border = _surfaceDecoration(tester).border! as Border;
-  expect(border.top.color, color, reason: reason);
-}
-
-void _expectLabelColor(
-  WidgetTester tester,
-  String label,
-  Color color, {
-  String? reason,
-}) {
-  expect(_labelSpan(tester, label).style?.color, color, reason: reason);
-}
-
-Future<TestGesture> _hoverOverButton(WidgetTester tester) async {
-  final TestGesture gesture = await tester.createGesture(
-    kind: PointerDeviceKind.mouse,
-  );
-  addTearDown(gesture.removePointer);
-  await gesture.addPointer(location: const Offset(1, 1));
-  await tester.pumpAndSettle();
-  await gesture.moveTo(tester.getCenter(find.byType(CtNinePatchButton)));
-  await tester.pump();
-  await tester.pump(CtNinePatchButton.animationDuration);
-  await tester.pumpAndSettle();
-  return gesture;
-}
-
-Future<TestGesture> _holdPress(WidgetTester tester) async {
-  final TestGesture gesture = await tester.startGesture(
-    tester.getCenter(find.byType(CtNinePatchButton)),
-  );
-  await tester.pump();
-  await tester.pump(CtNinePatchButton.animationDuration);
-  await tester.pumpAndSettle();
-  return gesture;
-}
+import 'ct_nine_patch_button_dark_test_support.dart';
 
 void main() {
   suppressLogsForTests();
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  testWidgets(
-    'default state paints buttonGradient and 1px --border border',
-    (WidgetTester tester) async {
-      await _pumpButton(tester, onPressed: () {});
-      final BoxDecoration decoration = _surfaceDecoration(tester);
-      final LinearGradient gradient = decoration.gradient! as LinearGradient;
-      expect(gradient.begin, Alignment.topCenter);
-      expect(gradient.end, Alignment.bottomCenter);
-      expect(gradient.colors, <Color>[
-        EditorialMonoclePalette.surfaceLite,
-        EditorialMonoclePalette.surface,
-      ]);
-      expect(gradient.colors, CtGradients.buttonGradient.colors);
-      final Border? border = decoration.border as Border?;
-      expect(border, isNotNull);
-      expect(border!.top.width, CtNinePatchButton.borderWidth);
-      expect(border.top.color, EditorialMonoclePalette.border);
-    },
-  );
+  testWidgets('default state paints buttonGradient and 1px --border border', (
+    WidgetTester tester,
+  ) async {
+    await pumpNinePatchButton(tester, onPressed: () {});
+    final BoxDecoration decoration = ninePatchButtonSurfaceDecoration(tester);
+    final LinearGradient gradient = decoration.gradient! as LinearGradient;
+    expect(gradient.begin, Alignment.topCenter);
+    expect(gradient.end, Alignment.bottomCenter);
+    expect(gradient.colors, <Color>[
+      EditorialMonoclePalette.surfaceLite,
+      EditorialMonoclePalette.surface,
+    ]);
+    expect(gradient.colors, CtGradients.buttonGradient.colors);
+    final Border? border = decoration.border as Border?;
+    expect(border, isNotNull);
+    expect(border!.top.width, CtNinePatchButton.borderWidth);
+    expect(border.top.color, EditorialMonoclePalette.border);
+  });
 
-  testWidgets(
-    'hover brightens corner brackets and shifts border to --accent',
-    (WidgetTester tester) async {
-      await _pumpButton(tester, onPressed: () {});
-      final TestGesture gesture = await _hoverOverButton(tester);
-      _expectBorderColor(tester, EditorialMonoclePalette.accent);
-      await gesture.moveTo(const Offset(-50, -50));
-      await tester.pumpAndSettle();
-      _expectBorderColor(tester, EditorialMonoclePalette.border);
-    },
-  );
+  testWidgets('hover brightens corner brackets and shifts border to --accent', (
+    WidgetTester tester,
+  ) async {
+    await pumpNinePatchButton(tester, onPressed: () {});
+    final TestGesture gesture = await hoverOverNinePatchButton(tester);
+    expectNinePatchBorderColor(tester, EditorialMonoclePalette.accent);
+    await gesture.moveTo(const Offset(-50, -50));
+    await tester.pumpAndSettle();
+    expectNinePatchBorderColor(tester, EditorialMonoclePalette.border);
+  });
 
   testWidgets(
     'engraved label text uses a 1px downward shadow coloured from --surface',
     (WidgetTester tester) async {
-      await _pumpButton(tester, onPressed: () {});
+      await pumpNinePatchButton(tester, onPressed: () {});
       expect(find.text('Confirm'), findsOneWidget);
-      final List<Shadow>? shadows = _labelSpan(tester, 'Confirm').style?.shadows;
+      final List<Shadow>? shadows = ninePatchButtonLabelSpan(
+        tester,
+        'Confirm',
+      ).style?.shadows;
       expect(shadows, isNotNull);
       expect(shadows!.length, 1);
       expect(shadows.first.offset, CtNinePatchButton.engravedShadowOffset);
@@ -177,8 +64,15 @@ void main() {
     'disabled state wraps button in 0.4 opacity and suppresses taps',
     (WidgetTester tester) async {
       int taps = 0;
-      await _pumpButton(tester, onPressed: () => taps += 1, enabled: false);
-      expect(_opacityFinder(CtNinePatchButton.disabledOpacity), findsOneWidget);
+      await pumpNinePatchButton(
+        tester,
+        onPressed: () => taps += 1,
+        enabled: false,
+      );
+      expect(
+        ninePatchButtonOpacityFinder(CtNinePatchButton.disabledOpacity),
+        findsOneWidget,
+      );
       expect(CtNinePatchButton.disabledOpacity, 0.4);
       await tester.tap(find.byType(CtNinePatchButton), warnIfMissed: false);
       await tester.pumpAndSettle();
@@ -190,33 +84,38 @@ void main() {
     'disabledOpacityOverride replaces the catalog 0.4 default when set '
     '(positive path — issue #2861 R1 / AC#9 next-turn button uses 0.35)',
     (WidgetTester tester) async {
-      await _pumpButton(
+      await pumpNinePatchButton(
         tester,
         onPressed: () {},
         enabled: false,
         disabledOpacityOverride: 0.35,
       );
-      expect(_opacityFinder(0.35), findsOneWidget);
-      expect(_opacityFinder(CtNinePatchButton.disabledOpacity), findsNothing);
+      expect(ninePatchButtonOpacityFinder(0.35), findsOneWidget);
+      expect(
+        ninePatchButtonOpacityFinder(CtNinePatchButton.disabledOpacity),
+        findsNothing,
+      );
     },
   );
 
-  testWidgets(
-    'disabledOpacityOverride: null preserves the catalog 0.4 default '
-    '(negative / regression guard — every other CtNinePatchButton call '
-    'site must keep the shared disabled convention)',
-    (WidgetTester tester) async {
-      await _pumpButton(tester, onPressed: () {}, enabled: false);
-      expect(_opacityFinder(CtNinePatchButton.disabledOpacity), findsOneWidget);
-      expect(_opacityFinder(0.35), findsNothing);
-    },
-  );
+  testWidgets('disabledOpacityOverride: null preserves the catalog 0.4 default '
+      '(negative / regression guard — every other CtNinePatchButton call '
+      'site must keep the shared disabled convention)', (
+    WidgetTester tester,
+  ) async {
+    await pumpNinePatchButton(tester, onPressed: () {}, enabled: false);
+    expect(
+      ninePatchButtonOpacityFinder(CtNinePatchButton.disabledOpacity),
+      findsOneWidget,
+    );
+    expect(ninePatchButtonOpacityFinder(0.35), findsNothing);
+  });
 
   testWidgets(
     'enabled state with disabledOpacityOverride does not apply any Opacity '
     'wrapper (the override only takes effect when the button is disabled)',
     (WidgetTester tester) async {
-      await _pumpButton(
+      await pumpNinePatchButton(
         tester,
         onPressed: () {},
         disabledOpacityOverride: 0.35,
@@ -236,60 +135,58 @@ void main() {
     },
   );
 
-  testWidgets(
-    'enabled state with non-null onPressed fires callback on tap',
-    (WidgetTester tester) async {
-      int taps = 0;
-      await _pumpButton(tester, onPressed: () => taps += 1);
-      await tester.tap(find.byType(CtNinePatchButton));
-      await tester.pumpAndSettle();
-      expect(taps, 1);
-    },
-  );
+  testWidgets('enabled state with non-null onPressed fires callback on tap', (
+    WidgetTester tester,
+  ) async {
+    int taps = 0;
+    await pumpNinePatchButton(tester, onPressed: () => taps += 1);
+    await tester.tap(find.byType(CtNinePatchButton));
+    await tester.pumpAndSettle();
+    expect(taps, 1);
+  });
 
-  testWidgets(
-    'four brass corner brackets are painted via CustomPaint',
-    (WidgetTester tester) async {
-      await _pumpButton(tester, onPressed: () {});
-      expect(
-        find.descendant(
-          of: find.byType(CtNinePatchButton),
-          matching: find.byWidgetPredicate(
-            (Widget w) =>
-                w is CustomPaint &&
-                w.painter != null &&
-                w.painter.runtimeType.toString() ==
-                    'CtNinePatchButtonBracketsPainter',
-          ),
+  testWidgets('four brass corner brackets are painted via CustomPaint', (
+    WidgetTester tester,
+  ) async {
+    await pumpNinePatchButton(tester, onPressed: () {});
+    expect(
+      find.descendant(
+        of: find.byType(CtNinePatchButton),
+        matching: find.byWidgetPredicate(
+          (Widget w) =>
+              w is CustomPaint &&
+              w.painter != null &&
+              w.painter.runtimeType.toString() ==
+                  'CtNinePatchButtonBracketsPainter',
         ),
-        findsOneWidget,
-      );
-      expect(CtNinePatchButton.cornerBracketSize, 10);
-    },
-  );
+      ),
+      findsOneWidget,
+    );
+    expect(CtNinePatchButton.cornerBracketSize, 10);
+  });
 
   testWidgets(
     'pressedGradient swaps the surface gradient transiently while held; '
     'reverts to the rest gradient after the gesture completes',
     (WidgetTester tester) async {
-      await _pumpButton(
+      await pumpNinePatchButton(
         tester,
         onPressed: () {},
         gradient: CtGradients.woodPanelButtonGradient,
         pressedGradient: CtGradients.woodPanelButtonGradientPressed,
       );
-      _expectGradientColors(
+      expectNinePatchGradientColors(
         tester,
         CtGradients.woodPanelButtonGradient.colors,
       );
-      final TestGesture gesture = await _holdPress(tester);
-      _expectGradientColors(
+      final TestGesture gesture = await holdNinePatchButtonPress(tester);
+      expectNinePatchGradientColors(
         tester,
         CtGradients.woodPanelButtonGradientPressed.colors,
       );
       await gesture.up();
       await tester.pumpAndSettle();
-      _expectGradientColors(
+      expectNinePatchGradientColors(
         tester,
         CtGradients.woodPanelButtonGradient.colors,
       );
@@ -300,90 +197,98 @@ void main() {
     'when pressedGradient is omitted, pressing the button does not swap the '
     'surface gradient (default 2-stop CtGradients.buttonGradient is preserved)',
     (WidgetTester tester) async {
-      await _pumpButton(tester, onPressed: () {});
-      final TestGesture gesture = await _holdPress(tester);
-      _expectGradientColors(tester, CtGradients.buttonGradient.colors);
+      await pumpNinePatchButton(tester, onPressed: () {});
+      final TestGesture gesture = await holdNinePatchButtonPress(tester);
+      expectNinePatchGradientColors(tester, CtGradients.buttonGradient.colors);
       await gesture.up();
       await tester.pumpAndSettle();
     },
   );
 
-  testWidgets(
-    'danger variant resolves border and engraved label to --danger',
-    (WidgetTester tester) async {
-      await _pumpButton(
-        tester,
-        onPressed: () {},
-        dangerVariant: true,
-        child: const Text('Declare War'),
-      );
-      _expectGradientColors(tester, CtGradients.buttonGradient.colors);
-      _expectBorderColor(tester, EditorialMonoclePalette.danger);
-      _expectLabelColor(tester, 'Declare War', EditorialMonoclePalette.danger);
-    },
-  );
+  testWidgets('danger variant resolves border and engraved label to --danger', (
+    WidgetTester tester,
+  ) async {
+    await pumpNinePatchButton(
+      tester,
+      onPressed: () {},
+      dangerVariant: true,
+      child: const Text('Declare War'),
+    );
+    expectNinePatchGradientColors(tester, CtGradients.buttonGradient.colors);
+    expectNinePatchBorderColor(tester, EditorialMonoclePalette.danger);
+    expectNinePatchLabelColor(
+      tester,
+      'Declare War',
+      EditorialMonoclePalette.danger,
+    );
+  });
 
   testWidgets(
     'muted variant resolves idle border to --accent-dim and idle label to '
     '--muted (positive — issue #2867 R26b)',
     (WidgetTester tester) async {
-      await _pumpButton(
+      await pumpNinePatchButton(
         tester,
         onPressed: () {},
         mutedVariant: true,
         child: const Text('Do naught'),
       );
-      _expectBorderColor(tester, EditorialMonoclePalette.accentDim);
+      expectNinePatchBorderColor(tester, EditorialMonoclePalette.accentDim);
       expect(
-        (_surfaceDecoration(tester).border! as Border).top.color,
+        (ninePatchButtonSurfaceDecoration(tester).border! as Border).top.color,
         isNot(EditorialMonoclePalette.border),
       );
-      _expectLabelColor(tester, 'Do naught', EditorialMonoclePalette.muted);
-      _expectGradientColors(tester, CtGradients.buttonGradient.colors);
+      expectNinePatchLabelColor(
+        tester,
+        'Do naught',
+        EditorialMonoclePalette.muted,
+      );
+      expectNinePatchGradientColors(tester, CtGradients.buttonGradient.colors);
     },
   );
 
-  testWidgets(
-    'muted variant lifts border + label to --accent on hover '
-    '(positive — issue #2867 R26b)',
-    (WidgetTester tester) async {
-      await _pumpButton(
-        tester,
-        onPressed: () {},
-        mutedVariant: true,
-        child: const Text('Diplomatic protest'),
-      );
-      await _hoverOverButton(tester);
-      _expectBorderColor(tester, EditorialMonoclePalette.accent);
-      _expectLabelColor(
-        tester,
-        'Diplomatic protest',
-        EditorialMonoclePalette.accent,
-      );
-      expect(
-        _labelSpan(tester, 'Diplomatic protest').style?.color,
-        isNot(EditorialMonoclePalette.accentBright),
-      );
-    },
-  );
+  testWidgets('muted variant lifts border + label to --accent on hover '
+      '(positive — issue #2867 R26b)', (WidgetTester tester) async {
+    await pumpNinePatchButton(
+      tester,
+      onPressed: () {},
+      mutedVariant: true,
+      child: const Text('Diplomatic protest'),
+    );
+    await hoverOverNinePatchButton(tester);
+    expectNinePatchBorderColor(tester, EditorialMonoclePalette.accent);
+    expectNinePatchLabelColor(
+      tester,
+      'Diplomatic protest',
+      EditorialMonoclePalette.accent,
+    );
+    expect(
+      ninePatchButtonLabelSpan(tester, 'Diplomatic protest').style?.color,
+      isNot(EditorialMonoclePalette.accentBright),
+    );
+  });
 
   testWidgets(
     'mutedVariant + dangerVariant: dangerVariant wins (negative — issue '
     '#2867 R26b mutual-exclusivity contract)',
     (WidgetTester tester) async {
-      await _pumpButton(
+      await pumpNinePatchButton(
         tester,
         onPressed: () {},
         dangerVariant: true,
         mutedVariant: true,
         child: const Text('Declare War'),
       );
-      _expectBorderColor(tester, EditorialMonoclePalette.danger);
+      expectNinePatchBorderColor(tester, EditorialMonoclePalette.danger);
       expect(
-        (_surfaceDecoration(tester).border! as Border).top.color,
+        (ninePatchButtonSurfaceDecoration(tester).border! as Border).top.color,
         isNot(EditorialMonoclePalette.accentDim),
       );
-      _expectLabelColor(tester, 'Declare War', EditorialMonoclePalette.danger);
+      expectNinePatchLabelColor(
+        tester,
+        'Declare War',
+        EditorialMonoclePalette.danger,
+      );
     },
   );
 
@@ -391,36 +296,37 @@ void main() {
     'default (no muted, no danger) keeps --border idle border and --accent '
     'idle label (negative regression guard for muted variant introduction)',
     (WidgetTester tester) async {
-      await _pumpButton(tester, onPressed: () {});
-      _expectBorderColor(tester, EditorialMonoclePalette.border);
+      await pumpNinePatchButton(tester, onPressed: () {});
+      expectNinePatchBorderColor(tester, EditorialMonoclePalette.border);
       expect(
-        (_surfaceDecoration(tester).border! as Border).top.color,
+        (ninePatchButtonSurfaceDecoration(tester).border! as Border).top.color,
         isNot(EditorialMonoclePalette.accentDim),
       );
-      _expectLabelColor(tester, 'Confirm', EditorialMonoclePalette.accent);
+      expectNinePatchLabelColor(
+        tester,
+        'Confirm',
+        EditorialMonoclePalette.accent,
+      );
       expect(
-        _labelSpan(tester, 'Confirm').style?.color,
+        ninePatchButtonLabelSpan(tester, 'Confirm').style?.color,
         isNot(EditorialMonoclePalette.muted),
       );
     },
   );
 
-  test(
-    'mutedCornerAlphaScale halves the bracket alpha (canonical 0.5 scale; '
-    '#2867 R26b — keeps brackets visible at narrow viewports while reading '
-    'as half-strength against a sibling primary)',
-    () {
-      expect(CtNinePatchButton.mutedCornerAlphaScale, 0.5);
-      expect(
-        CtNinePatchButton.defaultCornerAlpha *
-            CtNinePatchButton.mutedCornerAlphaScale,
-        closeTo(0.375, 1e-9),
-      );
-      expect(
-        CtNinePatchButton.hoverCornerAlpha *
-            CtNinePatchButton.mutedCornerAlphaScale,
-        closeTo(0.5, 1e-9),
-      );
-    },
-  );
+  test('mutedCornerAlphaScale halves the bracket alpha (canonical 0.5 scale; '
+      '#2867 R26b — keeps brackets visible at narrow viewports while reading '
+      'as half-strength against a sibling primary)', () {
+    expect(CtNinePatchButton.mutedCornerAlphaScale, 0.5);
+    expect(
+      CtNinePatchButton.defaultCornerAlpha *
+          CtNinePatchButton.mutedCornerAlphaScale,
+      closeTo(0.375, 1e-9),
+    );
+    expect(
+      CtNinePatchButton.hoverCornerAlpha *
+          CtNinePatchButton.mutedCornerAlphaScale,
+      closeTo(0.5, 1e-9),
+    );
+  });
 }

--- a/app/test/widgets/ct_nine_patch_button_dark_test_support.dart
+++ b/app/test/widgets/ct_nine_patch_button_dark_test_support.dart
@@ -1,0 +1,130 @@
+// Pump/inspect helpers for CtNinePatchButton dark-chrome tests (Refs #4352).
+
+import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../app_shell_harness.dart';
+
+Future<void> pumpNinePatchButton(
+  WidgetTester tester, {
+  required VoidCallback? onPressed,
+  bool enabled = true,
+  bool dangerVariant = false,
+  bool mutedVariant = false,
+  double? disabledOpacityOverride,
+  LinearGradient? gradient,
+  LinearGradient? pressedGradient,
+  Widget child = const Text('Confirm'),
+}) async {
+  await pumpAppShell(
+    tester,
+    settle: true,
+    child: Scaffold(
+      body: Center(
+        child: SizedBox(
+          width: 200,
+          child: CtNinePatchButton(
+            onPressed: onPressed,
+            enabled: enabled,
+            dangerVariant: dangerVariant,
+            mutedVariant: mutedVariant,
+            disabledOpacityOverride: disabledOpacityOverride,
+            gradient: gradient,
+            pressedGradient: pressedGradient,
+            child: child,
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+DecoratedBox findNinePatchButtonSurfaceDecoratedBox(WidgetTester tester) {
+  final Finder boxes = find.descendant(
+    of: find.byType(CtNinePatchButton),
+    matching: find.byWidgetPredicate(
+      (Widget widget) =>
+          widget is DecoratedBox &&
+          (widget.decoration is BoxDecoration) &&
+          (widget.decoration as BoxDecoration).gradient != null,
+    ),
+  );
+  expect(boxes, findsAtLeastNWidgets(1));
+  return tester.widget<DecoratedBox>(boxes.first);
+}
+
+BoxDecoration ninePatchButtonSurfaceDecoration(WidgetTester tester) =>
+    findNinePatchButtonSurfaceDecoratedBox(tester).decoration as BoxDecoration;
+
+TextSpan ninePatchButtonLabelSpan(WidgetTester tester, String label) {
+  final RichText rich = tester.widget<RichText>(
+    find.descendant(of: find.text(label), matching: find.byType(RichText)),
+  );
+  return rich.text as TextSpan;
+}
+
+Finder ninePatchButtonOpacityFinder(double opacity) => find.descendant(
+  of: find.byType(CtNinePatchButton),
+  matching: find.byWidgetPredicate(
+    (Widget w) => w is Opacity && w.opacity == opacity,
+  ),
+);
+
+void expectNinePatchGradientColors(
+  WidgetTester tester,
+  List<Color> colors, {
+  String? reason,
+}) {
+  final LinearGradient gradient =
+      ninePatchButtonSurfaceDecoration(tester).gradient! as LinearGradient;
+  expect(gradient.colors, colors, reason: reason);
+}
+
+void expectNinePatchBorderColor(
+  WidgetTester tester,
+  Color color, {
+  String? reason,
+}) {
+  final Border border =
+      ninePatchButtonSurfaceDecoration(tester).border! as Border;
+  expect(border.top.color, color, reason: reason);
+}
+
+void expectNinePatchLabelColor(
+  WidgetTester tester,
+  String label,
+  Color color, {
+  String? reason,
+}) {
+  expect(
+    ninePatchButtonLabelSpan(tester, label).style?.color,
+    color,
+    reason: reason,
+  );
+}
+
+Future<TestGesture> hoverOverNinePatchButton(WidgetTester tester) async {
+  final TestGesture gesture = await tester.createGesture(
+    kind: PointerDeviceKind.mouse,
+  );
+  addTearDown(gesture.removePointer);
+  await gesture.addPointer(location: const Offset(1, 1));
+  await tester.pumpAndSettle();
+  await gesture.moveTo(tester.getCenter(find.byType(CtNinePatchButton)));
+  await tester.pump();
+  await tester.pump(CtNinePatchButton.animationDuration);
+  await tester.pumpAndSettle();
+  return gesture;
+}
+
+Future<TestGesture> holdNinePatchButtonPress(WidgetTester tester) async {
+  final TestGesture gesture = await tester.startGesture(
+    tester.getCenter(find.byType(CtNinePatchButton)),
+  );
+  await tester.pump();
+  await tester.pump(CtNinePatchButton.animationDuration);
+  await tester.pumpAndSettle();
+  return gesture;
+}

--- a/tool/check_app_test_file_size.dart
+++ b/tool/check_app_test_file_size.dart
@@ -19,25 +19,16 @@ const String _appTestsRelativePath = 'app/test';
 /// Remove an entry only after the file is at or under [_maxPhysicalLines].
 const List<String> appTestFileSizeAllowlistForTests = <String>[
   'app/test/app_event_handler_test.dart',
-  'app/test/debug_console_overlay_panel_test.dart',
   'app/test/diplomacy_panel_orders_test.dart',
-  'app/test/diplomacy_panel_test.dart',
   'app/test/game_event_bridge_test.dart',
-  'app/test/mobile_320dp_min_viewport_test.dart',
-  'app/test/move_army_invasion_intel_test.dart',
-  'app/test/move_dialogs_specs_part1_test.dart',
   'app/test/move_fleet_dialog_test.dart',
   'app/test/naval_panel_part1_pins.dart',
-  'app/test/panels_320dp_min_viewport_test.dart',
-  'app/test/pause_menu_side_menu_specs_test.dart',
-  'app/test/province_overlay_extraction_available_test.dart',
   'app/test/trade_screen_deal_book_tab_e6_test.dart',
   'app/test/trade_screen_market_tab_treasury_bid_cap_test.dart',
   'app/test/trade_screen_scaffold_test.dart',
   'app/test/units_panel_shared_widgets_test.dart',
   'app/test/units_panel_test_support_test.dart',
   'app/test/widgetbook_in_game_shell_chrome_test.dart',
-  'app/test/widgets/ct_nine_patch_button_dark_test.dart',
 ];
 
 int runCheckAppTestFileSize(


### PR DESCRIPTION
## Summary
- Continue #4352 Slice D after #4400 merged: densify remaining `app/test/**` allowlisted suites to ≤400 physical lines via shared fixtures and concern splits (no new mechanical `*_partN_test.dart` shards).
- Shrink `appTestFileSizeAllowlistForTests` 20 → 11.

## Done in this push
- `debug_console_overlay_panel_test.dart` — extract helpers; split chrome suite
- `diplomacy_panel_test.dart` — split chrome groups to sibling
- `mobile_320dp_min_viewport_test.dart` — extract viewport fixtures
- `move_army_invasion_intel_test.dart` — extract intel fixtures
- `move_dialogs_specs_part1_test.dart` — extract army dialog fixtures
- `panels_320dp_min_viewport_test.dart` — extract panel viewport fixtures
- `pause_menu_side_menu_specs_test.dart` — split GameSideMenu suite
- `province_overlay_extraction_available_test.dart` — extract overlay fixtures
- `widgets/ct_nine_patch_button_dark_test.dart` — extract dark-button fixtures

Partial densify (still over 400 after `dart format`, remain on allowlist): `app_event_handler_test.dart`, `diplomacy_panel_orders_test.dart`, `trade_screen_deal_book_tab_e6_test.dart`, `units_panel_shared_widgets_test.dart`.

## Remaining for #4352
- Empty the remaining shrink-only allowlist (11 files) for AC8
- Finish AC10 densify for remaining dense suites (`game_event_bridge_test.dart`, `move_fleet_dialog_test.dart`, `naval_panel_part1_pins.dart`, trade scaffold/treasury bid-cap, `units_panel_test_support_test.dart`, `widgetbook_in_game_shell_chrome_test.dart`, plus the four still over cap above)

## Manual
N/A — justified non-update: test-structure densify only; no player-visible UX/gameplay change (AC11).

## Test plan
- [x] `dart run tool/check_app_test_file_size.dart`
- [x] `dart test test/check_app_test_file_size_test.dart`
- [x] `flutter test` on densified suites (debug console overlay + chrome, diplomacy panel + chrome + orders, 320dp viewport suites, move army intel, move dialogs part1, pause/side menu, province overlay, nine-patch dark, app event handler, deal-book E6, units shared widgets)
- [ ] CI Quality on this PR (do not wait in-agent)

Refs #4352

Made with [Cursor](https://cursor.com)