### PR TITLE
docs: align handbook chapter 13 Mastery of the Seas (#4510)

### DIFF
--- a/docs/manual/13-mastery-of-the-seas.md
+++ b/docs/manual/13-mastery-of-the-seas.md
@@ -2,140 +2,191 @@
 
 ## Purpose
 
-A navy connects a realm that land armies cannot reach. Merchant hulls in your **Home Fleet** carry overseas extraction and trade cargo; sea-going fleets reveal coasts, protect routes, threaten ports, and prepare invasions. A fleet at sea is also exposed to hostile interception, so naval strength is both an opportunity and a commitment.
+A navy connects a realm that land armies cannot reach. The **Home Fleet** is the permanent fleet at your capital port (it supplies cargo capacity and cannot sail). Merchant hulls in that fleet carry **extraction** — goods brought home from overseas provinces — and trade cargo. Sea-going fleets reveal coasts, protect routes, threaten ports, and prepare invasions. A fleet at sea is also exposed to **interception**: a patrol or blockade may try to catch a moving fleet. Naval strength is both an opportunity and a commitment.
 
-Ships are either **in port** at an owned province or **at sea** in a sea zone. Ports and sea zones connect only where the map’s naval topology provides an edge. Fleets may never dock in an enemy or neutral province.
+Ships are either **in port** at an owned province or **at sea** in a **sea zone** (a named stretch of water). Ports and sea zones connect only where the map shows they touch. You can sail from a port into a neighbouring sea, or from one sea into a neighbouring sea — not by skipping across the map. Fleets may never dock in an enemy or neutral province.
+
+The **Old World** and the **New World** are the two maps. The New World is the overseas map. Rival **Great Powers** (playable nations) also raise fleets and send them to sea.
 
 ## How it is done
 
 ### Raise ships for the realm
 
-1. From `UNIT30001` **Naval Units panel**, select **Train** to open `UNIT60001` **Train Naval dialog**.
-2. Each ship requires treasury, its listed materials, and one available Peasant. Each row also shows its **role** (Merchant or Warship) and a one-line capability gist — cargo holds for merchants, combat role for warships — so you can choose hulls before committing. The dialog subtracts pending choices from its resource bar, so queue only ships the realm can afford together.
-3. A locked row names its required technology. Research it before queuing the hull; the **Carrack** is the sole starting merchant and needs no technology.
-4. Close the dialog to commit the chosen build orders. During turn resolution, successful builds deduct their costs and place their new hulls in the Home Fleet at the capital.
+1. On `GAME10001` **Game screen**, tap **Naval Units** on the left of the map to open `UNIT30001` **Naval units panel**.
+2. Tap **Train** to open `UNIT60001` **Train naval dialog** (header **Train Naval**).
+3. Each ship requires treasury, its listed materials, and one available **Peasant** (one worker spent to build a ship). Each row also shows its **role** (**Merchant** or **Warship**) and a one-line summary — cargo holds for merchants, combat role for warships — so you can choose hulls before committing. The dialog subtracts pending choices from its resource bar, so queue only ships the realm can afford together.
+4. A locked row names its required technology. Research it before queuing the hull; the **Carrack** is the sole starting merchant and needs no technology.
+5. Close the dialog to queue the chosen ships. After you confirm **Next turn**, the game deducts the costs and the new hulls appear in the Home Fleet at the capital. You see them when that finishes — not when you close the dialog.
 
-| Ship | Role | Required technology |
+| Ship | Role (Train Naval) | Required technology |
 |---|---|---|
 | Carrack | Merchant | None |
 | Fluyte | Merchant | Superior Hull Design |
-| Sloop | Warship / fast interceptor | Navigation |
+| Sloop | Warship | Navigation |
 | Trader | Merchant | Improved Sail Design |
-| Galleon | Merchant / battle ship | Convoying |
+| Galleon | Merchant | Convoying |
 | Indiaman | Merchant | Large Hulls |
-| Frigate | Warship / fast interceptor | Advanced Hull Design |
-| Raider | Warship / fast interceptor | Paddlewheels |
-| Ship of the Line | Warship / battle ship | Ship of the Line |
+| Frigate | Warship | Advanced Hull Design |
+| Raider | Warship | Paddlewheels |
+| Ship of the Line | Warship | Ship of the Line |
 | Clipper | Merchant | Clipper Ships |
 | Merchant Steamship | Merchant | Merchant Steamships |
-| Ironclad | Warship / battle ship | Advanced Iron Working |
+| Ironclad | Warship | Advanced Iron Working |
 
-Merchant ships add cargo holds; warships add none. Every ship consumes two food each turn. Faster interceptors are best at catching or escaping fleets, while battle ships bring heavier firepower, armour, and hull strength.
+Merchant ships add cargo holds; warships add none. Every ship consumes two food each turn. Faster interceptors (Sloops, Frigates, Raiders) are best at catching or escaping fleets. Ships of the Line and Ironclads bring heavier firepower, armour, and hull strength.
 
-### Read the Home Fleet and make a squadron
+### Read cargo on the map
 
-The `UNIT30001` Naval Units panel lists every fleet by region and location. Your Home Fleet is pinned first in the capital’s region, even when empty. Expand it to inspect its ships, strength, and total cargo holds.
+On `GAME10001` **Game screen**, the row with the **Old World** and **New World** tabs on `MAP10001` **Empire overview / map area** shows a crate and `used/capacity` beside your treasury. Tap it for a plain-language breakdown: overseas extraction load, total Home Fleet holds, and how many holds remain open for trade bids. The numbers turn a warm accent when used is at least 80% of capacity but still below capacity, and red when used is at or over capacity — a quiet warning, not a popup.
 
-The Home Fleet remains docked at the capital. Its merchant cargo holds are the realm’s total overseas transport and trade capacity for the turn. Split ships from it when you need a sea-going squadron; the new fleet begins at the same location and can then receive movement and mission orders.
+### Read the Home Fleet, split, and combine
 
-When you split the Home Fleet (from `UNIT30001` or from the map path below), a line under the transfer lists how many cargo holds will remain versus this turn’s overseas load. The numbers change as you move merchant hulls. A warm accent means no spare holds; red means remaining holds would fall short. The game still lets you confirm a legal split — leaving merchants home is a real trade-off, not a blocked tap.
+The `UNIT30001` **Naval units panel** lists every fleet by region and location. Your Home Fleet is pinned first in the capital’s region, even when empty. Expand it to inspect its ships, strength, and total cargo holds.
 
-To send newly built ships to sea from the map:
+The Home Fleet remains docked at the capital. Its merchant cargo holds are the realm’s total overseas transport and trade capacity for the turn. Split ships from it when you need a sea-going squadron; the new fleet begins at the same port and can then receive movement and mission orders.
 
-1. Tap the **Home Fleet** marker at your capital harbor on `MAP10001` (or tap **Detach and sail** on `MAP20001` Naval when you have ships at home).
-2. Choose which ship types leave. Confirm **Detach and choose destination**.
-3. On `DLG30001` **Move Fleet**, pick an adjacent sea and confirm. The Home Fleet stays in port.
+**Split from the panel** (does not open **Move fleet** by itself):
 
-If the Home Fleet has no ships, the harbor marker still opens `UNIT30001` so you can **Train**.
+1. In `UNIT30001` **Naval units panel**, tap **Split** on a fleet row. The dialog title is **Split Fleet**.
+2. Move the ship types you want into the new fleet.
+3. Confirm **Confirm Split**. The new fleet stays at the same port (or the same sea, if you split a fleet already at sea).
+4. Then tap **Move** on that new fleet if you want it to sail.
 
-On the in-game map shell (`GAME10001`), the tab bar shows a compact **cargo** readout (`used/capacity`) beside your treasury. Tap it for a plain-language breakdown: overseas extraction load, total Home Fleet holds, and how many holds remain open for trade bids. The numbers turn a warm accent when holds are tight and red when full — a quiet warning, not a popup.
+When you split the Home Fleet, a line under the transfer lists how many cargo holds will remain versus this turn’s overseas load. The numbers change as you move merchant hulls. A warm accent means no spare holds; red means remaining holds would fall short. The game still lets you confirm a legal split — leaving merchants home is a real trade-off, not a blocked tap.
+
+**Combine** (happens at once, not after **Next turn**):
+
+1. In `UNIT30001` **Naval units panel**, check two or more fleets that share the same port or the same sea.
+2. Tap **Combine** at the top of the panel.
+3. Those fleets merge immediately. If the Home Fleet is among the checked fleets, the other checked fleets join it. Empty non-Home fleets are removed.
+
+### Send a squadron to sea from the map
+
+This path is separate from panel **Split**. It detaches ships and then opens **Move fleet** for the new fleet.
+
+1. Tap the **Home Fleet** marker at your capital harbor on `MAP10001` **Empire overview / map area**, or tap **Detach and sail** on `MAP20001` **Province sea-zone overlay** **Naval** when you have ships at home.
+2. The dialog title is **Detach a squadron**. Choose which ship types leave.
+3. Confirm **Detach and choose destination**.
+4. On `DLG30001` **Move fleet dialog** (title **Move fleet — Fleet \<id\>**), pick an adjacent sea and confirm. The Home Fleet stays in port.
+
+If the Home Fleet has no ships, the harbor marker still opens `UNIT30001` **Naval units panel** so you can **Train**.
+
+**Detach and sail** on your owned capital is hidden when you are only watching the game, on a foreign coast, or on a sea zone.
 
 ### Move a sea-going fleet
 
-1. In `UNIT30001`, select **Move** beside a sea-going fleet to open `DLG30001` **Move Fleet**. You can also open the same dialog from the map: tap an **in-port** sea-going fleet marker, or tap **Sail / Move** on `DLG31001` when the fleet is already at sea.
-2. Select one legal adjacent destination and confirm. A fleet at sea may move sea zone to sea zone, or dock at an adjacent **owned** port. A fleet in port may undock only into an adjacent sea zone.
-3. Port-to-port moves and multi-hop moves are not available. Docking at the capital merges the arriving fleet into the Home Fleet when the turn resolves.
-4. Entering a sea zone reveals its water and the coastal edge of adjacent provinces for your realm.
+1. In `UNIT30001` **Naval units panel**, tap **Move** beside a sea-going fleet to open `DLG30001` **Move fleet dialog** (title **Move fleet — Fleet \<id\>**).
+2. Select one legal adjacent destination and confirm.
+3. A fleet at sea may move sea to neighbouring sea, or dock at an adjacent **owned** port. A fleet in port may undock only into an adjacent sea.
+4. Some adjacent seas are passages to the other map. Those rows add **links to** the other region (**Old World** or **New World**). Still one hop per order — no skipping across the map, and no port-to-port hops.
+5. Docking at the capital merges the arriving fleet into the Home Fleet when you confirm **Next turn** and that turn finishes.
+
+Entering a sea zone reveals its water and the coastal edge of adjacent provinces for your realm.
 
 A move order replaces that fleet’s earlier move order and clears its pending mission for the turn. A fleet can move or perform one mission, never both.
 
+You can also open the same **Move fleet** dialog from the map: tap an **in-port** sea-going fleet marker, or tap **Sail / Move** on `DLG31001` **Naval mission menu dialog** when the fleet is already at sea.
+
 ### Assign a naval mission
 
-Only a sea-going fleet **at sea** may patrol, blockade, establish a beachhead, or defend. The Home Fleet cannot receive those missions. Fleets **in port** must undock (move to an adjacent sea zone) before missions are offered.
+Only a sea-going fleet **at sea** may patrol, blockade, establish a beachhead, or defend. The Home Fleet cannot receive those missions. Fleets **in port** must undock (move to an adjacent sea) before missions are offered.
 
-**Map shortcut (primary):** Tap your **fleet marker** on the map (`MAP10001`). When multiple fleets share the marker, choose which fleet in `DLG31003` **Select fleet** — each row shows that fleet’s ship mix (and a pending mission line when one is already staged) so you can tell stacked fleets apart. What opens next depends on that fleet:
+**From a fleet marker on the map:**
 
-- **Home Fleet with ships** — opens **Detach a squadron**, then `DLG30001` **Move Fleet** for the new sea-going fleet. The Home Fleet itself cannot sail.
-- **Home Fleet with no ships** — opens `UNIT30001` Naval Units scoped to that port so you can Train.
-- **Sea-going fleet in port** — opens `DLG30001` **Move Fleet** so you can undock immediately.
-- **Sea-going fleet at sea** — opens `DLG31001` **Assign mission** (Patrol / Defend / Blockade / Beachhead, plus **Cancel pending mission** when a mission is staged). Use **Sail / Move** on that menu to open `DLG30001` without returning to the rail panel. Blockade and Beachhead open `DLG31002` **Select target** so you choose an adjacent enemy province at war with you. Target rows keep the province name and add fog-honest decision support: Beachhead shows the same defender / unopposed / fort summary you see on invasion rows elsewhere; Blockade shows harbor posture (port or not, empty harbor, or hostile fleets in port)—or unknown copy when you lack full intel. Confirm still only requires a selected target.
+1. Tap your fleet marker on `MAP10001` **Empire overview / map area**.
+2. If several fleets share the marker, pick one in `DLG31003` **Naval mission fleet picker dialog** (title **Select fleet**). Each row shows that fleet’s ship mix, and a pending mission line when one is already staged.
+3. If you picked the **Home Fleet with ships**, the next dialog is **Detach a squadron**, then `DLG30001` **Move fleet dialog** for the new sea-going fleet. The Home Fleet itself cannot sail.
+4. If you picked the **Home Fleet with no ships**, `UNIT30001` **Naval units panel** opens for that port so you can **Train**.
+5. If you picked a **sea-going fleet in port**, `DLG30001` **Move fleet dialog** opens so you can undock.
+6. If you picked a **sea-going fleet at sea**, `DLG31001` **Naval mission menu dialog** (title **Assign mission — Fleet \<id\>**) opens. Use **Sail / Move** on that menu to open `DLG30001` **Move fleet dialog** without going back to the left-side **Naval Units** list.
+7. On that mission menu, choose **Patrol**, **Defend**, **Blockade**, or **Beachhead**. Choose **Cancel pending mission** when a mission is already staged and you want to drop it.
+8. **Blockade** and **Beachhead** open `DLG31002` **Naval mission target dialog** (title **Select target**) so you choose an adjacent enemy province at war with you. Target rows keep the province name. Beachhead shows the same defender / unopposed / fort summary you see on invasion rows. Blockade shows whether the harbor has a port, is empty, or already has hostile fleets — or says the harbor is unknown when you cannot see it. You can confirm once a target is selected, even if some harbor details are unknown.
 
+**From the Naval Units list:**
 
-**Panel parity:** In `UNIT30001` **Naval Units**, tap **Mission** on an eligible at-sea fleet row for the same `DLG31001` flow (including **Sail / Move**). The row shows a pending mission line after you confirm (for example `On mission: Patrol` or `Blockade → <province>`).
+1. In `UNIT30001` **Naval units panel**, tap **Mission** on an eligible at-sea fleet.
+2. Follow the same `DLG31001` flow, including **Sail / Move**. The row shows a pending mission line after you confirm (for example `On mission: Patrol` or `Blockade → <province>`).
 
-**Capital Naval shortcut:** On your owned capital, when the Home Fleet has at least one ship, `MAP20001` Naval offers **Detach and sail**. It starts the same split-then-move path as the harbor marker. This control is hidden when you are only watching the game, on a foreign coast, or on a sea zone.
+**Province shortcut:** On a foreign coastal province at war with you, `MAP20001` **Province sea-zone overlay** **Naval** offers **Blockade** and **Beachhead**.
 
-**Overlay shortcut:** On a foreign coastal province at war with you, `MAP20001` Naval offers **Blockade** and **Beachhead**. One eligible at-sea fleet skips `DLG31001` and opens `DLG31002` with that province already selected. Several eligible fleets open `DLG31003` first. If a fleet is at sea but not beside this coast, the controls stay visible and disabled until a fleet is at sea beside the coast — fleets in port cannot take missions. A fogged naval roster (`???`) still shows these actions when the Political owner is known. Map-marker and panel **Mission** still open `DLG31001` as usual.
+1. Tap **Blockade** or **Beachhead**.
+2. One eligible at-sea fleet skips `DLG31001` and opens `DLG31002` with that province already selected.
+3. Several eligible fleets open `DLG31003` first.
+4. If a fleet is at sea but not beside this coast, the controls stay visible and disabled until a fleet is at sea beside the coast — fleets in port cannot take missions. When the naval list shows `???`, these actions still appear if **Political** already names the owner.
+
+Map-marker and panel **Mission** still open `DLG31001` as usual.
 
 - **Patrol:** Remain in the current sea zone and attempt to intercept hostile fleets moving through it, including hostile patrols and blockaders.
 - **Blockade:** Remain in a sea zone adjacent to the target enemy province’s port. The blockader has a stronger interception chance against hostile fleets entering that sea zone, including fleets leaving the blockaded port. Use the target-row harbor line to compare empty harbors against ports with fleets already docked.
-- **Beachhead:** Remain at sea beside a hostile coastal province to establish a landing site. On the following turn, eligible friendly land units may invade that province; the marker expires after that invasion resolves, or after that following turn if no invasion occurs. Target intel helps you compare landing coasts; it does not mean the fleet captures the province this turn.
+- **Beachhead:** Remain at sea beside a hostile coastal province to establish a landing site. On the following turn, eligible friendly land units may invade that province; the marker expires after that invasion resolves, or after that following turn if no invasion occurs. The target row helps you compare landing coasts; it does not mean the fleet captures the province this turn.
 - **Defend:** Remain in place without actively seeking combat. Defending fleets can still be attacked or drawn into combat by hostile patrols or blockades.
 
 A fleet may have a pending **move** or a pending **mission** for the turn, never both. Staging a mission clears any pending move for that fleet, and vice versa.
 
-**Join Home Fleet** is not assigned through the mission menu. Dock a regular fleet at your capital (merging into the Home Fleet) or use **Transfer to Home Fleet** (`DLG40001`) from `UNIT30001` when already in port at the capital.
+**Join Home Fleet** is not assigned through the mission menu. Dock a regular fleet at your capital (the merge happens after **Next turn**) or use the transfer controls below.
 
 ### Transfer selected ships home
 
-For a regular fleet at the capital port, choose **Transfer to Home Fleet** in `UNIT30001` to open `DLG40001` **Transfer to Home Fleet**.
+`UNIT30001` **Naval units panel** shows **Transfer to Home Fleet** on a regular fleet row when a Home Fleet exists in that region (Old World or New World). Tapping it opens `DLG40001` **Transfer to home fleet** (title **Transfer Ships to Home Fleet**).
 
 1. Move one or more ship types from the source list to the Home Fleet list.
-2. Confirm **Transfer**. The selected hulls retain their identity and join the Home Fleet immediately.
+2. Confirm **Transfer**. The selected ships join the Home Fleet at once.
 3. A regular fleet that gives up every ship is removed; the Home Fleet remains, even with no ships.
 
-Use this for returning only merchants to carry cargo while leaving a warship squadron assembled, or for placing escorts with the ships that carry your overseas goods.
+The screens do not all describe the same moment when a transfer is allowed. **Transfer to Home Fleet** is the button you can tap whenever a Home Fleet exists in that region. The transfer dialog itself is written for a source fleet already in port at the capital. **Combine** can also move selected ships into the Home Fleet when the source is in port at the capital, or at sea in a sea next to the capital. Docking at the capital on **Next turn** merges the whole arriving fleet into the Home Fleet. Use the control you can tap; if confirm does not complete, that fleet is not in a place the game will accept.
+
+Use a selected-ship transfer to return only merchants to carry cargo while leaving a warship squadron assembled, or to place escorts with the ships that carry your overseas goods.
 
 ## Counsel
 
 **Counsel.** Hark, my liege: cargo ships win no battle, yet a victorious navy without Home-Fleet holds cannot bring distant bounty to your warehouses. Keep enough merchants at the capital for the trade and transport upon which your plans depend.
 
-**Warning.** A port is shelter, not a battlefield. Fleets in port do not join naval combat, but must leave port into an adjacent sea zone before they can operate — and a blockader may intercept them there.
+**Counsel.** Train Naval lists the **Galleon** as **Merchant** because it has cargo holds. In a fight it still behaves with the heavier battle-ship hulls. Do not read that Train role as “this ship cannot fight.”
+
+**Warning.** A port is shelter, not a battlefield. Fleets in port do not join naval combat, but must leave port into an adjacent sea before they can operate — and a blockader may intercept them there.
+
+**Warning.** Cargo capacity is not always safe. Only Home Fleet merchants carry transport and trade cargo. Hostile fleets at war that patrol or blockade the relevant seas can cut delivered goods and endanger merchant hulls. Warships left in the Home Fleet reduce those losses. An enemy that holds **Privateering Companies** raids more strongly.
 
 **Tip.** Return a fleet to the capital by docking it there when possible. That both ends its voyage and restores its hulls to the cargo fleet without a separate sea-going station.
 
 ## The other courts
 
-Other Great Powers plan naval activity as part of their strategic phase. In colonial phases, their naval planners prioritise New World sea zones, ports, beachheads, and invasion-transport targets; priority provinces receive stronger preference. In the more cautious colonial-lite phase, they can pursue New World exploration and cargo activity, but not invasion transport.
+Rival Great Powers also raise fleets and send them to sea. When they are pushing overseas, they favour New World seas, ports, landing sites, and carrying troops. When they are only beginning that push, they may explore and carry cargo there but do not stage invasions by sea.
 
-Their leaders also shape the danger. Victoria and Henry favour naval research and ships; Isabella favours exploration vessels; de Ruyter favours trade ships; Napoleon and Gustavus can support fleets alongside military ambitions. A rival’s chosen personality and hidden agenda influence its wider willingness to fight, trade, or pursue hostile policy.
+Victoria and Henry lean toward ships and naval learning; Isabella leans toward exploration and ships; de Ruyter leans toward trade ships; Napoleon and Gustavus can keep a navy beside their land wars. A chosen **leader** changes how bold or cautious they are — not how you win.
 
 ## Consequences
 
-- A ship built successfully joins the Home Fleet, increasing cargo capacity only while it remains there.
+- A ship built successfully joins the Home Fleet after **Next turn**, increasing cargo capacity only while it remains there.
 - Moving a fleet into a sea zone can expose new coasts, but it also creates opportunities for patrols and blockades to intercept it.
 - Naval combat occurs only between opposing fleets at sea in the same sea zone. An interception can create combat when a patrol or blockade catches a mover; combat also follows when hostile fleets finish movement together.
-- Combat aggregates ship firepower, range, armour, hull, and movement. Fleets may retreat only to an adjacent friendly or neutral sea zone free of hostile fleets; failure to retreat causes further losses.
-- Blockades are particularly dangerous to a port’s outbound fleet: ships safely docked do not fight, but become interceptable when they undock into the blockader’s sea zone.
+- Combat adds together ship firepower, range, armour, hull, and movement. Fleets may retreat only to an adjacent friendly or neutral sea zone free of hostile fleets; failure to retreat causes further losses.
+- Blockades are particularly dangerous to a port’s outbound fleet: ships safely docked do not fight, but can be caught when they leave port into the blockader’s sea zone.
 - The Home Fleet cannot sail because it is the permanent capital-port fleet that supplies the realm’s transport and trade capacity. Ships must first be split into a separate sea-going fleet before they can move or take missions.
+- Overseas cargo is not guaranteed. Hostile fleets at war that patrol or blockade the relevant seas can cut delivered goods and endanger merchant hulls. Warships left in the Home Fleet reduce those losses. **Privateering Companies** makes an enemy’s raids stronger when they hold that technology.
 
 ## Acceptance criteria for this chapter
 
-- [ ] Explains the complete merchant and warship roster, each ship’s technology gate, and the Carrack exception.
-- [ ] Documents `UNIT30001` and `UNIT60001` for building ships into the Home Fleet, including treasury, materials, Peasant, and technology constraints.
-- [ ] Documents `DLG30001` one-hop port⇄sea movement, owned-port docking, capital docking, and sea-zone revelation.
-- [ ] Documents map fleet-marker routing: Home Fleet with ships → detach-then-sail (`DLG30001` for the new fleet), empty Home Fleet → `UNIT30001`, in-port → `DLG30001`, at-sea → `DLG31001` with Sail/Move, plus `UNIT30001` **Mission** parity, `MAP20001` Naval **Detach and sail** on the owned capital, `MAP20001` Naval **Blockade** / **Beachhead** overlay entry (skip `DLG31001` when the mission is known; `DLG31003` when several fleets qualify), cancel-pending, move xor mission, fog-honest Beachhead/Blockade target intel on `DLG31002`, and `DLG31003` ship-mix rows when several fleets share a marker.
-- [ ] Explains Patrol, Blockade, Beachhead, and Defend, including their location and timing preconditions; Join Home Fleet via dock/transfer only (not mission menu).
-- [ ] Documents `DLG40001` transfer of selected hulls from an eligible capital-port fleet into the Home Fleet.
+- [ ] Explains the complete merchant and warship roster, each ship’s required technology, and the Carrack exception. Train Naval roles match the dialog (**Merchant** or **Warship**).
+- [ ] Documents opening `UNIT30001` **Naval units panel** from **Naval Units** on the left of the map, then `UNIT60001` **Train naval dialog** for building ships into the Home Fleet, including treasury, materials, Peasant, and technology constraints. Results appear after **Next turn**.
+- [ ] Documents `DLG30001` **Move fleet dialog** one adjacent hop (port to sea, or sea to sea or owned port), capital docking after **Next turn**, sea-zone revelation, and **links to** passages between the two maps.
+- [ ] Documents tapping a fleet marker: Home Fleet with ships → detach-then-sail (`DLG30001` for the new fleet), empty Home Fleet → `UNIT30001`, in-port → `DLG30001`, at-sea → `DLG31001` with **Sail / Move**, plus `UNIT30001` **Mission**, `MAP20001` **Naval** **Detach and sail** on the owned capital, and `MAP20001` **Naval** **Blockade** / **Beachhead** (skips the mission menu when the mission is already known; `DLG31003` when several fleets qualify). A fleet may move or take one mission, never both. Beachhead/Blockade target lines stay honest when you cannot see the coast. `DLG31003` rows show ship mix when several fleets share a marker.
+- [ ] Documents panel **Split** (**Split Fleet** / **Confirm Split**, then a separate **Move**) versus map **Detach a squadron** / **Detach and choose destination** (then `DLG30001`).
+- [ ] Documents **Combine**: two or more fleets in the same port or the same sea merge at once; ships join the Home Fleet when it is checked; empty non-Home fleets are removed.
+- [ ] Explains Patrol, Blockade, Beachhead, and Defend, including their location and timing; Join Home Fleet via dock/transfer only (not the mission menu).
+- [ ] Documents `DLG40001` **Transfer Ships to Home Fleet** as a button the player can tap, and records in player language that the screens do not all agree on when a transfer is allowed.
 - [ ] States when interception and naval combat occur, and that port-bound fleets do not fight.
-- [ ] Explains Home-Fleet cargo capacity and why the Home Fleet itself cannot sail.
-- [ ] Describes AI naval priorities and personality-driven naval behaviour without presenting hidden agenda data as player knowledge.
+- [ ] Explains Home-Fleet cargo capacity on the `MAP10001` crate `used/capacity` row, why the Home Fleet itself cannot sail, and that overseas cargo can be raided.
+- [ ] Describes other Great Powers only through what they do at sea and their chosen leader — not private motives the player cannot see.
 
 ## Sources
 
 - `SPEC/game/ships-and-naval.md`
 - `SPEC/game/tech-tree-naval.md`
 - `SPEC/program/orders.md`
+- `SPEC/program/naval-movement-resolution.md`
+- `SPEC/ui/screen-registry.md`
+- `SPEC/ui/empire-overview.md`
 - `SPEC/ui/naval-units-panel.md`
 - `SPEC/ui/naval-units-fleet-management.md`
 - `SPEC/ui/train-naval-dialog.md`

--- a/docs/manual/player-export/13-mastery-of-the-seas.md
+++ b/docs/manual/player-export/13-mastery-of-the-seas.md
@@ -2,118 +2,165 @@
 
 ## Purpose
 
-A navy connects a realm that land armies cannot reach. Merchant hulls in your **Home Fleet** carry overseas extraction and trade cargo; sea-going fleets reveal coasts, protect routes, threaten ports, and prepare invasions. A fleet at sea is also exposed to hostile interception, so naval strength is both an opportunity and a commitment.
+A navy connects a realm that land armies cannot reach. The **Home Fleet** is the permanent fleet at your capital port (it supplies cargo capacity and cannot sail). Merchant hulls in that fleet carry **extraction** — goods brought home from overseas provinces — and trade cargo. Sea-going fleets reveal coasts, protect routes, threaten ports, and prepare invasions. A fleet at sea is also exposed to **interception**: a patrol or blockade may try to catch a moving fleet. Naval strength is both an opportunity and a commitment.
 
-Ships are either **in port** at an owned province or **at sea** in a sea zone. Ports and sea zones connect only where the map’s naval topology provides an edge. Fleets may never dock in an enemy or neutral province.
+Ships are either **in port** at an owned province or **at sea** in a **sea zone** (a named stretch of water). Ports and sea zones connect only where the map shows they touch. You can sail from a port into a neighbouring sea, or from one sea into a neighbouring sea — not by skipping across the map. Fleets may never dock in an enemy or neutral province.
+
+The **Old World** and the **New World** are the two maps. The New World is the overseas map. Rival **Great Powers** (playable nations) also raise fleets and send them to sea.
 
 ## How it is done
 
 ### Raise ships for the realm
 
-1. From **Naval units panel**, select **Train** to open **Train naval dialog**.
-2. Each ship requires treasury, its listed materials, and one available Peasant. Each row also shows its **role** (Merchant or Warship) and a one-line capability gist — cargo holds for merchants, combat role for warships — so you can choose hulls before committing. The dialog subtracts pending choices from its resource bar, so queue only ships the realm can afford together.
-3. A locked row names its required technology. Research it before queuing the hull; the **Carrack** is the sole starting merchant and needs no technology.
-4. Close the dialog to commit the chosen build orders. During turn resolution, successful builds deduct their costs and place their new hulls in the Home Fleet at the capital.
+1. On **Game screen**, tap **Naval Units** on the left of the map to open **Naval units panel**.
+2. Tap **Train** to open **Train naval dialog** (header **Train Naval**).
+3. Each ship requires treasury, its listed materials, and one available **Peasant** (one worker spent to build a ship). Each row also shows its **role** (**Merchant** or **Warship**) and a one-line summary — cargo holds for merchants, combat role for warships — so you can choose hulls before committing. The dialog subtracts pending choices from its resource bar, so queue only ships the realm can afford together.
+4. A locked row names its required technology. Research it before queuing the hull; the **Carrack** is the sole starting merchant and needs no technology.
+5. Close the dialog to queue the chosen ships. After you confirm **Next turn**, the game deducts the costs and the new hulls appear in the Home Fleet at the capital. You see them when that finishes — not when you close the dialog.
 
-| Ship | Role | Required technology |
+| Ship | Role (Train Naval) | Required technology |
 |---|---|---|
 | Carrack | Merchant | None |
 | Fluyte | Merchant | Superior Hull Design |
-| Sloop | Warship / fast interceptor | Navigation |
+| Sloop | Warship | Navigation |
 | Trader | Merchant | Improved Sail Design |
-| Galleon | Merchant / battle ship | Convoying |
+| Galleon | Merchant | Convoying |
 | Indiaman | Merchant | Large Hulls |
-| Frigate | Warship / fast interceptor | Advanced Hull Design |
-| Raider | Warship / fast interceptor | Paddlewheels |
-| Ship of the Line | Warship / battle ship | Ship of the Line |
+| Frigate | Warship | Advanced Hull Design |
+| Raider | Warship | Paddlewheels |
+| Ship of the Line | Warship | Ship of the Line |
 | Clipper | Merchant | Clipper Ships |
 | Merchant Steamship | Merchant | Merchant Steamships |
-| Ironclad | Warship / battle ship | Advanced Iron Working |
+| Ironclad | Warship | Advanced Iron Working |
 
-Merchant ships add cargo holds; warships add none. Every ship consumes two food each turn. Faster interceptors are best at catching or escaping fleets, while battle ships bring heavier firepower, armour, and hull strength.
+Merchant ships add cargo holds; warships add none. Every ship consumes two food each turn. Faster interceptors (Sloops, Frigates, Raiders) are best at catching or escaping fleets. Ships of the Line and Ironclads bring heavier firepower, armour, and hull strength.
 
-### Read the Home Fleet and make a squadron
+### Read cargo on the map
+
+On **Game screen**, the row with the **Old World** and **New World** tabs on **Empire overview / map area** shows a crate and `used/capacity` beside your treasury. Tap it for a plain-language breakdown: overseas extraction load, total Home Fleet holds, and how many holds remain open for trade bids. The numbers turn a warm accent when used is at least 80% of capacity but still below capacity, and red when used is at or over capacity — a quiet warning, not a popup.
+
+### Read the Home Fleet, split, and combine
 
 The **Naval units panel** lists every fleet by region and location. Your Home Fleet is pinned first in the capital’s region, even when empty. Expand it to inspect its ships, strength, and total cargo holds.
 
-The Home Fleet remains docked at the capital. Its merchant cargo holds are the realm’s total overseas transport and trade capacity for the turn. Split ships from it when you need a sea-going squadron; the new fleet begins at the same location and can then receive movement and mission orders.
+The Home Fleet remains docked at the capital. Its merchant cargo holds are the realm’s total overseas transport and trade capacity for the turn. Split ships from it when you need a sea-going squadron; the new fleet begins at the same port and can then receive movement and mission orders.
 
-When you split the Home Fleet (from **Naval units panel** or from the map path below), a line under the transfer lists how many cargo holds will remain versus this turn’s overseas load. The numbers change as you move merchant hulls. A warm accent means no spare holds; red means remaining holds would fall short. The game still lets you confirm a legal split — leaving merchants home is a real trade-off, not a blocked tap.
+**Split from the panel** (does not open **Move fleet** by itself):
 
-To send newly built ships to sea from the map:
+1. In **Naval units panel**, tap **Split** on a fleet row. The dialog title is **Split Fleet**.
+2. Move the ship types you want into the new fleet.
+3. Confirm **Confirm Split**. The new fleet stays at the same port (or the same sea, if you split a fleet already at sea).
+4. Then tap **Move** on that new fleet if you want it to sail.
 
-1. Tap the **Home Fleet** marker at your capital harbor on **Empire overview / map area** (or tap **Detach and sail** on **Province sea-zone overlay** Naval when you have ships at home).
-2. Choose which ship types leave. Confirm **Detach and choose destination**.
-3. On **Move fleet dialog**, pick an adjacent sea and confirm. The Home Fleet stays in port.
+When you split the Home Fleet, a line under the transfer lists how many cargo holds will remain versus this turn’s overseas load. The numbers change as you move merchant hulls. A warm accent means no spare holds; red means remaining holds would fall short. The game still lets you confirm a legal split — leaving merchants home is a real trade-off, not a blocked tap.
+
+**Combine** (happens at once, not after **Next turn**):
+
+1. In **Naval units panel**, check two or more fleets that share the same port or the same sea.
+2. Tap **Combine** at the top of the panel.
+3. Those fleets merge immediately. If the Home Fleet is among the checked fleets, the other checked fleets join it. Empty non-Home fleets are removed.
+
+### Send a squadron to sea from the map
+
+This path is separate from panel **Split**. It detaches ships and then opens **Move fleet** for the new fleet.
+
+1. Tap the **Home Fleet** marker at your capital harbor on **Empire overview / map area**, or tap **Detach and sail** on **Province sea-zone overlay** **Naval** when you have ships at home.
+2. The dialog title is **Detach a squadron**. Choose which ship types leave.
+3. Confirm **Detach and choose destination**.
+4. On **Move fleet dialog** (title **Move fleet — Fleet \<id\>**), pick an adjacent sea and confirm. The Home Fleet stays in port.
 
 If the Home Fleet has no ships, the harbor marker still opens **Naval units panel** so you can **Train**.
 
-On the in-game map shell (**Game screen**), the tab bar shows a compact **cargo** readout (`used/capacity`) beside your treasury. Tap it for a plain-language breakdown: overseas extraction load, total Home Fleet holds, and how many holds remain open for trade bids. The numbers turn a warm accent when holds are tight and red when full — a quiet warning, not a popup.
+**Detach and sail** on your owned capital is hidden when you are only watching the game, on a foreign coast, or on a sea zone.
 
 ### Move a sea-going fleet
 
-1. In **Naval units panel**, select **Move** beside a sea-going fleet to open **Move fleet dialog**. You can also open the same dialog from the map: tap an **in-port** sea-going fleet marker, or tap **Sail / Move** on **Naval mission menu dialog** when the fleet is already at sea.
-2. Select one legal adjacent destination and confirm. A fleet at sea may move sea zone to sea zone, or dock at an adjacent **owned** port. A fleet in port may undock only into an adjacent sea zone.
-3. Port-to-port moves and multi-hop moves are not available. Docking at the capital merges the arriving fleet into the Home Fleet when the turn resolves.
-4. Entering a sea zone reveals its water and the coastal edge of adjacent provinces for your realm.
+1. In **Naval units panel**, tap **Move** beside a sea-going fleet to open **Move fleet dialog** (title **Move fleet — Fleet \<id\>**).
+2. Select one legal adjacent destination and confirm.
+3. A fleet at sea may move sea to neighbouring sea, or dock at an adjacent **owned** port. A fleet in port may undock only into an adjacent sea.
+4. Some adjacent seas are passages to the other map. Those rows add **links to** the other region (**Old World** or **New World**). Still one hop per order — no skipping across the map, and no port-to-port hops.
+5. Docking at the capital merges the arriving fleet into the Home Fleet when you confirm **Next turn** and that turn finishes.
+
+Entering a sea zone reveals its water and the coastal edge of adjacent provinces for your realm.
 
 A move order replaces that fleet’s earlier move order and clears its pending mission for the turn. A fleet can move or perform one mission, never both.
 
+You can also open the same **Move fleet** dialog from the map: tap an **in-port** sea-going fleet marker, or tap **Sail / Move** on **Naval mission menu dialog** when the fleet is already at sea.
+
 ### Assign a naval mission
 
-Only a sea-going fleet **at sea** may patrol, blockade, establish a beachhead, or defend. The Home Fleet cannot receive those missions. Fleets **in port** must undock (move to an adjacent sea zone) before missions are offered.
+Only a sea-going fleet **at sea** may patrol, blockade, establish a beachhead, or defend. The Home Fleet cannot receive those missions. Fleets **in port** must undock (move to an adjacent sea) before missions are offered.
 
-**Map shortcut (primary):** Tap your **fleet marker** on the map (**Empire overview / map area**). When multiple fleets share the marker, choose which fleet in **Naval mission fleet picker dialog** — each row shows that fleet’s ship mix (and a pending mission line when one is already staged) so you can tell stacked fleets apart. What opens next depends on that fleet:
+**From a fleet marker on the map:**
 
-- **Home Fleet with ships** — opens **Detach a squadron**, then **Move fleet dialog** for the new sea-going fleet. The Home Fleet itself cannot sail.
-- **Home Fleet with no ships** — opens **Naval units panel** Naval Units scoped to that port so you can Train.
-- **Sea-going fleet in port** — opens **Move fleet dialog** so you can undock immediately.
-- **Sea-going fleet at sea** — opens **Naval mission menu dialog** (Patrol / Defend / Blockade / Beachhead, plus **Cancel pending mission** when a mission is staged). Use **Sail / Move** on that menu to open **Move fleet dialog** without returning to the rail panel. Blockade and Beachhead open **Naval mission target dialog** so you choose an adjacent enemy province at war with you. Target rows keep the province name and add fog-honest decision support: Beachhead shows the same defender / unopposed / fort summary you see on invasion rows elsewhere; Blockade shows harbor posture (port or not, empty harbor, or hostile fleets in port)—or unknown copy when you lack full intel. Confirm still only requires a selected target.
+1. Tap your fleet marker on **Empire overview / map area**.
+2. If several fleets share the marker, pick one in **Naval mission fleet picker dialog** (title **Select fleet**). Each row shows that fleet’s ship mix, and a pending mission line when one is already staged.
+3. If you picked the **Home Fleet with ships**, the next dialog is **Detach a squadron**, then **Move fleet dialog** for the new sea-going fleet. The Home Fleet itself cannot sail.
+4. If you picked the **Home Fleet with no ships**, **Naval units panel** opens for that port so you can **Train**.
+5. If you picked a **sea-going fleet in port**, **Move fleet dialog** opens so you can undock.
+6. If you picked a **sea-going fleet at sea**, **Naval mission menu dialog** (title **Assign mission — Fleet \<id\>**) opens. Use **Sail / Move** on that menu to open **Move fleet dialog** without going back to the left-side **Naval Units** list.
+7. On that mission menu, choose **Patrol**, **Defend**, **Blockade**, or **Beachhead**. Choose **Cancel pending mission** when a mission is already staged and you want to drop it.
+8. **Blockade** and **Beachhead** open **Naval mission target dialog** (title **Select target**) so you choose an adjacent enemy province at war with you. Target rows keep the province name. Beachhead shows the same defender / unopposed / fort summary you see on invasion rows. Blockade shows whether the harbor has a port, is empty, or already has hostile fleets — or says the harbor is unknown when you cannot see it. You can confirm once a target is selected, even if some harbor details are unknown.
 
-**Panel parity:** In **Naval units panel**, tap **Mission** on an eligible at-sea fleet row for the same **Naval mission menu dialog** flow (including **Sail / Move**). The row shows a pending mission line after you confirm (for example `On mission: Patrol` or `Blockade → <province>`).
+**From the Naval Units list:**
 
-**Capital Naval shortcut:** On your owned capital, when the Home Fleet has at least one ship, **Province sea-zone overlay** Naval offers **Detach and sail**. It starts the same split-then-move path as the harbor marker. This control is hidden when you are only watching the game, on a foreign coast, or on a sea zone.
+1. In **Naval units panel**, tap **Mission** on an eligible at-sea fleet.
+2. Follow the same **Naval mission menu dialog** flow, including **Sail / Move**. The row shows a pending mission line after you confirm (for example `On mission: Patrol` or `Blockade → <province>`).
 
-**Overlay shortcut:** On a foreign coastal province at war with you, **Province sea-zone overlay** Naval offers **Blockade** and **Beachhead**. One eligible at-sea fleet skips **Naval mission menu dialog** and opens **Naval mission target dialog** with that province already selected. Several eligible fleets open **Naval mission fleet picker dialog** first. If a fleet is at sea but not beside this coast, the controls stay visible and disabled until a fleet is at sea beside the coast — fleets in port cannot take missions. A fogged naval roster (`???`) still shows these actions when the Political owner is known. Map-marker and panel **Mission** still open **Naval mission menu dialog** as usual.
+**Province shortcut:** On a foreign coastal province at war with you, **Province sea-zone overlay** **Naval** offers **Blockade** and **Beachhead**.
+
+1. Tap **Blockade** or **Beachhead**.
+2. One eligible at-sea fleet skips **Naval mission menu dialog** and opens **Naval mission target dialog** with that province already selected.
+3. Several eligible fleets open **Naval mission fleet picker dialog** first.
+4. If a fleet is at sea but not beside this coast, the controls stay visible and disabled until a fleet is at sea beside the coast — fleets in port cannot take missions. When the naval list shows `???`, these actions still appear if **Political** already names the owner.
+
+Map-marker and panel **Mission** still open **Naval mission menu dialog** as usual.
 
 - **Patrol:** Remain in the current sea zone and attempt to intercept hostile fleets moving through it, including hostile patrols and blockaders.
 - **Blockade:** Remain in a sea zone adjacent to the target enemy province’s port. The blockader has a stronger interception chance against hostile fleets entering that sea zone, including fleets leaving the blockaded port. Use the target-row harbor line to compare empty harbors against ports with fleets already docked.
-- **Beachhead:** Remain at sea beside a hostile coastal province to establish a landing site. On the following turn, eligible friendly land units may invade that province; the marker expires after that invasion resolves, or after that following turn if no invasion occurs. Target intel helps you compare landing coasts; it does not mean the fleet captures the province this turn.
+- **Beachhead:** Remain at sea beside a hostile coastal province to establish a landing site. On the following turn, eligible friendly land units may invade that province; the marker expires after that invasion resolves, or after that following turn if no invasion occurs. The target row helps you compare landing coasts; it does not mean the fleet captures the province this turn.
 - **Defend:** Remain in place without actively seeking combat. Defending fleets can still be attacked or drawn into combat by hostile patrols or blockades.
 
 A fleet may have a pending **move** or a pending **mission** for the turn, never both. Staging a mission clears any pending move for that fleet, and vice versa.
 
-**Join Home Fleet** is not assigned through the mission menu. Dock a regular fleet at your capital (merging into the Home Fleet) or use **Transfer to Home Fleet** (**Transfer to home fleet**) from **Naval units panel** when already in port at the capital.
+**Join Home Fleet** is not assigned through the mission menu. Dock a regular fleet at your capital (the merge happens after **Next turn**) or use the transfer controls below.
 
 ### Transfer selected ships home
 
-For a regular fleet at the capital port, choose **Transfer to Home Fleet** in **Naval units panel** to open **Transfer to home fleet**.
+**Naval units panel** shows **Transfer to Home Fleet** on a regular fleet row when a Home Fleet exists in that region (Old World or New World). Tapping it opens **Transfer to home fleet** (title **Transfer Ships to Home Fleet**).
 
 1. Move one or more ship types from the source list to the Home Fleet list.
-2. Confirm **Transfer**. The selected hulls retain their identity and join the Home Fleet immediately.
+2. Confirm **Transfer**. The selected ships join the Home Fleet at once.
 3. A regular fleet that gives up every ship is removed; the Home Fleet remains, even with no ships.
 
-Use this for returning only merchants to carry cargo while leaving a warship squadron assembled, or for placing escorts with the ships that carry your overseas goods.
+The screens do not all describe the same moment when a transfer is allowed. **Transfer to Home Fleet** is the button you can tap whenever a Home Fleet exists in that region. The transfer dialog itself is written for a source fleet already in port at the capital. **Combine** can also move selected ships into the Home Fleet when the source is in port at the capital, or at sea in a sea next to the capital. Docking at the capital on **Next turn** merges the whole arriving fleet into the Home Fleet. Use the control you can tap; if confirm does not complete, that fleet is not in a place the game will accept.
+
+Use a selected-ship transfer to return only merchants to carry cargo while leaving a warship squadron assembled, or to place escorts with the ships that carry your overseas goods.
 
 ## Counsel
 
 **Counsel.** Hark, my liege: cargo ships win no battle, yet a victorious navy without Home-Fleet holds cannot bring distant bounty to your warehouses. Keep enough merchants at the capital for the trade and transport upon which your plans depend.
 
-**Warning.** A port is shelter, not a battlefield. Fleets in port do not join naval combat, but must leave port into an adjacent sea zone before they can operate — and a blockader may intercept them there.
+**Counsel.** Train Naval lists the **Galleon** as **Merchant** because it has cargo holds. In a fight it still behaves with the heavier battle-ship hulls. Do not read that Train role as “this ship cannot fight.”
+
+**Warning.** A port is shelter, not a battlefield. Fleets in port do not join naval combat, but must leave port into an adjacent sea before they can operate — and a blockader may intercept them there.
+
+**Warning.** Cargo capacity is not always safe. Only Home Fleet merchants carry transport and trade cargo. Hostile fleets at war that patrol or blockade the relevant seas can cut delivered goods and endanger merchant hulls. Warships left in the Home Fleet reduce those losses. An enemy that holds **Privateering Companies** raids more strongly.
 
 **Tip.** Return a fleet to the capital by docking it there when possible. That both ends its voyage and restores its hulls to the cargo fleet without a separate sea-going station.
 
 ## The other courts
 
-Other Great Powers plan naval activity as part of their strategic phase. In colonial phases, their naval planners prioritise New World sea zones, ports, beachheads, and invasion-transport targets; priority provinces receive stronger preference. In the more cautious colonial-lite phase, they can pursue New World exploration and cargo activity, but not invasion transport.
+Rival Great Powers also raise fleets and send them to sea. When they are pushing overseas, they favour New World seas, ports, landing sites, and carrying troops. When they are only beginning that push, they may explore and carry cargo there but do not stage invasions by sea.
 
-Their leaders also shape the danger. Victoria and Henry favour naval research and ships; Isabella favours exploration vessels; de Ruyter favours trade ships; Napoleon and Gustavus can support fleets alongside military ambitions. A rival’s chosen personality and hidden agenda influence its wider willingness to fight, trade, or pursue hostile policy.
+Victoria and Henry lean toward ships and naval learning; Isabella leans toward exploration and ships; de Ruyter leans toward trade ships; Napoleon and Gustavus can keep a navy beside their land wars. A chosen **leader** changes how bold or cautious they are — not how you win.
 
 ## Consequences
 
-- A ship built successfully joins the Home Fleet, increasing cargo capacity only while it remains there.
+- A ship built successfully joins the Home Fleet after **Next turn**, increasing cargo capacity only while it remains there.
 - Moving a fleet into a sea zone can expose new coasts, but it also creates opportunities for patrols and blockades to intercept it.
 - Naval combat occurs only between opposing fleets at sea in the same sea zone. An interception can create combat when a patrol or blockade catches a mover; combat also follows when hostile fleets finish movement together.
-- Combat aggregates ship firepower, range, armour, hull, and movement. Fleets may retreat only to an adjacent friendly or neutral sea zone free of hostile fleets; failure to retreat causes further losses.
-- Blockades are particularly dangerous to a port’s outbound fleet: ships safely docked do not fight, but become interceptable when they undock into the blockader’s sea zone.
+- Combat adds together ship firepower, range, armour, hull, and movement. Fleets may retreat only to an adjacent friendly or neutral sea zone free of hostile fleets; failure to retreat causes further losses.
+- Blockades are particularly dangerous to a port’s outbound fleet: ships safely docked do not fight, but can be caught when they leave port into the blockader’s sea zone.
 - The Home Fleet cannot sail because it is the permanent capital-port fleet that supplies the realm’s transport and trade capacity. Ships must first be split into a separate sea-going fleet before they can move or take missions.
+- Overseas cargo is not guaranteed. Hostile fleets at war that patrol or blockade the relevant seas can cut delivered goods and endanger merchant hulls. Warships left in the Home Fleet reduce those losses. **Privateering Companies** makes an enemy’s raids stronger when they hold that technology.


### PR DESCRIPTION
## Summary

- Rewrites `docs/manual/13-mastery-of-the-seas.md` to satisfy all STYLE_GUIDE and SPEC-accuracy findings from #4510: first-use teaching (Home Fleet, sea zone, Great Power, Old/New World, Peasant, extraction, interception), Next-turn timing for ship builds, printed UI labels and registry titles, separate panel Split vs map Detach-and-sail paths, Combine (immediate), warp **links to** rows, Galleon Train role **Merchant**, cargo crate on `MAP10001`, overseas cargo raids, rival-leader wording without hidden-agenda teaching, and Transfer-to-Home-Fleet eligibility recorded as a screen conflict rather than a invented single rule.
- Regenerates `docs/manual/player-export/13-mastery-of-the-seas.md` via `export-player-manual`.

## Done in this PR

All Required-changes items in #4510 applied to chapter 13 authoring + export.

## Deferred

- `document-app-ui` gap: panel **Split Fleet** / map **Detach a squadron** has no registry screen ID. The chapter names printed titles only and does not invent an ID.

## AC coverage

| AC | Status |
|----|--------|
| Every Required-changes item applied | Done |
| STYLE_GUIDE reading-level gate | Done (player wording throughout) |
| Screen IDs / how-to match registry + Sources SPECs | Done |
| `export-player-manual` run | Done |

Refs #4510

## Test plan

- [x] `python3 pytool/export_player_manual.py` (exit 0)
- [x] `python3 pytool/export_player_manual.py --check` (pass)
- [ ] CI quality gates


Made with [Cursor](https://cursor.com)