### PR TITLE
refactor: extraction-cap kTechId SoT and family split (#4626)

### DIFF
--- a/SPEC/program/repo-lint.md
+++ b/SPEC/program/repo-lint.md
@@ -20,7 +20,7 @@
 
 **Implementation status (GitHub #1912 / #4352 / #4450 / #4582 / #4606, game widgets and core services file size):** `repo.game_widgets_file_size` enforces a universal **250** physical-line cap for every `.dart` file under `app/lib/features/game/widgets/**` with no keyed waivers (wave-21 #4606, down from wave-20 **260**). Per-rule contract: `SPEC/program/game-widgets-file-size.md`. Sibling `repo.app_catalog_widgets_file_size` enforces the same **250** cap under `app/lib/widgets/**` (Refs #4352 AC4, #4582, #4606; `SPEC/program/app-catalog-widgets-file-size.md`). Wave-16 `repo.app_core_services_file_size` enforces the same **250** cap under `app/lib/core/services/**` with an empty grandfather (Refs #4450, #4582, #4606; `SPEC/program/app-core-services-file-size.md`). Wave-17 `repo.app_turn_resolution_file_size` enforces the same **250** cap under `app/lib/features/game/turn_resolution/**` with an empty grandfather (Refs #4512, #4582, #4606; `SPEC/program/app-turn-resolution-file-size.md`).
 
-**Implementation status (GitHub #1912, tech id literals):** `repo.tech_id_constants` treats the string values of every `const String kTechId*` in `packages/colonizethis_data/lib/src/tech_ids.dart` as the canonical tech-id set (replacing the prior `tech_catalog.dart` map-key scrape). `tech_catalog.dart` uses those same constants for map keys and `TechDefinition` ids so the catalog stays aligned with the checker.
+**Implementation status (GitHub #1912 / #4626, tech id literals):** `repo.tech_id_constants` treats the string values of every `const String kTechId*` in `packages/colonizethis_data/lib/src/tech_ids.dart` as the canonical tech-id set (replacing the prior `tech_catalog.dart` map-key scrape). `tech_catalog.dart` uses those same constants for map keys and `TechDefinition` ids so the catalog stays aligned with the checker. Top-level map keys in `packages/colonizethis_data/lib/src/tech_extraction_caps*.dart` that match catalog tech ids are in scope (they are otherwise skipped as `TopLevelVariableDeclaration`). Pin: `test/check_tech_id_constants_test.dart`.
 
 **Implementation status (GitHub #1912, custom exceptions):** `repo.custom_exceptions` (`tool/check_custom_exceptions.dart` + `packages/colonizethis_exception_lint`) enforces the generic-throw ban on in-scope domain files only; it does **not** read keyed waiver YAML or per-symbol / per-file exemption tables. Whole-tree scope follows `collectRepoLintDomainDartFiles` / `shouldEnforceDomainExceptions` (generated suffixes and test-path skips are scope wiring, not violation waivers). Per-rule contract: `SPEC/program/exception-enforcement.md`.
 
@@ -32,6 +32,7 @@
 
 - Given a `repo.*` rule implementation, when a maintainer audits it for waiver data, then the maintainer finds no keyed tables loaded solely to raise effective limits for specific in-scope symbols or files.
 - Given `SPEC/program/repo-lint.md`, when a contributor adds or changes a manifest rule, then the contributor does not introduce a new violation-allowlist mechanism.
+- Given a raw catalog tech-id string used as a map key under `packages/colonizethis_data/lib/src/tech_extraction_caps*.dart`, when `dart run tool/ct_repo_lint.dart` runs `repo.tech_id_constants`, then the checker fails naming that literal.
 
 ## Source of truth
 

--- a/packages/colonizethis_data/lib/src/tech_extraction_caps.dart
+++ b/packages/colonizethis_data/lib/src/tech_extraction_caps.dart
@@ -2,6 +2,10 @@
 /// SPEC/game/tech-and-extraction-cap.md, SPEC/game/extraction-and-improvements.md.
 
 import 'resource.dart';
+import 'tech_extraction_caps_nw.dart';
+import 'tech_extraction_caps_ow_food.dart';
+import 'tech_extraction_caps_precious.dart';
+import 'tech_extraction_caps_timber_minerals.dart';
 import 'terrain_type.dart';
 
 /// Default max effective extraction level for a resource with no cap-raising tech unlocked.
@@ -19,90 +23,10 @@ final Map<String, int> extractionCapDesignExceptions = {
 /// resource id -> (tech id -> max extraction level for that resource).
 final Map<String, Map<String, int>> _extractionCapByResourceByTechId =
     _validatedExtractionCapTable({
-      Resource.grain.name: const {
-        'land_enclosure': 2,
-        'seed_drill': 3,
-        'moldboard_plow': 4,
-      },
-      Resource.timber.name: const {
-        'saw_mill': 2,
-        'wind_saw_mill': 3,
-        'circular_saw': 4,
-      },
-      Resource.iron.name: const {
-        'iron_mining': 2,
-        'steam_in_mining': 3,
-        'industrial_iron_mining': 4,
-      },
-      Resource.copper.name: const {
-        'copper_and_tin_mining': 2,
-        'large_copper_and_tin_mines': 3,
-        'efficient_extraction_of_copper_and_tin': 4,
-      },
-      Resource.tin.name: const {
-        'copper_and_tin_mining': 2,
-        'large_copper_and_tin_mines': 3,
-        'efficient_extraction_of_copper_and_tin': 4,
-      },
-      Resource.coal.name: const {
-        'coal_mining': 1,
-        'square_set_timbering': 2,
-        'large_coal_mines': 3,
-        'safety_lamp': 4,
-      },
-      Resource.wool.name: const {
-        'sheep_ranching': 2,
-        'scientific_sheep_breeding': 3,
-      },
-      Resource.meat.name: const {
-        'animal_husbandry': 3,
-        'scientific_cattle_breeding': 4,
-      },
-      Resource.sugarCane.name: const {
-        'sugar_planting': 2,
-        'large_sugar_plantations': 3,
-        'sugar_industry': 4,
-      },
-      Resource.tobacco.name: const {
-        'tobacco_planting': 2,
-        'large_tobacco_plantations': 3,
-        'tobacco_industry': 4,
-      },
-      Resource.cotton.name: const {
-        'cotton_planting': 2,
-        'large_cotton_plantations': 3,
-        'cotton_gin': 4,
-      },
-      Resource.furs.name: const {
-        'improved_trapping_techniques': 2,
-        'riverboats': 3,
-        'excessive_fur_harvesting': 4,
-      },
-      Resource.spices.name: const {
-        'improved_sea_routes': 2,
-        'large_spice_plantations': 3,
-        'improved_food_preservation': 4,
-      },
-      Resource.silver.name: const {
-        'precious_metals_mining': 2,
-        'extraction_of_precious_metals': 3,
-        'amalgamation_process': 4,
-      },
-      Resource.gold.name: const {
-        'precious_metals_mining': 2,
-        'extraction_of_precious_metals': 3,
-        'amalgamation_process': 4,
-      },
-      Resource.gems.name: const {
-        'precious_stone_mining': 2,
-        'large_precious_stone_mines': 3,
-        'geological_prospecting': 4,
-      },
-      Resource.diamonds.name: const {
-        'precious_stone_mining': 2,
-        'large_precious_stone_mines': 3,
-        'geological_prospecting': 4,
-      },
+      ...extractionCapTableOwFoodFibre,
+      ...extractionCapTableTimberMinerals,
+      ...extractionCapTableNwPlantationHarvest,
+      ...extractionCapTablePrecious,
     });
 
 /// All tech ids that raise an extraction cap for at least one resource.

--- a/packages/colonizethis_data/lib/src/tech_extraction_caps_nw.dart
+++ b/packages/colonizethis_data/lib/src/tech_extraction_caps_nw.dart
@@ -1,0 +1,34 @@
+/// New-World plantation and harvest extraction-cap rows.
+/// SPEC/game/tech-and-extraction-cap.md.
+
+import 'resource.dart';
+import 'tech_ids.dart';
+
+/// Sugar, tobacco, cotton, furs, and spices cap progression by tech.
+final Map<String, Map<String, int>> extractionCapTableNwPlantationHarvest = {
+  Resource.sugarCane.name: const {
+    kTechIdSugarPlanting: 2,
+    kTechIdLargeSugarPlantations: 3,
+    kTechIdSugarIndustry: 4,
+  },
+  Resource.tobacco.name: const {
+    kTechIdTobaccoPlanting: 2,
+    kTechIdLargeTobaccoPlantations: 3,
+    kTechIdTobaccoIndustry: 4,
+  },
+  Resource.cotton.name: const {
+    kTechIdCottonPlanting: 2,
+    kTechIdLargeCottonPlantations: 3,
+    kTechIdCottonGin: 4,
+  },
+  Resource.furs.name: const {
+    kTechIdImprovedTrappingTechniques: 2,
+    kTechIdRiverboats: 3,
+    kTechIdExcessiveFurHarvesting: 4,
+  },
+  Resource.spices.name: const {
+    kTechIdImprovedSeaRoutes: 2,
+    kTechIdLargeSpicePlantations: 3,
+    kTechIdImprovedFoodPreservation: 4,
+  },
+};

--- a/packages/colonizethis_data/lib/src/tech_extraction_caps_ow_food.dart
+++ b/packages/colonizethis_data/lib/src/tech_extraction_caps_ow_food.dart
@@ -1,0 +1,22 @@
+/// Old-World food and fibre extraction-cap rows.
+/// SPEC/game/tech-and-extraction-cap.md.
+
+import 'resource.dart';
+import 'tech_ids.dart';
+
+/// Grain, wool, and meat cap progression by gathering tech.
+final Map<String, Map<String, int>> extractionCapTableOwFoodFibre = {
+  Resource.grain.name: const {
+    kTechIdLandEnclosure: 2,
+    kTechIdSeedDrill: 3,
+    kTechIdMoldboardPlow: 4,
+  },
+  Resource.wool.name: const {
+    kTechIdSheepRanching: 2,
+    kTechIdScientificSheepBreeding: 3,
+  },
+  Resource.meat.name: const {
+    kTechIdAnimalHusbandry: 3,
+    kTechIdScientificCattleBreeding: 4,
+  },
+};

--- a/packages/colonizethis_data/lib/src/tech_extraction_caps_precious.dart
+++ b/packages/colonizethis_data/lib/src/tech_extraction_caps_precious.dart
@@ -1,0 +1,29 @@
+/// Precious-metal and precious-stone extraction-cap rows.
+/// SPEC/game/tech-and-extraction-cap.md.
+
+import 'resource.dart';
+import 'tech_ids.dart';
+
+/// Silver, gold, gems, and diamonds cap progression by mining tech.
+final Map<String, Map<String, int>> extractionCapTablePrecious = {
+  Resource.silver.name: const {
+    kTechIdPreciousMetalsMining: 2,
+    kTechIdExtractionOfPreciousMetals: 3,
+    kTechIdAmalgamationProcess: 4,
+  },
+  Resource.gold.name: const {
+    kTechIdPreciousMetalsMining: 2,
+    kTechIdExtractionOfPreciousMetals: 3,
+    kTechIdAmalgamationProcess: 4,
+  },
+  Resource.gems.name: const {
+    kTechIdPreciousStoneMining: 2,
+    kTechIdLargePreciousStoneMines: 3,
+    kTechIdGeologicalProspecting: 4,
+  },
+  Resource.diamonds.name: const {
+    kTechIdPreciousStoneMining: 2,
+    kTechIdLargePreciousStoneMines: 3,
+    kTechIdGeologicalProspecting: 4,
+  },
+};

--- a/packages/colonizethis_data/lib/src/tech_extraction_caps_timber_minerals.dart
+++ b/packages/colonizethis_data/lib/src/tech_extraction_caps_timber_minerals.dart
@@ -1,0 +1,35 @@
+/// Timber and Old-World mineral extraction-cap rows.
+/// SPEC/game/tech-and-extraction-cap.md.
+
+import 'resource.dart';
+import 'tech_ids.dart';
+
+/// Timber, iron, copper, tin, and coal cap progression by gathering tech.
+final Map<String, Map<String, int>> extractionCapTableTimberMinerals = {
+  Resource.timber.name: const {
+    kTechIdSawMill: 2,
+    kTechIdWindSawMill: 3,
+    kTechIdCircularSaw: 4,
+  },
+  Resource.iron.name: const {
+    kTechIdIronMining: 2,
+    kTechIdSteamInMining: 3,
+    kTechIdIndustrialIronMining: 4,
+  },
+  Resource.copper.name: const {
+    kTechIdCopperAndTinMining: 2,
+    kTechIdLargeCopperAndTinMines: 3,
+    kTechIdEfficientExtractionOfCopperAndTin: 4,
+  },
+  Resource.tin.name: const {
+    kTechIdCopperAndTinMining: 2,
+    kTechIdLargeCopperAndTinMines: 3,
+    kTechIdEfficientExtractionOfCopperAndTin: 4,
+  },
+  Resource.coal.name: const {
+    kTechIdCoalMining: 1,
+    kTechIdSquareSetTimbering: 2,
+    kTechIdLargeCoalMines: 3,
+    kTechIdSafetyLamp: 4,
+  },
+};

--- a/packages/colonizethis_data/test/wave7_slice_b_extraction_cap_splits_test.dart
+++ b/packages/colonizethis_data/test/wave7_slice_b_extraction_cap_splits_test.dart
@@ -1,0 +1,48 @@
+import 'dart:io';
+
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_test/test.dart';
+
+void main() {
+  group('wave 7 Slice B extraction-cap splits (Refs #4626 AC4)', () {
+    test('family libraries exist and do not use part directives', () {
+      const names = <String>[
+        'tech_extraction_caps_ow_food.dart',
+        'tech_extraction_caps_timber_minerals.dart',
+        'tech_extraction_caps_nw.dart',
+        'tech_extraction_caps_precious.dart',
+      ];
+      for (final name in names) {
+        final file = File('lib/src/$name');
+        expect(file.existsSync(), isTrue, reason: name);
+        final text = file.readAsStringSync();
+        expect(text.contains('part '), isFalse, reason: name);
+        expect(text.contains('part of '), isFalse, reason: name);
+      }
+    });
+
+    test('family tables use kTechId identifiers not raw catalog strings', () {
+      const names = <String>[
+        'tech_extraction_caps_ow_food.dart',
+        'tech_extraction_caps_timber_minerals.dart',
+        'tech_extraction_caps_nw.dart',
+        'tech_extraction_caps_precious.dart',
+      ];
+      final rawKey = RegExp(r"'[a-z][a-z0-9_]*'\s*:");
+      for (final name in names) {
+        final text = File('lib/src/$name').readAsStringSync();
+        expect(text.contains('kTechId'), isTrue, reason: name);
+        expect(rawKey.hasMatch(text), isFalse, reason: name);
+      }
+    });
+
+    test('merged cap lookup still raises grain with land enclosure', () {
+      expect(
+        extractionCapForResourceForUnlocked({
+          kTechIdLandEnclosure: true,
+        }, Resource.grain.name),
+        2,
+      );
+    });
+  });
+}

--- a/test/check_tech_id_constants_test.dart
+++ b/test/check_tech_id_constants_test.dart
@@ -1,0 +1,118 @@
+import 'package:test/test.dart';
+
+import '../tool/check_tech_id_constants.dart';
+
+void main() {
+  const techIds = <String>{'land_enclosure', 'saw_mill'};
+  const constantNameByTechId = <String, String>{
+    'land_enclosure': 'kTechIdLandEnclosure',
+    'saw_mill': 'kTechIdSawMill',
+  };
+
+  group('findTechIdConstantViolations', () {
+    test('flags executable raw tech id string literal', () {
+      const src = r'''
+void f() {
+  const t = 'land_enclosure';
+  print(t);
+}
+''';
+      final violations = findTechIdConstantViolations(
+        relativePath: 'packages/foo/lib/x.dart',
+        source: src,
+        techIds: techIds,
+        constantNameByTechId: constantNameByTechId,
+      );
+      expect(violations, isNotEmpty);
+      expect(violations.first.message, contains('kTechIdLandEnclosure'));
+      expect(violations.first.line, greaterThan(0));
+      expect(violations.first.column, greaterThan(0));
+    });
+
+    test('allows non-catalog literal', () {
+      const src = r'''
+void f() {
+  const t = 'not_a_tech';
+  print(t);
+}
+''';
+      final violations = findTechIdConstantViolations(
+        relativePath: 'packages/foo/lib/x.dart',
+        source: src,
+        techIds: techIds,
+        constantNameByTechId: constantNameByTechId,
+      );
+      expect(violations, isEmpty);
+    });
+
+    test('does not flag top-level constant declarations', () {
+      const src = r'''
+const String kDemo = 'land_enclosure';
+void f() {}
+''';
+      final violations = findTechIdConstantViolations(
+        relativePath: 'packages/foo/lib/x.dart',
+        source: src,
+        techIds: techIds,
+        constantNameByTechId: constantNameByTechId,
+      );
+      expect(violations, isEmpty);
+    });
+
+    test('flags raw catalog tech-id map keys in extraction-cap table files', () {
+      const src = r'''
+final Map<String, Map<String, int>> table = {
+  'grain': const {
+    'land_enclosure': 2,
+  },
+};
+''';
+      final violations = findTechIdConstantViolations(
+        relativePath:
+            'packages/colonizethis_data/lib/src/tech_extraction_caps_ow_food.dart',
+        source: src,
+        techIds: techIds,
+        constantNameByTechId: constantNameByTechId,
+      );
+      expect(violations, isNotEmpty);
+      expect(violations.first.message, contains('land_enclosure'));
+      expect(violations.first.message, contains('kTechIdLandEnclosure'));
+    });
+
+    test(
+      'does not flag extraction-cap map keys outside tech_extraction_caps*.dart',
+      () {
+        const src = r'''
+final Map<String, Map<String, int>> table = {
+  'grain': const {
+    'land_enclosure': 2,
+  },
+};
+''';
+        final violations = findTechIdConstantViolations(
+          relativePath: 'packages/colonizethis_data/lib/src/other_tables.dart',
+          source: src,
+          techIds: techIds,
+          constantNameByTechId: constantNameByTechId,
+        );
+        expect(violations, isEmpty);
+      },
+    );
+
+    test('skips generated file paths', () {
+      const src = r'''
+void f() {
+  final t = 'saw_mill';
+  print(t);
+}
+''';
+      final violations = findTechIdConstantViolations(
+        relativePath: 'packages/foo/lib/x.g.dart',
+        source: src,
+        techIds: techIds,
+        constantNameByTechId: constantNameByTechId,
+      );
+      expect(violations, isEmpty);
+    });
+  });
+}

--- a/tool/check_tech_id_constants.dart
+++ b/tool/check_tech_id_constants.dart
@@ -35,26 +35,21 @@ int runCheckTechIdConstants(
   final requested = incrementalRelativeDartPaths ?? const <String>[];
   final candidateFiles = _collectCandidateFiles(root, requested);
 
-  final violations = <_Violation>[];
+  final violations = <TechIdConstantViolation>[];
   for (final file in candidateFiles) {
     final relPath = p.normalize(p.relative(file.path, from: root));
     if (repoLintIdentifierLiteralShouldSkipFile(relPath, _excludedPaths)) {
       continue;
     }
     final source = file.readAsStringSync();
-    final parsed = parseString(
-      content: source,
-      path: file.path,
-      throwIfDiagnostics: false,
+    violations.addAll(
+      findTechIdConstantViolations(
+        relativePath: relPath,
+        source: source,
+        techIds: techIds,
+        constantNameByTechId: constantNameByTechId,
+      ),
     );
-    final visitor = _TechIdLiteralVisitor(
-      path: relPath,
-      unit: parsed.unit,
-      techIds: techIds,
-      constantNameByTechId: constantNameByTechId,
-    );
-    parsed.unit.visitChildren(visitor);
-    violations.addAll(visitor.violations);
   }
 
   if (violations.isEmpty) {
@@ -85,6 +80,45 @@ void main(List<String> args) {
           : parsedArgs.files,
     ),
   );
+}
+
+/// Extraction-cap table libraries (Refs #4626 AC5): top-level map keys that
+/// match catalog tech ids are treated as executable literals.
+bool isTechExtractionCapsLibPath(String relativePath) {
+  final normalized = p.posix.normalize(relativePath.replaceAll(r'\', '/'));
+  const prefix = 'packages/colonizethis_data/lib/src/';
+  if (!normalized.startsWith(prefix)) {
+    return false;
+  }
+  final name = p.basename(normalized);
+  return name.startsWith('tech_extraction_caps') && name.endsWith('.dart');
+}
+
+List<TechIdConstantViolation> findTechIdConstantViolations({
+  required String relativePath,
+  required String source,
+  required Set<String> techIds,
+  required Map<String, String> constantNameByTechId,
+}) {
+  if (!relativePath.endsWith('.dart')) {
+    return const [];
+  }
+  if (repoLintIdentifierLiteralShouldSkipFile(relativePath, _excludedPaths)) {
+    return const [];
+  }
+  final parsed = parseString(
+    content: source,
+    path: relativePath,
+    throwIfDiagnostics: false,
+  );
+  final visitor = _TechIdLiteralVisitor(
+    path: relativePath,
+    unit: parsed.unit,
+    techIds: techIds,
+    constantNameByTechId: constantNameByTechId,
+  );
+  parsed.unit.visitChildren(visitor);
+  return visitor.violations;
 }
 
 _ParsedArgs _parseArgs(List<String> args) {
@@ -172,7 +206,7 @@ class _TechIdLiteralVisitor extends RecursiveAstVisitor<void> {
   final CompilationUnit unit;
   final Set<String> techIds;
   final Map<String, String> constantNameByTechId;
-  final List<_Violation> violations = <_Violation>[];
+  final List<TechIdConstantViolation> violations = <TechIdConstantViolation>[];
 
   @override
   void visitSimpleStringLiteral(SimpleStringLiteral node) {
@@ -189,7 +223,7 @@ class _TechIdLiteralVisitor extends RecursiveAstVisitor<void> {
         ? 'Use a kTechId* constant from colonizethis_data.'
         : 'Use $suggestedConstant from colonizethis_data.';
     violations.add(
-      _Violation(
+      TechIdConstantViolation(
         path: path,
         line: location.lineNumber,
         column: location.columnNumber,
@@ -211,16 +245,21 @@ class _TechIdLiteralVisitor extends RecursiveAstVisitor<void> {
         return true;
       }
       if (cursor is TopLevelVariableDeclaration || cursor is FieldDeclaration) {
-        return false;
+        return isTechExtractionCapsLibPath(path) && _isMapKeyLiteral(node);
       }
       cursor = cursor.parent;
     }
     return false;
   }
+
+  bool _isMapKeyLiteral(AstNode node) {
+    final parent = node.parent;
+    return parent is MapLiteralEntry && identical(parent.key, node);
+  }
 }
 
-class _Violation {
-  const _Violation({
+class TechIdConstantViolation {
+  const TechIdConstantViolation({
     required this.path,
     required this.line,
     required this.column,


### PR DESCRIPTION
## Summary
- Successor slice after merged #4638: family-split the extraction-cap table and replace raw tech-id map keys with `kTechId*`.
- Extend `repo.tech_id_constants` so catalog strings used as map keys under `tech_extraction_caps*.dart` fail CI.
- Add `test/check_tech_id_constants_test.dart` (no new `quality.yml` job).

## Done in this push
- OW food/fibre, timber/minerals, NW plantation/harvest, and precious family libraries; facade merge + validation stay in `tech_extraction_caps.dart`.
- Public names `extractionCapForResourceForUnlocked`, `extractionCapTechIds`, `terrainExtractionHardCap`, `defaultExtractionCap`, and `extractionCapDesignExceptions` unchanged via `tech_extraction.dart`.
- SPEC `repo-lint.md` AC for extraction-cap map-key scanning.

## Remaining for #4626
- Slice C: victory-config / new-world catalog splits.
- Slice D: test densify + 250/250 file-size ratchets (depends on A–C).

## Tests
- `dart test test/check_tech_id_constants_test.dart`
- `dart run tool/check_tech_id_constants.dart`
- `dart test test/wave7_slice_b_extraction_cap_splits_test.dart test/tech_extraction_test.dart` (in `packages/colonizethis_data`)

## Manual
N/A — structure-only; no player-visible UX (`docs/manual/` unchanged).

Refs #4626


Made with [Cursor](https://cursor.com)