### PR TITLE
docs: align handbook chapter 12 The Art of War (#4507)

### DIFF
--- a/docs/manual/12-art-of-war.md
+++ b/docs/manual/12-art-of-war.md
@@ -2,79 +2,82 @@
 
 ## Purpose
 
-War changes the map more quickly than any workshop or treaty. A successful army move can seize a province, weaken a rival’s field forces, and open a route toward their capital. A failed assault may instead leave your border exposed and your trained regiments gone.
+War changes the map more quickly than any workshop or treaty. A successful march can seize a province, weaken a rival’s field forces, and open a route toward their capital. A failed assault may instead leave your border exposed and your trained regiments gone.
 
-This chapter covers how an army attacks, how you choose between a swift resolution and a Quick Battle, and how forts turn an ordinary clash into a siege.
+A **Great Power** is a playable nation. **Minor Nations** and **Tribes** are the non-playable courts that can defend when you attack. A **regiment** is one land fighting unit. The **Home Army** stays at the capital and cannot march; a **field army** is a group of regiments you can send away from home.
+
+This chapter covers how a field army attacks, how you choose between **Auto-Resolve** (the game decides the fight at once) and **Quick Battle** (you give orders in the fight), and how forts turn an ordinary clash into a **siege** — a fight against a province that has a fort.
 
 ## How it is done
 
 ### Attacking a province
 
-1. Open `UNIT20001` **Military units panel**, select a non-Home army, and choose **Move** to open `DLG20001` **Move army dialog** — or from `MAP20001` tap **Invade** on the foreign province you are studying (or **Move** on an owned province that already holds a field army). When only a non-empty Home Army can start the campaign, **Invade** or **Move** opens Split Army first, then `DLG20001` for the new field army. When several armies can act, `DLG20002` picks the army first and lists each army’s regiment mix; Invade preselects that province on `DLG20001`. Invasion rows show known defender totals, **Unopposed capture**, or **Defenders unknown**, plus open-field or siege labels when intel allows.
-2. Select a legal destination. Your own provinces appear separately from invasion targets. An enemy province may require a declaration of war; confirm that declaration and the move together when the dialog asks. That confirmation uses the same named-court lines as Diplomacy Declare War when other courts may be called to defend or asked to intervene.
-3. End the turn. When the army finishes in an enemy-controlled province, every regiment in that army attacks together. Great Powers initiate these attacks; Minor Nations and Tribes defend.
-4. An enemy province with no combat-capable defenders can be captured without a battle when your army arrives during a war. Otherwise, the combat phase creates a battle.
+1. Open `UNIT20001` **Military units panel** and select a non-Home field army — or open `MAP20001` **Province sea-zone overlay** on the foreign province you mean to study, or tap a field-army stack marker on `MAP10001` **Empire overview / map area**. The Home Army is never listed on the map stack path.
+2. Choose **Move** on an owned province that already holds a field army, or **Invade** on a foreign province.
+3. If more than one field army can act, `DLG20002` **Overlay army move picker** opens (title **Select army**). Pick the army and tap **Confirm**. Each row shows that army’s regiment mix.
+4. If only the non-empty Home Army can start the campaign, the **Detach a field army** dialog opens first (confirm **Detach and choose destination**). That creates a new field army before the move continues.
+5. `DLG20001` **Move army dialog** opens (title **Move army — Army &lt;id&gt;**). Invasion rows show **Defenders: N regiments**, **Unopposed capture**, or **Defenders unknown**, plus **Open field**, **Wood fort siege**, **Stone fort siege**, or **Modern fort siege** when you can see them. When **Invade** started the flow, that province is preselected.
+6. Select a legal destination. Your own provinces appear separately from invasion targets. An invasion destination may show **Invasions this turn: N · Generals: G** (a muted warning if you have more invasions than generals — **Confirm** stays enabled) and a muted rations warning if your land forces are short on food this turn. Owned-province destinations show neither line.
+7. Tap **Confirm**. If the row requires war, confirm **Declare war?** with **Declare war and move**. That confirm shows the same Effect lines as declaring war from Diplomacy, naming other courts that may be called to defend or asked to intervene.
+8. Tap **Next turn**. After you confirm **Next turn**, the game carries out the march. You see the fight or the unopposed capture when that finishes — not when you tap **Confirm**.
+9. If a battle needs a choice, `CMPT10001` **Combat mode choice dialog** opens then (title **Combat at &lt;province&gt;**).
+10. An empty enemy province — no owner troops and no third-court troops — transfers at the start of fighting, before a battle is created, and only while you are already at war. Otherwise, when your army finishes in an enemy-controlled province, every regiment in that army attacks together. Great Powers initiate these attacks; Minor Nations and Tribes defend.
 
-### Military Counsel (`GAME90001` Military tab)
+### Military Counsel (`GAME90001` Counsel screen)
 
-1. Open `UNIT20001` **Military units panel** and tap **Counsel**, or open **Counsel** from Production or Trade and select the **Military** tab.
-2. Ranked cards suggest affordable train builds (type, count, costs) and invasion targets (army, province, owner, defender intel when known). Home Army is never suggested to march.
-3. **Agree** on a train card queues that many build orders when still valid. **Agree** on an invade card stages the move; declare-war confirmation matches `DLG20001` when required.
+1. Open `UNIT20001` **Military units panel** and tap **Counsel**, or open **Counsel** from Production, Trade, or Development and select the **Military** tab on `GAME90001` **Counsel screen**.
+2. At most three ranked cards suggest affordable train builds (land or ship — type, count, costs) and invasion targets (army, province, owner, **Defenders: N regiments** or **Defenders unknown** when shown). The Home Army is never suggested to march.
+3. **Agree** on a train card queues that many build orders when still valid. **Agree** on an invade card stages the move; declare-war confirmation matches `DLG20001` when required. If **Agree** is no longer valid, a short on-screen message explains why nothing was staged.
 
-If several attackers reach the same province, they fight in initiative order. The surviving side carries its losses into the next engagement; it does not recover between them.
+If several attacking armies reach the same province, they fight one after another. The side that is still standing keeps its losses and fights the next army; it does not get fresh troops between those fights (except the recovered garrison in the mutual-annihilation case below).
 
 ### Choosing the combat mode
 
-1. When a coming battle needs a choice, `CMPT10001` **Combat mode choice dialog** names the province. It also shows how many of your regiments are already there, the enemy count you can see (or **Defenders unknown** if you cannot see the garrison), and whether the ground is open or a wood, stone, or modern fort siege. If you are defending, the enemy line is labeled **Attackers**. Tap **Details** for regiment types. If your armies are short on rations this turn, a soft line warns that they will fight weaker; you may still choose Auto-Resolve or Quick Battle.
+1. When a coming battle needs a choice, `CMPT10001` **Combat mode choice dialog** names the province (**Combat at &lt;province&gt;**). It also shows how many of your regiments are already there, **Defenders: N regiments** or **Attackers: N** (or **Defenders unknown** if you cannot see the garrison), and whether the ground is **Open field** or a **Wood fort siege**, **Stone fort siege**, or **Modern fort siege**. If you are defending, the enemy line is labeled **Attackers**. Tap **Details** for regiment types. If your armies are short on rations this turn, a muted italic warning says they will fight weaker; **Auto-Resolve** and **Quick Battle** stay available.
 2. **Auto-Resolve** decides the battle at once. **Quick Battle** lets you give orders in the fight. The dialog does not tell you who will win.
-3. A capital siege permits only Quick Battle. Auto-Resolve is not offered then.
-
-A province without a fort is a field battle. A province with a fort level of 1 or more is a siege, whether you choose Auto-Resolve or Quick Battle.
+3. A capital siege permits only Quick Battle. Auto-Resolve is not offered then. (The game SPECs do not yet state this restriction; the screen behaviour above is what you see.)
+4. A province without a fort is a field battle. A province with a fort level of 1 or more is a siege, whether you choose Auto-Resolve or Quick Battle.
 
 ### Quick Battle
 
 1. Choosing Quick Battle opens `CMPT20001` **Quick battle screen**. It shows the attacker first, then the defender, with the deployed groups, their unit counts, and cohesion.
-2. In the current battlefield, both sides begin in the centre front with cohesion 3. The battle lasts at most three rounds.
-3. In an interactive battle, spend the available Command Points to choose an action:
-   - **Volley Fire** costs 1 CP and attacks the opposing front.
-   - **Defend** costs 1 CP and improves a lane’s defence for the round.
-   - **Maneuver** costs 1 CP and repositions a group.
-   - **Fall Back** costs 2 CP and trades ground and cohesion to preserve troops.
-   - **Assault** costs 2 CP for a forceful, risky attack.
-4. Actions that cost more Command Points than remain are unavailable. The battle resolves after the selected action plan; unused tactical decisions default to Volley Fire.
-5. In non-interactive battles, the game resolves with default actions.
+2. In the current battlefield, both sides begin at **Center Front** with **Cohesion 3**.
+3. The current screen lets you pick one action from the five available:
+   - **Volley Fire** costs 1 Command Point and attacks the opposing front.
+   - **Defend** costs 1 Command Point and improves that group’s defence for the round.
+   - **Maneuver** costs 1 Command Point and repositions a group.
+   - **Fall Back** costs 2 Command Points and trades ground and cohesion to preserve troops.
+   - **Assault** costs 2 Command Points for a forceful, risky attack.
+   Actions that cost more Command Points than you have are unavailable. After you choose, the rest of the fight uses **Volley Fire**. (The full three-round orders desk described in the game rules is not yet operable on screen.)
+4. In rival Quick Battles, the game resolves with default actions; you do not pick their fight orders.
 
-The present Quick Battle battlefield uses open terrain and a simplified centre-front deployment. Province terrain can still affect the wider combat context, but hills, woods, towns, swamps, flanking lines, and full reserve manoeuvres are not yet tactical choices.
+The present Quick Battle battlefield uses open terrain and a simplified **Center Front** deployment. Province terrain can still affect the wider combat context, but hills, woods, towns, swamps, flanking lines, and full reserve manoeuvres are not yet tactical choices.
 
 ### Auto-Resolve
 
-Auto-Resolve compares the two sides’ effective strength and applies the configured terrain, fort, leader, medal, and supply effects. It is deterministic: the same armies, orders, and ruleset produce the same result.
+Auto-Resolve compares the two sides’ effective strength and applies terrain, fort, leader, medal, and rations. The same armies and the same situation always produce the same Auto-Resolve result.
 
-A stronger attacker can destroy the defenders and take the province. A defender can hold and destroy the attackers. Both sides may survive in a stalemate, or both may be eliminated in mutual annihilation. Casualties are applied before any change of ownership.
+Four outcomes are possible: **attacker victory** (defender eliminated, province may flip), **defender victory** (attackers eliminated, no change), **stalemate** (both sides may survive with no flip), and **mutual annihilation** (both wiped). A stronger attacker does not always take the land: when morale is low and the strength ratio is middling, an attacker victory can be blunted into a stalemate instead. Equal or greater defender strength with defenders still standing is a defender victory that wipes the attackers. Casualties are applied before any change of ownership.
 
 ### Sieges and forts
 
 A fort makes the battle a siege:
 
-| Fort | Effect in a siege |
-|------|-------------------|
-| Wood, level 1 | Wall protection and 1 emplaced gun |
-| Stone, level 2 | Stronger wall protection and 2 emplaced guns |
-| Modern, level 3 | Strongest wall protection and 3 emplaced guns |
+| Fort | Auto-Resolve wall soak | Quick Battle damage reduction | Emplaced guns |
+|------|------------------------|-------------------------------|---------------|
+| Wood, level 1 | 10 (configurable) | 25% | 1 gun |
+| Stone, level 2 | 20 (configurable) | 45% | 2 guns |
+| Modern, level 3 | 30 (configurable) | 60% | 3 guns |
 
-In Auto-Resolve, walls first absorb a fixed amount of attacking strength before the remaining force affects defender losses. The exact values are ruleset-configurable.
+In Auto-Resolve, walls first absorb their soak amount of attacking strength before the remaining force affects defender losses. Exact soak numbers can change with the game’s combat settings.
 
-In Quick Battle, the defender receives virtual emplaced guns behind the fort. They are part of that battle only, not separate map regiments. If every emplaced gun is destroyed, the fort loses one level after the battle—even if the defender holds or both sides are exhausted. Auto-Resolve uses an aggregate fort-gun bonus instead and does not currently reduce a fort in this way.
+In Quick Battle, the defender receives extra fortress guns for this fight only (they are not extra map regiments). **Defend** improves that group’s defence for the round. If every one of those guns is destroyed, the fort drops one level after the fight — even if the defender holds or both sides are exhausted. Auto-Resolve instead adds a single fortress-gun bonus and does not currently lower the fort this way.
 
 ### Reading the result
 
-After Quick Battle, `CMPT50001` **Quick battle result dialog** reports one of three outcomes:
+After Quick Battle, `CMPT20001` **Quick battle screen** shows the result first (**Continue**). The three printed outcomes are **Attacker wins**, **Defender holds**, and **Mutual exhaustion** — without assuming every regiment on a side is gone unless the casualties show it. A bold province-captured notice appears when ownership flips.
 
-- **Attacker wins:** the defender is eliminated. A bold province-captured notice appears when ownership flips.
-- **Defender holds:** the attackers are eliminated and the province remains theirs.
-- **Mutual exhaustion:** neither side takes the province; the casualty rows still show the cost.
-
-The dialog always lists casualties for attacker and defender, including zero when a side lost no regiments. Read those numbers with the map result: victory with severe losses may still leave a frontier too weak to hold.
+Then `CMPT50001` **Quick battle result dialog** opens (**OK**), repeating the outcome and listing casualties for attacker and defender, including zero when a side lost no regiments. Read those numbers with the map result: victory with severe losses may still leave a frontier too weak to hold.
 
 ## Counsel
 
@@ -82,34 +85,34 @@ The dialog always lists casualties for attacker and defender, including zero whe
 
 **Warning.** Your Home Army cannot march. Raise and move field armies if you mean to invade.
 
-**Tip.** Choose Quick Battle when the immediate tactical choice matters to you; choose Auto-Resolve when you accept the same ruleset-driven result without directing its actions. Neither path excuses an army from the consequences of poor strength, supply, or preparation.
+**Tip.** Choose Quick Battle when the immediate tactical choice matters to you; choose Auto-Resolve when you accept the same computed result without directing the fight’s actions. Neither path excuses an army from the consequences of poor strength, supply, or preparation.
 
 **Counsel.** Before storming walls, count what shall remain to guard the new banner. A captured province is little comfort if the army that won it cannot meet the counterstroke.
 
 ## The other courts
 
-Other Great Powers plan declarations of war before their invasion moves, so a rival may legally combine both in one turn. Their planners favour reachable, valid conquest targets and weigh military pressure against broader goals such as expansion, colonial acquisition, survival, and economic need.
+Other Great Powers declare war before they march, so a rival may legally combine both in one turn. They look for neighbouring foreign provinces they can legally enter. Their Quick Battles use the automatic path and default actions; you do not pick their fight orders. You still see their marches and attacks.
 
-AI-controlled Quick Battles use the non-interactive path and default actions. You will not negotiate their tactical choices during their turn, but their attacks and visible army movements remain evidence of their public conduct. An attack on a court allied to another power, or on a minor nation or tribe with which that court has ties, can provoke diplomatic reactions.
+An attack on a Great Power that holds a formal alliance with another court can provoke that court. An attack on a Minor Nation or Tribe can provoke a court that has an embassy or close friendship there.
 
 ## Consequences
 
-- An attacker victory eliminates the defending regiments, then transfers the province to the attacker. Connectivity and extraction effects are recalculated in later turn processing.
+- An attacker victory eliminates the defending regiments, then transfers the province to the attacker. After ownership changes, whether the land still links to a capital and whether tiles still extract is checked on the next turn.
 - A defender victory leaves ownership unchanged and eliminates the attacking regiments.
 - A stalemate leaves surviving forces in place and keeps the current owner.
-- In a final mutual annihilation, the original defender keeps the province but may be left without a garrison. If more attackers remain in the same battle chain, the defender instead receives a small recovered garrison before the next fight.
+- In a final mutual annihilation, the original defender keeps the province but may be left without a garrison. If another attacking army is still waiting to fight in that province, the defender instead receives a recovered garrison equal to one-fifth of its initial regiment count in that fight, rounded up (minimum one regiment). Every recovered regiment is the defender’s most advanced infantry type for its era.
 - A destroyed siege battery in Quick Battle lowers its fort by one level, making a later assault less protected.
 
 ## Acceptance criteria for this chapter
 
 - [ ] Explains how a non-Home army attacks an enemy province, including declaration-of-war confirmation and unopposed capture.
-- [ ] Documents `MAP20001` Military **Invade** / **Move** as an alternate path into `DLG20001` (with optional `DLG20002` showing each army’s regiment mix, or Home Army split then `DLG20001`).
-- [ ] Documents `CMPT10001` combat-mode choice, including the capital-siege Quick-Battle-only restriction.
-- [ ] Documents `CMPT20001` Quick Battle deployment, Command Points, the five current actions, default actions, and the result flow.
-- [ ] Explains deterministic Auto-Resolve and attacker victory, defender victory, stalemate, and mutual annihilation.
-- [ ] Explains field battles, siege triggers, fort levels, wall protection, emplaced artillery, and Quick-Battle fort downgrade.
-- [ ] Documents `GAME90001` Military Counsel invasion/train Agree and declare-war confirm parity with `DLG20001`.
-- [ ] Documents `CMPT50001` outcome and casualty reading.
+- [ ] Documents `MAP20001` Military **Invade** / **Move** and `MAP10001` field-army stack taps as alternate paths into `DLG20001` (with optional `DLG20002` showing each army’s regiment mix, or Home Army detach then Move army).
+- [ ] Documents `CMPT10001` combat-mode choice, including the capital-siege Quick-Battle-only restriction the screen shows.
+- [ ] Documents `CMPT20001` Quick Battle deployment, one chosen action followed by default **Volley Fire**, and the result flow through `CMPT50001`.
+- [ ] Explains Auto-Resolve and attacker victory, defender victory, stalemate, mutual annihilation, and the blunted-to-stalemate case.
+- [ ] Explains field battles, siege triggers, fort levels, wall soak, Quick Battle damage reduction, emplaced guns, and Quick-Battle fort downgrade.
+- [ ] Documents `GAME90001` Military Counsel invasion/train **Agree**, at most three cards, and declare-war confirm matching the Move army dialog.
+- [ ] Documents `CMPT50001` outcome and casualty reading after the on-screen Quick Battle result.
 - [ ] Describes other Great Powers only through their documented military planning and observable diplomatic reactions.
 
 ## Sources
@@ -117,9 +120,13 @@ AI-controlled Quick Battles use the non-interactive path and default actions. Yo
 - `SPEC/game/combat.md`
 - `SPEC/game/quick-battle.md`
 - `SPEC/game/siege-mechanics.md`
+- `SPEC/game/military-armies.md`
 - `SPEC/ui/move-army-dialog.md`
 - `SPEC/ui/province-sea-zone-detail-overlay.md`
 - `SPEC/ui/overlay-army-move-picker-dialog.md`
+- `SPEC/ui/empire-overview.md`
+- `SPEC/ui/military-units-panel.md`
+- `SPEC/ui/military-units-army-management.md`
 - `SPEC/ui/counsel-panel.md`
 - `SPEC/program/military-counsel-ranking.md`
 - `SPEC/ui/combat-mode-choice-dialog.md`

--- a/docs/manual/player-export/12-art-of-war.md
+++ b/docs/manual/player-export/12-art-of-war.md
@@ -2,79 +2,82 @@
 
 ## Purpose
 
-War changes the map more quickly than any workshop or treaty. A successful army move can seize a province, weaken a rival’s field forces, and open a route toward their capital. A failed assault may instead leave your border exposed and your trained regiments gone.
+War changes the map more quickly than any workshop or treaty. A successful march can seize a province, weaken a rival’s field forces, and open a route toward their capital. A failed assault may instead leave your border exposed and your trained regiments gone.
 
-This chapter covers how an army attacks, how you choose between a swift resolution and a Quick Battle, and how forts turn an ordinary clash into a siege.
+A **Great Power** is a playable nation. **Minor Nations** and **Tribes** are the non-playable courts that can defend when you attack. A **regiment** is one land fighting unit. The **Home Army** stays at the capital and cannot march; a **field army** is a group of regiments you can send away from home.
+
+This chapter covers how a field army attacks, how you choose between **Auto-Resolve** (the game decides the fight at once) and **Quick Battle** (you give orders in the fight), and how forts turn an ordinary clash into a **siege** — a fight against a province that has a fort.
 
 ## How it is done
 
 ### Attacking a province
 
-1. Open **Military units panel**, select a non-Home army, and choose **Move** to open **Move army dialog** — or from **Province sea-zone overlay** tap **Invade** on the foreign province you are studying (or **Move** on an owned province that already holds a field army). When only a non-empty Home Army can start the campaign, **Invade** or **Move** opens Split Army first, then **Move army dialog** for the new field army. When several armies can act, **Overlay army move picker** picks the army first and lists each army’s regiment mix; Invade preselects that province on **Move army dialog**. Invasion rows show known defender totals, **Unopposed capture**, or **Defenders unknown**, plus open-field or siege labels when intel allows.
-2. Select a legal destination. Your own provinces appear separately from invasion targets. An enemy province may require a declaration of war; confirm that declaration and the move together when the dialog asks. That confirmation uses the same named-court lines as Diplomacy Declare War when other courts may be called to defend or asked to intervene.
-3. End the turn. When the army finishes in an enemy-controlled province, every regiment in that army attacks together. Great Powers initiate these attacks; Minor Nations and Tribes defend.
-4. An enemy province with no combat-capable defenders can be captured without a battle when your army arrives during a war. Otherwise, the combat phase creates a battle.
+1. Open **Military units panel** and select a non-Home field army — or open **Province sea-zone overlay** on the foreign province you mean to study, or tap a field-army stack marker on **Empire overview / map area**. The Home Army is never listed on the map stack path.
+2. Choose **Move** on an owned province that already holds a field army, or **Invade** on a foreign province.
+3. If more than one field army can act, **Overlay army move picker** opens (title **Select army**). Pick the army and tap **Confirm**. Each row shows that army’s regiment mix.
+4. If only the non-empty Home Army can start the campaign, the **Detach a field army** dialog opens first (confirm **Detach and choose destination**). That creates a new field army before the move continues.
+5. **Move army dialog** opens (title **Move army — Army &lt;id&gt;**). Invasion rows show **Defenders: N regiments**, **Unopposed capture**, or **Defenders unknown**, plus **Open field**, **Wood fort siege**, **Stone fort siege**, or **Modern fort siege** when you can see them. When **Invade** started the flow, that province is preselected.
+6. Select a legal destination. Your own provinces appear separately from invasion targets. An invasion destination may show **Invasions this turn: N · Generals: G** (a muted warning if you have more invasions than generals — **Confirm** stays enabled) and a muted rations warning if your land forces are short on food this turn. Owned-province destinations show neither line.
+7. Tap **Confirm**. If the row requires war, confirm **Declare war?** with **Declare war and move**. That confirm shows the same Effect lines as declaring war from Diplomacy, naming other courts that may be called to defend or asked to intervene.
+8. Tap **Next turn**. After you confirm **Next turn**, the game carries out the march. You see the fight or the unopposed capture when that finishes — not when you tap **Confirm**.
+9. If a battle needs a choice, **Combat mode choice dialog** opens then (title **Combat at &lt;province&gt;**).
+10. An empty enemy province — no owner troops and no third-court troops — transfers at the start of fighting, before a battle is created, and only while you are already at war. Otherwise, when your army finishes in an enemy-controlled province, every regiment in that army attacks together. Great Powers initiate these attacks; Minor Nations and Tribes defend.
 
-### Military Counsel (**Counsel screen** Military tab)
+### Military Counsel (**Counsel screen**)
 
-1. Open **Military units panel** and tap **Counsel**, or open **Counsel** from Production or Trade and select the **Military** tab.
-2. Ranked cards suggest affordable train builds (type, count, costs) and invasion targets (army, province, owner, defender intel when known). Home Army is never suggested to march.
-3. **Agree** on a train card queues that many build orders when still valid. **Agree** on an invade card stages the move; declare-war confirmation matches **Move army dialog** when required.
+1. Open **Military units panel** and tap **Counsel**, or open **Counsel** from Production, Trade, or Development and select the **Military** tab on **Counsel screen**.
+2. At most three ranked cards suggest affordable train builds (land or ship — type, count, costs) and invasion targets (army, province, owner, **Defenders: N regiments** or **Defenders unknown** when shown). The Home Army is never suggested to march.
+3. **Agree** on a train card queues that many build orders when still valid. **Agree** on an invade card stages the move; declare-war confirmation matches **Move army dialog** when required. If **Agree** is no longer valid, a short on-screen message explains why nothing was staged.
 
-If several attackers reach the same province, they fight in initiative order. The surviving side carries its losses into the next engagement; it does not recover between them.
+If several attacking armies reach the same province, they fight one after another. The side that is still standing keeps its losses and fights the next army; it does not get fresh troops between those fights (except the recovered garrison in the mutual-annihilation case below).
 
 ### Choosing the combat mode
 
-1. When a coming battle needs a choice, **Combat mode choice dialog** names the province. It also shows how many of your regiments are already there, the enemy count you can see (or **Defenders unknown** if you cannot see the garrison), and whether the ground is open or a wood, stone, or modern fort siege. If you are defending, the enemy line is labeled **Attackers**. Tap **Details** for regiment types. If your armies are short on rations this turn, a soft line warns that they will fight weaker; you may still choose Auto-Resolve or Quick Battle.
+1. When a coming battle needs a choice, **Combat mode choice dialog** names the province (**Combat at &lt;province&gt;**). It also shows how many of your regiments are already there, **Defenders: N regiments** or **Attackers: N** (or **Defenders unknown** if you cannot see the garrison), and whether the ground is **Open field** or a **Wood fort siege**, **Stone fort siege**, or **Modern fort siege**. If you are defending, the enemy line is labeled **Attackers**. Tap **Details** for regiment types. If your armies are short on rations this turn, a muted italic warning says they will fight weaker; **Auto-Resolve** and **Quick Battle** stay available.
 2. **Auto-Resolve** decides the battle at once. **Quick Battle** lets you give orders in the fight. The dialog does not tell you who will win.
-3. A capital siege permits only Quick Battle. Auto-Resolve is not offered then.
-
-A province without a fort is a field battle. A province with a fort level of 1 or more is a siege, whether you choose Auto-Resolve or Quick Battle.
+3. A capital siege permits only Quick Battle. Auto-Resolve is not offered then. (The game SPECs do not yet state this restriction; the screen behaviour above is what you see.)
+4. A province without a fort is a field battle. A province with a fort level of 1 or more is a siege, whether you choose Auto-Resolve or Quick Battle.
 
 ### Quick Battle
 
 1. Choosing Quick Battle opens **Quick battle screen**. It shows the attacker first, then the defender, with the deployed groups, their unit counts, and cohesion.
-2. In the current battlefield, both sides begin in the centre front with cohesion 3. The battle lasts at most three rounds.
-3. In an interactive battle, spend the available Command Points to choose an action:
- - **Volley Fire** costs 1 CP and attacks the opposing front.
- - **Defend** costs 1 CP and improves a lane’s defence for the round.
- - **Maneuver** costs 1 CP and repositions a group.
- - **Fall Back** costs 2 CP and trades ground and cohesion to preserve troops.
- - **Assault** costs 2 CP for a forceful, risky attack.
-4. Actions that cost more Command Points than remain are unavailable. The battle resolves after the selected action plan; unused tactical decisions default to Volley Fire.
-5. In non-interactive battles, the game resolves with default actions.
+2. In the current battlefield, both sides begin at **Center Front** with **Cohesion 3**.
+3. The current screen lets you pick one action from the five available:
+ - **Volley Fire** costs 1 Command Point and attacks the opposing front.
+ - **Defend** costs 1 Command Point and improves that group’s defence for the round.
+ - **Maneuver** costs 1 Command Point and repositions a group.
+ - **Fall Back** costs 2 Command Points and trades ground and cohesion to preserve troops.
+ - **Assault** costs 2 Command Points for a forceful, risky attack.
+ Actions that cost more Command Points than you have are unavailable. After you choose, the rest of the fight uses **Volley Fire**. (The full three-round orders desk described in the game rules is not yet operable on screen.)
+4. In rival Quick Battles, the game resolves with default actions; you do not pick their fight orders.
 
-The present Quick Battle battlefield uses open terrain and a simplified centre-front deployment. Province terrain can still affect the wider combat context, but hills, woods, towns, swamps, flanking lines, and full reserve manoeuvres are not yet tactical choices.
+The present Quick Battle battlefield uses open terrain and a simplified **Center Front** deployment. Province terrain can still affect the wider combat context, but hills, woods, towns, swamps, flanking lines, and full reserve manoeuvres are not yet tactical choices.
 
 ### Auto-Resolve
 
-Auto-Resolve compares the two sides’ effective strength and applies the configured terrain, fort, leader, medal, and supply effects. It is deterministic: the same armies, orders, and ruleset produce the same result.
+Auto-Resolve compares the two sides’ effective strength and applies terrain, fort, leader, medal, and rations. The same armies and the same situation always produce the same Auto-Resolve result.
 
-A stronger attacker can destroy the defenders and take the province. A defender can hold and destroy the attackers. Both sides may survive in a stalemate, or both may be eliminated in mutual annihilation. Casualties are applied before any change of ownership.
+Four outcomes are possible: **attacker victory** (defender eliminated, province may flip), **defender victory** (attackers eliminated, no change), **stalemate** (both sides may survive with no flip), and **mutual annihilation** (both wiped). A stronger attacker does not always take the land: when morale is low and the strength ratio is middling, an attacker victory can be blunted into a stalemate instead. Equal or greater defender strength with defenders still standing is a defender victory that wipes the attackers. Casualties are applied before any change of ownership.
 
 ### Sieges and forts
 
 A fort makes the battle a siege:
 
-| Fort | Effect in a siege |
-|------|-------------------|
-| Wood, level 1 | Wall protection and 1 emplaced gun |
-| Stone, level 2 | Stronger wall protection and 2 emplaced guns |
-| Modern, level 3 | Strongest wall protection and 3 emplaced guns |
+| Fort | Auto-Resolve wall soak | Quick Battle damage reduction | Emplaced guns |
+|------|------------------------|-------------------------------|---------------|
+| Wood, level 1 | 10 (configurable) | 25% | 1 gun |
+| Stone, level 2 | 20 (configurable) | 45% | 2 guns |
+| Modern, level 3 | 30 (configurable) | 60% | 3 guns |
 
-In Auto-Resolve, walls first absorb a fixed amount of attacking strength before the remaining force affects defender losses. The exact values are ruleset-configurable.
+In Auto-Resolve, walls first absorb their soak amount of attacking strength before the remaining force affects defender losses. Exact soak numbers can change with the game’s combat settings.
 
-In Quick Battle, the defender receives virtual emplaced guns behind the fort. They are part of that battle only, not separate map regiments. If every emplaced gun is destroyed, the fort loses one level after the battle—even if the defender holds or both sides are exhausted. Auto-Resolve uses an aggregate fort-gun bonus instead and does not currently reduce a fort in this way.
+In Quick Battle, the defender receives extra fortress guns for this fight only (they are not extra map regiments). **Defend** improves that group’s defence for the round. If every one of those guns is destroyed, the fort drops one level after the fight — even if the defender holds or both sides are exhausted. Auto-Resolve instead adds a single fortress-gun bonus and does not currently lower the fort this way.
 
 ### Reading the result
 
-After Quick Battle, **Quick battle result dialog** reports one of three outcomes:
+After Quick Battle, **Quick battle screen** shows the result first (**Continue**). The three printed outcomes are **Attacker wins**, **Defender holds**, and **Mutual exhaustion** — without assuming every regiment on a side is gone unless the casualties show it. A bold province-captured notice appears when ownership flips.
 
-- **Attacker wins:** the defender is eliminated. A bold province-captured notice appears when ownership flips.
-- **Defender holds:** the attackers are eliminated and the province remains theirs.
-- **Mutual exhaustion:** neither side takes the province; the casualty rows still show the cost.
-
-The dialog always lists casualties for attacker and defender, including zero when a side lost no regiments. Read those numbers with the map result: victory with severe losses may still leave a frontier too weak to hold.
+Then **Quick battle result dialog** opens (**OK**), repeating the outcome and listing casualties for attacker and defender, including zero when a side lost no regiments. Read those numbers with the map result: victory with severe losses may still leave a frontier too weak to hold.
 
 ## Counsel
 
@@ -82,20 +85,20 @@ The dialog always lists casualties for attacker and defender, including zero whe
 
 **Warning.** Your Home Army cannot march. Raise and move field armies if you mean to invade.
 
-**Tip.** Choose Quick Battle when the immediate tactical choice matters to you; choose Auto-Resolve when you accept the same ruleset-driven result without directing its actions. Neither path excuses an army from the consequences of poor strength, supply, or preparation.
+**Tip.** Choose Quick Battle when the immediate tactical choice matters to you; choose Auto-Resolve when you accept the same computed result without directing the fight’s actions. Neither path excuses an army from the consequences of poor strength, supply, or preparation.
 
 **Counsel.** Before storming walls, count what shall remain to guard the new banner. A captured province is little comfort if the army that won it cannot meet the counterstroke.
 
 ## The other courts
 
-Other Great Powers plan declarations of war before their invasion moves, so a rival may legally combine both in one turn. Their planners favour reachable, valid conquest targets and weigh military pressure against broader goals such as expansion, colonial acquisition, survival, and economic need.
+Other Great Powers declare war before they march, so a rival may legally combine both in one turn. They look for neighbouring foreign provinces they can legally enter. Their Quick Battles use the automatic path and default actions; you do not pick their fight orders. You still see their marches and attacks.
 
-AI-controlled Quick Battles use the non-interactive path and default actions. You will not negotiate their tactical choices during their turn, but their attacks and visible army movements remain evidence of their public conduct. An attack on a court allied to another power, or on a minor nation or tribe with which that court has ties, can provoke diplomatic reactions.
+An attack on a Great Power that holds a formal alliance with another court can provoke that court. An attack on a Minor Nation or Tribe can provoke a court that has an embassy or close friendship there.
 
 ## Consequences
 
-- An attacker victory eliminates the defending regiments, then transfers the province to the attacker. Connectivity and extraction effects are recalculated in later turn processing.
+- An attacker victory eliminates the defending regiments, then transfers the province to the attacker. After ownership changes, whether the land still links to a capital and whether tiles still extract is checked on the next turn.
 - A defender victory leaves ownership unchanged and eliminates the attacking regiments.
 - A stalemate leaves surviving forces in place and keeps the current owner.
-- In a final mutual annihilation, the original defender keeps the province but may be left without a garrison. If more attackers remain in the same battle chain, the defender instead receives a small recovered garrison before the next fight.
+- In a final mutual annihilation, the original defender keeps the province but may be left without a garrison. If another attacking army is still waiting to fight in that province, the defender instead receives a recovered garrison equal to one-fifth of its initial regiment count in that fight, rounded up (minimum one regiment). Every recovered regiment is the defender’s most advanced infantry type for its era.
 - A destroyed siege battery in Quick Battle lowers its fort by one level, making a later assault less protected.


### PR DESCRIPTION
## Summary

- Rewrites `docs/manual/12-art-of-war.md` to satisfy all STYLE_GUIDE and SPEC-accuracy findings from #4507: first-use noun teaching, one-action how-to steps, printed UI labels, correct screen IDs/titles, Confirm → Next turn → combat-mode flow, unopposed capture and garrison-recovery rules, Auto-Resolve outcome nuance, Quick Battle one-action-then-Volley-Fire behaviour (with noted SPEC/UI conflict), CMPT20001 → CMPT50001 result sequence, Move army invasion warnings, Military Counsel limits, siege protection table, and diplomacy reaction scope.
- Regenerates `docs/manual/player-export/12-art-of-war.md` via `export-player-manual`.

## Done in this PR

All Required-changes items in #4507 applied to chapter 12 authoring + export.

## Deferred

- `document-app-ui` gap: detach-army dialog has no registry row (issue notes not to invent an ID in the handbook).

## AC coverage

| AC | Status |
|----|--------|
| Every Required-changes item applied | Done |
| STYLE_GUIDE reading-level gate | Done (player wording throughout) |
| Screen IDs / how-to match registry + Sources SPECs | Done |
| `export-player-manual` run | Done |

Refs #4507

## Test plan

- [x] `python3 pytool/export_player_manual.py` (exit 0)
- [ ] CI quality gates


Made with [Cursor](https://cursor.com)