### PR TITLE
docs: align handbook chapter 1 with STYLE_GUIDE and cited SPECs (#4449)

### DIFF
--- a/docs/manual/01-primer.md
+++ b/docs/manual/01-primer.md
@@ -2,21 +2,21 @@
 
 ## Purpose
 
-You have inherited a **Great Power** — one of the playable nations — in an age of discovery that runs from **1500 to about 1850**. Two maps matter: the **Old World**, where military victory is decided, and the **New World**, where colonies, tribes, and riches await. You issue **decrees** (actions you choose on your turn); rival courts do the same. This chapter orients you to the premise, what winning means, the rhythm of a turn, and the game screen you will live in.
+You have inherited a **Great Power** — one of the playable nations — in an age of discovery that runs from **1500 to about 1850**. Two maps matter: the **Old World**, where military victory is decided, and the **New World**, where colonies, tribes, and riches await. A **province** is a named piece of land on the map; a **sea zone** is a named stretch of water. You issue **decrees** (actions you choose on your turn); rival courts do the same. This chapter orients you to the premise, what winning means, the rhythm of a turn, and the game screen you will live in.
 
 ## How it is done
 
 ### The premise at a glance
 
-- **Great Powers** (default six) are the only factions that submit orders and can win. You always play a Great Power.
-- **Minor Nations** live in the Old World. They do not issue orders, but their provinces **count toward victory** for whoever owns them. Minor Nations keep their armies as strong as the strongest Great Power, so they are hard to conquer casually.
-- **Tribes** live in the New World. Their provinces **do not** count toward the 31-province victory threshold. They are weaker militarily and can be contested without a formal declaration of war (unless another Great Power has invested in the province).
-- Calendar pacing (default): turns 1–100 advance **two years** per turn (1500→1700); thereafter **one year** per turn. The top bar and **Next turn** show the year and the turn number.
+- **Great Powers** (default six) are the only nations that issue decrees and can win. You always play a Great Power.
+- **Minor Nations** live in the Old World. They do not choose decrees of their own, but their provinces **count toward victory** for whoever owns them. Minor Nations keep their armies as strong as the strongest Great Power, so they are hard to conquer casually.
+- **Tribes** live in the New World. Their provinces **do not** count toward military victory. They are weaker militarily and can be contested without a formal declaration of war, unless another Great Power already has a stake there (Chapter 10).
+- On the usual calendar, turns 1–100 move **two years** each (1500 to 1700). After that, each turn is **one year**. The top bar and **Next turn** show the year and the turn number.
 
 ### Victory at a glance
 
-- **Military victory:** control **31 or more Old World provinces** (provinces you own). Checked at the end of the turn, after the game has carried out everything for that turn.
-- **Calendar campaign end:** without military victory, the campaign can halt at calendar year **1800** (default mapping: turn **201**). That is not a military victory. Summaries may name the strongest Great Power; if two or more tie for strongest (or there are no scorers), the declared winner is no-one. A campaign-complete screen in the game is not part of this primer. **Infinite mode** (chosen at new game) bypasses the calendar halt; only military victory or quitting ends the campaign.
+- **Military victory:** control **31 or more Old World provinces** (provinces you own). Checked at the end of the turn, after the game has carried out everything for that turn. When someone wins this way, Chapter 15 covers `OVL20001` **Victory overlay**. The left-side **Victory** icon opens `GAME70001` **Victory screen**, which is mid-campaign standings and conditions — not that overlay.
+- **Calendar campaign end:** without military victory, the campaign can stop at year **1800** (usually turn **201**). That stop is not a military victory, and this primer does not describe a special “campaign over” screen for it. Summaries may name the strongest Great Power; if two or more tie for strongest (or there are no scorers), the declared winner is no-one. **Infinite mode** (chosen at new game) bypasses the calendar halt; only military victory or quitting ends the campaign.
 
 Later chapters deepen victory counsel; start here so you know the finish line.
 
@@ -29,12 +29,12 @@ Later chapters deepen victory counsel; start here so you know the finish line.
 
 ### Orientation tour of the game screen
 
-1. From the shell, after a game is created or loaded, you arrive on `GAME10001` **Game screen**. This is the main game screen: the map, **Next turn**, and the menus that open from here.
-2. The map area is `MAP10001` **Empire overview / map area**: pan, zoom, region tabs (Old World / New World), and selection of provinces and sea zones. When resource icons are on, gold and brown discs near the bottom-left map tools teach extraction colours (Chapter 3). When **Show improvements** is on, owned improved tiles show **1 of 1** / **1 of 2** marks (Chapter 3).
-3. **Empire buttons** sit as an always-visible **icon column on the left** of the map (labels on hover), in this order: Production (`GAME20001`), Trade (`GAME60001`), Development (`GAME80001`), Civilian Units (`UNIT10001` **Civilian units panel**), Military Units (`UNIT20001` **Military units panel**), Naval Units (`UNIT30001` **Naval units panel**), Diplomacy (`GAME30001`), Technology (`GAME40001`), Victory (`GAME70001`). Trade is the Trade screen (Chapter 8). Victory opens mid-campaign standings and conditions (Chapter 15).
-4. The top bar carries turn controls, region tabs, and the hamburger that opens `GAME50001` **Game side menu** (Game Parameters read-only + Debug log — not a second empire toolbar).
-5. Tap a province or sea zone to open `MAP20001` **Province sea-zone overlay** for identity, ownership, and local actions. Right-click a tile (or press and hold on a touch screen) to open `MAP30001`, a small ring of nearby actions: **Explore**, **Prospect**, **Build improvement**, and **More**. **More** opens `MAP30002` **More tile actions**, which starts with **Province details** — the same panel as a tap.
-6. The buttons on the map change what you see. They are map tools, not separate screens. **Map display options** prints seven switches: **Show resources**, **Show improvements**, **Show roads and rails**, **Show province and sea borders**, **Show province ownership**, **Show province names**, and **Highlight land not bound to the capital**. Defaults: all **ON** except **Show province ownership** **OFF**. The hatch itself is Chapter 3. A shortcut button cycles four presets; its tooltip names the current combination. Preferences persist across save and load.
+1. After you create or load a game, you arrive on `GAME10001` **Game screen**. This is the main game screen: the map, **Next turn**, and the menus that open from here.
+2. The map area is `MAP10001` **Empire overview / map area**: pan, zoom, **Old World** / **New World** tabs, and selection of provinces and sea zones. When **Show resources** is on, resource tiles can show gold and brown discs. A small key near the bottom-left map tools explains those colours (Chapter 3). When **Show improvements** is on, your owned revealed resource tiles can show marks such as **1 of 1** / **1 of 2** (Chapter 3).
+3. Nine **icons on the left of the map** stay visible. On a pointer device, rest on an icon to read its name. On a phone the nine icons have no hover labels. In this order: Production (`GAME20001` **Production screen**), Trade (`GAME60001` **Trade screen**), Development (`GAME80001` **Development screen**), Civilian Units (`UNIT10001` **Civilian units panel**), Military Units (`UNIT20001` **Military units panel**), Naval Units (`UNIT30001` **Naval units panel**), Diplomacy (`GAME30001` **Diplomacy screen**), Technology (`GAME40001` **Technology screen**), Victory (`GAME70001` **Victory screen**). Trade is the Trade screen (Chapter 8). Victory opens mid-campaign standings and conditions (Chapter 15).
+4. You will see a hamburger, **Next turn**, and **Old World** / **New World** tabs. Whether those tabs sit in the top bar or on a row under it is not settled; this primer names only what they share. The hamburger opens `GAME50001` **Game side menu**. Whether that menu lists only **Debug log**, or **Game Parameters** (read-only) plus **Debug log**, is likewise not settled. Those nine icons are not in that menu — they stay on the left of the map, not as a second set of left-side icons.
+5. Tap a province or sea zone to open `MAP20001` **Province sea-zone overlay** for identity, ownership, and local actions. Right-click a tile (or press and hold on a touch screen) to open `MAP30001`, a small ring of nearby actions. Possible actions include **Explore**, **Prospect**, **Build improvement**, and **More**. Only those that apply appear. On a small screen the ring may be skipped and `MAP30002` **More tile actions** opens instead. **More** opens `MAP30002` **More tile actions**, which starts with **Province details** — the same panel as a tap.
+6. Three buttons sit at the **bottom-left** of the map. They are map tools, not separate screens. Leftmost: a shortcut that cycles four combinations; rest on it to read the current combination. Middle: jump home to your capital. Rightmost (gear): opens a dialog titled **Map display options**. That dialog prints seven switches: **Show resources**, **Show improvements**, **Show roads and rails**, **Show province and sea borders**, **Show province ownership**, **Show province names**, and **Highlight land not bound to the capital**. The same borders switch is also named **Show province overlay**; this primer does not treat one printed name as the only name. Defaults: all **ON** except **Show province ownership** **OFF**. When **Show improvements** is off, **Show roads and rails** is off and you cannot turn it on. The hatch itself is Chapter 3. Your choices are remembered when you save and load.
 
 You may see a short “please wait” screen before the map appears (Chapter 2).
 
@@ -48,7 +48,7 @@ You may see a short “please wait” screen before the map appears (Chapter 2).
 
 ## The other courts
 
-Rival Great Powers issue the same kinds of orders you do. A chosen **leader** changes how bold or cautious they are — not how you win. They do not get a secret victory rule.
+Rival Great Powers choose the same kinds of decrees you do. A chosen **leader** changes how bold or cautious they are — not how you win. They do not get a secret victory rule.
 
 ## Consequences
 
@@ -58,8 +58,8 @@ Rival Great Powers issue the same kinds of orders you do. A chosen **leader** ch
 
 ## Acceptance criteria for this chapter
 
-- [ ] Premise covers 1500–1850 framing, Old & New Worlds, and GP / Minor / Tribe roles.
-- [ ] Victory at a glance states 31+ OW provinces, calendar halt vs infinite mode, and that only GPs win.
+- [ ] Premise covers 1500–1850 framing, Old World and New World, and Great Power / Minor Nation / Tribe roles.
+- [ ] Victory at a glance states 31 or more Old World provinces, calendar halt vs infinite mode, and that only Great Powers win.
 - [ ] Turn rhythm describes choose actions → **Next turn** → the game carries out the turn → choose actions again (or end).
 - [ ] Orientation cites `GAME10001`, `MAP10001` **Empire overview / map area**, empire buttons in Production / Trade / Development order with unit-panel IDs `UNIT10001` / `UNIT20001` / `UNIT30001`, `GAME50001`, `MAP20001` **Province sea-zone overlay**.
 - [ ] Orientation names right-click / press-and-hold `MAP30001` and **More** `MAP30002` **Province details**.

--- a/docs/manual/player-export/01-primer.md
+++ b/docs/manual/player-export/01-primer.md
@@ -2,21 +2,21 @@
 
 ## Purpose
 
-You have inherited a **Great Power** — one of the playable nations — in an age of discovery that runs from **1500 to about 1850**. Two maps matter: the **Old World**, where military victory is decided, and the **New World**, where colonies, tribes, and riches await. You issue **decrees** (actions you choose on your turn); rival courts do the same. This chapter orients you to the premise, what winning means, the rhythm of a turn, and the game screen you will live in.
+You have inherited a **Great Power** — one of the playable nations — in an age of discovery that runs from **1500 to about 1850**. Two maps matter: the **Old World**, where military victory is decided, and the **New World**, where colonies, tribes, and riches await. A **province** is a named piece of land on the map; a **sea zone** is a named stretch of water. You issue **decrees** (actions you choose on your turn); rival courts do the same. This chapter orients you to the premise, what winning means, the rhythm of a turn, and the game screen you will live in.
 
 ## How it is done
 
 ### The premise at a glance
 
-- **Great Powers** (default six) are the only factions that submit orders and can win. You always play a Great Power.
-- **Minor Nations** live in the Old World. They do not issue orders, but their provinces **count toward victory** for whoever owns them. Minor Nations keep their armies as strong as the strongest Great Power, so they are hard to conquer casually.
-- **Tribes** live in the New World. Their provinces **do not** count toward the 31-province victory threshold. They are weaker militarily and can be contested without a formal declaration of war (unless another Great Power has invested in the province).
-- Calendar pacing (default): turns 1–100 advance **two years** per turn (1500→1700); thereafter **one year** per turn. The top bar and **Next turn** show the year and the turn number.
+- **Great Powers** (default six) are the only nations that issue decrees and can win. You always play a Great Power.
+- **Minor Nations** live in the Old World. They do not choose decrees of their own, but their provinces **count toward victory** for whoever owns them. Minor Nations keep their armies as strong as the strongest Great Power, so they are hard to conquer casually.
+- **Tribes** live in the New World. Their provinces **do not** count toward military victory. They are weaker militarily and can be contested without a formal declaration of war, unless another Great Power already has a stake there (Chapter 10).
+- On the usual calendar, turns 1–100 move **two years** each (1500 to 1700). After that, each turn is **one year**. The top bar and **Next turn** show the year and the turn number.
 
 ### Victory at a glance
 
-- **Military victory:** control **31 or more Old World provinces** (provinces you own). Checked at the end of the turn, after the game has carried out everything for that turn.
-- **Calendar campaign end:** without military victory, the campaign can halt at calendar year **1800** (default mapping: turn **201**). That is not a military victory. Summaries may name the strongest Great Power; if two or more tie for strongest (or there are no scorers), the declared winner is no-one. A campaign-complete screen in the game is not part of this primer. **Infinite mode** (chosen at new game) bypasses the calendar halt; only military victory or quitting ends the campaign.
+- **Military victory:** control **31 or more Old World provinces** (provinces you own). Checked at the end of the turn, after the game has carried out everything for that turn. When someone wins this way, Chapter 15 covers **Victory overlay**. The left-side **Victory** icon opens **Victory screen**, which is mid-campaign standings and conditions — not that overlay.
+- **Calendar campaign end:** without military victory, the campaign can stop at year **1800** (usually turn **201**). That stop is not a military victory, and this primer does not describe a special “campaign over” screen for it. Summaries may name the strongest Great Power; if two or more tie for strongest (or there are no scorers), the declared winner is no-one. **Infinite mode** (chosen at new game) bypasses the calendar halt; only military victory or quitting ends the campaign.
 
 Later chapters deepen victory counsel; start here so you know the finish line.
 
@@ -29,12 +29,12 @@ Later chapters deepen victory counsel; start here so you know the finish line.
 
 ### Orientation tour of the game screen
 
-1. From the shell, after a game is created or loaded, you arrive on **Game screen**. This is the main game screen: the map, **Next turn**, and the menus that open from here.
-2. The map area is **Empire overview / map area**: pan, zoom, region tabs (Old World / New World), and selection of provinces and sea zones. When resource icons are on, gold and brown discs near the bottom-left map tools teach extraction colours (Chapter 3). When **Show improvements** is on, owned improved tiles show **1 of 1** / **1 of 2** marks (Chapter 3).
-3. **Empire buttons** sit as an always-visible **icon column on the left** of the map (labels on hover), in this order: Production (**Production screen**), Trade (**Trade screen**), Development (**Development screen**), Civilian Units (**Civilian units panel**), Military Units (**Military units panel**), Naval Units (**Naval units panel**), Diplomacy (**Diplomacy screen**), Technology (**Technology screen**), Victory (**Victory screen**). Trade is the Trade screen (Chapter 8). Victory opens mid-campaign standings and conditions (Chapter 15).
-4. The top bar carries turn controls, region tabs, and the hamburger that opens **Game side menu** (Game Parameters read-only + Debug log — not a second empire toolbar).
-5. Tap a province or sea zone to open **Province sea-zone overlay** for identity, ownership, and local actions. Right-click a tile (or press and hold on a touch screen) to open **Tile context radial**, a small ring of nearby actions: **Explore**, **Prospect**, **Build improvement**, and **More**. **More** opens **More tile actions**, which starts with **Province details** — the same panel as a tap.
-6. The buttons on the map change what you see. They are map tools, not separate screens. **Map display options** prints seven switches: **Show resources**, **Show improvements**, **Show roads and rails**, **Show province and sea borders**, **Show province ownership**, **Show province names**, and **Highlight land not bound to the capital**. Defaults: all **ON** except **Show province ownership** **OFF**. The hatch itself is Chapter 3. A shortcut button cycles four presets; its tooltip names the current combination. Preferences persist across save and load.
+1. After you create or load a game, you arrive on **Game screen**. This is the main game screen: the map, **Next turn**, and the menus that open from here.
+2. The map area is **Empire overview / map area**: pan, zoom, **Old World** / **New World** tabs, and selection of provinces and sea zones. When **Show resources** is on, resource tiles can show gold and brown discs. A small key near the bottom-left map tools explains those colours (Chapter 3). When **Show improvements** is on, your owned revealed resource tiles can show marks such as **1 of 1** / **1 of 2** (Chapter 3).
+3. Nine **icons on the left of the map** stay visible. On a pointer device, rest on an icon to read its name. On a phone the nine icons have no hover labels. In this order: Production (**Production screen**), Trade (**Trade screen**), Development (**Development screen**), Civilian Units (**Civilian units panel**), Military Units (**Military units panel**), Naval Units (**Naval units panel**), Diplomacy (**Diplomacy screen**), Technology (**Technology screen**), Victory (**Victory screen**). Trade is the Trade screen (Chapter 8). Victory opens mid-campaign standings and conditions (Chapter 15).
+4. You will see a hamburger, **Next turn**, and **Old World** / **New World** tabs. Whether those tabs sit in the top bar or on a row under it is not settled; this primer names only what they share. The hamburger opens **Game side menu**. Whether that menu lists only **Debug log**, or **Game Parameters** (read-only) plus **Debug log**, is likewise not settled. Those nine icons are not in that menu — they stay on the left of the map, not as a second set of left-side icons.
+5. Tap a province or sea zone to open **Province sea-zone overlay** for identity, ownership, and local actions. Right-click a tile (or press and hold on a touch screen) to open **Tile context radial**, a small ring of nearby actions. Possible actions include **Explore**, **Prospect**, **Build improvement**, and **More**. Only those that apply appear. On a small screen the ring may be skipped and **More tile actions** opens instead. **More** opens **More tile actions**, which starts with **Province details** — the same panel as a tap.
+6. Three buttons sit at the **bottom-left** of the map. They are map tools, not separate screens. Leftmost: a shortcut that cycles four combinations; rest on it to read the current combination. Middle: jump home to your capital. Rightmost (gear): opens a dialog titled **Map display options**. That dialog prints seven switches: **Show resources**, **Show improvements**, **Show roads and rails**, **Show province and sea borders**, **Show province ownership**, **Show province names**, and **Highlight land not bound to the capital**. The same borders switch is also named **Show province overlay**; this primer does not treat one printed name as the only name. Defaults: all **ON** except **Show province ownership** **OFF**. When **Show improvements** is off, **Show roads and rails** is off and you cannot turn it on. The hatch itself is Chapter 3. Your choices are remembered when you save and load.
 
 You may see a short “please wait” screen before the map appears (Chapter 2).
 
@@ -48,7 +48,7 @@ You may see a short “please wait” screen before the map appears (Chapter 2).
 
 ## The other courts
 
-Rival Great Powers issue the same kinds of orders you do. A chosen **leader** changes how bold or cautious they are — not how you win. They do not get a secret victory rule.
+Rival Great Powers choose the same kinds of decrees you do. A chosen **leader** changes how bold or cautious they are — not how you win. They do not get a secret victory rule.
 
 ## Consequences
 

--- a/docs/manual/player-export/05-people-and-prosperity.md
+++ b/docs/manual/player-export/05-people-and-prosperity.md
@@ -54,7 +54,7 @@ Civilians are map units. Open **Civilian units panel** from the left empire rail
 
 Training queues a build decree. Units appear at the **capital tile** after **Build/work** resolves (after recruit/train workers in that phase). Use the panel thereafter to select units, assign work (Chapters 4 and 6), or relocate Spies.
 
-**Spies — station and relocate.** On **Civilian units panel**, an idle Spy shows **Relocate** to pick a legal foreign (or own) land tile on the map; **Assign** still offers **counter-espionage** on owned provinces only. While a Spy holds a foreign province, status reads **Holding intel**; leaving when yours is the last Spy there warns that full intel will fog after the turn ends. End-turn confirmation does **not** nag idle Spies — stationing is strategic portfolio, not wasted capacity.
+**Spies — station and relocate.** On the selected tile’s province panel (**Province sea-zone overlay**), tap **Station spy** in the Civilian section when it is available, then tap **Relocate** on an idle Spy. That posts the Spy to the tile you already selected, without picking again on the map. You can still open **Civilian units panel** and tap **Relocate** to pick any legal land tile. **Assign** still offers **counter-espionage** on owned provinces only. While a Spy holds a foreign province, status reads **Holding intel**; leaving when yours is the last Spy there warns that full intel will fog after the turn ends. End-turn confirmation does **not** nag idle Spies — stationing is a chosen post, not wasted capacity.
 
 ## Counsel
 

--- a/docs/manual/player-export/09-pursuit-of-knowledge.md
+++ b/docs/manual/player-export/09-pursuit-of-knowledge.md
@@ -51,7 +51,7 @@ Eras (Renaissance → Industrial) are flavour for the chart; they do **not** har
 
 ### Spy insight (optional boost)
 
-Station Spies in rival Great Power provinces via **Relocate** on **Civilian units panel** (Chapter 5) to hold presence intel and, when funding is at least **Low**, add roughly **+15% RP per such rival** (stacks) for techs they have already unlocked — after spy resolution that turn. Counter-espionage on home soil is separate (**Assign** → counter-spy). Do not bet a whole plan on spies alone.
+Station Spies in rival Great Power provinces from the selected tile’s province panel (**Province sea-zone overlay**) with **Station spy**, then **Relocate** on **Civilian units panel** (Chapter 5), or pick a tile from the units panel **Relocate** path. Presence intel holds while they stay; when funding is at least **Low**, add roughly **+15% RP per such rival** (stacks) for techs they have already unlocked — after spy resolution that turn. Counter-espionage on home soil is separate (**Assign** → counter-spy). Do not bet a whole plan on spies alone.
 
 ## Counsel
 


### PR DESCRIPTION
## Summary
- Rewrite `docs/manual/01-primer.md` so first-use glosses, decree wording, map how-to, and registry titles match `STYLE_GUIDE.md`.
- Name the three unresolved SPEC disagreements (hamburger contents, top bar vs region tabs, borders toggle name) instead of inventing a single winner.
- Regenerate `docs/manual/player-export/` after the authoring edit.

## Done in this push
- All 22 Required-changes items from #4449 (12 style + 10 accuracy).
- Chapter ACs spell out Great Power, Old World, and Minor Nation / Tribe.
- Player export for chapter 1. Export regeneration also synced chapters 5 and 9 to already-updated authoring (stale export drift).

## Remaining for #4449
- None intended for this slice; leave the issue open for verification.

## Acceptance criteria (this PR)
- Every Required-changes item is applied in `docs/manual/01-primer.md`.
- Touched sections pass the STYLE_GUIDE reading-level gate.
- Cited screen IDs and how-to steps match `SPEC/ui/screen-registry.md` and chapter Sources, except the three SPEC-conflict items.
- Those three items describe shared ground / name the disagreement; they do not invent a single resolution.
- `export-player-manual` run after the authoring edit (`python3 pytool/export_player_manual.py --check` passed).

## SPEC
- No SPEC files changed. Primer cites existing Sources; conflicts between `SPEC/ui/game-side-menu.md` vs `SPEC/ui/empire-buttons.md`, `SPEC/ui/empire-buttons.md` vs `SPEC/ui/empire-overview.md`, and `SPEC/ui/empire-overview.md` vs `SPEC/ui/map-widget.md` are named, not resolved.

## Manual
- `docs/manual/01-primer.md` (authoring)
- `docs/manual/player-export/01-primer.md` (and incidental 05 / 09 export sync)

## Tests
- `python3 pytool/export_player_manual.py` and `--check` (forbidden-identifier scan clean). Pytest is not installed in this environment; export unit tests were not run.

Refs #4449


Made with [Cursor](https://cursor.com)