### PR TITLE
docs: align handbook chapter 14 Passage of Turns (#4514)

### DIFF
--- a/docs/manual/14-passage-of-turns.md
+++ b/docs/manual/14-passage-of-turns.md
@@ -2,51 +2,91 @@
 
 ## Purpose
 
-A turn is the span in which your court gives its orders, the other Great Powers make their own plans, and the world answers both. Ending it commits the orders you have already set; the result is a new political, military, and economic situation to read before issuing the next decrees.
+A **Great Power** is a playable nation. A **decree** is an action you choose on your turn. A turn is the span in which you choose those decrees, the other Great Powers make their own plans, and the world answers both.
 
-The campaign calendar advances with the turn. By default, turn 1 is 1500; turns through 100 advance two years each, reaching 1700, and later turns advance one year at a time. The HUD and turn news use that calendar to place your reign in its age.
+The **Old World** and the **New World** are the two maps. **Next turn** is the only way the calendar advances, and the only way the game checks **military victory** (holding 31 or more Old World provinces; Chapter 15). Once you confirm, you cannot take those decrees back. Ending the turn commits what you have already set; the result is a new political, military, and economic situation to read before you choose again.
+
+The campaign calendar advances with the turn. By default, turn 1 is 1500; turns through 100 advance two years each, reaching 1700, and later turns advance one year at a time. The top bar and **Next turn** show the year and the turn number. `DLG50001` **Turn news dialog** uses the same calendar.
 
 ## How it is done
 
 ### Ending a turn
 
-1. On `GAME10001` **Game screen**, finish the orders and immediate actions you mean to give this turn, then use **Next turn** in the top bar.
-2. Confirm in `DLG60001` **Next turn confirmation** (“End turn?”). When you have already given decrees this turn, the dialog shows **Staged this turn** with a short count by kind (army moves, trade, and so on). Tap **Review decrees** to read each line in ordinary words. A locate button beside each kind opens that panel or screen without ending the turn, so you can still change your mind. If you gave no decrees, that list is simply absent — the court does not scold you for a quiet turn. **Yes** stays available while you read. If any of your **work-order civilians** (Explorer, Builder, Engineer, Merchant, Rail Builder) have no work order queued, the dialog may list them so you can locate each unit before committing. **Spies are not listed** — foreign station, home counter-spy, and capital reserve are deliberate posts, not wasted capacity. Choose **Yes** to commit the displayed turn, or **No** to abort and keep planning. You can turn this warning off in `DLG90001` **Settings** (or dismiss it for future turns from the dialog). Empty research seats or funding set to **None** are **not** listed here: holding gold back from research is a normal strategic choice, so the court does not nag at end-turn about unused research capacity (review `GAME40001` **Technology** only when you mean to). A funded research assignment you already set can appear under **Staged this turn**; unused seats still do not.
-3. Once resolution begins, the game blocks map interaction and further Next turn requests while it processes the turn. The hamburger side menu remains available, but changes that would alter the resolving turn must wait.
-4. Resolution may pause for a decision when diplomacy requires your answer: for example, an overture, intervention, or call to arms. Give that answer before the remaining phases can continue.
+1. On `GAME10001` **Game screen**, finish the decrees you mean to give this turn, then tap **Next turn** in the top bar.
+2. `DLG60001` **Next turn confirmation** opens. The title is **End turn?** or **Proceed to next turn?** The body says **Turn {N} will end. Continue?**
+3. If you already staged decrees this turn, the dialog shows **Staged this turn** with a short count by kind (army moves, trade, and so on). If you gave none, that list is simply absent — the court does not scold you for a quiet turn.
+4. Tap **Review decrees** to read each staged line in ordinary words. A locate button beside each kind opens that panel or screen and closes the dialog **without** ending the turn, so you can still change your mind. **Yes** stays available while you read.
+5. Five working civilians can do assigned tasks: Explorer, Builder, Engineer, Merchant, and Rail Builder. If any of yours have **no work order** for the next turn, the dialog may list them under **These civilians have no work order for the next turn:**. Each row shows type, location, **No work order**, and a go-to button.
+6. Tap go-to on a listed civilian to leave without ending the turn. The map finds that person and opens `UNIT10001` **Civilian units panel**. A **Spy** is a civilian posted in a foreign court or at home; Spies are **not** listed here — foreign station, home counter-spy, and capital reserve are deliberate posts, not wasted capacity.
+7. To stop seeing that no-work-order list, turn on **Don't show this warning again** and then tap **Yes**. Tapping **No** leaves the warning on. You can also change the same warning in `DLG90001` **Settings** with **Warn when civilians have no work order on end turn**; that switch applies on the next end-turn confirm, without restarting the app.
+8. Empty research seats or funding set to **None** are **not** listed here: holding gold back from research is a normal choice. Review `GAME40001` **Technology screen** only when you mean to. A funded research assignment you already set can appear under **Staged this turn**; unused seats still do not.
+9. Choose **Yes** to commit the displayed turn, or **No** to keep planning.
+10. After **Yes**, a **Processing Turn** screen appears. You cannot close it, tap the map, or tap **Next turn** until the turn finishes. The three-line button still opens `GAME50001` **Game side menu**. **Game Paused** / `SHEL40001` **Pause menu panel** does not open until **Processing Turn** closes.
+11. The turn may pause when diplomacy needs your answer. Give that answer on `OVL30001` **Overture dialogue**, `OVL50001` **Pending intervention overlay**, or `OVL40001` **Call to arms dialogue overlay** before the rest of the turn can continue.
 
-### What the realm resolves
+### What happens after Next turn
 
-The game completes its phases in a fixed order. You see their combined consequences after resolution rather than watching every individual exchange as it happens.
+After you confirm, the game carries out the turn in a fixed order. You see the combined results when that finishes — not while each step runs.
 
-1. **Orders:** your decrees and the other Great Powers’ orders are gathered and checked together.
-2. **The economy:** extraction fills stockpiles; riches become treasury; food and luxuries are consumed; then idle labour produces goods. This is why a stockpile, treasury, or labour forecast can differ after the turn.
-3. **Courts and knowledge:** diplomacy resolves before research, so agreements, wars, and ownership changes can affect what follows. Spy activity and research then resolve.
-4. **Forces in motion:** land and naval movement occur, followed by minor-nation military adjustment, naval interception and combat, then land combat. Expect losses, new positions, and captured provinces only after these stages have finished.
-5. **Works and trade:** units build, explore, prospect, improve, and perform other assigned work; the World Market then settles submitted offers and bids.
-6. **The reckoning:** victory and campaign-end conditions are checked, visibility updates, and the turn advances. If the campaign continues, you return to the Orders phase with the new state.
+1. Your decrees and the other Great Powers’ plans are gathered and checked together.
+2. Resource tiles add goods to your stores.
+3. Riches become treasury.
+4. Armies, workers, and ships eat food and luxuries.
+5. Assigned recipes and unused labour then make finished goods. This is why a store, treasury, or labour forecast can differ after the turn.
+6. Diplomacy then runs — agreements, wars, and ownership can change what follows. The game may pause here for your answer on the diplomacy screens listed above.
+7. Spy work then takes effect, then research.
+8. Armies and fleets move. Minor Nations keep their armies as strong as the strongest Great Power, so they are hard to conquer casually.
+9. Patrols and blockades may try to catch moving fleets; sea fighting comes next, then land fighting. Expect losses, new positions, and captured provinces only after these stages have finished.
+10. People then do assigned work: build, explore, prospect, improve, and the rest.
+11. The **World Market** is the shared market on `GAME60001` **Trade screen**. It then settles the bids and offers you submitted. **Deal Book** is that screen’s tab of your bids and offers.
+12. The game checks **military victory** and whether the campaign calendar has ended, updates what you can see, and advances the turn. Then you can choose actions again (or the campaign ends).
 
-A completed turn’s principal report appears in `DLG50001` **Turn news dialog**, unless victory takes precedence. It lists major events from the resolved turn; if none qualify, it plainly says so. Close the report, inspect the map and your empire screens, and prepare the next turn. When your Spies still stood in a foreign court after that turn, a muted line at the bottom of turn news says **Your spies report N items — open Intelligence**. Tap it to close the newspaper and open `GAME30003` **Intelligence** (also reached from **Intelligence** on `GAME30001` **Diplomacy**). Closing the newspaper does not forget those reports; Intelligence keeps last turn’s world briefing and spy lines until the next completed turn replaces them.
+### Turn news
 
-After you close turn news — or, when `OVL20001` **Victory overlay** is up for a military win or **Campaign complete**, after you choose **View Final State** — `MAP10001` may briefly pulse a few places where last turn’s fights, captures, finished civilian work, or new sight landed. The pulses wait until **Victory overlay** is gone; closing the newspaper while it is still up does not start them. The camera moves to each place in turn; a short caption names what happened. Tap the map or **Skip** to end the sequence early. At most six places play this way; the full list stays in `OVL70001` **Player turn event feed**. Research, diplomacy, and market lines stay in news and the feed only.
+A completed turn’s main report appears in `DLG50001` **Turn news dialog**, unless victory takes precedence. If nothing major happened, it says **No major events last turn.** Close the report, inspect the map and your empire screens, and prepare the next turn.
 
-On the map, the news toggle opens `OVL70001` **Player turn event feed** — a compact, human-scoped card of outcomes over the map. It replaces its entries each resolved turn and can be shown or hidden without leaving `GAME10001`. Use it with turn news: the dialog is the formal summary; the feed keeps relevant lines on the map while you inspect. When a technology finishes researching, its feed line shows the tech by name; tap that line to open `GAME40001` **Technology** on the Slots tab and choose your next project. Diplomacy, overture, and spy lines open the counterpart faction's `GAME30002` **Diplomacy detail** screen; spy-court report lines from last turn (the same **Our spy in {court} reports:** wording as Intelligence) open `GAME30003`. Completed work orders open `UNIT10001` **Civilian units** focused on the builder; land combat and province capture lines open the province overlay on the map. Rejected orders open the panel or screen that owns that order type (for example civilian work opens Civilian units, trade opens Trade). When your own market bids or offers filled or carried forward last turn, a short **Market:** line summarizes bought and sold totals (and carry-forwards when any); tap it to open `GAME60001` **Trade** on the Deal Book tab for the full ledger. Overseas-profit lines remain separate and use the same Deal Book deep-link. When treasury or stockpile changed materially last turn, a **Realm:** line summarizes the net treasury and largest stockpile movers; tap it to open `GAME20001` **Production** for the full picture (this is last-turn actuals, not the forward preview on Available). A rival’s research or a fight you were not in does **not** appear here unless a Spy of yours still stood in that court.
+When your Spies still stood in a foreign court after that turn, a line at the bottom of turn news says **Your spies report N items — open Intelligence**. Tap it to close the newspaper and open `GAME30003` **Intelligence Council** (the printed bar says **Intelligence**; you can also open it from **Intelligence** on `GAME30001` **Diplomacy screen**). Closing the newspaper does not forget those reports; Intelligence keeps last turn’s world briefing and spy lines until the next completed turn replaces them.
+
+### Last-turn pulses on the map
+
+After you close turn news — or, when `OVL20001` **Victory overlay** is up for a military win or **Campaign complete**, after you choose **View Final State** — `MAP10001` **Empire overview / map area** may briefly pulse a few places where last turn’s fights, captures, finished civilian work, or new sight landed.
+
+The pulses wait until **Victory overlay** is gone; closing the newspaper while it is still up does not start them. Each pulse also switches the **Old World** / **New World** tab the same way a locate button does. The camera moves to each place in turn; a short caption names what happened. Tap the map or **Skip** to end the sequence early. Skip or a map tap does **not** open `MAP20001` **Province sea-zone overlay** or a unit panel. At most six places play this way; the full list stays in `OVL70001` **Player turn event feed**. Research, diplomacy, and market lines stay in news and the feed only.
+
+### The newspaper feed
+
+On `MAP10001` **Empire overview / map area**, the newspaper button sits on the map bar after treasury and cargo. The feed starts **hidden**. A badge on the button shows how many lines it holds. Tap the button to show or hide `OVL70001` **Player turn event feed** without leaving `GAME10001` **Game screen**.
+
+Use the feed with turn news: the dialog is the formal summary; the feed keeps relevant lines on the map while you inspect. It replaces its entries each completed turn.
+
+Tap a line for the matching place or screen:
+
+1. When a technology finishes researching, its feed line shows the tech by name. Tap it to open `GAME40001` **Technology screen** on the Slots tab and choose your next project.
+2. Diplomacy and overture lines open the other nation’s `GAME30002` **Diplomacy detail screen**. Spy-caught and spy-defected rows also open that court’s `GAME30002` **Diplomacy detail screen**.
+3. Spy report lines (the same **Our spy in {court} reports:** wording as Intelligence) open `GAME30003` **Intelligence Council** or that court’s `GAME30002` **Diplomacy detail screen**.
+4. Completed work orders open `UNIT10001` **Civilian units panel** focused on the person who finished the task.
+5. Land combat and province capture lines open `MAP20001` **Province sea-zone overlay**. Naval combat opens that same screen when the map can find the sea; otherwise that line is not tappable. Discovery pans the map to the new province or sea. Medal lines use the word **general**.
+6. Rejected orders open the panel or screen that owns that order type (for example civilian work opens Civilian units, trade opens Trade).
+7. When your own market bids or offers filled or carried forward last turn, a short **Market:** line summarizes bought and sold totals (and orders carried when any). Tap it to open `GAME60001` **Trade screen** on the **Deal Book** tab. Overseas-profit lines remain separate and use the same Trade / Deal Book tap.
+8. When treasury or stores changed materially last turn, a **Realm:** line summarizes the net treasury and largest store movers. Tap it to open `GAME20001` **Production screen** for last turn’s real totals, not the **Available** forecast.
+
+A rival’s research or a fight you were not in does **not** appear here unless a Spy of yours still stood in that court.
 
 ### Pausing, saving, and loading
 
-1. Open `SHEL40001` **Pause menu panel** when the game is not resolving. Choose **Resume**, **Save Game**, **Load Game**, **Settings**, or **Exit to Main Menu**.
-2. Choose **Save Game** to open `DLG70001` **Save Game Name dialog**. Its proposed name includes your nation, leader, and current turn. Enter a valid name and save it. A conflicting name asks before overwriting; invalid names remain unsaved. You may keep up to 20 manual saves, though an existing save may still be overwritten at that limit.
-3. Choose **Load Game** to open `DLG80001` **Load Game List dialog**. The auto-save, when available, is kept apart from the manual list; manual saves are shown newest first and are paged after ten entries. Select a save, confirm that you wish to discard the current session, and the chosen game replaces it. You may also delete a listed save after confirmation.
-4. Choose **Settings** to open `DLG90001` **Settings dialog**. Select among available map-theme choices, then close the dialog. Settings persist, but take effect after restarting the app; a theme group with only one choice is not shown.
+1. Open `SHEL40001` **Pause menu panel** when **Processing Turn** is not on screen. The title is **Game Paused**. Choose **Resume**, **Save Game**, **Load Game**, **Settings**, or **Exit to Main Menu**.
+2. Choose **Save Game** to open `DLG70001` **Save game name**. Its proposed name includes your nation, leader, and current turn. Enter a valid name and save it. A conflicting name asks before overwriting; invalid names remain unsaved. You may keep 20 named saves. A new name at that limit is refused. Overwriting a save that already exists still works.
+3. Choose **Load Game** to open `DLG80001` **Load game list**. The auto-save, when available, is kept apart from the manual list; manual saves are shown newest first and are paged after ten entries. Select a save, confirm that you wish to discard the current session, and the chosen game replaces it. You may also delete a listed save after confirmation.
+4. Choose **Settings** to open `DLG90001` **Settings**. The **Warn when civilians have no work order on end turn** switch applies on the next end-turn confirm, without restarting the app. Map-theme choices persist and apply after you restart the app. A theme group with only one choice is not shown.
 5. Choose **Exit to Main Menu** only when you mean to leave the current game. The pause panel closes first and the game asks for confirmation before returning to the main menu.
 
-The `GAME50001` **Game side menu** is separate from the pause menu. It offers read-only Game Parameters and the Debug log; it is not the place to save, load, or change settings.
+`GAME50001` **Game side menu** is separate from the pause menu. It offers read-only Game Parameters (including whether you chose **Infinite mode** at new game) and the Debug log. It is not the place to save, load, or change settings.
 
 ## Counsel
 
-**Counsel.** Hark, my liege: treat the final review before Next turn as a council meeting. Check food, treasury, vulnerable armies, and unfinished work before you commit the realm to events you cannot recall.
+**Counsel.** Hark, my liege: treat the final review before **Next turn** as a council meeting. Check food, treasury, vulnerable armies, and unfinished work before you commit the realm to events you cannot recall.
 
-**Warning.** Do not mistake an order for its result. A march, treaty, recipe, or market offer is settled in its appointed phase and may meet another court’s decree before the next Orders phase begins.
+**Warning.** Do not mistake a decree for its result. A march, treaty, recipe, or market offer is settled in its appointed step and may meet another court’s decree before you can choose actions again.
 
 **Tip.** Name manual saves for a decision you may wish to revisit—before a war, great purchase, or expedition—rather than trusting memory alone.
 
@@ -54,34 +94,36 @@ The `GAME50001` **Game side menu** is separate from the pause menu. It offers re
 
 ## The other courts
 
-Every AI-controlled Great Power plans during the turn before its orders are merged with yours. Its court observes only what it can legitimately know, chooses goals according to personality and circumstances, and makes economic, military, diplomatic, and research plans under the same rules that govern your realm.
+Every other Great Power plans while you plan. It only uses what it can see. A chosen **leader** makes that court bolder or more cautious. It may build, seek an alliance, research, move, or make war before you tap **Next turn**.
 
-Their choices are deterministic for the same world state and seeds, but they are not passive. A rival may strengthen its industry, seek an alliance, pursue research, move into a contested frontier, or make war while your own orders await resolution.
+Their choices are not passive. A rival may strengthen its industry, seek an alliance, pursue research, move into a contested frontier, or make war while your own decrees still await **Next turn**.
 
 ## Consequences
 
-- A completed turn can change your stockpile, treasury, labour, relations, research, unit locations, province ownership, and market holdings before you act again.
-- News is a summary, not a substitute for inspection. Read `DLG50001` Turn news, then check the affected province, fleet, diplomacy, production, and technology views.
+- A completed turn can change your stores, treasury, labour, relations, research, unit locations, province ownership, and market holdings before you act again.
+- News is a summary, not a substitute for inspection. Read `DLG50001` **Turn news dialog**, then check the affected province, fleet, diplomacy, production, and technology views.
 - Saving preserves a named point in your campaign; loading from pause deliberately discards the active session in favour of the selected save.
 - The fixed calendar keeps moving with each completed turn: early decades pass quickly, while the years after 1700 become more granular.
-- In a standard campaign, after the last full turn of year **1800** resolves without a province-count winner, further **Next turn** actions stay blocked. `OVL20001` **Victory overlay** announces **Campaign complete** (see Chapter 15); dismissing it to view the map does not reopen the turn clock.
+- **Military victory** is holding 31 or more Old World provinces (see Chapter 15). After the last full turn of year **1800** finishes with no military victory, `OVL20001` **Victory overlay** announces **Campaign complete** and further **Next turn** actions stay blocked. **Infinite mode** (chosen at new game; shown read-only on `GAME50001` **Game side menu** Game Parameters) does not halt the calendar that way. Choosing **View Final State** to look at the map does not turn **Next turn** back on.
 
 ## Acceptance criteria for this chapter
 
-- [ ] Explains ending a turn via operable `DLG60001` Next turn confirmation, including **Staged this turn**, **Review decrees**, go-to without ending the turn, and resolution blocking.
-- [ ] States that `DLG60001` may warn about idle work-order civilians (not Spies) but does **not** warn about empty or unfunded research seats.
-- [ ] Summarizes the player-visible resolution sequence and states that results appear after resolution, including possible diplomacy decisions that suspend it.
-- [ ] Documents `DLG50001` Turn news, its empty state, victory precedence, and the spy-report **open Intelligence** line to `GAME30003`; documents operable `OVL70001` Player turn event feed (news toggle), including spy-court report rows.
-- [ ] Documents last-turn spatial pulses on `MAP10001` after turn news (or after **View Final State** on military victory or **Campaign complete**), Skip, the six-beat cap, and that the feed keeps the full list.
-- [ ] Documents `SHEL40001` pause actions plus `DLG70001` saving, `DLG80001` loading, and `DLG90001` settings.
-- [ ] Distinguishes `GAME50001` Game side menu from the pause menu.
-- [ ] States default turn-to-year pacing and accurately describes rival Great Powers’ per-turn planning.
+- [ ] Explains ending a turn via operable `DLG60001` **Next turn confirmation**, including both titles, the turn-number body, **Staged this turn**, **Review decrees**, go-to without ending the turn, **No work order** rows, and **Processing Turn**.
+- [ ] States that `DLG60001` may warn about idle Explorer, Builder, Engineer, Merchant, and Rail Builder civilians (not Spies) but does **not** warn about empty or unfunded research seats.
+- [ ] Summarizes what happens after **Next turn** in the game’s fixed order, including recipes and unused labour, and states that results appear after that work, including possible diplomacy answers on `OVL30001`, `OVL50001`, and `OVL40001`.
+- [ ] Documents `DLG50001` **Turn news dialog**, **No major events last turn.**, victory precedence, and the spy-report **open Intelligence** line to `GAME30003` **Intelligence Council**; documents operable `OVL70001` **Player turn event feed** (newspaper button after treasury and cargo; hidden default; badge), including spy-court, combat, discovery, and medal taps.
+- [ ] Documents last-turn pulses on `MAP10001` **Empire overview / map area** after turn news (or after **View Final State** on military victory or **Campaign complete**), Old/New World tab switch, Skip/tap without opening panels, the six-place cap, and that the feed keeps the full list.
+- [ ] Documents `SHEL40001` pause actions plus `DLG70001` saving (20-save cap), `DLG80001` loading, and `DLG90001` settings (no-work-order switch immediate; map themes on restart).
+- [ ] Distinguishes `GAME50001` **Game side menu** from the pause menu, including read-only Infinite mode.
+- [ ] States default calendar pacing, military victory vs **Campaign complete**, Infinite mode, and rival Great Powers’ per-turn planning in everyday words.
 
 ## Sources
 
 - `SPEC/game/turn-time-mapping.md`
+- `SPEC/game/victory.md`
 - `SPEC/program/turn-resolution-phases.md`
 - `SPEC/ui/next-turn-confirmation.md`
+- `SPEC/ui/components/staged-decree-review.md`
 - `SPEC/ui/ux-design-decisions.md`
 - `SPEC/ui/turn-news-dialog.md`
 - `SPEC/ui/player-turn-event-feed.md`
@@ -96,4 +138,10 @@ Their choices are deterministic for the same world state and seeds, but they are
 - `SPEC/ui/settings-dialog.md`
 - `SPEC/ui/screen-registry.md`
 - `SPEC/ui/game-side-menu.md`
+- `SPEC/ui/overture-dialogue-overlay.md`
+- `SPEC/ui/screens/pending-intervention-overlay.md`
+- `SPEC/ui/call-to-arms-dialogue-overlay.md`
+- `SPEC/ui/province-sea-zone-detail-overlay.md`
+- `SPEC/ui/production-panel.md`
+- `SPEC/ui/trade-screen.md`
 - `SPEC/ai/ai-architecture.md`

--- a/docs/manual/player-export/14-passage-of-turns.md
+++ b/docs/manual/player-export/14-passage-of-turns.md
@@ -2,51 +2,91 @@
 
 ## Purpose
 
-A turn is the span in which your court gives its orders, the other Great Powers make their own plans, and the world answers both. Ending it commits the orders you have already set; the result is a new political, military, and economic situation to read before issuing the next decrees.
+A **Great Power** is a playable nation. A **decree** is an action you choose on your turn. A turn is the span in which you choose those decrees, the other Great Powers make their own plans, and the world answers both.
 
-The campaign calendar advances with the turn. By default, turn 1 is 1500; turns through 100 advance two years each, reaching 1700, and later turns advance one year at a time. The HUD and turn news use that calendar to place your reign in its age.
+The **Old World** and the **New World** are the two maps. **Next turn** is the only way the calendar advances, and the only way the game checks **military victory** (holding 31 or more Old World provinces; Chapter 15). Once you confirm, you cannot take those decrees back. Ending the turn commits what you have already set; the result is a new political, military, and economic situation to read before you choose again.
+
+The campaign calendar advances with the turn. By default, turn 1 is 1500; turns through 100 advance two years each, reaching 1700, and later turns advance one year at a time. The top bar and **Next turn** show the year and the turn number. **Turn news dialog** uses the same calendar.
 
 ## How it is done
 
 ### Ending a turn
 
-1. On **Game screen**, finish the orders and immediate actions you mean to give this turn, then use **Next turn** in the top bar.
-2. Confirm in **Next turn confirmation** (“End turn?”). When you have already given decrees this turn, the dialog shows **Staged this turn** with a short count by kind (army moves, trade, and so on). Tap **Review decrees** to read each line in ordinary words. A locate button beside each kind opens that panel or screen without ending the turn, so you can still change your mind. If you gave no decrees, that list is simply absent — the court does not scold you for a quiet turn. **Yes** stays available while you read. If any of your **work-order civilians** (Explorer, Builder, Engineer, Merchant, Rail Builder) have no work order queued, the dialog may list them so you can locate each unit before committing. **Spies are not listed** — foreign station, home counter-spy, and capital reserve are deliberate posts, not wasted capacity. Choose **Yes** to commit the displayed turn, or **No** to abort and keep planning. You can turn this warning off in **Settings** (or dismiss it for future turns from the dialog). Empty research seats or funding set to **None** are **not** listed here: holding gold back from research is a normal strategic choice, so the court does not nag at end-turn about unused research capacity (review **Technology screen** only when you mean to). A funded research assignment you already set can appear under **Staged this turn**; unused seats still do not.
-3. Once resolution begins, the game blocks map interaction and further Next turn requests while it processes the turn. The hamburger side menu remains available, but changes that would alter the resolving turn must wait.
-4. Resolution may pause for a decision when diplomacy requires your answer: for example, an overture, intervention, or call to arms. Give that answer before the remaining phases can continue.
+1. On **Game screen**, finish the decrees you mean to give this turn, then tap **Next turn** in the top bar.
+2. **Next turn confirmation** opens. The title is **End turn?** or **Proceed to next turn?** The body says **Turn {N} will end. Continue?**
+3. If you already staged decrees this turn, the dialog shows **Staged this turn** with a short count by kind (army moves, trade, and so on). If you gave none, that list is simply absent — the court does not scold you for a quiet turn.
+4. Tap **Review decrees** to read each staged line in ordinary words. A locate button beside each kind opens that panel or screen and closes the dialog **without** ending the turn, so you can still change your mind. **Yes** stays available while you read.
+5. Five working civilians can do assigned tasks: Explorer, Builder, Engineer, Merchant, and Rail Builder. If any of yours have **no work order** for the next turn, the dialog may list them under **These civilians have no work order for the next turn:**. Each row shows type, location, **No work order**, and a go-to button.
+6. Tap go-to on a listed civilian to leave without ending the turn. The map finds that person and opens **Civilian units panel**. A **Spy** is a civilian posted in a foreign court or at home; Spies are **not** listed here — foreign station, home counter-spy, and capital reserve are deliberate posts, not wasted capacity.
+7. To stop seeing that no-work-order list, turn on **Don't show this warning again** and then tap **Yes**. Tapping **No** leaves the warning on. You can also change the same warning in **Settings** with **Warn when civilians have no work order on end turn**; that switch applies on the next end-turn confirm, without restarting the app.
+8. Empty research seats or funding set to **None** are **not** listed here: holding gold back from research is a normal choice. Review **Technology screen** only when you mean to. A funded research assignment you already set can appear under **Staged this turn**; unused seats still do not.
+9. Choose **Yes** to commit the displayed turn, or **No** to keep planning.
+10. After **Yes**, a **Processing Turn** screen appears. You cannot close it, tap the map, or tap **Next turn** until the turn finishes. The three-line button still opens **Game side menu**. **Game Paused** / **Pause menu panel** does not open until **Processing Turn** closes.
+11. The turn may pause when diplomacy needs your answer. Give that answer on **Overture dialogue**, **Pending intervention overlay**, or **Call to arms dialogue overlay** before the rest of the turn can continue.
 
-### What the realm resolves
+### What happens after Next turn
 
-The game completes its phases in a fixed order. You see their combined consequences after resolution rather than watching every individual exchange as it happens.
+After you confirm, the game carries out the turn in a fixed order. You see the combined results when that finishes — not while each step runs.
 
-1. **Orders:** your decrees and the other Great Powers’ orders are gathered and checked together.
-2. **The economy:** extraction fills stockpiles; riches become treasury; food and luxuries are consumed; then idle labour produces goods. This is why a stockpile, treasury, or labour forecast can differ after the turn.
-3. **Courts and knowledge:** diplomacy resolves before research, so agreements, wars, and ownership changes can affect what follows. Spy activity and research then resolve.
-4. **Forces in motion:** land and naval movement occur, followed by minor-nation military adjustment, naval interception and combat, then land combat. Expect losses, new positions, and captured provinces only after these stages have finished.
-5. **Works and trade:** units build, explore, prospect, improve, and perform other assigned work; the World Market then settles submitted offers and bids.
-6. **The reckoning:** victory and campaign-end conditions are checked, visibility updates, and the turn advances. If the campaign continues, you return to the Orders phase with the new state.
+1. Your decrees and the other Great Powers’ plans are gathered and checked together.
+2. Resource tiles add goods to your stores.
+3. Riches become treasury.
+4. Armies, workers, and ships eat food and luxuries.
+5. Assigned recipes and unused labour then make finished goods. This is why a store, treasury, or labour forecast can differ after the turn.
+6. Diplomacy then runs — agreements, wars, and ownership can change what follows. The game may pause here for your answer on the diplomacy screens listed above.
+7. Spy work then takes effect, then research.
+8. Armies and fleets move. Minor Nations keep their armies as strong as the strongest Great Power, so they are hard to conquer casually.
+9. Patrols and blockades may try to catch moving fleets; sea fighting comes next, then land fighting. Expect losses, new positions, and captured provinces only after these stages have finished.
+10. People then do assigned work: build, explore, prospect, improve, and the rest.
+11. The **World Market** is the shared market on **Trade screen**. It then settles the bids and offers you submitted. **Deal Book** is that screen’s tab of your bids and offers.
+12. The game checks **military victory** and whether the campaign calendar has ended, updates what you can see, and advances the turn. Then you can choose actions again (or the campaign ends).
 
-A completed turn’s principal report appears in **Turn news dialog**, unless victory takes precedence. It lists major events from the resolved turn; if none qualify, it plainly says so. Close the report, inspect the map and your empire screens, and prepare the next turn. When your Spies still stood in a foreign court after that turn, a muted line at the bottom of turn news says **Your spies report N items — open Intelligence**. Tap it to close the newspaper and open **Intelligence Council** (also reached from **Intelligence** on **Diplomacy screen**). Closing the newspaper does not forget those reports; Intelligence keeps last turn’s world briefing and spy lines until the next completed turn replaces them.
+### Turn news
 
-After you close turn news — or, when **Victory overlay** is up for a military win or **Campaign complete**, after you choose **View Final State** — **Empire overview / map area** may briefly pulse a few places where last turn’s fights, captures, finished civilian work, or new sight landed. The pulses wait until **Victory overlay** is gone; closing the newspaper while it is still up does not start them. The camera moves to each place in turn; a short caption names what happened. Tap the map or **Skip** to end the sequence early. At most six places play this way; the full list stays in **Player turn event feed**. Research, diplomacy, and market lines stay in news and the feed only.
+A completed turn’s main report appears in **Turn news dialog**, unless victory takes precedence. If nothing major happened, it says **No major events last turn.** Close the report, inspect the map and your empire screens, and prepare the next turn.
 
-On the map, the news toggle opens **Player turn event feed** — a compact, human-scoped card of outcomes over the map. It replaces its entries each resolved turn and can be shown or hidden without leaving **Game screen**. Use it with turn news: the dialog is the formal summary; the feed keeps relevant lines on the map while you inspect. When a technology finishes researching, its feed line shows the tech by name; tap that line to open **Technology screen** on the Slots tab and choose your next project. Diplomacy, overture, and spy lines open the counterpart faction's **Diplomacy detail screen** screen; spy-court report lines from last turn (the same **Our spy in {court} reports:** wording as Intelligence) open **Intelligence Council**. Completed work orders open **Civilian units panel** focused on the builder; land combat and province capture lines open the province overlay on the map. Rejected orders open the panel or screen that owns that order type (for example civilian work opens Civilian units, trade opens Trade). When your own market bids or offers filled or carried forward last turn, a short **Market:** line summarizes bought and sold totals (and carry-forwards when any); tap it to open **Trade screen** on the Deal Book tab for the full ledger. Overseas-profit lines remain separate and use the same Deal Book deep-link. When treasury or stockpile changed materially last turn, a **Realm:** line summarizes the net treasury and largest stockpile movers; tap it to open **Production screen** for the full picture (this is last-turn actuals, not the forward preview on Available). A rival’s research or a fight you were not in does **not** appear here unless a Spy of yours still stood in that court.
+When your Spies still stood in a foreign court after that turn, a line at the bottom of turn news says **Your spies report N items — open Intelligence**. Tap it to close the newspaper and open **Intelligence Council** (the printed bar says **Intelligence**; you can also open it from **Intelligence** on **Diplomacy screen**). Closing the newspaper does not forget those reports; Intelligence keeps last turn’s world briefing and spy lines until the next completed turn replaces them.
+
+### Last-turn pulses on the map
+
+After you close turn news — or, when **Victory overlay** is up for a military win or **Campaign complete**, after you choose **View Final State** — **Empire overview / map area** may briefly pulse a few places where last turn’s fights, captures, finished civilian work, or new sight landed.
+
+The pulses wait until **Victory overlay** is gone; closing the newspaper while it is still up does not start them. Each pulse also switches the **Old World** / **New World** tab the same way a locate button does. The camera moves to each place in turn; a short caption names what happened. Tap the map or **Skip** to end the sequence early. Skip or a map tap does **not** open **Province sea-zone overlay** or a unit panel. At most six places play this way; the full list stays in **Player turn event feed**. Research, diplomacy, and market lines stay in news and the feed only.
+
+### The newspaper feed
+
+On **Empire overview / map area**, the newspaper button sits on the map bar after treasury and cargo. The feed starts **hidden**. A badge on the button shows how many lines it holds. Tap the button to show or hide **Player turn event feed** without leaving **Game screen**.
+
+Use the feed with turn news: the dialog is the formal summary; the feed keeps relevant lines on the map while you inspect. It replaces its entries each completed turn.
+
+Tap a line for the matching place or screen:
+
+1. When a technology finishes researching, its feed line shows the tech by name. Tap it to open **Technology screen** on the Slots tab and choose your next project.
+2. Diplomacy and overture lines open the other nation’s **Diplomacy detail screen**. Spy-caught and spy-defected rows also open that court’s **Diplomacy detail screen**.
+3. Spy report lines (the same **Our spy in {court} reports:** wording as Intelligence) open **Intelligence Council** or that court’s **Diplomacy detail screen**.
+4. Completed work orders open **Civilian units panel** focused on the person who finished the task.
+5. Land combat and province capture lines open **Province sea-zone overlay**. Naval combat opens that same screen when the map can find the sea; otherwise that line is not tappable. Discovery pans the map to the new province or sea. Medal lines use the word **general**.
+6. Rejected orders open the panel or screen that owns that order type (for example civilian work opens Civilian units, trade opens Trade).
+7. When your own market bids or offers filled or carried forward last turn, a short **Market:** line summarizes bought and sold totals (and orders carried when any). Tap it to open **Trade screen** on the **Deal Book** tab. Overseas-profit lines remain separate and use the same Trade / Deal Book tap.
+8. When treasury or stores changed materially last turn, a **Realm:** line summarizes the net treasury and largest store movers. Tap it to open **Production screen** for last turn’s real totals, not the **Available** forecast.
+
+A rival’s research or a fight you were not in does **not** appear here unless a Spy of yours still stood in that court.
 
 ### Pausing, saving, and loading
 
-1. Open **Pause menu panel** when the game is not resolving. Choose **Resume**, **Save Game**, **Load Game**, **Settings**, or **Exit to Main Menu**.
-2. Choose **Save Game** to open **Save game name**. Its proposed name includes your nation, leader, and current turn. Enter a valid name and save it. A conflicting name asks before overwriting; invalid names remain unsaved. You may keep up to 20 manual saves, though an existing save may still be overwritten at that limit.
+1. Open **Pause menu panel** when **Processing Turn** is not on screen. The title is **Game Paused**. Choose **Resume**, **Save Game**, **Load Game**, **Settings**, or **Exit to Main Menu**.
+2. Choose **Save Game** to open **Save game name**. Its proposed name includes your nation, leader, and current turn. Enter a valid name and save it. A conflicting name asks before overwriting; invalid names remain unsaved. You may keep 20 named saves. A new name at that limit is refused. Overwriting a save that already exists still works.
 3. Choose **Load Game** to open **Load game list**. The auto-save, when available, is kept apart from the manual list; manual saves are shown newest first and are paged after ten entries. Select a save, confirm that you wish to discard the current session, and the chosen game replaces it. You may also delete a listed save after confirmation.
-4. Choose **Settings** to open **Settings**. Select among available map-theme choices, then close the dialog. Settings persist, but take effect after restarting the app; a theme group with only one choice is not shown.
+4. Choose **Settings** to open **Settings**. The **Warn when civilians have no work order on end turn** switch applies on the next end-turn confirm, without restarting the app. Map-theme choices persist and apply after you restart the app. A theme group with only one choice is not shown.
 5. Choose **Exit to Main Menu** only when you mean to leave the current game. The pause panel closes first and the game asks for confirmation before returning to the main menu.
 
-The **Game side menu** is separate from the pause menu. It offers read-only Game Parameters and the Debug log; it is not the place to save, load, or change settings.
+**Game side menu** is separate from the pause menu. It offers read-only Game Parameters (including whether you chose **Infinite mode** at new game) and the Debug log. It is not the place to save, load, or change settings.
 
 ## Counsel
 
-**Counsel.** Hark, my liege: treat the final review before Next turn as a council meeting. Check food, treasury, vulnerable armies, and unfinished work before you commit the realm to events you cannot recall.
+**Counsel.** Hark, my liege: treat the final review before **Next turn** as a council meeting. Check food, treasury, vulnerable armies, and unfinished work before you commit the realm to events you cannot recall.
 
-**Warning.** Do not mistake an order for its result. A march, treaty, recipe, or market offer is settled in its appointed phase and may meet another court’s decree before the next Orders phase begins.
+**Warning.** Do not mistake a decree for its result. A march, treaty, recipe, or market offer is settled in its appointed step and may meet another court’s decree before you can choose actions again.
 
 **Tip.** Name manual saves for a decision you may wish to revisit—before a war, great purchase, or expedition—rather than trusting memory alone.
 
@@ -54,14 +94,14 @@ The **Game side menu** is separate from the pause menu. It offers read-only Game
 
 ## The other courts
 
-Every AI-controlled Great Power plans during the turn before its orders are merged with yours. Its court observes only what it can legitimately know, chooses goals according to personality and circumstances, and makes economic, military, diplomatic, and research plans under the same rules that govern your realm.
+Every other Great Power plans while you plan. It only uses what it can see. A chosen **leader** makes that court bolder or more cautious. It may build, seek an alliance, research, move, or make war before you tap **Next turn**.
 
-Their choices are deterministic for the same world state and seeds, but they are not passive. A rival may strengthen its industry, seek an alliance, pursue research, move into a contested frontier, or make war while your own orders await resolution.
+Their choices are not passive. A rival may strengthen its industry, seek an alliance, pursue research, move into a contested frontier, or make war while your own decrees still await **Next turn**.
 
 ## Consequences
 
-- A completed turn can change your stockpile, treasury, labour, relations, research, unit locations, province ownership, and market holdings before you act again.
-- News is a summary, not a substitute for inspection. Read **Turn news dialog** Turn news, then check the affected province, fleet, diplomacy, production, and technology views.
+- A completed turn can change your stores, treasury, labour, relations, research, unit locations, province ownership, and market holdings before you act again.
+- News is a summary, not a substitute for inspection. Read **Turn news dialog**, then check the affected province, fleet, diplomacy, production, and technology views.
 - Saving preserves a named point in your campaign; loading from pause deliberately discards the active session in favour of the selected save.
 - The fixed calendar keeps moving with each completed turn: early decades pass quickly, while the years after 1700 become more granular.
-- In a standard campaign, after the last full turn of year **1800** resolves without a province-count winner, further **Next turn** actions stay blocked. **Victory overlay** announces **Campaign complete** (see Chapter 15); dismissing it to view the map does not reopen the turn clock.
+- **Military victory** is holding 31 or more Old World provinces (see Chapter 15). After the last full turn of year **1800** finishes with no military victory, **Victory overlay** announces **Campaign complete** and further **Next turn** actions stay blocked. **Infinite mode** (chosen at new game; shown read-only on **Game side menu** Game Parameters) does not halt the calendar that way. Choosing **View Final State** to look at the map does not turn **Next turn** back on.


### PR DESCRIPTION
## Summary

- Rewrites `docs/manual/14-passage-of-turns.md` for all STYLE_GUIDE and SPEC-accuracy findings in #4514: first-use teaching (Great Power, decree, Old/New World, Spy, World Market, Deal Book, Intelligence), **Next turn** as the only calendar / military-victory advance, printed confirmation titles and **Processing Turn**, idle-civilian **No work order** copy, diplomacy pause screens, SPEC-order turn sequence without invented phase titles, newspaper feed placement and taps, save cap, settings timings, **Campaign complete** vs Infinite mode.
- Regenerates `docs/manual/player-export/14-passage-of-turns.md` via `export-player-manual`.

## Done in this PR

All Required-changes items in #4514 applied to chapter 14 authoring + export.

## Deferred

None for #4514.

## AC coverage

| AC | Status |
|----|--------|
| Every Required-changes item applied | Done |
| STYLE_GUIDE reading-level gate | Done (player wording throughout) |
| Screen IDs / how-to match registry + Sources SPECs | Done |
| `export-player-manual` run | Done |

## Test plan

- [x] `python3 pytool/export_player_manual.py` (exit 0)
- [x] `python3 pytool/export_player_manual.py --check` (pass)
- [ ] CI quality gates

Refs #4514

Made with [Cursor](https://cursor.com)